### PR TITLE
Show retry-payment UI when returning from a failed Mollie checkout

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -198,6 +198,26 @@ class EventSignupController extends WP_REST_Controller {
 			)
 		);
 
+		// POST /fair-audience/v1/event-signup/retry-payment
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/retry-payment',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'retry_payment' ),
+					'permission_callback' => array( $this, 'retry_payment_permissions_check' ),
+					'args'                => array(
+						'transaction_id' => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+
 		// POST /fair-audience/v1/event-signup/request-link
 		register_rest_route(
 			$this->namespace,
@@ -1145,6 +1165,264 @@ class EventSignupController extends WP_REST_Controller {
 			array(
 				'success' => true,
 				'message' => __( 'If your email is in our system, you will receive a signup link shortly. Please check your inbox.', 'fair-audience' ),
+			)
+		);
+	}
+
+	/**
+	 * Permission check for retry-payment: visitor must own the failed
+	 * transaction, either via WP login or matching audience session cookie.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool|WP_Error True if allowed, error otherwise.
+	 */
+	public function retry_payment_permissions_check( $request ) {
+		$transaction_id = (int) $request->get_param( 'transaction_id' );
+		if ( $transaction_id <= 0 ) {
+			return new WP_Error(
+				'invalid_transaction',
+				__( 'Invalid transaction.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! class_exists( \FairPayment\API\TransactionAPI::class ) ) {
+			return new WP_Error(
+				'payment_unavailable',
+				__( 'Payment plugin is missing.', 'fair-audience' ),
+				array( 'status' => 503 )
+			);
+		}
+
+		$transaction = \FairPayment\API\TransactionAPI::get_transaction( $transaction_id );
+		if ( ! $transaction ) {
+			return new WP_Error(
+				'transaction_not_found',
+				__( 'Transaction not found.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$wp_user_id        = get_current_user_id();
+		$tx_user_id        = isset( $transaction->user_id ) ? (int) $transaction->user_id : 0;
+		$tx_participant_id = isset( $transaction->participant_id ) ? (int) $transaction->participant_id : 0;
+
+		if ( $wp_user_id && $tx_user_id && $wp_user_id === $tx_user_id ) {
+			return true;
+		}
+
+		if ( $tx_participant_id > 0 ) {
+			if ( $wp_user_id ) {
+				$linked = $this->participant_repository->get_by_user_id( $wp_user_id );
+				if ( $linked && (int) $linked->id === $tx_participant_id ) {
+					return true;
+				}
+			}
+
+			$cookie_participant_id = \FairAudience\Services\AudienceSession::get_participant_id();
+			if ( $cookie_participant_id && (int) $cookie_participant_id === $tx_participant_id ) {
+				return true;
+			}
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'You are not authorized to retry this payment.', 'fair-audience' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	/**
+	 * Re-initiate payment for a previously failed/canceled/expired transaction.
+	 *
+	 * The existing EventParticipant.pending_payment row is reused when the
+	 * 15-minute hold has not yet elapsed; otherwise the hold is refreshed (or
+	 * the row recreated if a cleanup cron already removed it). A new
+	 * fair-payment transaction is always created since fair-payment refuses
+	 * to re-initiate a transaction once a Mollie payment has been attached.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	public function retry_payment( $request ) {
+		$transaction_id = (int) $request->get_param( 'transaction_id' );
+
+		$old_transaction = \FairPayment\API\TransactionAPI::get_transaction( $transaction_id );
+		if ( ! $old_transaction ) {
+			return new WP_Error(
+				'transaction_not_found',
+				__( 'Transaction not found.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Reject obvious wrong states. 'draft' is allowed only when payment
+		// was never initiated (e.g., transient failure during initial signup);
+		// 'paid' and 'pending' mean retry does not apply.
+		$status = (string) $old_transaction->status;
+		if ( 'paid' === $status || 'pending' === $status ) {
+			return new WP_Error(
+				'invalid_retry_state',
+				__( 'This payment cannot be retried.', 'fair-audience' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$metadata = ! empty( $old_transaction->metadata ) ? json_decode( $old_transaction->metadata, true ) : array();
+		if ( empty( $metadata['source'] ) || 'fair-audience-signup' !== $metadata['source'] ) {
+			return new WP_Error(
+				'invalid_retry_source',
+				__( 'This payment is not retriable from this endpoint.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$event_id       = isset( $metadata['post_id'] ) ? (int) $metadata['post_id'] : (int) $old_transaction->post_id;
+		$event_date_id  = isset( $metadata['event_date_id'] ) ? (int) $metadata['event_date_id'] : (int) $old_transaction->event_date_id;
+		$participant_id = isset( $metadata['participant_id'] ) ? (int) $metadata['participant_id'] : (int) $old_transaction->participant_id;
+		$user_id        = isset( $old_transaction->user_id ) ? (int) $old_transaction->user_id : 0;
+
+		if ( ! $event_id || ! $participant_id ) {
+			return new WP_Error(
+				'invalid_retry_state',
+				__( 'This payment is missing context needed to retry.', 'fair-audience' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$event = get_post( $event_id );
+		if ( ! $event ) {
+			return new WP_Error(
+				'invalid_event',
+				__( 'Event not found.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Look up the EventParticipant row. handle_signup_failed nulls out the
+		// transaction_id so get_by_transaction_id may miss; fall back to the
+		// (event_date_id, participant_id) pair which is the natural key.
+		$event_participant = null;
+		if ( $event_date_id ) {
+			$event_participant = $this->event_participant_repository->get_by_event_date_and_participant(
+				$event_date_id,
+				$participant_id
+			);
+		}
+		if ( ! $event_participant ) {
+			$event_participant = $this->event_participant_repository->get_by_event_and_participant(
+				$event_id,
+				$participant_id
+			);
+		}
+
+		// Reject when the slot is already paid for from another transaction.
+		if ( $event_participant && 'signed_up' === $event_participant->label ) {
+			return rest_ensure_response(
+				array(
+					'success' => true,
+					'status'  => 'already_signed_up',
+					'message' => __( 'You are already signed up for this event.', 'fair-audience' ),
+				)
+			);
+		}
+
+		// Build line items from the old transaction so the retry mirrors the
+		// original purchase exactly (same prices the visitor agreed to).
+		$old_line_items = \FairPayment\Models\LineItem::get_by_transaction_id( $transaction_id );
+		if ( empty( $old_line_items ) ) {
+			return new WP_Error(
+				'invalid_retry_state',
+				__( 'Original line items could not be loaded.', 'fair-audience' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$line_items = array();
+		foreach ( $old_line_items as $li ) {
+			$line_items[] = array(
+				'name'     => (string) $li->name,
+				'quantity' => (int) ( $li->quantity ?? 1 ),
+				'amount'   => (float) $li->amount,
+			);
+		}
+
+		// Refresh / acquire the 15-minute hold for this retry attempt.
+		$expires_at = gmdate( 'Y-m-d H:i:s', time() + 15 * MINUTE_IN_SECONDS );
+
+		if ( $event_participant ) {
+			$event_participant->label              = 'pending_payment';
+			$event_participant->payment_expires_at = $expires_at;
+			$event_participant->transaction_id     = null;
+			$event_participant->save();
+		} else {
+			$event_participant = new \FairAudience\Models\EventParticipant(
+				array(
+					'event_id'           => $event_id,
+					'event_date_id'      => $event_date_id,
+					'participant_id'     => $participant_id,
+					'label'              => 'pending_payment',
+					'payment_expires_at' => $expires_at,
+					'ticket_type_id'     => isset( $old_transaction->ticket_type_id ) ? (int) $old_transaction->ticket_type_id : null,
+					'seats'              => 1,
+				)
+			);
+			$event_participant->save();
+		}
+
+		$new_transaction_id = \FairPayment\API\TransactionAPI::create_transaction(
+			$line_items,
+			array(
+				'currency'      => $old_transaction->currency,
+				'description'   => $old_transaction->description,
+				'post_id'       => $event_id,
+				'event_date_id' => $event_date_id,
+				'user_id'       => $user_id ? $user_id : null,
+				'metadata'      => array(
+					'source'                  => 'fair-audience-signup',
+					'event_date_id'           => $event_date_id,
+					'event_participant_id'    => (int) $event_participant->id,
+					'participant_id'          => $participant_id,
+					'retry_of_transaction_id' => $transaction_id,
+				),
+			)
+		);
+
+		if ( is_wp_error( $new_transaction_id ) ) {
+			return $new_transaction_id;
+		}
+
+		$event_participant->transaction_id = (int) $new_transaction_id;
+		$event_participant->save();
+
+		$redirect_url = add_query_arg(
+			array(
+				'fair_payment_callback' => 'true',
+				'fair_signup_tx'        => $new_transaction_id,
+			),
+			get_permalink( $event_id )
+		);
+
+		$payment = \FairPayment\API\TransactionAPI::initiate_payment(
+			$new_transaction_id,
+			array(
+				'redirect_url' => $redirect_url,
+			)
+		);
+
+		if ( is_wp_error( $payment ) ) {
+			return $payment;
+		}
+
+		return rest_ensure_response(
+			array(
+				'success'        => true,
+				'status'         => 'payment_required',
+				'message'        => __( 'Redirecting to payment…', 'fair-audience' ),
+				'checkout_url'   => $payment['checkout_url'],
+				'transaction_id' => (int) $new_transaction_id,
+				'amount'         => $old_transaction->amount,
+				'currency'       => $old_transaction->currency,
 			)
 		);
 	}

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -197,8 +197,13 @@ class PaymentHooks {
 	}
 
 	/**
-	 * Release the slot held by a pending_payment event_participant row when
-	 * Mollie reports the payment failed/canceled/expired.
+	 * Detach the failed transaction from its pending_payment row so the buyer
+	 * can retry from the event page without losing their slot.
+	 *
+	 * The row stays pending_payment with payment_expires_at intact: the user
+	 * still holds capacity for the remainder of the original 15-minute window,
+	 * and the cleanup cron releases the slot when that hold expires (capacity
+	 * counts already filter out expired holds, so over-booking can't happen).
 	 *
 	 * @param object $payment     Mollie payment object.
 	 * @param object $transaction Transaction row from fair-payment.
@@ -215,7 +220,8 @@ class PaymentHooks {
 			return;
 		}
 
-		$event_participant->delete();
+		$event_participant->transaction_id = null;
+		$event_participant->save();
 
 		do_action( 'fair_audience_event_signup_failed', $event_participant, $transaction );
 	}

--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -43,6 +43,23 @@ const CSS_PREFIX = 'fair-audience-signup';
 		const isSignedUp = block.dataset.isSignedUp === 'true';
 		const hasPicker = block.dataset.hasOccurrencePicker === 'true';
 
+		// Return-from-Mollie retry UI: the rest of the form is not rendered
+		// when the callback container is present, so we wire it and stop.
+		const retryContainer = block.querySelector(
+			'.fair-audience-signup-retry'
+		);
+		if (retryContainer) {
+			const retryButton = retryContainer.querySelector(
+				'.fair-audience-signup-retry-button'
+			);
+			if (retryButton) {
+				retryButton.addEventListener('click', function () {
+					submitRetryPayment(retryContainer, this);
+				});
+			}
+			return;
+		}
+
 		// Initialize unsignup button(s) if present
 		const unsignupButtons = block.querySelectorAll(
 			'.fair-audience-unsignup-button'
@@ -867,6 +884,81 @@ const CSS_PREFIX = 'fair-audience-signup';
 				showNotification(errorMessage, 'error');
 			})
 			.finally(function () {
+				restoreButton();
+			});
+	}
+
+	/**
+	 * Submit retry-payment for a previously failed transaction.
+	 * @param {HTMLElement} container The retry container element
+	 * @param {HTMLElement} button The retry button
+	 */
+	function submitRetryPayment(container, button) {
+		const transactionId = parseInt(container.dataset.transactionId, 10);
+		if (!transactionId) {
+			return;
+		}
+		const messageContainer = container.querySelector(
+			'.fair-audience-signup-message'
+		);
+
+		const restoreButton = setButtonLoading(
+			button,
+			__('Redirecting…', 'fair-audience')
+		);
+
+		apiFetch({
+			path: '/fair-audience/v1/event-signup/retry-payment',
+			method: 'POST',
+			data: { transaction_id: transactionId },
+		})
+			.then(function (response) {
+				if (
+					response &&
+					response.status === 'payment_required' &&
+					response.checkout_url
+				) {
+					window.location = response.checkout_url;
+					return;
+				}
+				if (response && response.status === 'already_signed_up') {
+					showMessage(
+						messageContainer,
+						response.message,
+						'success',
+						CSS_PREFIX
+					);
+					window.location = window.location.pathname;
+					return;
+				}
+				const fallback = __(
+					'Could not start the retry. Please try again.',
+					'fair-audience'
+				);
+				showMessage(
+					messageContainer,
+					(response && response.message) || fallback,
+					'error',
+					CSS_PREFIX
+				);
+				restoreButton();
+			})
+			.catch(function (error) {
+				console.error('Retry payment error:', error);
+				const errorMessage = extractErrorMessage(
+					error,
+					__(
+						'Could not start the retry. Please try again.',
+						'fair-audience'
+					)
+				);
+				showMessage(
+					messageContainer,
+					errorMessage,
+					'error',
+					CSS_PREFIX
+				);
+				showNotification(errorMessage, 'error');
 				restoreButton();
 			});
 	}

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -20,6 +20,29 @@ use FairAudience\Services\ParticipantToken;
 use FairEvents\Models\EventDates;
 use FairEvents\Models\EventDateSetting;
 
+// Detect a return-from-Mollie callback. When a fair_signup_tx is present we
+// short-circuit the regular signup UI and render a transaction-scoped state
+// (retry / success / processing) so the visitor sees an actionable message
+// instead of a blank signup form. See issue #554.
+$callback_tx_id     = 0;
+$callback_tx        = null;
+$callback_tx_status = '';
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+if ( isset( $_GET['fair_payment_callback'] ) && 'true' === $_GET['fair_payment_callback'] ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$callback_tx_id = isset( $_GET['fair_signup_tx'] ) ? absint( wp_unslash( $_GET['fair_signup_tx'] ) ) : 0;
+	if ( $callback_tx_id > 0 && class_exists( \FairPayment\API\TransactionAPI::class ) ) {
+		$callback_tx = \FairPayment\API\TransactionAPI::get_transaction( $callback_tx_id );
+		if ( $callback_tx ) {
+			$callback_tx_status = (string) $callback_tx->status;
+		}
+	}
+}
+$has_callback_state    = null !== $callback_tx;
+$callback_is_retriable = $has_callback_state && in_array( $callback_tx_status, array( 'failed', 'canceled', 'expired', 'draft' ), true );
+$callback_is_paid      = $has_callback_state && 'paid' === $callback_tx_status;
+$callback_is_pending   = $has_callback_state && 'pending' === $callback_tx_status;
+
 // Get block attributes — translate defaults so stored English values get localized.
 $signup_button_text       = __( $attributes['signupButtonText'] ?? 'Sign Up', 'fair-audience' );
 $register_button_text     = __( $attributes['registerButtonText'] ?? 'Register & Sign Up', 'fair-audience' );
@@ -599,7 +622,68 @@ $wrapper_attributes = get_block_wrapper_attributes(
 </p>
 <?php else : ?>
 <div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
-	<?php if ( $is_signed_up && 'anonymous' === $state ) : ?>
+	<?php if ( $has_callback_state ) : ?>
+		<?php
+		$amount_display = sprintf( '%s %s', number_format_i18n( (float) $callback_tx->amount, 2 ), esc_html( $callback_tx->currency ) );
+		?>
+		<?php if ( $callback_is_paid ) : ?>
+			<div class="fair-audience-signup-status fair-audience-signup-status-success fair-audience-signup-callback">
+				<p>
+					<?php
+					printf(
+						/* translators: %s: formatted amount with currency */
+						esc_html__( 'Thank you! Your payment of %s has been received and your signup is confirmed.', 'fair-audience' ),
+						esc_html( $amount_display )
+					);
+					?>
+				</p>
+			</div>
+		<?php elseif ( $callback_is_pending ) : ?>
+			<div class="fair-audience-signup-status fair-audience-signup-callback">
+				<p><?php esc_html_e( 'Your payment is being processed. This page will reflect the final status once the bank confirms.', 'fair-audience' ); ?></p>
+			</div>
+		<?php elseif ( $callback_is_retriable ) : ?>
+			<div class="fair-audience-signup-callback fair-audience-signup-retry"
+				data-transaction-id="<?php echo esc_attr( (string) $callback_tx_id ); ?>">
+				<p class="fair-audience-signup-retry-heading">
+					<strong><?php esc_html_e( "Your payment didn't go through.", 'fair-audience' ); ?></strong>
+				</p>
+				<p class="fair-audience-signup-retry-amount">
+					<?php
+					printf(
+						/* translators: %s: formatted amount with currency */
+						esc_html__( 'Amount due: %s', 'fair-audience' ),
+						esc_html( $amount_display )
+					);
+					?>
+				</p>
+				<div class="wp-block-button">
+					<button type="button" class="wp-block-button__link wp-element-button fair-audience-signup-retry-button">
+						<?php esc_html_e( 'Retry payment', 'fair-audience' ); ?>
+					</button>
+				</div>
+				<p class="fair-audience-signup-retry-cancel">
+					<a href="<?php echo esc_url( remove_query_arg( array( 'fair_payment_callback', 'fair_signup_tx' ) ) ); ?>">
+						<?php esc_html_e( 'Cancel and start over', 'fair-audience' ); ?>
+					</a>
+				</p>
+				<div class="fair-audience-signup-message" style="display: none;"></div>
+			</div>
+		<?php else : ?>
+			<div class="fair-audience-signup-status fair-audience-signup-callback">
+				<p>
+					<?php
+					printf(
+						/* translators: %s: transaction status */
+						esc_html__( 'Payment status: %s', 'fair-audience' ),
+						esc_html( $callback_tx_status )
+					);
+					?>
+				</p>
+			</div>
+		<?php endif; ?>
+
+	<?php elseif ( $is_signed_up && 'anonymous' === $state ) : ?>
 		<!-- Signed up: anonymous user (no cancel option) -->
 		<div class="fair-audience-signup-status fair-audience-signup-status-success">
 			<p><?php echo esc_html__( 'You are signed up for this event!', 'fair-audience' ); ?></p>

--- a/fair-audience/src/blocks/event-signup/style.css
+++ b/fair-audience/src/blocks/event-signup/style.css
@@ -315,3 +315,28 @@
 .fair-audience-not-you:focus {
 	color: #005a87;
 }
+
+/* Return-from-Mollie retry / success / pending callback container. */
+.fair-audience-signup-callback {
+	padding: 16px;
+	border-radius: 4px;
+	margin-bottom: 12px;
+}
+
+.fair-audience-signup-retry {
+	background: #fbeaea;
+	border: 1px solid #d63638;
+}
+
+.fair-audience-signup-retry-heading {
+	margin: 0 0 8px;
+}
+
+.fair-audience-signup-retry-amount {
+	margin: 0 0 12px;
+}
+
+.fair-audience-signup-retry-cancel {
+	margin: 12px 0 0;
+	font-size: 0.9em;
+}


### PR DESCRIPTION
When the buyer comes back from Mollie with a failed/canceled/expired
transaction, the event-signup block now renders a transaction-scoped
retry UI instead of a blank signup form (issue #554):

- New POST /fair-audience/v1/event-signup/retry-payment endpoint
  re-initiates payment by creating a new fair-payment transaction tied
  to the same participant and event date. fair-payment refuses to
  re-initiate an already-attempted transaction, so a fresh one is
  required.
- Reuses the existing EventParticipant.pending_payment row when the
  15-minute hold is still active; refreshes the hold (or recreates the
  row) when it has elapsed or the cleanup cron already removed it.
- PaymentHooks::handle_signup_failed no longer deletes the
  EventParticipant row on Mollie failure — it now only clears
  transaction_id, leaving the hold intact so the retry can land on the
  same row. Stale rows are still released by the 5-minute cleanup cron
  once payment_expires_at passes, and capacity counts already exclude
  expired holds.
- event-signup render.php detects fair_payment_callback=true with
  fair_signup_tx=X and renders a retry / paid / pending branch based on
  the transaction status, suppressing the regular form.

Permission: the retry endpoint requires the visitor to own the
transaction — either via WP login matching transaction.user_id, or a
linked participant matching transaction.participant_id, or an audience
session cookie pointing to that participant.

Closes #554.
