### PR TITLE
Safe "email already known" flow on signup

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -1615,6 +1615,31 @@ class EventSignupController extends WP_REST_Controller {
 			$this->increment_rate_limit( $email );
 
 			$participant = $this->participant_repository->get_by_email( $email );
+
+			// Known email + anonymous flow: if the browser doesn't already
+			// hold a session for *this* participant, don't act on their
+			// identity. A stranger guessing the email shouldn't sign someone
+			// up or trigger any pre-fill — send a resume link to the address
+			// instead so only the inbox owner can continue.
+			if ( $participant ) {
+				$session_pid = (int) AudienceSession::get_participant_id();
+				if ( $session_pid !== (int) $participant->id ) {
+					$token_url = ParticipantToken::get_url(
+						$participant->id,
+						(int) $event_date_id,
+						(int) $event->ID
+					);
+					$this->email_service->send_signup_link_email( $event, $participant, $token_url );
+
+					return rest_ensure_response(
+						array(
+							'success' => true,
+							'status'  => 'email_recognized',
+							'message' => __( 'We recognise this email — check your inbox to continue.', 'fair-audience' ),
+						)
+					);
+				}
+			}
 		}
 
 		if ( $participant ) {

--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -445,6 +445,24 @@ const CSS_PREFIX = 'fair-audience-signup';
 						return;
 					}
 
+					// Known email + no matching session: server sent a resume
+					// link instead of creating a signup. Surface the message,
+					// leave the form so a typo'd email can be corrected, and
+					// don't flip into the success UI.
+					if (response.status === 'email_recognized') {
+						showMessage(
+							messageContainer,
+							response.message ||
+								__(
+									'We recognise this email — check your inbox to continue.',
+									'fair-audience'
+								),
+							'info',
+							CSS_PREFIX
+						);
+						return;
+					}
+
 					showMessage(
 						messageContainer,
 						response.message || successMessage,


### PR DESCRIPTION
## Summary
- Anonymous register flow short-circuits when the submitted email matches an existing participant and the browser's `AudienceSession` doesn't already belong to that participant: no participant row is touched, no signup is created, and a resume link is emailed to the address.
- Response shape: `{ success: true, status: 'email_recognized', message: 'We recognise this email — check your inbox to continue.' }` — frontend surfaces it as an info notice and leaves the form interactive so a typo'd email can be corrected.
- Logged-in WP users and same-browser-as-the-participant submissions are unaffected.

Closes #557.

## Notes
- Reuses the existing `send_signup_link_email` template — its copy currently reads as if the recipient requested the link. If we want a dedicated "someone tried to sign up with your email" template, happy to add it as a follow-up.
- Rate-limit hooks already wrap this path so the email can't be abused to flood an inbox.
- No DB migration.

## Test plan
- [ ] Stranger submits the form with a known email → form shows the recognition message; no new participant or signup rows; resume email arrives at the address.
- [ ] Same browser as the last signup (matching `fair_audience_session` cookie) submits → normal signup flow proceeds.
- [ ] Brand-new email → new participant created, signup row added, success UI (regression check).
- [ ] Logged-in WP user typing someone else's email → unaffected; their WP identity wins over the email lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)