### PR TITLE
Add bulk 'Load Missing Mollie Fees' action to transactions list

### DIFF
--- a/fair-payment/src/API/TransactionsController.php
+++ b/fair-payment/src/API/TransactionsController.php
@@ -112,6 +112,26 @@ class TransactionsController extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/transactions/missing-mollie-fee',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_missing_mollie_fee_ids' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'mode' => array(
+							'type'              => 'string',
+							'default'           => '',
+							'enum'              => array( '', 'live', 'test' ),
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/transactions/(?P<id>\d+)/sync-mollie',
 			array(
 				array(
@@ -350,6 +370,24 @@ class TransactionsController extends WP_REST_Controller {
 					$updated,
 					$skipped
 				),
+			),
+			200
+		);
+	}
+
+	/**
+	 * List IDs of paid transactions missing Mollie fee data.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_missing_mollie_fee_ids( $request ) {
+		$ids = Transaction::get_ids_missing_mollie_fee( (string) $request->get_param( 'mode' ) );
+
+		return new WP_REST_Response(
+			array(
+				'ids'   => $ids,
+				'total' => count( $ids ),
 			),
 			200
 		);

--- a/fair-payment/src/Admin/transactions/TransactionsApp.js
+++ b/fair-payment/src/Admin/transactions/TransactionsApp.js
@@ -79,6 +79,7 @@ const TransactionsApp = () => {
 	const [success, setSuccess] = useState(null);
 	const [selectedTransactions, setSelectedTransactions] = useState(new Set());
 	const [isImporting, setIsImporting] = useState(false);
+	const [feeSync, setFeeSync] = useState(null);
 
 	const loadTransactions = useCallback(async () => {
 		setLoading(true);
@@ -321,6 +322,87 @@ const TransactionsApp = () => {
 		}
 	};
 
+	const handleLoadMissingFees = async () => {
+		setError(null);
+		setSuccess(null);
+		setFeeSync({
+			running: true,
+			processed: 0,
+			total: 0,
+			succeeded: 0,
+			failed: 0,
+		});
+
+		try {
+			const params = new URLSearchParams();
+			if (filters.mode) params.append('mode', filters.mode);
+
+			const response = await apiFetch({
+				path: `/fair-payment/v1/transactions/missing-mollie-fee?${params.toString()}`,
+			});
+
+			const ids = response.ids || [];
+
+			if (ids.length === 0) {
+				setFeeSync(null);
+				setSuccess(
+					__(
+						'No paid transactions are missing Mollie fee data.',
+						'fair-payment'
+					)
+				);
+				return;
+			}
+
+			setFeeSync((prev) => ({ ...prev, total: ids.length }));
+
+			let succeeded = 0;
+			let failed = 0;
+
+			for (let i = 0; i < ids.length; i++) {
+				try {
+					const result = await apiFetch({
+						path: `/fair-payment/v1/transactions/${ids[i]}/sync-mollie`,
+						method: 'POST',
+					});
+					if (result && result.mollie_fee !== null) {
+						succeeded += 1;
+					} else {
+						failed += 1;
+					}
+				} catch (err) {
+					failed += 1;
+				}
+				setFeeSync({
+					running: i + 1 < ids.length,
+					processed: i + 1,
+					total: ids.length,
+					succeeded,
+					failed,
+				});
+			}
+
+			setFeeSync(null);
+			setSuccess(
+				/* translators: 1: synced count, 2: failed count, 3: total count */
+				__(
+					'Mollie fee sync complete: %1$d updated, %2$d failed (out of %3$d).',
+					'fair-payment'
+				)
+					.replace('%1$d', succeeded)
+					.replace('%2$d', failed)
+					.replace('%3$d', ids.length)
+			);
+			loadTransactions();
+		} catch (err) {
+			setFeeSync(null);
+			setError(
+				err.message ||
+					__('Failed to load missing Mollie fees.', 'fair-payment')
+			);
+		}
+	};
+
 	const sortableHeader = (column, label) => (
 		<th style={{ cursor: 'pointer' }} onClick={() => handleSort(column)}>
 			{label}
@@ -334,7 +416,11 @@ const TransactionsApp = () => {
 
 			<Card>
 				<CardHeader>
-					<HStack justify="space-between">
+					<HStack
+						justify="space-between"
+						wrap
+						style={{ rowGap: '8px' }}
+					>
 						<HStack>
 							<SelectControl
 								label={__('Status', 'fair-payment')}
@@ -369,15 +455,39 @@ const TransactionsApp = () => {
 								__nextHasNoMarginBottom
 							/>
 						</HStack>
-						<HStack spacing={2} expanded={false}>
+						<HStack
+							spacing={2}
+							expanded={false}
+							wrap
+							style={{ rowGap: '8px' }}
+						>
 							{selectedTransactions.size > 0 && (
 								<Button
 									variant="secondary"
 									onClick={handleExport}
+									style={{ flexShrink: 0, width: 'auto' }}
 								>
 									{__('Export Selected', 'fair-payment')}
 								</Button>
 							)}
+							<Button
+								variant="secondary"
+								onClick={handleLoadMissingFees}
+								isBusy={!!feeSync?.running}
+								disabled={!!feeSync?.running}
+								style={{
+									whiteSpace: 'nowrap',
+									flexShrink: 0,
+									width: 'auto',
+								}}
+							>
+								{feeSync?.running
+									? __('Syncing…', 'fair-payment')
+									: __(
+											'Load Missing Mollie Fees',
+											'fair-payment'
+									  )}
+							</Button>
 							<Button
 								variant="secondary"
 								onClick={() =>
@@ -389,6 +499,7 @@ const TransactionsApp = () => {
 								}
 								isBusy={isImporting}
 								disabled={isImporting}
+								style={{ flexShrink: 0, width: 'auto' }}
 							>
 								{__('Import', 'fair-payment')}
 							</Button>
@@ -420,6 +531,22 @@ const TransactionsApp = () => {
 							onRemove={() => setSuccess(null)}
 						>
 							{success}
+						</Notice>
+					)}
+
+					{feeSync && feeSync.running && (
+						<Notice status="info" isDismissible={false}>
+							{
+								/* translators: 1: processed count, 2: total count, 3: succeeded count, 4: failed count */
+								__(
+									'Syncing Mollie fees: %1$d / %2$d (updated: %3$d, failed: %4$d)',
+									'fair-payment'
+								)
+									.replace('%1$d', feeSync.processed)
+									.replace('%2$d', feeSync.total)
+									.replace('%3$d', feeSync.succeeded)
+									.replace('%4$d', feeSync.failed)
+							}
 						</Notice>
 					)}
 

--- a/fair-payment/src/Models/Transaction.php
+++ b/fair-payment/src/Models/Transaction.php
@@ -232,6 +232,39 @@ class Transaction {
 	}
 
 	/**
+	 * Get IDs of paid transactions that have a Mollie payment ID but no Mollie fee captured yet.
+	 *
+	 * @param string $mode Optional 'live'|'test'|'' for all.
+	 * @return int[]
+	 */
+	public static function get_ids_missing_mollie_fee( $mode = '' ) {
+		global $wpdb;
+		$table_name = \FairPayment\Database\Schema::get_payments_table_name();
+
+		$where_clauses = array(
+			"status = 'paid'",
+			'mollie_fee IS NULL',
+			"mollie_payment_id IS NOT NULL AND mollie_payment_id <> ''",
+		);
+
+		if ( '' !== $mode ) {
+			$testmode        = 'test' === $mode ? 1 : 0;
+			$where_clauses[] = $wpdb->prepare( 'testmode = %d', $testmode );
+		}
+
+		$where = implode( ' AND ', $where_clauses );
+
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT id FROM %i WHERE {$where} ORDER BY created_at DESC",
+				$table_name
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+
+	/**
 	 * Get transaction by Mollie payment ID
 	 *
 	 * @param string $mollie_payment_id Mollie payment ID.


### PR DESCRIPTION
Iterates paid transactions that still lack a captured Mollie fee and runs
the existing per-transaction sync, with live progress in the admin UI.
Honors the current mode filter so live and test batches stay separate.
