### PR TITLE
Add data sharing API for cross-site transaction access

### DIFF
--- a/fair-payment/src/API/ApiTokenAuth.php
+++ b/fair-payment/src/API/ApiTokenAuth.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Bearer token authentication for the data sharing API.
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\API;
+
+use FairPayment\Models\ApiToken;
+use WP_Error;
+use WP_REST_Request;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Authenticates public external REST endpoints via scoped bearer tokens.
+ *
+ * Note: rate limiting is a deliberate follow-up and is not implemented here.
+ */
+class ApiTokenAuth {
+	/**
+	 * Authenticate a request and verify it carries the required scope.
+	 *
+	 * On success the resolved token row is stashed on the request as the
+	 * `_fair_api_token` param and the token's last_used_at is updated.
+	 *
+	 * @param WP_REST_Request $request        Incoming request.
+	 * @param string          $required_scope Scope the endpoint requires.
+	 * @return true|WP_Error True when authorized, WP_Error otherwise.
+	 */
+	public static function authenticate( WP_REST_Request $request, $required_scope ) {
+		$header = $request->get_header( 'authorization' );
+
+		$token = self::parse_bearer_token( $header );
+
+		if ( '' === $token ) {
+			return self::unauthorized();
+		}
+
+		$row = ApiToken::find_by_token( $token );
+
+		// Generic 401 for missing/invalid/revoked tokens (no existence leak).
+		if ( ! $row || ! ApiToken::is_active( $row ) ) {
+			return self::unauthorized();
+		}
+
+		if ( ! ApiToken::has_scope( $row, $required_scope ) ) {
+			return new WP_Error(
+				'rest_insufficient_scope',
+				__( 'This token does not have the required scope.', 'fair-payment' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		ApiToken::touch_last_used( (int) $row->id );
+		$request->set_param( '_fair_api_token', $row );
+
+		return true;
+	}
+
+	/**
+	 * Build a permission_callback that requires a given scope.
+	 *
+	 * @param string $scope Required scope.
+	 * @return callable permission_callback for register_rest_route().
+	 */
+	public static function require_scope( $scope ) {
+		return function ( WP_REST_Request $request ) use ( $scope ) {
+			return self::authenticate( $request, $scope );
+		};
+	}
+
+	/**
+	 * Extract the token from an Authorization header value.
+	 *
+	 * @param string|null $header Header value.
+	 * @return string Token, or empty string when not a valid Bearer header.
+	 */
+	private static function parse_bearer_token( $header ) {
+		if ( ! is_string( $header ) || '' === $header ) {
+			return '';
+		}
+
+		if ( ! preg_match( '/^Bearer\s+(.+)$/i', trim( $header ), $matches ) ) {
+			return '';
+		}
+
+		return trim( $matches[1] );
+	}
+
+	/**
+	 * Standard 401 error for missing/invalid tokens.
+	 *
+	 * @return WP_Error
+	 */
+	private static function unauthorized() {
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'Invalid or missing API token.', 'fair-payment' ),
+			array( 'status' => 401 )
+		);
+	}
+}

--- a/fair-payment/src/API/ApiTokenAuth.php
+++ b/fair-payment/src/API/ApiTokenAuth.php
@@ -26,10 +26,11 @@ class ApiTokenAuth {
 	 * `_fair_api_token` param and the token's last_used_at is updated.
 	 *
 	 * @param WP_REST_Request $request        Incoming request.
-	 * @param string          $required_scope Scope the endpoint requires.
+	 * @param string|null     $required_scope Scope the endpoint requires, or null
+	 *                                        to require only a valid active token.
 	 * @return true|WP_Error True when authorized, WP_Error otherwise.
 	 */
-	public static function authenticate( WP_REST_Request $request, $required_scope ) {
+	public static function authenticate( WP_REST_Request $request, $required_scope = null ) {
 		$header = $request->get_header( 'authorization' );
 
 		$token = self::parse_bearer_token( $header );
@@ -45,7 +46,7 @@ class ApiTokenAuth {
 			return self::unauthorized();
 		}
 
-		if ( ! ApiToken::has_scope( $row, $required_scope ) ) {
+		if ( null !== $required_scope && ! ApiToken::has_scope( $row, $required_scope ) ) {
 			return new WP_Error(
 				'rest_insufficient_scope',
 				__( 'This token does not have the required scope.', 'fair-payment' ),
@@ -68,6 +69,20 @@ class ApiTokenAuth {
 	public static function require_scope( $scope ) {
 		return function ( WP_REST_Request $request ) use ( $scope ) {
 			return self::authenticate( $request, $scope );
+		};
+	}
+
+	/**
+	 * Build a permission_callback that requires only a valid active token.
+	 *
+	 * Used by endpoints (e.g. /external/me) that any authenticated consumer may
+	 * call regardless of which scopes the token grants.
+	 *
+	 * @return callable permission_callback for register_rest_route().
+	 */
+	public static function require_token() {
+		return function ( WP_REST_Request $request ) {
+			return self::authenticate( $request );
 		};
 	}
 

--- a/fair-payment/src/API/ApiTokensController.php
+++ b/fair-payment/src/API/ApiTokensController.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Admin REST API controller for API tokens.
+ *
+ * Admin-only CRUD for the data sharing API tokens management page.
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\API;
+
+defined( 'WPINC' ) || die;
+
+use FairPayment\Models\ApiToken;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+/**
+ * Handles admin endpoints for listing, creating and revoking API tokens.
+ */
+class ApiTokensController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-payment/v1';
+
+	/**
+	 * Register the admin API token routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/admin/api-tokens',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'label'  => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'scopes' => array(
+							'type'     => 'array',
+							'required' => true,
+							'items'    => array(
+								'type' => 'string',
+								'enum' => ApiToken::ALLOWED_SCOPES,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/admin/api-tokens/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'type'              => 'integer',
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Admin capability check for all routes.
+	 *
+	 * @return bool
+	 */
+	public function permissions_check() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * List all API tokens.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$tokens = ApiToken::get_all();
+
+		$data = array_map(
+			array( ApiToken::class, 'to_array' ),
+			$tokens
+		);
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Create a new API token.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$label  = $request->get_param( 'label' );
+		$scopes = (array) $request->get_param( 'scopes' );
+
+		if ( empty( $label ) ) {
+			return new WP_Error(
+				'rest_invalid_label',
+				__( 'A label is required.', 'fair-payment' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$valid_scopes = array_values( array_intersect( $scopes, ApiToken::ALLOWED_SCOPES ) );
+
+		if ( empty( $valid_scopes ) ) {
+			return new WP_Error(
+				'rest_invalid_scopes',
+				__( 'At least one valid scope is required.', 'fair-payment' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$result = ApiToken::create( $label, $valid_scopes );
+
+		if ( ! $result ) {
+			return new WP_Error(
+				'rest_api_token_creation_failed',
+				__( 'Failed to create API token.', 'fair-payment' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$row      = ApiToken::get_by_id( $result['id'] );
+		$response = ApiToken::to_array( $row );
+
+		// One-time plaintext token; never retrievable again.
+		$response['token'] = $result['token'];
+
+		return new WP_REST_Response( $response, 201 );
+	}
+
+	/**
+	 * Revoke an API token.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$id = (int) $request->get_param( 'id' );
+
+		$existing = ApiToken::get_by_id( $id );
+		if ( ! $existing ) {
+			return new WP_Error(
+				'rest_api_token_not_found',
+				__( 'API token not found.', 'fair-payment' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		ApiToken::revoke( $id );
+
+		$row = ApiToken::get_by_id( $id );
+
+		return new WP_REST_Response( ApiToken::to_array( $row ), 200 );
+	}
+}

--- a/fair-payment/src/API/ConnectedSitesController.php
+++ b/fair-payment/src/API/ConnectedSitesController.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * Admin REST API controller for connected sites.
+ *
+ * Admin-only CRUD plus a connection test for the data sharing consumer side:
+ * the remote sites this site pulls transaction data from.
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\API;
+
+defined( 'WPINC' ) || die;
+
+use FairPayment\Models\ConnectedSite;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+/**
+ * Handles admin endpoints for managing connected sites.
+ */
+class ConnectedSitesController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-payment/v1';
+
+	/**
+	 * Register the admin connected-sites routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		$args = array(
+			'label'    => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'base_url' => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'esc_url_raw',
+			),
+			'token'    => array(
+				'type' => 'string',
+			),
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/admin/connected-sites',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $args,
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/admin/connected-sites/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $args,
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/admin/connected-sites/(?P<id>\d+)/test',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'test_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Admin capability check for all routes.
+	 *
+	 * @return bool
+	 */
+	public function permissions_check() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * List all connected sites.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$data = array_map(
+			array( ConnectedSite::class, 'to_array' ),
+			ConnectedSite::get_all()
+		);
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Create a new connected site.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$label    = (string) $request->get_param( 'label' );
+		$base_url = (string) $request->get_param( 'base_url' );
+		$token    = (string) $request->get_param( 'token' );
+
+		if ( '' === trim( $label ) || '' === trim( $base_url ) || '' === trim( $token ) ) {
+			return new WP_Error(
+				'rest_invalid_connected_site',
+				__( 'Label, base URL and token are all required.', 'fair-payment' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$record = ConnectedSite::create(
+			array(
+				'label'    => $label,
+				'base_url' => $base_url,
+				'token'    => $token,
+			)
+		);
+
+		return new WP_REST_Response( ConnectedSite::to_array( $record ), 201 );
+	}
+
+	/**
+	 * Update a connected site.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$id = (int) $request->get_param( 'id' );
+
+		if ( ! ConnectedSite::get_by_id( $id ) ) {
+			return $this->not_found();
+		}
+
+		$data = array();
+		if ( null !== $request->get_param( 'label' ) ) {
+			$data['label'] = (string) $request->get_param( 'label' );
+		}
+		if ( null !== $request->get_param( 'base_url' ) ) {
+			$data['base_url'] = (string) $request->get_param( 'base_url' );
+		}
+		if ( null !== $request->get_param( 'token' ) ) {
+			$data['token'] = (string) $request->get_param( 'token' );
+		}
+
+		$record = ConnectedSite::update( $id, $data );
+
+		return new WP_REST_Response( ConnectedSite::to_array( $record ), 200 );
+	}
+
+	/**
+	 * Delete a connected site.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$id = (int) $request->get_param( 'id' );
+
+		if ( ! ConnectedSite::get_by_id( $id ) ) {
+			return $this->not_found();
+		}
+
+		ConnectedSite::delete( $id );
+
+		return new WP_REST_Response( array( 'deleted' => true ), 200 );
+	}
+
+	/**
+	 * Test a connected site's token against its remote /external/me endpoint.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function test_item( $request ) {
+		$id     = (int) $request->get_param( 'id' );
+		$record = ConnectedSite::get_by_id( $id );
+
+		if ( ! $record ) {
+			return $this->not_found();
+		}
+
+		$url = trailingslashit( $record['base_url'] ) . 'wp-json/fair-payment/v1/external/me';
+
+		$response = wp_safe_remote_get(
+			$url,
+			array(
+				'timeout' => 10,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $record['token'],
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			ConnectedSite::mark_failed( $id );
+
+			return new WP_Error(
+				'rest_connected_site_unreachable',
+				__( 'Could not reach the remote site.', 'fair-payment' ),
+				array( 'status' => 502 )
+			);
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( 200 !== $code || ! is_array( $body ) ) {
+			ConnectedSite::mark_failed( $id );
+
+			$message = 401 === $code || 403 === $code
+				? __( 'The remote site rejected the token.', 'fair-payment' )
+				: __( 'The remote site returned an unexpected response.', 'fair-payment' );
+
+			return new WP_Error(
+				'rest_connected_site_test_failed',
+				$message,
+				array( 'status' => 400 )
+			);
+		}
+
+		$scopes = isset( $body['scopes'] ) && is_array( $body['scopes'] ) ? $body['scopes'] : array();
+		ConnectedSite::record_test_result( $id, $scopes );
+
+		return new WP_REST_Response(
+			array(
+				'ok'     => true,
+				'label'  => isset( $body['label'] ) ? sanitize_text_field( $body['label'] ) : '',
+				'scopes' => array_values( array_map( 'sanitize_text_field', $scopes ) ),
+			),
+			200
+		);
+	}
+
+	/**
+	 * Standard 404 error.
+	 *
+	 * @return WP_Error
+	 */
+	private function not_found() {
+		return new WP_Error(
+			'rest_connected_site_not_found',
+			__( 'Connected site not found.', 'fair-payment' ),
+			array( 'status' => 404 )
+		);
+	}
+}

--- a/fair-payment/src/API/ExternalMeController.php
+++ b/fair-payment/src/API/ExternalMeController.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Public external REST API controller for token introspection.
+ *
+ * Read-only, token-authenticated endpoint that lets a consumer site verify a
+ * token and discover the scopes it was granted (data sharing API).
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\API;
+
+defined( 'WPINC' ) || die;
+
+use FairPayment\Models\ApiToken;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Handles the public GET /external/me endpoint.
+ */
+class ExternalMeController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-payment/v1';
+
+	/**
+	 * Register the route for token introspection.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/external/me',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => ApiTokenAuth::require_token(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Return the authenticated token's label and scopes.
+	 *
+	 * The resolved token row is stashed on the request by ApiTokenAuth.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$row = $request->get_param( '_fair_api_token' );
+
+		return new WP_REST_Response( ApiToken::to_array( $row ), 200 );
+	}
+}

--- a/fair-payment/src/API/ExternalTransactionsController.php
+++ b/fair-payment/src/API/ExternalTransactionsController.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Public external REST API controller for transactions.
+ *
+ * Read-only, token-authenticated endpoint exposing transaction data to
+ * authorized consumer sites (data sharing API).
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\API;
+
+defined( 'WPINC' ) || die;
+
+use FairPayment\Models\Transaction;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Handles the public GET /external/transactions endpoint.
+ */
+class ExternalTransactionsController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-payment/v1';
+
+	/**
+	 * Maximum number of items per page.
+	 *
+	 * @var int
+	 */
+	const MAX_PER_PAGE = 200;
+
+	/**
+	 * Register the routes for external transactions.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/external/transactions',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => ApiTokenAuth::require_scope( 'transactions:read' ),
+					'args'                => $this->get_collection_params(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Collection parameters for the external transactions endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		return array(
+			'page'     => array(
+				'type'              => 'integer',
+				'default'           => 1,
+				'minimum'           => 1,
+				'sanitize_callback' => 'absint',
+			),
+			'per_page' => array(
+				'type'              => 'integer',
+				'default'           => 50,
+				'minimum'           => 1,
+				'maximum'           => self::MAX_PER_PAGE,
+				'sanitize_callback' => 'absint',
+			),
+			'status'   => array(
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'from'     => array(
+				'type'              => 'string',
+				'default'           => '',
+				'description'       => __( 'Filter by transaction date (created_at) from this date, e.g. 2026-01-01.', 'fair-payment' ),
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => array( $this, 'validate_date' ),
+			),
+			'to'       => array(
+				'type'              => 'string',
+				'default'           => '',
+				'description'       => __( 'Filter by transaction date (created_at) up to this date, e.g. 2026-12-31.', 'fair-payment' ),
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => array( $this, 'validate_date' ),
+			),
+		);
+	}
+
+	/**
+	 * Validate an ISO date / datetime query parameter.
+	 *
+	 * @param string $value Value to validate.
+	 * @return bool True when empty or a parseable date.
+	 */
+	public function validate_date( $value ) {
+		if ( '' === $value || null === $value ) {
+			return true;
+		}
+
+		return false !== strtotime( $value );
+	}
+
+	/**
+	 * Get a collection of transactions.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$per_page = (int) $request->get_param( 'per_page' );
+		$page     = (int) $request->get_param( 'page' );
+
+		if ( $per_page < 1 ) {
+			$per_page = 50;
+		}
+		$per_page = min( $per_page, self::MAX_PER_PAGE );
+		$page     = max( $page, 1 );
+		$offset   = ( $page - 1 ) * $per_page;
+
+		$status = (string) $request->get_param( 'status' );
+		$from   = (string) $request->get_param( 'from' );
+		$to     = (string) $request->get_param( 'to' );
+
+		$query_args = array(
+			'limit'     => $per_page,
+			'offset'    => $offset,
+			'status'    => $status,
+			'date_from' => $from,
+			'date_to'   => $to,
+			'orderby'   => 'created_at',
+			'order'     => 'DESC',
+		);
+
+		$transactions = Transaction::get_all( $query_args );
+		$total        = Transaction::count(
+			array(
+				'status'    => $status,
+				'date_from' => $from,
+				'date_to'   => $to,
+			)
+		);
+
+		$data = array();
+		foreach ( $transactions as $transaction ) {
+			$data[] = $this->prepare_transaction( $transaction );
+		}
+
+		return new WP_REST_Response(
+			array(
+				'transactions' => $data,
+				'total'        => $total,
+				'page'         => $page,
+				'per_page'     => $per_page,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Shape a transaction row for the external response.
+	 *
+	 * Deliberately excludes user_name and participant details (PII). Includes
+	 * description and mollie_payment_id for reconciliation.
+	 *
+	 * @param object $transaction Transaction row.
+	 * @return array
+	 */
+	private function prepare_transaction( $transaction ) {
+		$event_date_id = $transaction->event_date_id ? (int) $transaction->event_date_id : null;
+		$event_url     = '';
+
+		if ( $event_date_id && class_exists( '\\FairEvents\\Models\\EventDates' ) ) {
+			$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+			if ( $event_date && ! empty( $event_date->event_id ) ) {
+				$permalink = get_permalink( (int) $event_date->event_id );
+				if ( $permalink ) {
+					$event_url = $permalink;
+				}
+			}
+		}
+
+		return array(
+			'id'                => (int) $transaction->id,
+			'mollie_payment_id' => $transaction->mollie_payment_id ?? '',
+			'amount'            => (float) ( $transaction->amount ?? 0 ),
+			'currency'          => $transaction->currency ?? 'EUR',
+			'application_fee'   => null !== $transaction->application_fee ? (float) $transaction->application_fee : null,
+			'status'            => $transaction->status ?? 'unknown',
+			'testmode'          => ! empty( $transaction->testmode ),
+			'description'       => $transaction->description ?? '',
+			'event_date_id'     => $event_date_id,
+			'event_url'         => $event_url,
+			'created_at'        => $transaction->created_at ?? '',
+		);
+	}
+}

--- a/fair-payment/src/API/RestHooks.php
+++ b/fair-payment/src/API/RestHooks.php
@@ -56,5 +56,11 @@ class RestHooks {
 
 		$external_transactions = new \FairPayment\API\ExternalTransactionsController();
 		$external_transactions->register_routes();
+
+		$external_me = new \FairPayment\API\ExternalMeController();
+		$external_me->register_routes();
+
+		$connected_sites_controller = new \FairPayment\API\ConnectedSitesController();
+		$connected_sites_controller->register_routes();
 	}
 }

--- a/fair-payment/src/API/RestHooks.php
+++ b/fair-payment/src/API/RestHooks.php
@@ -50,5 +50,11 @@ class RestHooks {
 
 		$telegram_controller = new \FairPayment\API\TelegramSettingsController();
 		$telegram_controller->register_routes();
+
+		$api_tokens_controller = new \FairPayment\API\ApiTokensController();
+		$api_tokens_controller->register_routes();
+
+		$external_transactions = new \FairPayment\API\ExternalTransactionsController();
+		$external_transactions->register_routes();
 	}
 }

--- a/fair-payment/src/Admin/AdminPages.php
+++ b/fair-payment/src/Admin/AdminPages.php
@@ -114,6 +114,16 @@ class AdminPages {
 			'fair-payment-api-tokens',
 			array( $this, 'render_api_tokens_page' )
 		);
+
+		// Connected Sites submenu.
+		add_submenu_page(
+			'fair-payment-transactions',
+			__( 'Connected Sites', 'fair-payment' ),
+			__( 'Connected Sites', 'fair-payment' ),
+			'manage_options',
+			'fair-payment-connected-sites',
+			array( $this, 'render_connected_sites_page' )
+		);
 	}
 
 	/**
@@ -145,6 +155,12 @@ class AdminPages {
 		// API Tokens page.
 		if ( false !== strpos( $hook, 'fair-payment-api-tokens' ) ) {
 			$this->enqueue_admin_page_script( 'api-tokens' );
+			return;
+		}
+
+		// Connected Sites page.
+		if ( false !== strpos( $hook, 'fair-payment-connected-sites' ) ) {
+			$this->enqueue_admin_page_script( 'connected-sites' );
 			return;
 		}
 
@@ -311,6 +327,17 @@ class AdminPages {
 	public function render_api_tokens_page() {
 		?>
 		<div id="fair-payment-api-tokens-root"></div>
+		<?php
+	}
+
+	/**
+	 * Render connected sites page
+	 *
+	 * @return void
+	 */
+	public function render_connected_sites_page() {
+		?>
+		<div id="fair-payment-connected-sites-root"></div>
 		<?php
 	}
 }

--- a/fair-payment/src/Admin/AdminPages.php
+++ b/fair-payment/src/Admin/AdminPages.php
@@ -104,6 +104,16 @@ class AdminPages {
 			'fair-payment-settings',
 			array( $this, 'render_settings_page' )
 		);
+
+		// API Tokens submenu.
+		add_submenu_page(
+			'fair-payment-transactions',
+			__( 'API Tokens', 'fair-payment' ),
+			__( 'API Tokens', 'fair-payment' ),
+			'manage_options',
+			'fair-payment-api-tokens',
+			array( $this, 'render_api_tokens_page' )
+		);
 	}
 
 	/**
@@ -129,6 +139,12 @@ class AdminPages {
 		// Settings page.
 		if ( false !== strpos( $hook, 'fair-payment-settings' ) ) {
 			$this->enqueue_admin_page_script( 'settings' );
+			return;
+		}
+
+		// API Tokens page.
+		if ( false !== strpos( $hook, 'fair-payment-api-tokens' ) ) {
+			$this->enqueue_admin_page_script( 'api-tokens' );
 			return;
 		}
 
@@ -284,6 +300,17 @@ class AdminPages {
 	public function render_transactions_page() {
 		?>
 		<div id="fair-payment-transactions-root"></div>
+		<?php
+	}
+
+	/**
+	 * Render API tokens page
+	 *
+	 * @return void
+	 */
+	public function render_api_tokens_page() {
+		?>
+		<div id="fair-payment-api-tokens-root"></div>
 		<?php
 	}
 }

--- a/fair-payment/src/Admin/api-tokens/ApiTokensApp.js
+++ b/fair-payment/src/Admin/api-tokens/ApiTokensApp.js
@@ -1,0 +1,419 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	Button,
+	Spinner,
+	Notice,
+	Modal,
+	TextControl,
+	CheckboxControl,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+const AVAILABLE_SCOPES = [
+	{
+		value: 'transactions:read',
+		label: __('Read transactions', 'fair-payment'),
+	},
+	{ value: 'locations:read', label: __('Read locations', 'fair-payment') },
+];
+
+const ApiTokensApp = () => {
+	const [tokens, setTokens] = useState([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(null);
+	const [success, setSuccess] = useState(null);
+	const [isFormOpen, setIsFormOpen] = useState(false);
+	const [isSaving, setIsSaving] = useState(false);
+	const [label, setLabel] = useState('');
+	const [scopes, setScopes] = useState(['transactions:read']);
+	const [newToken, setNewToken] = useState(null);
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		loadTokens();
+	}, []);
+
+	const loadTokens = async () => {
+		setLoading(true);
+		setError(null);
+
+		try {
+			const data = await apiFetch({
+				path: '/fair-payment/v1/admin/api-tokens',
+			});
+			setTokens(data);
+		} catch (err) {
+			setError(
+				err.message || __('Failed to load API tokens.', 'fair-payment')
+			);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleOpenForm = () => {
+		setLabel('');
+		setScopes(['transactions:read']);
+		setNewToken(null);
+		setCopied(false);
+		setError(null);
+		setIsFormOpen(true);
+	};
+
+	const toggleScope = (scope, checked) => {
+		setScopes((current) =>
+			checked ? [...current, scope] : current.filter((s) => s !== scope)
+		);
+	};
+
+	const handleCreate = async (e) => {
+		e.preventDefault();
+		setIsSaving(true);
+		setError(null);
+
+		try {
+			const response = await apiFetch({
+				path: '/fair-payment/v1/admin/api-tokens',
+				method: 'POST',
+				data: { label, scopes },
+			});
+			setNewToken(response.token);
+			setSuccess(__('API token created.', 'fair-payment'));
+			loadTokens();
+		} catch (err) {
+			setError(
+				err.message || __('Failed to create API token.', 'fair-payment')
+			);
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const handleRevoke = async (id) => {
+		if (
+			!window.confirm(
+				__(
+					'Revoke this token? Any site using it will immediately lose access.',
+					'fair-payment'
+				)
+			)
+		) {
+			return;
+		}
+
+		setError(null);
+		setSuccess(null);
+
+		try {
+			await apiFetch({
+				path: `/fair-payment/v1/admin/api-tokens/${id}`,
+				method: 'DELETE',
+			});
+			setSuccess(__('API token revoked.', 'fair-payment'));
+			loadTokens();
+		} catch (err) {
+			setError(
+				err.message || __('Failed to revoke API token.', 'fair-payment')
+			);
+		}
+	};
+
+	const handleCopy = () => {
+		if (newToken && navigator.clipboard) {
+			navigator.clipboard.writeText(newToken).then(() => {
+				setCopied(true);
+			});
+		}
+	};
+
+	const handleCloseForm = () => {
+		setIsFormOpen(false);
+		setNewToken(null);
+	};
+
+	return (
+		<div className="wrap fair-payment-api-tokens-page">
+			<VStack spacing={4}>
+				<Card>
+					<CardHeader>
+						<HStack justify="space-between">
+							<h1>{__('API Tokens', 'fair-payment')}</h1>
+							<Button variant="primary" onClick={handleOpenForm}>
+								{__('Generate Token', 'fair-payment')}
+							</Button>
+						</HStack>
+					</CardHeader>
+					<CardBody>
+						<VStack spacing={4}>
+							<p style={{ color: '#666', margin: 0 }}>
+								{__(
+									'Issue scoped tokens so other sites can read this site’s data over the data sharing API.',
+									'fair-payment'
+								)}
+							</p>
+
+							{error && (
+								<Notice
+									status="error"
+									isDismissible
+									onRemove={() => setError(null)}
+								>
+									{error}
+								</Notice>
+							)}
+
+							{success && (
+								<Notice
+									status="success"
+									isDismissible
+									onRemove={() => setSuccess(null)}
+								>
+									{success}
+								</Notice>
+							)}
+
+							{loading && (
+								<div>
+									<Spinner />
+									<p>
+										{__('Loading tokens…', 'fair-payment')}
+									</p>
+								</div>
+							)}
+
+							{!loading && tokens.length === 0 && (
+								<p>
+									{__(
+										'No API tokens yet. Generate one to share data with another site.',
+										'fair-payment'
+									)}
+								</p>
+							)}
+
+							{!loading && tokens.length > 0 && (
+								<table className="wp-list-table widefat fixed striped">
+									<thead>
+										<tr>
+											<th>
+												{__('Label', 'fair-payment')}
+											</th>
+											<th>
+												{__('Scopes', 'fair-payment')}
+											</th>
+											<th>
+												{__('Created', 'fair-payment')}
+											</th>
+											<th>
+												{__(
+													'Last used',
+													'fair-payment'
+												)}
+											</th>
+											<th>
+												{__('Status', 'fair-payment')}
+											</th>
+											<th style={{ width: '120px' }}>
+												{__('Actions', 'fair-payment')}
+											</th>
+										</tr>
+									</thead>
+									<tbody>
+										{tokens.map((token) => (
+											<tr key={token.id}>
+												<td>
+													<strong>
+														{token.label}
+													</strong>
+												</td>
+												<td>
+													{token.scopes.join(', ')}
+												</td>
+												<td>{token.created_at}</td>
+												<td>
+													{token.last_used_at || (
+														<em>
+															{__(
+																'Never',
+																'fair-payment'
+															)}
+														</em>
+													)}
+												</td>
+												<td>
+													<span
+														style={{
+															color:
+																token.status ===
+																'active'
+																	? '#007017'
+																	: '#d63638',
+															fontWeight: 'bold',
+														}}
+													>
+														{token.status ===
+														'active'
+															? __(
+																	'Active',
+																	'fair-payment'
+															  )
+															: __(
+																	'Revoked',
+																	'fair-payment'
+															  )}
+													</span>
+												</td>
+												<td>
+													{token.status ===
+														'active' && (
+														<Button
+															variant="tertiary"
+															size="small"
+															isDestructive
+															onClick={() =>
+																handleRevoke(
+																	token.id
+																)
+															}
+														>
+															{__(
+																'Revoke',
+																'fair-payment'
+															)}
+														</Button>
+													)}
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							)}
+						</VStack>
+					</CardBody>
+				</Card>
+			</VStack>
+
+			{isFormOpen && (
+				<Modal
+					title={
+						newToken
+							? __('Token created', 'fair-payment')
+							: __('Generate API Token', 'fair-payment')
+					}
+					onRequestClose={handleCloseForm}
+					style={{ maxWidth: '500px', width: '100%' }}
+				>
+					{newToken ? (
+						<VStack spacing={4}>
+							<Notice status="warning" isDismissible={false}>
+								{__(
+									'Copy this token now. For security it will not be shown again.',
+									'fair-payment'
+								)}
+							</Notice>
+							<code
+								style={{
+									display: 'block',
+									padding: '12px',
+									background: '#f0f0f1',
+									wordBreak: 'break-all',
+								}}
+							>
+								{newToken}
+							</code>
+							<HStack justify="flex-end" spacing={2}>
+								<Button
+									variant="secondary"
+									onClick={handleCopy}
+								>
+									{copied
+										? __('Copied!', 'fair-payment')
+										: __('Copy token', 'fair-payment')}
+								</Button>
+								<Button
+									variant="primary"
+									onClick={handleCloseForm}
+								>
+									{__('Done', 'fair-payment')}
+								</Button>
+							</HStack>
+						</VStack>
+					) : (
+						<form onSubmit={handleCreate}>
+							<VStack spacing={4}>
+								<TextControl
+									label={__('Label', 'fair-payment')}
+									value={label}
+									onChange={setLabel}
+									help={__(
+										'A name to identify who this token is for, e.g. lamutable.es',
+										'fair-payment'
+									)}
+									required
+								/>
+								<fieldset>
+									<legend
+										style={{
+											fontWeight: 'bold',
+											marginBottom: '8px',
+										}}
+									>
+										{__('Scopes', 'fair-payment')}
+									</legend>
+									<VStack spacing={2}>
+										{AVAILABLE_SCOPES.map((scope) => (
+											<CheckboxControl
+												key={scope.value}
+												label={scope.label}
+												checked={scopes.includes(
+													scope.value
+												)}
+												onChange={(checked) =>
+													toggleScope(
+														scope.value,
+														checked
+													)
+												}
+											/>
+										))}
+									</VStack>
+								</fieldset>
+								<HStack justify="flex-end" spacing={2}>
+									<Button
+										variant="tertiary"
+										onClick={handleCloseForm}
+										disabled={isSaving}
+									>
+										{__('Cancel', 'fair-payment')}
+									</Button>
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={isSaving}
+										disabled={
+											isSaving ||
+											!label ||
+											scopes.length === 0
+										}
+									>
+										{__('Generate', 'fair-payment')}
+									</Button>
+								</HStack>
+							</VStack>
+						</form>
+					)}
+				</Modal>
+			)}
+		</div>
+	);
+};
+
+export default ApiTokensApp;

--- a/fair-payment/src/Admin/api-tokens/index.js
+++ b/fair-payment/src/Admin/api-tokens/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ApiTokensApp from './ApiTokensApp.js';
+
+/**
+ * Initialize the API tokens page
+ */
+domReady(() => {
+	const root = document.getElementById('fair-payment-api-tokens-root');
+	if (root) {
+		createRoot(root).render(<ApiTokensApp />);
+	}
+});

--- a/fair-payment/src/Admin/connected-sites/ConnectedSitesApp.js
+++ b/fair-payment/src/Admin/connected-sites/ConnectedSitesApp.js
@@ -1,0 +1,457 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	Button,
+	Spinner,
+	Notice,
+	Modal,
+	TextControl,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+const STATUS_LABELS = {
+	connected: { text: __('Connected', 'fair-payment'), color: '#007017' },
+	error: { text: __('Error', 'fair-payment'), color: '#d63638' },
+	unverified: { text: __('Unverified', 'fair-payment'), color: '#946800' },
+};
+
+const ConnectedSitesApp = () => {
+	const [sites, setSites] = useState([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(null);
+	const [success, setSuccess] = useState(null);
+	const [isFormOpen, setIsFormOpen] = useState(false);
+	const [isSaving, setIsSaving] = useState(false);
+	const [editingId, setEditingId] = useState(null);
+	const [testingId, setTestingId] = useState(null);
+	const [label, setLabel] = useState('');
+	const [baseUrl, setBaseUrl] = useState('');
+	const [token, setToken] = useState('');
+
+	useEffect(() => {
+		loadSites();
+	}, []);
+
+	const loadSites = async () => {
+		setLoading(true);
+		setError(null);
+
+		try {
+			const data = await apiFetch({
+				path: '/fair-payment/v1/admin/connected-sites',
+			});
+			setSites(data);
+		} catch (err) {
+			setError(
+				err.message ||
+					__('Failed to load connected sites.', 'fair-payment')
+			);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleOpenAdd = () => {
+		setEditingId(null);
+		setLabel('');
+		setBaseUrl('');
+		setToken('');
+		setError(null);
+		setIsFormOpen(true);
+	};
+
+	const handleOpenEdit = (site) => {
+		setEditingId(site.id);
+		setLabel(site.label);
+		setBaseUrl(site.base_url);
+		setToken('');
+		setError(null);
+		setIsFormOpen(true);
+	};
+
+	const handleCloseForm = () => {
+		setIsFormOpen(false);
+		setEditingId(null);
+	};
+
+	const handleSave = async (e) => {
+		e.preventDefault();
+		setIsSaving(true);
+		setError(null);
+
+		try {
+			if (editingId) {
+				const data = { label, base_url: baseUrl };
+				// Only send token when the admin entered a new one.
+				if (token) {
+					data.token = token;
+				}
+				await apiFetch({
+					path: `/fair-payment/v1/admin/connected-sites/${editingId}`,
+					method: 'PUT',
+					data,
+				});
+				setSuccess(__('Connected site updated.', 'fair-payment'));
+			} else {
+				await apiFetch({
+					path: '/fair-payment/v1/admin/connected-sites',
+					method: 'POST',
+					data: { label, base_url: baseUrl, token },
+				});
+				setSuccess(__('Connected site added.', 'fair-payment'));
+			}
+			handleCloseForm();
+			loadSites();
+		} catch (err) {
+			setError(
+				err.message ||
+					__('Failed to save connected site.', 'fair-payment')
+			);
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const handleTest = async (id) => {
+		setTestingId(id);
+		setError(null);
+		setSuccess(null);
+
+		try {
+			const result = await apiFetch({
+				path: `/fair-payment/v1/admin/connected-sites/${id}/test`,
+				method: 'POST',
+			});
+			const scopes =
+				result.scopes && result.scopes.length
+					? result.scopes.join(', ')
+					: __('no scopes', 'fair-payment');
+			setSuccess(
+				__('Connection succeeded. Granted scopes: ', 'fair-payment') +
+					scopes
+			);
+			loadSites();
+		} catch (err) {
+			setError(
+				err.message || __('Connection test failed.', 'fair-payment')
+			);
+			loadSites();
+		} finally {
+			setTestingId(null);
+		}
+	};
+
+	const handleRemove = async (id) => {
+		if (
+			!window.confirm(
+				__(
+					'Remove this connected site? Stored token will be deleted.',
+					'fair-payment'
+				)
+			)
+		) {
+			return;
+		}
+
+		setError(null);
+		setSuccess(null);
+
+		try {
+			await apiFetch({
+				path: `/fair-payment/v1/admin/connected-sites/${id}`,
+				method: 'DELETE',
+			});
+			setSuccess(__('Connected site removed.', 'fair-payment'));
+			loadSites();
+		} catch (err) {
+			setError(
+				err.message ||
+					__('Failed to remove connected site.', 'fair-payment')
+			);
+		}
+	};
+
+	const renderStatus = (status) => {
+		const meta = STATUS_LABELS[status] || STATUS_LABELS.unverified;
+		return (
+			<span style={{ color: meta.color, fontWeight: 'bold' }}>
+				{meta.text}
+			</span>
+		);
+	};
+
+	return (
+		<div className="wrap fair-payment-connected-sites-page">
+			<VStack spacing={4}>
+				<Card>
+					<CardHeader>
+						<HStack justify="space-between">
+							<h1>{__('Connected Sites', 'fair-payment')}</h1>
+							<Button variant="primary" onClick={handleOpenAdd}>
+								{__('Add Site', 'fair-payment')}
+							</Button>
+						</HStack>
+					</CardHeader>
+					<CardBody>
+						<VStack spacing={4}>
+							<p style={{ color: '#666', margin: 0 }}>
+								{__(
+									'Register other sites this site pulls data from. Paste a token generated on the other site’s API Tokens page.',
+									'fair-payment'
+								)}
+							</p>
+
+							{error && (
+								<Notice
+									status="error"
+									isDismissible
+									onRemove={() => setError(null)}
+								>
+									{error}
+								</Notice>
+							)}
+
+							{success && (
+								<Notice
+									status="success"
+									isDismissible
+									onRemove={() => setSuccess(null)}
+								>
+									{success}
+								</Notice>
+							)}
+
+							{loading && (
+								<div>
+									<Spinner />
+									<p>
+										{__('Loading sites…', 'fair-payment')}
+									</p>
+								</div>
+							)}
+
+							{!loading && sites.length === 0 && (
+								<p>
+									{__(
+										'No connected sites yet. Add one to pull data from another site.',
+										'fair-payment'
+									)}
+								</p>
+							)}
+
+							{!loading && sites.length > 0 && (
+								<table className="wp-list-table widefat fixed striped">
+									<thead>
+										<tr>
+											<th>
+												{__('Label', 'fair-payment')}
+											</th>
+											<th>
+												{__('Base URL', 'fair-payment')}
+											</th>
+											<th>
+												{__('Scopes', 'fair-payment')}
+											</th>
+											<th>
+												{__('Status', 'fair-payment')}
+											</th>
+											<th>
+												{__(
+													'Last sync',
+													'fair-payment'
+												)}
+											</th>
+											<th style={{ width: '220px' }}>
+												{__('Actions', 'fair-payment')}
+											</th>
+										</tr>
+									</thead>
+									<tbody>
+										{sites.map((site) => (
+											<tr key={site.id}>
+												<td>
+													<strong>
+														{site.label}
+													</strong>
+												</td>
+												<td>{site.base_url}</td>
+												<td>
+													{site.scopes.length ? (
+														site.scopes.join(', ')
+													) : (
+														<em>—</em>
+													)}
+												</td>
+												<td>
+													{renderStatus(site.status)}
+												</td>
+												<td>
+													{site.last_sync_at || (
+														<em>
+															{__(
+																'Never',
+																'fair-payment'
+															)}
+														</em>
+													)}
+												</td>
+												<td>
+													<HStack
+														spacing={1}
+														justify="flex-start"
+													>
+														<Button
+															variant="secondary"
+															size="small"
+															isBusy={
+																testingId ===
+																site.id
+															}
+															disabled={
+																testingId !==
+																null
+															}
+															onClick={() =>
+																handleTest(
+																	site.id
+																)
+															}
+														>
+															{__(
+																'Test',
+																'fair-payment'
+															)}
+														</Button>
+														<Button
+															variant="tertiary"
+															size="small"
+															onClick={() =>
+																handleOpenEdit(
+																	site
+																)
+															}
+														>
+															{__(
+																'Edit',
+																'fair-payment'
+															)}
+														</Button>
+														<Button
+															variant="tertiary"
+															size="small"
+															isDestructive
+															onClick={() =>
+																handleRemove(
+																	site.id
+																)
+															}
+														>
+															{__(
+																'Remove',
+																'fair-payment'
+															)}
+														</Button>
+													</HStack>
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							)}
+						</VStack>
+					</CardBody>
+				</Card>
+			</VStack>
+
+			{isFormOpen && (
+				<Modal
+					title={
+						editingId
+							? __('Edit Connected Site', 'fair-payment')
+							: __('Add Connected Site', 'fair-payment')
+					}
+					onRequestClose={handleCloseForm}
+					style={{ maxWidth: '500px', width: '100%' }}
+				>
+					<form onSubmit={handleSave}>
+						<VStack spacing={4}>
+							<TextControl
+								label={__('Label', 'fair-payment')}
+								value={label}
+								onChange={setLabel}
+								help={__(
+									'A name to identify this site, e.g. acroyoga-club.es',
+									'fair-payment'
+								)}
+								required
+							/>
+							<TextControl
+								label={__('Base URL', 'fair-payment')}
+								type="url"
+								value={baseUrl}
+								onChange={setBaseUrl}
+								help={__(
+									'The other site’s address, e.g. https://acroyoga-club.es',
+									'fair-payment'
+								)}
+								required
+							/>
+							<TextControl
+								label={__('Token', 'fair-payment')}
+								type="password"
+								value={token}
+								onChange={setToken}
+								help={
+									editingId
+										? __(
+												'Leave blank to keep the existing token.',
+												'fair-payment'
+										  )
+										: __(
+												'Paste the token from the other site’s API Tokens page.',
+												'fair-payment'
+										  )
+								}
+								required={!editingId}
+							/>
+							<HStack justify="flex-end" spacing={2}>
+								<Button
+									variant="tertiary"
+									onClick={handleCloseForm}
+									disabled={isSaving}
+								>
+									{__('Cancel', 'fair-payment')}
+								</Button>
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={isSaving}
+									disabled={
+										isSaving ||
+										!label ||
+										!baseUrl ||
+										(!editingId && !token)
+									}
+								>
+									{editingId
+										? __('Save', 'fair-payment')
+										: __('Add Site', 'fair-payment')}
+								</Button>
+							</HStack>
+						</VStack>
+					</form>
+				</Modal>
+			)}
+		</div>
+	);
+};
+
+export default ConnectedSitesApp;

--- a/fair-payment/src/Admin/connected-sites/index.js
+++ b/fair-payment/src/Admin/connected-sites/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ConnectedSitesApp from './ConnectedSitesApp.js';
+
+/**
+ * Initialize the connected sites page
+ */
+domReady(() => {
+	const root = document.getElementById('fair-payment-connected-sites-root');
+	if (root) {
+		createRoot(root).render(<ConnectedSitesApp />);
+	}
+});

--- a/fair-payment/src/Database/Schema.php
+++ b/fair-payment/src/Database/Schema.php
@@ -74,6 +74,16 @@ class Schema {
 	}
 
 	/**
+	 * Get the table name for API tokens
+	 *
+	 * @return string Full table name with prefix.
+	 */
+	public static function get_api_tokens_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . 'fair_payment_api_tokens';
+	}
+
+	/**
 	 * Create database tables
 	 *
 	 * @return void
@@ -132,6 +142,9 @@ class Schema {
 		// Create log table.
 		self::create_log_table();
 
+		// Create API tokens table.
+		self::create_api_tokens_table();
+
 		// Run migrations if needed.
 		self::migrate_to_v2();
 		self::migrate_to_v3();
@@ -150,9 +163,10 @@ class Schema {
 		self::migrate_to_v16();
 		self::migrate_to_v17();
 		self::migrate_to_v18();
+		self::migrate_to_v19();
 
 		// Store database version for future migrations.
-		update_option( 'fair_payment_db_version', '18.0' );
+		update_option( 'fair_payment_db_version', '19.0' );
 	}
 
 	/**
@@ -306,6 +320,38 @@ class Schema {
 			KEY event (event),
 			KEY request_id (request_id),
 			KEY created_at (created_at)
+		) $charset_collate;";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Create API tokens table
+	 *
+	 * Stores scoped API tokens issued to consumer sites for the data sharing API.
+	 * Only the SHA-256 hash of each token is stored; the plaintext is shown once
+	 * on creation and never persisted.
+	 *
+	 * @return void
+	 */
+	public static function create_api_tokens_table() {
+		global $wpdb;
+
+		$table_name      = self::get_api_tokens_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE $table_name (
+			id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+			label varchar(191) NOT NULL,
+			token_hash varchar(64) NOT NULL,
+			scopes text DEFAULT NULL,
+			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			last_used_at datetime DEFAULT NULL,
+			revoked_at datetime DEFAULT NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY token_hash (token_hash),
+			KEY revoked_at (revoked_at)
 		) $charset_collate;";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
@@ -1035,6 +1081,21 @@ class Schema {
 	}
 
 	/**
+	 * Migrate database from v18.0 to v19.0
+	 *
+	 * Adds the API tokens table for the data sharing API.
+	 *
+	 * @return void
+	 */
+	public static function migrate_to_v19() {
+		$current_version = get_option( 'fair_payment_db_version', '1.0' );
+
+		if ( version_compare( $current_version, '19.0', '<' ) ) {
+			self::create_api_tokens_table();
+		}
+	}
+
+	/**
 	 * Drop database tables (used for uninstall)
 	 *
 	 * @return void
@@ -1048,6 +1109,11 @@ class Schema {
 		$budgets_table            = self::get_budgets_table_name();
 		$entry_transactions_table = self::get_entry_transactions_table_name();
 		$log_table                = self::get_log_table_name();
+		$api_tokens_table         = self::get_api_tokens_table_name();
+
+		// Drop API tokens table (standalone, no FK references).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $api_tokens_table ) );
 
 		// Drop log table (references transactions but only via informational FK, drop first).
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange

--- a/fair-payment/src/Models/ApiToken.php
+++ b/fair-payment/src/Models/ApiToken.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * API Token Model
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\Models;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Model class for data sharing API tokens.
+ *
+ * Tokens are stored only as a SHA-256 hash. The plaintext token is generated
+ * once on creation, returned to the caller so it can be shown to the admin a
+ * single time, and never persisted.
+ */
+class ApiToken {
+	/**
+	 * Allowed scopes for API tokens.
+	 *
+	 * @var string[]
+	 */
+	const ALLOWED_SCOPES = array( 'transactions:read', 'locations:read' );
+
+	/**
+	 * Generate a new cryptographically random plaintext token.
+	 *
+	 * @return string 40-character token.
+	 */
+	public static function generate_token() {
+		return wp_generate_password( 40, false );
+	}
+
+	/**
+	 * Hash a plaintext token for storage / lookup.
+	 *
+	 * @param string $plaintext Plaintext token.
+	 * @return string SHA-256 hex hash.
+	 */
+	public static function hash_token( $plaintext ) {
+		return hash( 'sha256', $plaintext );
+	}
+
+	/**
+	 * Create a new API token.
+	 *
+	 * @param string   $label  Human-readable label (e.g. "lamutable.es").
+	 * @param string[] $scopes List of scopes to grant.
+	 * @return array|false Array with 'id' and one-time plaintext 'token', or false on failure.
+	 */
+	public static function create( $label, array $scopes ) {
+		global $wpdb;
+		$table_name = \FairPayment\Database\Schema::get_api_tokens_table_name();
+
+		$valid_scopes = array_values( array_intersect( $scopes, self::ALLOWED_SCOPES ) );
+
+		$plaintext  = self::generate_token();
+		$token_hash = self::hash_token( $plaintext );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$inserted = $wpdb->insert(
+			$table_name,
+			array(
+				'label'      => $label,
+				'token_hash' => $token_hash,
+				'scopes'     => wp_json_encode( $valid_scopes ),
+				'created_at' => current_time( 'mysql', true ),
+			),
+			array( '%s', '%s', '%s', '%s' )
+		);
+
+		if ( ! $inserted ) {
+			return false;
+		}
+
+		return array(
+			'id'    => (int) $wpdb->insert_id,
+			'token' => $plaintext,
+		);
+	}
+
+	/**
+	 * Find an active (non-revoked) token row by its plaintext value.
+	 *
+	 * @param string $plaintext Plaintext token.
+	 * @return object|null Token row or null if not found / revoked.
+	 */
+	public static function find_by_token( $plaintext ) {
+		global $wpdb;
+		$table_name = \FairPayment\Database\Schema::get_api_tokens_table_name();
+
+		$token_hash = self::hash_token( $plaintext );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE token_hash = %s AND revoked_at IS NULL',
+				$table_name,
+				$token_hash
+			)
+		);
+	}
+
+	/**
+	 * Get a single token row by ID.
+	 *
+	 * @param int $id Token ID.
+	 * @return object|null Token row or null.
+	 */
+	public static function get_by_id( $id ) {
+		global $wpdb;
+		$table_name = \FairPayment\Database\Schema::get_api_tokens_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE id = %d',
+				$table_name,
+				$id
+			)
+		);
+	}
+
+	/**
+	 * Get all token rows, newest first.
+	 *
+	 * @return object[] Array of token rows.
+	 */
+	public static function get_all() {
+		global $wpdb;
+		$table_name = \FairPayment\Database\Schema::get_api_tokens_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i ORDER BY created_at DESC',
+				$table_name
+			)
+		);
+	}
+
+	/**
+	 * Revoke a token by ID.
+	 *
+	 * @param int $id Token ID.
+	 * @return bool True on success.
+	 */
+	public static function revoke( $id ) {
+		global $wpdb;
+		$table_name = \FairPayment\Database\Schema::get_api_tokens_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (bool) $wpdb->update(
+			$table_name,
+			array( 'revoked_at' => current_time( 'mysql', true ) ),
+			array( 'id' => $id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+	}
+
+	/**
+	 * Update the last_used_at timestamp for a token.
+	 *
+	 * @param int $id Token ID.
+	 * @return void
+	 */
+	public static function touch_last_used( $id ) {
+		global $wpdb;
+		$table_name = \FairPayment\Database\Schema::get_api_tokens_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->update(
+			$table_name,
+			array( 'last_used_at' => current_time( 'mysql', true ) ),
+			array( 'id' => $id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+	}
+
+	/**
+	 * Whether a token row is active (not revoked).
+	 *
+	 * @param object $row Token row.
+	 * @return bool
+	 */
+	public static function is_active( $row ) {
+		return $row && null === $row->revoked_at;
+	}
+
+	/**
+	 * Decode the scopes stored on a token row.
+	 *
+	 * @param object $row Token row.
+	 * @return string[] List of scopes.
+	 */
+	public static function get_scopes( $row ) {
+		if ( ! $row || empty( $row->scopes ) ) {
+			return array();
+		}
+
+		$scopes = json_decode( $row->scopes, true );
+
+		return is_array( $scopes ) ? $scopes : array();
+	}
+
+	/**
+	 * Whether a token row grants the given scope.
+	 *
+	 * @param object $row   Token row.
+	 * @param string $scope Scope to check.
+	 * @return bool
+	 */
+	public static function has_scope( $row, $scope ) {
+		return in_array( $scope, self::get_scopes( $row ), true );
+	}
+
+	/**
+	 * Convert a token row to a safe array for API responses.
+	 *
+	 * Never includes the token hash or any plaintext.
+	 *
+	 * @param object $row Token row.
+	 * @return array
+	 */
+	public static function to_array( $row ) {
+		return array(
+			'id'           => (int) $row->id,
+			'label'        => $row->label,
+			'scopes'       => self::get_scopes( $row ),
+			'created_at'   => $row->created_at,
+			'last_used_at' => $row->last_used_at,
+			'status'       => self::is_active( $row ) ? 'active' : 'revoked',
+		);
+	}
+}

--- a/fair-payment/src/Models/ConnectedSite.php
+++ b/fair-payment/src/Models/ConnectedSite.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Connected Site Model
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\Models;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Model for secondary sites this site pulls data from (data sharing consumer side).
+ *
+ * Records are stored in a single option as an array keyed by integer id. The
+ * remote bearer token is stored as-is (plaintext), consistent with how the
+ * plugin already stores Mollie access/refresh tokens; it is only ever exposed
+ * through the admin-only REST controller, never in list responses.
+ */
+class ConnectedSite {
+	/**
+	 * Option name holding the array of connected site records.
+	 *
+	 * @var string
+	 */
+	const OPTION = 'fair_payment_connected_sites';
+
+	/**
+	 * Read the raw array of records from the option.
+	 *
+	 * @return array[] Array of associative records.
+	 */
+	private static function read() {
+		$sites = get_option( self::OPTION, array() );
+
+		return is_array( $sites ) ? array_values( $sites ) : array();
+	}
+
+	/**
+	 * Persist the array of records to the option.
+	 *
+	 * @param array[] $sites Records to store.
+	 * @return void
+	 */
+	private static function write( array $sites ) {
+		update_option( self::OPTION, array_values( $sites ) );
+	}
+
+	/**
+	 * Get all connected sites, newest first.
+	 *
+	 * @return array[] Records ordered by id descending.
+	 */
+	public static function get_all() {
+		$sites = self::read();
+
+		usort(
+			$sites,
+			static function ( $a, $b ) {
+				return (int) $b['id'] - (int) $a['id'];
+			}
+		);
+
+		return $sites;
+	}
+
+	/**
+	 * Get a single connected site by id.
+	 *
+	 * @param int $id Site id.
+	 * @return array|null Record or null when not found.
+	 */
+	public static function get_by_id( $id ) {
+		foreach ( self::read() as $site ) {
+			if ( (int) $site['id'] === (int) $id ) {
+				return $site;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Create a new connected site.
+	 *
+	 * @param array $data Input with label, base_url, token.
+	 * @return array The created record.
+	 */
+	public static function create( array $data ) {
+		$sites = self::read();
+
+		$next_id = 1;
+		foreach ( $sites as $site ) {
+			$next_id = max( $next_id, (int) $site['id'] + 1 );
+		}
+
+		$record = array(
+			'id'           => $next_id,
+			'label'        => sanitize_text_field( $data['label'] ?? '' ),
+			'base_url'     => esc_url_raw( $data['base_url'] ?? '' ),
+			'token'        => trim( (string) ( $data['token'] ?? '' ) ),
+			'scopes'       => array(),
+			'status'       => 'unverified',
+			'created_at'   => current_time( 'mysql', true ),
+			'last_sync_at' => null,
+		);
+
+		$sites[] = $record;
+		self::write( $sites );
+
+		return $record;
+	}
+
+	/**
+	 * Update an existing connected site.
+	 *
+	 * Only label, base_url and a non-empty token are merged; an empty token
+	 * leaves the stored token untouched.
+	 *
+	 * @param int   $id   Site id.
+	 * @param array $data Fields to update.
+	 * @return array|null Updated record, or null when not found.
+	 */
+	public static function update( $id, array $data ) {
+		$sites   = self::read();
+		$updated = null;
+
+		foreach ( $sites as $index => $site ) {
+			if ( (int) $site['id'] !== (int) $id ) {
+				continue;
+			}
+
+			if ( isset( $data['label'] ) ) {
+				$site['label'] = sanitize_text_field( $data['label'] );
+			}
+			if ( isset( $data['base_url'] ) ) {
+				$site['base_url'] = esc_url_raw( $data['base_url'] );
+			}
+			if ( ! empty( $data['token'] ) ) {
+				$site['token'] = trim( (string) $data['token'] );
+			}
+
+			$sites[ $index ] = $site;
+			$updated         = $site;
+			break;
+		}
+
+		if ( null !== $updated ) {
+			self::write( $sites );
+		}
+
+		return $updated;
+	}
+
+	/**
+	 * Delete a connected site.
+	 *
+	 * @param int $id Site id.
+	 * @return bool True when a record was removed.
+	 */
+	public static function delete( $id ) {
+		$sites     = self::read();
+		$remaining = array();
+		$found     = false;
+
+		foreach ( $sites as $site ) {
+			if ( (int) $site['id'] === (int) $id ) {
+				$found = true;
+				continue;
+			}
+			$remaining[] = $site;
+		}
+
+		if ( $found ) {
+			self::write( $remaining );
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Record a successful connection test: store discovered scopes and sync time.
+	 *
+	 * @param int      $id     Site id.
+	 * @param string[] $scopes Scopes reported by the remote token.
+	 * @return void
+	 */
+	public static function record_test_result( $id, array $scopes ) {
+		$sites = self::read();
+
+		foreach ( $sites as $index => $site ) {
+			if ( (int) $site['id'] === (int) $id ) {
+				$site['scopes']       = array_values( array_map( 'sanitize_text_field', $scopes ) );
+				$site['status']       = 'connected';
+				$site['last_sync_at'] = current_time( 'mysql', true );
+				$sites[ $index ]      = $site;
+				break;
+			}
+		}
+
+		self::write( $sites );
+	}
+
+	/**
+	 * Mark a connected site as failing its connection test.
+	 *
+	 * @param int $id Site id.
+	 * @return void
+	 */
+	public static function mark_failed( $id ) {
+		$sites = self::read();
+
+		foreach ( $sites as $index => $site ) {
+			if ( (int) $site['id'] === (int) $id ) {
+				$site['status']  = 'error';
+				$sites[ $index ] = $site;
+				break;
+			}
+		}
+
+		self::write( $sites );
+	}
+
+	/**
+	 * Convert a record to a safe array for admin responses.
+	 *
+	 * Never returns the raw token; exposes only whether one is set and a short
+	 * hint (last 4 characters).
+	 *
+	 * @param array $record Connected site record.
+	 * @return array
+	 */
+	public static function to_array( $record ) {
+		$token = (string) ( $record['token'] ?? '' );
+
+		return array(
+			'id'           => (int) $record['id'],
+			'label'        => $record['label'] ?? '',
+			'base_url'     => $record['base_url'] ?? '',
+			'scopes'       => isset( $record['scopes'] ) && is_array( $record['scopes'] ) ? $record['scopes'] : array(),
+			'status'       => $record['status'] ?? 'unverified',
+			'created_at'   => $record['created_at'] ?? '',
+			'last_sync_at' => $record['last_sync_at'] ?? null,
+			'has_token'    => '' !== $token,
+			'token_hint'   => '' !== $token ? substr( $token, -4 ) : '',
+		);
+	}
+}

--- a/fair-payment/src/Models/Transaction.php
+++ b/fair-payment/src/Models/Transaction.php
@@ -302,6 +302,8 @@ class Transaction {
 			'status'        => '',
 			'mode'          => '',
 			'event_date_id' => 0,
+			'date_from'     => '',
+			'date_to'       => '',
 			'orderby'       => 'created_at',
 			'order'         => 'DESC',
 		);
@@ -321,6 +323,14 @@ class Transaction {
 
 		if ( ! empty( $args['event_date_id'] ) ) {
 			$where_clauses[] = $wpdb->prepare( 'event_date_id = %d', (int) $args['event_date_id'] );
+		}
+
+		if ( ! empty( $args['date_from'] ) ) {
+			$where_clauses[] = $wpdb->prepare( 'created_at >= %s', $args['date_from'] );
+		}
+
+		if ( ! empty( $args['date_to'] ) ) {
+			$where_clauses[] = $wpdb->prepare( 'created_at <= %s', $args['date_to'] );
 		}
 
 		$where = '';
@@ -365,6 +375,14 @@ class Transaction {
 
 		if ( ! empty( $args['event_date_id'] ) ) {
 			$where_clauses[] = $wpdb->prepare( 'event_date_id = %d', (int) $args['event_date_id'] );
+		}
+
+		if ( ! empty( $args['date_from'] ) ) {
+			$where_clauses[] = $wpdb->prepare( 'created_at >= %s', $args['date_from'] );
+		}
+
+		if ( ! empty( $args['date_to'] ) ) {
+			$where_clauses[] = $wpdb->prepare( 'created_at <= %s', $args['date_to'] );
 		}
 
 		$where = '';

--- a/fair-payment/webpack.config.cjs
+++ b/fair-payment/webpack.config.cjs
@@ -41,6 +41,10 @@ module.exports = {
       process.cwd(),
       "src/Admin/api-tokens/index.js",
     ),
+    "admin/connected-sites/index": path.resolve(
+      process.cwd(),
+      "src/Admin/connected-sites/index.js",
+    ),
     "payment-callback": path.resolve(
       process.cwd(),
       "src/payment-callback.js",

--- a/fair-payment/webpack.config.cjs
+++ b/fair-payment/webpack.config.cjs
@@ -37,6 +37,10 @@ module.exports = {
       process.cwd(),
       "src/Admin/reconciliation/index.js",
     ),
+    "admin/api-tokens/index": path.resolve(
+      process.cwd(),
+      "src/Admin/api-tokens/index.js",
+    ),
     "payment-callback": path.resolve(
       process.cwd(),
       "src/payment-callback.js",


### PR DESCRIPTION
## Summary

Stage 1 of the cross-site **data sharing API** (issues #588–591). Secondary sites running `fair-payment` can now expose transaction data to a consumer site (e.g. lamutable.es) over a scoped, token-authenticated REST API. An admin mints a token (shown once), hands it to the consumer, and that site pulls data with `Authorization: Bearer <token>` — scoped, revocable, and PII-limited.

## What's included

- **#588 — Storage & model:** `wp_fair_payment_api_tokens` table (`migrate_to_v19`, db version → 19.0) and an `ApiToken` model. Only the SHA-256 hash is stored; plaintext is shown once and never persisted. Includes scope helpers and revocation.
- **#590 — Auth middleware:** `ApiTokenAuth::authenticate()` + a `require_scope()` `permission_callback` factory. Generic 401 for missing/invalid/revoked tokens (no token-existence leak), 403 for missing scope, and `last_used_at` is touched on success.
- **#591 — Public endpoint:** `GET /fair-payment/v1/external/transactions` (scope `transactions:read`) with `page`/`per_page` (max 200)/`from`/`to`/`status`. `Transaction::get_all()`/`count()` gained optional `date_from`/`date_to` filters. The response item exposes `id, mollie_payment_id, amount, currency, application_fee, status, testmode, description, event_date_id, event_url, created_at` and **deliberately excludes** `user_name`/`participant` (PII).
- **#589 — Admin page:** admin-only `ApiTokensController` (list / create / revoke) plus a React **Fair Payment → API Tokens** page to issue tokens (one-time plaintext with copy + warning), list them (label, scopes, created, last used, status), and revoke.

## Decisions

- "Location" in the response = `event_date_id` + `event_url` (reusing the existing `EventDates` → permalink lookup). No synthetic `location_id`.
- Response includes `description` and `mollie_payment_id` for reconciliation, but no names/participant objects.
- `locations:read` scope is offered in the admin UI for forward-compat; no locations endpoint is built in this batch.
- No automated tests in this batch (per request); verified manually.

## Verification

- `npm run build` ✅, `npm run format` ✅, `phpcs` (project config) clean ✅, JS tests 4/4 ✅.
- Verified live against the Docker WP instance by dispatching real `WP_REST_Request`s through `rest_do_request()`:
  - External endpoint: valid token → 200 with correct envelope; wrong scope → 403; no header → 401; `from` date filter excludes correctly; item payload confirmed to omit `user_name`/`participant`; `last_used_at` updated.
  - Admin endpoints: create → 201 with one-time plaintext; list hides `token_hash`; invalid scope → 400; revoke → 200 (status `revoked`); anonymous → 401.
  - Table created with all columns; `fair_payment_db_version` → 19.0.

> Note: the live `curl` test over `?rest_route=` returned 401 even with a valid token because this Docker setup uses plain permalinks and Apache doesn't forward the `Authorization` header to PHP (and `.htaccess` can't be regenerated in the container). This is a local-env transport quirk, not a code issue — confirmed via `rest_do_request()`. Production sites with normal permalinks/`.htaccess` forward the header normally.

## Activation note

The new table is created via the activation hook (`Schema::create_tables()`), so the plugin must be (re)activated for `wp_fair_payment_api_tokens` to be created on existing installs.