### PR TITLE
Record verbal marketing consent from the Audience tab

### DIFF
--- a/fair-audience/fair-audience.php
+++ b/fair-audience/fair-audience.php
@@ -69,9 +69,10 @@ function fair_audience_activate() {
 	dbDelta( \FairAudience\Database\Schema::get_questionnaire_answers_table_sql() );
 	dbDelta( \FairAudience\Database\Schema::get_participant_categories_table_sql() );
 	dbDelta( \FairAudience\Database\Schema::get_event_participant_options_table_sql() );
+	dbDelta( \FairAudience\Database\Schema::get_email_consent_log_table_sql() );
 
 	// Update database version.
-	update_option( 'fair_audience_db_version', '1.33.0' );
+	update_option( 'fair_audience_db_version', '1.34.0' );
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\\fair_audience_activate' );
 
@@ -636,6 +637,12 @@ function fair_audience_maybe_upgrade_db() {
 		}
 
 		update_option( 'fair_audience_db_version', '1.33.0' );
+	}
+
+	if ( version_compare( $db_version, '1.34.0', '<' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( \FairAudience\Database\Schema::get_email_consent_log_table_sql() );
+		update_option( 'fair_audience_db_version', '1.34.0' );
 	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_audience_maybe_upgrade_db' );

--- a/fair-audience/src/API/EventParticipantsController.php
+++ b/fair-audience/src/API/EventParticipantsController.php
@@ -9,6 +9,8 @@ namespace FairAudience\API;
 
 use FairAudience\Database\EventParticipantRepository;
 use FairAudience\Database\ParticipantRepository;
+use FairAudience\Models\EmailConsentLog;
+use FairAudience\Services\EmailService;
 use WP_REST_Controller;
 use WP_REST_Server;
 use WP_REST_Request;
@@ -234,6 +236,38 @@ class EventParticipantsController extends WP_REST_Controller {
 			)
 		);
 
+		// POST /fair-audience/v1/event-dates/{event_date_id}/participants/marketing-upgrade.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/marketing-upgrade',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'upgrade_to_marketing_batch' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array(
+						'event_date_id'   => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'validate_callback' => function ( $param ) {
+								return is_numeric( $param );
+							},
+						),
+						'participant_ids' => array(
+							'type'              => 'array',
+							'required'          => true,
+							'items'             => array(
+								'type' => 'integer',
+							),
+							'validate_callback' => function ( $param ) {
+								return is_array( $param ) && ! empty( $param );
+							},
+						),
+					),
+				),
+			)
+		);
+
 		// GET /fair-audience/v1/events (list events with participant counts).
 		register_rest_route(
 			$this->namespace,
@@ -394,6 +428,7 @@ class EventParticipantsController extends WP_REST_Controller {
 					'name'                 => $participant ? $participant->name : '',
 					'surname'              => $participant ? $participant->surname : '',
 					'participant_email'    => $participant ? $participant->email : '',
+					'email_profile'        => $participant ? $participant->email_profile : '',
 					'instagram'            => $participant ? $participant->instagram : '',
 					'label'                => $ep->label,
 					'ticket_type_id'       => $ep->ticket_type_id ? (int) $ep->ticket_type_id : null,
@@ -834,6 +869,134 @@ class EventParticipantsController extends WP_REST_Controller {
 				++$results['skipped'];
 			} else {
 				++$results['added'];
+			}
+		}
+
+		return rest_ensure_response( $results );
+	}
+
+	/**
+	 * Upgrade selected participants of an event to the marketing email profile.
+	 *
+	 * Records the organizer's marketing consent (e.g. collected verbally / on a
+	 * paper list at the event), flips each eligible participant's email_profile
+	 * from "minimal" to "marketing", writes an audit-trail entry, and sends a
+	 * one-time "welcome to the mailing list" email. Already-marketing
+	 * participants and participants without an email are skipped (never
+	 * re-emailed), making the operation idempotent.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	public function upgrade_to_marketing_batch( $request ) {
+		$event_date_id   = (int) $request['event_date_id'];
+		$participant_ids = $request->get_param( 'participant_ids' );
+
+		// Resolve event_id from event_date_id.
+		$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+		if ( ! $event_date ) {
+			return new WP_Error(
+				'invalid_event_date',
+				__( 'Event date not found.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+		$event_id = (int) $event_date->event_id;
+
+		// Validate event exists.
+		$event = get_post( $event_id );
+		if ( ! $event || ! \FairEvents\Database\EventRepository::is_event( $event ) ) {
+			return new WP_Error(
+				'invalid_event',
+				__( 'Invalid event ID.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$results = array(
+			'upgraded'     => 0,
+			'skipped'      => 0,
+			'failed'       => 0,
+			'emailed'      => 0,
+			'email_failed' => 0,
+			'errors'       => array(),
+		);
+
+		$email_service = new EmailService();
+
+		$performed_by = get_current_user_id();
+		$admin_user   = get_userdata( $performed_by );
+		$admin_name   = $admin_user ? $admin_user->display_name : '';
+		$event_title  = get_the_title( $event_id );
+
+		foreach ( $participant_ids as $participant_id ) {
+			$participant_id = (int) $participant_id;
+
+			$participant = $this->participant_repo->get_by_id( $participant_id );
+			if ( ! $participant ) {
+				++$results['failed'];
+				$results['errors'][] = sprintf(
+					/* translators: %d: participant ID */
+					__( 'Participant ID %d not found', 'fair-audience' ),
+					$participant_id
+				);
+				continue;
+			}
+
+			// Must be linked to this event date.
+			$ep_row = $this->event_participant_repo->get_by_event_date_and_participant( $event_date_id, $participant_id );
+			if ( ! $ep_row ) {
+				++$results['skipped'];
+				continue;
+			}
+
+			// Skip participants without an email or already on the marketing list
+			// (the latter guarantees we never re-email an already-subscribed person).
+			if ( empty( $participant->email ) || 'minimal' !== $participant->email_profile ) {
+				++$results['skipped'];
+				continue;
+			}
+
+			$old_profile                = $participant->email_profile;
+			$participant->email_profile = 'marketing';
+
+			if ( ! $participant->save() ) {
+				++$results['failed'];
+				$results['errors'][] = sprintf(
+					/* translators: %d: participant ID */
+					__( 'Failed to upgrade participant ID %d', 'fair-audience' ),
+					$participant_id
+				);
+				continue;
+			}
+
+			++$results['upgraded'];
+
+			// Audit trail.
+			EmailConsentLog::create(
+				array(
+					'participant_id' => $participant_id,
+					'event_id'       => $event_id,
+					'event_date_id'  => $event_date_id,
+					'old_profile'    => $old_profile,
+					'new_profile'    => 'marketing',
+					'source'         => 'verbal_admin',
+					'comment'        => sprintf(
+						/* translators: 1: admin display name, 2: date, 3: event title */
+						__( 'Verbal consent recorded by %1$s on %2$s at event %3$s', 'fair-audience' ),
+						$admin_name,
+						gmdate( 'Y-m-d' ),
+						$event_title
+					),
+					'performed_by'   => $performed_by,
+				)
+			);
+
+			// Welcome email (single opt-in: they already consented in person).
+			if ( $email_service->send_mailing_list_welcome( $participant, $event_id ) ) {
+				++$results['emailed'];
+			} else {
+				++$results['email_failed'];
 			}
 		}
 

--- a/fair-audience/src/API/__tests__/EventParticipantsMarketingUpgrade.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventParticipantsMarketingUpgrade.api.spec.js
@@ -1,0 +1,180 @@
+/**
+ * Playwright API tests for the marketing-upgrade endpoint on
+ * EventParticipantsController.
+ *
+ * Exercises POST
+ * /fair-audience/v1/event-dates/{event_date_id}/participants/marketing-upgrade
+ * against a live WordPress instance. Fixtures (event, participants, links) are
+ * created via the admin REST API using Application Password credentials
+ * (WP_ADMIN_USER / WP_ADMIN_PASSWORD) and torn down at the end of the suite.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+async function createParticipant(api, { name, email, email_profile }) {
+	const res = await api.post('/wp-json/fair-audience/v1/participants', {
+		headers: authHeaders,
+		data: { name, email, email_profile },
+	});
+	expect(res.ok()).toBeTruthy();
+	const body = await res.json();
+	return body.id;
+}
+
+test.describe('EventParticipantsController marketing-upgrade', () => {
+	let api;
+	let eventId;
+	let eventDateId;
+	let minimalId;
+	let marketingId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		// Publish an event; fair-events lifecycle hooks create its event-date row.
+		const eventRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: authHeaders,
+			data: {
+				title: `Marketing Upgrade Test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(eventRes.ok()).toBeTruthy();
+		eventId = (await eventRes.json()).id;
+
+		// Resolve the event_date_id for the freshly created event.
+		const eventsRes = await api.get('/wp-json/fair-audience/v1/events', {
+			headers: authHeaders,
+			params: { per_page: 100 },
+		});
+		expect(eventsRes.ok()).toBeTruthy();
+		const events = await eventsRes.json();
+		const match = events.find((e) => e.event_id === eventId);
+		expect(match, 'event-date row for the test event').toBeTruthy();
+		eventDateId = match.event_date_id;
+
+		// One eligible participant (minimal + email), one already on the list.
+		minimalId = await createParticipant(api, {
+			name: 'Minimal Person',
+			email: uniqueEmail('minimal'),
+			email_profile: 'minimal',
+		});
+		marketingId = await createParticipant(api, {
+			name: 'Marketing Person',
+			email: uniqueEmail('marketing'),
+			email_profile: 'marketing',
+		});
+
+		// Link both to this event date.
+		const linkRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/batch`,
+			{
+				headers: authHeaders,
+				data: {
+					participant_ids: [minimalId, marketingId],
+					label: 'signed_up',
+				},
+			}
+		);
+		expect(linkRes.ok()).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		for (const id of [minimalId, marketingId]) {
+			if (id) {
+				await api.delete(
+					`/wp-json/fair-audience/v1/participants/${id}`,
+					{ headers: authHeaders }
+				);
+			}
+		}
+		if (eventId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${eventId}`, {
+				headers: authHeaders,
+				params: { force: 'true' },
+			});
+		}
+		await api.dispose();
+	});
+
+	test('participant list exposes email_profile', async () => {
+		const res = await api.get(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants`,
+			{ headers: authHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const list = await res.json();
+
+		const minimal = list.find((p) => p.participant_id === minimalId);
+		const marketing = list.find((p) => p.participant_id === marketingId);
+		expect(minimal.email_profile).toBe('minimal');
+		expect(marketing.email_profile).toBe('marketing');
+	});
+
+	test('already-marketing participant is skipped, not upgraded', async () => {
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/marketing-upgrade`,
+			{ headers: authHeaders, data: { participant_ids: [marketingId] } }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		expect(body.upgraded).toBe(0);
+		expect(body.skipped).toBeGreaterThanOrEqual(1);
+	});
+
+	test('upgrade flips minimal → marketing and is idempotent (no re-email)', async () => {
+		// First upgrade: the minimal participant is flipped and emailed once.
+		const first = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/marketing-upgrade`,
+			{ headers: authHeaders, data: { participant_ids: [minimalId] } }
+		);
+		expect(first.ok()).toBeTruthy();
+		const firstBody = await first.json();
+		expect(firstBody.upgraded).toBe(1);
+
+		// The profile is now marketing.
+		const listRes = await api.get(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants`,
+			{ headers: authHeaders }
+		);
+		const list = await listRes.json();
+		const upgraded = list.find((p) => p.participant_id === minimalId);
+		expect(upgraded.email_profile).toBe('marketing');
+
+		// Re-running upgrades nobody and skips the now-marketing participant,
+		// proving the welcome email is not sent a second time.
+		const second = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/marketing-upgrade`,
+			{ headers: authHeaders, data: { participant_ids: [minimalId] } }
+		);
+		expect(second.ok()).toBeTruthy();
+		const secondBody = await second.json();
+		expect(secondBody.upgraded).toBe(0);
+		expect(secondBody.skipped).toBeGreaterThanOrEqual(1);
+	});
+
+	test('unauthenticated upgrade is rejected', async () => {
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/marketing-upgrade`,
+			{ data: { participant_ids: [minimalId] } }
+		);
+		expect(res.status()).toBeGreaterThanOrEqual(401);
+		expect(res.status()).toBeLessThan(404);
+	});
+});

--- a/fair-audience/src/Database/Schema.php
+++ b/fair-audience/src/Database/Schema.php
@@ -488,6 +488,37 @@ class Schema {
 	}
 
 	/**
+	 * Get SQL for creating the email consent log table.
+	 *
+	 * Insert-only audit trail of email_profile changes (e.g. an organizer
+	 * recording verbal/paper marketing consent at an event).
+	 *
+	 * @return string SQL statement.
+	 */
+	public static function get_email_consent_log_table_sql() {
+		global $wpdb;
+
+		$table_name      = $wpdb->prefix . 'fair_audience_email_consent_log';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		return "CREATE TABLE $table_name (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			participant_id BIGINT UNSIGNED NOT NULL,
+			event_id BIGINT UNSIGNED DEFAULT NULL,
+			event_date_id BIGINT UNSIGNED DEFAULT NULL,
+			old_profile VARCHAR(20) DEFAULT NULL,
+			new_profile VARCHAR(20) NOT NULL,
+			source VARCHAR(50) NOT NULL,
+			comment TEXT,
+			performed_by BIGINT UNSIGNED NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY  (id),
+			KEY idx_participant_id (participant_id),
+			KEY idx_created_at (created_at)
+		) ENGINE=InnoDB $charset_collate;";
+	}
+
+	/**
 	 * Get SQL for creating the participant categories junction table.
 	 *
 	 * @return string SQL statement.

--- a/fair-audience/src/Models/EmailConsentLog.php
+++ b/fair-audience/src/Models/EmailConsentLog.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Email Consent Log Model
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Models;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Email consent log model (insert-only).
+ *
+ * Records changes to a participant's email_profile so there is an audit trail
+ * of who recorded a marketing consent, when, and at which event.
+ */
+class EmailConsentLog {
+
+	/**
+	 * Log entry ID.
+	 *
+	 * @var int|null
+	 */
+	public $id;
+
+	/**
+	 * Participant ID.
+	 *
+	 * @var int
+	 */
+	public $participant_id;
+
+	/**
+	 * Event post ID.
+	 *
+	 * @var int|null
+	 */
+	public $event_id;
+
+	/**
+	 * Event date ID.
+	 *
+	 * @var int|null
+	 */
+	public $event_date_id;
+
+	/**
+	 * Previous email profile.
+	 *
+	 * @var string|null
+	 */
+	public $old_profile;
+
+	/**
+	 * New email profile.
+	 *
+	 * @var string
+	 */
+	public $new_profile;
+
+	/**
+	 * Consent source identifier (e.g. 'verbal_admin').
+	 *
+	 * @var string
+	 */
+	public $source;
+
+	/**
+	 * Human-readable audit comment.
+	 *
+	 * @var string|null
+	 */
+	public $comment;
+
+	/**
+	 * Performed by user ID.
+	 *
+	 * @var int
+	 */
+	public $performed_by;
+
+	/**
+	 * Created timestamp.
+	 *
+	 * @var string
+	 */
+	public $created_at;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $data Optional data to populate.
+	 */
+	public function __construct( $data = array() ) {
+		if ( ! empty( $data ) ) {
+			$this->populate( $data );
+		}
+	}
+
+	/**
+	 * Populate from data array.
+	 *
+	 * @param array $data Data array.
+	 */
+	public function populate( $data ) {
+		$this->id             = isset( $data['id'] ) ? (int) $data['id'] : null;
+		$this->participant_id = isset( $data['participant_id'] ) ? (int) $data['participant_id'] : 0;
+		$this->event_id       = isset( $data['event_id'] ) && $data['event_id'] ? (int) $data['event_id'] : null;
+		$this->event_date_id  = isset( $data['event_date_id'] ) && $data['event_date_id'] ? (int) $data['event_date_id'] : null;
+		$this->old_profile    = isset( $data['old_profile'] ) ? sanitize_text_field( $data['old_profile'] ) : null;
+		$this->new_profile    = isset( $data['new_profile'] ) ? sanitize_text_field( $data['new_profile'] ) : '';
+		$this->source         = isset( $data['source'] ) ? sanitize_text_field( $data['source'] ) : '';
+		$this->comment        = isset( $data['comment'] ) ? sanitize_textarea_field( $data['comment'] ) : null;
+		$this->performed_by   = isset( $data['performed_by'] ) ? (int) $data['performed_by'] : 0;
+		$this->created_at     = isset( $data['created_at'] ) ? $data['created_at'] : '';
+	}
+
+	/**
+	 * Save to database (insert only).
+	 *
+	 * @return bool Success.
+	 */
+	public function save() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_audience_email_consent_log';
+
+		// Consent log is insert-only.
+		if ( $this->id ) {
+			return false;
+		}
+
+		// Validate required fields.
+		if ( empty( $this->participant_id ) || empty( $this->new_profile ) || empty( $this->source ) ) {
+			return false;
+		}
+
+		// Auto-set performed_by from current user if not set.
+		if ( empty( $this->performed_by ) ) {
+			$this->performed_by = get_current_user_id();
+		}
+
+		$data = array(
+			'participant_id' => $this->participant_id,
+			'event_id'       => $this->event_id,
+			'event_date_id'  => $this->event_date_id,
+			'old_profile'    => $this->old_profile,
+			'new_profile'    => $this->new_profile,
+			'source'         => $this->source,
+			'comment'        => $this->comment,
+			'performed_by'   => $this->performed_by,
+		);
+
+		$format = array( '%d', '%d', '%d', '%s', '%s', '%s', '%s', '%d' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->insert( $table_name, $data, $format );
+		if ( $result ) {
+			$this->id = $wpdb->insert_id;
+		}
+
+		return false !== $result;
+	}
+
+	/**
+	 * Create and persist a consent log entry in one step.
+	 *
+	 * @param array $data Data array.
+	 * @return bool Success.
+	 */
+	public static function create( $data ) {
+		$entry = new self( $data );
+		return $entry->save();
+	}
+}

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -2725,4 +2725,99 @@ class EmailService {
 
 		return (bool) $result;
 	}
+
+	/**
+	 * Send a "welcome to the mailing list" email.
+	 *
+	 * Sent when an organizer records a participant's marketing consent (e.g. a
+	 * verbal/paper consent collected at an event). This is single opt-in: the
+	 * participant has already consented, so the email confirms the subscription
+	 * and provides a manage-subscription / unsubscribe link rather than asking
+	 * them to confirm.
+	 *
+	 * @param Participant $participant Participant who was added to the list.
+	 * @param int         $event_id    Event post ID where consent was given.
+	 * @return bool True if mail dispatched.
+	 */
+	public function send_mailing_list_welcome( Participant $participant, int $event_id ): bool {
+		if ( ! $this->has_valid_email( $participant ) ) {
+			return false;
+		}
+
+		$site_name   = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+		$event_title = $event_id ? get_the_title( $event_id ) : '';
+
+		$manage_subscription_url = ManageSubscriptionToken::get_url( (int) $participant->id );
+
+		$subject = sprintf(
+			/* translators: %s: site name */
+			__( 'Welcome to the %s mailing list', 'fair-audience' ),
+			$site_name
+		);
+
+		$greeting_name = ! empty( $participant->name ) ? $participant->name : __( 'there', 'fair-audience' );
+
+		if ( ! empty( $event_title ) ) {
+			$intro = sprintf(
+				/* translators: 1: site name, 2: event title */
+				esc_html__( 'You\'ve been added to the %1$s mailing list following the consent you gave at %2$s. We\'ll keep you posted about upcoming events and news.', 'fair-audience' ),
+				'<strong>' . esc_html( $site_name ) . '</strong>',
+				'<strong>' . esc_html( $event_title ) . '</strong>'
+			);
+		} else {
+			$intro = sprintf(
+				/* translators: %s: site name */
+				esc_html__( 'You\'ve been added to the %s mailing list following the consent you gave. We\'ll keep you posted about upcoming events and news.', 'fair-audience' ),
+				'<strong>' . esc_html( $site_name ) . '</strong>'
+			);
+		}
+
+		$message = '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #333333; background-color: #f4f4f4;">
+	<table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f4;">
+		<tr>
+			<td align="center" style="padding: 20px 0;">
+				<table width="600" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+					<tr>
+						<td style="background-color: #0073aa; color: #ffffff; padding: 30px; border-radius: 8px 8px 0 0; text-align: center;">
+							<h1 style="margin: 0; font-size: 24px; font-weight: bold;">' . esc_html( $site_name ) . '</h1>
+						</td>
+					</tr>
+					<tr>
+						<td style="padding: 40px 30px;">
+							<p style="margin: 0 0 20px 0;">' . sprintf(
+								/* translators: %s: participant name */
+								esc_html__( 'Hi %s,', 'fair-audience' ),
+								'<strong>' . esc_html( $greeting_name ) . '</strong>'
+							) . '</p>
+							<p style="margin: 0 0 20px 0;">' . $intro . '</p>
+						</td>
+					</tr>
+					<tr>
+						<td style="background-color: #f8f8f8; padding: 20px 30px; border-radius: 0 0 8px 8px; text-align: center; font-size: 12px; color: #666666;">
+							<p style="margin: 0 0 5px 0;">' . esc_html__( 'Changed your mind?', 'fair-audience' ) . '</p>
+							<p style="margin: 0;"><a href="' . esc_url( $manage_subscription_url ) . '" style="color: #0073aa;">' . esc_html__( 'Manage your subscription or unsubscribe', 'fair-audience' ) . '</a></p>
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+</body>
+</html>';
+
+		$content_type_filter = function () {
+			return 'text/html';
+		};
+		add_filter( 'wp_mail_content_type', $content_type_filter );
+		$result = wp_mail( $participant->email, $subject, $message );
+		remove_filter( 'wp_mail_content_type', $content_type_filter );
+
+		return (bool) $result;
+	}
 }

--- a/fair-events/src/Admin/manage-event/EventAudience.js
+++ b/fair-events/src/Admin/manage-event/EventAudience.js
@@ -72,6 +72,12 @@ export default function EventAudience({
 	const [selectedToAdd, setSelectedToAdd] = useState(new Set());
 	const [isAdding, setIsAdding] = useState(false);
 
+	// Mailing-list (verbal consent) modal state
+	const [mailingModalOpen, setMailingModalOpen] = useState(false);
+	const [mailingSearch, setMailingSearch] = useState('');
+	const [selectedForMailing, setSelectedForMailing] = useState(new Set());
+	const [isUpgrading, setIsUpgrading] = useState(false);
+
 	// Invite groups state
 	const [invitedGroups, setInvitedGroups] = useState([]);
 	const [inviteModalOpen, setInviteModalOpen] = useState(false);
@@ -377,6 +383,99 @@ export default function EventAudience({
 			);
 		} finally {
 			setIsAdding(false);
+		}
+	};
+
+	// Participants eligible for a marketing-list upgrade: currently on the
+	// "minimal" email profile and reachable (have an email address).
+	const mailingEligible = useMemo(
+		() =>
+			participants.filter(
+				(p) => p.email_profile === 'minimal' && p.participant_email
+			),
+		[participants]
+	);
+
+	const filteredMailingEligible = useMemo(() => {
+		if (!mailingSearch) return mailingEligible;
+		const term = mailingSearch.toLowerCase();
+		return mailingEligible.filter(
+			(p) =>
+				(p.name || '').toLowerCase().includes(term) ||
+				(p.surname || '').toLowerCase().includes(term) ||
+				(p.participant_email || '').toLowerCase().includes(term)
+		);
+	}, [mailingEligible, mailingSearch]);
+
+	const handleOpenMailingModal = () => {
+		setMailingModalOpen(true);
+		setSelectedForMailing(new Set());
+		setMailingSearch('');
+	};
+
+	const handleCloseMailingModal = () => {
+		setMailingModalOpen(false);
+		setSelectedForMailing(new Set());
+		setMailingSearch('');
+	};
+
+	const handleToggleMailing = (participantId) => {
+		const next = new Set(selectedForMailing);
+		if (next.has(participantId)) {
+			next.delete(participantId);
+		} else {
+			next.add(participantId);
+		}
+		setSelectedForMailing(next);
+	};
+
+	const handleSelectAllMailing = () => {
+		const shownIds = filteredMailingEligible.map((p) => p.participant_id);
+		const allSelected = shownIds.every((id) => selectedForMailing.has(id));
+		const next = new Set(selectedForMailing);
+		if (allSelected) {
+			shownIds.forEach((id) => next.delete(id));
+		} else {
+			shownIds.forEach((id) => next.add(id));
+		}
+		setSelectedForMailing(next);
+	};
+
+	const handleUpgradeToMarketing = async () => {
+		if (selectedForMailing.size === 0) return;
+		setIsUpgrading(true);
+		try {
+			const response = await apiFetch({
+				path: `/fair-audience/v1/event-dates/${eventDateId}/participants/marketing-upgrade`,
+				method: 'POST',
+				data: { participant_ids: Array.from(selectedForMailing) },
+			});
+			handleCloseMailingModal();
+			loadParticipants();
+			const upgraded = response.upgraded ?? 0;
+			const skipped = response.skipped ?? 0;
+			const emailFailed = response.email_failed ?? 0;
+			showToast(
+				sprintf(
+					/* translators: 1: number upgraded, 2: number skipped, 3: number of failed emails */
+					__(
+						'Added %1$d to the mailing list. Skipped %2$d, %3$d email(s) failed.',
+						'fair-events'
+					),
+					upgraded,
+					skipped,
+					emailFailed
+				),
+				emailFailed > 0 ? 'error' : 'success'
+			);
+		} catch (err) {
+			showToast(
+				__('Error updating mailing list: ', 'fair-events') +
+					err.message,
+				'error'
+			);
+		} finally {
+			setIsUpgrading(false);
 		}
 	};
 
@@ -1486,6 +1585,16 @@ export default function EventAudience({
 											)}
 										</Button>
 									)}
+									<Button
+										variant="secondary"
+										onClick={handleOpenMailingModal}
+										disabled={mailingEligible.length === 0}
+									>
+										{__(
+											'Add to mailing list (verbal consent)',
+											'fair-events'
+										)}
+									</Button>
 								</HStack>
 							</VStack>
 						)}
@@ -1856,6 +1965,190 @@ export default function EventAudience({
 													'fair-events'
 												),
 												selectedToAdd.size
+										  )}
+								</Button>
+							</div>
+						</>
+					)}
+				</Modal>
+			)}
+
+			{mailingModalOpen && (
+				<Modal
+					title={__(
+						'Add to mailing list (verbal consent)',
+						'fair-events'
+					)}
+					onRequestClose={handleCloseMailingModal}
+					style={{ maxWidth: '640px', width: '100%' }}
+				>
+					{mailingEligible.length === 0 ? (
+						<p>
+							{__(
+								'No participants are eligible. People are listed here when they have an email address and are not already on the marketing list.',
+								'fair-events'
+							)}
+						</p>
+					) : (
+						<>
+							<p style={{ marginTop: 0, color: '#666' }}>
+								{__(
+									'Tick the people who gave you their consent in person. They will be added to the marketing list and emailed a welcome message with an unsubscribe link.',
+									'fair-events'
+								)}
+							</p>
+
+							<div
+								style={{
+									display: 'flex',
+									gap: '10px',
+									marginBottom: '10px',
+									alignItems: 'center',
+								}}
+							>
+								<input
+									type="text"
+									placeholder={__(
+										'Search by name or email…',
+										'fair-events'
+									)}
+									value={mailingSearch}
+									onChange={(e) =>
+										setMailingSearch(e.target.value)
+									}
+									style={{
+										flex: 1,
+										padding: '8px 12px',
+										border: '1px solid #ddd',
+										borderRadius: '4px',
+									}}
+								/>
+								<Button
+									variant="link"
+									onClick={handleSelectAllMailing}
+									disabled={
+										filteredMailingEligible.length === 0
+									}
+								>
+									{filteredMailingEligible.length > 0 &&
+									filteredMailingEligible.every((p) =>
+										selectedForMailing.has(p.participant_id)
+									)
+										? __('Deselect all', 'fair-events')
+										: __('Select all', 'fair-events')}
+								</Button>
+							</div>
+
+							<div
+								style={{
+									marginBottom: '10px',
+									fontSize: '12px',
+									color: '#666',
+								}}
+							>
+								{sprintf(
+									/* translators: 1: selected count, 2: shown count */
+									__(
+										'%1$d selected, %2$d shown',
+										'fair-events'
+									),
+									selectedForMailing.size,
+									filteredMailingEligible.length
+								)}
+							</div>
+
+							<div
+								style={{
+									maxHeight: '400px',
+									overflowY: 'auto',
+									border: '1px solid #ddd',
+									borderRadius: '4px',
+								}}
+							>
+								{filteredMailingEligible.map((p) => (
+									<div
+										key={p.participant_id}
+										style={{
+											padding: '10px 15px',
+											borderBottom: '1px solid #eee',
+											display: 'flex',
+											alignItems: 'center',
+											gap: '10px',
+										}}
+									>
+										<CheckboxControl
+											checked={selectedForMailing.has(
+												p.participant_id
+											)}
+											onChange={() =>
+												handleToggleMailing(
+													p.participant_id
+												)
+											}
+											__nextHasNoMarginBottom
+										/>
+										<div>
+											<strong>
+												{p.name} {p.surname}
+											</strong>
+											<br />
+											<span
+												style={{
+													color: '#666',
+													fontSize: '12px',
+												}}
+											>
+												{p.participant_email}
+											</span>
+										</div>
+									</div>
+								))}
+								{filteredMailingEligible.length === 0 && (
+									<p
+										style={{
+											padding: '15px',
+											color: '#666',
+										}}
+									>
+										{__(
+											'No participants match your search.',
+											'fair-events'
+										)}
+									</p>
+								)}
+							</div>
+
+							<div
+								style={{
+									marginTop: '20px',
+									display: 'flex',
+									justifyContent: 'flex-end',
+									gap: '10px',
+								}}
+							>
+								<Button
+									variant="secondary"
+									onClick={handleCloseMailingModal}
+								>
+									{__('Cancel', 'fair-events')}
+								</Button>
+								<Button
+									variant="primary"
+									onClick={handleUpgradeToMarketing}
+									disabled={
+										selectedForMailing.size === 0 ||
+										isUpgrading
+									}
+								>
+									{isUpgrading
+										? __('Adding…', 'fair-events')
+										: sprintf(
+												/* translators: %d: number of selected participants */
+												__(
+													'Add %d to mailing list',
+													'fair-events'
+												),
+												selectedForMailing.size
 										  )}
 								</Button>
 							</div>


### PR DESCRIPTION
## Summary

- Adds an **"Add to mailing list (verbal consent)"** button on the event Audience tab so organizers can record paper/verbal mailing-list consent collected in person. Closes #613.
- Opens a modal of this event's participants still on the `minimal` email profile who have an email address (per-row checkboxes + select-all). Confirming flips each to `marketing`, sends a one-time welcome email with the existing manage-subscription / unsubscribe link, and writes an audit-trail row.
- New insert-only `wp_fair_audience_email_consent_log` table records who recorded the consent, when, and at which event (`source=verbal_admin`).

## Notes

- **Single opt-in**: participants already consented in person, so they're added directly rather than asked to re-confirm (distinct from the existing double opt-in `send_confirmation_email` flow).
- **Idempotent**: already-`marketing` and email-less participants are skipped, so re-running never double-emails. The endpoint returns `{ upgraded, skipped, failed, emailed, email_failed }`.
- New REST endpoint `POST /fair-audience/v1/event-dates/{event_date_id}/participants/marketing-upgrade`, guarded by `manage_options`. The existing participant-list response now also exposes `email_profile`.
- DB version bumped `1.33.0 → 1.34.0` with a migration that creates the new table.
- **The Playwright API tests could not be executed locally**: this machine's Docker daemon is returning HTTP 500 for all API calls, and the local WP instance lacks pretty permalinks + a configured admin Application Password. The pre-existing `EventInterestController.api.spec.js` fails at the identical `beforeAll` step, so the new spec follows the established pattern and needs the CI env (`WP_ADMIN_USER`/`WP_ADMIN_PASSWORD`) to run.

## Test plan

- [x] `php -l` clean on all changed PHP files
- [x] `phpcs` clean for new code
- [x] `npm run build` (fair-events) compiles; format + makejson succeed
- [ ] Confirm migration created `wp_fair_audience_email_consent_log` and `fair_audience_db_version` reads `1.34.0`
- [ ] Audience tab: button lists only `minimal`+email participants; select-all + per-row work
- [ ] Confirm flips profile to `marketing`, sends welcome email with working manage-subscription link, and the participant drops off the eligible list
- [ ] Re-opening the modal no longer shows the upgraded participant (no re-email)
- [ ] Consent-log row recorded with `source=verbal_admin`, correct `performed_by`, event_id/event_date_id, and human-readable comment
- [ ] `npm run test:api` (fair-audience) green in CI