### PR TITLE
Share submission markdown template between detail and responses pages

### DIFF
--- a/fair-audience/src/Admin/questionnaire-responses/QuestionnaireResponses.js
+++ b/fair-audience/src/Admin/questionnaire-responses/QuestionnaireResponses.js
@@ -13,6 +13,7 @@ import {
 	Notice,
 } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
+import { submissionToMarkdown } from '../utils/submission-markdown.js';
 
 const DEFAULT_VIEW = {
 	type: 'table',
@@ -397,9 +398,6 @@ export default function QuestionnaireResponses() {
 		const exportedLabel = __('Exported', 'fair-audience');
 		const responsesLabel = __('Responses', 'fair-audience');
 		const adminLinkLabel = __('Admin link', 'fair-audience');
-		const submittedLabel = __('Submitted', 'fair-audience');
-
-		const adminBase = `${window.location.origin}${window.location.pathname}`;
 
 		const today = new Date().toISOString().split('T')[0];
 
@@ -412,41 +410,9 @@ export default function QuestionnaireResponses() {
 		lines.push('');
 
 		responses.forEach((response) => {
-			const respondent =
-				response.participant_name ||
-				response.participant_email ||
-				`#${response.id}`;
-
 			lines.push('---');
 			lines.push('');
-			if (response.participant_id) {
-				const participantUrl = `${adminBase}?page=fair-audience-participant-detail&participant_id=${response.participant_id}`;
-				lines.push(`## [${respondent}](${participantUrl})`);
-			} else {
-				lines.push(`## ${respondent}`);
-			}
-			lines.push('');
-			if (response.created_at) {
-				lines.push(`_${submittedLabel} ${response.created_at}_`);
-				lines.push('');
-			}
-
-			(response.answers || []).forEach((answer) => {
-				lines.push(`### ${answer.question_text}`);
-				lines.push('');
-
-				if (answer.file_url) {
-					const alt = answer.question_text || '';
-					if (answer.is_image) {
-						lines.push(`![${alt}](${answer.file_url})`);
-					} else {
-						lines.push(`[${alt}](${answer.file_url})`);
-					}
-				} else {
-					lines.push(answer.answer_value || '');
-				}
-				lines.push('');
-			});
+			lines.push(submissionToMarkdown(response));
 		});
 
 		return lines.join('\n');

--- a/fair-audience/src/Admin/submission-detail/SubmissionDetail.js
+++ b/fair-audience/src/Admin/submission-detail/SubmissionDetail.js
@@ -10,6 +10,7 @@ import {
 	Button,
 	SelectControl,
 } from '@wordpress/components';
+import { submissionToMarkdown } from '../utils/submission-markdown.js';
 
 function formatDate(dateString) {
 	if (!dateString) {
@@ -26,7 +27,7 @@ function AnswerDisplay({ answer }) {
 		return (
 			<div>
 				<a href={file_url} target="_blank" rel="noopener noreferrer">
-					{file_url.match(/\.(jpg|jpeg|png|gif|webp)$/i) ? (
+					{answer.is_image ? (
 						<img
 							src={file_url}
 							alt={answer.question_text}
@@ -169,6 +170,34 @@ export default function SubmissionDetail() {
 	const [submission, setSubmission] = useState(null);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState(null);
+	const [copyFeedback, setCopyFeedback] = useState(null);
+
+	const copyMarkdown = () => {
+		if (!navigator.clipboard) {
+			setCopyFeedback({
+				status: 'error',
+				message: __('Clipboard not available.', 'fair-audience'),
+			});
+			return;
+		}
+		navigator.clipboard
+			.writeText(submissionToMarkdown(submission))
+			.then(() => {
+				setCopyFeedback({
+					status: 'success',
+					message: __(
+						'Markdown copied to clipboard. Paste into Google Docs.',
+						'fair-audience'
+					),
+				});
+			})
+			.catch(() => {
+				setCopyFeedback({
+					status: 'error',
+					message: __('Failed to copy.', 'fair-audience'),
+				});
+			});
+	};
 
 	useEffect(() => {
 		if (!submissionId) {
@@ -215,9 +244,30 @@ export default function SubmissionDetail() {
 
 	return (
 		<div style={{ maxWidth: '800px', margin: '20px 0' }}>
-			<h1>
-				{submission.title || __('Form Submission', 'fair-audience')}
-			</h1>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					gap: '16px',
+				}}
+			>
+				<h1>
+					{submission.title || __('Form Submission', 'fair-audience')}
+				</h1>
+				<Button variant="secondary" onClick={copyMarkdown}>
+					{__('Copy markdown', 'fair-audience')}
+				</Button>
+			</div>
+
+			{copyFeedback && (
+				<Notice
+					status={copyFeedback.status}
+					onRemove={() => setCopyFeedback(null)}
+				>
+					{copyFeedback.message}
+				</Notice>
+			)}
 
 			<Card style={{ marginBottom: '16px' }}>
 				<CardHeader>

--- a/fair-audience/src/Admin/utils/submission-markdown.js
+++ b/fair-audience/src/Admin/utils/submission-markdown.js
@@ -1,0 +1,64 @@
+import { __ } from '@wordpress/i18n';
+
+// Serialize one answer to markdown lines (### heading + value/link).
+function answerToMarkdownLines(answer) {
+	const lines = [`### ${answer.question_text}`, ''];
+
+	if (answer.file_url) {
+		const alt = answer.question_text || '';
+		// is_image comes from the server mime check — single source of truth.
+		lines.push(
+			answer.is_image
+				? `![${alt}](${answer.file_url})`
+				: `[${alt}](${answer.file_url})`
+		);
+	} else if (answer.question_type === 'multiselect' && answer.answer_value) {
+		let value = answer.answer_value;
+		try {
+			const parsed = JSON.parse(answer.answer_value);
+			if (Array.isArray(parsed)) {
+				value = parsed.join(', ');
+			}
+		} catch {
+			// Keep the raw value.
+		}
+		lines.push(value);
+	} else {
+		lines.push(answer.answer_value || '');
+	}
+
+	return lines;
+}
+
+// One submission → markdown block (## respondent, submitted date, answers).
+// No leading `---` separator; callers add that when listing multiple.
+export function submissionToMarkdown(submission) {
+	const submittedLabel = __('Submitted', 'fair-audience');
+	const adminBase = `${window.location.origin}${window.location.pathname}`;
+
+	const respondent =
+		submission.participant_name ||
+		submission.participant_email ||
+		`#${submission.id}`;
+
+	const lines = [];
+	if (submission.participant_id) {
+		const participantUrl = `${adminBase}?page=fair-audience-participant-detail&participant_id=${submission.participant_id}`;
+		lines.push(`## [${respondent}](${participantUrl})`);
+	} else {
+		lines.push(`## ${respondent}`);
+	}
+	lines.push('');
+
+	if (submission.created_at) {
+		lines.push(`_${submittedLabel} ${submission.created_at}_`);
+		lines.push('');
+	}
+
+	(submission.answers || []).forEach((answer) => {
+		lines.push(...answerToMarkdownLines(answer));
+		lines.push('');
+	});
+
+	return lines.join('\n');
+}


### PR DESCRIPTION
Closes #629.

## What

The individual submission-detail page now has a **Copy markdown** button matching the responses list, and the per-submission markdown template lives in one shared module instead of being duplicated.

## Changes

- **New** `fair-audience/src/Admin/utils/submission-markdown.js` exporting `submissionToMarkdown(submission)` — the single source for serializing one form submission to markdown (`## respondent` heading + participant link, `_Submitted …_`, then `### question` blocks).
- **`QuestionnaireResponses.buildMarkdown()`** maps responses over `submissionToMarkdown()`, keeping the list-level heading / exported-date / count / admin-link wrapper. Duplicated answer loop removed.
- **`SubmissionDetail`** gains a **Copy markdown** button beside the title, reusing the same `navigator.clipboard` handler and success/error `Notice` pattern.
- **Reconciled answer rendering** across both pages:
  - File-vs-image detection now uses the server-provided `answer.is_image` everywhere (detail's filename regex dropped, including the on-screen render) — one source of truth.
  - Multiselect JSON is parsed and joined as `a, b, c` consistently (the list previously dumped raw JSON).

## Acceptance criteria

- [x] Detail page shows a Copy markdown button with the same clipboard + feedback behavior as the list.
- [x] Copying a single submission from the detail page produces the same markdown block the list produces for that submission.
- [x] The per-submission template exists in exactly one shared module, imported by both pages.
- [x] File/image and multiselect answers render consistently across both pages.

## Testing

- `npm run build` in `fair-audience` passes (exit 0).