### PR TITLE
Pre-fill signup forms via 1h audience session cookie

### DIFF
--- a/fair-audience/src/API/AudienceSignupController.php
+++ b/fair-audience/src/API/AudienceSignupController.php
@@ -13,6 +13,7 @@ use FairAudience\Database\QuestionnaireSubmissionRepository;
 use FairAudience\Database\QuestionnaireAnswerRepository;
 use FairAudience\Models\Participant;
 use FairAudience\Models\QuestionnaireSubmission;
+use FairAudience\Services\AudienceSession;
 use FairAudience\Services\EmailService;
 use WP_REST_Controller;
 use WP_REST_Server;
@@ -296,6 +297,8 @@ class AudienceSignupController extends WP_REST_Controller {
 		if ( $submission_id > 0 && ! empty( $questionnaire_answers ) ) {
 			$this->email_service->send_audience_signup_answers_email( $participant, $submission_id, $questionnaire_answers, $post_id );
 		}
+
+		AudienceSession::set( (int) $participant->id );
 
 		// If keep_informed, send confirmation email.
 		if ( $keep_informed ) {

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -11,6 +11,7 @@ use FairAudience\Database\ParticipantRepository;
 use FairAudience\Database\EventParticipantRepository;
 use FairAudience\Database\EmailConfirmationTokenRepository;
 use FairAudience\Models\Participant;
+use FairAudience\Services\AudienceSession;
 use FairAudience\Services\EmailService;
 use FairAudience\Services\ParticipantToken;
 use WP_REST_Controller;
@@ -493,6 +494,7 @@ class EventSignupController extends WP_REST_Controller {
 		}
 
 		if ( $existing && 'signed_up' === $existing->label ) {
+			AudienceSession::set( (int) $participant->id );
 			return rest_ensure_response(
 				array(
 					'success' => true,
@@ -511,6 +513,9 @@ class EventSignupController extends WP_REST_Controller {
 
 		$paid_response = $this->maybe_start_paid_signup( $event_id, $event_date_id, $participant, $existing, $user_id, $ticket_type_id, $option_items, $invitation_token );
 		if ( null !== $paid_response ) {
+			if ( ! is_wp_error( $paid_response ) ) {
+				AudienceSession::set( (int) $participant->id );
+			}
 			return $paid_response;
 		}
 
@@ -530,6 +535,8 @@ class EventSignupController extends WP_REST_Controller {
 
 		$option_names = array_map( fn( $o ) => $o->name, $option_items );
 		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names );
+
+		AudienceSession::set( (int) $participant->id );
 
 		return rest_ensure_response(
 			array(
@@ -1208,8 +1215,9 @@ class EventSignupController extends WP_REST_Controller {
 		$this->increment_rate_limit( $email );
 
 		// Check if participant already exists.
-		$participant = $this->participant_repository->get_by_email( $email );
-		$existing    = null;
+		$participant        = $this->participant_repository->get_by_email( $email );
+		$existing           = null;
+		$is_new_participant = false;
 
 		if ( $participant ) {
 			// Participant exists - check if already signed up.
@@ -1255,6 +1263,8 @@ class EventSignupController extends WP_REST_Controller {
 					array( 'status' => 500 )
 				);
 			}
+
+			$is_new_participant = true;
 		}
 
 		// Validate ticket type group restrictions (and invitation tokens for invitation-only types).
@@ -1273,6 +1283,9 @@ class EventSignupController extends WP_REST_Controller {
 
 		$paid_response = $this->maybe_start_paid_signup( $event_id, $event_date_id, $participant, $existing, 0, $ticket_type_id, $option_items, $invitation_token );
 		if ( null !== $paid_response ) {
+			if ( $is_new_participant && ! is_wp_error( $paid_response ) ) {
+				AudienceSession::set( (int) $participant->id );
+			}
 			return $paid_response;
 		}
 
@@ -1292,6 +1305,10 @@ class EventSignupController extends WP_REST_Controller {
 
 		$option_names = array_map( fn( $o ) => $o->name, $option_items );
 		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names );
+
+		if ( $is_new_participant ) {
+			AudienceSession::set( (int) $participant->id );
+		}
 
 		// If keep_informed, send confirmation email.
 		if ( $keep_informed ) {

--- a/fair-audience/src/API/MailingSignupController.php
+++ b/fair-audience/src/API/MailingSignupController.php
@@ -11,6 +11,7 @@ use FairAudience\Database\ParticipantRepository;
 use FairAudience\Database\ParticipantCategoryRepository;
 use FairAudience\Database\EmailConfirmationTokenRepository;
 use FairAudience\Models\Participant;
+use FairAudience\Services\AudienceSession;
 use FairAudience\Services\EmailService;
 use WP_REST_Controller;
 use WP_REST_Server;
@@ -276,6 +277,8 @@ class MailingSignupController extends WP_REST_Controller {
 			);
 		}
 
+		AudienceSession::set( (int) $participant->id );
+
 		return rest_ensure_response(
 			array(
 				'success' => true,
@@ -353,6 +356,8 @@ class MailingSignupController extends WP_REST_Controller {
 
 		// Delete the token (one-time use).
 		$token->delete();
+
+		AudienceSession::set( (int) $participant->id );
 
 		return rest_ensure_response(
 			array(

--- a/fair-audience/src/API/SessionController.php
+++ b/fair-audience/src/API/SessionController.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Audience Session REST API Controller
+ *
+ * Exposes a single endpoint that clears the audience session cookie. Used by
+ * the "Not you?" affordance on signup forms.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\API;
+
+use FairAudience\Services\AudienceSession;
+use WP_REST_Controller;
+use WP_REST_Server;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * REST API controller for the audience session cookie.
+ */
+class SessionController extends WP_REST_Controller {
+
+	/**
+	 * REST API namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-audience/v1';
+
+	/**
+	 * REST API base route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'session';
+
+	/**
+	 * Register REST API routes.
+	 */
+	public function register_routes() {
+		// DELETE /fair-audience/v1/session — clear the cookie.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'clear' ),
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Clear the audience session cookie.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function clear() {
+		AudienceSession::clear();
+		return rest_ensure_response( array( 'success' => true ) );
+	}
+}

--- a/fair-audience/src/Core/Plugin.php
+++ b/fair-audience/src/Core/Plugin.php
@@ -47,6 +47,7 @@ class Plugin {
 		load_plugin_textdomain( 'fair-audience', false, 'fair-audience/languages' );
 
 		add_action( 'rest_api_init', array( $this, 'register_api_endpoints' ) );
+		add_filter( 'rest_post_dispatch', array( $this, 'slide_audience_session_cookie' ), 10, 3 );
 		add_filter( 'query_vars', array( $this, 'add_query_vars' ) );
 		add_action( 'template_redirect', array( $this, 'handle_poll_response' ) );
 		add_action( 'template_redirect', array( $this, 'handle_email_confirmation' ) );
@@ -152,11 +153,50 @@ class Plugin {
 		$timeline_controller = new \FairAudience\API\TimelineController();
 		$timeline_controller->register_routes();
 
+		$session_controller = new \FairAudience\API\SessionController();
+		$session_controller->register_routes();
+
 		// Membership fees (only when fair-payment plugin is active).
 		if ( class_exists( 'FairPayment\Core\Plugin' ) ) {
 			$fees_controller = new \FairAudience\API\FeesController();
 			$fees_controller->register_routes();
 		}
+	}
+
+	/**
+	 * Slide the audience session cookie forward on every successful
+	 * fair-audience REST request that carried a valid session cookie.
+	 *
+	 * Hooked into rest_post_dispatch so it runs after the route handler.
+	 * Skipped when the response is an error or for routes outside the
+	 * fair-audience namespace.
+	 *
+	 * @param \WP_HTTP_Response $response Response object.
+	 * @param \WP_REST_Server   $server   REST server instance.
+	 * @param \WP_REST_Request  $request  Request object.
+	 * @return \WP_HTTP_Response Unmodified response.
+	 */
+	public function slide_audience_session_cookie( $response, $server, $request ) {
+		if ( ! $response instanceof \WP_HTTP_Response ) {
+			return $response;
+		}
+		if ( ! $request instanceof \WP_REST_Request ) {
+			return $response;
+		}
+
+		$route = $request->get_route();
+		if ( 0 !== strpos( $route, '/fair-audience/' ) ) {
+			return $response;
+		}
+
+		$status = $response->get_status();
+		if ( $status < 200 || $status >= 300 ) {
+			return $response;
+		}
+
+		\FairAudience\Services\AudienceSession::slide();
+
+		return $response;
 	}
 
 	/**

--- a/fair-audience/src/Services/AudienceSession.php
+++ b/fair-audience/src/Services/AudienceSession.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Audience Session Service
+ *
+ * Manages a short-lived, HMAC-signed cookie that identifies a participant
+ * across signup forms on the site. The cookie lets the next signup form a
+ * visitor opens pre-fill name / surname / email / phone without re-asking.
+ *
+ * Cookie format: "{participant_id}.{expires_at}.{signature}"
+ *
+ * The expiry is part of the signed payload so a client cannot extend the
+ * lifetime by editing the cookie.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Service for setting / reading / clearing the audience session cookie.
+ */
+class AudienceSession {
+
+	/**
+	 * Cookie name.
+	 */
+	const COOKIE_NAME = 'fair_audience_session';
+
+	/**
+	 * Cookie lifetime in seconds (1 hour).
+	 */
+	const LIFETIME = HOUR_IN_SECONDS;
+
+	/**
+	 * Set or refresh the session cookie for a participant.
+	 *
+	 * Safe to call multiple times per request; each call replaces the cookie
+	 * value and slides the expiry forward to LIFETIME seconds from now.
+	 *
+	 * @param int $participant_id Participant ID to bind the session to.
+	 * @return void
+	 */
+	public static function set( int $participant_id ): void {
+		if ( $participant_id <= 0 ) {
+			return;
+		}
+		if ( headers_sent() ) {
+			return;
+		}
+
+		$expires_at = time() + self::LIFETIME;
+		$value      = self::build_value( $participant_id, $expires_at );
+
+		self::send_cookie( $value, $expires_at );
+		$_COOKIE[ self::COOKIE_NAME ] = $value;
+	}
+
+	/**
+	 * Get the participant ID from a valid session cookie, or null.
+	 *
+	 * Returns null when the cookie is missing, malformed, tampered, or expired.
+	 *
+	 * @return int|null Participant ID, or null when no valid session.
+	 */
+	public static function get_participant_id(): ?int {
+		if ( empty( $_COOKIE[ self::COOKIE_NAME ] ) ) {
+			return null;
+		}
+
+		$raw = wp_unslash( $_COOKIE[ self::COOKIE_NAME ] );
+		if ( ! is_string( $raw ) ) {
+			return null;
+		}
+
+		$parts = explode( '.', $raw, 3 );
+		if ( 3 !== count( $parts ) ) {
+			return null;
+		}
+
+		list( $participant_id_str, $expires_at_str, $signature ) = $parts;
+
+		if ( ! ctype_digit( $participant_id_str ) || ! ctype_digit( $expires_at_str ) ) {
+			return null;
+		}
+
+		$participant_id = (int) $participant_id_str;
+		$expires_at     = (int) $expires_at_str;
+
+		if ( $participant_id <= 0 || $expires_at <= time() ) {
+			return null;
+		}
+
+		$expected = self::sign( $participant_id . '.' . $expires_at );
+		if ( ! hash_equals( $expected, $signature ) ) {
+			return null;
+		}
+
+		return $participant_id;
+	}
+
+	/**
+	 * Slide the expiry forward on a valid session.
+	 *
+	 * No-op when no valid cookie is present. Equivalent to calling set() with
+	 * the participant id currently stored in the cookie.
+	 *
+	 * @return void
+	 */
+	public static function slide(): void {
+		$participant_id = self::get_participant_id();
+		if ( null === $participant_id ) {
+			return;
+		}
+		self::set( $participant_id );
+	}
+
+	/**
+	 * Clear the session cookie.
+	 *
+	 * @return void
+	 */
+	public static function clear(): void {
+		if ( headers_sent() ) {
+			unset( $_COOKIE[ self::COOKIE_NAME ] );
+			return;
+		}
+		self::send_cookie( '', time() - HOUR_IN_SECONDS );
+		unset( $_COOKIE[ self::COOKIE_NAME ] );
+	}
+
+	/**
+	 * Build the signed cookie value.
+	 *
+	 * @param int $participant_id Participant ID.
+	 * @param int $expires_at     Unix timestamp when the cookie should expire.
+	 * @return string Signed cookie payload.
+	 */
+	private static function build_value( int $participant_id, int $expires_at ): string {
+		$data      = $participant_id . '.' . $expires_at;
+		$signature = self::sign( $data );
+		return $data . '.' . $signature;
+	}
+
+	/**
+	 * Send the Set-Cookie header.
+	 *
+	 * @param string $value      Cookie value (empty string clears).
+	 * @param int    $expires_at Unix timestamp.
+	 * @return void
+	 */
+	private static function send_cookie( string $value, int $expires_at ): void {
+		setcookie(
+			self::COOKIE_NAME,
+			$value,
+			array(
+				'expires'  => $expires_at,
+				'path'     => defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/',
+				'domain'   => defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : '',
+				'secure'   => is_ssl(),
+				'httponly' => true,
+				'samesite' => 'Lax',
+			)
+		);
+	}
+
+	/**
+	 * Sign data with HMAC-SHA256 using a service-specific salt.
+	 *
+	 * @param string $data Data to sign.
+	 * @return string Hex-encoded signature.
+	 */
+	private static function sign( string $data ): string {
+		$secret = 'fair_audience_session_' . wp_salt( 'auth' );
+		return hash_hmac( 'sha256', $data, $secret );
+	}
+}

--- a/fair-audience/src/blocks/audience-signup/frontend.js
+++ b/fair-audience/src/blocks/audience-signup/frontend.js
@@ -46,14 +46,17 @@ const CSS_PREFIX = 'fair-audience-audience';
 	}
 
 	/**
-	 * Setup participant link UI (pre-filled form with "Not you?" button)
+	 * Setup participant link UI (pre-filled form with "Not you?" button).
+	 * Shown for either URL-token pre-fill (data-participant-id) or
+	 * cookie-based pre-fill (data-session-prefill).
 	 * @param {HTMLElement} form The form element
 	 */
 	function setupParticipantLink(form) {
 		const container = form.closest('.fair-audience-audience-signup');
 		const participantId = container?.dataset.participantId;
+		const hasSessionPrefill = container?.dataset.sessionPrefill === '1';
 
-		if (!participantId) return;
+		if (!participantId && !hasSessionPrefill) return;
 
 		// Create "Not you?" button
 		const notYouButton = document.createElement('button');
@@ -62,8 +65,9 @@ const CSS_PREFIX = 'fair-audience-audience';
 		notYouButton.textContent = __('Not you? Start fresh', 'fair-audience');
 
 		notYouButton.addEventListener('click', function () {
-			// Clear participant link
+			// Clear participant link and session-prefill marker
 			delete container.dataset.participantId;
+			delete container.dataset.sessionPrefill;
 
 			// Clear pre-filled fields
 			const nameInput = form.querySelector('input[name="audience_name"]');
@@ -85,6 +89,15 @@ const CSS_PREFIX = 'fair-audience-audience';
 			const url = new URL(window.location);
 			url.searchParams.delete('participant_token');
 			window.history.replaceState({}, '', url);
+
+			// Clear the audience session cookie on the server. Fire-and-forget;
+			// the cookie is HttpOnly so the browser alone cannot remove it.
+			apiFetch({
+				path: '/fair-audience/v1/session',
+				method: 'DELETE',
+			}).catch(function () {
+				// Best-effort: nothing useful to show the user if this fails.
+			});
 		});
 
 		// Insert before the submit button

--- a/fair-audience/src/blocks/audience-signup/render.php
+++ b/fair-audience/src/blocks/audience-signup/render.php
@@ -15,6 +15,7 @@
 defined( 'WPINC' ) || die;
 
 use FairEvents\Models\EventDates;
+use FairAudience\Services\AudienceSession;
 use FairAudience\Services\AudienceSignupToken;
 use FairAudience\Services\ParticipantToken;
 use FairAudience\Database\QuestionnaireSubmissionRepository;
@@ -100,6 +101,26 @@ if ( ! empty( $edit_token ) ) {
 	}
 }
 
+// Cookie-based pre-fill: when there's no URL token and we're not in edit
+// mode, fall back to the audience session cookie. Unlike the URL token case,
+// this does NOT set $linked_participant_id — the visitor hasn't proven they
+// own the identity, so we just pre-fill fields and let the controller go
+// through its normal flow.
+$has_session_prefill = false;
+if ( ! $linked_participant_id && ! $is_edit_mode ) {
+	$session_participant_id = AudienceSession::get_participant_id();
+	if ( $session_participant_id ) {
+		$session_repo        = new ParticipantRepository();
+		$session_participant = $session_repo->get_by_id( $session_participant_id );
+		if ( $session_participant ) {
+			$existing_name       = (string) $session_participant->name;
+			$existing_surname    = (string) ( $session_participant->surname ?? '' );
+			$existing_email      = (string) $session_participant->email;
+			$has_session_prefill = true;
+		}
+	}
+}
+
 // Generate unique ID for this form instance.
 $form_id = 'fair-audience-audience-' . wp_unique_id();
 
@@ -109,6 +130,13 @@ $wrapper_data = array(
 	'data-success-message' => esc_attr( $success_message ),
 	'data-questions'       => wp_json_encode( $questions ),
 );
+
+if ( $has_session_prefill ) {
+	$wrapper_data['data-session-prefill']  = '1';
+	$wrapper_data['data-existing-name']    = esc_attr( $existing_name );
+	$wrapper_data['data-existing-surname'] = esc_attr( $existing_surname );
+	$wrapper_data['data-existing-email']   = esc_attr( $existing_email );
+}
 
 if ( '' !== $event_date_id ) {
 	$wrapper_data['data-event-date-id'] = esc_attr( $event_date_id );

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -15,6 +15,7 @@ defined( 'WPINC' ) || die;
 
 use FairAudience\Database\ParticipantRepository;
 use FairAudience\Database\EventParticipantRepository;
+use FairAudience\Services\AudienceSession;
 use FairAudience\Services\ParticipantToken;
 use FairEvents\Models\EventDates;
 use FairEvents\Models\EventDateSetting;
@@ -102,6 +103,16 @@ $participant      = null;
 $participant_data = array();
 $is_signed_up     = false;
 
+// Cookie-based pre-fill values for the anonymous registration form. Only
+// populated when the visitor has a valid fair_audience_session cookie *and*
+// no stronger identity (URL token / logged-in user) applies. The cookie is
+// NOT treated as authentication — fields are still editable, the form still
+// goes through register_and_signup, and the visitor can hit "Not you?".
+$session_prefill_name    = '';
+$session_prefill_surname = '';
+$session_prefill_email   = '';
+$has_session_prefill     = false;
+
 if ( $is_valid_post_type ) {
 	$participant_repository       = new ParticipantRepository();
 	$event_participant_repository = new EventParticipantRepository();
@@ -156,6 +167,21 @@ if ( $is_valid_post_type ) {
 			'surname' => $participant->surname,
 			'email'   => $participant->email,
 		);
+	}
+
+	// Anonymous viewer: fall back to the audience session cookie for pre-fill.
+	// Only applies when no URL token or logged-in user produced a participant.
+	if ( null === $participant ) {
+		$session_participant_id = AudienceSession::get_participant_id();
+		if ( $session_participant_id ) {
+			$session_participant = $participant_repository->get_by_id( $session_participant_id );
+			if ( $session_participant ) {
+				$session_prefill_name    = (string) $session_participant->name;
+				$session_prefill_surname = (string) ( $session_participant->surname ?? '' );
+				$session_prefill_email   = (string) $session_participant->email;
+				$has_session_prefill     = true;
+			}
+		}
 	}
 }
 
@@ -657,6 +683,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 						name="signup_name"
 						required
 						placeholder="<?php echo esc_attr__( 'Enter your first name', 'fair-audience' ); ?>"
+						value="<?php echo esc_attr( $session_prefill_name ); ?>"
 					/>
 				</p>
 				<p>
@@ -668,6 +695,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 						id="<?php echo esc_attr( $form_id ); ?>-surname"
 						name="signup_surname"
 						placeholder="<?php echo esc_attr__( 'Enter your surname', 'fair-audience' ); ?>"
+						value="<?php echo esc_attr( $session_prefill_surname ); ?>"
 					/>
 				</p>
 				<p>
@@ -680,6 +708,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 						name="signup_email"
 						required
 						placeholder="<?php echo esc_attr__( 'Enter your email', 'fair-audience' ); ?>"
+						value="<?php echo esc_attr( $session_prefill_email ); ?>"
 					/>
 				</p>
 				<p class="fair-audience-signup-checkbox">

--- a/fair-audience/src/blocks/mailing-signup/render.php
+++ b/fair-audience/src/blocks/mailing-signup/render.php
@@ -14,12 +14,30 @@
 
 defined( 'WPINC' ) || die;
 
+use FairAudience\Database\ParticipantRepository;
+use FairAudience\Services\AudienceSession;
+
 // Get block attributes — translate defaults so stored English values get localized.
 $submit_text              = __( $attributes['submitButtonText'] ?? 'Subscribe', 'fair-audience' );
 $success_message          = __( $attributes['successMessage'] ?? 'Please check your email to confirm your subscription.', 'fair-audience' );
 $show_categories          = ! empty( $attributes['showCategories'] );
 $category_ids             = $attributes['categoryIds'] ?? array();
 $preselected_category_ids = $attributes['preselectedCategoryIds'] ?? array();
+
+// Cookie-based pre-fill from the audience session.
+$session_prefill_name    = '';
+$session_prefill_surname = '';
+$session_prefill_email   = '';
+$session_participant_id  = AudienceSession::get_participant_id();
+if ( $session_participant_id ) {
+	$session_repo        = new ParticipantRepository();
+	$session_participant = $session_repo->get_by_id( $session_participant_id );
+	if ( $session_participant ) {
+		$session_prefill_name    = (string) $session_participant->name;
+		$session_prefill_surname = (string) ( $session_participant->surname ?? '' );
+		$session_prefill_email   = (string) $session_participant->email;
+	}
+}
 
 // Generate unique ID for this form instance.
 $form_id = 'fair-audience-mailing-' . wp_unique_id();
@@ -66,6 +84,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				name="mailing_name"
 				required
 				placeholder="<?php echo esc_attr__( 'Enter your first name', 'fair-audience' ); ?>"
+				value="<?php echo esc_attr( $session_prefill_name ); ?>"
 			/>
 		</p>
 		<p>
@@ -78,6 +97,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				name="mailing_surname"
 				required
 				placeholder="<?php echo esc_attr__( 'Enter your last name', 'fair-audience' ); ?>"
+				value="<?php echo esc_attr( $session_prefill_surname ); ?>"
 			/>
 		</p>
 		<p>
@@ -90,6 +110,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				name="mailing_email"
 				required
 				placeholder="<?php echo esc_attr__( 'Enter your email', 'fair-audience' ); ?>"
+				value="<?php echo esc_attr( $session_prefill_email ); ?>"
 			/>
 		</p>
 


### PR DESCRIPTION
Drops an HMAC-signed, HttpOnly fair_audience_session cookie after a successful signup so other audience/event/mailing signup forms on the site can pre-fill name / surname / email for the next hour. Each successful fair-audience REST request slides the expiry forward.

The cookie is convenience, not authentication: pre-filled fields stay editable, and the cookie is only set when the visitor has just proved ownership of the identity (fresh participant creation, authenticated event signup, or email-link confirmation) so it cannot be used to claim someone else's record.

Closes #553.