### PR TITLE
Per-ticket-type minimum activities that raises the global minimum (#625)

### DIFF
--- a/.changeset/per-ticket-type-min-activities.md
+++ b/.changeset/per-ticket-type-min-activities.md
@@ -1,0 +1,6 @@
+---
+"fair-events": minor
+"fair-audience": minor
+---
+
+Add an optional per-ticket-type minimum activities requirement that can raise the event-date-wide minimum (e.g. an "Early bird" ticket requiring at least 2 activities). The per-type value only ever increases the requirement; a value below the global minimum is ignored. Enforced both in the signup form (the gate updates live as the buyer switches ticket type) and server-side.

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -540,7 +540,7 @@ class EventSignupController extends WP_REST_Controller {
 
 		$option_items = $this->load_valid_options( $event_date_id, $raw_option_ids );
 
-		$min_error = $this->validate_minimum_activities( $event_date_id, $option_items );
+		$min_error = $this->validate_minimum_activities( $event_date_id, $option_items, $ticket_type_id );
 		if ( is_wp_error( $min_error ) ) {
 			return $min_error;
 		}
@@ -763,11 +763,12 @@ class EventSignupController extends WP_REST_Controller {
 	 * Enforce the minimum-activities event setting.  When the event date has
 	 * no minimum configured (or no options at all), this is a no-op.
 	 *
-	 * @param int   $event_date_id Event date ID.
-	 * @param array $option_items  Validated TicketOption objects selected by the participant.
+	 * @param int      $event_date_id  Event date ID.
+	 * @param array    $option_items   Validated TicketOption objects selected by the participant.
+	 * @param int|null $ticket_type_id Selected ticket type ID, or null when none chosen.
 	 * @return WP_Error|null WP_Error when the minimum is not met, null otherwise.
 	 */
-	private function validate_minimum_activities( $event_date_id, $option_items ) {
+	private function validate_minimum_activities( $event_date_id, $option_items, $ticket_type_id = null ) {
 		if ( ! $event_date_id || ! class_exists( \FairEvents\Models\EventDateSetting::class ) ) {
 			return null;
 		}
@@ -781,6 +782,16 @@ class EventSignupController extends WP_REST_Controller {
 		}
 
 		$minimum = (int) \FairEvents\Models\EventDateSetting::get( $lookup_id, 'minimum_activities' );
+
+		// A ticket type can raise the requirement above the event-date global
+		// (issue #625). A per-type value below the global is ignored via max().
+		if ( $ticket_type_id && class_exists( \FairEvents\Models\TicketType::class ) ) {
+			$ticket_type = \FairEvents\Models\TicketType::get_by_id( $ticket_type_id );
+			if ( $ticket_type ) {
+				$minimum = max( $minimum, (int) $ticket_type->minimum_activities );
+			}
+		}
+
 		if ( $minimum <= 0 ) {
 			return null;
 		}
@@ -1726,7 +1737,7 @@ class EventSignupController extends WP_REST_Controller {
 		// Paid path takes over when a positive price resolves for this participant.
 		$option_items = $this->load_valid_options( $event_date_id, $raw_option_ids );
 
-		$min_error = $this->validate_minimum_activities( $event_date_id, $option_items );
+		$min_error = $this->validate_minimum_activities( $event_date_id, $option_items, $ticket_type_id );
 		if ( is_wp_error( $min_error ) ) {
 			return $min_error;
 		}

--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -1,6 +1,6 @@
 import './style.css';
 import apiFetch from '@wordpress/api-fetch';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	extractErrorMessage,
 	showNotification,
@@ -146,19 +146,68 @@ const CSS_PREFIX = 'fair-audience-signup';
 	 * @param {HTMLElement} block The block element
 	 */
 	function updateMinActivitiesGate(block) {
-		const minActivities = parseInt(block.dataset.minActivities || '0', 10);
-		if (!minActivities) {
+		// Event-date global baseline.
+		const globalMin = parseInt(block.dataset.minActivities || '0', 10);
+
+		// A selected ticket type can raise the requirement (issue #625); a value
+		// below the global is ignored because we take the max.
+		const selectedTicketType = block.querySelector(
+			'input[name="ticket_type_id"]:checked'
+		);
+		const typeMin = selectedTicketType
+			? parseInt(selectedTicketType.dataset.minActivities || '0', 10)
+			: 0;
+
+		const optionInputs = block.querySelectorAll(
+			'input[name="ticket_option_ids[]"]'
+		);
+		// Cap at the number of options available so the requirement is never
+		// impossible to satisfy.
+		const effectiveMin = Math.min(
+			Math.max(globalMin, typeMin),
+			optionInputs.length
+		);
+
+		// Keep the hint paragraph in sync with the effective minimum.
+		const hint = block.querySelector(
+			'.fair-audience-ticket-options-min-hint'
+		);
+		if (hint) {
+			if (effectiveMin > 0) {
+				hint.textContent = sprintf(
+					/* translators: %d: minimum number of activities required */
+					_n(
+						'Please select at least %d activity to sign up.',
+						'Please select at least %d activities to sign up.',
+						effectiveMin,
+						'fair-audience'
+					),
+					effectiveMin
+				);
+				hint.style.display = '';
+			} else {
+				hint.style.display = 'none';
+			}
+		}
+
+		const buttons = block.querySelectorAll(
+			'.fair-audience-signup-button, .fair-audience-signup-submit-button'
+		);
+
+		if (!effectiveMin) {
+			// No minimum in effect: never leave a button disabled by this gate.
+			buttons.forEach(function (btn) {
+				btn.disabled = false;
+				btn.classList.remove('is-disabled');
+			});
 			return;
 		}
 
 		const checkedCount = block.querySelectorAll(
 			'input[name="ticket_option_ids[]"]:checked'
 		).length;
-		const meetsMin = checkedCount >= minActivities;
+		const meetsMin = checkedCount >= effectiveMin;
 
-		const buttons = block.querySelectorAll(
-			'.fair-audience-signup-button, .fair-audience-signup-submit-button'
-		);
 		buttons.forEach(function (btn) {
 			btn.disabled = !meetsMin;
 			btn.classList.toggle('is-disabled', !meetsMin);
@@ -238,6 +287,7 @@ const CSS_PREFIX = 'fair-audience-signup';
 		ticketTypeRadios.forEach(function (radio) {
 			radio.addEventListener('change', function () {
 				updateButtonTotal(block);
+				updateMinActivitiesGate(block);
 			});
 		});
 

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -393,12 +393,13 @@ if ( $pricing_event_date_id && class_exists( \FairEvents\Models\TicketType::clas
 		}
 
 		$ticket_types_for_display[] = array(
-			'id'               => (int) $tt->id,
-			'name'             => $tt->name,
-			'price'            => $tt_price,
-			'seats_per_ticket' => (int) $tt->seats_per_ticket,
-			'invitation_only'  => (bool) $tt->invitation_only,
-			'is_full'          => $tt_is_full,
+			'id'                 => (int) $tt->id,
+			'name'               => $tt->name,
+			'price'              => $tt_price,
+			'seats_per_ticket'   => (int) $tt->seats_per_ticket,
+			'invitation_only'    => (bool) $tt->invitation_only,
+			'minimum_activities' => (int) $tt->minimum_activities,
+			'is_full'            => $tt_is_full,
 		);
 	}
 }
@@ -473,6 +474,27 @@ if ( $has_ticket_options && $pricing_event_date_id && class_exists( EventDateSet
 	$minimum_activities = (int) EventDateSetting::get( (int) $pricing_event_date_id, 'minimum_activities' );
 	$minimum_activities = max( 0, min( $minimum_activities, count( $ticket_options_for_display ) ) );
 }
+
+// A ticket type can raise the minimum above the event-date global (issue #625).
+// Determine whether any selectable type carries a higher requirement, and the
+// effective minimum for the type that's pre-selected on first paint (the first
+// not-sold-out type, mirroring the button price selection below). The frontend
+// recomputes this live as the buyer switches ticket type.
+$option_count            = count( $ticket_options_for_display );
+$any_ticket_type_min     = 0;
+$preselected_type_min    = 0;
+$preselected_type_chosen = false;
+if ( $has_ticket_options && $has_ticket_types ) {
+	foreach ( $ticket_types_for_display as $tt_for_min ) {
+		$tt_min              = (int) ( $tt_for_min['minimum_activities'] ?? 0 );
+		$any_ticket_type_min = max( $any_ticket_type_min, $tt_min );
+		if ( ! $preselected_type_chosen && empty( $tt_for_min['is_full'] ) ) {
+			$preselected_type_min    = $tt_min;
+			$preselected_type_chosen = true;
+		}
+	}
+}
+$initial_minimum_activities = min( $option_count, max( $minimum_activities, $preselected_type_min ) );
 
 // Read block attribute to control whether option prices are displayed.
 $show_option_prices = $attributes['showOptionPrices'] ?? true;
@@ -602,7 +624,7 @@ $render_ticket_types = static function () use ( $ticket_types_for_display, $has_
 			$classes .= ' fair-audience-ticket-type-full';
 		}
 		echo '<label class="' . esc_attr( $classes ) . '" for="' . $radio_id . '">';
-		echo '<input type="radio" name="ticket_type_id" id="' . $radio_id . '" value="' . (int) $tt['id'] . '" data-ticket-price="' . ( null !== $tt['price'] ? esc_attr( number_format( (float) $tt['price'], 2, '.', '' ) ) : '' ) . '"';
+		echo '<input type="radio" name="ticket_type_id" id="' . $radio_id . '" value="' . (int) $tt['id'] . '" data-ticket-price="' . ( null !== $tt['price'] ? esc_attr( number_format( (float) $tt['price'], 2, '.', '' ) ) : '' ) . '" data-min-activities="' . esc_attr( (string) ( $tt['minimum_activities'] ?? 0 ) ) . '"';
 		if ( $tt_is_full ) {
 			echo ' disabled';
 		} elseif ( ! $default_selected ) {
@@ -619,27 +641,35 @@ $render_ticket_types = static function () use ( $ticket_types_for_display, $has_
 /**
  * Render the ticket options checkbox fieldset. No-op when no options configured.
  */
-$render_ticket_options = static function () use ( $ticket_options_for_display, $has_ticket_options, $form_id, $show_option_prices, $minimum_activities ) {
+$render_ticket_options = static function () use ( $ticket_options_for_display, $has_ticket_options, $form_id, $show_option_prices, $minimum_activities, $any_ticket_type_min, $initial_minimum_activities ) {
 	if ( ! $has_ticket_options ) {
 		return;
 	}
 	echo '<fieldset class="fair-audience-ticket-options">';
 	echo '<legend>' . esc_html__( 'Select activities', 'fair-audience' ) . '</legend>';
-	if ( $minimum_activities > 0 ) {
-		printf(
-			'<p class="fair-audience-ticket-options-min-hint">%s</p>',
-			esc_html(
-				sprintf(
-					/* translators: %d: minimum number of activities required */
-					_n(
-						'Please select at least %d activity to sign up.',
-						'Please select at least %d activities to sign up.',
-						$minimum_activities,
-						'fair-audience'
-					),
-					$minimum_activities
-				)
+	// Render the hint whenever a minimum is possible — either the event-date
+	// global requires one, or a ticket type can raise it (issue #625). The
+	// element is always present so the frontend JS can rewrite/toggle it as the
+	// buyer switches ticket type; it starts hidden when the pre-selected type's
+	// effective minimum is 0.
+	if ( $minimum_activities > 0 || $any_ticket_type_min > 0 ) {
+		$hint_text = $initial_minimum_activities > 0
+			? sprintf(
+				/* translators: %d: minimum number of activities required */
+				_n(
+					'Please select at least %d activity to sign up.',
+					'Please select at least %d activities to sign up.',
+					$initial_minimum_activities,
+					'fair-audience'
+				),
+				$initial_minimum_activities
 			)
+			: '';
+		$hint_style = $initial_minimum_activities > 0 ? '' : ' style="display: none;"';
+		printf(
+			'<p class="fair-audience-ticket-options-min-hint"%s>%s</p>',
+			$hint_style, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static literal.
+			esc_html( $hint_text )
 		);
 	}
 	foreach ( $ticket_options_for_display as $opt ) {

--- a/fair-events/src/API/TicketsController.php
+++ b/fair-events/src/API/TicketsController.php
@@ -343,14 +343,15 @@ class TicketsController extends WP_REST_Controller {
 			? $body['ticket_types']
 			: array();
 		foreach ( $incoming_types as $index => $item ) {
-			$name             = sanitize_text_field( $item['name'] ?? '' );
-			$capacity         = isset( $item['capacity'] ) && '' !== $item['capacity'] && null !== $item['capacity']
+			$name               = sanitize_text_field( $item['name'] ?? '' );
+			$capacity           = isset( $item['capacity'] ) && '' !== $item['capacity'] && null !== $item['capacity']
 				? absint( $item['capacity'] )
 				: null;
-			$seats_per_ticket = isset( $item['seats_per_ticket'] ) ? max( 1, absint( $item['seats_per_ticket'] ) ) : 1;
-			$invitation_only  = ! empty( $item['invitation_only'] );
+			$seats_per_ticket   = isset( $item['seats_per_ticket'] ) ? max( 1, absint( $item['seats_per_ticket'] ) ) : 1;
+			$invitation_only    = ! empty( $item['invitation_only'] );
+			$minimum_activities = isset( $item['minimum_activities'] ) ? absint( $item['minimum_activities'] ) : 0;
 
-			$new_id = TicketType::create( $event_date_id, $name, $capacity, $index, $seats_per_ticket, $invitation_only );
+			$new_id = TicketType::create( $event_date_id, $name, $capacity, $index, $seats_per_ticket, $invitation_only, $minimum_activities );
 			if ( $new_id ) {
 				$type_ids_by_index[ $index ] = (int) $new_id;
 
@@ -497,30 +498,32 @@ class TicketsController extends WP_REST_Controller {
 		// Update existing / insert new.
 		$id_map = array();
 		foreach ( $incoming as $index => $item ) {
-			$name             = sanitize_text_field( $item['name'] ?? '' );
-			$capacity         = isset( $item['capacity'] ) && '' !== $item['capacity'] && null !== $item['capacity']
+			$name               = sanitize_text_field( $item['name'] ?? '' );
+			$capacity           = isset( $item['capacity'] ) && '' !== $item['capacity'] && null !== $item['capacity']
 				? absint( $item['capacity'] )
 				: null;
-			$seats_per_ticket = isset( $item['seats_per_ticket'] ) ? max( 1, absint( $item['seats_per_ticket'] ) ) : 1;
-			$invitation_only  = ! empty( $item['invitation_only'] );
-			$sort_order       = $index;
-			$group_ids        = isset( $item['group_ids'] ) && is_array( $item['group_ids'] ) ? array_map( 'absint', $item['group_ids'] ) : array();
+			$seats_per_ticket   = isset( $item['seats_per_ticket'] ) ? max( 1, absint( $item['seats_per_ticket'] ) ) : 1;
+			$invitation_only    = ! empty( $item['invitation_only'] );
+			$minimum_activities = isset( $item['minimum_activities'] ) ? absint( $item['minimum_activities'] ) : 0;
+			$sort_order         = $index;
+			$group_ids          = isset( $item['group_ids'] ) && is_array( $item['group_ids'] ) ? array_map( 'absint', $item['group_ids'] ) : array();
 
 			if ( ! empty( $item['id'] ) && in_array( (int) $item['id'], $existing_ids, true ) ) {
 				$id_map[ $index ] = (int) $item['id'];
 				TicketType::update(
 					(int) $item['id'],
 					array(
-						'name'             => $name,
-						'capacity'         => $capacity,
-						'seats_per_ticket' => $seats_per_ticket,
-						'invitation_only'  => $invitation_only,
-						'sort_order'       => $sort_order,
+						'name'               => $name,
+						'capacity'           => $capacity,
+						'seats_per_ticket'   => $seats_per_ticket,
+						'invitation_only'    => $invitation_only,
+						'minimum_activities' => $minimum_activities,
+						'sort_order'         => $sort_order,
 					)
 				);
 				TicketTypeGroupRestriction::sync_for_ticket_type( (int) $item['id'], $group_ids );
 			} else {
-				$new_id           = TicketType::create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket, $invitation_only );
+				$new_id           = TicketType::create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket, $invitation_only, $minimum_activities );
 				$id_map[ $index ] = (int) $new_id;
 				if ( $new_id && ! empty( $group_ids ) ) {
 					TicketTypeGroupRestriction::sync_for_ticket_type( (int) $new_id, $group_ids );

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -354,6 +354,7 @@ export default function EventTickets({
 						: null,
 				seats_per_ticket: t.seats_per_ticket || 1,
 				invitation_only: t.invitation_only || false,
+				minimum_activities: t.minimum_activities || 0,
 				group_ids: t.group_ids || [],
 			})),
 			sale_periods: getEffectiveSalePeriods().map((p) => ({
@@ -486,6 +487,7 @@ export default function EventTickets({
 				capacity: null,
 				seats_per_ticket: 1,
 				invitation_only: false,
+				minimum_activities: 0,
 				group_ids: [],
 				sort_order: ticketTypes.length,
 			},
@@ -1283,6 +1285,14 @@ export default function EventTickets({
 															)}
 														</th>
 													)}
+													{options.length > 0 && (
+														<th>
+															{__(
+																'Min. activities',
+																'fair-events'
+															)}
+														</th>
+													)}
 													{salePeriods.map(
 														(period, pIndex) => {
 															const isContinuous =
@@ -1517,6 +1527,43 @@ export default function EventTickets({
 																				v
 																			)
 																		}
+																	/>
+																</td>
+															)}
+															{options.length >
+																0 && (
+																<td>
+																	<TextControl
+																		type="number"
+																		min="0"
+																		placeholder="0"
+																		value={String(
+																			type.minimum_activities ||
+																				0
+																		)}
+																		onChange={(
+																			v
+																		) =>
+																			updateTicketType(
+																				tIndex,
+																				'minimum_activities',
+																				v !==
+																					''
+																					? Math.max(
+																							0,
+																							parseInt(
+																								v,
+																								10
+																							) ||
+																								0
+																					  )
+																					: 0
+																			)
+																		}
+																		help={__(
+																			'Only raises the event-wide minimum for this ticket type. Leave 0 to inherit.',
+																			'fair-events'
+																		)}
 																	/>
 																</td>
 															)}

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -209,6 +209,11 @@ class Installer {
 			self::migrate_to_3_9_0();
 		}
 
+		// Run migration if upgrading from pre-3.10.0 (add minimum_activities to ticket_types).
+		if ( version_compare( $current_version, '3.10.0', '<' ) ) {
+			self::migrate_to_3_10_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -327,6 +332,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.9.0', '<' ) ) {
 				self::migrate_to_3_9_0();
+			}
+
+			if ( version_compare( $current_version, '3.10.0', '<' ) ) {
+				self::migrate_to_3_10_0();
 			}
 
 			// Install/update tables
@@ -1282,6 +1291,33 @@ class Installer {
 			$wpdb->query(
 				$wpdb->prepare(
 					'ALTER TABLE %i ADD COLUMN derive_price_from_sale_period TINYINT(1) NOT NULL DEFAULT 0 AFTER capacity',
+					$table_name
+				)
+			);
+		}
+	}
+
+	/**
+	 * Migrate to version 3.10.0 - Add minimum_activities column to ticket_types table.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_10_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_events_ticket_types';
+
+		$column_exists = $wpdb->get_results(
+			$wpdb->prepare(
+				"SHOW COLUMNS FROM %i LIKE 'minimum_activities'",
+				$table_name
+			)
+		);
+
+		if ( empty( $column_exists ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD COLUMN minimum_activities INT UNSIGNED NOT NULL DEFAULT 0 AFTER invitation_only',
 					$table_name
 				)
 			);

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.9.0';
+	const DB_VERSION = '3.10.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -253,6 +253,7 @@ class Schema {
 			capacity INT UNSIGNED DEFAULT NULL,
 			seats_per_ticket INT UNSIGNED NOT NULL DEFAULT 1,
 			invitation_only TINYINT(1) NOT NULL DEFAULT 0,
+			minimum_activities INT UNSIGNED NOT NULL DEFAULT 0,
 			sort_order INT UNSIGNED NOT NULL DEFAULT 0,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/fair-events/src/Models/TicketType.php
+++ b/fair-events/src/Models/TicketType.php
@@ -59,6 +59,16 @@ class TicketType {
 	public $invitation_only = false;
 
 	/**
+	 * Minimum activities this ticket type requires (0 = inherit event-date global).
+	 *
+	 * Only ever raises the event-date-wide minimum; a value below the global is
+	 * ignored at enforcement time.
+	 *
+	 * @var int
+	 */
+	public $minimum_activities = 0;
+
+	/**
 	 * Sort order
 	 *
 	 * @var int
@@ -155,9 +165,10 @@ class TicketType {
 	 * @param int      $sort_order      Sort order.
 	 * @param int      $seats_per_ticket Seats consumed per ticket (default 1).
 	 * @param bool     $invitation_only Whether this ticket requires an invitation token.
+	 * @param int      $minimum_activities Minimum activities this type requires (0 = inherit global).
 	 * @return int|false The ticket type ID on success, false on failure.
 	 */
-	public static function create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket = 1, $invitation_only = false ) {
+	public static function create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket = 1, $invitation_only = false, $minimum_activities = 0 ) {
 		global $wpdb;
 
 		$table_name = self::get_table_name();
@@ -165,14 +176,15 @@ class TicketType {
 		$result = $wpdb->insert(
 			$table_name,
 			array(
-				'event_date_id'    => $event_date_id,
-				'name'             => $name,
-				'capacity'         => $capacity,
-				'seats_per_ticket' => max( 1, (int) $seats_per_ticket ),
-				'invitation_only'  => $invitation_only ? 1 : 0,
-				'sort_order'       => $sort_order,
+				'event_date_id'      => $event_date_id,
+				'name'               => $name,
+				'capacity'           => $capacity,
+				'seats_per_ticket'   => max( 1, (int) $seats_per_ticket ),
+				'invitation_only'    => $invitation_only ? 1 : 0,
+				'minimum_activities' => max( 0, (int) $minimum_activities ),
+				'sort_order'         => $sort_order,
 			),
-			array( '%d', '%s', '%d', '%d', '%d', '%d' )
+			array( '%d', '%s', '%d', '%d', '%d', '%d', '%d' )
 		);
 
 		if ( $result ) {
@@ -215,6 +227,11 @@ class TicketType {
 		if ( array_key_exists( 'invitation_only', $data ) ) {
 			$update_data['invitation_only'] = $data['invitation_only'] ? 1 : 0;
 			$update_format[]                = '%d';
+		}
+
+		if ( array_key_exists( 'minimum_activities', $data ) ) {
+			$update_data['minimum_activities'] = max( 0, (int) $data['minimum_activities'] );
+			$update_format[]                   = '%d';
 		}
 
 		if ( isset( $data['sort_order'] ) ) {
@@ -284,16 +301,17 @@ class TicketType {
 	 * @return TicketType Ticket type object.
 	 */
 	private static function hydrate( $row ) {
-		$item                   = new self();
-		$item->id               = (int) $row->id;
-		$item->event_date_id    = (int) $row->event_date_id;
-		$item->name             = $row->name;
-		$item->capacity         = null !== $row->capacity ? (int) $row->capacity : null;
-		$item->seats_per_ticket = isset( $row->seats_per_ticket ) ? max( 1, (int) $row->seats_per_ticket ) : 1;
-		$item->invitation_only  = isset( $row->invitation_only ) && (int) $row->invitation_only === 1;
-		$item->sort_order       = (int) $row->sort_order;
-		$item->created_at       = $row->created_at;
-		$item->updated_at       = $row->updated_at;
+		$item                     = new self();
+		$item->id                 = (int) $row->id;
+		$item->event_date_id      = (int) $row->event_date_id;
+		$item->name               = $row->name;
+		$item->capacity           = null !== $row->capacity ? (int) $row->capacity : null;
+		$item->seats_per_ticket   = isset( $row->seats_per_ticket ) ? max( 1, (int) $row->seats_per_ticket ) : 1;
+		$item->invitation_only    = isset( $row->invitation_only ) && (int) $row->invitation_only === 1;
+		$item->minimum_activities = isset( $row->minimum_activities ) ? (int) $row->minimum_activities : 0;
+		$item->sort_order         = (int) $row->sort_order;
+		$item->created_at         = $row->created_at;
+		$item->updated_at         = $row->updated_at;
 
 		return $item;
 	}
@@ -305,15 +323,16 @@ class TicketType {
 	 */
 	public function to_array() {
 		return array(
-			'id'               => $this->id,
-			'event_date_id'    => $this->event_date_id,
-			'name'             => $this->name,
-			'capacity'         => $this->capacity,
-			'seats_per_ticket' => $this->seats_per_ticket,
-			'invitation_only'  => $this->invitation_only,
-			'sort_order'       => $this->sort_order,
-			'created_at'       => $this->created_at,
-			'updated_at'       => $this->updated_at,
+			'id'                 => $this->id,
+			'event_date_id'      => $this->event_date_id,
+			'name'               => $this->name,
+			'capacity'           => $this->capacity,
+			'seats_per_ticket'   => $this->seats_per_ticket,
+			'invitation_only'    => $this->invitation_only,
+			'minimum_activities' => $this->minimum_activities,
+			'sort_order'         => $this->sort_order,
+			'created_at'         => $this->created_at,
+			'updated_at'         => $this->updated_at,
 		);
 	}
 }


### PR DESCRIPTION
## Summary

Implements #625. A ticket type can now **raise** the minimum number of activities a buyer must select, on top of the existing event-date-wide minimum — enabling offers like an "Early bird" type that requires at least 2 activities.

The effective requirement is `max(event-date global, ticket-type value)`. A per-type value below the global is ignored, and events relying only on the global minimum keep working with no migration action needed.

## Changes

**Data model (`fair-events`)**
- New `minimum_activities` column on `fair_events_ticket_types` (DB `3.10.0` + `migrate_to_3_10_0`), wired into both `install()` and `maybe_upgrade()`.
- Surfaced on the `TicketType` model (`create`/`update`/`hydrate`/`to_array`) and persisted through the REST controller's save, import, and export paths.

**Admin UI (`fair-events`)**
- Optional **"Min. activities"** field per ticket type in `EventTickets.js`, shown only when the event has activity options, with helper text that it can only raise the global.

**Frontend (`fair-audience`)**
- Each ticket-type radio carries `data-min-activities`; `updateMinActivitiesGate()` recomputes `max(global, type)` live as the buyer switches type, rewrites the hint text, and caps at the number of available options.

**Backend (`fair-audience`)**
- `validate_minimum_activities()` folds in the selected type's minimum and still rejects with `minimum_activities_not_met`.

## Acceptance criteria
- [x] Global event-date minimum still applies to all ticket types unchanged
- [x] An "Early bird" type set to 2 raises its requirement
- [x] A per-type value below the global has no effect
- [x] Buyer on "Early bird" is gated in the UI and rejected server-side until ≥2 activities are selected
- [x] Switching ticket types updates the gate live
- [x] No migration action needed for events using only the global minimum

## Notes
- A changeset (`minor` for both `fair-events` and `fair-audience`) is included.
- `php -l`, `phpcs` (no new violations), and `npm run build` for both plugins all pass.

Closes #625