### PR TITLE
Close payment callback popup without page reload (#579)

### DIFF
--- a/fair-payment/src/blocks/simple-payment/render.php
+++ b/fair-payment/src/blocks/simple-payment/render.php
@@ -24,11 +24,6 @@ $show_success = isset( $_GET['payment_redirect'] ) && '1' === $_GET['payment_red
 $is_configured = \FairPayment\Payment\MolliePaymentHandler::is_configured();
 
 $block_id = 'fair-payment-' . wp_unique_id();
-
-// Generate clean URL without callback parameters.
-if ( $is_callback ) {
-	$clean_url = remove_query_arg( array( 'fair_payment_callback', 'transaction_id' ) );
-}
 ?>
 
 <div <?php echo get_block_wrapper_attributes( array( 'id' => $block_id ) ); ?>>
@@ -38,9 +33,9 @@ if ( $is_callback ) {
 				<div class="fair-payment-success">
 					<p><?php esc_html_e( 'Thank you! Your payment has been received and is being processed.', 'fair-payment' ); ?></p>
 				</div>
-				<a href="<?php echo esc_url( $clean_url ); ?>" class="wp-element-button">
+				<button type="button" class="fair-payment-callback-dismiss wp-element-button">
 					<?php esc_html_e( 'Continue', 'fair-payment' ); ?>
-				</a>
+				</button>
 			</div>
 		<?php else : ?>
 			<?php if ( $show_success ) : ?>

--- a/fair-payment/src/blocks/simple-payment/view.js
+++ b/fair-payment/src/blocks/simple-payment/view.js
@@ -11,9 +11,14 @@ import apiFetch from '@wordpress/api-fetch';
 
 	// Defensive: handle both scenarios (DOM loading or already loaded)
 	if (document.readyState === 'loading') {
-		document.addEventListener('DOMContentLoaded', initPaymentButtons);
+		document.addEventListener('DOMContentLoaded', init);
 	} else {
+		init();
+	}
+
+	function init() {
 		initPaymentButtons();
+		initCallbackDismiss();
 	}
 
 	function initPaymentButtons() {
@@ -22,6 +27,30 @@ import apiFetch from '@wordpress/api-fetch';
 		buttons.forEach(function (button) {
 			button.addEventListener('click', handlePaymentClick);
 		});
+	}
+
+	function initCallbackDismiss() {
+		const buttons = document.querySelectorAll(
+			'.fair-payment-callback-dismiss'
+		);
+
+		buttons.forEach(function (button) {
+			button.addEventListener('click', handleCallbackDismiss);
+		});
+	}
+
+	function handleCallbackDismiss(event) {
+		const button = event.currentTarget;
+		const callback = button.closest('.fair-payment-callback');
+
+		if (callback) {
+			callback.remove();
+		}
+
+		const url = new URL(window.location.href);
+		url.searchParams.delete('fair_payment_callback');
+		url.searchParams.delete('transaction_id');
+		window.history.replaceState({}, '', url.toString());
 	}
 
 	async function handlePaymentClick(event) {


### PR DESCRIPTION
## Summary
- Convert the payment callback "Continue" / "Entendido" link in the `simple-payment` block to an in-place dismiss button.
- On click, the popup is removed from the DOM and `fair_payment_callback` + `transaction_id` are stripped from the URL via `history.replaceState()` — no page reload, no leftover query params.

Closes #579.

## Test plan
- [ ] Trigger a payment so the page loads with `?fair_payment_callback=true&transaction_id=…`
- [ ] Click "Continue" / "Entendido" — popup disappears in place, no full reload
- [ ] Address bar no longer contains `fair_payment_callback` or `transaction_id`
- [ ] Reload the page — popup does not reappear