### PR TITLE
Derive activity option price from active sale period (#598)

### DIFF
--- a/PLAN-598.md
+++ b/PLAN-598.md
@@ -1,0 +1,103 @@
+# Plan: Activity option price derived from active sale period (#598)
+
+## Background
+
+`TicketOption` (the "activity option") currently stores a single `price`
+on the `wp_fair_events_ticket_options` row. We want an opt-in mode where
+that price is computed on read from the currently active
+`TicketSalePeriod` for the event date, mirroring how ticket-type pricing
+already works via `TicketPrice` (`ticket_type_id`, `sale_period_id`).
+
+Key call sites that read `$option->price` today:
+- `fair-audience/src/blocks/event-signup/render.php:424` — frontend display.
+- `fair-audience/src/API/EventSignupController.php:905` — signup/checkout pricing
+  (`compute_option_price`).
+- `fair-audience/src/Hooks/PaymentHooks.php:318` — payment line totals.
+- `fair-audience/src/API/EventParticipantsController.php:617` — admin
+  participants view.
+- `fair-events/src/API/TicketsController.php` — admin editor read/write.
+
+## Open question (flag during review)
+
+`TicketSalePeriod` itself carries no price column — for ticket types the
+period+price pair lives in `TicketPrice`. To "derive from the active sale
+period" we need a per-(option, period) price store.
+
+**Proposed:** add a sibling table `wp_fair_events_ticket_option_prices`
+keyed (`ticket_option_id`, `sale_period_id`, `price`), mirroring
+`TicketPrice`. Editor shows a price-per-period grid for the option when
+the toggle is ON.
+
+Alternative: a single "active-period multiplier" or reusing
+`TicketPrice` of a designated ticket type — both feel like the wrong
+shape. Confirm the new-table approach before schema work begins.
+
+## Tasks
+
+### 1. Schema
+- Add `derive_price_from_sale_period TINYINT(1) NOT NULL DEFAULT 0` to
+  `wp_fair_events_ticket_options` in
+  `fair-events/src/Database/Schema.php::get_ticket_options_table_sql()`.
+- Add new table `wp_fair_events_ticket_option_prices` (
+  `ticket_option_id`, `sale_period_id`, `price DECIMAL(10,2)`,
+  PK on the pair, FK-ish index on both columns).
+- Bump `Installer` schema version so `dbDelta` picks the column up on
+  existing installs.
+
+### 2. Model layer
+- Add `derive_price_from_sale_period` field + accessors on
+  `TicketOption` (hydrate, `to_array`, `create`, `update`).
+- New `TicketOptionPrice` model alongside `TicketPrice` with
+  `get_by_option_and_period()`,
+  `get_all_by_option_id()`, `upsert()`, `delete_by_option_id()`,
+  `delete_by_sale_period_id()`.
+
+### 3. Resolver service
+- New `ActivityOptionPriceResolver::resolve( TicketOption $option, int $event_date_id, ?int $participant_id = null, ?string $now = null ): ?float`.
+- When the toggle is OFF, return `(float) $option->price`.
+- When ON: pick the active `TicketSalePeriod` using the same
+  "continues_pricing_period" logic as
+  `EventSignupPricing::resolve_price_for_ticket_type()`; look up the
+  matching `TicketOptionPrice`. **Fallback behaviour is identical to
+  ticket types**: if `continues_pricing_period` is on and now is past
+  the last period start, use the last period; otherwise return `null`
+  (option not purchasable right now).
+- Reuse `EventSignupPricing::apply_discount()` + group-rule lookup so
+  group discounts still apply on top of the resolved base price (keeps
+  parity with current `compute_option_price` behaviour).
+
+### 4. Call-site audit
+Replace every direct `$option->price` read with the resolver:
+- `fair-audience/src/blocks/event-signup/render.php`
+- `fair-audience/src/API/EventSignupController.php::compute_option_price`
+  (resolve before group-discount + invitation-price branches).
+- `fair-audience/src/Hooks/PaymentHooks.php` (payment totals).
+- `fair-audience/src/API/EventParticipantsController.php` (display only).
+- Anywhere `to_array()` output is forwarded to the editor: keep raw
+  stored `price` for admin editing, but expose a `resolved_price` field
+  for read-only consumers.
+
+### 5. Admin editor
+- `fair-events/src/Admin/manage-event/` — add a toggle on each activity
+  option row ("Derive price from active sale period").
+- When ON: hide/disable the manual price input; render a price grid
+  keyed by the event date's sale periods (similar to the existing
+  ticket-type price grid).
+- Persist via `TicketsController` — extend the options PUT payload with
+  the flag and `period_prices: [{ sale_period_id, price }]`.
+
+### 6. Tests
+- Resolver unit-ish test: toggle off returns stored price; toggle on
+  matches the active period; no active period uses fallback; participant
+  with group discount gets discounted price.
+- `EventSignupController` checkout total test with toggle ON to confirm
+  totals match resolver output.
+- Editor save round-trip: toggle persists; period grid persists.
+
+## Out of scope
+- Ticket-type pricing changes.
+- Storing a derived snapshot anywhere — always resolved live.
+- Migrating existing manual prices into the period grid (left to the
+  user when they flip the toggle).
+
+Closes #598

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -902,7 +902,12 @@ class EventSignupController extends WP_REST_Controller {
 			}
 		}
 
-		$opt_price = (float) $option->price;
+		if ( class_exists( \FairEvents\Services\ActivityOptionPriceResolver::class ) ) {
+			$resolved  = \FairEvents\Services\ActivityOptionPriceResolver::resolve( $option );
+			$opt_price = null !== $resolved ? (float) $resolved : 0.0;
+		} else {
+			$opt_price = (float) $option->price;
+		}
 		if ( $best_discount_rule && $opt_price > 0 && class_exists( \FairEvents\Services\EventSignupPricing::class ) ) {
 			$opt_price = \FairEvents\Services\EventSignupPricing::apply_discount(
 				$opt_price,

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -314,8 +314,13 @@ class PaymentHooks {
 		$labels   = array();
 
 		foreach ( $options as $opt ) {
-			$name             = (string) $opt->name;
-			$price            = (float) $opt->price;
+			$name = (string) $opt->name;
+			if ( class_exists( \FairEvents\Services\ActivityOptionPriceResolver::class ) ) {
+				$resolved = \FairEvents\Services\ActivityOptionPriceResolver::resolve( $opt );
+				$price    = null !== $resolved ? (float) $resolved : (float) $opt->price;
+			} else {
+				$price = (float) $opt->price;
+			}
 			$discounted_price = (float) $opt->discounted_price;
 			if ( $discounted_price >= $price || ! isset( $amounts_by_name[ $name ] ) ) {
 				continue;

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -421,7 +421,14 @@ if ( $pricing_event_date_id && class_exists( \FairEvents\Models\TicketOption::cl
 	$invitation_inviter_id = $valid_invitation_token ? (int) $valid_invitation_token->inviter_participant_id : null;
 
 	foreach ( $raw_options as $opt ) {
-		$opt_price        = (float) $opt->price;
+		$resolved_base = class_exists( \FairEvents\Services\ActivityOptionPriceResolver::class )
+			? \FairEvents\Services\ActivityOptionPriceResolver::resolve( $opt )
+			: (float) $opt->price;
+		if ( null === $resolved_base ) {
+			// Derived mode with no active period / no row → option not purchasable; skip.
+			continue;
+		}
+		$opt_price        = (float) $resolved_base;
 		$invitation_price = null;
 		if ( $invitation_inviter_id && class_exists( \FairEvents\Services\EventSignupPricing::class ) ) {
 			$invitation_price = \FairEvents\Services\EventSignupPricing::resolve_option_invitation_price(

--- a/fair-events/src/API/TicketsController.php
+++ b/fair-events/src/API/TicketsController.php
@@ -16,6 +16,7 @@ use FairEvents\Models\TicketSalePeriod;
 use FairEvents\Models\TicketPrice;
 use FairEvents\Models\TicketOption;
 use FairEvents\Models\TicketOptionCollaborator;
+use FairEvents\Models\TicketOptionPrice;
 use FairEvents\Models\TicketTypeGroupRestriction;
 use WP_REST_Controller;
 use WP_REST_Server;
@@ -210,28 +211,55 @@ class TicketsController extends WP_REST_Controller {
 			$capacity             = ( null === $capacity_raw || '' === $capacity_raw )
 				? null
 				: absint( $capacity_raw );
+			$derive               = ! empty( $option_data['derive_price_from_sale_period'] );
 			$collaborator_ids     = isset( $option_data['collaborator_ids'] ) && is_array( $option_data['collaborator_ids'] )
 				? array_values( array_unique( array_filter( array_map( 'absint', $option_data['collaborator_ids'] ) ) ) )
+				: array();
+			$period_prices_raw    = isset( $option_data['period_prices'] ) && is_array( $option_data['period_prices'] )
+				? $option_data['period_prices']
 				: array();
 			if ( '' === $name ) {
 				continue;
 			}
 			$option_id = isset( $option_data['id'] ) ? (int) $option_data['id'] : 0;
 			if ( $option_id && in_array( $option_id, $existing_ids, true ) ) {
-				TicketOption::update( $option_id, $name, $price, $index, $short_name, $discounted_price, $capacity );
+				TicketOption::update( $option_id, $name, $price, $index, $short_name, $discounted_price, $capacity, $derive );
 				TicketOptionCollaborator::sync_for_option( $option_id, $collaborator_ids );
-				$kept_ids[] = $option_id;
+				$kept_ids[]      = $option_id;
+				$saved_option_id = $option_id;
 			} else {
-				$new_id = TicketOption::create( $event_date_id, $name, $price, $index, $short_name, $discounted_price, $capacity );
+				$new_id = TicketOption::create( $event_date_id, $name, $price, $index, $short_name, $discounted_price, $capacity, $derive );
 				if ( $new_id ) {
 					TicketOptionCollaborator::sync_for_option( (int) $new_id, $collaborator_ids );
-					$kept_ids[] = $new_id;
+					$kept_ids[]      = $new_id;
+					$saved_option_id = (int) $new_id;
+				} else {
+					$saved_option_id = 0;
+				}
+			}
+
+			// Replace per-period prices for this option (only meaningful when derive is on).
+			if ( $saved_option_id ) {
+				TicketOptionPrice::delete_by_option_id( $saved_option_id );
+				if ( $derive ) {
+					foreach ( $period_prices_raw as $pp ) {
+						$pp_index     = (int) ( $pp['sale_period_index'] ?? -1 );
+						$pp_period_id = isset( $pp['sale_period_id'] )
+							? (int) $pp['sale_period_id']
+							: ( $period_ids[ $pp_index ] ?? 0 );
+						if ( ! $pp_period_id ) {
+							continue;
+						}
+						$pp_price = isset( $pp['price'] ) ? (float) $pp['price'] : 0.0;
+						TicketOptionPrice::upsert( $saved_option_id, $pp_period_id, $pp_price );
+					}
 				}
 			}
 		}
 		$to_delete = array_diff( $existing_ids, $kept_ids );
 		foreach ( $to_delete as $del_id ) {
 			TicketOptionCollaborator::delete_by_option_id( (int) $del_id );
+			TicketOptionPrice::delete_by_option_id( (int) $del_id );
 			global $wpdb;
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->delete(
@@ -387,6 +415,7 @@ class TicketsController extends WP_REST_Controller {
 		foreach ( $existing_options_for_clear as $existing_option ) {
 			TicketOptionCollaborator::delete_by_option_id( (int) $existing_option->id );
 		}
+		TicketOptionPrice::delete_by_event_date_id( $event_date_id );
 		TicketOption::delete_by_event_date_id( $event_date_id );
 		$incoming_options = isset( $body['options'] ) && is_array( $body['options'] )
 			? $body['options']
@@ -406,14 +435,27 @@ class TicketsController extends WP_REST_Controller {
 			$capacity             = ( null === $capacity_raw || '' === $capacity_raw )
 				? null
 				: absint( $capacity_raw );
+			$derive               = ! empty( $option_data['derive_price_from_sale_period'] );
 			if ( '' !== $name ) {
-				$new_id = TicketOption::create( $event_date_id, $name, $price, $index, $short_name, $discounted_price, $capacity );
-				if ( $new_id && isset( $option_data['collaborator_ids'] ) && is_array( $option_data['collaborator_ids'] ) ) {
-					$collaborator_ids = array_values(
-						array_unique( array_filter( array_map( 'absint', $option_data['collaborator_ids'] ) ) )
-					);
-					if ( ! empty( $collaborator_ids ) ) {
-						TicketOptionCollaborator::sync_for_option( (int) $new_id, $collaborator_ids );
+				$new_id = TicketOption::create( $event_date_id, $name, $price, $index, $short_name, $discounted_price, $capacity, $derive );
+				if ( $new_id ) {
+					if ( isset( $option_data['collaborator_ids'] ) && is_array( $option_data['collaborator_ids'] ) ) {
+						$collaborator_ids = array_values(
+							array_unique( array_filter( array_map( 'absint', $option_data['collaborator_ids'] ) ) )
+						);
+						if ( ! empty( $collaborator_ids ) ) {
+							TicketOptionCollaborator::sync_for_option( (int) $new_id, $collaborator_ids );
+						}
+					}
+					if ( $derive && isset( $option_data['period_prices'] ) && is_array( $option_data['period_prices'] ) ) {
+						foreach ( $option_data['period_prices'] as $pp ) {
+							$pp_period_index = (int) ( $pp['sale_period_index'] ?? -1 );
+							if ( ! isset( $period_ids_by_index[ $pp_period_index ] ) ) {
+								continue;
+							}
+							$pp_price = isset( $pp['price'] ) ? (float) $pp['price'] : 0.0;
+							TicketOptionPrice::upsert( (int) $new_id, $period_ids_by_index[ $pp_period_index ], $pp_price );
+						}
 					}
 				}
 			}
@@ -510,6 +552,7 @@ class TicketsController extends WP_REST_Controller {
 		foreach ( $existing_ids as $eid ) {
 			if ( ! in_array( $eid, $incoming_ids, true ) ) {
 				TicketPrice::delete_by_sale_period_id( $eid );
+				TicketOptionPrice::delete_by_sale_period_id( $eid );
 				TicketSalePeriod::delete( $eid );
 			}
 		}
@@ -577,6 +620,15 @@ class TicketsController extends WP_REST_Controller {
 		$options       = TicketOption::get_all_by_event_date_id( $event_date_id );
 		$restrictions  = TicketTypeGroupRestriction::get_all_by_event_date_id( $event_date_id );
 		$collaborators = TicketOptionCollaborator::get_all_by_event_date_id( $event_date_id );
+		$option_prices = TicketOptionPrice::get_all_by_event_date_id( $event_date_id );
+
+		$option_prices_by_option = array();
+		foreach ( $option_prices as $op ) {
+			$option_prices_by_option[ $op->ticket_option_id ][] = array(
+				'sale_period_id' => $op->sale_period_id,
+				'price'          => $op->price,
+			);
+		}
 
 		$settings = array();
 		foreach ( $raw_settings as $key => $value ) {
@@ -603,9 +655,10 @@ class TicketsController extends WP_REST_Controller {
 			'prices'       => array_map( fn( $pr ) => $pr->to_array(), $prices ),
 			'settings'     => $settings,
 			'options'      => array_map(
-				function ( $o ) use ( $collaborators ) {
+				function ( $o ) use ( $collaborators, $option_prices_by_option ) {
 					$data                     = $o->to_array();
 					$data['collaborator_ids'] = $collaborators[ $o->id ] ?? array();
+					$data['period_prices']    = $option_prices_by_option[ $o->id ] ?? array();
 					return $data;
 				},
 				$options

--- a/fair-events/src/Admin/calendar/CalendarApp.js
+++ b/fair-events/src/Admin/calendar/CalendarApp.js
@@ -200,9 +200,6 @@ export default function CalendarApp() {
 					manageEventUrl={
 						window.fairEventsCalendarData?.manageEventUrl
 					}
-					participantsUrl={
-						window.fairEventsCalendarData?.participantsUrl
-					}
 				/>
 			)}
 

--- a/fair-events/src/Admin/calendar/components/CalendarGrid.js
+++ b/fair-events/src/Admin/calendar/components/CalendarGrid.js
@@ -20,7 +20,6 @@ export default function CalendarGrid({
 	onAddEvent,
 	manageEventUrl,
 	startOfWeek: startOfWeekProp,
-	participantsUrl,
 }) {
 	// Get start_of_week setting (0 = Sunday, 1 = Monday)
 	const startOfWeek =
@@ -109,7 +108,6 @@ export default function CalendarGrid({
 							isPast={isPast}
 							onAddEvent={onAddEvent}
 							manageEventUrl={manageEventUrl}
-							participantsUrl={participantsUrl}
 						/>
 					);
 				})}

--- a/fair-events/src/Admin/calendar/components/DayCell.js
+++ b/fair-events/src/Admin/calendar/components/DayCell.js
@@ -101,7 +101,6 @@ export default function DayCell({
 	isPast,
 	onAddEvent,
 	manageEventUrl,
-	participantsUrl,
 }) {
 	const dayNumber = date.getDate();
 	const hasEvents = events.length > 0;
@@ -193,22 +192,29 @@ export default function DayCell({
 										)}
 									</span>
 								)}
-								{participantsUrl &&
-									getEventDateId(event.uid) && (
-										<a
-											href={`${participantsUrl}${getEventDateId(
-												event.uid
-											)}`}
-											className="fair-events-calendar-participants-link"
-											title={__(
-												'View Participants',
-												'fair-events'
-											)}
-											onClick={(e) => e.stopPropagation()}
-										>
-											<span className="dashicons dashicons-groups" />
-										</a>
-									)}
+								{event.url && (
+									<a
+										href={event.url}
+										className="fair-events-calendar-destination-link"
+										title={__(
+											'Open link destination',
+											'fair-events'
+										)}
+										target={
+											linkType === 'external'
+												? '_blank'
+												: undefined
+										}
+										rel={
+											linkType === 'external'
+												? 'noopener noreferrer'
+												: undefined
+										}
+										onClick={(e) => e.stopPropagation()}
+									>
+										<span className="dashicons dashicons-external" />
+									</a>
+								)}
 							</div>
 						);
 					})}

--- a/fair-events/src/Admin/calendar/style.css
+++ b/fair-events/src/Admin/calendar/style.css
@@ -191,7 +191,7 @@ a.fair-events-calendar-event:visited {
 	border-radius: 3px 0 0 3px;
 }
 
-.fair-events-calendar-event-row .fair-events-calendar-participants-link {
+.fair-events-calendar-event-row .fair-events-calendar-destination-link {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -203,11 +203,11 @@ a.fair-events-calendar-event:visited {
 	flex-shrink: 0;
 }
 
-.fair-events-calendar-event-row .fair-events-calendar-participants-link:hover {
+.fair-events-calendar-event-row .fair-events-calendar-destination-link:hover {
 	background: #0e4a78;
 }
 
-.fair-events-calendar-event-row .fair-events-calendar-participants-link .dashicons {
+.fair-events-calendar-event-row .fair-events-calendar-destination-link .dashicons {
 	font-size: 12px;
 	width: 12px;
 	height: 12px;
@@ -217,7 +217,7 @@ a.fair-events-calendar-event:visited {
 	border-radius: 3px;
 }
 
-.fair-events-calendar-event-row:has(.fair-events-calendar-participants-link) .fair-events-calendar-event {
+.fair-events-calendar-event-row:has(.fair-events-calendar-destination-link) .fair-events-calendar-event {
 	border-radius: 3px 0 0 3px;
 }
 

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -122,7 +122,7 @@ export default function EventTickets({
 		if (data.settings) {
 			setSettings((prev) => ({ ...prev, ...data.settings }));
 		}
-		setOptions(data.options || []);
+		setOptions((data.options || []).map(normalizeOption));
 	}, []);
 
 	const loadTickets = useCallback(async () => {
@@ -260,10 +260,9 @@ export default function EventTickets({
 					})),
 					prices: pricesArray,
 					settings,
-					options: options.map((o, i) => ({
-						...o,
-						sort_order: i,
-					})),
+					options: options.map((o, i) =>
+						serializeOptionForSave(o, i)
+					),
 				},
 			});
 
@@ -306,7 +305,7 @@ export default function EventTickets({
 			if (data.settings) {
 				setSettings((prev) => ({ ...prev, ...data.settings }));
 			}
-			setOptions(data.options || []);
+			setOptions((data.options || []).map(normalizeOption));
 
 			setSuccess(__('Tickets saved successfully.', 'fair-events'));
 		} catch (err) {
@@ -379,6 +378,12 @@ export default function EventTickets({
 					o.capacity !== ''
 						? o.capacity
 						: null,
+				derive_price_from_sale_period:
+					!!o.derive_price_from_sale_period,
+				period_prices: serializeOptionPeriodPrices(o).map((pp) => ({
+					sale_period_index: pp.sale_period_index,
+					price: pp.price,
+				})),
 				collaborator_ids: Array.isArray(o.collaborator_ids)
 					? o.collaborator_ids
 					: [],
@@ -512,6 +517,57 @@ export default function EventTickets({
 		return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(
 			now.getDate()
 		)} ${pad(now.getHours())}:${pad(now.getMinutes())}:00`;
+	};
+
+	const periodPriceKey = (period, pIndex) =>
+		period && period.id ? String(period.id) : `new-${pIndex}`;
+
+	const normalizeOption = (o) => {
+		const map = {};
+		(o.period_prices || []).forEach((pp) => {
+			if (
+				pp &&
+				pp.sale_period_id !== undefined &&
+				pp.sale_period_id !== null
+			) {
+				map[String(pp.sale_period_id)] = String(pp.price);
+			}
+		});
+		return {
+			...o,
+			derive_price_from_sale_period: !!o.derive_price_from_sale_period,
+			period_prices_map: map,
+		};
+	};
+
+	const serializeOptionPeriodPrices = (option) => {
+		if (!option.derive_price_from_sale_period) {
+			return [];
+		}
+		const out = [];
+		salePeriods.forEach((p, pIdx) => {
+			const key = periodPriceKey(p, pIdx);
+			const raw = option.period_prices_map?.[key];
+			if (raw === undefined || raw === '') return;
+			const entry = {
+				sale_period_index: pIdx,
+				price: parseFloat(raw) || 0,
+			};
+			if (p.id) entry.sale_period_id = p.id;
+			out.push(entry);
+		});
+		return out;
+	};
+
+	const serializeOptionForSave = (option, index) => {
+		const { period_prices_map: _unused, ...rest } = option;
+		return {
+			...rest,
+			sort_order: index,
+			derive_price_from_sale_period:
+				!!option.derive_price_from_sale_period,
+			period_prices: serializeOptionPeriodPrices(option),
+		};
 	};
 
 	const addSalePeriod = () => {
@@ -1725,6 +1781,12 @@ export default function EventTickets({
 												</th>
 												<th>
 													{__(
+														'Per-period pricing',
+														'fair-events'
+													)}
+												</th>
+												<th>
+													{__(
 														'Collaborator(s)',
 														'fair-events'
 													)}
@@ -1812,6 +1874,9 @@ export default function EventTickets({
 																type="number"
 																step="0.01"
 																min="0"
+																disabled={
+																	!!option.derive_price_from_sale_period
+																}
 																value={
 																	option.price !==
 																	undefined
@@ -1949,6 +2014,126 @@ export default function EventTickets({
 															/>
 														</td>
 														<td>
+															<CheckboxControl
+																label={__(
+																	'Per period',
+																	'fair-events'
+																)}
+																checked={
+																	!!option.derive_price_from_sale_period
+																}
+																onChange={(
+																	checked
+																) => {
+																	const updated =
+																		[
+																			...options,
+																		];
+																	updated[
+																		index
+																	] = {
+																		...updated[
+																			index
+																		],
+																		derive_price_from_sale_period:
+																			checked,
+																	};
+																	setOptions(
+																		updated
+																	);
+																}}
+																__nextHasNoMarginBottom
+															/>
+															{option.derive_price_from_sale_period && (
+																<VStack
+																	spacing={2}
+																>
+																	{salePeriods.length ===
+																	0 ? (
+																		<em>
+																			{__(
+																				'Add sale periods first.',
+																				'fair-events'
+																			)}
+																		</em>
+																	) : (
+																		salePeriods.map(
+																			(
+																				period,
+																				pIdx
+																			) => {
+																				const key =
+																					periodPriceKey(
+																						period,
+																						pIdx
+																					);
+																				const val =
+																					option
+																						.period_prices_map?.[
+																						key
+																					] ??
+																					'';
+																				return (
+																					<TextControl
+																						key={
+																							key
+																						}
+																						type="number"
+																						step="0.01"
+																						min="0"
+																						label={
+																							period.name ||
+																							__(
+																								'Period',
+																								'fair-events'
+																							) +
+																								' ' +
+																								(pIdx +
+																									1)
+																						}
+																						value={
+																							val
+																						}
+																						onChange={(
+																							v
+																						) => {
+																							const updated =
+																								[
+																									...options,
+																								];
+																							const prev =
+																								updated[
+																									index
+																								]
+																									.period_prices_map ||
+																								{};
+																							updated[
+																								index
+																							] =
+																								{
+																									...updated[
+																										index
+																									],
+																									period_prices_map:
+																										{
+																											...prev,
+																											[key]: v,
+																										},
+																								};
+																							setOptions(
+																								updated
+																							);
+																						}}
+																						__nextHasNoMarginBottom
+																					/>
+																				);
+																			}
+																		)
+																	)}
+																</VStack>
+															)}
+														</td>
+														<td>
 															<FormTokenField
 																value={collaboratorIds.map(
 																	(id) =>
@@ -2044,6 +2229,8 @@ export default function EventTickets({
 											price: 0,
 											discounted_price: null,
 											capacity: null,
+											derive_price_from_sale_period: false,
+											period_prices_map: {},
 											collaborator_ids: [],
 											sort_order: options.length,
 										},

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -77,6 +77,9 @@ class Installer {
 		$sql = Schema::get_ticket_option_collaborators_table_sql();
 		dbDelta( $sql );
 
+		$sql = Schema::get_ticket_option_prices_table_sql();
+		dbDelta( $sql );
+
 		// Run migration if upgrading from pre-1.0.0
 		if ( version_compare( $current_version, '1.0.0', '<' ) ) {
 			self::migrate_to_1_0_0();
@@ -200,6 +203,12 @@ class Installer {
 			self::migrate_to_3_8_0();
 		}
 
+		// Run migration if upgrading from pre-3.9.0 (add derive_price_from_sale_period to ticket_options).
+		// Version 3.9.0 - Ticket option prices table (no data migration needed, table created by dbDelta).
+		if ( version_compare( $current_version, '3.9.0', '<' ) ) {
+			self::migrate_to_3_9_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -314,6 +323,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.8.0', '<' ) ) {
 				self::migrate_to_3_8_0();
+			}
+
+			if ( version_compare( $current_version, '3.9.0', '<' ) ) {
+				self::migrate_to_3_9_0();
 			}
 
 			// Install/update tables
@@ -1242,6 +1255,33 @@ class Installer {
 			$wpdb->query(
 				$wpdb->prepare(
 					'ALTER TABLE %i ADD COLUMN capacity INT UNSIGNED DEFAULT NULL AFTER discounted_price',
+					$table_name
+				)
+			);
+		}
+	}
+
+	/**
+	 * Migrate to version 3.9.0 - Add derive_price_from_sale_period column to ticket_options table.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_9_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_events_ticket_options';
+
+		$column_exists = $wpdb->get_results(
+			$wpdb->prepare(
+				"SHOW COLUMNS FROM %i LIKE 'derive_price_from_sale_period'",
+				$table_name
+			)
+		);
+
+		if ( empty( $column_exists ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD COLUMN derive_price_from_sale_period TINYINT(1) NOT NULL DEFAULT 0 AFTER capacity',
 					$table_name
 				)
 			);

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.8.0';
+	const DB_VERSION = '3.9.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -404,11 +404,38 @@ class Schema {
 			price DECIMAL(10,2) NOT NULL DEFAULT 0.00,
 			discounted_price DECIMAL(10,2) DEFAULT NULL,
 			capacity INT UNSIGNED DEFAULT NULL,
+			derive_price_from_sale_period TINYINT(1) NOT NULL DEFAULT 0,
 			sort_order INT UNSIGNED NOT NULL DEFAULT 0,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY (id),
 			KEY idx_event_date_id (event_date_id)
+		) ENGINE=InnoDB {$charset_collate};";
+	}
+
+	/**
+	 * Get the SQL for creating the fair_events_ticket_option_prices table
+	 *
+	 * Per-(option, sale_period) price store for activity options whose
+	 * `derive_price_from_sale_period` flag is on. Mirrors how `TicketPrice`
+	 * keys ticket-type prices to sale periods.
+	 *
+	 * @return string SQL statement for creating the table.
+	 */
+	public static function get_ticket_option_prices_table_sql() {
+		global $wpdb;
+
+		$table_name      = $wpdb->prefix . 'fair_events_ticket_option_prices';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		return "CREATE TABLE {$table_name} (
+			ticket_option_id BIGINT UNSIGNED NOT NULL,
+			sale_period_id BIGINT UNSIGNED NOT NULL,
+			price DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY (ticket_option_id, sale_period_id),
+			KEY idx_sale_period_id (sale_period_id)
 		) ENGINE=InnoDB {$charset_collate};";
 	}
 

--- a/fair-events/src/Models/TicketOption.php
+++ b/fair-events/src/Models/TicketOption.php
@@ -66,6 +66,15 @@ class TicketOption {
 	public $capacity;
 
 	/**
+	 * When true, the effective price is resolved from the currently
+	 * active TicketSalePeriod via TicketOptionPrice rather than
+	 * the stored $price column.
+	 *
+	 * @var bool
+	 */
+	public $derive_price_from_sale_period = false;
+
+	/**
 	 * Sort order
 	 *
 	 * @var int
@@ -163,9 +172,10 @@ class TicketOption {
 	 * @param string|null $short_name       Optional short name.
 	 * @param float|null  $discounted_price Optional discounted price.
 	 * @param int|null    $capacity         Optional capacity (null = unlimited).
+	 * @param bool        $derive_price_from_sale_period Whether to derive price from active sale period.
 	 * @return int|false The option ID on success, false on failure.
 	 */
-	public static function create( $event_date_id, $name, $price, $sort_order, $short_name = null, $discounted_price = null, $capacity = null ) {
+	public static function create( $event_date_id, $name, $price, $sort_order, $short_name = null, $discounted_price = null, $capacity = null, $derive_price_from_sale_period = false ) {
 		global $wpdb;
 
 		$table_name = self::get_table_name();
@@ -173,15 +183,16 @@ class TicketOption {
 		$result = $wpdb->insert(
 			$table_name,
 			array(
-				'event_date_id'    => $event_date_id,
-				'name'             => $name,
-				'short_name'       => $short_name,
-				'price'            => (float) $price,
-				'discounted_price' => null !== $discounted_price ? (float) $discounted_price : null,
-				'capacity'         => null !== $capacity ? (int) $capacity : null,
-				'sort_order'       => $sort_order,
+				'event_date_id'                 => $event_date_id,
+				'name'                          => $name,
+				'short_name'                    => $short_name,
+				'price'                         => (float) $price,
+				'discounted_price'              => null !== $discounted_price ? (float) $discounted_price : null,
+				'capacity'                      => null !== $capacity ? (int) $capacity : null,
+				'derive_price_from_sale_period' => $derive_price_from_sale_period ? 1 : 0,
+				'sort_order'                    => $sort_order,
 			),
-			array( '%d', '%s', '%s', '%f', '%f', '%d', '%d' )
+			array( '%d', '%s', '%s', '%f', '%f', '%d', '%d', '%d' )
 		);
 
 		if ( $result ) {
@@ -201,9 +212,10 @@ class TicketOption {
 	 * @param string|null $short_name       Optional short name.
 	 * @param float|null  $discounted_price Optional discounted price.
 	 * @param int|null    $capacity         Optional capacity (null = unlimited).
+	 * @param bool        $derive_price_from_sale_period Whether to derive price from active sale period.
 	 * @return bool True on success, false on failure.
 	 */
-	public static function update( $id, $name, $price, $sort_order, $short_name = null, $discounted_price = null, $capacity = null ) {
+	public static function update( $id, $name, $price, $sort_order, $short_name = null, $discounted_price = null, $capacity = null, $derive_price_from_sale_period = false ) {
 		global $wpdb;
 
 		$table_name = self::get_table_name();
@@ -211,15 +223,16 @@ class TicketOption {
 		$result = $wpdb->update(
 			$table_name,
 			array(
-				'name'             => $name,
-				'short_name'       => $short_name,
-				'price'            => (float) $price,
-				'discounted_price' => null !== $discounted_price ? (float) $discounted_price : null,
-				'capacity'         => null !== $capacity ? (int) $capacity : null,
-				'sort_order'       => $sort_order,
+				'name'                          => $name,
+				'short_name'                    => $short_name,
+				'price'                         => (float) $price,
+				'discounted_price'              => null !== $discounted_price ? (float) $discounted_price : null,
+				'capacity'                      => null !== $capacity ? (int) $capacity : null,
+				'derive_price_from_sale_period' => $derive_price_from_sale_period ? 1 : 0,
+				'sort_order'                    => $sort_order,
 			),
 			array( 'id' => $id ),
-			array( '%s', '%s', '%f', '%f', '%d', '%d' ),
+			array( '%s', '%s', '%f', '%f', '%d', '%d', '%d' ),
 			array( '%d' )
 		);
 
@@ -253,21 +266,24 @@ class TicketOption {
 	 * @return TicketOption Ticket option object.
 	 */
 	private static function hydrate( $row ) {
-		$item                   = new self();
-		$item->id               = (int) $row->id;
-		$item->event_date_id    = (int) $row->event_date_id;
-		$item->name             = $row->name;
-		$item->short_name       = isset( $row->short_name ) ? $row->short_name : null;
-		$item->price            = (float) $row->price;
-		$item->discounted_price = isset( $row->discounted_price ) && null !== $row->discounted_price
+		$item                                = new self();
+		$item->id                            = (int) $row->id;
+		$item->event_date_id                 = (int) $row->event_date_id;
+		$item->name                          = $row->name;
+		$item->short_name                    = isset( $row->short_name ) ? $row->short_name : null;
+		$item->price                         = (float) $row->price;
+		$item->discounted_price              = isset( $row->discounted_price ) && null !== $row->discounted_price
 			? (float) $row->discounted_price
 			: null;
-		$item->capacity         = isset( $row->capacity ) && null !== $row->capacity
+		$item->capacity                      = isset( $row->capacity ) && null !== $row->capacity
 			? (int) $row->capacity
 			: null;
-		$item->sort_order       = (int) $row->sort_order;
-		$item->created_at       = $row->created_at;
-		$item->updated_at       = $row->updated_at;
+		$item->derive_price_from_sale_period = isset( $row->derive_price_from_sale_period )
+			? (bool) (int) $row->derive_price_from_sale_period
+			: false;
+		$item->sort_order                    = (int) $row->sort_order;
+		$item->created_at                    = $row->created_at;
+		$item->updated_at                    = $row->updated_at;
 
 		return $item;
 	}
@@ -279,16 +295,17 @@ class TicketOption {
 	 */
 	public function to_array() {
 		return array(
-			'id'               => $this->id,
-			'event_date_id'    => $this->event_date_id,
-			'name'             => $this->name,
-			'short_name'       => $this->short_name,
-			'price'            => $this->price,
-			'discounted_price' => $this->discounted_price,
-			'capacity'         => $this->capacity,
-			'sort_order'       => $this->sort_order,
-			'created_at'       => $this->created_at,
-			'updated_at'       => $this->updated_at,
+			'id'                            => $this->id,
+			'event_date_id'                 => $this->event_date_id,
+			'name'                          => $this->name,
+			'short_name'                    => $this->short_name,
+			'price'                         => $this->price,
+			'discounted_price'              => $this->discounted_price,
+			'capacity'                      => $this->capacity,
+			'derive_price_from_sale_period' => $this->derive_price_from_sale_period,
+			'sort_order'                    => $this->sort_order,
+			'created_at'                    => $this->created_at,
+			'updated_at'                    => $this->updated_at,
 		);
 	}
 }

--- a/fair-events/src/Models/TicketOptionPrice.php
+++ b/fair-events/src/Models/TicketOptionPrice.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Ticket Option Price model for Fair Events
+ *
+ * Per-(option, sale_period) price row used when the option has
+ * `derive_price_from_sale_period` enabled.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Models;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Ticket Option Price model class
+ *
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery
+ */
+class TicketOptionPrice {
+
+	/**
+	 * Ticket option ID
+	 *
+	 * @var int
+	 */
+	public $ticket_option_id;
+
+	/**
+	 * Sale period ID
+	 *
+	 * @var int
+	 */
+	public $sale_period_id;
+
+	/**
+	 * Price
+	 *
+	 * @var float
+	 */
+	public $price;
+
+	/**
+	 * Created at timestamp
+	 *
+	 * @var string
+	 */
+	public $created_at;
+
+	/**
+	 * Updated at timestamp
+	 *
+	 * @var string
+	 */
+	public $updated_at;
+
+	/**
+	 * Get table name
+	 *
+	 * @return string Table name with prefix.
+	 */
+	private static function get_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . 'fair_events_ticket_option_prices';
+	}
+
+	/**
+	 * Get price row by option + sale period.
+	 *
+	 * @param int $ticket_option_id Ticket option ID.
+	 * @param int $sale_period_id   Sale period ID.
+	 * @return TicketOptionPrice|null
+	 */
+	public static function get_by_option_and_period( $ticket_option_id, $sale_period_id ) {
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		$result = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE ticket_option_id = %d AND sale_period_id = %d LIMIT 1',
+				$table_name,
+				$ticket_option_id,
+				$sale_period_id
+			)
+		);
+
+		if ( ! $result ) {
+			return null;
+		}
+
+		return self::hydrate( $result );
+	}
+
+	/**
+	 * Get all price rows for a ticket option.
+	 *
+	 * @param int $ticket_option_id Ticket option ID.
+	 * @return TicketOptionPrice[]
+	 */
+	public static function get_all_by_option_id( $ticket_option_id ) {
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE ticket_option_id = %d ORDER BY sale_period_id ASC',
+				$table_name,
+				$ticket_option_id
+			)
+		);
+
+		if ( ! $results ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $results as $row ) {
+			$items[] = self::hydrate( $row );
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Get all price rows for ticket options belonging to an event date.
+	 *
+	 * @param int $event_date_id Event date ID.
+	 * @return TicketOptionPrice[]
+	 */
+	public static function get_all_by_event_date_id( $event_date_id ) {
+		global $wpdb;
+
+		$prices_table  = self::get_table_name();
+		$options_table = $wpdb->prefix . 'fair_events_ticket_options';
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT p.* FROM %i p INNER JOIN %i o ON p.ticket_option_id = o.id WHERE o.event_date_id = %d',
+				$prices_table,
+				$options_table,
+				$event_date_id
+			)
+		);
+
+		if ( ! $results ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $results as $row ) {
+			$items[] = self::hydrate( $row );
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Insert or update a price row for (option, period).
+	 *
+	 * @param int   $ticket_option_id Ticket option ID.
+	 * @param int   $sale_period_id   Sale period ID.
+	 * @param float $price            Price value.
+	 * @return bool True on success.
+	 */
+	public static function upsert( $ticket_option_id, $sale_period_id, $price ) {
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+		$existing   = self::get_by_option_and_period( $ticket_option_id, $sale_period_id );
+
+		if ( $existing ) {
+			$result = $wpdb->update(
+				$table_name,
+				array( 'price' => (float) $price ),
+				array(
+					'ticket_option_id' => $ticket_option_id,
+					'sale_period_id'   => $sale_period_id,
+				),
+				array( '%f' ),
+				array( '%d', '%d' )
+			);
+
+			return false !== $result;
+		}
+
+		$result = $wpdb->insert(
+			$table_name,
+			array(
+				'ticket_option_id' => $ticket_option_id,
+				'sale_period_id'   => $sale_period_id,
+				'price'            => (float) $price,
+			),
+			array( '%d', '%d', '%f' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Delete all price rows for an option.
+	 *
+	 * @param int $ticket_option_id Ticket option ID.
+	 * @return bool
+	 */
+	public static function delete_by_option_id( $ticket_option_id ) {
+		global $wpdb;
+
+		$result = $wpdb->delete(
+			self::get_table_name(),
+			array( 'ticket_option_id' => $ticket_option_id ),
+			array( '%d' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Delete all price rows for a sale period (called when a period is removed).
+	 *
+	 * @param int $sale_period_id Sale period ID.
+	 * @return bool
+	 */
+	public static function delete_by_sale_period_id( $sale_period_id ) {
+		global $wpdb;
+
+		$result = $wpdb->delete(
+			self::get_table_name(),
+			array( 'sale_period_id' => $sale_period_id ),
+			array( '%d' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Delete all price rows for ticket options belonging to an event date.
+	 *
+	 * @param int $event_date_id Event date ID.
+	 * @return void
+	 */
+	public static function delete_by_event_date_id( $event_date_id ) {
+		global $wpdb;
+
+		$prices_table  = self::get_table_name();
+		$options_table = $wpdb->prefix . 'fair_events_ticket_options';
+
+		$wpdb->query(
+			$wpdb->prepare(
+				'DELETE p FROM %i p INNER JOIN %i o ON p.ticket_option_id = o.id WHERE o.event_date_id = %d',
+				$prices_table,
+				$options_table,
+				$event_date_id
+			)
+		);
+	}
+
+	/**
+	 * Hydrate from a DB row.
+	 *
+	 * @param object $row Row.
+	 * @return TicketOptionPrice
+	 */
+	private static function hydrate( $row ) {
+		$item                   = new self();
+		$item->ticket_option_id = (int) $row->ticket_option_id;
+		$item->sale_period_id   = (int) $row->sale_period_id;
+		$item->price            = (float) $row->price;
+		$item->created_at       = $row->created_at;
+		$item->updated_at       = $row->updated_at;
+
+		return $item;
+	}
+
+	/**
+	 * Convert to array.
+	 *
+	 * @return array
+	 */
+	public function to_array() {
+		return array(
+			'ticket_option_id' => $this->ticket_option_id,
+			'sale_period_id'   => $this->sale_period_id,
+			'price'            => $this->price,
+			'created_at'       => $this->created_at,
+			'updated_at'       => $this->updated_at,
+		);
+	}
+}

--- a/fair-events/src/Services/ActivityOptionPriceResolver.php
+++ b/fair-events/src/Services/ActivityOptionPriceResolver.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Activity Option Price Resolver Service
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Services;
+
+use FairEvents\Models\TicketOption;
+use FairEvents\Models\TicketOptionPrice;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Resolves the effective base price of an activity option (TicketOption).
+ *
+ * When the option's `derive_price_from_sale_period` flag is off, the
+ * stored `price` column wins (legacy behaviour). When the flag is on,
+ * the price comes from the `TicketOptionPrice` row matching the active
+ * sale period for the option's event date, using the same active-period
+ * selection (and `continues_pricing_period` fallback) as ticket types.
+ */
+class ActivityOptionPriceResolver {
+
+	/**
+	 * Resolve the effective base price for an option.
+	 *
+	 * Returns null only in derived mode when there is no active period
+	 * or no matching `TicketOptionPrice` row — i.e. the option is not
+	 * purchasable right now (mirrors ticket-type behaviour). Callers
+	 * that previously trusted a static price must handle null.
+	 *
+	 * Group discounts are NOT applied here; callers layer those on top
+	 * via `EventSignupPricing::apply_discount()` as before.
+	 *
+	 * @param object $option Activity option (TicketOption-like, needs id, price, derive_price_from_sale_period, event_date_id).
+	 * @return float|null
+	 */
+	public static function resolve( $option ) {
+		if ( ! $option ) {
+			return null;
+		}
+
+		if ( empty( $option->derive_price_from_sale_period ) ) {
+			return isset( $option->price ) ? (float) $option->price : null;
+		}
+
+		$event_date_id = isset( $option->event_date_id ) ? (int) $option->event_date_id : 0;
+		if ( ! $event_date_id ) {
+			return null;
+		}
+
+		$active_period = EventSignupPricing::resolve_active_sale_period( $event_date_id );
+		if ( ! $active_period ) {
+			return null;
+		}
+
+		$price_row = TicketOptionPrice::get_by_option_and_period( (int) $option->id, (int) $active_period->id );
+		if ( ! $price_row ) {
+			return null;
+		}
+
+		return (float) $price_row->price;
+	}
+}

--- a/fair-events/src/Services/EventSignupPricing.php
+++ b/fair-events/src/Services/EventSignupPricing.php
@@ -107,23 +107,7 @@ class EventSignupPricing {
 			return null;
 		}
 
-		$now           = current_time( 'mysql' );
-		$sale_periods  = TicketSalePeriod::get_all_by_event_date_id( $ticket_type->event_date_id );
-		$active_period = null;
-
-		$continues  = class_exists( EventDateSetting::class )
-			&& '1' === EventDateSetting::get( $ticket_type->event_date_id, 'continues_pricing_period' );
-		$last_index = count( $sale_periods ) - 1;
-
-		foreach ( $sale_periods as $index => $period ) {
-			if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
-				$active_period = $period;
-				break;
-			}
-			if ( $continues && $index === $last_index && $period->sale_start <= $now ) {
-				$active_period = $period;
-			}
-		}
+		$active_period = self::resolve_active_sale_period( $ticket_type->event_date_id );
 		if ( ! $active_period ) {
 			return null;
 		}
@@ -157,6 +141,38 @@ class EventSignupPricing {
 		}
 
 		return $best_price;
+	}
+
+	/**
+	 * Resolve the currently active sale period for an event date.
+	 *
+	 * Matches the period whose [sale_start, sale_end] window covers
+	 * "now". When no period matches and the per-event-date
+	 * `continues_pricing_period` setting is on, falls back to the last
+	 * period whose start is already in the past.
+	 *
+	 * @param int $event_date_id Event date ID.
+	 * @return TicketSalePeriod|null Active period or null.
+	 */
+	public static function resolve_active_sale_period( $event_date_id ) {
+		$now           = current_time( 'mysql' );
+		$sale_periods  = TicketSalePeriod::get_all_by_event_date_id( $event_date_id );
+		$active_period = null;
+
+		$continues  = class_exists( EventDateSetting::class )
+			&& '1' === EventDateSetting::get( $event_date_id, 'continues_pricing_period' );
+		$last_index = count( $sale_periods ) - 1;
+
+		foreach ( $sale_periods as $index => $period ) {
+			if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
+				return $period;
+			}
+			if ( $continues && $index === $last_index && $period->sale_start <= $now ) {
+				$active_period = $period;
+			}
+		}
+
+		return $active_period;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Adds an opt-in per-option flag `derive_price_from_sale_period`. When on, an activity option's effective price is resolved live from the currently active `TicketSalePeriod` via a new `wp_fair_events_ticket_option_prices` table (mirrors how ticket-type prices work).
- Active-period selection and the `continues_pricing_period` fallback are factored into a shared `EventSignupPricing::resolve_active_sale_period()` helper so ticket types and activity options behave identically; when no period is active in derived mode the option is treated as not purchasable.
- Editor (Manage Event → Tickets → Options) gets a "Per period" checkbox per option and a per-period price input column; the manual price field is disabled when the toggle is on.
- All option-price read sites (signup render, checkout total via `EventSignupController::compute_option_price`, post-payment label in `PaymentHooks`) go through the new `ActivityOptionPriceResolver`.

## Notes

- Schema bumped to 3.9.0: new table + new column on `ticket_options` (additive). Backfill not needed — existing options keep the flag off and continue to read `price` as before.
- Per-period prices are wiped+rewritten on every options save (same pattern as `TicketPrice`). Removing a sale period also clears its `TicketOptionPrice` rows.
- Group discounts still stack on top of the resolved base price; activity-collaborator discount and invitation pricing are unchanged.

## Test plan

- [ ] Existing options keep working with the toggle off after upgrade.
- [ ] With the toggle on and an active sale period, the signup form, REST response, and checkout total all show the per-period price.
- [ ] With the toggle on and no active period, the option is hidden from signup (not purchasable).
- [ ] `continues_pricing_period` setting carries the last period's price forward — same as for ticket types.
- [ ] Group discount still applies on top of the resolved price.
- [ ] Editor: toggling on, entering per-period prices, saving, and reloading round-trips correctly. Removing a period clears its option-price rows.
- [ ] Import/export of ticket configuration preserves the flag and per-period prices.

Closes #598