### PR TITLE
Defer signup confirmation emails off the request path

### DIFF
--- a/fair-audience/src/API/AudienceSignupController.php
+++ b/fair-audience/src/API/AudienceSignupController.php
@@ -264,9 +264,13 @@ class AudienceSignupController extends WP_REST_Controller {
 			// Save questionnaire answers even for existing participants.
 			$submission_id = $this->save_questionnaire_answers( $existing->id, $questionnaire_answers, $event_date_id, $post_id );
 
-			// Send answers email if there are answers.
+			// Send answers email if there are answers (deferred so a slow mail
+			// transport can't make this request time out).
 			if ( $submission_id > 0 && ! empty( $questionnaire_answers ) ) {
-				$this->email_service->send_audience_signup_answers_email( $existing, $submission_id, $questionnaire_answers, $post_id );
+				EmailService::defer(
+					'send_audience_signup_answers_email',
+					array( $existing, $submission_id, $questionnaire_answers, $post_id )
+				);
 			}
 
 			return rest_ensure_response(
@@ -302,18 +306,23 @@ class AudienceSignupController extends WP_REST_Controller {
 		// Save questionnaire answers.
 		$submission_id = $this->save_questionnaire_answers( $participant->id, $questionnaire_answers, $event_date_id, $post_id );
 
-		// Send answers email if there are answers.
+		// Send answers email if there are answers (deferred so a slow mail
+		// transport can't make this request time out).
 		if ( $submission_id > 0 && ! empty( $questionnaire_answers ) ) {
-			$this->email_service->send_audience_signup_answers_email( $participant, $submission_id, $questionnaire_answers, $post_id );
+			EmailService::defer(
+				'send_audience_signup_answers_email',
+				array( $participant, $submission_id, $questionnaire_answers, $post_id )
+			);
 		}
 
 		AudienceSession::set( (int) $participant->id );
 
-		// If keep_informed, send confirmation email.
+		// If keep_informed, send confirmation email (deferred so a slow mail
+		// transport can't make this request time out).
 		if ( $keep_informed ) {
 			$token = $this->token_repository->create_token( $participant->id );
 			if ( $token ) {
-				$this->email_service->send_confirmation_email( $participant, $token->token );
+				EmailService::defer( 'send_confirmation_email', array( $participant, $token->token ) );
 			}
 
 			return rest_ensure_response(

--- a/fair-audience/src/API/EventInterestController.php
+++ b/fair-audience/src/API/EventInterestController.php
@@ -58,13 +58,6 @@ class EventInterestController extends WP_REST_Controller {
 	private $event_participant_repository;
 
 	/**
-	 * Email service instance.
-	 *
-	 * @var EmailService
-	 */
-	private $email_service;
-
-	/**
 	 * Rate limit: max requests per email per hour.
 	 */
 	const RATE_LIMIT_MAX = 5;
@@ -80,7 +73,6 @@ class EventInterestController extends WP_REST_Controller {
 	public function __construct() {
 		$this->participant_repository       = new ParticipantRepository();
 		$this->event_participant_repository = new EventParticipantRepository();
-		$this->email_service                = new EmailService();
 	}
 
 	/**
@@ -224,12 +216,12 @@ class EventInterestController extends WP_REST_Controller {
 			$event_date_id
 		);
 
-		// Best-effort confirmation email. Don't fail the request if the mail
-		// transport hiccups — the row is already saved.
-		$this->email_service->send_event_interest_confirmation(
-			$participant,
-			$event_id,
-			$event_date_id
+		// Best-effort confirmation email, deferred to a cron tick so a slow or
+		// unreachable mail transport can't make this request time out — the row
+		// is already saved.
+		EmailService::defer(
+			'send_event_interest_confirmation',
+			array( $participant, $event_id, $event_date_id )
 		);
 
 		return $this->success_response();

--- a/fair-audience/src/API/FairFormController.php
+++ b/fair-audience/src/API/FairFormController.php
@@ -310,10 +310,11 @@ class FairFormController extends WP_REST_Controller {
 				$participant->status = 'pending';
 				$participant->save();
 
-				// Create confirmation token and send email.
+				// Create confirmation token and send email (deferred so a slow
+				// mail transport can't make this request time out).
 				$token = $this->token_repository->create_token( $participant->id );
 				if ( $token ) {
-					$this->email_service->send_confirmation_email( $participant, $token->token );
+					EmailService::defer( 'send_confirmation_email', array( $participant, $token->token ) );
 				}
 			}
 
@@ -338,23 +339,19 @@ class FairFormController extends WP_REST_Controller {
 		// Save questionnaire answers.
 		$this->save_questionnaire_answers( $participant->id, $questionnaire_answers, $event_date_id, $post_id );
 
-		// Send confirmation email to the submitter.
-		$this->email_service->send_form_confirmation(
-			$participant,
-			$questionnaire_answers,
-			$post_id
+		// Send confirmation email to the submitter (deferred so a slow mail
+		// transport can't make this request time out).
+		EmailService::defer(
+			'send_form_confirmation',
+			array( $participant, $questionnaire_answers, $post_id )
 		);
 
-		// Send admin notification email if configured.
+		// Send admin notification email if configured (also deferred).
 		$notification_email = $request->get_param( 'notification_email' );
 		if ( ! empty( $notification_email ) && is_email( $notification_email ) ) {
-			$this->email_service->send_form_notification(
-				$notification_email,
-				$name,
-				$surname,
-				$email,
-				$questionnaire_answers,
-				$post_id
+			EmailService::defer(
+				'send_form_notification',
+				array( $notification_email, $name, $surname, $email, $questionnaire_answers, $post_id )
 			);
 		}
 

--- a/fair-audience/src/API/MailingSignupController.php
+++ b/fair-audience/src/API/MailingSignupController.php
@@ -225,7 +225,7 @@ class MailingSignupController extends WP_REST_Controller {
 				}
 
 				if ( $token ) {
-					$this->email_service->send_confirmation_email( $existing, $token->token );
+					EmailService::defer( 'send_confirmation_email', array( $existing, $token->token ) );
 				}
 
 				return rest_ensure_response(
@@ -277,16 +277,13 @@ class MailingSignupController extends WP_REST_Controller {
 			);
 		}
 
-		// Send confirmation email.
-		$email_sent = $this->email_service->send_confirmation_email( $participant, $token->token );
-
-		if ( ! $email_sent ) {
-			return new WP_Error(
-				'email_failed',
-				__( 'Failed to send confirmation email. Please try again.', 'fair-audience' ),
-				array( 'status' => 500 )
-			);
-		}
+		// Send confirmation email, deferred to a cron tick so a slow or
+		// unreachable mail transport can't make this request time out. The
+		// pending participant + token are already persisted, so we report
+		// success optimistically; if delivery fails the visitor simply doesn't
+		// receive the mail and can sign up again (same outcome as the mail
+		// landing in spam). We can no longer surface a send failure here.
+		EmailService::defer( 'send_confirmation_email', array( $participant, $token->token ) );
 
 		AudienceSession::set( (int) $participant->id );
 

--- a/fair-audience/src/Core/Plugin.php
+++ b/fair-audience/src/Core/Plugin.php
@@ -61,6 +61,16 @@ class Plugin {
 		// Instagram token refresh cron.
 		add_action( 'fair_audience_refresh_instagram_token', array( $this, 'refresh_instagram_token' ) );
 
+		// Deferred email dispatch: confirmation emails are scheduled rather than
+		// sent inline so a slow/unreachable mail transport can't make signup
+		// requests time out. See EmailService::defer().
+		add_action(
+			\FairAudience\Services\EmailService::DEFERRED_EMAIL_HOOK,
+			array( \FairAudience\Services\EmailService::class, 'run_deferred' ),
+			10,
+			2
+		);
+
 		// Initialize settings.
 		$settings = new \FairAudience\Settings\Settings();
 		$settings->init();

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -2820,4 +2820,64 @@ class EmailService {
 
 		return (bool) $result;
 	}
+
+	/**
+	 * Cron hook used to dispatch deferred emails.
+	 */
+	const DEFERRED_EMAIL_HOOK = 'fair_audience_send_deferred_email';
+
+	/**
+	 * Methods that may be invoked through the deferred-email cron hook.
+	 *
+	 * Acts as an allow-list so a tampered cron entry can't call arbitrary
+	 * EmailService methods.
+	 *
+	 * @var string[]
+	 */
+	const DEFERRABLE_METHODS = array(
+		'send_event_interest_confirmation',
+		'send_audience_signup_answers_email',
+		'send_confirmation_email',
+		'send_form_confirmation',
+		'send_form_notification',
+	);
+
+	/**
+	 * Queue an email to be sent after the current request, off the critical path.
+	 *
+	 * Front-end signup endpoints persist their row first, then send a
+	 * confirmation email. Sending it synchronously blocks the HTTP response on
+	 * the mail transport: a slow or unreachable SMTP server makes the request
+	 * hang until the socket times out, which surfaces in the browser as
+	 * net::ERR_TIMED_OUT even though the signup was already saved. Scheduling a
+	 * single cron event lets the REST response return immediately; the mail goes
+	 * out on the next cron tick regardless of transport health.
+	 *
+	 * @param string $method EmailService method name to invoke (must be in DEFERRABLE_METHODS).
+	 * @param array  $args   Positional arguments for that method.
+	 * @return void
+	 */
+	public static function defer( string $method, array $args ): void {
+		if ( ! in_array( $method, self::DEFERRABLE_METHODS, true ) ) {
+			return;
+		}
+
+		wp_schedule_single_event( time(), self::DEFERRED_EMAIL_HOOK, array( $method, $args ) );
+	}
+
+	/**
+	 * Cron callback: invoke a previously deferred EmailService method.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Positional arguments.
+	 * @return void
+	 */
+	public static function run_deferred( string $method, array $args ): void {
+		if ( ! in_array( $method, self::DEFERRABLE_METHODS, true ) ) {
+			return;
+		}
+
+		$service = new self();
+		call_user_func_array( array( $service, $method ), $args );
+	}
 }


### PR DESCRIPTION
Front-end signup endpoints sent their confirmation email synchronously
with wp_mail() as the last step before responding. When the mail
transport is slow or unreachable the call blocks until the socket times
out, holding the HTTP connection open with no response — the browser
reports net::ERR_TIMED_OUT even though the signup row was already saved.

EmailService::defer() now schedules these sends onto a WP-Cron single
event so the REST response returns immediately and the mail goes out on
the next cron tick regardless of transport health. Applied to the
event-interest, audience-signup, fair-form, and mailing-signup
endpoints.

Mailing signup no longer hard-fails with email_failed when wp_mail()
fails: the send is deferred, so success can't be known synchronously.
The pending participant and token are persisted and success is reported
optimistically; a failed delivery just means the visitor signs up again,
the same outcome as the mail landing in spam.
