### PR TITLE
Send mailing-list confirmation email for paid event signups

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -1688,6 +1688,20 @@ class EventSignupController extends WP_REST_Controller {
 			}
 
 			$is_new_participant = true;
+
+			// Mailing-list double opt-in: dispatch the confirmation email as
+			// soon as the participant lands in 'pending' status. Doing it here
+			// (rather than only in the free-signup tail below) ensures the
+			// paid-signup branch — which short-circuits with a payment URL —
+			// still triggers the email. Without this, paid signups with
+			// keep_informed=true left the subscriber stuck on 'pending' with
+			// no way to confirm.
+			if ( $keep_informed ) {
+				$token = $this->token_repository->create_token( $participant->id );
+				if ( $token ) {
+					$this->email_service->send_confirmation_email( $participant, $token->token );
+				}
+			}
 		}
 
 		// Validate ticket type group restrictions (and invitation tokens for invitation-only types).
@@ -1741,13 +1755,10 @@ class EventSignupController extends WP_REST_Controller {
 			AudienceSession::set( (int) $participant->id );
 		}
 
-		// If keep_informed, send confirmation email.
+		// The mailing-list confirmation email (when keep_informed=true) is
+		// dispatched at participant-creation time so both free and paid signup
+		// branches trigger it — see the participant-creation block above.
 		if ( $keep_informed ) {
-			$token = $this->token_repository->create_token( $participant->id );
-			if ( $token ) {
-				$this->email_service->send_confirmation_email( $participant, $token->token );
-			}
-
 			return rest_ensure_response(
 				array(
 					'success' => true,

--- a/fair-audience/src/API/ParticipantsController.php
+++ b/fair-audience/src/API/ParticipantsController.php
@@ -11,7 +11,9 @@ use FairAudience\Database\ParticipantRepository;
 use FairAudience\Database\EventParticipantRepository;
 use FairAudience\Database\GroupParticipantRepository;
 use FairAudience\Database\QuestionnaireSubmissionRepository;
+use FairAudience\Database\EmailConfirmationTokenRepository;
 use FairAudience\Models\Participant;
+use FairAudience\Services\EmailService;
 use FairAudience\Services\ManageSubscriptionToken;
 use WP_REST_Controller;
 use WP_REST_Server;
@@ -179,6 +181,25 @@ class ParticipantsController extends WP_REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_subscription_url' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+				'args'                => array(
+					'id' => array(
+						'type'     => 'integer',
+						'required' => true,
+					),
+				),
+			)
+		);
+
+		// POST /fair-audience/v1/participants/{id}/resend-mailing-confirmation.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>\d+)/resend-mailing-confirmation',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'resend_mailing_confirmation' ),
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' );
 				},
@@ -667,6 +688,62 @@ class ParticipantsController extends WP_REST_Controller {
 		return rest_ensure_response(
 			array(
 				'url' => ManageSubscriptionToken::get_url( $participant->id ),
+			)
+		);
+	}
+
+	/**
+	 * Resend the mailing-list confirmation email to a participant stuck in
+	 * 'pending' status — used to recover subscribers who slipped through the
+	 * paid-signup gap (where the original confirmation email was never sent).
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function resend_mailing_confirmation( $request ) {
+		$id          = (int) $request->get_param( 'id' );
+		$participant = $this->repository->get_by_id( $id );
+
+		if ( ! $participant ) {
+			return new WP_Error(
+				'participant_not_found',
+				__( 'Participant not found.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( 'pending' !== $participant->status ) {
+			return new WP_Error(
+				'participant_not_pending',
+				__( 'Participant is not awaiting mailing-list confirmation.', 'fair-audience' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$token_repository = new EmailConfirmationTokenRepository();
+		$token            = $token_repository->create_token( $participant->id );
+		if ( ! $token ) {
+			return new WP_Error(
+				'token_creation_failed',
+				__( 'Failed to create confirmation token.', 'fair-audience' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$email_service = new EmailService();
+		$sent          = $email_service->send_confirmation_email( $participant, $token->token );
+		if ( ! $sent ) {
+			return new WP_Error(
+				'email_send_failed',
+				__( 'Failed to send confirmation email.', 'fair-audience' ),
+				array( 'status' => 502 )
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'message' => __( 'Confirmation email sent.', 'fair-audience' ),
 			)
 		);
 	}

--- a/fair-audience/src/Admin/all-participants/AllParticipants.js
+++ b/fair-audience/src/Admin/all-participants/AllParticipants.js
@@ -418,21 +418,48 @@ export default function AllParticipants() {
 				id: 'resend-mailing-confirmation',
 				label: __('Resend mailing confirmation email', 'fair-audience'),
 				isEligible: (item) => 'pending' === item.status,
-				callback: async ([item]) => {
-					try {
-						const response = await apiFetch({
-							path: `/fair-audience/v1/participants/${item.id}/resend-mailing-confirmation`,
-							method: 'POST',
-						});
+				callback: async (items) => {
+					const results = await Promise.all(
+						items.map((item) =>
+							apiFetch({
+								path: `/fair-audience/v1/participants/${item.id}/resend-mailing-confirmation`,
+								method: 'POST',
+							})
+								.then(() => ({ ok: true, item }))
+								.catch((err) => ({ ok: false, item, err }))
+						)
+					);
+
+					const failures = results.filter((r) => !r.ok);
+					if (failures.length === 0) {
 						alert(
-							response.message ||
-								__('Confirmation email sent.', 'fair-audience')
+							/* translators: %d: number of confirmation emails sent. */
+							__(
+								'Sent %d confirmation email(s).',
+								'fair-audience'
+							).replace('%d', results.length)
 						);
-					} catch (err) {
-						alert(__('Error: ', 'fair-audience') + err.message);
+						return;
 					}
+
+					const summary = failures
+						.map(
+							(r) =>
+								`${r.item.name} ${r.item.surname}: ${
+									r.err?.message || 'error'
+								}`
+						)
+						.join('\n');
+					alert(
+						__(
+							'Some confirmation emails failed:',
+							'fair-audience'
+						) +
+							'\n' +
+							summary
+					);
 				},
-				supportsBulk: false,
+				supportsBulk: true,
 			},
 			{
 				id: 'delete',

--- a/fair-audience/src/Admin/all-participants/AllParticipants.js
+++ b/fair-audience/src/Admin/all-participants/AllParticipants.js
@@ -415,6 +415,26 @@ export default function AllParticipants() {
 				supportsBulk: false,
 			},
 			{
+				id: 'resend-mailing-confirmation',
+				label: __('Resend mailing confirmation email', 'fair-audience'),
+				isEligible: (item) => 'pending' === item.status,
+				callback: async ([item]) => {
+					try {
+						const response = await apiFetch({
+							path: `/fair-audience/v1/participants/${item.id}/resend-mailing-confirmation`,
+							method: 'POST',
+						});
+						alert(
+							response.message ||
+								__('Confirmation email sent.', 'fair-audience')
+						);
+					} catch (err) {
+						alert(__('Error: ', 'fair-audience') + err.message);
+					}
+				},
+				supportsBulk: false,
+			},
+			{
 				id: 'delete',
 				label: __('Delete', 'fair-audience'),
 				icon: 'trash',

--- a/fair-audience/src/Admin/all-participants/AllParticipants.js
+++ b/fair-audience/src/Admin/all-participants/AllParticipants.js
@@ -9,7 +9,7 @@ import {
 	Popover,
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
-import { Icon, caution, link } from '@wordpress/icons';
+import { Icon, caution, link, send } from '@wordpress/icons';
 import ParticipantEditModal from '../components/ParticipantEditModal.js';
 
 const DEFAULT_VIEW = {
@@ -417,6 +417,7 @@ export default function AllParticipants() {
 			{
 				id: 'resend-mailing-confirmation',
 				label: __('Resend mailing confirmation email', 'fair-audience'),
+				icon: send,
 				isEligible: (item) => 'pending' === item.status,
 				callback: async (items) => {
 					const results = await Promise.all(


### PR DESCRIPTION
The keep_informed branch that created the double opt-in token and sent
the confirmation email sat in the free-signup tail of create_item, after
the maybe_start_paid_signup short-circuit. Paid signups returned the
payment URL and never reached it, so new participants who ticked
"keep me informed" on a paid event were created with status='pending'
and email_profile='marketing' but never received a confirmation email —
no way for them to transition to 'confirmed'.

Move the token + send_confirmation_email call into the new-participant
creation block so both branches trigger it. The free-path tail keeps
the success-message response branch (different user-facing copy) but no
longer duplicates the dispatch.
