### PR TITLE
Make event-signup payment confirmation unambiguous

### DIFF
--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -60,6 +60,21 @@ const CSS_PREFIX = 'fair-audience-signup';
 			return;
 		}
 
+		// Return-from-Mollie pending UI: poll for status until the webhook
+		// resolves the transaction, then swap to success in place.
+		const pendingContainer = block.querySelector(
+			'.fair-audience-signup-pending'
+		);
+		if (pendingContainer) {
+			startPendingPoll(pendingContainer);
+			return;
+		}
+
+		// Return-from-Mollie paid UI: nothing to wire, just bail.
+		if (block.querySelector('.fair-audience-signup-paid')) {
+			return;
+		}
+
 		// Initialize unsignup button(s) if present
 		const unsignupButtons = block.querySelectorAll(
 			'.fair-audience-unsignup-button'
@@ -886,6 +901,147 @@ const CSS_PREFIX = 'fair-audience-signup';
 			.finally(function () {
 				restoreButton();
 			});
+	}
+
+	/**
+	 * Poll the payment status endpoint while the transaction is still
+	 * pending. Swaps the container to the paid markup once Mollie reports
+	 * success, or to a retry-link message on terminal failure. Stops after
+	 * ~30 seconds to avoid hammering the API; the user can refresh manually
+	 * if the bank takes longer than that.
+	 * @param {HTMLElement} container The pending container element
+	 */
+	function startPendingPoll(container) {
+		const transactionId = parseInt(container.dataset.transactionId, 10);
+		if (!transactionId) {
+			return;
+		}
+
+		const POLL_INTERVAL_MS = 2000;
+		const MAX_ATTEMPTS = 15;
+		let attempts = 0;
+
+		const tick = function () {
+			attempts += 1;
+			apiFetch({
+				path: `/fair-payment/v1/payments/${transactionId}/status`,
+				method: 'GET',
+			})
+				.then(function (response) {
+					const status = response && response.status;
+					if (status === 'paid' || status === 'completed') {
+						swapPendingToPaid(container, response);
+						return;
+					}
+					if (
+						status === 'failed' ||
+						status === 'canceled' ||
+						status === 'expired'
+					) {
+						swapPendingToTerminal(container);
+						return;
+					}
+					if (attempts < MAX_ATTEMPTS) {
+						setTimeout(tick, POLL_INTERVAL_MS);
+					}
+				})
+				.catch(function () {
+					// Swallow polling errors silently; we'll try again on the
+					// next tick, and the user can always refresh.
+					if (attempts < MAX_ATTEMPTS) {
+						setTimeout(tick, POLL_INTERVAL_MS);
+					}
+				});
+		};
+
+		setTimeout(tick, POLL_INTERVAL_MS);
+	}
+
+	/**
+	 * Replace the pending container's contents with the paid confirmation.
+	 * @param {HTMLElement} container The pending container element
+	 * @param {Object} transaction Transaction status response
+	 */
+	function swapPendingToPaid(container, transaction) {
+		const amount =
+			transaction && transaction.amount
+				? `${transaction.amount} ${transaction.currency || ''}`.trim()
+				: '';
+
+		container.classList.remove('fair-audience-signup-pending');
+		container.classList.add('fair-audience-signup-paid');
+
+		container.innerHTML = '';
+		container.appendChild(
+			createElement('div', 'fair-audience-signup-paid-icon', '✓', {
+				'aria-hidden': 'true',
+			})
+		);
+		container.appendChild(
+			createElement(
+				'h2',
+				'fair-audience-signup-paid-heading',
+				__('Payment confirmed', 'fair-audience')
+			)
+		);
+		container.appendChild(
+			createElement(
+				'p',
+				'fair-audience-signup-paid-amount',
+				amount ? __('Amount paid:', 'fair-audience') + ' ' + amount : ''
+			)
+		);
+		container.appendChild(
+			createElement(
+				'p',
+				'fair-audience-signup-paid-email',
+				__(
+					'A confirmation email is on its way. You can close this page.',
+					'fair-audience'
+				)
+			)
+		);
+	}
+
+	/**
+	 * Replace the pending container's contents with a terminal-failure note
+	 * pointing the user back to the event page so they can retry.
+	 * @param {HTMLElement} container The pending container element
+	 */
+	function swapPendingToTerminal(container) {
+		container.classList.remove('fair-audience-signup-pending');
+		container.innerHTML = '';
+		const message = createElement(
+			'p',
+			'fair-audience-signup-pending-status',
+			__(
+				"Your payment didn't go through. Refresh this page to retry.",
+				'fair-audience'
+			)
+		);
+		container.appendChild(message);
+	}
+
+	/**
+	 * Tiny helper to build a DOM element with class + text.
+	 * @param {string} tag Element tag name
+	 * @param {string} className Class to apply
+	 * @param {string} text Text content
+	 * @param {Object} attrs Optional attributes
+	 * @return {HTMLElement} The created element
+	 */
+	function createElement(tag, className, text, attrs) {
+		const el = document.createElement(tag);
+		el.className = className;
+		if (text) {
+			el.textContent = text;
+		}
+		if (attrs) {
+			Object.keys(attrs).forEach(function (key) {
+				el.setAttribute(key, attrs[key]);
+			});
+		}
+		return el;
 	}
 
 	/**

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -32,6 +32,14 @@ if ( isset( $_GET['fair_payment_callback'] ) && 'true' === $_GET['fair_payment_c
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$callback_tx_id = isset( $_GET['fair_signup_tx'] ) ? absint( wp_unslash( $_GET['fair_signup_tx'] ) ) : 0;
 	if ( $callback_tx_id > 0 && class_exists( \FairPayment\API\TransactionAPI::class ) ) {
+		// Proactively pull the latest status from Mollie so the page reflects
+		// reality when the webhook hasn't landed yet. This is the same trick
+		// the fee-payment template uses to avoid the "is it paid or not?"
+		// confusion on the redirect race window.
+		if ( function_exists( 'fair_payment_sync_transaction_status' ) ) {
+			fair_payment_sync_transaction_status( $callback_tx_id );
+		}
+
 		$callback_tx = \FairPayment\API\TransactionAPI::get_transaction( $callback_tx_id );
 		if ( $callback_tx ) {
 			$callback_tx_status = (string) $callback_tx->status;
@@ -627,20 +635,51 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		$amount_display = sprintf( '%s %s', number_format_i18n( (float) $callback_tx->amount, 2 ), esc_html( $callback_tx->currency ) );
 		?>
 		<?php if ( $callback_is_paid ) : ?>
-			<div class="fair-audience-signup-status fair-audience-signup-status-success fair-audience-signup-callback">
-				<p>
+			<div class="fair-audience-signup-callback fair-audience-signup-paid" data-transaction-id="<?php echo esc_attr( (string) $callback_tx_id ); ?>">
+				<div class="fair-audience-signup-paid-icon" aria-hidden="true">✓</div>
+				<h2 class="fair-audience-signup-paid-heading">
+					<?php esc_html_e( 'Payment confirmed', 'fair-audience' ); ?>
+				</h2>
+				<p class="fair-audience-signup-paid-event">
+					<?php
+					printf(
+						/* translators: %s: event title */
+						esc_html__( "You're signed up for %s.", 'fair-audience' ),
+						'<strong>' . esc_html( get_the_title( $event_id ) ) . '</strong>'
+					);
+					?>
+				</p>
+				<p class="fair-audience-signup-paid-amount">
 					<?php
 					printf(
 						/* translators: %s: formatted amount with currency */
-						esc_html__( 'Thank you! Your payment of %s has been received and your signup is confirmed.', 'fair-audience' ),
+						esc_html__( 'Amount paid: %s', 'fair-audience' ),
 						esc_html( $amount_display )
 					);
 					?>
 				</p>
+				<p class="fair-audience-signup-paid-email">
+					<?php esc_html_e( 'A confirmation email is on its way. You can close this page.', 'fair-audience' ); ?>
+				</p>
 			</div>
 		<?php elseif ( $callback_is_pending ) : ?>
-			<div class="fair-audience-signup-status fair-audience-signup-callback">
-				<p><?php esc_html_e( 'Your payment is being processed. This page will reflect the final status once the bank confirms.', 'fair-audience' ); ?></p>
+			<div class="fair-audience-signup-callback fair-audience-signup-pending" data-transaction-id="<?php echo esc_attr( (string) $callback_tx_id ); ?>">
+				<div class="fair-audience-signup-pending-spinner" aria-hidden="true"></div>
+				<h2 class="fair-audience-signup-pending-heading">
+					<?php esc_html_e( 'Thank you for your payment!', 'fair-audience' ); ?>
+				</h2>
+				<p class="fair-audience-signup-pending-status">
+					<?php esc_html_e( "We're confirming with your bank. This usually takes a few seconds — the page will update as soon as it's done.", 'fair-audience' ); ?>
+				</p>
+				<p class="fair-audience-signup-pending-amount">
+					<?php
+					printf(
+						/* translators: %s: formatted amount with currency */
+						esc_html__( 'Amount: %s', 'fair-audience' ),
+						esc_html( $amount_display )
+					);
+					?>
+				</p>
 			</div>
 		<?php elseif ( $callback_is_retriable ) : ?>
 			<div class="fair-audience-signup-callback fair-audience-signup-retry"

--- a/fair-audience/src/blocks/event-signup/style.css
+++ b/fair-audience/src/blocks/event-signup/style.css
@@ -340,3 +340,78 @@
 	margin: 12px 0 0;
 	font-size: 0.9em;
 }
+
+/* Return-from-Mollie "paid" confirmation — visually prominent so users
+   leave the page sure the payment went through. */
+.fair-audience-signup-paid {
+	background: #f0faf3;
+	border: 1px solid #00a32a;
+	color: #0d2f17;
+	padding: 28px 24px;
+	text-align: center;
+}
+
+.fair-audience-signup-paid-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 56px;
+	height: 56px;
+	margin: 0 auto 12px;
+	border-radius: 50%;
+	background: #00a32a;
+	color: #fff;
+	font-size: 32px;
+	line-height: 1;
+}
+
+.fair-audience-signup-paid-heading {
+	margin: 0 0 12px;
+	font-size: 1.5em;
+	color: #0d2f17;
+}
+
+.fair-audience-signup-paid-event,
+.fair-audience-signup-paid-amount {
+	margin: 0 0 8px;
+}
+
+.fair-audience-signup-paid-email {
+	margin: 16px 0 0;
+	color: #2d4a37;
+	font-size: 0.95em;
+}
+
+/* Return-from-Mollie "pending" — reassuring while we wait for the webhook. */
+.fair-audience-signup-pending {
+	background: #fbf7e3;
+	border: 1px solid #dba617;
+	padding: 28px 24px;
+	text-align: center;
+}
+
+.fair-audience-signup-pending-spinner {
+	width: 36px;
+	height: 36px;
+	margin: 0 auto 12px;
+	border: 3px solid #dba617;
+	border-top-color: transparent;
+	border-radius: 50%;
+	animation: fair-audience-signup-spin 0.9s linear infinite;
+}
+
+@keyframes fair-audience-signup-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.fair-audience-signup-pending-heading {
+	margin: 0 0 12px;
+	font-size: 1.35em;
+}
+
+.fair-audience-signup-pending-status,
+.fair-audience-signup-pending-amount {
+	margin: 0 0 8px;
+}


### PR DESCRIPTION
End users were reporting that after a successful Mollie payment they
couldn't tell whether the purchase had actually gone through. The
return-from-Mollie page now leans hard into reassurance:

- render.php proactively syncs the transaction with Mollie (same trick
  the fee-payment template uses) so most pending/paid race conditions
  resolve to "paid" at first paint instead of staying ambiguous.
- The paid state is now a prominent green confirmation card with a
  large check, "Payment confirmed" heading, event title, amount paid,
  and an "email is on its way" note.
- The pending state opens with "Thank you for your payment!" and a
  spinner, then explains the bank confirmation delay so the visitor
  knows the click registered.
- frontend.js polls /fair-payment/v1/payments/{id}/status every 2s for
  ~30s and swaps the pending container to the paid card in place when
  the webhook lands, so users typically don't need to refresh.
