### PR TITLE
Auto-split matched entry into one child per transaction

### DIFF
--- a/fair-payment/src/API/FinancialEntryController.php
+++ b/fair-payment/src/API/FinancialEntryController.php
@@ -961,6 +961,33 @@ class FinancialEntryController extends WP_REST_Controller {
 			);
 		}
 
+		// Auto-split the entry into one child per matched transaction so the
+		// user can later assign budgets per transaction. Only do this when the
+		// entry isn't already split and there are at least two transactions.
+		if ( count( $ids_to_match ) >= 2 && ! FinancialEntry::has_children( $id ) ) {
+			$allocations = array();
+			foreach ( $ids_to_match as $tid ) {
+				$transaction = Transaction::get_by_id( $tid );
+				if ( ! $transaction ) {
+					continue;
+				}
+
+				$net = (float) $transaction->amount
+					- (float) ( $transaction->application_fee ?? 0 )
+					- (float) ( $transaction->mollie_fee ?? 0 );
+
+				$allocations[] = array(
+					'amount'      => $net,
+					'description' => $transaction->description ?? '',
+					'budget_id'   => null,
+				);
+			}
+
+			if ( count( $allocations ) >= 2 ) {
+				FinancialEntry::split_entry( $id, $allocations );
+			}
+		}
+
 		$entry = FinancialEntry::get_by_id( $id );
 
 		return new WP_REST_Response( $entry->to_array(), 200 );


### PR DESCRIPTION
When the reconciliation flow matches 2+ transactions to a single bank entry, automatically split the entry into per-transaction children using each transaction's net amount and description. Children are created without a budget so the user can assign budgets manually afterwards.