### PR TITLE
Add anonymous event-interest signup

### DIFF
--- a/fair-audience/jest.config.js
+++ b/fair-audience/jest.config.js
@@ -2,7 +2,12 @@ export default {
 	preset: '@wordpress/jest-preset-default',
 	testEnvironment: 'jsdom',
 	testMatch: ['**/__tests__/**/*.js', '**/?(*.)+(spec|test).js'],
-	testPathIgnorePatterns: ['/node_modules/', '/vendor/', '/e2e/'],
+	testPathIgnorePatterns: [
+		'/node_modules/',
+		'/vendor/',
+		'/e2e/',
+		'\\.api\\.spec\\.js$',
+	],
 	collectCoverageFrom: [
 		'src/**/*.js',
 		'!src/**/index.js',

--- a/fair-audience/playwright.config.js
+++ b/fair-audience/playwright.config.js
@@ -4,7 +4,8 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 export default defineConfig({
-	testDir: './e2e',
+	testDir: './',
+	testMatch: ['e2e/**/*.spec.js', 'src/API/__tests__/**/*.api.spec.js'],
 	fullyParallel: false,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 0,

--- a/fair-audience/src/API/EventInterestController.php
+++ b/fair-audience/src/API/EventInterestController.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * Event Interest REST API Controller
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\API;
+
+use FairAudience\Database\EventParticipantRepository;
+use FairAudience\Database\ParticipantRepository;
+use FairAudience\Models\Participant;
+use FairAudience\Services\EmailService;
+use FairAudience\Services\ParticipantToken;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * REST API controller for anonymous event-interest signups.
+ *
+ * Visitors register interest in a specific event without creating an account
+ * or buying a ticket. Identity is established by email alone — the explicit
+ * product decision is to keep this frictionless, so endpoints are public.
+ */
+class EventInterestController extends WP_REST_Controller {
+
+	/**
+	 * REST API namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-audience/v1';
+
+	/**
+	 * REST API base route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'event-interest';
+
+	/**
+	 * Participant repository instance.
+	 *
+	 * @var ParticipantRepository
+	 */
+	private $participant_repository;
+
+	/**
+	 * Event participant repository instance.
+	 *
+	 * @var EventParticipantRepository
+	 */
+	private $event_participant_repository;
+
+	/**
+	 * Email service instance.
+	 *
+	 * @var EmailService
+	 */
+	private $email_service;
+
+	/**
+	 * Rate limit: max requests per email per hour.
+	 */
+	const RATE_LIMIT_MAX = 5;
+
+	/**
+	 * Rate limit window in seconds (1 hour).
+	 */
+	const RATE_LIMIT_WINDOW = 3600;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->participant_repository       = new ParticipantRepository();
+		$this->event_participant_repository = new EventParticipantRepository();
+		$this->email_service                = new EmailService();
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					// Public by design: anonymous interest signup is the
+					// explicit feature. Spam mitigated by honeypot + rate limit.
+					'permission_callback' => '__return_true',
+					'args'                => array(
+						'event_id' => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+						'email'    => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_email',
+							'validate_callback' => function ( $value ) {
+								return is_email( $value );
+							},
+						),
+						'name'     => array(
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'honeypot' => array(
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					// Public by design: authorization is the signed token.
+					'permission_callback' => '__return_true',
+					'args'                => array(
+						'token' => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register interest in an event.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$event_id = (int) $request->get_param( 'event_id' );
+		$email    = $request->get_param( 'email' );
+		$name     = $request->get_param( 'name' ) ?? '';
+		$honeypot = $request->get_param( 'honeypot' ) ?? '';
+
+		// Bot-trap: honeypot field should always be empty for real users.
+		// Return generic success to avoid revealing the trap.
+		if ( '' !== trim( $honeypot ) ) {
+			return $this->success_response();
+		}
+
+		if ( ! is_email( $email ) ) {
+			return new WP_Error(
+				'invalid_email',
+				__( 'Please enter a valid email address.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Resolve the event date for this event (the junction table is keyed
+		// by event_date_id, not event_id).
+		$event_date_id = 0;
+		if ( class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_dates_obj = \FairEvents\Models\EventDates::get_by_event_id( $event_id );
+			if ( $event_dates_obj ) {
+				$event_date_id = (int) $event_dates_obj->id;
+			}
+		}
+
+		if ( $event_date_id <= 0 ) {
+			return new WP_Error(
+				'event_not_found',
+				__( 'This event is not available for interest registration.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( $this->is_rate_limited( $email ) ) {
+			return new WP_Error(
+				'rate_limited',
+				__( 'Too many requests. Please try again later.', 'fair-audience' ),
+				array( 'status' => 429 )
+			);
+		}
+		$this->increment_rate_limit( $email );
+
+		// Resolve or create the participant. Identity is the email address —
+		// matches the pattern used by MailingSignupController.
+		$participant = $this->participant_repository->get_by_email( $email );
+		if ( ! $participant ) {
+			$participant = new Participant();
+			$participant->populate(
+				array(
+					'name'  => $name,
+					'email' => $email,
+				)
+			);
+			if ( ! $participant->save() ) {
+				return new WP_Error(
+					'creation_failed',
+					__( 'Failed to register interest. Please try again.', 'fair-audience' ),
+					array( 'status' => 500 )
+				);
+			}
+		}
+
+		// Upsert the EventParticipant row.
+		// add_participant_to_event() returns false when the row already exists —
+		// for interest signup that is a no-op success: we never want to demote
+		// a signed_up / collaborator row back to "interested".
+		$this->event_participant_repository->add_participant_to_event(
+			$event_id,
+			(int) $participant->id,
+			'interested',
+			$event_date_id
+		);
+
+		// Best-effort confirmation email. Don't fail the request if the mail
+		// transport hiccups — the row is already saved.
+		$this->email_service->send_event_interest_confirmation(
+			$participant,
+			$event_id,
+			$event_date_id
+		);
+
+		return $this->success_response();
+	}
+
+	/**
+	 * Unsubscribe from event interest via tokenized link.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$token = $request->get_param( 'token' );
+
+		$parsed = ParticipantToken::verify( $token );
+		if ( ! $parsed ) {
+			return new WP_Error(
+				'invalid_token',
+				__( 'Invalid or expired unsubscribe link.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$participant_id = $parsed['participant_id'];
+		$event_date_id  = $parsed['event_date_id'];
+
+		$relationship = $this->event_participant_repository->get_by_event_date_and_participant(
+			$event_date_id,
+			$participant_id
+		);
+
+		// Only delete a row that's still in the 'interested' state. Don't
+		// silently strip an upgraded role (signed_up, collaborator) when the
+		// same person later bought a ticket — that would be data loss.
+		if ( $relationship && 'interested' === $relationship->label ) {
+			$relationship->delete();
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'message' => __( 'You will no longer receive updates about this event.', 'fair-audience' ),
+			)
+		);
+	}
+
+	/**
+	 * Build the generic success response.
+	 *
+	 * Worded so it doesn't leak whether the email already existed.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function success_response() {
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'message' => __( 'Thanks! We will keep you posted about this event.', 'fair-audience' ),
+			)
+		);
+	}
+
+	/**
+	 * Check whether the given email is currently rate-limited.
+	 *
+	 * @param string $email Email address.
+	 * @return bool
+	 */
+	private function is_rate_limited( $email ) {
+		$transient_key = 'fair_audience_interest_' . md5( $email );
+		$count         = get_transient( $transient_key );
+		return $count && (int) $count >= self::RATE_LIMIT_MAX;
+	}
+
+	/**
+	 * Increment the rate-limit counter for the given email.
+	 *
+	 * @param string $email Email address.
+	 * @return void
+	 */
+	private function increment_rate_limit( $email ) {
+		$transient_key = 'fair_audience_interest_' . md5( $email );
+		$count         = get_transient( $transient_key );
+		set_transient(
+			$transient_key,
+			$count ? (int) $count + 1 : 1,
+			self::RATE_LIMIT_WINDOW
+		);
+	}
+}

--- a/fair-audience/src/API/__tests__/EventInterestController.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventInterestController.api.spec.js
@@ -1,0 +1,147 @@
+/**
+ * Playwright API tests for the EventInterestController.
+ *
+ * Exercises POST and DELETE /fair-audience/v1/event-interest against a live
+ * WordPress instance. The test event is created via the WP REST API using
+ * admin Application Password credentials (WP_ADMIN_USER / WP_ADMIN_PASSWORD
+ * env vars) and torn down at the end of the suite.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminAuth = {
+	username: ADMIN_USER,
+	password: ADMIN_PASSWORD,
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+test.describe('EventInterestController', () => {
+	let api;
+	let eventId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		// Create a draft event post to act as our test event. The event-dates
+		// row is created by fair-events lifecycle hooks on publish.
+		const res = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: {
+				Authorization:
+					'Basic ' +
+					Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString(
+						'base64'
+					),
+			},
+			data: {
+				title: `Event Interest Test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		eventId = body.id;
+	});
+
+	test.afterAll(async () => {
+		if (eventId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${eventId}`, {
+				headers: {
+					Authorization:
+						'Basic ' +
+						Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString(
+							'base64'
+						),
+				},
+				params: { force: 'true' },
+			});
+		}
+		await api.dispose();
+	});
+
+	test('POST creates a new interest registration', async () => {
+		const res = await api.post('/wp-json/fair-audience/v1/event-interest', {
+			data: {
+				event_id: eventId,
+				email: uniqueEmail('new'),
+				name: 'New User',
+			},
+		});
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(body.success).toBe(true);
+	});
+
+	test('POST a second time with the same email is a no-op success', async () => {
+		const email = uniqueEmail('dup');
+		const first = await api.post(
+			'/wp-json/fair-audience/v1/event-interest',
+			{ data: { event_id: eventId, email } }
+		);
+		expect(first.ok()).toBeTruthy();
+
+		const second = await api.post(
+			'/wp-json/fair-audience/v1/event-interest',
+			{ data: { event_id: eventId, email } }
+		);
+		expect(second.ok()).toBeTruthy();
+		const body = await second.json();
+		expect(body.success).toBe(true);
+	});
+
+	test('POST with honeypot filled is silently accepted without writes', async () => {
+		const res = await api.post('/wp-json/fair-audience/v1/event-interest', {
+			data: {
+				event_id: eventId,
+				email: uniqueEmail('bot'),
+				honeypot: 'http://spammy.example/',
+			},
+		});
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(body.success).toBe(true);
+	});
+
+	test('POST with invalid email is rejected with 400', async () => {
+		const res = await api.post('/wp-json/fair-audience/v1/event-interest', {
+			data: {
+				event_id: eventId,
+				email: 'not-an-email',
+			},
+		});
+		expect(res.status()).toBe(400);
+	});
+
+	test('POST with missing event_id returns an error', async () => {
+		const res = await api.post('/wp-json/fair-audience/v1/event-interest', {
+			data: { email: uniqueEmail('noevent') },
+		});
+		expect(res.status()).toBeGreaterThanOrEqual(400);
+	});
+
+	test('DELETE with invalid token returns 400', async () => {
+		const res = await api.delete(
+			'/wp-json/fair-audience/v1/event-interest',
+			{ params: { token: 'not-a-valid-token' } }
+		);
+		expect(res.status()).toBe(400);
+	});
+
+	test('DELETE with a well-formed but unsigned token returns 400', async () => {
+		// base64('999:1:badsig') — passes the shape check, fails the HMAC.
+		const fake = Buffer.from('999:1:badsig').toString('base64url');
+		const res = await api.delete(
+			'/wp-json/fair-audience/v1/event-interest',
+			{ params: { token: fake } }
+		);
+		expect(res.status()).toBe(400);
+	});
+});

--- a/fair-audience/src/Core/Plugin.php
+++ b/fair-audience/src/Core/Plugin.php
@@ -56,6 +56,7 @@ class Plugin {
 		add_action( 'template_redirect', array( $this, 'handle_collaborator_profile' ) );
 		add_action( 'template_redirect', array( $this, 'handle_fee_payment' ) );
 		add_action( 'template_redirect', array( $this, 'handle_photo_upload' ) );
+		add_action( 'template_redirect', array( $this, 'handle_unsubscribe_event_interest' ) );
 
 		// Instagram token refresh cron.
 		add_action( 'fair_audience_refresh_instagram_token', array( $this, 'refresh_instagram_token' ) );
@@ -157,6 +158,9 @@ class Plugin {
 		$session_controller = new \FairAudience\API\SessionController();
 		$session_controller->register_routes();
 
+		$event_interest_controller = new \FairAudience\API\EventInterestController();
+		$event_interest_controller->register_routes();
+
 		// Membership fees (only when fair-payment plugin is active).
 		if ( class_exists( 'FairPayment\Core\Plugin' ) ) {
 			$fees_controller = new \FairAudience\API\FeesController();
@@ -252,7 +256,62 @@ class Plugin {
 		$vars[] = 'edit_audience_signup';
 		$vars[] = 'photo_upload';
 		$vars[] = 'invitation';
+		$vars[] = 'unsubscribe_event_interest';
 		return $vars;
+	}
+
+	/**
+	 * Handle one-click unsubscribe from event-interest signups.
+	 *
+	 * Triggered by the tokenized link in the confirmation email
+	 * (`?unsubscribe_event_interest=1&token=…`). Validates the token, removes
+	 * the EventParticipant row when it still carries the 'interested' label,
+	 * and renders a thank-you page. A relationship that has been upgraded to
+	 * signed_up / collaborator is preserved.
+	 */
+	public function handle_unsubscribe_event_interest() {
+		$flag = get_query_var( 'unsubscribe_event_interest' );
+
+		if ( empty( $flag ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Authorization is the signed token below.
+		$token = isset( $_GET['token'] ) ? sanitize_text_field( wp_unslash( $_GET['token'] ) ) : '';
+
+		if ( empty( $token ) ) {
+			wp_die(
+				esc_html__( 'Missing unsubscribe token.', 'fair-audience' ),
+				esc_html__( 'Unsubscribe', 'fair-audience' ),
+				array( 'response' => 400 )
+			);
+		}
+
+		$parsed = \FairAudience\Services\ParticipantToken::verify( $token );
+
+		if ( ! $parsed ) {
+			wp_die(
+				esc_html__( 'This unsubscribe link is invalid or has expired.', 'fair-audience' ),
+				esc_html__( 'Unsubscribe', 'fair-audience' ),
+				array( 'response' => 400 )
+			);
+		}
+
+		$repository   = new \FairAudience\Database\EventParticipantRepository();
+		$relationship = $repository->get_by_event_date_and_participant(
+			$parsed['event_date_id'],
+			$parsed['participant_id']
+		);
+
+		if ( $relationship && 'interested' === $relationship->label ) {
+			$relationship->delete();
+		}
+
+		wp_die(
+			esc_html__( 'You will no longer receive updates about this event.', 'fair-audience' ),
+			esc_html__( 'Unsubscribed', 'fair-audience' ),
+			array( 'response' => 200 )
+		);
 	}
 
 	/**

--- a/fair-audience/src/Hooks/BlockHooks.php
+++ b/fair-audience/src/Hooks/BlockHooks.php
@@ -31,6 +31,7 @@ class BlockHooks {
 		register_block_type( FAIR_AUDIENCE_PLUGIN_DIR . 'build/blocks/event-signup' );
 		register_block_type( FAIR_AUDIENCE_PLUGIN_DIR . 'build/blocks/signups-list' );
 		register_block_type( FAIR_AUDIENCE_PLUGIN_DIR . 'build/blocks/audience-signup' );
+		register_block_type( FAIR_AUDIENCE_PLUGIN_DIR . 'build/blocks/event-interest' );
 		register_block_type( FAIR_AUDIENCE_PLUGIN_DIR . 'build/blocks/fair-form' );
 		register_block_type( FAIR_AUDIENCE_PLUGIN_DIR . 'build/blocks/fair-form-short-text' );
 		register_block_type( FAIR_AUDIENCE_PLUGIN_DIR . 'build/blocks/fair-form-long-text' );
@@ -88,6 +89,20 @@ class BlockHooks {
 		// Set script translations for audience-signup blocks (frontend scripts).
 		wp_set_script_translations(
 			'fair-audience-audience-signup-view-script',
+			'fair-audience',
+			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+		);
+
+		// Set script translations for event-interest blocks (editor scripts).
+		wp_set_script_translations(
+			'fair-audience-event-interest-editor-script',
+			'fair-audience',
+			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+		);
+
+		// Set script translations for event-interest blocks (frontend scripts).
+		wp_set_script_translations(
+			'fair-audience-event-interest-view-script',
 			'fair-audience',
 			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
 		);

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -2628,4 +2628,101 @@ class EmailService {
 
 		return $results;
 	}
+
+	/**
+	 * Send confirmation for an anonymous event-interest signup.
+	 *
+	 * Includes a tokenized unsubscribe link so the recipient can pull out
+	 * without needing an account.
+	 *
+	 * @param Participant $participant   Participant who registered interest.
+	 * @param int         $event_id      Event post ID.
+	 * @param int         $event_date_id Event date ID (scopes the unsubscribe token).
+	 * @return bool True if mail dispatched.
+	 */
+	public function send_event_interest_confirmation( Participant $participant, int $event_id, int $event_date_id ): bool {
+		if ( ! $this->has_valid_email( $participant ) ) {
+			return false;
+		}
+
+		$site_name   = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+		$event_title = get_the_title( $event_id );
+		if ( empty( $event_title ) ) {
+			$event_title = $site_name;
+		}
+
+		// Token encodes (participant_id, event_date_id) so the unsubscribe is
+		// scoped to this single event. The query var triggers a
+		// template_redirect handler that runs the same logic as the DELETE
+		// endpoint and renders a thank-you page.
+		$token           = ParticipantToken::generate( (int) $participant->id, $event_date_id );
+		$unsubscribe_url = add_query_arg(
+			array(
+				'unsubscribe_event_interest' => '1',
+				'token'                      => $token,
+			),
+			home_url( '/' )
+		);
+
+		$subject = sprintf(
+			/* translators: %s: event title */
+			__( 'Thanks for your interest in %s', 'fair-audience' ),
+			$event_title
+		);
+
+		$greeting_name = ! empty( $participant->name ) ? $participant->name : __( 'there', 'fair-audience' );
+
+		$message = '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #333333; background-color: #f4f4f4;">
+	<table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f4;">
+		<tr>
+			<td align="center" style="padding: 20px 0;">
+				<table width="600" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+					<tr>
+						<td style="background-color: #0073aa; color: #ffffff; padding: 30px; border-radius: 8px 8px 0 0; text-align: center;">
+							<h1 style="margin: 0; font-size: 24px; font-weight: bold;">' . esc_html( $event_title ) . '</h1>
+						</td>
+					</tr>
+					<tr>
+						<td style="padding: 40px 30px;">
+							<p style="margin: 0 0 20px 0;">' . sprintf(
+								/* translators: %s: participant name */
+								esc_html__( 'Hi %s,', 'fair-audience' ),
+								'<strong>' . esc_html( $greeting_name ) . '</strong>'
+							) . '</p>
+							<p style="margin: 0 0 20px 0;">' . sprintf(
+								/* translators: %s: event title */
+								esc_html__( 'Thanks for registering your interest in %s. We will let you know when there are updates.', 'fair-audience' ),
+								'<strong>' . esc_html( $event_title ) . '</strong>'
+							) . '</p>
+							<p style="margin: 0 0 10px 0; font-size: 14px; color: #666666;">' . esc_html__( "If you didn't register your interest, you can safely ignore this email.", 'fair-audience' ) . '</p>
+						</td>
+					</tr>
+					<tr>
+						<td style="background-color: #f8f8f8; padding: 20px 30px; border-radius: 0 0 8px 8px; text-align: center; font-size: 12px; color: #666666;">
+							<p style="margin: 0 0 5px 0;">' . esc_html__( 'No longer interested?', 'fair-audience' ) . '</p>
+							<p style="margin: 0;"><a href="' . esc_url( $unsubscribe_url ) . '" style="color: #0073aa;">' . esc_html__( 'Unsubscribe from updates about this event', 'fair-audience' ) . '</a></p>
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+</body>
+</html>';
+
+		$content_type_filter = function () {
+			return 'text/html';
+		};
+		add_filter( 'wp_mail_content_type', $content_type_filter );
+		$result = wp_mail( $participant->email, $subject, $message );
+		remove_filter( 'wp_mail_content_type', $content_type_filter );
+
+		return (bool) $result;
+	}
 }

--- a/fair-audience/src/blocks/event-interest/block.json
+++ b/fair-audience/src/blocks/event-interest/block.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "fair-audience/event-interest",
+	"version": "1.0.0",
+	"title": "Event Interest",
+	"category": "widgets",
+	"icon": "heart",
+	"description": "Let visitors register interest in an event without buying a ticket.",
+	"keywords": ["event", "interest", "signup", "audience"],
+	"textdomain": "fair-audience",
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"],
+		"spacing": {
+			"padding": true,
+			"margin": ["top", "bottom"]
+		}
+	},
+	"attributes": {
+		"submitButtonText": {
+			"type": "string",
+			"default": "Register interest"
+		},
+		"successMessage": {
+			"type": "string",
+			"default": "Thanks! Check your inbox for confirmation."
+		},
+		"namePlaceholder": {
+			"type": "string",
+			"default": "Your name (optional)"
+		},
+		"emailPlaceholder": {
+			"type": "string",
+			"default": "Your email"
+		}
+	},
+	"editorScript": "file:./editor.js",
+	"viewScript": "file:./frontend.js",
+	"render": "file:./render.php",
+	"style": ["wp-block-button", "file:./style-frontend.css"],
+	"editorStyle": "file:./editor.css"
+}

--- a/fair-audience/src/blocks/event-interest/editor.css
+++ b/fair-audience/src/blocks/event-interest/editor.css
@@ -1,0 +1,12 @@
+.fair-audience-event-interest-preview {
+	padding: 16px;
+	border: 1px dashed #ccc;
+	border-radius: 4px;
+	background: #fafafa;
+}
+
+.fair-audience-event-interest-preview input,
+.fair-audience-event-interest-preview button {
+	display: block;
+	margin-top: 8px;
+}

--- a/fair-audience/src/blocks/event-interest/editor.js
+++ b/fair-audience/src/blocks/event-interest/editor.js
@@ -1,9 +1,11 @@
+import './style.css';
 import './editor.css';
 
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl, TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import ServerSideRender from '@wordpress/server-side-render';
 
 registerBlockType('fair-audience/event-interest', {
 	edit: ({ attributes, setAttributes }) => {
@@ -28,6 +30,10 @@ registerBlockType('fair-audience/event-interest', {
 							onChange={(value) =>
 								setAttributes({ submitButtonText: value })
 							}
+							placeholder={__(
+								'Register interest',
+								'fair-audience'
+							)}
 						/>
 						<TextareaControl
 							label={__('Success Message', 'fair-audience')}
@@ -35,8 +41,12 @@ registerBlockType('fair-audience/event-interest', {
 							onChange={(value) =>
 								setAttributes({ successMessage: value })
 							}
+							placeholder={__(
+								'Thanks! Check your inbox for confirmation.',
+								'fair-audience'
+							)}
 							help={__(
-								'Shown after the visitor submits the form.',
+								'Message shown after the visitor submits the form.',
 								'fair-audience'
 							)}
 						/>
@@ -56,33 +66,12 @@ registerBlockType('fair-audience/event-interest', {
 						/>
 					</PanelBody>
 				</InspectorControls>
+
 				<div {...blockProps}>
-					<div className="fair-audience-event-interest-preview">
-						<p>
-							<strong>
-								{__('Event Interest', 'fair-audience')}
-							</strong>
-						</p>
-						<p>
-							{__(
-								'Visitors can register their interest in this event without buying a ticket. The form is shown on the front end when this block is placed on an event page.',
-								'fair-audience'
-							)}
-						</p>
-						<input
-							type="email"
-							placeholder={emailPlaceholder}
-							disabled
-						/>
-						<input
-							type="text"
-							placeholder={namePlaceholder}
-							disabled
-						/>
-						<button type="button" disabled>
-							{submitButtonText}
-						</button>
-					</div>
+					<ServerSideRender
+						block="fair-audience/event-interest"
+						attributes={attributes}
+					/>
 				</div>
 			</>
 		);

--- a/fair-audience/src/blocks/event-interest/editor.js
+++ b/fair-audience/src/blocks/event-interest/editor.js
@@ -1,0 +1,91 @@
+import './editor.css';
+
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl, TextareaControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+registerBlockType('fair-audience/event-interest', {
+	edit: ({ attributes, setAttributes }) => {
+		const {
+			submitButtonText,
+			successMessage,
+			namePlaceholder,
+			emailPlaceholder,
+		} = attributes;
+
+		const blockProps = useBlockProps({
+			className: 'fair-audience-event-interest',
+		});
+
+		return (
+			<>
+				<InspectorControls>
+					<PanelBody title={__('Form Settings', 'fair-audience')}>
+						<TextControl
+							label={__('Submit Button Text', 'fair-audience')}
+							value={submitButtonText}
+							onChange={(value) =>
+								setAttributes({ submitButtonText: value })
+							}
+						/>
+						<TextareaControl
+							label={__('Success Message', 'fair-audience')}
+							value={successMessage}
+							onChange={(value) =>
+								setAttributes({ successMessage: value })
+							}
+							help={__(
+								'Shown after the visitor submits the form.',
+								'fair-audience'
+							)}
+						/>
+						<TextControl
+							label={__('Email Placeholder', 'fair-audience')}
+							value={emailPlaceholder}
+							onChange={(value) =>
+								setAttributes({ emailPlaceholder: value })
+							}
+						/>
+						<TextControl
+							label={__('Name Placeholder', 'fair-audience')}
+							value={namePlaceholder}
+							onChange={(value) =>
+								setAttributes({ namePlaceholder: value })
+							}
+						/>
+					</PanelBody>
+				</InspectorControls>
+				<div {...blockProps}>
+					<div className="fair-audience-event-interest-preview">
+						<p>
+							<strong>
+								{__('Event Interest', 'fair-audience')}
+							</strong>
+						</p>
+						<p>
+							{__(
+								'Visitors can register their interest in this event without buying a ticket. The form is shown on the front end when this block is placed on an event page.',
+								'fair-audience'
+							)}
+						</p>
+						<input
+							type="email"
+							placeholder={emailPlaceholder}
+							disabled
+						/>
+						<input
+							type="text"
+							placeholder={namePlaceholder}
+							disabled
+						/>
+						<button type="button" disabled>
+							{submitButtonText}
+						</button>
+					</div>
+				</div>
+			</>
+		);
+	},
+	save: () => null,
+});

--- a/fair-audience/src/blocks/event-interest/frontend.js
+++ b/fair-audience/src/blocks/event-interest/frontend.js
@@ -1,0 +1,105 @@
+import './style.css';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+import {
+	extractErrorMessage,
+	showMessage,
+	setButtonLoading,
+	onDomReady,
+} from '../shared/form-utils.js';
+
+const CSS_PREFIX = 'fair-audience-event-interest';
+
+(function () {
+	'use strict';
+
+	onDomReady(initializeForms);
+
+	function initializeForms() {
+		const forms = document.querySelectorAll(
+			'.fair-audience-event-interest-form'
+		);
+		forms.forEach(setupForm);
+	}
+
+	function setupForm(form) {
+		form.addEventListener('submit', function (e) {
+			e.preventDefault();
+			submitForm(form);
+		});
+	}
+
+	function submitForm(form) {
+		const container = form.closest('.fair-audience-event-interest');
+		const submitButton = form.querySelector(
+			'.fair-audience-event-interest-submit-button'
+		);
+		const messageContainer = form.querySelector(
+			'.fair-audience-event-interest-message'
+		);
+
+		const eventId = parseInt(container.dataset.eventId, 10);
+		const successMessage =
+			container.dataset.successMessage ||
+			__('Thanks! Check your inbox for confirmation.', 'fair-audience');
+
+		const emailInput = form.querySelector('input[name="interest_email"]');
+		const nameInput = form.querySelector('input[name="interest_name"]');
+		const honeypotInput = form.querySelector(
+			'input[name="interest_website"]'
+		);
+
+		if (!emailInput || !emailInput.value.trim()) {
+			showMessage(
+				messageContainer,
+				__('Please enter your email.', 'fair-audience'),
+				'error',
+				CSS_PREFIX
+			);
+			return;
+		}
+
+		const restoreButton = setButtonLoading(
+			submitButton,
+			__('Submitting...', 'fair-audience')
+		);
+
+		apiFetch({
+			path: '/fair-audience/v1/event-interest',
+			method: 'POST',
+			data: {
+				event_id: eventId,
+				email: emailInput.value.trim(),
+				name: nameInput ? nameInput.value.trim() : '',
+				honeypot: honeypotInput ? honeypotInput.value : '',
+			},
+		})
+			.then(function () {
+				showMessage(
+					messageContainer,
+					successMessage,
+					'success',
+					CSS_PREFIX
+				);
+				form.reset();
+			})
+			.catch(function (error) {
+				const errorMessage = extractErrorMessage(
+					error,
+					__(
+						'Failed to register your interest. Please try again.',
+						'fair-audience'
+					)
+				);
+				showMessage(
+					messageContainer,
+					errorMessage,
+					'error',
+					CSS_PREFIX
+				);
+			})
+			.finally(function () {
+				restoreButton();
+			});
+	}
+})();

--- a/fair-audience/src/blocks/event-interest/frontend.js
+++ b/fair-audience/src/blocks/event-interest/frontend.js
@@ -8,7 +8,10 @@ import {
 	onDomReady,
 } from '../shared/form-utils.js';
 
-const CSS_PREFIX = 'fair-audience-event-interest';
+// Use the shared signup CSS prefix so messages render with the same look as
+// the event-signup block. The message container in render.php carries the
+// matching class.
+const CSS_PREFIX = 'fair-audience-signup';
 
 (function () {
 	'use strict';

--- a/fair-audience/src/blocks/event-interest/frontend.js
+++ b/fair-audience/src/blocks/event-interest/frontend.js
@@ -6,6 +6,7 @@ import {
 	showMessage,
 	setButtonLoading,
 	onDomReady,
+	wireNotYouButton,
 } from '../shared/form-utils.js';
 
 // Use the shared signup CSS prefix so messages render with the same look as
@@ -30,6 +31,7 @@ const CSS_PREFIX = 'fair-audience-signup';
 			e.preventDefault();
 			submitForm(form);
 		});
+		wireNotYouButton(form.querySelector('.fair-audience-not-you'));
 	}
 
 	function submitForm(form) {

--- a/fair-audience/src/blocks/event-interest/render.php
+++ b/fair-audience/src/blocks/event-interest/render.php
@@ -10,6 +10,9 @@
 
 defined( 'WPINC' ) || die;
 
+use FairAudience\Database\ParticipantRepository;
+use FairAudience\Services\AudienceSession;
+use FairAudience\Services\ParticipantToken;
 use FairEvents\Database\EventRepository;
 use FairEvents\Models\EventDates;
 
@@ -44,15 +47,67 @@ if ( $is_valid_post_type ) {
 	}
 }
 
+// Resolve the visitor's identity in the same priority order as event-signup
+// and audience-signup: signed URL token > logged-in WP user > session cookie.
+// The first two are strong identities (we trust them to belong to the
+// visitor); the cookie is a softer pre-fill that lets the visitor edit
+// before submitting.
+$participant_token_value = get_query_var( 'participant_token', '' );
+$existing_name           = '';
+$existing_email          = '';
+$linked_participant_id   = 0;
+$has_session_prefill     = false;
+
+if ( $is_valid_post_type ) {
+	$participant_repo = new ParticipantRepository();
+	$participant      = null;
+
+	if ( ! empty( $participant_token_value ) ) {
+		$token_data = ParticipantToken::verify( $participant_token_value );
+		if ( $token_data ) {
+			$participant = $participant_repo->get_by_id( $token_data['participant_id'] );
+		}
+	}
+
+	if ( null === $participant ) {
+		$wp_user_id = get_current_user_id();
+		if ( $wp_user_id ) {
+			$participant = $participant_repo->get_by_user_id( $wp_user_id );
+		}
+	}
+
+	if ( $participant ) {
+		$existing_name         = (string) $participant->name;
+		$existing_email        = (string) $participant->email;
+		$linked_participant_id = (int) $participant->id;
+	} else {
+		// Anonymous viewer with a known browser session — pre-fill but don't
+		// claim identity. The form still submits through the regular flow.
+		$session_participant_id = AudienceSession::get_participant_id();
+		if ( $session_participant_id ) {
+			$session_participant = $participant_repo->get_by_id( $session_participant_id );
+			if ( $session_participant ) {
+				$existing_name       = (string) $session_participant->name;
+				$existing_email      = (string) $session_participant->email;
+				$has_session_prefill = true;
+			}
+		}
+	}
+}
+
 $form_id = 'fair-audience-event-interest-' . wp_unique_id();
 
-$wrapper_attributes = get_block_wrapper_attributes(
-	array(
-		'class'                => 'fair-audience-event-interest',
-		'data-event-id'        => (string) $event_id,
-		'data-success-message' => esc_attr( $success_message ),
-	)
+$wrapper_data = array(
+	'class'                => 'fair-audience-event-interest',
+	'data-event-id'        => (string) $event_id,
+	'data-success-message' => esc_attr( $success_message ),
 );
+
+if ( $linked_participant_id ) {
+	$wrapper_data['data-participant-id'] = (string) $linked_participant_id;
+}
+
+$wrapper_attributes = get_block_wrapper_attributes( $wrapper_data );
 ?>
 
 <?php if ( ! $is_valid_post_type || $event_date_id <= 0 ) : ?>
@@ -72,6 +127,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				name="interest_email"
 				required
 				placeholder="<?php echo esc_attr( $email_placeholder ); ?>"
+				value="<?php echo esc_attr( $existing_email ); ?>"
 			/>
 		</p>
 		<p>
@@ -83,6 +139,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				id="<?php echo esc_attr( $form_id ); ?>-name"
 				name="interest_name"
 				placeholder="<?php echo esc_attr( $name_placeholder ); ?>"
+				value="<?php echo esc_attr( $existing_name ); ?>"
 			/>
 		</p>
 
@@ -98,6 +155,12 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				autocomplete="off"
 			/>
 		</p>
+
+		<?php if ( $has_session_prefill ) : ?>
+		<button type="button" class="fair-audience-not-you">
+			<?php echo esc_html__( 'Not you? Start fresh', 'fair-audience' ); ?>
+		</button>
+		<?php endif; ?>
 
 		<div class="wp-block-button">
 			<button type="submit" class="wp-block-button__link wp-element-button fair-audience-event-interest-submit-button">

--- a/fair-audience/src/blocks/event-interest/render.php
+++ b/fair-audience/src/blocks/event-interest/render.php
@@ -18,21 +18,30 @@ $success_message   = __( $attributes['successMessage'] ?? 'Thanks! Check your in
 $name_placeholder  = __( $attributes['namePlaceholder'] ?? 'Your name (optional)', 'fair-audience' );
 $email_placeholder = __( $attributes['emailPlaceholder'] ?? 'Your email', 'fair-audience' );
 
-// Resolve the event from the current post. The block only renders on event
-// pages — anywhere else it is silently skipped.
-$post_id  = get_the_ID();
-$event_id = 0;
-if ( $post_id && class_exists( EventRepository::class ) && EventRepository::is_event( $post_id ) ) {
-	$event_id = $post_id;
+// Resolve the event from the current post — same approach as event-signup so
+// the block works on event pages and on junction-linked pages.
+$current_post_id    = get_the_ID();
+$event_dates_obj    = null;
+$is_valid_post_type = false;
+$event_id           = 0;
+$event_date_id      = 0;
+
+if ( $current_post_id && class_exists( EventDates::class ) ) {
+	$event_dates_obj = EventDates::get_by_event_id( $current_post_id );
 }
 
-if ( $event_id <= 0 || ! class_exists( EventDates::class ) ) {
-	return '';
+if ( $current_post_id && class_exists( EventRepository::class ) ) {
+	$is_valid_post_type = EventRepository::is_event( $current_post_id ) || null !== $event_dates_obj;
 }
 
-$event_dates_obj = EventDates::get_by_event_id( $event_id );
-if ( ! $event_dates_obj ) {
-	return '';
+if ( $is_valid_post_type ) {
+	$event_id = $current_post_id;
+	if ( $event_dates_obj && $event_dates_obj->event_id && $event_dates_obj->event_id !== $current_post_id ) {
+		$event_id = (int) $event_dates_obj->event_id;
+	}
+	if ( $event_dates_obj ) {
+		$event_date_id = (int) $event_dates_obj->id;
+	}
 }
 
 $form_id = 'fair-audience-event-interest-' . wp_unique_id();
@@ -45,8 +54,14 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	)
 );
 ?>
+
+<?php if ( ! $is_valid_post_type || $event_date_id <= 0 ) : ?>
+<p class="fair-audience-event-signup-error">
+	<?php echo esc_html__( 'This block can only be used on event pages.', 'fair-audience' ); ?>
+</p>
+<?php else : ?>
 <div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
-	<form class="fair-audience-event-interest-form">
+	<form class="fair-audience-signup-form fair-audience-event-interest-form">
 		<p>
 			<label for="<?php echo esc_attr( $form_id ); ?>-email">
 				<?php echo esc_html__( 'Email', 'fair-audience' ); ?> <span class="required">*</span>
@@ -90,6 +105,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 			</button>
 		</div>
 
-		<div class="fair-audience-event-interest-message" style="display: none;"></div>
+		<div class="fair-audience-signup-message fair-audience-event-interest-message" style="display: none;"></div>
 	</form>
 </div>
+<?php endif; ?>

--- a/fair-audience/src/blocks/event-interest/render.php
+++ b/fair-audience/src/blocks/event-interest/render.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Render callback for the Event Interest block.
+ *
+ * @package FairAudience
+ * @param array $attributes Block attributes.
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ */
+
+defined( 'WPINC' ) || die;
+
+use FairEvents\Database\EventRepository;
+use FairEvents\Models\EventDates;
+
+$submit_text       = __( $attributes['submitButtonText'] ?? 'Register interest', 'fair-audience' );
+$success_message   = __( $attributes['successMessage'] ?? 'Thanks! Check your inbox for confirmation.', 'fair-audience' );
+$name_placeholder  = __( $attributes['namePlaceholder'] ?? 'Your name (optional)', 'fair-audience' );
+$email_placeholder = __( $attributes['emailPlaceholder'] ?? 'Your email', 'fair-audience' );
+
+// Resolve the event from the current post. The block only renders on event
+// pages — anywhere else it is silently skipped.
+$post_id  = get_the_ID();
+$event_id = 0;
+if ( $post_id && class_exists( EventRepository::class ) && EventRepository::is_event( $post_id ) ) {
+	$event_id = $post_id;
+}
+
+if ( $event_id <= 0 || ! class_exists( EventDates::class ) ) {
+	return '';
+}
+
+$event_dates_obj = EventDates::get_by_event_id( $event_id );
+if ( ! $event_dates_obj ) {
+	return '';
+}
+
+$form_id = 'fair-audience-event-interest-' . wp_unique_id();
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class'                => 'fair-audience-event-interest',
+		'data-event-id'        => (string) $event_id,
+		'data-success-message' => esc_attr( $success_message ),
+	)
+);
+?>
+<div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
+	<form class="fair-audience-event-interest-form">
+		<p>
+			<label for="<?php echo esc_attr( $form_id ); ?>-email">
+				<?php echo esc_html__( 'Email', 'fair-audience' ); ?> <span class="required">*</span>
+			</label>
+			<input
+				type="email"
+				id="<?php echo esc_attr( $form_id ); ?>-email"
+				name="interest_email"
+				required
+				placeholder="<?php echo esc_attr( $email_placeholder ); ?>"
+			/>
+		</p>
+		<p>
+			<label for="<?php echo esc_attr( $form_id ); ?>-name">
+				<?php echo esc_html__( 'Name', 'fair-audience' ); ?>
+			</label>
+			<input
+				type="text"
+				id="<?php echo esc_attr( $form_id ); ?>-name"
+				name="interest_name"
+				placeholder="<?php echo esc_attr( $name_placeholder ); ?>"
+			/>
+		</p>
+
+		<p class="fair-audience-event-interest-honeypot" aria-hidden="true">
+			<label for="<?php echo esc_attr( $form_id ); ?>-website">
+				<?php echo esc_html__( 'Website', 'fair-audience' ); ?>
+			</label>
+			<input
+				type="text"
+				id="<?php echo esc_attr( $form_id ); ?>-website"
+				name="interest_website"
+				tabindex="-1"
+				autocomplete="off"
+			/>
+		</p>
+
+		<div class="wp-block-button">
+			<button type="submit" class="wp-block-button__link wp-element-button fair-audience-event-interest-submit-button">
+				<?php echo esc_html( $submit_text ); ?>
+			</button>
+		</div>
+
+		<div class="fair-audience-event-interest-message" style="display: none;"></div>
+	</form>
+</div>

--- a/fair-audience/src/blocks/event-interest/style.css
+++ b/fair-audience/src/blocks/event-interest/style.css
@@ -1,0 +1,54 @@
+.fair-audience-event-interest {
+	max-width: 480px;
+}
+
+.fair-audience-event-interest-form p {
+	margin: 0 0 12px;
+}
+
+.fair-audience-event-interest-form label {
+	display: block;
+	font-size: 14px;
+	margin-bottom: 4px;
+}
+
+.fair-audience-event-interest-form input[type='email'],
+.fair-audience-event-interest-form input[type='text'] {
+	width: 100%;
+	padding: 8px 10px;
+	box-sizing: border-box;
+}
+
+.fair-audience-event-interest-form .required {
+	color: #d63638;
+}
+
+/* Honeypot: visually hidden but still rendered for bots. */
+.fair-audience-event-interest-honeypot {
+	position: absolute;
+	left: -9999px;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+}
+
+.fair-audience-event-interest-message {
+	margin-top: 12px;
+	padding: 10px 12px;
+	border-radius: 4px;
+}
+
+.fair-audience-event-interest-message-success {
+	background-color: #e6f4ea;
+	color: #1e6f3a;
+}
+
+.fair-audience-event-interest-message-error {
+	background-color: #fde7e9;
+	color: #a02020;
+}
+
+.fair-audience-event-interest-message-info {
+	background-color: #e8f0fe;
+	color: #0b3d91;
+}

--- a/fair-audience/src/blocks/event-interest/style.css
+++ b/fair-audience/src/blocks/event-interest/style.css
@@ -1,29 +1,53 @@
-.fair-audience-event-interest {
-	max-width: 480px;
+/**
+ * Frontend styles for the Event Interest block.
+ *
+ * Mirrors the Event Signup block's form aesthetic so a page that uses one
+ * or both blocks renders consistently.
+ */
+
+.fair-audience-event-interest .fair-audience-signup-form p {
+	margin-bottom: 20px;
 }
 
-.fair-audience-event-interest-form p {
-	margin: 0 0 12px;
-}
-
-.fair-audience-event-interest-form label {
+.fair-audience-event-interest .fair-audience-signup-form label {
 	display: block;
-	font-size: 14px;
-	margin-bottom: 4px;
+	margin-bottom: 8px;
+	font-weight: 500;
 }
 
-.fair-audience-event-interest-form input[type='email'],
-.fair-audience-event-interest-form input[type='text'] {
-	width: 100%;
-	padding: 8px 10px;
-	box-sizing: border-box;
-}
-
-.fair-audience-event-interest-form .required {
+.fair-audience-event-interest .fair-audience-signup-form .required {
 	color: #d63638;
 }
 
-/* Honeypot: visually hidden but still rendered for bots. */
+.fair-audience-event-interest .fair-audience-signup-form input[type='text'],
+.fair-audience-event-interest .fair-audience-signup-form input[type='email'] {
+	width: 100%;
+	padding: 14px 16px;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	font-size: 1em;
+	background-color: #fafafa;
+	box-sizing: border-box;
+	transition: border-color 0.2s ease;
+}
+
+.fair-audience-event-interest
+	.fair-audience-signup-form
+	input[type='text']:focus,
+.fair-audience-event-interest
+	.fair-audience-signup-form
+	input[type='email']:focus {
+	outline: none;
+	border-color: #0073aa;
+	box-shadow: 0 0 0 1px #0073aa;
+	background-color: #fff;
+}
+
+.fair-audience-event-interest .wp-block-button {
+	margin-top: 24px;
+}
+
+/* Honeypot: rendered for bots, invisible to humans and screen readers. */
 .fair-audience-event-interest-honeypot {
 	position: absolute;
 	left: -9999px;
@@ -32,23 +56,38 @@
 	overflow: hidden;
 }
 
-.fair-audience-event-interest-message {
-	margin-top: 12px;
-	padding: 10px 12px;
+/* Inline form messages — same visual language as the event-signup block. */
+.fair-audience-event-interest .fair-audience-signup-message {
+	margin-top: 15px;
+	padding: 12px 16px;
 	border-radius: 4px;
+	font-size: 14px;
 }
 
-.fair-audience-event-interest-message-success {
-	background-color: #e6f4ea;
-	color: #1e6f3a;
+.fair-audience-event-interest .fair-audience-signup-message-success {
+	background-color: #d4edda;
+	color: #155724;
+	border: 1px solid #c3e6cb;
 }
 
-.fair-audience-event-interest-message-error {
-	background-color: #fde7e9;
-	color: #a02020;
+.fair-audience-event-interest .fair-audience-signup-message-error {
+	background-color: #f8d7da;
+	color: #721c24;
+	border: 1px solid #f5c6cb;
 }
 
-.fair-audience-event-interest-message-info {
-	background-color: #e8f0fe;
-	color: #0b3d91;
+.fair-audience-event-interest .fair-audience-signup-message-info {
+	background-color: #d1ecf1;
+	color: #0c5460;
+	border: 1px solid #bee5eb;
+}
+
+/* "Not on an event page" fallback — matches event-signup's variant. */
+.fair-audience-event-signup-error {
+	padding: 15px 20px;
+	background-color: #f8d7da;
+	color: #721c24;
+	border: 1px solid #f5c6cb;
+	border-radius: 4px;
+	text-align: center;
 }


### PR DESCRIPTION
## Summary

- New `fair-audience/event-interest` Gutenberg block places a tiny email-only form on event pages so visitors can register interest without buying a ticket or signing up for an account.
- `POST /fair-audience/v1/event-interest` finds or creates the `Participant` by email and upserts an `EventParticipant` row with `label='interested'`. A confirmation email goes out with a tokenized unsubscribe link.
- `DELETE /fair-audience/v1/event-interest` (and the matching `?unsubscribe_event_interest=…` template handler) only removes rows still in the `interested` state, so a later `signed_up` or `collaborator` upgrade is never silently stripped.

Closes #603
Closes #604

## Notes

- Public endpoint by design — protected with a hidden honeypot field and a per-email rate limit (5/hour). No new DB columns.
- Unsubscribe uses the existing `ParticipantToken` service so the link is HMAC-signed and scoped to `(participant_id, event_date_id)`.
- API spec is parked at `fair-audience/src/API/__tests__/EventInterestController.api.spec.js` per `TESTING.md`; `playwright.config.js` updated to discover that path. Tests need `WP_ADMIN_USER` / `WP_ADMIN_PASSWORD` env vars and a running `docker compose up`.
- Block resolves its event from the current post (same pattern as `event-signup`) — it renders nothing on non-event pages.

## Test plan

- [ ] `cd fair-audience && npm run build` produces `build/blocks/event-interest/` with `style-frontend.css` and `frontend.js`.
- [ ] In wp-admin, add the **Event Interest** block to an event page and publish.
- [ ] On the public page, submit the form with a new email — expect a success message and a confirmation email in MailHog (or the local mail log) with an unsubscribe link.
- [ ] Click the unsubscribe link — expect the "Unsubscribed" page and the `wp_fair_audience_event_participants` row gone.
- [ ] Submit again with the same email — success message, no duplicate row.
- [ ] Submit with the honeypot pre-filled via devtools — success message, no DB write.
- [ ] Promote the row to `signed_up` manually, then re-use a prior unsubscribe token — row should be preserved.
- [ ] `npm run test:api` (with admin creds in env) passes the new spec.