### PR TITLE
Offer connected-site or file source when importing transactions

### DIFF
--- a/fair-payment/src/API/ConnectedSitesController.php
+++ b/fair-payment/src/API/ConnectedSitesController.php
@@ -13,6 +13,7 @@ namespace FairPayment\API;
 defined( 'WPINC' ) || die;
 
 use FairPayment\Models\ConnectedSite;
+use FairPayment\Models\Transaction;
 use WP_REST_Controller;
 use WP_REST_Server;
 use WP_REST_Request;
@@ -94,6 +95,18 @@ class ConnectedSitesController extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'test_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/admin/connected-sites/(?P<id>\d+)/import-transactions',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'import_transactions' ),
 					'permission_callback' => array( $this, 'permissions_check' ),
 				),
 			)
@@ -262,6 +275,135 @@ class ConnectedSitesController extends WP_REST_Controller {
 				'ok'     => true,
 				'label'  => isset( $body['label'] ) ? sanitize_text_field( $body['label'] ) : '',
 				'scopes' => array_values( array_map( 'sanitize_text_field', $scopes ) ),
+			),
+			200
+		);
+	}
+
+	/**
+	 * Pull transactions from a connected site and import them locally.
+	 *
+	 * Paginates through the remote /external/transactions endpoint using the
+	 * stored bearer token, maps each row to the local import shape, and runs it
+	 * through Transaction::import (which deduplicates by mollie_payment_id).
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function import_transactions( $request ) {
+		$id     = (int) $request->get_param( 'id' );
+		$record = ConnectedSite::get_by_id( $id );
+
+		if ( ! $record ) {
+			return $this->not_found();
+		}
+
+		$source_domain = (string) wp_parse_url( $record['base_url'], PHP_URL_HOST );
+		$base          = trailingslashit( $record['base_url'] ) . 'wp-json/fair-payment/v1/external/transactions';
+		$per_page      = 200;
+		$page          = 1;
+		$created       = 0;
+		$updated       = 0;
+		$skipped       = 0;
+
+		do {
+			$url = add_query_arg(
+				array(
+					'page'     => $page,
+					'per_page' => $per_page,
+				),
+				$base
+			);
+
+			$response = wp_safe_remote_get(
+				$url,
+				array(
+					'timeout' => 30,
+					'headers' => array(
+						'Authorization' => 'Bearer ' . $record['token'],
+					),
+				)
+			);
+
+			if ( is_wp_error( $response ) ) {
+				ConnectedSite::mark_failed( $id );
+
+				return new WP_Error(
+					'rest_connected_site_unreachable',
+					__( 'Could not reach the remote site.', 'fair-payment' ),
+					array( 'status' => 502 )
+				);
+			}
+
+			$code = (int) wp_remote_retrieve_response_code( $response );
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			if ( 200 !== $code || ! is_array( $body ) || ! isset( $body['transactions'] ) ) {
+				ConnectedSite::mark_failed( $id );
+
+				$message = 401 === $code || 403 === $code
+					? __( 'The remote site rejected the token, or it lacks the transactions:read scope.', 'fair-payment' )
+					: __( 'The remote site returned an unexpected response.', 'fair-payment' );
+
+				return new WP_Error(
+					'rest_connected_site_import_failed',
+					$message,
+					array( 'status' => 400 )
+				);
+			}
+
+			$transactions = is_array( $body['transactions'] ) ? $body['transactions'] : array();
+
+			foreach ( $transactions as $transaction ) {
+				if ( ! is_array( $transaction ) ) {
+					++$skipped;
+					continue;
+				}
+
+				$result = Transaction::import(
+					array(
+						'mollie_payment_id' => $transaction['mollie_payment_id'] ?? '',
+						'amount'            => $transaction['amount'] ?? 0,
+						'currency'          => $transaction['currency'] ?? 'EUR',
+						'application_fee'   => $transaction['application_fee'] ?? null,
+						'status'            => $transaction['status'] ?? 'paid',
+						'testmode'          => ! empty( $transaction['testmode'] ),
+						'description'       => $transaction['description'] ?? '',
+						'created_at'        => $transaction['created_at'] ?? '',
+						'event_date_id'     => $transaction['event_date_id'] ?? null,
+						'detail_url'        => $transaction['event_url'] ?? '',
+						'source_domain'     => $source_domain,
+					)
+				);
+
+				if ( 'created' === $result ) {
+					++$created;
+				} elseif ( 'updated' === $result ) {
+					++$updated;
+				} else {
+					++$skipped;
+				}
+			}
+
+			$total    = isset( $body['total'] ) ? (int) $body['total'] : 0;
+			$fetched  = $page * $per_page;
+			$has_more = count( $transactions ) === $per_page && $fetched < $total;
+			++$page;
+		} while ( $has_more );
+
+		return new WP_REST_Response(
+			array(
+				'created' => $created,
+				'updated' => $updated,
+				'skipped' => $skipped,
+				'message' => sprintf(
+					/* translators: 1: created count, 2: updated count, 3: skipped count, 4: connected site label */
+					__( 'Imported %1$d new, updated %2$d, skipped %3$d transaction(s) from %4$s.', 'fair-payment' ),
+					$created,
+					$updated,
+					$skipped,
+					$record['label']
+				),
 			),
 			200
 		);

--- a/fair-payment/src/Admin/transactions/TransactionsApp.js
+++ b/fair-payment/src/Admin/transactions/TransactionsApp.js
@@ -15,6 +15,11 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import ImportTransactionsModal from './components/ImportTransactionsModal.js';
+
 const STATUS_OPTIONS = [
 	{ label: __('All statuses', 'fair-payment'), value: '' },
 	{ label: __('Paid', 'fair-payment'), value: 'paid' },
@@ -78,7 +83,7 @@ const TransactionsApp = () => {
 	const [error, setError] = useState(null);
 	const [success, setSuccess] = useState(null);
 	const [selectedTransactions, setSelectedTransactions] = useState(new Set());
-	const [isImporting, setIsImporting] = useState(false);
+	const [isImportModalOpen, setIsImportModalOpen] = useState(false);
 	const [feeSync, setFeeSync] = useState(null);
 
 	const loadTransactions = useCallback(async () => {
@@ -191,135 +196,11 @@ const TransactionsApp = () => {
 		);
 	};
 
-	const parseMollieCsv = (text) => {
-		const lines = text.split('\n').filter((line) => line.trim());
-		if (lines.length < 2) {
-			return [];
-		}
-
-		const parseRow = (line) => {
-			const values = [];
-			let current = '';
-			let inQuotes = false;
-			for (let i = 0; i < line.length; i++) {
-				const ch = line[i];
-				if (ch === '"') {
-					inQuotes = !inQuotes;
-				} else if (ch === ',' && !inQuotes) {
-					values.push(current);
-					current = '';
-				} else {
-					current += ch;
-				}
-			}
-			values.push(current);
-			return values;
-		};
-
-		const headers = parseRow(lines[0]);
-		const idxId = headers.indexOf('ID');
-		const idxAmount = headers.indexOf('Amount');
-		const idxCurrency = headers.indexOf('Currency');
-		const idxStatus = headers.indexOf('Status');
-		const idxDescription = headers.indexOf('Description');
-		const idxDate = headers.indexOf('Date');
-
-		if (idxId === -1) {
-			return [];
-		}
-
-		const mollieStatusMap = {
-			paidout: 'paid',
-			paid: 'paid',
-			open: 'open',
-			failed: 'failed',
-			canceled: 'canceled',
-			expired: 'expired',
-			refunded: 'refunded',
-			charged_back: 'charged_back',
-		};
-
-		return lines
-			.slice(1)
-			.map((line) => {
-				const values = parseRow(line);
-				const rawStatus = (values[idxStatus] || '').toLowerCase();
-				return {
-					mollie_payment_id: values[idxId] || '',
-					amount: parseFloat(values[idxAmount]) || 0,
-					currency: values[idxCurrency] || 'EUR',
-					status: mollieStatusMap[rawStatus] || rawStatus,
-					description:
-						idxDescription !== -1
-							? values[idxDescription] || ''
-							: '',
-					created_at: idxDate !== -1 ? values[idxDate] || '' : '',
-				};
-			})
-			.filter((t) => t.mollie_payment_id);
-	};
-
-	const handleImport = async (e) => {
-		const file = e.target.files[0];
-		if (!file) {
-			return;
-		}
-
-		// Reset the input so the same file can be re-selected
-		e.target.value = '';
-
-		setIsImporting(true);
+	const handleImported = (message) => {
 		setError(null);
-		setSuccess(null);
-
-		try {
-			const text = await file.text();
-			let toImport;
-
-			if (file.name.endsWith('.csv')) {
-				toImport = parseMollieCsv(text);
-			} else {
-				const imported = JSON.parse(text);
-
-				if (!Array.isArray(imported)) {
-					throw new Error(
-						__(
-							'Invalid file format. Expected a JSON array.',
-							'fair-payment'
-						)
-					);
-				}
-
-				toImport = imported.filter((t) => t.mollie_payment_id);
-			}
-
-			if (toImport.length === 0) {
-				throw new Error(
-					__(
-						'No valid transactions found in the file.',
-						'fair-payment'
-					)
-				);
-			}
-
-			const response = await apiFetch({
-				path: '/fair-payment/v1/transactions/import',
-				method: 'POST',
-				data: {
-					transactions: toImport,
-				},
-			});
-
-			setSuccess(response.message);
-			loadTransactions();
-		} catch (err) {
-			setError(
-				err.message ||
-					__('Failed to import transactions.', 'fair-payment')
-			);
-		} finally {
-			setIsImporting(false);
-		}
+		setSuccess(message);
+		setIsImportModalOpen(false);
+		loadTransactions();
 	};
 
 	const handleLoadMissingFees = async () => {
@@ -490,26 +371,11 @@ const TransactionsApp = () => {
 							</Button>
 							<Button
 								variant="secondary"
-								onClick={() =>
-									document
-										.getElementById(
-											'fair-payment-transaction-import'
-										)
-										.click()
-								}
-								isBusy={isImporting}
-								disabled={isImporting}
+								onClick={() => setIsImportModalOpen(true)}
 								style={{ flexShrink: 0, width: 'auto' }}
 							>
 								{__('Import', 'fair-payment')}
 							</Button>
-							<input
-								id="fair-payment-transaction-import"
-								type="file"
-								accept=".json,.csv"
-								style={{ display: 'none' }}
-								onChange={handleImport}
-							/>
 						</HStack>
 					</HStack>
 				</CardHeader>
@@ -780,6 +646,13 @@ const TransactionsApp = () => {
 					)}
 				</CardBody>
 			</Card>
+
+			{isImportModalOpen && (
+				<ImportTransactionsModal
+					onClose={() => setIsImportModalOpen(false)}
+					onImported={handleImported}
+				/>
+			)}
 		</div>
 	);
 };

--- a/fair-payment/src/Admin/transactions/components/ImportTransactionsModal.js
+++ b/fair-payment/src/Admin/transactions/components/ImportTransactionsModal.js
@@ -1,0 +1,322 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Modal,
+	Button,
+	Notice,
+	Spinner,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { parseMollieCsv } from '../parseMollieCsv.js';
+
+const STATUS_COLORS = {
+	connected: '#007017',
+	error: '#d63638',
+	unverified: '#946800',
+};
+
+const ImportTransactionsModal = ({ onClose, onImported }) => {
+	const [view, setView] = useState('choose');
+	const [error, setError] = useState(null);
+	const [isImporting, setIsImporting] = useState(false);
+	const [sites, setSites] = useState([]);
+	const [loadingSites, setLoadingSites] = useState(false);
+	const [busySiteId, setBusySiteId] = useState(null);
+	const fileInputRef = useRef(null);
+
+	useEffect(() => {
+		if (view !== 'sites') {
+			return;
+		}
+
+		const loadSites = async () => {
+			setLoadingSites(true);
+			setError(null);
+
+			try {
+				const data = await apiFetch({
+					path: '/fair-payment/v1/admin/connected-sites',
+				});
+				setSites(data);
+			} catch (err) {
+				setError(
+					err.message ||
+						__('Failed to load connected sites.', 'fair-payment')
+				);
+			} finally {
+				setLoadingSites(false);
+			}
+		};
+
+		loadSites();
+	}, [view]);
+
+	const handleFileChange = async (e) => {
+		const file = e.target.files[0];
+		if (!file) {
+			return;
+		}
+
+		// Reset the input so the same file can be re-selected.
+		e.target.value = '';
+
+		setIsImporting(true);
+		setError(null);
+
+		try {
+			const text = await file.text();
+			let toImport;
+
+			if (file.name.endsWith('.csv')) {
+				toImport = parseMollieCsv(text);
+			} else {
+				const imported = JSON.parse(text);
+
+				if (!Array.isArray(imported)) {
+					throw new Error(
+						__(
+							'Invalid file format. Expected a JSON array.',
+							'fair-payment'
+						)
+					);
+				}
+
+				toImport = imported.filter((t) => t.mollie_payment_id);
+			}
+
+			if (toImport.length === 0) {
+				throw new Error(
+					__(
+						'No valid transactions found in the file.',
+						'fair-payment'
+					)
+				);
+			}
+
+			const response = await apiFetch({
+				path: '/fair-payment/v1/transactions/import',
+				method: 'POST',
+				data: { transactions: toImport },
+			});
+
+			onImported(response.message);
+		} catch (err) {
+			setError(
+				err.message ||
+					__('Failed to import transactions.', 'fair-payment')
+			);
+		} finally {
+			setIsImporting(false);
+		}
+	};
+
+	const handleSiteImport = async (site) => {
+		setBusySiteId(site.id);
+		setError(null);
+
+		try {
+			const response = await apiFetch({
+				path: `/fair-payment/v1/admin/connected-sites/${site.id}/import-transactions`,
+				method: 'POST',
+			});
+
+			onImported(response.message);
+		} catch (err) {
+			setError(
+				err.message ||
+					__(
+						'Failed to import transactions from the connected site.',
+						'fair-payment'
+					)
+			);
+		} finally {
+			setBusySiteId(null);
+		}
+	};
+
+	const renderChoose = () => (
+		<VStack spacing={4}>
+			<p style={{ margin: 0 }}>
+				{__(
+					'Where do you want to import transactions from?',
+					'fair-payment'
+				)}
+			</p>
+			<HStack spacing={3} justify="flex-start">
+				<Button
+					variant="secondary"
+					onClick={() => {
+						setError(null);
+						setView('sites');
+					}}
+				>
+					{__('Connected Sites', 'fair-payment')}
+				</Button>
+				<Button
+					variant="secondary"
+					onClick={() => {
+						setError(null);
+						setView('file');
+					}}
+				>
+					{__('From File', 'fair-payment')}
+				</Button>
+			</HStack>
+		</VStack>
+	);
+
+	const renderFile = () => (
+		<VStack spacing={4}>
+			<p style={{ margin: 0 }}>
+				{__(
+					'Select a JSON file exported from another site, or a Mollie payments CSV export.',
+					'fair-payment'
+				)}
+			</p>
+			<input
+				ref={fileInputRef}
+				type="file"
+				accept=".json,.csv"
+				onChange={handleFileChange}
+				disabled={isImporting}
+			/>
+			{isImporting && (
+				<HStack justify="flex-start" spacing={2}>
+					<Spinner />
+					<span>{__('Importing…', 'fair-payment')}</span>
+				</HStack>
+			)}
+			<HStack justify="flex-start">
+				<Button
+					variant="tertiary"
+					onClick={() => setView('choose')}
+					disabled={isImporting}
+				>
+					{__('Back', 'fair-payment')}
+				</Button>
+			</HStack>
+		</VStack>
+	);
+
+	const renderSites = () => (
+		<VStack spacing={4}>
+			<p style={{ margin: 0 }}>
+				{__(
+					'Pull transactions from a registered connected site. Existing transactions are matched by payment ID and updated rather than duplicated.',
+					'fair-payment'
+				)}
+			</p>
+
+			{loadingSites && (
+				<HStack justify="flex-start" spacing={2}>
+					<Spinner />
+					<span>{__('Loading sites…', 'fair-payment')}</span>
+				</HStack>
+			)}
+
+			{!loadingSites && sites.length === 0 && (
+				<p>
+					{__(
+						'No connected sites yet. Add one on the Connected Sites page first.',
+						'fair-payment'
+					)}
+				</p>
+			)}
+
+			{!loadingSites && sites.length > 0 && (
+				<table className="wp-list-table widefat fixed striped">
+					<thead>
+						<tr>
+							<th>{__('Label', 'fair-payment')}</th>
+							<th>{__('Status', 'fair-payment')}</th>
+							<th style={{ width: '120px' }}>
+								{__('Actions', 'fair-payment')}
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{sites.map((site) => (
+							<tr key={site.id}>
+								<td>
+									<strong>{site.label}</strong>
+									<br />
+									<span style={{ color: '#666' }}>
+										{site.base_url}
+									</span>
+								</td>
+								<td>
+									<span
+										style={{
+											color:
+												STATUS_COLORS[site.status] ||
+												STATUS_COLORS.unverified,
+											fontWeight: 'bold',
+										}}
+									>
+										{site.status}
+									</span>
+								</td>
+								<td>
+									<Button
+										variant="primary"
+										size="small"
+										isBusy={busySiteId === site.id}
+										disabled={busySiteId !== null}
+										onClick={() => handleSiteImport(site)}
+									>
+										{__('Import', 'fair-payment')}
+									</Button>
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			)}
+
+			<HStack justify="flex-start">
+				<Button
+					variant="tertiary"
+					onClick={() => setView('choose')}
+					disabled={busySiteId !== null}
+				>
+					{__('Back', 'fair-payment')}
+				</Button>
+			</HStack>
+		</VStack>
+	);
+
+	return (
+		<Modal
+			title={__('Import Transactions', 'fair-payment')}
+			onRequestClose={onClose}
+			style={{ maxWidth: '640px', width: '100%' }}
+		>
+			<VStack spacing={4}>
+				{error && (
+					<Notice
+						status="error"
+						isDismissible
+						onRemove={() => setError(null)}
+					>
+						{error}
+					</Notice>
+				)}
+
+				{view === 'choose' && renderChoose()}
+				{view === 'file' && renderFile()}
+				{view === 'sites' && renderSites()}
+			</VStack>
+		</Modal>
+	);
+};
+
+export default ImportTransactionsModal;

--- a/fair-payment/src/Admin/transactions/parseMollieCsv.js
+++ b/fair-payment/src/Admin/transactions/parseMollieCsv.js
@@ -1,0 +1,71 @@
+/**
+ * Parse a Mollie payments CSV export into the transaction import shape.
+ *
+ * @param {string} text Raw CSV file contents.
+ * @return {Array<Object>} Parsed transactions keyed by mollie_payment_id.
+ */
+export const parseMollieCsv = (text) => {
+	const lines = text.split('\n').filter((line) => line.trim());
+	if (lines.length < 2) {
+		return [];
+	}
+
+	const parseRow = (line) => {
+		const values = [];
+		let current = '';
+		let inQuotes = false;
+		for (let i = 0; i < line.length; i++) {
+			const ch = line[i];
+			if (ch === '"') {
+				inQuotes = !inQuotes;
+			} else if (ch === ',' && !inQuotes) {
+				values.push(current);
+				current = '';
+			} else {
+				current += ch;
+			}
+		}
+		values.push(current);
+		return values;
+	};
+
+	const headers = parseRow(lines[0]);
+	const idxId = headers.indexOf('ID');
+	const idxAmount = headers.indexOf('Amount');
+	const idxCurrency = headers.indexOf('Currency');
+	const idxStatus = headers.indexOf('Status');
+	const idxDescription = headers.indexOf('Description');
+	const idxDate = headers.indexOf('Date');
+
+	if (idxId === -1) {
+		return [];
+	}
+
+	const mollieStatusMap = {
+		paidout: 'paid',
+		paid: 'paid',
+		open: 'open',
+		failed: 'failed',
+		canceled: 'canceled',
+		expired: 'expired',
+		refunded: 'refunded',
+		charged_back: 'charged_back',
+	};
+
+	return lines
+		.slice(1)
+		.map((line) => {
+			const values = parseRow(line);
+			const rawStatus = (values[idxStatus] || '').toLowerCase();
+			return {
+				mollie_payment_id: values[idxId] || '',
+				amount: parseFloat(values[idxAmount]) || 0,
+				currency: values[idxCurrency] || 'EUR',
+				status: mollieStatusMap[rawStatus] || rawStatus,
+				description:
+					idxDescription !== -1 ? values[idxDescription] || '' : '',
+				created_at: idxDate !== -1 ? values[idxDate] || '' : '',
+			};
+		})
+		.filter((t) => t.mollie_payment_id);
+};


### PR DESCRIPTION
The Import button on the transactions page now opens a modal asking where to pull transactions from, instead of jumping straight to a file picker. "From File" keeps the existing JSON / Mollie-CSV flow; "Connected Sites" lists the registered sites and imports directly from one.

A new admin endpoint paginates a connected site's external transactions feed using its stored token and runs each row through the existing importer, which deduplicates by payment ID so re-imports update rather than duplicate.