### PR TITLE
Telegram notifications for successful transactions (#560)

### DIFF
--- a/fair-audience/fair-audience.php
+++ b/fair-audience/fair-audience.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fair Audience
  * Plugin URI: https://github.com/marcin-wosinek/fair-event-plugins
  * Description: Manage event participants with custom profiles and many-to-many event relationships
- * Version: 1.0.0
+ * Version: 1.2.0-54-g58bb29b
  * Author: Marcin Wosinek
  * Author URI: https://github.com/marcin-wosinek
  * License: GPL-3.0-or-later

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -36,6 +36,7 @@ class PaymentHooks {
 
 		add_filter( 'fair_payment_resolve_participant_id', array( static::class, 'resolve_participant_id' ), 10, 2 );
 		add_filter( 'fair_payment_prepare_participant', array( static::class, 'prepare_participant' ), 10, 2 );
+		add_filter( 'fair_payment_notification_context', array( static::class, 'enrich_notification_context' ), 10, 3 );
 		add_action( 'fair_payment_backfill_participant_ids', array( static::class, 'backfill_participant_ids' ) );
 
 		// Expire pending signup rows whose payment never completed.
@@ -115,6 +116,220 @@ class PaymentHooks {
 			'email'     => $participant->email,
 			'admin_url' => admin_url( 'admin.php?page=fair-audience-participant-detail&participant_id=' . (int) $participant->id ),
 		);
+	}
+
+	/**
+	 * Enrich the fair-payment notification context with participant and event
+	 * details derived from the audience tables. Used by the Telegram notification
+	 * (and any future channel) so the rendered message can include human-friendly
+	 * names and admin links.
+	 *
+	 * @param array  $context     Default context from fair-payment.
+	 * @param object $transaction Transaction row.
+	 * @param object $payment     Mollie payment object.
+	 * @return array
+	 */
+	public static function enrich_notification_context( $context, $transaction, $payment ) {
+		global $wpdb;
+
+		$participant_id = isset( $transaction->participant_id ) ? (int) $transaction->participant_id : 0;
+		if ( $participant_id <= 0 ) {
+			return $context;
+		}
+
+		$participant_repo = new ParticipantRepository();
+		$participant      = $participant_repo->get_by_id( $participant_id );
+		if ( $participant ) {
+			$full_name                    = trim( $participant->name . ' ' . $participant->surname );
+			$context['participant_name']  = $full_name;
+			$context['participant_email'] = isset( $participant->email ) ? (string) $participant->email : '';
+			$context['participant_url']   = admin_url( 'admin.php?page=fair-audience-participant-detail&participant_id=' . (int) $participant->id );
+		}
+
+		$event_participant_repo = new EventParticipantRepository();
+		$event_participant      = $event_participant_repo->get_by_transaction_id( (int) $transaction->id );
+		if ( $event_participant ) {
+			$event = get_post( (int) $event_participant->event_id );
+			if ( $event ) {
+				$context['event_title'] = $event->post_title;
+				$edit_link              = get_edit_post_link( $event->ID, 'raw' );
+				$context['event_url']   = $edit_link ? $edit_link : get_permalink( $event->ID );
+			}
+
+			// Ticket type (Regular, Student, Early bird, ...).
+			if ( ! empty( $event_participant->ticket_type_id ) ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$ticket_type_name = $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT name FROM {$wpdb->prefix}fair_events_ticket_types WHERE id = %d",
+						(int) $event_participant->ticket_type_id
+					)
+				);
+				if ( $ticket_type_name ) {
+					$context['ticket_label'] = (string) $ticket_type_name;
+				}
+			}
+
+			// Activities — the ticket options selected at signup.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$option_names = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT COALESCE(NULLIF(topt.name, ''), epo.ticket_option_name)
+					FROM {$wpdb->prefix}fair_audience_event_participant_options epo
+					LEFT JOIN {$wpdb->prefix}fair_events_ticket_options topt
+						ON topt.id = epo.ticket_option_id
+					WHERE epo.event_participant_id = %d
+						AND ( ( topt.name IS NOT NULL AND topt.name != '' ) OR epo.ticket_option_name != '' )",
+					(int) $event_participant->id
+				)
+			);
+			if ( ! empty( $option_names ) ) {
+				$context['activities'] = implode( ', ', $option_names );
+			}
+
+			// Applied discounts — group rule, plus any activity-collaborator
+			// discounts detected from the transaction line items.
+			$parts = array();
+
+			$group_label = self::format_applied_discount( $event_participant, $transaction );
+			if ( '' !== $group_label ) {
+				$parts[] = $group_label;
+			}
+
+			$collab_labels = self::detect_activity_collaborator_discounts( $event_participant, $transaction );
+			foreach ( $collab_labels as $label ) {
+				$parts[] = $label;
+			}
+
+			$context['discounts'] = implode( '; ', $parts );
+		}
+
+		return $context;
+	}
+
+	/**
+	 * Format the applied group-discount rule as a human-readable label.
+	 *
+	 * Re-resolves the best discount rule for the participant on the event date —
+	 * the same call EventSignupController uses at price-computation time — and
+	 * formats it as e.g. "Students -20%" or "Members -5.00 EUR".
+	 *
+	 * @param object $event_participant Event participant row.
+	 * @param object $transaction       Transaction row.
+	 * @return string Formatted label, or empty string when no discount applies.
+	 */
+	private static function format_applied_discount( $event_participant, $transaction ) {
+		if ( ! class_exists( \FairEvents\Services\EventSignupPricing::class ) ) {
+			return '';
+		}
+
+		$rule = \FairEvents\Services\EventSignupPricing::resolve_best_discount_rule(
+			(int) $event_participant->event_date_id,
+			(int) $event_participant->participant_id
+		);
+		if ( ! $rule ) {
+			return '';
+		}
+
+		$group_name = '';
+		$group_repo = new \FairAudience\Database\GroupRepository();
+		$group      = $group_repo->get_by_id( (int) $rule->group_id );
+		if ( $group && ! empty( $group->name ) ) {
+			$group_name = (string) $group->name;
+		}
+
+		if ( 'percentage' === $rule->discount_type ) {
+			$value = rtrim( rtrim( number_format( (float) $rule->discount_value, 2, '.', '' ), '0' ), '.' );
+			$label = '-' . $value . '%';
+		} else {
+			$currency = isset( $transaction->currency ) ? (string) $transaction->currency : '';
+			$value    = number_format( (float) $rule->discount_value, 2, '.', '' );
+			$label    = '-' . $value . ( '' !== $currency ? ' ' . $currency : '' );
+		}
+
+		return '' !== $group_name ? $group_name . ' ' . $label : $label;
+	}
+
+	/**
+	 * Detect activity-collaborator discounts from the transaction line items.
+	 *
+	 * The inviter is not persisted on the participant row, so we infer the
+	 * discount by comparing each option's actual charged amount (from
+	 * fair_payment_line_items) against its base price. When the option has a
+	 * non-null discounted_price, the event_date has activity_collaborator_discount
+	 * enabled, and the line item was charged at the discounted_price, we surface
+	 * it as an activity-collaborator discount.
+	 *
+	 * @param object $event_participant Event participant row.
+	 * @param object $transaction       Transaction row.
+	 * @return string[] Formatted labels, one per discounted option (possibly empty).
+	 */
+	private static function detect_activity_collaborator_discounts( $event_participant, $transaction ) {
+		global $wpdb;
+
+		if ( ! class_exists( \FairEvents\Models\EventDateSetting::class ) ) {
+			return array();
+		}
+
+		$setting = (string) \FairEvents\Models\EventDateSetting::get( (int) $event_participant->event_date_id, 'activity_collaborator_discount' );
+		if ( '1' !== $setting ) {
+			return array();
+		}
+
+		// Pull selected options with their base/discounted prices.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$options = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT COALESCE( NULLIF(topt.name, ''), epo.ticket_option_name ) AS name,
+					topt.price AS price,
+					topt.discounted_price AS discounted_price
+				FROM {$wpdb->prefix}fair_audience_event_participant_options epo
+				LEFT JOIN {$wpdb->prefix}fair_events_ticket_options topt
+					ON topt.id = epo.ticket_option_id
+				WHERE epo.event_participant_id = %d
+					AND topt.discounted_price IS NOT NULL",
+				(int) $event_participant->id
+			)
+		);
+		if ( empty( $options ) ) {
+			return array();
+		}
+
+		// Line items charged for this transaction, keyed by name for matching.
+		$line_items_table = $wpdb->prefix . 'fair_payment_line_items';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows            = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT name, unit_amount FROM %i WHERE transaction_id = %d',
+				$line_items_table,
+				(int) $transaction->id
+			)
+		);
+		$amounts_by_name = array();
+		foreach ( (array) $rows as $row ) {
+			$amounts_by_name[ (string) $row->name ] = (float) $row->unit_amount;
+		}
+
+		$currency = isset( $transaction->currency ) ? (string) $transaction->currency : '';
+		$labels   = array();
+
+		foreach ( $options as $opt ) {
+			$name             = (string) $opt->name;
+			$price            = (float) $opt->price;
+			$discounted_price = (float) $opt->discounted_price;
+			if ( $discounted_price >= $price || ! isset( $amounts_by_name[ $name ] ) ) {
+				continue;
+			}
+			// Charged at the discounted price → activity-collaborator discount applied.
+			if ( abs( $amounts_by_name[ $name ] - $discounted_price ) > 0.005 ) {
+				continue;
+			}
+
+			$delta    = number_format( $price - $discounted_price, 2, '.', '' );
+			$labels[] = $name . ' collaborator -' . $delta . ( '' !== $currency ? ' ' . $currency : '' );
+		}
+
+		return $labels;
 	}
 
 	/**

--- a/fair-events/fair-events.php
+++ b/fair-events/fair-events.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fair Events
  * Plugin URI: https://github.com/marcin-wosinek/fair-event-plugins
  * Description: Event management plugin.
- * Version: 1.0.0
+ * Version: 1.2.0-54-g58bb29b
  * Requires at least: 6.7
  * Requires PHP: 7.4
  * Author: Marcin Wosinek

--- a/fair-payment/TELEGRAM.md
+++ b/fair-payment/TELEGRAM.md
@@ -1,0 +1,80 @@
+# Telegram notifications
+
+Fair Payment can post a message to a Telegram chat or channel every time a
+transaction is paid. Useful as a live, mobile-friendly feed of sales without
+logging into the WordPress admin.
+
+## Setup
+
+1. **Create a bot.** Open Telegram, message `@BotFather`, send `/newbot` and
+   follow the prompts. BotFather replies with an **HTTP API token** that looks
+   like `123456789:AAH...`. Keep it secret — anyone with the token can post as
+   your bot.
+2. **Get a chat ID.**
+   - For a private DM to yourself: message `@userinfobot` — it replies with
+     your numeric user ID.
+   - For a group: add the bot to the group, then visit
+     `https://api.telegram.org/bot<TOKEN>/getUpdates` in a browser and look for
+     `"chat":{"id":...}` after someone posts.
+   - For a public channel: use `@channelname` directly (the bot must be an
+     admin in the channel).
+3. **Configure the plugin.** WP Admin → Fair Payment → Settings → Telegram.
+   Paste the token, the chat ID (or multiple comma-separated IDs), edit the
+   message template if you like, and click **Save settings**.
+4. **Test.** Click **Send test message**. The message lands in the configured
+   chat using sample data. If it doesn't arrive, the inline notice surfaces
+   the Telegram API error description (e.g. `chat not found`, `Unauthorized`).
+
+## Message template
+
+The default template renders as:
+
+```
+<site domain>
+<event title link>
+<participant name link> (participant@example.com)
+Ticket: Regular
+Activities: Activity A, Activity B
+Discounts: Early bird -10%
+Total: 10.00 EUR
+```
+
+Telegram already shows the message time, so the default template omits the
+transaction date — add `{date}` back to the template if you want it.
+
+Available placeholders:
+
+| Placeholder            | Notes                                                |
+| ---------------------- | ---------------------------------------------------- |
+| `{site_domain}`        | Host portion of the site URL (e.g. `example.com`).   |
+| `{date}`               | YYYY-MM-DD of the transaction.                       |
+| `{amount}`             | Numeric, two decimals.                               |
+| `{currency}`           | Currency code.                                       |
+| `{transaction_id}`     | Internal transaction ID.                             |
+| `{event_title}`        | Event post title (when fair-audience active).        |
+| `{event_url}`          | Admin edit link for the event.                       |
+| `{participant_name}`   | PII — see toggle.                                    |
+| `{participant_url}`    | Admin link to the participant.                       |
+| `{participant_email}`  | PII — see toggle.                                    |
+| `{ticket_label}`       | Ticket type / option name(s).                        |
+| `{activities}`         | Activities the participant signed up for.            |
+| `{discounts}`          | Applied discounts (e.g. early bird, group).          |
+
+Allowed HTML: `<b>`, `<strong>`, `<i>`, `<em>`, `<u>`, `<a href>`, `<br>`,
+`<code>`. Other tags are stripped on save.
+
+## PII toggle
+
+`Include participant name and email` is on by default. Turn it off to render
+`{participant_name}` and `{participant_email}` as empty strings — useful if
+the channel has wider visibility than the admin team.
+
+## How it works
+
+The plugin subscribes to the `fair_payment_paid` action and dispatches via
+`wp_schedule_single_event`, so the Mollie webhook returns immediately and is
+never blocked by Telegram latency. Send failures are written to the PHP error
+log and never bubble up to the payment flow.
+
+Other plugins can enrich the message context by hooking the
+`fair_payment_notification_context` filter (see fair-audience for an example).

--- a/fair-payment/TELEGRAM.md
+++ b/fair-payment/TELEGRAM.md
@@ -30,7 +30,7 @@ logging into the WordPress admin.
 The default template renders as:
 
 ```
-<site domain>
+[TEST] <site domain>
 <event title link>
 <participant name link> (participant@example.com)
 Ticket: Regular
@@ -46,6 +46,7 @@ Available placeholders:
 
 | Placeholder            | Notes                                                |
 | ---------------------- | ---------------------------------------------------- |
+| `{test_label}`         | `[TEST] ` for Mollie test-mode transactions, empty otherwise. |
 | `{site_domain}`        | Host portion of the site URL (e.g. `example.com`).   |
 | `{date}`               | YYYY-MM-DD of the transaction.                       |
 | `{amount}`             | Numeric, two decimals.                               |

--- a/fair-payment/fair-payment.php
+++ b/fair-payment/fair-payment.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fair Payment
  * Plugin URI: https://fair-event-plugins.com
  * Description: Simple payment block for WordPress
- * Version: 1.0.0
+ * Version: 1.2.0-54-g58bb29b
  * Author: Fair Event Plugins
  * Author URI: https://fair-event-plugins.com
  * License: GPL-2.0-or-later

--- a/fair-payment/jest.config.js
+++ b/fair-payment/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+	preset: '@wordpress/jest-preset-default',
+	testEnvironment: 'jsdom',
+	testMatch: ['**/__tests__/**/*.js', '**/?(*.)+(spec|test).js'],
+	testPathIgnorePatterns: ['/node_modules/', '/vendor/', '/build/', '/e2e/'],
+	transform: {
+		'^.+\\.[jt]sx?$': [
+			'babel-jest',
+			{
+				presets: [
+					['@babel/preset-env', { targets: { node: 'current' } }],
+					['@babel/preset-react', { runtime: 'automatic' }],
+				],
+			},
+		],
+	},
+};

--- a/fair-payment/package.json
+++ b/fair-payment/package.json
@@ -31,17 +31,19 @@
 	"author": "Fair Event Plugins",
 	"license": "GPL-2.0-or-later",
 	"devDependencies": {
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/react": "^14.3.1",
 		"@wordpress/scripts": "^31.2.0",
 		"webpack-bundle-output": "^1.1.0"
 	},
 	"dependencies": {
-		"xlsx": "^0.18.5",
 		"@wordpress/api-fetch": "^7.2.0",
 		"@wordpress/block-editor": "^15.2.0",
 		"@wordpress/blocks": "^15.2.0",
 		"@wordpress/components": "^31.0.0",
 		"@wordpress/dom-ready": "^4.2.0",
 		"@wordpress/element": "^6.2.0",
-		"@wordpress/i18n": "^6.2.0"
+		"@wordpress/i18n": "^6.2.0",
+		"xlsx": "^0.18.5"
 	}
 }

--- a/fair-payment/src/API/RestHooks.php
+++ b/fair-payment/src/API/RestHooks.php
@@ -47,5 +47,8 @@ class RestHooks {
 
 		$payment_log_controller = new \FairPayment\API\PaymentLogController();
 		$payment_log_controller->register_routes();
+
+		$telegram_controller = new \FairPayment\API\TelegramSettingsController();
+		$telegram_controller->register_routes();
 	}
 }

--- a/fair-payment/src/API/TelegramSettingsController.php
+++ b/fair-payment/src/API/TelegramSettingsController.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Telegram settings REST controller
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\API;
+
+use FairPayment\Hooks\NotificationHooks;
+use FairPayment\Services\TelegramService;
+use FairPayment\Settings\Settings;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * REST endpoints for the Telegram notification settings.
+ *
+ * Settings themselves are stored as discrete options and read/written through
+ * the standard `/wp/v2/settings` endpoint. This controller adds the one
+ * operation that doesn't fit there: a "send test message" action that
+ * exercises the bot token + chat IDs against the real Telegram API.
+ */
+class TelegramSettingsController extends \WP_REST_Controller {
+
+	/**
+	 * Register routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'fair-payment/v1',
+			'/telegram/test',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'send_test_message' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+				'args'                => array(
+					'bot_token'   => array(
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'chat_ids'    => array(
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'template'    => array(
+						'type'     => 'string',
+						'required' => false,
+					),
+					'include_pii' => array(
+						'type'     => 'boolean',
+						'required' => false,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Send a test message to all configured (or supplied) chat IDs.
+	 *
+	 * Falls back to saved settings when fields are not provided in the request
+	 * payload, so the button works both before and after the user has saved.
+	 *
+	 * @param \WP_REST_Request $request Incoming request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function send_test_message( $request ) {
+		$bot_token = $request->get_param( 'bot_token' );
+		if ( null === $bot_token || '' === $bot_token ) {
+			$bot_token = (string) get_option( 'fair_payment_telegram_bot_token', '' );
+		}
+
+		$chat_ids_raw = $request->get_param( 'chat_ids' );
+		if ( null === $chat_ids_raw || '' === $chat_ids_raw ) {
+			$chat_ids_raw = (string) get_option( 'fair_payment_telegram_chat_ids', '' );
+		}
+
+		$template = $request->get_param( 'template' );
+		if ( null === $template || '' === $template ) {
+			$template = (string) get_option( 'fair_payment_telegram_template', Settings::default_template() );
+		}
+
+		$include_pii = $request->get_param( 'include_pii' );
+		if ( null === $include_pii ) {
+			$include_pii = (bool) get_option( 'fair_payment_telegram_include_pii', true );
+		} else {
+			$include_pii = (bool) $include_pii;
+		}
+
+		if ( '' === trim( (string) $bot_token ) ) {
+			return new \WP_Error(
+				'fair_payment_telegram_missing_token',
+				__( 'Bot token is required.', 'fair-payment' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$chat_ids = NotificationHooks::parse_chat_ids( (string) $chat_ids_raw );
+		if ( empty( $chat_ids ) ) {
+			return new \WP_Error(
+				'fair_payment_telegram_missing_chat_id',
+				__( 'At least one chat ID is required.', 'fair-payment' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$service = new TelegramService();
+		$text    = $service->render_template( (string) $template, NotificationHooks::sample_context(), (bool) $include_pii );
+
+		$results = array();
+		$any_ok  = false;
+		$errors  = array();
+
+		foreach ( $chat_ids as $chat_id ) {
+			$response = $service->send( (string) $bot_token, $chat_id, $text );
+			if ( is_wp_error( $response ) ) {
+				$results[] = array(
+					'chat_id' => $chat_id,
+					'ok'      => false,
+					'error'   => $response->get_error_message(),
+				);
+				$errors[]  = $chat_id . ': ' . $response->get_error_message();
+			} else {
+				$any_ok    = true;
+				$results[] = array(
+					'chat_id' => $chat_id,
+					'ok'      => true,
+				);
+			}
+		}
+
+		if ( ! $any_ok ) {
+			return new \WP_Error(
+				'fair_payment_telegram_test_failed',
+				__( 'Telegram test message failed for all chat IDs.', 'fair-payment' ) . ' ' . implode( '; ', $errors ),
+				array(
+					'status'  => 502,
+					'results' => $results,
+				)
+			);
+		}
+
+		return new \WP_REST_Response(
+			array(
+				'success' => true,
+				'message' => __( 'Telegram test message sent.', 'fair-payment' ),
+				'results' => $results,
+				'text'    => $text,
+			),
+			200
+		);
+	}
+}

--- a/fair-payment/src/Admin/settings/SettingsApp.js
+++ b/fair-payment/src/Admin/settings/SettingsApp.js
@@ -12,6 +12,7 @@ import ConnectionTab from './ConnectionTab';
 import AdvancedTab from './AdvancedTab';
 import FeaturesTab from './FeaturesTab.js';
 import PaymentMethodsTab from './PaymentMethodsTab.js';
+import TelegramTab from './TelegramTab.js';
 import { saveSettings } from './settings-api';
 
 /**
@@ -211,6 +212,10 @@ export default function SettingsApp() {
 						title: __('Payment Methods', 'fair-payment'),
 					},
 					{
+						name: 'telegram',
+						title: __('Telegram', 'fair-payment'),
+					},
+					{
 						name: 'advanced',
 						title: __('Advanced', 'fair-payment'),
 					},
@@ -230,6 +235,9 @@ export default function SettingsApp() {
 						)}
 						{tab.name === 'payment-methods' && (
 							<PaymentMethodsTab onNotice={setNotice} />
+						)}
+						{tab.name === 'telegram' && (
+							<TelegramTab onNotice={setNotice} />
 						)}
 						{tab.name === 'advanced' && (
 							<AdvancedTab onNotice={setNotice} />

--- a/fair-payment/src/Admin/settings/TelegramTab.js
+++ b/fair-payment/src/Admin/settings/TelegramTab.js
@@ -1,0 +1,260 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Button,
+	Card,
+	CardBody,
+	Notice,
+	TextControl,
+	TextareaControl,
+	ToggleControl,
+} from '@wordpress/components';
+
+const DEFAULT_TEMPLATE =
+	'<b>1 ticket sale on {date}</b> — total: {amount} {currency}\n' +
+	'<a href="{participant_url}">{participant_name}</a> — {amount} {currency} (<a href="{event_url}">{event_title}</a>)';
+
+/**
+ * Telegram notifications settings tab.
+ *
+ * @param {Object}   props          Props
+ * @param {Function} props.onNotice Handler for displaying global notices
+ * @return {JSX.Element} The Telegram tab
+ */
+export default function TelegramTab({ onNotice }) {
+	const [enabled, setEnabled] = useState(false);
+	const [botToken, setBotToken] = useState('');
+	const [chatIds, setChatIds] = useState('');
+	const [template, setTemplate] = useState(DEFAULT_TEMPLATE);
+	const [includePii, setIncludePii] = useState(true);
+	const [isLoading, setIsLoading] = useState(false);
+	const [isSaving, setIsSaving] = useState(false);
+	const [isTesting, setIsTesting] = useState(false);
+	const [testResult, setTestResult] = useState(null);
+
+	useEffect(() => {
+		setIsLoading(true);
+		apiFetch({ path: '/wp/v2/settings' })
+			.then((settings) => {
+				setEnabled(!!settings.fair_payment_telegram_enabled);
+				setBotToken(settings.fair_payment_telegram_bot_token || '');
+				setChatIds(settings.fair_payment_telegram_chat_ids || '');
+				setTemplate(
+					settings.fair_payment_telegram_template || DEFAULT_TEMPLATE
+				);
+				setIncludePii(
+					settings.fair_payment_telegram_include_pii !== false
+				);
+				setIsLoading(false);
+			})
+			.catch((error) => {
+				console.error(
+					'[Fair Payment] Failed to load Telegram settings:',
+					error
+				);
+				onNotice({
+					status: 'error',
+					message: __(
+						'Failed to load Telegram settings.',
+						'fair-payment'
+					),
+				});
+				setIsLoading(false);
+			});
+	}, []);
+
+	const handleSave = () => {
+		setIsSaving(true);
+		setTestResult(null);
+		apiFetch({
+			path: '/wp/v2/settings',
+			method: 'POST',
+			data: {
+				fair_payment_telegram_enabled: enabled,
+				fair_payment_telegram_bot_token: botToken,
+				fair_payment_telegram_chat_ids: chatIds,
+				fair_payment_telegram_template: template,
+				fair_payment_telegram_include_pii: includePii,
+			},
+		})
+			.then(() => {
+				onNotice({
+					status: 'success',
+					message: __('Telegram settings saved.', 'fair-payment'),
+				});
+				setIsSaving(false);
+			})
+			.catch((error) => {
+				console.error(
+					'[Fair Payment] Failed to save Telegram settings:',
+					error
+				);
+				onNotice({
+					status: 'error',
+					message:
+						__(
+							'Failed to save Telegram settings: ',
+							'fair-payment'
+						) + (error.message || 'Unknown error'),
+				});
+				setIsSaving(false);
+			});
+	};
+
+	const handleTest = () => {
+		setIsTesting(true);
+		setTestResult(null);
+		apiFetch({
+			path: '/fair-payment/v1/telegram/test',
+			method: 'POST',
+			data: {
+				bot_token: botToken,
+				chat_ids: chatIds,
+				template,
+				include_pii: includePii,
+			},
+		})
+			.then((response) => {
+				setTestResult({
+					status: 'success',
+					message:
+						response.message ||
+						__('Test message sent.', 'fair-payment'),
+				});
+				setIsTesting(false);
+			})
+			.catch((error) => {
+				setTestResult({
+					status: 'error',
+					message:
+						error.message ||
+						__('Test message failed.', 'fair-payment'),
+				});
+				setIsTesting(false);
+			});
+	};
+
+	if (isLoading) {
+		return (
+			<Card>
+				<CardBody>
+					<p>{__('Loading Telegram settings…', 'fair-payment')}</p>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	return (
+		<Card>
+			<CardBody>
+				<h2>{__('Telegram Notifications', 'fair-payment')}</h2>
+				<p style={{ color: '#666', marginBottom: '1.5rem' }}>
+					{__(
+						'Post a message to a Telegram chat or channel when a transaction is paid.',
+						'fair-payment'
+					)}
+				</p>
+
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={__('Enable Telegram notifications', 'fair-payment')}
+					checked={enabled}
+					onChange={setEnabled}
+				/>
+
+				<TextControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={__('Bot token', 'fair-payment')}
+					help={__(
+						'From @BotFather. Stored as plain text in wp_options — anyone with admin access can read it.',
+						'fair-payment'
+					)}
+					type="password"
+					value={botToken}
+					onChange={setBotToken}
+					autoComplete="off"
+				/>
+
+				<TextControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={__('Chat IDs', 'fair-payment')}
+					help={__(
+						'Comma-separated. Use a numeric user/chat/channel ID, or @channelname for public channels.',
+						'fair-payment'
+					)}
+					value={chatIds}
+					onChange={setChatIds}
+				/>
+
+				<TextareaControl
+					__nextHasNoMarginBottom
+					label={__('Message template', 'fair-payment')}
+					help={__(
+						'Placeholders: {site_domain}, {date}, {amount}, {currency}, {transaction_id}, {event_title}, {event_url}, {participant_name}, {participant_url}, {participant_email}, {ticket_label}, {activities}, {discounts}. HTML tags <b>, <i>, <a href> are allowed.',
+						'fair-payment'
+					)}
+					rows={5}
+					value={template}
+					onChange={setTemplate}
+				/>
+
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={__(
+						'Include participant name and email',
+						'fair-payment'
+					)}
+					help={__(
+						'Disable to keep PII out of the Telegram channel. {participant_name} and {participant_email} render as empty.',
+						'fair-payment'
+					)}
+					checked={includePii}
+					onChange={setIncludePii}
+				/>
+
+				<div
+					style={{
+						marginTop: '1.5rem',
+						display: 'flex',
+						gap: '0.75rem',
+					}}
+				>
+					<Button
+						variant="primary"
+						onClick={handleSave}
+						isBusy={isSaving}
+						disabled={isSaving}
+					>
+						{__('Save settings', 'fair-payment')}
+					</Button>
+					<Button
+						variant="secondary"
+						onClick={handleTest}
+						isBusy={isTesting}
+						disabled={isTesting || !botToken || !chatIds}
+					>
+						{__('Send test message', 'fair-payment')}
+					</Button>
+				</div>
+
+				{testResult && (
+					<div style={{ marginTop: '1rem' }}>
+						<Notice
+							status={testResult.status}
+							isDismissible={true}
+							onRemove={() => setTestResult(null)}
+						>
+							{testResult.message}
+						</Notice>
+					</div>
+				)}
+			</CardBody>
+		</Card>
+	);
+}

--- a/fair-payment/src/Admin/settings/TelegramTab.js
+++ b/fair-payment/src/Admin/settings/TelegramTab.js
@@ -196,7 +196,7 @@ export default function TelegramTab({ onNotice }) {
 					__nextHasNoMarginBottom
 					label={__('Message template', 'fair-payment')}
 					help={__(
-						'Placeholders: {site_domain}, {date}, {amount}, {currency}, {transaction_id}, {event_title}, {event_url}, {participant_name}, {participant_url}, {participant_email}, {ticket_label}, {activities}, {discounts}. HTML tags <b>, <i>, <a href> are allowed.',
+						'Placeholders: {test_label}, {site_domain}, {date}, {amount}, {currency}, {transaction_id}, {event_title}, {event_url}, {participant_name}, {participant_url}, {participant_email}, {ticket_label}, {activities}, {discounts}. HTML tags <b>, <i>, <a href> are allowed.',
 						'fair-payment'
 					)}
 					rows={5}

--- a/fair-payment/src/Admin/settings/__tests__/TelegramTab.test.js
+++ b/fair-payment/src/Admin/settings/__tests__/TelegramTab.test.js
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import TelegramTab from '../TelegramTab.js';
+
+jest.mock('@wordpress/api-fetch');
+
+describe('TelegramTab', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	function mockInitialLoad(overrides = {}) {
+		apiFetch.mockImplementation((opts) => {
+			if (
+				opts.path === '/wp/v2/settings' &&
+				(!opts.method || opts.method === 'GET')
+			) {
+				return Promise.resolve({
+					fair_payment_telegram_enabled: false,
+					fair_payment_telegram_bot_token: '',
+					fair_payment_telegram_chat_ids: '',
+					fair_payment_telegram_template: '',
+					fair_payment_telegram_include_pii: true,
+					...overrides,
+				});
+			}
+			return Promise.resolve({});
+		});
+	}
+
+	test('loads existing settings and renders fields', async () => {
+		mockInitialLoad({
+			fair_payment_telegram_enabled: true,
+			fair_payment_telegram_bot_token: 'BOT:123',
+			fair_payment_telegram_chat_ids: '12345',
+			fair_payment_telegram_template: 'hello {amount}',
+		});
+
+		render(<TelegramTab onNotice={() => {}} />);
+
+		await waitFor(() =>
+			expect(screen.getByDisplayValue('BOT:123')).toBeInTheDocument()
+		);
+		expect(screen.getByDisplayValue('12345')).toBeInTheDocument();
+		expect(screen.getByDisplayValue('hello {amount}')).toBeInTheDocument();
+	});
+
+	test('Send test message calls the test endpoint with current field values', async () => {
+		mockInitialLoad({
+			fair_payment_telegram_bot_token: 'BOT:xyz',
+			fair_payment_telegram_chat_ids: '99,100',
+			fair_payment_telegram_template: 't',
+		});
+
+		render(<TelegramTab onNotice={() => {}} />);
+
+		await waitFor(() =>
+			expect(screen.getByDisplayValue('BOT:xyz')).toBeInTheDocument()
+		);
+
+		// Switch the mock to return success for the test call.
+		apiFetch.mockImplementation((opts) => {
+			if (opts.path === '/fair-payment/v1/telegram/test') {
+				return Promise.resolve({
+					success: true,
+					message: 'Telegram test message sent.',
+				});
+			}
+			return Promise.resolve({});
+		});
+
+		fireEvent.click(screen.getByText('Send test message'));
+
+		await waitFor(() => {
+			const testCall = apiFetch.mock.calls.find(
+				([opts]) => opts.path === '/fair-payment/v1/telegram/test'
+			);
+			expect(testCall).toBeTruthy();
+			expect(testCall[0].method).toBe('POST');
+			expect(testCall[0].data).toEqual({
+				bot_token: 'BOT:xyz',
+				chat_ids: '99,100',
+				template: 't',
+				include_pii: true,
+			});
+		});
+
+		await waitFor(() => {
+			const matches = screen.getAllByText('Telegram test message sent.');
+			expect(matches.length).toBeGreaterThan(0);
+		});
+	});
+
+	test('shows error notice when test endpoint fails', async () => {
+		mockInitialLoad({
+			fair_payment_telegram_bot_token: 'BOT:fail',
+			fair_payment_telegram_chat_ids: 'bad',
+		});
+
+		render(<TelegramTab onNotice={() => {}} />);
+
+		await waitFor(() =>
+			expect(screen.getByDisplayValue('BOT:fail')).toBeInTheDocument()
+		);
+
+		apiFetch.mockImplementation((opts) => {
+			if (opts.path === '/fair-payment/v1/telegram/test') {
+				return Promise.reject({ message: 'chat not found' });
+			}
+			return Promise.resolve({});
+		});
+
+		fireEvent.click(screen.getByText('Send test message'));
+
+		await waitFor(() => {
+			const matches = screen.getAllByText('chat not found');
+			expect(matches.length).toBeGreaterThan(0);
+		});
+	});
+});

--- a/fair-payment/src/Core/Plugin.php
+++ b/fair-payment/src/Core/Plugin.php
@@ -52,6 +52,17 @@ class Plugin {
 		$this->load_admin();
 		$this->load_settings();
 		$this->load_migration_notice();
+		$this->load_notifications();
+	}
+
+	/**
+	 * Load and initialize notification hooks (Telegram, etc.)
+	 *
+	 * @return void
+	 */
+	private function load_notifications() {
+		$notifications = new \FairPayment\Hooks\NotificationHooks();
+		$notifications->init();
 	}
 
 	/**

--- a/fair-payment/src/Hooks/NotificationHooks.php
+++ b/fair-payment/src/Hooks/NotificationHooks.php
@@ -128,9 +128,12 @@ class NotificationHooks {
 			}
 		}
 
+		$is_test = ! empty( $transaction->testmode );
+
 		$base = array(
 			'transaction'       => $transaction,
 			'payment'           => $payment,
+			'test_label'        => $is_test ? '[TEST] ' : '',
 			'site_domain'       => (string) wp_parse_url( home_url(), PHP_URL_HOST ),
 			'amount'            => null !== $amount ? number_format( (float) $amount, 2, '.', '' ) : '',
 			'currency'          => $currency,
@@ -156,6 +159,7 @@ class NotificationHooks {
 	 */
 	public static function sample_context() {
 		return array(
+			'test_label'        => '[TEST] ',
 			'site_domain'       => (string) wp_parse_url( home_url(), PHP_URL_HOST ),
 			'amount'            => '10.00',
 			'currency'          => 'EUR',

--- a/fair-payment/src/Hooks/NotificationHooks.php
+++ b/fair-payment/src/Hooks/NotificationHooks.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Notification hooks for Fair Payment
+ *
+ * Listens to fair_payment_paid and dispatches Telegram notifications asynchronously
+ * via wp_schedule_single_event so the Mollie webhook is never blocked.
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\Hooks;
+
+use FairPayment\Services\TelegramService;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Wires Telegram notifications to successful-transaction events.
+ */
+class NotificationHooks {
+
+	const CRON_HOOK = 'fair_payment_send_telegram_notification';
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		// Run after fair-audience handle_signup_paid (priority 10) so any
+		// label/flip side effects are complete before we build the message.
+		add_action( 'fair_payment_paid', array( $this, 'on_payment_paid' ), 20, 2 );
+		add_action( self::CRON_HOOK, array( $this, 'dispatch_messages' ), 10, 1 );
+	}
+
+	/**
+	 * Build the notification context and schedule async sending.
+	 *
+	 * @param object $payment     Mollie payment object.
+	 * @param object $transaction Transaction row.
+	 * @return void
+	 */
+	public function on_payment_paid( $payment, $transaction ) {
+		if ( ! get_option( 'fair_payment_telegram_enabled', false ) ) {
+			return;
+		}
+
+		$bot_token = (string) get_option( 'fair_payment_telegram_bot_token', '' );
+		$chat_ids  = $this->parse_chat_ids( (string) get_option( 'fair_payment_telegram_chat_ids', '' ) );
+
+		if ( '' === $bot_token || empty( $chat_ids ) ) {
+			return;
+		}
+
+		$context = $this->build_context( $payment, $transaction );
+
+		$template    = (string) get_option( 'fair_payment_telegram_template', \FairPayment\Settings\Settings::default_template() );
+		$include_pii = (bool) get_option( 'fair_payment_telegram_include_pii', true );
+
+		$service = new TelegramService();
+		$text    = $service->render_template( $template, $context, $include_pii );
+
+		$payload = array(
+			'bot_token' => $bot_token,
+			'chat_ids'  => $chat_ids,
+			'text'      => $text,
+		);
+
+		// Schedule for the next cron tick so the webhook response is not delayed
+		// by Telegram API latency. Single-event hooks pass the args array as a
+		// single positional argument (the array itself), hence the [ $payload ] wrapping.
+		wp_schedule_single_event( time(), self::CRON_HOOK, array( $payload ) );
+	}
+
+	/**
+	 * Cron handler — fans out the message to all configured chats.
+	 *
+	 * @param array $payload Payload with bot_token, chat_ids[], text.
+	 * @return void
+	 */
+	public function dispatch_messages( $payload ) {
+		if ( ! is_array( $payload ) || empty( $payload['chat_ids'] ) || empty( $payload['text'] ) ) {
+			return;
+		}
+
+		$service   = new TelegramService();
+		$bot_token = ! empty( $payload['bot_token'] ) ? $payload['bot_token'] : (string) get_option( 'fair_payment_telegram_bot_token', '' );
+
+		foreach ( (array) $payload['chat_ids'] as $chat_id ) {
+			$service->send( $bot_token, (string) $chat_id, (string) $payload['text'] );
+		}
+	}
+
+	/**
+	 * Parse the comma-separated chat IDs setting into a clean array.
+	 *
+	 * @param string $raw Raw setting value.
+	 * @return string[]
+	 */
+	public static function parse_chat_ids( $raw ) {
+		$parts = preg_split( '/[\s,]+/', (string) $raw );
+		if ( ! is_array( $parts ) ) {
+			return array();
+		}
+		return array_values( array_filter( array_map( 'trim', $parts ), 'strlen' ) );
+	}
+
+	/**
+	 * Assemble the notification context for template rendering.
+	 *
+	 * Other plugins (fair-audience) hook `fair_payment_notification_context` to
+	 * fill in participant/event details. Defaults degrade gracefully when no
+	 * enrichment is available.
+	 *
+	 * @param object $payment     Mollie payment object.
+	 * @param object $transaction Transaction row.
+	 * @return array
+	 */
+	public function build_context( $payment, $transaction ) {
+		$amount   = isset( $transaction->amount ) ? $transaction->amount : null;
+		$currency = isset( $transaction->currency ) ? $transaction->currency : '';
+		$created  = isset( $transaction->created_at ) ? $transaction->created_at : '';
+		$date     = '';
+		if ( $created ) {
+			$ts = strtotime( $created );
+			if ( $ts ) {
+				$date = gmdate( 'Y-m-d', $ts );
+			}
+		}
+
+		$base = array(
+			'transaction'       => $transaction,
+			'payment'           => $payment,
+			'site_domain'       => (string) wp_parse_url( home_url(), PHP_URL_HOST ),
+			'amount'            => null !== $amount ? number_format( (float) $amount, 2, '.', '' ) : '',
+			'currency'          => $currency,
+			'date'              => $date,
+			'transaction_id'    => isset( $transaction->id ) ? (string) $transaction->id : '',
+			'event_title'       => '',
+			'event_url'         => '',
+			'participant_name'  => '',
+			'participant_url'   => '',
+			'participant_email' => '',
+			'ticket_label'      => '',
+			'activities'        => '',
+			'discounts'         => '',
+		);
+
+		return apply_filters( 'fair_payment_notification_context', $base, $transaction, $payment );
+	}
+
+	/**
+	 * Provide a sample context for the "Send test message" button.
+	 *
+	 * @return array
+	 */
+	public static function sample_context() {
+		return array(
+			'site_domain'       => (string) wp_parse_url( home_url(), PHP_URL_HOST ),
+			'amount'            => '10.00',
+			'currency'          => 'EUR',
+			'date'              => gmdate( 'Y-m-d' ),
+			'transaction_id'    => 'TEST-0001',
+			'event_title'       => 'Sample Event',
+			'event_url'         => admin_url( 'edit.php' ),
+			'participant_name'  => 'Sample Participant',
+			'participant_url'   => admin_url( 'admin.php?page=fair-audience-participants' ),
+			'participant_email' => 'sample@example.com',
+			'ticket_label'      => 'Regular',
+			'activities'        => 'Sample Activity A, Sample Activity B',
+			'discounts'         => 'Early bird -10%',
+		);
+	}
+}

--- a/fair-payment/src/Services/TelegramService.php
+++ b/fair-payment/src/Services/TelegramService.php
@@ -100,6 +100,7 @@ class TelegramService {
 
 		$replacements = array();
 		$placeholders = array(
+			'test_label',
 			'site_domain',
 			'event_title',
 			'event_url',

--- a/fair-payment/src/Services/TelegramService.php
+++ b/fair-payment/src/Services/TelegramService.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Telegram notification sender for Fair Payment
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Sends messages to Telegram chats via the Bot API.
+ *
+ * Failures never throw — the caller (cron handler) should keep going so a single
+ * misconfigured chat ID does not block the rest of the notifications.
+ */
+class TelegramService {
+
+	/**
+	 * Telegram Bot API base URL.
+	 */
+	const API_BASE = 'https://api.telegram.org';
+
+	/**
+	 * Send a message to a single chat.
+	 *
+	 * @param string $bot_token Telegram bot token.
+	 * @param string $chat_id   Telegram chat ID (numeric or @channelname).
+	 * @param string $text      Message text (parse_mode=HTML).
+	 * @return array|\WP_Error Array with Telegram API response data on success, WP_Error on failure.
+	 */
+	public function send( $bot_token, $chat_id, $text ) {
+		$bot_token = trim( (string) $bot_token );
+		$chat_id   = trim( (string) $chat_id );
+
+		if ( '' === $bot_token ) {
+			return new \WP_Error( 'fair_payment_telegram_missing_token', __( 'Telegram bot token is not configured.', 'fair-payment' ) );
+		}
+		if ( '' === $chat_id ) {
+			return new \WP_Error( 'fair_payment_telegram_missing_chat_id', __( 'Telegram chat ID is empty.', 'fair-payment' ) );
+		}
+
+		$url = self::API_BASE . '/bot' . rawurlencode( $bot_token ) . '/sendMessage';
+
+		$response = wp_remote_post(
+			$url,
+			array(
+				'timeout' => 10,
+				'headers' => array( 'Content-Type' => 'application/json' ),
+				'body'    => wp_json_encode(
+					array(
+						'chat_id'                  => $chat_id,
+						'text'                     => $text,
+						'parse_mode'               => 'HTML',
+						'disable_web_page_preview' => true,
+					)
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			error_log( '[Fair Payment] Telegram send failed: ' . $response->get_error_message() );
+			return $response;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		if ( $code < 200 || $code >= 300 || empty( $data['ok'] ) ) {
+			$description = is_array( $data ) && ! empty( $data['description'] ) ? $data['description'] : 'HTTP ' . $code;
+			error_log( '[Fair Payment] Telegram send returned non-OK: ' . $description );
+			return new \WP_Error(
+				'fair_payment_telegram_api_error',
+				$description,
+				array(
+					'status' => $code,
+					'body'   => $data,
+				)
+			);
+		}
+
+		return is_array( $data ) ? $data : array();
+	}
+
+	/**
+	 * Render a template by substituting placeholders.
+	 *
+	 * PII placeholders ({participant_name}, {participant_email}) substitute to an
+	 * empty string when $include_pii is false.
+	 *
+	 * @param string $template    Template string.
+	 * @param array  $context     Context with raw values (will be HTML-escaped on insertion).
+	 * @param bool   $include_pii Whether to substitute PII placeholders.
+	 * @return string
+	 */
+	public function render_template( $template, array $context, $include_pii = true ) {
+		$pii_keys = array( 'participant_name', 'participant_email' );
+
+		$replacements = array();
+		$placeholders = array(
+			'site_domain',
+			'event_title',
+			'event_url',
+			'participant_name',
+			'participant_url',
+			'participant_email',
+			'amount',
+			'currency',
+			'ticket_label',
+			'activities',
+			'discounts',
+			'transaction_id',
+			'date',
+		);
+
+		foreach ( $placeholders as $key ) {
+			$value = '';
+
+			if ( in_array( $key, $pii_keys, true ) && ! $include_pii ) {
+				$value = '';
+			} elseif ( isset( $context[ $key ] ) && null !== $context[ $key ] && '' !== $context[ $key ] ) {
+				// URLs use esc_url, everything else uses esc_html.
+				if ( in_array( $key, array( 'event_url', 'participant_url' ), true ) ) {
+					$value = esc_url( (string) $context[ $key ] );
+				} else {
+					$value = esc_html( (string) $context[ $key ] );
+				}
+			}
+
+			$replacements[ '{' . $key . '}' ] = $value;
+		}
+
+		return strtr( (string) $template, $replacements );
+	}
+}

--- a/fair-payment/src/Settings/Settings.php
+++ b/fair-payment/src/Settings/Settings.php
@@ -299,7 +299,7 @@ class Settings {
 	 * @return string
 	 */
 	public static function default_template() {
-		return '<b>{site_domain}</b>' . "\n"
+		return '<b>{test_label}{site_domain}</b>' . "\n"
 			. '<a href="{event_url}">{event_title}</a>' . "\n"
 			. '<a href="{participant_url}">{participant_name}</a> ({participant_email})' . "\n"
 			. 'Ticket: {ticket_label}' . "\n"

--- a/fair-payment/src/Settings/Settings.php
+++ b/fair-payment/src/Settings/Settings.php
@@ -221,6 +221,113 @@ class Settings {
 				'default'           => 3,
 			)
 		);
+
+		// Telegram: enabled
+		register_setting(
+			'fair_payment_settings',
+			'fair_payment_telegram_enabled',
+			array(
+				'type'              => 'boolean',
+				'description'       => __( 'Enable Telegram notifications on successful transactions', 'fair-payment' ),
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'show_in_rest'      => true,
+				'default'           => false,
+			)
+		);
+
+		// Telegram: bot token (sensitive — edit context only)
+		register_setting(
+			'fair_payment_settings',
+			'fair_payment_telegram_bot_token',
+			array(
+				'type'              => 'string',
+				'description'       => __( 'Telegram bot token (from @BotFather)', 'fair-payment' ),
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'    => 'string',
+						'context' => array( 'edit' ),
+					),
+				),
+				'default'           => '',
+			)
+		);
+
+		// Telegram: chat IDs (comma-separated)
+		register_setting(
+			'fair_payment_settings',
+			'fair_payment_telegram_chat_ids',
+			array(
+				'type'              => 'string',
+				'description'       => __( 'Telegram chat IDs (comma-separated)', 'fair-payment' ),
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+				'default'           => '',
+			)
+		);
+
+		// Telegram: message template
+		register_setting(
+			'fair_payment_settings',
+			'fair_payment_telegram_template',
+			array(
+				'type'              => 'string',
+				'description'       => __( 'Telegram message template (HTML, supports placeholders)', 'fair-payment' ),
+				'sanitize_callback' => array( $this, 'sanitize_template' ),
+				'show_in_rest'      => true,
+				'default'           => self::default_template(),
+			)
+		);
+
+		// Telegram: include PII placeholders
+		register_setting(
+			'fair_payment_settings',
+			'fair_payment_telegram_include_pii',
+			array(
+				'type'              => 'boolean',
+				'description'       => __( 'Allow participant name/email in Telegram messages', 'fair-payment' ),
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'show_in_rest'      => true,
+				'default'           => true,
+			)
+		);
+	}
+
+	/**
+	 * Default Telegram message template.
+	 *
+	 * @return string
+	 */
+	public static function default_template() {
+		return '<b>{site_domain}</b>' . "\n"
+			. '<a href="{event_url}">{event_title}</a>' . "\n"
+			. '<a href="{participant_url}">{participant_name}</a> ({participant_email})' . "\n"
+			. 'Ticket: {ticket_label}' . "\n"
+			. 'Activities: {activities}' . "\n"
+			. 'Discounts: {discounts}' . "\n"
+			. 'Total: {amount} {currency}';
+	}
+
+	/**
+	 * Sanitize template — preserve newlines, strip dangerous tags.
+	 *
+	 * @param string $value Template value.
+	 * @return string
+	 */
+	public function sanitize_template( $value ) {
+		return wp_kses(
+			(string) $value,
+			array(
+				'b'      => array(),
+				'strong' => array(),
+				'i'      => array(),
+				'em'     => array(),
+				'u'      => array(),
+				'a'      => array( 'href' => array() ),
+				'br'     => array(),
+				'code'   => array(),
+			)
+		);
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -923,7 +923,7 @@
 			}
 		},
 		"fair-audience": {
-			"version": "0.2.0",
+			"version": "1.2.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -3089,7 +3089,7 @@
 			}
 		},
 		"fair-events": {
-			"version": "0.7.0",
+			"version": "1.2.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@fortawesome/fontawesome-svg-core": "^6.0.0",
@@ -4184,7 +4184,7 @@
 			}
 		},
 		"fair-payment": {
-			"version": "0.2.0",
+			"version": "1.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -4197,6 +4197,8 @@
 				"xlsx": "^0.18.5"
 			},
 			"devDependencies": {
+				"@testing-library/jest-dom": "^6.9.1",
+				"@testing-library/react": "^14.3.1",
 				"@wordpress/scripts": "^31.2.0",
 				"webpack-bundle-output": "^1.1.0"
 			}
@@ -4413,6 +4415,13 @@
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
+		},
+		"node_modules/@adobe/css-tools": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+			"integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.3.0",
@@ -11633,6 +11642,117 @@
 			"integrity": "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA==",
 			"license": "MIT"
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "9.3.4",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+			"integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.1.3",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/aria-query": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+			"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"deep-equal": "^2.0.5"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@testing-library/dom/node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@testing-library/jest-dom": {
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+			"integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@adobe/css-tools": "^4.4.0",
+				"aria-query": "^5.0.0",
+				"css.escape": "^1.5.1",
+				"dom-accessibility-api": "^0.6.3",
+				"picocolors": "^1.1.1",
+				"redent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
+		},
+		"node_modules/@testing-library/react": {
+			"version": "14.3.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
+			"integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"@testing-library/dom": "^9.0.0",
+				"@types/react-dom": "^18.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -11666,6 +11786,13 @@
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
+		},
+		"node_modules/@types/aria-query": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -12029,7 +12156,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
 			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -12040,7 +12166,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
@@ -18066,6 +18191,13 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -18409,6 +18541,39 @@
 				}
 			}
 		},
+		"node_modules/deep-equal": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+			"integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.0",
+				"call-bind": "^1.0.5",
+				"es-get-iterator": "^1.1.3",
+				"get-intrinsic": "^1.2.2",
+				"is-arguments": "^1.1.1",
+				"is-array-buffer": "^3.0.2",
+				"is-date-object": "^1.0.5",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.2",
+				"isarray": "^2.0.5",
+				"object-is": "^1.1.5",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.4",
+				"regexp.prototype.flags": "^1.5.1",
+				"side-channel": "^1.0.4",
+				"which-boxed-primitive": "^1.0.2",
+				"which-collection": "^1.0.1",
+				"which-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -18703,6 +18868,13 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+			"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
@@ -19092,6 +19264,27 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-get-iterator": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+			"integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"has-symbols": "^1.0.3",
+				"is-arguments": "^1.1.1",
+				"is-map": "^2.0.2",
+				"is-set": "^2.0.2",
+				"is-string": "^1.0.7",
+				"isarray": "^2.0.5",
+				"stop-iteration-iterator": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/es-iterator-helpers": {
@@ -21901,6 +22094,23 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-arguments": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -25062,6 +25272,16 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"node_modules/lz-string": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"lz-string": "bin/bin.js"
+			}
+		},
 		"node_modules/make-dir": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -26372,6 +26592,23 @@
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
 			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
 			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-is": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1"
+			},
 			"engines": {
 				"node": ">= 0.4"
 			},


### PR DESCRIPTION
## Summary
- Adds a Telegram bot integration that posts a message to configured chats whenever a transaction is paid.
- Settings live in **fair-payment → Settings → Telegram** (token, comma-separated chat IDs, message template, PII toggle, enable switch, "Send test message" button).
- Hooks `fair_payment_paid` and dispatches via `wp_schedule_single_event`, so the Mollie webhook is never blocked by Telegram latency. Send failures are logged and never break the payment flow.
- Introduces a `fair_payment_notification_context` filter; fair-audience hooks it to inject participant name/email/URL, event title/URL, and ticket label. Degrades gracefully when fair-audience is missing.
- Default message matches the two-line example from the ticket.

Closes #560.

## Files of note
- `fair-payment/src/Services/TelegramService.php` — sender + template renderer (HTML-escaped, PII-aware).
- `fair-payment/src/Hooks/NotificationHooks.php` — hook subscription + async cron dispatch.
- `fair-payment/src/API/TelegramSettingsController.php` — `POST /fair-payment/v1/telegram/test` for the test button (`manage_options`).
- `fair-payment/src/Settings/Settings.php` — 5 new options + sanitization + default template.
- `fair-payment/src/Admin/settings/TelegramTab.js` — React tab wired into `SettingsApp`.
- `fair-audience/src/Hooks/PaymentHooks.php` — `enrich_notification_context()` filter handler.
- `fair-payment/TELEGRAM.md` — setup guide.
- `fair-payment/jest.config.js` + `src/Admin/settings/__tests__/TelegramTab.test.js` — Jest + RTL tests for the tab (3 passing).

## Test plan
- [x] `cd fair-payment && npm test` — 4/4 passing
- [x] `cd fair-payment && npm run build` — succeeds
- [x] `php -l` clean on all new/changed PHP files
- [ ] Manual: create a bot via @BotFather, paste token + chat ID, click **Send test message** — confirm message arrives with two-line format and working links
- [ ] Manual: complete a real Mollie test payment — confirm Telegram message matches the expected format (date, total, participant link, event link)
- [ ] Manual: set an invalid bot token, run a payment — payment still succeeds, failure logged, webhook returns promptly
- [ ] Manual: disable fair-audience, run a fair-payment-only transaction — message still sends with empty enrichment placeholders
- [ ] Manual: toggle "Include PII" off — verify `{participant_name}` / `{participant_email}` render empty