### PR TITLE
Add Mollie settlement CSV import to reconciliation

### DIFF
--- a/fair-payment/src/API/RestHooks.php
+++ b/fair-payment/src/API/RestHooks.php
@@ -62,5 +62,8 @@ class RestHooks {
 
 		$connected_sites_controller = new \FairPayment\API\ConnectedSitesController();
 		$connected_sites_controller->register_routes();
+
+		$settlement_controller = new \FairPayment\API\SettlementController();
+		$settlement_controller->register_routes();
 	}
 }

--- a/fair-payment/src/API/SettlementController.php
+++ b/fair-payment/src/API/SettlementController.php
@@ -1,0 +1,379 @@
+<?php
+/**
+ * REST API Controller for Mollie settlement reconciliation
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\API;
+
+defined( 'WPINC' ) || die;
+
+use FairPayment\Models\EntryTransaction;
+use FairPayment\Models\FinancialEntry;
+use FairPayment\Models\Transaction;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+/**
+ * Handles Mollie settlement import reconciliation endpoints.
+ *
+ * Parsing of the settlement CSV happens client-side; this controller receives
+ * the already-parsed rows, matches payment rows to transactions by
+ * mollie_payment_id, reconciles fees, and suggests the bank entry that the
+ * payout corresponds to. Persisting matches is done by the existing
+ * financial-entries match endpoint.
+ */
+class SettlementController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-payment/v1';
+
+	/**
+	 * Amount tolerance (in currency units) for matching the settlement total
+	 * against an unmatched bank entry.
+	 *
+	 * @var float
+	 */
+	const ENTRY_MATCH_TOLERANCE = 0.02;
+
+	/**
+	 * Register the routes for settlement reconciliation
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		// POST /fair-payment/v1/reconciliation/settlement/preview - Match a parsed settlement.
+		register_rest_route(
+			$this->namespace,
+			'/reconciliation/settlement/preview',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'preview_settlement' ),
+					'permission_callback' => array( $this, 'preview_permissions_check' ),
+					'args'                => array(
+						'settlement_reference' => array(
+							'description'       => __( 'Mollie settlement reference shared by all rows.', 'fair-payment' ),
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'currency'             => array(
+							'description'       => __( 'Settlement currency.', 'fair-payment' ),
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'settlement_total'     => array(
+							'description' => __( 'Sum of all settlement amount cells.', 'fair-payment' ),
+							'type'        => 'number',
+							'required'    => false,
+						),
+						'payment_rows'         => array(
+							'description' => __( 'Parsed payment rows from the settlement CSV.', 'fair-payment' ),
+							'type'        => 'array',
+							'required'    => true,
+							'items'       => array(
+								'type'       => 'object',
+								'properties' => array(
+									'mollie_payment_id' => array(
+										'type'     => 'string',
+										'required' => true,
+									),
+									'amount'            => array(
+										'type' => 'number',
+									),
+									'status'            => array(
+										'type' => 'string',
+									),
+									'description'       => array(
+										'type' => 'string',
+									),
+									'settlement_amount' => array(
+										'type' => 'number',
+									),
+								),
+							),
+						),
+						'fee_rows'             => array(
+							'description' => __( 'Parsed aggregate fee rows from the settlement CSV.', 'fair-payment' ),
+							'type'        => 'array',
+							'required'    => false,
+							'items'       => array(
+								'type'       => 'object',
+								'properties' => array(
+									'description' => array(
+										'type' => 'string',
+									),
+									'amount'      => array(
+										'type' => 'number',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Check permissions for the preview endpoint.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool True if user has permission.
+	 */
+	public function preview_permissions_check( $request ) {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Match a parsed settlement against transactions and bank entries.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error Report object on success, WP_Error on failure.
+	 */
+	public function preview_settlement( $request ) {
+		$settlement_reference = sanitize_text_field( (string) $request->get_param( 'settlement_reference' ) );
+		$currency             = sanitize_text_field( (string) $request->get_param( 'currency' ) );
+		$payment_rows         = $request->get_param( 'payment_rows' );
+		$fee_rows             = $request->get_param( 'fee_rows' );
+		$settlement_total     = (float) $request->get_param( 'settlement_total' );
+
+		if ( '' === $settlement_reference ) {
+			return new WP_Error(
+				'rest_settlement_invalid',
+				__( 'Missing settlement reference. This does not look like a Mollie settlement export.', 'fair-payment' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( empty( $payment_rows ) || ! is_array( $payment_rows ) ) {
+			return new WP_Error(
+				'rest_settlement_invalid',
+				__( 'No payment rows found. This does not look like a Mollie settlement export.', 'fair-payment' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! is_array( $fee_rows ) ) {
+			$fee_rows = array();
+		}
+
+		$matched                  = array();
+		$unmatched_csv_rows       = array();
+		$resolved_transaction_ids = array();
+		$payments_total           = 0.0;
+		$transaction_fees_total   = 0.0;
+		$row_dates                = array();
+
+		foreach ( $payment_rows as $row ) {
+			$mollie_payment_id = isset( $row['mollie_payment_id'] ) ? sanitize_text_field( (string) $row['mollie_payment_id'] ) : '';
+			$csv_amount        = isset( $row['amount'] ) ? (float) $row['amount'] : 0.0;
+			$payments_total   += $csv_amount;
+
+			if ( '' === $mollie_payment_id ) {
+				$unmatched_csv_rows[] = $this->format_unmatched_row( $row );
+				continue;
+			}
+
+			$transaction = Transaction::get_by_mollie_id( $mollie_payment_id );
+			if ( ! $transaction ) {
+				$unmatched_csv_rows[] = $this->format_unmatched_row( $row );
+				continue;
+			}
+
+			$transaction_id             = (int) $transaction->id;
+			$db_amount                  = (float) $transaction->amount;
+			$application_fee            = null !== $transaction->application_fee ? (float) $transaction->application_fee : 0.0;
+			$mollie_fee                 = null !== $transaction->mollie_fee ? (float) $transaction->mollie_fee : 0.0;
+			$transaction_fees_total    += $application_fee + $mollie_fee;
+			$resolved_transaction_ids[] = $transaction_id;
+
+			if ( ! empty( $transaction->created_at ) ) {
+				$row_dates[] = substr( $transaction->created_at, 0, 10 );
+			}
+
+			$matched[] = array(
+				'transaction_id'    => $transaction_id,
+				'mollie_payment_id' => $mollie_payment_id,
+				'csv_amount'        => $csv_amount,
+				'amount'            => $db_amount,
+				'application_fee'   => $application_fee,
+				'mollie_fee'        => $mollie_fee,
+				'status'            => $transaction->status,
+				'description'       => $transaction->description,
+				'created_at'        => $transaction->created_at,
+				'already_matched'   => EntryTransaction::is_transaction_matched( $transaction_id ),
+				'amount_mismatch'   => abs( $csv_amount - $db_amount ) > 0.001,
+			);
+		}
+
+		$resolved_transaction_ids = array_values( array_unique( $resolved_transaction_ids ) );
+
+		$csv_fees_total = 0.0;
+		foreach ( $fee_rows as $fee_row ) {
+			$csv_fees_total += isset( $fee_row['amount'] ) ? (float) $fee_row['amount'] : 0.0;
+		}
+
+		$fee_reconciliation = array(
+			'csv_fees_total'         => $csv_fees_total,
+			'transaction_fees_total' => $transaction_fees_total,
+			// CSV fee rows carry negative amounts; compare against the positive
+			// total of fees recorded on the transactions.
+			'difference'             => abs( $csv_fees_total ) - $transaction_fees_total,
+		);
+
+		$entry_suggestions   = $this->suggest_bank_entry( $settlement_total );
+		$transactions_no_csv = $this->find_transactions_without_csv( $payment_rows, $row_dates );
+
+		return new WP_REST_Response(
+			array(
+				'settlement_reference'     => $settlement_reference,
+				'currency'                 => $currency,
+				'settlement_total'         => $settlement_total,
+				'payments_total'           => $payments_total,
+				'fees_total'               => $csv_fees_total,
+				'payment_count'            => count( $payment_rows ),
+				'matched'                  => $matched,
+				'unmatched_csv_rows'       => $unmatched_csv_rows,
+				'transactions_without_csv' => $transactions_no_csv,
+				'fee_reconciliation'       => $fee_reconciliation,
+				'suggested_entry'          => $entry_suggestions['suggested'],
+				'alternative_entries'      => $entry_suggestions['alternatives'],
+				'resolved_transaction_ids' => $resolved_transaction_ids,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Format a settlement payment row that could not be matched.
+	 *
+	 * @param array $row Parsed payment row.
+	 * @return array
+	 */
+	private function format_unmatched_row( $row ) {
+		return array(
+			'mollie_payment_id' => isset( $row['mollie_payment_id'] ) ? sanitize_text_field( (string) $row['mollie_payment_id'] ) : '',
+			'amount'            => isset( $row['amount'] ) ? (float) $row['amount'] : 0.0,
+			'status'            => isset( $row['status'] ) ? sanitize_text_field( (string) $row['status'] ) : '',
+			'description'       => isset( $row['description'] ) ? sanitize_text_field( (string) $row['description'] ) : '',
+		);
+	}
+
+	/**
+	 * Suggest the unmatched bank entry whose amount best matches the settlement total.
+	 *
+	 * @param float $settlement_total Sum of all settlement amount cells.
+	 * @return array {
+	 *     @type array|null $suggested    Closest entry within tolerance, or null.
+	 *     @type array      $alternatives Remaining unmatched entries (closest first).
+	 * }
+	 */
+	private function suggest_bank_entry( $settlement_total ) {
+		$result = FinancialEntry::get_filtered(
+			array(
+				'unmatched' => true,
+				'per_page'  => 100,
+				'page'      => 1,
+			)
+		);
+
+		$candidates = array();
+		foreach ( $result['entries'] as $entry ) {
+			$difference   = abs( (float) $entry->amount - $settlement_total );
+			$candidates[] = array(
+				'id'          => (int) $entry->id,
+				'amount'      => (float) $entry->amount,
+				'description' => $entry->description,
+				'entry_date'  => $entry->entry_date,
+				'difference'  => $difference,
+			);
+		}
+
+		usort(
+			$candidates,
+			static function ( $a, $b ) {
+				return $a['difference'] <=> $b['difference'];
+			}
+		);
+
+		$suggested = null;
+		if ( ! empty( $candidates ) && $candidates[0]['difference'] <= self::ENTRY_MATCH_TOLERANCE ) {
+			$suggested = array_shift( $candidates );
+		}
+
+		return array(
+			'suggested'    => $suggested,
+			'alternatives' => array_values( $candidates ),
+		);
+	}
+
+	/**
+	 * Find paid live transactions in the payout window that are unmatched and
+	 * absent from the settlement CSV, so nothing is silently dropped.
+	 *
+	 * @param array $payment_rows Parsed payment rows.
+	 * @param array $row_dates    Y-m-d dates of matched transactions.
+	 * @return array
+	 */
+	private function find_transactions_without_csv( $payment_rows, $row_dates ) {
+		if ( empty( $row_dates ) ) {
+			return array();
+		}
+
+		$csv_payment_ids = array();
+		foreach ( $payment_rows as $row ) {
+			if ( ! empty( $row['mollie_payment_id'] ) ) {
+				$csv_payment_ids[ (string) $row['mollie_payment_id'] ] = true;
+			}
+		}
+
+		sort( $row_dates );
+		$date_from = $row_dates[0];
+		$date_to   = $row_dates[ count( $row_dates ) - 1 ];
+
+		$transactions = Transaction::get_all(
+			array(
+				'limit'  => 500,
+				'status' => 'paid',
+				'mode'   => 'live',
+			)
+		);
+
+		$without_csv = array();
+		foreach ( $transactions as $t ) {
+			if ( empty( $t->mollie_payment_id ) || isset( $csv_payment_ids[ $t->mollie_payment_id ] ) ) {
+				continue;
+			}
+			if ( EntryTransaction::is_transaction_matched( (int) $t->id ) ) {
+				continue;
+			}
+
+			$t_date = substr( (string) $t->created_at, 0, 10 );
+			if ( $t_date < $date_from || $t_date > $date_to ) {
+				continue;
+			}
+
+			$without_csv[] = array(
+				'id'                => (int) $t->id,
+				'mollie_payment_id' => $t->mollie_payment_id,
+				'amount'            => (float) $t->amount,
+				'currency'          => $t->currency,
+				'description'       => $t->description,
+				'created_at'        => $t->created_at,
+			);
+		}
+
+		return $without_csv;
+	}
+}

--- a/fair-payment/src/Admin/reconciliation/ReconciliationApp.js
+++ b/fair-payment/src/Admin/reconciliation/ReconciliationApp.js
@@ -17,6 +17,11 @@ import {
 	TextControl,
 } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import SettlementImportModal from './components/SettlementImportModal';
+
 const formatAmount = (amount, currency = 'EUR') => {
 	return new Intl.NumberFormat('en-US', {
 		style: 'currency',
@@ -46,6 +51,7 @@ const ReconciliationApp = () => {
 	const [descriptionFilter, setDescriptionFilter] = useState(
 		'trf. stichting mollie payments'
 	);
+	const [showSettlementModal, setShowSettlementModal] = useState(false);
 
 	const filteredUnmatchedEntries = unmatchedEntries.filter((entry) => {
 		if (!descriptionFilter) return true;
@@ -204,7 +210,31 @@ const ReconciliationApp = () => {
 
 	return (
 		<div className="wrap">
-			<h1>{__('Reconciliation', 'fair-payment')}</h1>
+			<HStack justify="space-between" alignment="center">
+				<h1>{__('Reconciliation', 'fair-payment')}</h1>
+				<Button
+					variant="secondary"
+					onClick={() => setShowSettlementModal(true)}
+				>
+					{__('Import settlement CSV', 'fair-payment')}
+				</Button>
+			</HStack>
+
+			{showSettlementModal && (
+				<SettlementImportModal
+					onImport={() => {
+						setShowSettlementModal(false);
+						setSuccess(
+							__(
+								'Settlement matched successfully.',
+								'fair-payment'
+							)
+						);
+						loadData();
+					}}
+					onCancel={() => setShowSettlementModal(false)}
+				/>
+			)}
 
 			{error && (
 				<Notice

--- a/fair-payment/src/Admin/reconciliation/__tests__/parseSettlement.test.js
+++ b/fair-payment/src/Admin/reconciliation/__tests__/parseSettlement.test.js
@@ -1,0 +1,138 @@
+/**
+ * Internal dependencies
+ */
+import { parseSettlementRows } from '../parseSettlement';
+
+const HEADER = [
+	'ID',
+	'Settlement reference',
+	'Status',
+	'Amount',
+	'Settlement amount',
+	'Currency',
+	'Description',
+];
+
+const buildRow = ({
+	id = '',
+	reference = '19415110.2605.03',
+	status = '',
+	amount = 0,
+	settlementAmount = 0,
+	currency = 'EUR',
+	description = '',
+}) => [id, reference, status, amount, settlementAmount, currency, description];
+
+const validRows = () => [
+	['Mollie settlement export'],
+	HEADER,
+	buildRow({
+		id: 'tr_jrvX5d2SRpB2chSyrb7RJ',
+		status: 'paid',
+		amount: 25,
+		settlementAmount: 24.5,
+		description: 'Ticket A',
+	}),
+	buildRow({
+		id: 'tr_aaaBBBcccDDDeeeFFF111',
+		status: 'paid',
+		amount: 40,
+		settlementAmount: 39.2,
+		description: 'Ticket B',
+	}),
+	buildRow({
+		id: '',
+		status: '',
+		amount: -1.3,
+		settlementAmount: -1.3,
+		description: 'Mollie fees',
+	}),
+];
+
+describe('parseSettlementRows', () => {
+	it('classifies payment rows vs fee rows and extracts the reference', () => {
+		const result = parseSettlementRows(validRows());
+
+		expect(result.settlement_reference).toBe('19415110.2605.03');
+		expect(result.currency).toBe('EUR');
+		expect(result.payment_rows).toHaveLength(2);
+		expect(result.fee_rows).toHaveLength(1);
+
+		expect(result.payment_rows[0]).toEqual({
+			mollie_payment_id: 'tr_jrvX5d2SRpB2chSyrb7RJ',
+			amount: 25,
+			status: 'paid',
+			description: 'Ticket A',
+			settlement_amount: 24.5,
+		});
+		expect(result.fee_rows[0]).toEqual({
+			description: 'Mollie fees',
+			amount: -1.3,
+		});
+	});
+
+	it('computes settlement_total from all settlement amount cells', () => {
+		const result = parseSettlementRows(validRows());
+		// 24.5 + 39.2 - 1.3
+		expect(result.settlement_total).toBeCloseTo(62.4, 5);
+	});
+
+	it('parses amounts that carry currency symbols and thousands separators', () => {
+		const rows = [
+			HEADER,
+			buildRow({
+				id: 'tr_withFormattedAmount0001',
+				status: 'paid',
+				amount: '€1,234.56',
+				settlementAmount: '1,200.00',
+			}),
+		];
+		const result = parseSettlementRows(rows);
+		expect(result.payment_rows[0].amount).toBeCloseTo(1234.56, 2);
+		expect(result.settlement_total).toBeCloseTo(1200, 2);
+	});
+
+	it('throws when expected columns are missing', () => {
+		const rows = [
+			['Date', 'Description', 'Value'],
+			['2026-05-01', 'Something', 10],
+		];
+		expect(() => parseSettlementRows(rows)).toThrow();
+	});
+
+	it('throws when there are multiple settlement references', () => {
+		const rows = [
+			HEADER,
+			buildRow({
+				id: 'tr_first0000000000000001',
+				reference: 'ref-A',
+				amount: 10,
+				settlementAmount: 10,
+			}),
+			buildRow({
+				id: 'tr_second000000000000002',
+				reference: 'ref-B',
+				amount: 10,
+				settlementAmount: 10,
+			}),
+		];
+		expect(() => parseSettlementRows(rows)).toThrow();
+	});
+
+	it('throws when no payment rows are present', () => {
+		const rows = [
+			HEADER,
+			buildRow({
+				id: '',
+				amount: -1.3,
+				settlementAmount: -1.3,
+				description: 'Mollie fees',
+			}),
+		];
+		expect(() => parseSettlementRows(rows)).toThrow();
+	});
+
+	it('throws on empty input', () => {
+		expect(() => parseSettlementRows([])).toThrow();
+	});
+});

--- a/fair-payment/src/Admin/reconciliation/components/SettlementImportModal.js
+++ b/fair-payment/src/Admin/reconciliation/components/SettlementImportModal.js
@@ -1,0 +1,411 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useRef, useEffect } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Modal,
+	Button,
+	Notice,
+	Spinner,
+	SelectControl,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+/**
+ * External dependencies
+ */
+import * as XLSX from 'xlsx';
+
+/**
+ * Internal dependencies
+ */
+import { parseSettlementRows } from '../parseSettlement';
+
+const formatAmount = (amount, currency = 'EUR') => {
+	return new Intl.NumberFormat('en-US', {
+		style: 'currency',
+		currency: currency || 'EUR',
+	}).format(amount || 0);
+};
+
+const SettlementImportModal = ({ onImport, onCancel }) => {
+	const [isParsing, setIsParsing] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+	const [isConfirming, setIsConfirming] = useState(false);
+	const [error, setError] = useState(null);
+	const [report, setReport] = useState(null);
+	const [selectedEntryId, setSelectedEntryId] = useState('');
+	const [success, setSuccess] = useState(null);
+	const fileInputRef = useRef(null);
+
+	useEffect(() => {
+		if (report?.suggested_entry) {
+			setSelectedEntryId(String(report.suggested_entry.id));
+		} else {
+			setSelectedEntryId('');
+		}
+	}, [report]);
+
+	const readFile = (selectedFile) => {
+		return new Promise((resolve, reject) => {
+			const reader = new FileReader();
+			reader.onload = (e) => {
+				try {
+					const data = new Uint8Array(e.target.result);
+					const workbook = XLSX.read(data, { type: 'array' });
+					const sheetName = workbook.SheetNames[0];
+					const sheet = workbook.Sheets[sheetName];
+					const rows = XLSX.utils.sheet_to_json(sheet, {
+						header: 1,
+					});
+					resolve(parseSettlementRows(rows));
+				} catch (err) {
+					reject(err);
+				}
+			};
+			reader.onerror = () =>
+				reject(new Error(__('Failed to read file.', 'fair-payment')));
+			reader.readAsArrayBuffer(selectedFile);
+		});
+	};
+
+	const handleFileChange = async (e) => {
+		const selectedFile = e.target.files[0];
+		if (!selectedFile) {
+			return;
+		}
+
+		setError(null);
+		setSuccess(null);
+		setReport(null);
+		setIsParsing(true);
+
+		let parsed;
+		try {
+			parsed = await readFile(selectedFile);
+		} catch (err) {
+			setError(
+				err.message || __('Failed to parse file.', 'fair-payment')
+			);
+			setIsParsing(false);
+			return;
+		}
+		setIsParsing(false);
+
+		setIsLoading(true);
+		try {
+			const response = await apiFetch({
+				path: '/fair-payment/v1/reconciliation/settlement/preview',
+				method: 'POST',
+				data: parsed,
+			});
+			setReport(response);
+		} catch (err) {
+			setError(
+				err.message || __('Failed to match settlement.', 'fair-payment')
+			);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	const handleConfirm = async () => {
+		if (!report || !selectedEntryId) {
+			return;
+		}
+
+		setIsConfirming(true);
+		setError(null);
+		try {
+			await apiFetch({
+				path: `/fair-payment/v1/financial-entries/${selectedEntryId}/match`,
+				method: 'POST',
+				data: { transaction_ids: report.resolved_transaction_ids },
+			});
+			setSuccess(__('Settlement matched successfully.', 'fair-payment'));
+			setTimeout(() => {
+				onImport();
+			}, 1500);
+		} catch (err) {
+			setError(
+				err.message ||
+					__('Failed to match transactions.', 'fair-payment')
+			);
+		} finally {
+			setIsConfirming(false);
+		}
+	};
+
+	const entryOptions = report
+		? [
+				...(report.suggested_entry
+					? [
+							{
+								value: String(report.suggested_entry.id),
+								label: sprintf(
+									/* translators: 1: amount, 2: date */
+									__(
+										'%1$s — %2$s (suggested)',
+										'fair-payment'
+									),
+									formatAmount(
+										report.suggested_entry.amount,
+										report.currency
+									),
+									report.suggested_entry.entry_date
+								),
+							},
+					  ]
+					: []),
+				...report.alternative_entries.map((entry) => ({
+					value: String(entry.id),
+					label: sprintf(
+						/* translators: 1: amount, 2: date */
+						__('%1$s — %2$s', 'fair-payment'),
+						formatAmount(entry.amount, report.currency),
+						entry.entry_date
+					),
+				})),
+		  ]
+		: [];
+
+	const selectedEntry =
+		report &&
+		[report.suggested_entry, ...(report.alternative_entries || [])].find(
+			(entry) => entry && String(entry.id) === selectedEntryId
+		);
+
+	const settlementMatchesEntry =
+		selectedEntry &&
+		Math.abs(selectedEntry.amount - report.settlement_total) <= 0.02;
+
+	const feeDiff = report?.fee_reconciliation?.difference ?? 0;
+	const hasFeeDiscrepancy = Math.abs(feeDiff) > 0.01;
+
+	return (
+		<Modal
+			title={__('Import Mollie Settlement CSV', 'fair-payment')}
+			onRequestClose={onCancel}
+			style={{ maxWidth: '720px', width: '100%' }}
+		>
+			<VStack spacing={4}>
+				{error && (
+					<Notice status="error" isDismissible={false}>
+						{error}
+					</Notice>
+				)}
+
+				{success && (
+					<Notice status="success" isDismissible={false}>
+						{success}
+					</Notice>
+				)}
+
+				<div>
+					<p>
+						{__(
+							'Select a Mollie settlement export (.csv). Payment rows are matched to transactions by their Mollie payment ID, and the payout is matched to a bank entry.',
+							'fair-payment'
+						)}
+					</p>
+					<input
+						ref={fileInputRef}
+						type="file"
+						accept=".csv"
+						onChange={handleFileChange}
+						style={{ marginBottom: '8px' }}
+					/>
+				</div>
+
+				{(isParsing || isLoading) && (
+					<HStack justify="center">
+						<Spinner />
+						<span>
+							{isParsing
+								? __('Parsing file…', 'fair-payment')
+								: __('Matching settlement…', 'fair-payment')}
+						</span>
+					</HStack>
+				)}
+
+				{report && !success && (
+					<div
+						style={{
+							backgroundColor: '#f0f0f1',
+							padding: '16px',
+							borderRadius: '4px',
+						}}
+					>
+						<h4 style={{ marginTop: 0 }}>
+							{sprintf(
+								/* translators: %s: settlement reference */
+								__('Settlement %s', 'fair-payment'),
+								report.settlement_reference
+							)}
+						</h4>
+						<p>
+							<strong>
+								{__('Payments matched:', 'fair-payment')}
+							</strong>{' '}
+							{report.matched.length} / {report.payment_count}
+						</p>
+						<p>
+							<strong>
+								{__('Settlement total:', 'fair-payment')}
+							</strong>{' '}
+							{formatAmount(
+								report.settlement_total,
+								report.currency
+							)}
+						</p>
+						<p>
+							<strong>{__('Fees total:', 'fair-payment')}</strong>{' '}
+							{formatAmount(report.fees_total, report.currency)}
+							{hasFeeDiscrepancy && (
+								<span style={{ color: '#d63638' }}>
+									{' '}
+									{sprintf(
+										/* translators: %s: amount difference */
+										__(
+											'(differs from recorded fees by %s)',
+											'fair-payment'
+										),
+										formatAmount(feeDiff, report.currency)
+									)}
+								</span>
+							)}
+						</p>
+
+						<div style={{ marginTop: '16px' }}>
+							<SelectControl
+								label={__(
+									'Match to bank entry',
+									'fair-payment'
+								)}
+								value={selectedEntryId}
+								options={[
+									{
+										value: '',
+										label: __(
+											'— Select a bank entry —',
+											'fair-payment'
+										),
+									},
+									...entryOptions,
+								]}
+								onChange={setSelectedEntryId}
+								__nextHasNoMarginBottom
+							/>
+							{selectedEntry && !settlementMatchesEntry && (
+								<Notice status="warning" isDismissible={false}>
+									{sprintf(
+										/* translators: 1: entry amount, 2: settlement total */
+										__(
+											'Selected entry (%1$s) does not equal the settlement total (%2$s).',
+											'fair-payment'
+										),
+										formatAmount(
+											selectedEntry.amount,
+											report.currency
+										),
+										formatAmount(
+											report.settlement_total,
+											report.currency
+										)
+									)}
+								</Notice>
+							)}
+						</div>
+
+						{report.unmatched_csv_rows.length > 0 && (
+							<div style={{ marginTop: '16px' }}>
+								<strong style={{ color: '#d63638' }}>
+									{sprintf(
+										/* translators: %d: count */
+										__(
+											'%d payment row(s) had no matching transaction:',
+											'fair-payment'
+										),
+										report.unmatched_csv_rows.length
+									)}
+								</strong>
+								<ul style={{ margin: '8px 0' }}>
+									{report.unmatched_csv_rows.map(
+										(row, idx) => (
+											<li key={idx}>
+												<code>
+													{row.mollie_payment_id}
+												</code>{' '}
+												{formatAmount(
+													row.amount,
+													report.currency
+												)}
+											</li>
+										)
+									)}
+								</ul>
+							</div>
+						)}
+
+						{report.transactions_without_csv.length > 0 && (
+							<div style={{ marginTop: '16px' }}>
+								<strong style={{ color: '#dba617' }}>
+									{sprintf(
+										/* translators: %d: count */
+										__(
+											'%d unmatched transaction(s) in this date window are absent from the CSV:',
+											'fair-payment'
+										),
+										report.transactions_without_csv.length
+									)}
+								</strong>
+								<ul style={{ margin: '8px 0' }}>
+									{report.transactions_without_csv.map(
+										(t) => (
+											<li key={t.id}>
+												<code>
+													{t.mollie_payment_id}
+												</code>{' '}
+												{formatAmount(
+													t.amount,
+													t.currency
+												)}
+											</li>
+										)
+									)}
+								</ul>
+							</div>
+						)}
+					</div>
+				)}
+
+				<HStack justify="flex-end" spacing={2}>
+					<Button variant="tertiary" onClick={onCancel}>
+						{__('Cancel', 'fair-payment')}
+					</Button>
+					<Button
+						variant="primary"
+						onClick={handleConfirm}
+						isBusy={isConfirming}
+						disabled={
+							isConfirming ||
+							isParsing ||
+							isLoading ||
+							!report ||
+							!selectedEntryId ||
+							report.resolved_transaction_ids.length === 0 ||
+							success
+						}
+					>
+						{__('Confirm Match', 'fair-payment')}
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+};
+
+export default SettlementImportModal;

--- a/fair-payment/src/Admin/reconciliation/parseSettlement.js
+++ b/fair-payment/src/Admin/reconciliation/parseSettlement.js
@@ -1,0 +1,223 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Column headers expected in a Mollie settlement export. Matching is
+ * case-insensitive and trimmed.
+ */
+const REQUIRED_HEADERS = ['id', 'settlement reference', 'amount', 'status'];
+
+/**
+ * Parse a numeric cell into a Number.
+ *
+ * Assumes dot-decimal formatting (as in the Mollie sample export). Currency
+ * symbols, spaces, and thousands separators are stripped. Returns 0 for empty
+ * or unparseable cells.
+ *
+ * @param {*} value Raw cell value.
+ * @return {number} Parsed number.
+ */
+function parseNumber(value) {
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? value : 0;
+	}
+	if (value === null || value === undefined) {
+		return 0;
+	}
+	const cleaned = String(value).replace(/[^0-9.\-]/g, '');
+	if (cleaned === '' || cleaned === '-' || cleaned === '.') {
+		return 0;
+	}
+	const parsed = parseFloat(cleaned);
+	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * Normalize a header cell for comparison.
+ *
+ * @param {*} cell Raw header cell.
+ * @return {string} Lowercased, trimmed string.
+ */
+function normalizeHeader(cell) {
+	return typeof cell === 'string' ? cell.trim().toLowerCase() : '';
+}
+
+/**
+ * Locate the header row and build a map of column name to column index.
+ *
+ * @param {Array<Array>} rows Array-of-arrays from XLSX.utils.sheet_to_json.
+ * @return {{ headerRowIndex: number, columns: Object }} Header location and index map.
+ */
+function findHeader(rows) {
+	for (let i = 0; i < rows.length; i++) {
+		const row = rows[i];
+		if (!Array.isArray(row)) {
+			continue;
+		}
+
+		const normalized = row.map(normalizeHeader);
+		const hasAll = REQUIRED_HEADERS.every((header) =>
+			normalized.includes(header)
+		);
+
+		if (hasAll) {
+			const columns = {};
+			normalized.forEach((name, index) => {
+				if (name && !(name in columns)) {
+					columns[name] = index;
+				}
+			});
+			return { headerRowIndex: i, columns };
+		}
+	}
+
+	return { headerRowIndex: -1, columns: {} };
+}
+
+/**
+ * Parse the raw rows of a Mollie settlement CSV into a request body for the
+ * settlement preview endpoint.
+ *
+ * Pure function (no FileReader/DOM) so it can be unit-tested. Throws an Error
+ * with a translated message for files that are not a recognizable Mollie
+ * settlement export.
+ *
+ * @param {Array<Array>} rows Array-of-arrays from XLSX.utils.sheet_to_json(sheet, { header: 1 }).
+ * @return {Object} Parsed settlement: { settlement_reference, currency, payment_rows, fee_rows, settlement_total }.
+ */
+export function parseSettlementRows(rows) {
+	if (!Array.isArray(rows) || rows.length === 0) {
+		throw new Error(
+			__('The file is empty or could not be read.', 'fair-payment')
+		);
+	}
+
+	const { headerRowIndex, columns } = findHeader(rows);
+	if (headerRowIndex === -1) {
+		throw new Error(
+			__(
+				'This does not look like a Mollie settlement export (missing expected columns).',
+				'fair-payment'
+			)
+		);
+	}
+
+	const idCol = columns.id;
+	const amountCol = columns.amount;
+	const statusCol = columns.status;
+	const descriptionCol = columns.description;
+	const settlementRefCol = columns['settlement reference'];
+	const settlementAmountCol = columns['settlement amount'];
+	const currencyCol = columns.currency;
+
+	const paymentRows = [];
+	const feeRows = [];
+	const references = new Set();
+	const currencies = new Set();
+	let settlementTotal = 0;
+
+	for (let i = headerRowIndex + 1; i < rows.length; i++) {
+		const row = rows[i];
+		if (!Array.isArray(row) || row.length === 0) {
+			continue;
+		}
+
+		const id =
+			typeof row[idCol] === 'string'
+				? row[idCol].trim()
+				: row[idCol]
+				? String(row[idCol]).trim()
+				: '';
+		const amount = parseNumber(row[amountCol]);
+		const status =
+			statusCol !== undefined && row[statusCol] !== undefined
+				? String(row[statusCol]).trim()
+				: '';
+		const description =
+			descriptionCol !== undefined && row[descriptionCol] !== undefined
+				? String(row[descriptionCol]).trim()
+				: '';
+		const settlementAmount =
+			settlementAmountCol !== undefined
+				? parseNumber(row[settlementAmountCol])
+				: 0;
+
+		const reference =
+			settlementRefCol !== undefined &&
+			row[settlementRefCol] !== undefined
+				? String(row[settlementRefCol]).trim()
+				: '';
+		if (reference) {
+			references.add(reference);
+		}
+
+		if (currencyCol !== undefined && row[currencyCol] !== undefined) {
+			const currency = String(row[currencyCol]).trim();
+			if (currency) {
+				currencies.add(currency);
+			}
+		}
+
+		// Skip fully blank rows (no id, no amount, no settlement amount).
+		if (id === '' && amount === 0 && settlementAmount === 0) {
+			continue;
+		}
+
+		settlementTotal += settlementAmount;
+
+		if (id.startsWith('tr_')) {
+			paymentRows.push({
+				mollie_payment_id: id,
+				amount,
+				status,
+				description,
+				settlement_amount: settlementAmount,
+			});
+		} else if (id === '' && amount !== 0) {
+			feeRows.push({
+				description,
+				amount,
+			});
+		}
+		// Other rows (refunds, chargebacks) are not matched here but still
+		// contribute to settlement_total above.
+	}
+
+	if (references.size === 0) {
+		throw new Error(
+			__('No settlement reference found in the file.', 'fair-payment')
+		);
+	}
+	if (references.size > 1) {
+		throw new Error(
+			__(
+				'The file contains multiple settlement references. Upload one settlement at a time.',
+				'fair-payment'
+			)
+		);
+	}
+	if (currencies.size > 1) {
+		throw new Error(
+			__(
+				'The file contains multiple currencies. Upload one settlement at a time.',
+				'fair-payment'
+			)
+		);
+	}
+
+	if (paymentRows.length === 0) {
+		throw new Error(
+			__('No payment rows found in the settlement file.', 'fair-payment')
+		);
+	}
+
+	return {
+		settlement_reference: references.values().next().value,
+		currency: currencies.size === 1 ? currencies.values().next().value : '',
+		payment_rows: paymentRows,
+		fee_rows: feeRows,
+		settlement_total: settlementTotal,
+	};
+}


### PR DESCRIPTION
Reconciling a Mollie payout previously meant hand-matching a single lump-sum bank deposit to many individual transactions. The settlement export is the authoritative breakdown of that payout, so importing it lets us match deterministically by Mollie payment ID.

The reconciliation page gains an "Import settlement CSV" action that parses the export client-side (reusing the existing xlsx dependency), posts the parsed rows to a new preview endpoint, and shows which payment rows matched transactions, aggregate fee reconciliation, and the bank entry whose amount equals the settlement total. Confirming routes through the existing financial-entries match endpoint, so the persisted result is identical to manual matching and idempotent on re-import.

Closes #624