### PR TITLE
Update CI to PHP 8.3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # 2.37.0
               with:
-                  php-version: '8.2'
+                  php-version: '8.3'
                   extensions: mbstring, intl, zip
                   coverage: none
 


### PR DESCRIPTION
## Summary
- Bump `php-version` in the CI workflow from 8.2 to 8.3.

Closes #311

## Test plan
- [ ] CI passes on the PR (build + tests run on PHP 8.3)