### PR TITLE
Export questionnaire responses to Markdown

### DIFF
--- a/fair-audience/fair-audience.php
+++ b/fair-audience/fair-audience.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fair Audience
  * Plugin URI: https://github.com/marcin-wosinek/fair-event-plugins
  * Description: Manage event participants with custom profiles and many-to-many event relationships
- * Version: 1.2.0-54-g58bb29b
+ * Version: 1.2.0-71-gc03700d-dirty
  * Author: Marcin Wosinek
  * Author URI: https://github.com/marcin-wosinek
  * License: GPL-3.0-or-later

--- a/fair-audience/src/API/QuestionnaireResponsesController.php
+++ b/fair-audience/src/API/QuestionnaireResponsesController.php
@@ -199,12 +199,24 @@ class QuestionnaireResponsesController extends WP_REST_Controller {
 
 			$answers_data = array();
 			foreach ( $answers as $answer ) {
-				$answers_data[] = array(
+				$answer_item = array(
 					'question_key'  => $answer->question_key,
 					'question_text' => $answer->question_text,
 					'question_type' => $answer->question_type,
 					'answer_value'  => $answer->answer_value,
 				);
+
+				if ( 'file_upload' === $answer->question_type && is_numeric( $answer->answer_value ) ) {
+					$attachment_id  = (int) $answer->answer_value;
+					$attachment_url = wp_get_attachment_url( $attachment_id );
+					if ( $attachment_url ) {
+						$answer_item['file_url'] = $attachment_url;
+						$mime                    = get_post_mime_type( $attachment_id );
+						$answer_item['is_image'] = $mime && 0 === strpos( $mime, 'image/' );
+					}
+				}
+
+				$answers_data[] = $answer_item;
 			}
 
 			$participant_name    = '';
@@ -335,9 +347,12 @@ class QuestionnaireResponsesController extends WP_REST_Controller {
 
 			// For file uploads, include the attachment URL.
 			if ( 'file_upload' === $answer->question_type && is_numeric( $answer->answer_value ) ) {
-				$attachment_url = wp_get_attachment_url( (int) $answer->answer_value );
+				$attachment_id  = (int) $answer->answer_value;
+				$attachment_url = wp_get_attachment_url( $attachment_id );
 				if ( $attachment_url ) {
 					$answer_item['file_url'] = $attachment_url;
+					$mime                    = get_post_mime_type( $attachment_id );
+					$answer_item['is_image'] = $mime && 0 === strpos( $mime, 'image/' );
 				}
 			}
 

--- a/fair-audience/src/Admin/questionnaire-responses/QuestionnaireResponses.js
+++ b/fair-audience/src/Admin/questionnaire-responses/QuestionnaireResponses.js
@@ -35,6 +35,9 @@ export default function QuestionnaireResponses() {
 	const [isLoading, setIsLoading] = useState(true);
 	const [view, setView] = useState(DEFAULT_VIEW);
 
+	// Markdown export feedback state.
+	const [copyFeedback, setCopyFeedback] = useState(null);
+
 	// Add-to-group modal state.
 	const [isGroupModalOpen, setIsGroupModalOpen] = useState(false);
 	const [groupMode, setGroupMode] = useState('existing');
@@ -388,6 +391,94 @@ export default function QuestionnaireResponses() {
 		((groupMode === 'existing' && selectedGroupId) ||
 			(groupMode === 'new' && newGroupName.trim()));
 
+	const buildMarkdown = () => {
+		const lines = [];
+		const heading = title || __('Questionnaire Responses', 'fair-audience');
+		const exportedLabel = __('Exported', 'fair-audience');
+		const responsesLabel = __('Responses', 'fair-audience');
+		const adminLinkLabel = __('Admin link', 'fair-audience');
+		const submittedLabel = __('Submitted', 'fair-audience');
+
+		const adminBase = `${window.location.origin}${window.location.pathname}`;
+
+		const today = new Date().toISOString().split('T')[0];
+
+		lines.push(`# ${heading}`);
+		lines.push('');
+		lines.push(`_${exportedLabel} ${today}_`);
+		lines.push('');
+		lines.push(`- ${responsesLabel}: ${responses.length}`);
+		lines.push(`- ${adminLinkLabel}: ${window.location.href}`);
+		lines.push('');
+
+		responses.forEach((response) => {
+			const respondent =
+				response.participant_name ||
+				response.participant_email ||
+				`#${response.id}`;
+
+			lines.push('---');
+			lines.push('');
+			if (response.participant_id) {
+				const participantUrl = `${adminBase}?page=fair-audience-participant-detail&participant_id=${response.participant_id}`;
+				lines.push(`## [${respondent}](${participantUrl})`);
+			} else {
+				lines.push(`## ${respondent}`);
+			}
+			lines.push('');
+			if (response.created_at) {
+				lines.push(`_${submittedLabel} ${response.created_at}_`);
+				lines.push('');
+			}
+
+			(response.answers || []).forEach((answer) => {
+				lines.push(`### ${answer.question_text}`);
+				lines.push('');
+
+				if (answer.file_url) {
+					const alt = answer.question_text || '';
+					if (answer.is_image) {
+						lines.push(`![${alt}](${answer.file_url})`);
+					} else {
+						lines.push(`[${alt}](${answer.file_url})`);
+					}
+				} else {
+					lines.push(answer.answer_value || '');
+				}
+				lines.push('');
+			});
+		});
+
+		return lines.join('\n');
+	};
+
+	const copyMarkdown = () => {
+		if (!navigator.clipboard) {
+			setCopyFeedback({
+				status: 'error',
+				message: __('Clipboard not available.', 'fair-audience'),
+			});
+			return;
+		}
+		navigator.clipboard
+			.writeText(buildMarkdown())
+			.then(() => {
+				setCopyFeedback({
+					status: 'success',
+					message: __(
+						'Markdown copied to clipboard. Paste into Google Docs.',
+						'fair-audience'
+					),
+				});
+			})
+			.catch(() => {
+				setCopyFeedback({
+					status: 'error',
+					message: __('Failed to copy.', 'fair-audience'),
+				});
+			});
+	};
+
 	const exportCsv = () => {
 		if (responses.length === 0) {
 			return;
@@ -502,7 +593,23 @@ export default function QuestionnaireResponses() {
 				>
 					{__('Export CSV', 'fair-audience')}
 				</Button>
+				<Button
+					variant="secondary"
+					onClick={copyMarkdown}
+					disabled={responses.length === 0}
+				>
+					{__('Copy Markdown', 'fair-audience')}
+				</Button>
 			</div>
+
+			{copyFeedback && (
+				<Notice
+					status={copyFeedback.status}
+					onRemove={() => setCopyFeedback(null)}
+				>
+					{copyFeedback.message}
+				</Notice>
+			)}
 
 			{isGroupModalOpen && (
 				<Modal

--- a/fair-events/fair-events.php
+++ b/fair-events/fair-events.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fair Events
  * Plugin URI: https://github.com/marcin-wosinek/fair-event-plugins
  * Description: Event management plugin.
- * Version: 1.2.0-54-g58bb29b
+ * Version: 1.2.0-71-gc03700d-dirty
  * Requires at least: 6.7
  * Requires PHP: 7.4
  * Author: Marcin Wosinek

--- a/fair-payment/fair-payment.php
+++ b/fair-payment/fair-payment.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fair Payment
  * Plugin URI: https://fair-event-plugins.com
  * Description: Simple payment block for WordPress
- * Version: 1.2.0-54-g58bb29b
+ * Version: 1.2.0-71-gc03700d-dirty
  * Author: Fair Event Plugins
  * Author URI: https://fair-event-plugins.com
  * License: GPL-2.0-or-later


### PR DESCRIPTION
Adds an Export to Markdown button on the questionnaire responses admin
page. Opens a modal with the generated markdown and a copy-to-clipboard
button so it can be pasted into Google Docs (or any other editor),
where headings and inline images render automatically.

Image file_upload answers are emitted as ![alt](url) for inline embed;
non-image uploads as plain links. The list endpoint now returns file_url
and is_image for file_upload answers, mirroring the single-item endpoint.

Refs #586
