### PR TITLE
Event mailings: backend + Mailings tab (#606, #607)

### DIFF
--- a/.changeset/event-mailings.md
+++ b/.changeset/event-mailings.md
@@ -1,0 +1,6 @@
+---
+'fair-audience': minor
+'fair-events': minor
+---
+
+Add scheduled per-event mailings: queue an email anchored to an event date's start/end with a signed offset, sent automatically by a recurring cron, managed from a new "Mailings" tab in the event admin.

--- a/fair-audience/fair-audience.php
+++ b/fair-audience/fair-audience.php
@@ -70,9 +70,10 @@ function fair_audience_activate() {
 	dbDelta( \FairAudience\Database\Schema::get_participant_categories_table_sql() );
 	dbDelta( \FairAudience\Database\Schema::get_event_participant_options_table_sql() );
 	dbDelta( \FairAudience\Database\Schema::get_email_consent_log_table_sql() );
+	dbDelta( \FairAudience\Database\Schema::get_event_scheduled_messages_table_sql() );
 
 	// Update database version.
-	update_option( 'fair_audience_db_version', '1.34.0' );
+	update_option( 'fair_audience_db_version', '1.35.0' );
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\\fair_audience_activate' );
 
@@ -644,6 +645,12 @@ function fair_audience_maybe_upgrade_db() {
 		dbDelta( \FairAudience\Database\Schema::get_email_consent_log_table_sql() );
 		update_option( 'fair_audience_db_version', '1.34.0' );
 	}
+
+	if ( version_compare( $db_version, '1.35.0', '<' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( \FairAudience\Database\Schema::get_event_scheduled_messages_table_sql() );
+		update_option( 'fair_audience_db_version', '1.35.0' );
+	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_audience_maybe_upgrade_db' );
 
@@ -654,5 +661,6 @@ function fair_audience_deactivate() {
 	// Clear scheduled Instagram token refresh.
 	wp_clear_scheduled_hook( 'fair_audience_refresh_instagram_token' );
 	wp_clear_scheduled_hook( 'fair_audience_cleanup_expired_signups' );
+	wp_clear_scheduled_hook( 'fair_audience_send_scheduled_messages' );
 }
 register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\fair_audience_deactivate' );

--- a/fair-audience/src/API/ScheduledMessagesController.php
+++ b/fair-audience/src/API/ScheduledMessagesController.php
@@ -84,6 +84,18 @@ class ScheduledMessagesController extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/events/(?P<event_id>[\d]+)/event-dates',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_event_dates' ),
+					'permission_callback' => array( $this, 'admin_permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/events/(?P<event_id>[\d]+)/scheduled-messages/preview-recipients',
 			array(
 				array(
@@ -333,6 +345,46 @@ class ScheduledMessagesController extends WP_REST_Controller {
 		$recipients = $this->resolver->resolve( $message->recipients_filter, $message->event_id );
 
 		return rest_ensure_response( $recipients );
+	}
+
+	/**
+	 * List an event's dates for the anchor picker.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response Response object.
+	 */
+	public function get_event_dates( $request ) {
+		global $wpdb;
+
+		$event_id = (int) $request->get_param( 'event_id' );
+		$table    = $wpdb->prefix . 'fair_event_dates';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT id, start_datetime, end_datetime, all_day FROM %i WHERE event_id = %d ORDER BY start_datetime ASC',
+				$table,
+				$event_id
+			),
+			ARRAY_A
+		);
+
+		$data = array_map(
+			static function ( $row ) {
+				$start_display = empty( $row['start_datetime'] ) ? '' : wp_date( 'Y-m-d H:i', strtotime( $row['start_datetime'] ) );
+
+				return array(
+					'id'             => (int) $row['id'],
+					'start_datetime' => $row['start_datetime'],
+					'end_datetime'   => $row['end_datetime'],
+					'all_day'        => ! empty( $row['all_day'] ),
+					'display_label'  => $start_display,
+				);
+			},
+			$rows
+		);
+
+		return rest_ensure_response( $data );
 	}
 
 	/**

--- a/fair-audience/src/API/ScheduledMessagesController.php
+++ b/fair-audience/src/API/ScheduledMessagesController.php
@@ -1,0 +1,426 @@
+<?php
+/**
+ * Scheduled Messages REST API Controller
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\API;
+
+use FairAudience\Database\ScheduledMessageRepository;
+use FairAudience\Models\ScheduledMessage;
+use FairAudience\Services\RecipientResolver;
+use FairAudience\Services\ScheduledMessageScheduler;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_Error;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * REST API controller for scheduled per-event mailings.
+ */
+class ScheduledMessagesController extends WP_REST_Controller {
+
+	/**
+	 * REST API namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-audience/v1';
+
+	/**
+	 * Repository instance.
+	 *
+	 * @var ScheduledMessageRepository
+	 */
+	private $repository;
+
+	/**
+	 * Recipient resolver instance.
+	 *
+	 * @var RecipientResolver
+	 */
+	private $resolver;
+
+	/**
+	 * Scheduler instance.
+	 *
+	 * @var ScheduledMessageScheduler
+	 */
+	private $scheduler;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->repository = new ScheduledMessageRepository();
+		$this->resolver   = new RecipientResolver();
+		$this->scheduler  = new ScheduledMessageScheduler();
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/events/(?P<event_id>[\d]+)/scheduled-messages',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'admin_permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'admin_permissions_check' ),
+					'args'                => $this->get_message_args(),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/events/(?P<event_id>[\d]+)/scheduled-messages/preview-recipients',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'preview_draft_recipients' ),
+					'permission_callback' => array( $this, 'admin_permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/scheduled-messages/(?P<id>[\d]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'admin_permissions_check' ),
+					'args'                => $this->get_message_args(),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'admin_permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/scheduled-messages/(?P<id>[\d]+)/preview-recipients',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'preview_recipients' ),
+					'permission_callback' => array( $this, 'admin_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Argument schema shared by create and update.
+	 *
+	 * @return array Args definition.
+	 */
+	private function get_message_args() {
+		return array(
+			'subject'           => array(
+				'type'              => 'string',
+				'required'          => true,
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'body'              => array(
+				'type'     => 'string',
+				'required' => true,
+			),
+			'anchor_type'       => array(
+				'type'     => 'string',
+				'required' => true,
+				'enum'     => array( 'event_date_start', 'event_date_end', 'sale_period_start', 'sale_period_end' ),
+			),
+			'anchor_ref_id'     => array(
+				'type'              => 'integer',
+				'required'          => true,
+				'sanitize_callback' => 'absint',
+			),
+			'offset_minutes'    => array(
+				'type'              => 'integer',
+				'required'          => false,
+				'default'           => 0,
+				'sanitize_callback' => static function ( $value ) {
+					return (int) $value;
+				},
+			),
+			'recipients_filter' => array(
+				'type'     => 'object',
+				'required' => false,
+				'default'  => array(),
+			),
+		);
+	}
+
+	/**
+	 * Check admin permissions.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool|WP_Error True if allowed.
+	 */
+	public function admin_permissions_check( $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to manage scheduled messages.', 'fair-audience' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * List scheduled messages for an event.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response Response object.
+	 */
+	public function get_items( $request ) {
+		$event_id = (int) $request->get_param( 'event_id' );
+		$messages = $this->repository->get_by_event( $event_id );
+
+		$data = array_map(
+			function ( $message ) {
+				return $this->prepare_message( $message );
+			},
+			$messages
+		);
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Create a scheduled message for an event.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response|WP_Error Response object.
+	 */
+	public function create_item( $request ) {
+		$event_id = (int) $request->get_param( 'event_id' );
+
+		if ( ! get_post( $event_id ) ) {
+			return new WP_Error( 'invalid_event', __( 'Event not found.', 'fair-audience' ), array( 'status' => 404 ) );
+		}
+
+		$anchor = $this->validate_anchor( $request, $event_id );
+		if ( is_wp_error( $anchor ) ) {
+			return $anchor;
+		}
+
+		$message                    = new ScheduledMessage();
+		$message->event_id          = $event_id;
+		$message->event_date_id     = $anchor['event_date_id'];
+		$message->subject           = $request->get_param( 'subject' );
+		$message->body              = wp_kses_post( $request->get_param( 'body' ) );
+		$message->anchor_type       = $request->get_param( 'anchor_type' );
+		$message->anchor_ref_id     = $anchor['anchor_ref_id'];
+		$message->offset_minutes    = (int) $request->get_param( 'offset_minutes' );
+		$message->recipients_filter = $this->resolver->normalize_filter( $request->get_param( 'recipients_filter' ) );
+		$message->status            = 'scheduled';
+		$message->created_by        = get_current_user_id();
+		$message->scheduled_for     = $this->scheduler->compute_scheduled_for(
+			$message->anchor_type,
+			$message->anchor_ref_id,
+			$message->offset_minutes
+		);
+
+		if ( ! $message->save() ) {
+			return new WP_Error( 'save_failed', __( 'Could not save the scheduled message.', 'fair-audience' ), array( 'status' => 500 ) );
+		}
+
+		return rest_ensure_response( $this->prepare_message( $this->repository->get_by_id( $message->id ) ) );
+	}
+
+	/**
+	 * Update a scheduled message (only while status=scheduled).
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response|WP_Error Response object.
+	 */
+	public function update_item( $request ) {
+		$message = $this->repository->get_by_id( (int) $request->get_param( 'id' ) );
+		if ( ! $message ) {
+			return new WP_Error( 'not_found', __( 'Scheduled message not found.', 'fair-audience' ), array( 'status' => 404 ) );
+		}
+
+		if ( 'scheduled' !== $message->status ) {
+			return new WP_Error(
+				'not_editable',
+				__( 'Only scheduled messages can be edited.', 'fair-audience' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$anchor = $this->validate_anchor( $request, $message->event_id );
+		if ( is_wp_error( $anchor ) ) {
+			return $anchor;
+		}
+
+		$message->event_date_id     = $anchor['event_date_id'];
+		$message->subject           = $request->get_param( 'subject' );
+		$message->body              = wp_kses_post( $request->get_param( 'body' ) );
+		$message->anchor_type       = $request->get_param( 'anchor_type' );
+		$message->anchor_ref_id     = $anchor['anchor_ref_id'];
+		$message->offset_minutes    = (int) $request->get_param( 'offset_minutes' );
+		$message->recipients_filter = $this->resolver->normalize_filter( $request->get_param( 'recipients_filter' ) );
+		$message->scheduled_for     = $this->scheduler->compute_scheduled_for(
+			$message->anchor_type,
+			$message->anchor_ref_id,
+			$message->offset_minutes
+		);
+
+		if ( ! $message->save() ) {
+			return new WP_Error( 'save_failed', __( 'Could not update the scheduled message.', 'fair-audience' ), array( 'status' => 500 ) );
+		}
+
+		return rest_ensure_response( $this->prepare_message( $this->repository->get_by_id( $message->id ) ) );
+	}
+
+	/**
+	 * Cancel a scheduled message (only while status=scheduled).
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response|WP_Error Response object.
+	 */
+	public function delete_item( $request ) {
+		$message = $this->repository->get_by_id( (int) $request->get_param( 'id' ) );
+		if ( ! $message ) {
+			return new WP_Error( 'not_found', __( 'Scheduled message not found.', 'fair-audience' ), array( 'status' => 404 ) );
+		}
+
+		if ( 'scheduled' !== $message->status ) {
+			return new WP_Error(
+				'not_cancelable',
+				__( 'Only scheduled messages can be canceled.', 'fair-audience' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$message->status = 'canceled';
+		$message->save();
+
+		return rest_ensure_response( $this->prepare_message( $this->repository->get_by_id( $message->id ) ) );
+	}
+
+	/**
+	 * Resolve recipients for a stored message, as of now.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response|WP_Error Response object.
+	 */
+	public function preview_recipients( $request ) {
+		$message = $this->repository->get_by_id( (int) $request->get_param( 'id' ) );
+		if ( ! $message ) {
+			return new WP_Error( 'not_found', __( 'Scheduled message not found.', 'fair-audience' ), array( 'status' => 404 ) );
+		}
+
+		$recipients = $this->resolver->resolve( $message->recipients_filter, $message->event_id );
+
+		return rest_ensure_response( $recipients );
+	}
+
+	/**
+	 * Resolve recipients for an unsaved draft from a posted filter.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response Response object.
+	 */
+	public function preview_draft_recipients( $request ) {
+		$event_id = (int) $request->get_param( 'event_id' );
+		$filter   = $request->get_param( 'recipients_filter' );
+
+		$recipients = $this->resolver->resolve( $filter, $event_id );
+
+		return rest_ensure_response( $recipients );
+	}
+
+	/**
+	 * Validate the anchor for a create/update request.
+	 *
+	 * Rejects sale-period anchors (until #617) and verifies the referenced
+	 * event date belongs to the event.
+	 *
+	 * @param WP_REST_Request $request  Request object.
+	 * @param int             $event_id Event post ID.
+	 * @return array|WP_Error {anchor_ref_id, event_date_id} or error.
+	 */
+	private function validate_anchor( $request, $event_id ) {
+		$anchor_type   = $request->get_param( 'anchor_type' );
+		$anchor_ref_id = (int) $request->get_param( 'anchor_ref_id' );
+
+		if ( ! ScheduledMessageScheduler::is_supported_anchor( $anchor_type ) ) {
+			return new WP_Error(
+				'unsupported_anchor',
+				__( 'Sale-period anchors are not supported yet.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'fair_event_dates';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$event_date = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT id, event_id FROM %i WHERE id = %d', $table, $anchor_ref_id ),
+			ARRAY_A
+		);
+
+		if ( ! $event_date || (int) $event_date['event_id'] !== $event_id ) {
+			return new WP_Error(
+				'invalid_anchor',
+				__( 'The chosen event date does not belong to this event.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return array(
+			'anchor_ref_id' => $anchor_ref_id,
+			'event_date_id' => $anchor_ref_id,
+		);
+	}
+
+	/**
+	 * Prepare a message for the REST response.
+	 *
+	 * @param ScheduledMessage $message Message object.
+	 * @return array Prepared data.
+	 */
+	private function prepare_message( $message ) {
+		return array(
+			'id'                => $message->id,
+			'event_id'          => $message->event_id,
+			'event_date_id'     => $message->event_date_id,
+			'subject'           => $message->subject,
+			'body'              => $message->body,
+			'anchor_type'       => $message->anchor_type,
+			'anchor_ref_id'     => $message->anchor_ref_id,
+			'offset_minutes'    => $message->offset_minutes,
+			'recipients_filter' => $message->recipients_filter,
+			'scheduled_for'     => $message->scheduled_for,
+			'status'            => $message->status,
+			'sent_count'        => $message->sent_count,
+			'failed_count'      => $message->failed_count,
+			'skipped_count'     => $message->skipped_count,
+			'sent_at'           => $message->sent_at,
+			'last_error'        => $message->last_error,
+			'created_at'        => $message->created_at,
+			'updated_at'        => $message->updated_at,
+		);
+	}
+}

--- a/fair-audience/src/API/__tests__/ScheduledMessagesController.api.spec.js
+++ b/fair-audience/src/API/__tests__/ScheduledMessagesController.api.spec.js
@@ -1,0 +1,326 @@
+/**
+ * Playwright API tests for the ScheduledMessagesController.
+ *
+ * Exercises the scheduled per-event mailing endpoints against a live WordPress
+ * instance:
+ *   GET/POST  /fair-audience/v1/events/{event_id}/scheduled-messages
+ *   POST      /fair-audience/v1/events/{event_id}/scheduled-messages/preview-recipients
+ *   PUT/DELETE /fair-audience/v1/scheduled-messages/{id}
+ *   POST      /fair-audience/v1/scheduled-messages/{id}/preview-recipients
+ *
+ * Fixtures (event, event-date, participants, links) are created via the admin
+ * REST API using Application Password credentials (WP_ADMIN_USER /
+ * WP_ADMIN_PASSWORD) and torn down at the end of the suite.
+ *
+ * Out of HTTP scope (validated by design / manually): the 5-minute cron tick
+ * (claim-and-send idempotency) and reschedule-on-event-date-move, which require
+ * triggering WP-Cron and editing event-date times outside this controller.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+async function createParticipant(api, { name, email, email_profile }) {
+	const res = await api.post('/wp-json/fair-audience/v1/participants', {
+		headers: authHeaders,
+		data: { name, email, email_profile },
+	});
+	expect(res.ok()).toBeTruthy();
+	return (await res.json()).id;
+}
+
+async function publishEvent(api, title) {
+	const res = await api.post('/wp-json/wp/v2/fair_event', {
+		headers: authHeaders,
+		data: { title, status: 'publish' },
+	});
+	expect(res.ok()).toBeTruthy();
+	return (await res.json()).id;
+}
+
+async function resolveEventDateId(api, eventId) {
+	const res = await api.get('/wp-json/fair-audience/v1/events', {
+		headers: authHeaders,
+		params: { per_page: 100 },
+	});
+	expect(res.ok()).toBeTruthy();
+	const events = await res.json();
+	const match = events.find((e) => e.event_id === eventId);
+	expect(match, 'event-date row for the test event').toBeTruthy();
+	return match.event_date_id;
+}
+
+async function deleteEvent(api, eventId) {
+	await api.delete(`/wp-json/wp/v2/fair_event/${eventId}`, {
+		headers: authHeaders,
+		params: { force: 'true' },
+	});
+}
+
+const baseMessage = (anchorRefId, overrides = {}) => ({
+	subject: 'Reminder',
+	body: 'Hi {participant_name}, see you at {event_name} on {event_date}. {unsubscribe_link}',
+	anchor_type: 'event_date_start',
+	anchor_ref_id: anchorRefId,
+	offset_minutes: -60,
+	recipients_filter: {
+		labels: ['signed_up'],
+		group_ids: [],
+		is_marketing: false,
+	},
+	...overrides,
+});
+
+test.describe('ScheduledMessagesController', () => {
+	let api;
+	let eventId;
+	let eventDateId;
+	let signedUpId;
+	let interestedId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		eventId = await publishEvent(api, `Scheduled Mail Test ${Date.now()}`);
+		eventDateId = await resolveEventDateId(api, eventId);
+
+		signedUpId = await createParticipant(api, {
+			name: 'Signed Up',
+			email: uniqueEmail('signed'),
+			email_profile: 'marketing',
+		});
+		interestedId = await createParticipant(api, {
+			name: 'Interested',
+			email: uniqueEmail('interested'),
+			email_profile: 'marketing',
+		});
+
+		// Link with distinct labels so recipient filtering is observable.
+		const linkSigned = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/batch`,
+			{
+				headers: authHeaders,
+				data: { participant_ids: [signedUpId], label: 'signed_up' },
+			}
+		);
+		expect(linkSigned.ok()).toBeTruthy();
+
+		const linkInterested = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/batch`,
+			{
+				headers: authHeaders,
+				data: { participant_ids: [interestedId], label: 'interested' },
+			}
+		);
+		expect(linkInterested.ok()).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		for (const id of [signedUpId, interestedId]) {
+			if (id) {
+				await api.delete(
+					`/wp-json/fair-audience/v1/participants/${id}`,
+					{ headers: authHeaders }
+				);
+			}
+		}
+		if (eventId) {
+			await deleteEvent(api, eventId);
+		}
+		await api.dispose();
+	});
+
+	test('unauthenticated create is rejected', async () => {
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
+			{ data: baseMessage(eventDateId) }
+		);
+		expect(res.status()).toBeGreaterThanOrEqual(401);
+		expect(res.status()).toBeLessThan(404);
+	});
+
+	test('create schedules a message with a computed send time', async () => {
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
+			{ headers: authHeaders, data: baseMessage(eventDateId) }
+		);
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(body.id).toBeGreaterThan(0);
+		expect(body.status).toBe('scheduled');
+		expect(body.event_date_id).toBe(eventDateId);
+		expect(body.scheduled_for).toBeTruthy();
+		expect(body.recipients_filter.labels).toEqual(['signed_up']);
+
+		// Clean up this row so other tests start from a known state.
+		await api.delete(
+			`/wp-json/fair-audience/v1/scheduled-messages/${body.id}`,
+			{ headers: authHeaders }
+		);
+	});
+
+	test('sale-period anchors are rejected until #617', async () => {
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
+			{
+				headers: authHeaders,
+				data: baseMessage(eventDateId, {
+					anchor_type: 'sale_period_start',
+				}),
+			}
+		);
+		expect(res.status()).toBe(400);
+	});
+
+	test('anchor from a different event is rejected', async () => {
+		const otherEventId = await publishEvent(
+			api,
+			`Other Event ${Date.now()}`
+		);
+		const otherDateId = await resolveEventDateId(api, otherEventId);
+
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
+			{ headers: authHeaders, data: baseMessage(otherDateId) }
+		);
+		expect(res.status()).toBe(400);
+
+		await deleteEvent(api, otherEventId);
+	});
+
+	test('list, edit, preview, and cancel lifecycle', async () => {
+		// Create.
+		const createRes = await api.post(
+			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
+			{ headers: authHeaders, data: baseMessage(eventDateId) }
+		);
+		expect(createRes.ok()).toBeTruthy();
+		const created = await createRes.json();
+		const originalSchedule = created.scheduled_for;
+
+		// List includes it.
+		const listRes = await api.get(
+			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
+			{ headers: authHeaders }
+		);
+		expect(listRes.ok()).toBeTruthy();
+		const list = await listRes.json();
+		expect(list.some((m) => m.id === created.id)).toBe(true);
+
+		// Preview recipients (stored filter) resolves only the signed_up one.
+		const previewRes = await api.post(
+			`/wp-json/fair-audience/v1/scheduled-messages/${created.id}/preview-recipients`,
+			{ headers: authHeaders }
+		);
+		expect(previewRes.ok()).toBeTruthy();
+		const recipients = await previewRes.json();
+		const ids = recipients.map((r) => r.participant_id);
+		expect(ids).toContain(signedUpId);
+		expect(ids).not.toContain(interestedId);
+
+		// Edit: a larger negative offset moves the send time earlier.
+		const editRes = await api.put(
+			`/wp-json/fair-audience/v1/scheduled-messages/${created.id}`,
+			{
+				headers: authHeaders,
+				data: baseMessage(eventDateId, {
+					subject: 'Updated subject',
+					offset_minutes: -180,
+				}),
+			}
+		);
+		expect(editRes.ok()).toBeTruthy();
+		const edited = await editRes.json();
+		expect(edited.subject).toBe('Updated subject');
+		expect(edited.offset_minutes).toBe(-180);
+		expect(new Date(edited.scheduled_for).getTime()).toBeLessThan(
+			new Date(originalSchedule).getTime()
+		);
+
+		// Cancel.
+		const cancelRes = await api.delete(
+			`/wp-json/fair-audience/v1/scheduled-messages/${created.id}`,
+			{ headers: authHeaders }
+		);
+		expect(cancelRes.ok()).toBeTruthy();
+		expect((await cancelRes.json()).status).toBe('canceled');
+
+		// Editing a canceled message is a conflict.
+		const reEdit = await api.put(
+			`/wp-json/fair-audience/v1/scheduled-messages/${created.id}`,
+			{ headers: authHeaders, data: baseMessage(eventDateId) }
+		);
+		expect(reEdit.status()).toBe(409);
+
+		// Canceling again is a conflict.
+		const reCancel = await api.delete(
+			`/wp-json/fair-audience/v1/scheduled-messages/${created.id}`,
+			{ headers: authHeaders }
+		);
+		expect(reCancel.status()).toBe(409);
+	});
+
+	test('draft preview honors label filters without saving', async () => {
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages/preview-recipients`,
+			{
+				headers: authHeaders,
+				data: {
+					recipients_filter: {
+						labels: ['interested'],
+						group_ids: [],
+						is_marketing: false,
+					},
+				},
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const recipients = await res.json();
+		const ids = recipients.map((r) => r.participant_id);
+		expect(ids).toContain(interestedId);
+		expect(ids).not.toContain(signedUpId);
+	});
+
+	test('deleting the event cancels its scheduled messages', async () => {
+		const tempEventId = await publishEvent(api, `Temp Event ${Date.now()}`);
+		const tempDateId = await resolveEventDateId(api, tempEventId);
+
+		const createRes = await api.post(
+			`/wp-json/fair-audience/v1/events/${tempEventId}/scheduled-messages`,
+			{ headers: authHeaders, data: baseMessage(tempDateId) }
+		);
+		expect(createRes.ok()).toBeTruthy();
+		const messageId = (await createRes.json()).id;
+
+		// Force-delete the event post; before_delete_post cascades the cancel.
+		await deleteEvent(api, tempEventId);
+
+		const listRes = await api.get(
+			`/wp-json/fair-audience/v1/events/${tempEventId}/scheduled-messages`,
+			{ headers: authHeaders }
+		);
+		expect(listRes.ok()).toBeTruthy();
+		const list = await listRes.json();
+		const message = list.find((m) => m.id === messageId);
+		expect(
+			message,
+			'scheduled message row survives event deletion'
+		).toBeTruthy();
+		expect(message.status).toBe('canceled');
+	});
+});

--- a/fair-audience/src/Core/Plugin.php
+++ b/fair-audience/src/Core/Plugin.php
@@ -90,6 +90,7 @@ class Plugin {
 
 		// Initialize payment hooks (for fair-payment webhook integration).
 		\FairAudience\Hooks\PaymentHooks::init();
+		\FairAudience\Hooks\ScheduledMessageHooks::init();
 
 		// Initialize blocks.
 		$block_hooks = new \FairAudience\Hooks\BlockHooks();
@@ -149,6 +150,9 @@ class Plugin {
 
 		$custom_mail_controller = new \FairAudience\API\CustomMailController();
 		$custom_mail_controller->register_routes();
+
+		$scheduled_messages_controller = new \FairAudience\API\ScheduledMessagesController();
+		$scheduled_messages_controller->register_routes();
 
 		$questionnaire_responses_controller = new \FairAudience\API\QuestionnaireResponsesController();
 		$questionnaire_responses_controller->register_routes();

--- a/fair-audience/src/Database/ScheduledMessageRepository.php
+++ b/fair-audience/src/Database/ScheduledMessageRepository.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Scheduled Message Repository
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Database;
+
+use FairAudience\Models\ScheduledMessage;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Repository for scheduled message data access.
+ *
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery
+ */
+class ScheduledMessageRepository {
+
+	/**
+	 * Get table name.
+	 *
+	 * @return string Table name.
+	 */
+	private function get_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . 'fair_audience_event_scheduled_messages';
+	}
+
+	/**
+	 * Get a scheduled message by ID.
+	 *
+	 * @param int $id Message ID.
+	 * @return ScheduledMessage|null Message or null if not found.
+	 */
+	public function get_by_id( $id ) {
+		global $wpdb;
+
+		$result = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE id = %d',
+				$this->get_table_name(),
+				$id
+			),
+			ARRAY_A
+		);
+
+		return $result ? new ScheduledMessage( $result ) : null;
+	}
+
+	/**
+	 * Get all scheduled messages for an event, newest first.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return ScheduledMessage[] Array of messages.
+	 */
+	public function get_by_event( $event_id ) {
+		global $wpdb;
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE event_id = %d ORDER BY created_at DESC',
+				$this->get_table_name(),
+				$event_id
+			),
+			ARRAY_A
+		);
+
+		return array_map(
+			static function ( $row ) {
+				return new ScheduledMessage( $row );
+			},
+			$results
+		);
+	}
+
+	/**
+	 * Get scheduled (still-pending) messages anchored to a given row.
+	 *
+	 * Used by reschedule hooks when the underlying anchor moves.
+	 *
+	 * @param string $anchor_type   Anchor type.
+	 * @param int    $anchor_ref_id Anchor row ID.
+	 * @return ScheduledMessage[] Array of messages with status='scheduled'.
+	 */
+	public function get_scheduled_by_anchor( $anchor_type, $anchor_ref_id ) {
+		global $wpdb;
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM %i WHERE status = 'scheduled' AND anchor_type = %s AND anchor_ref_id = %d",
+				$this->get_table_name(),
+				$anchor_type,
+				$anchor_ref_id
+			),
+			ARRAY_A
+		);
+
+		return array_map(
+			static function ( $row ) {
+				return new ScheduledMessage( $row );
+			},
+			$results
+		);
+	}
+
+	/**
+	 * Atomically claim due messages for sending.
+	 *
+	 * Selects candidate scheduled rows whose send time has elapsed, then claims
+	 * each one with a conditional UPDATE (status='scheduled' -> 'sending'). Only
+	 * rows the UPDATE actually flipped are returned, so two overlapping cron
+	 * ticks can never both claim the same row (idempotency).
+	 *
+	 * @param int $limit Maximum rows to claim per tick.
+	 * @return ScheduledMessage[] Claimed messages (now status='sending').
+	 */
+	public function claim_due( $limit = 20 ) {
+		global $wpdb;
+
+		$table = $this->get_table_name();
+		$now   = current_time( 'mysql' );
+
+		$candidate_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT id FROM %i
+				WHERE status = 'scheduled'
+				AND scheduled_for IS NOT NULL
+				AND scheduled_for <= %s
+				ORDER BY scheduled_for ASC
+				LIMIT %d",
+				$table,
+				$now,
+				$limit
+			)
+		);
+
+		$claimed = array();
+
+		foreach ( $candidate_ids as $id ) {
+			$affected = $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE %i SET status = 'sending', updated_at = %s WHERE id = %d AND status = 'scheduled'",
+					$table,
+					$now,
+					$id
+				)
+			);
+
+			// Only the tick that flips the row wins the claim.
+			if ( 1 === (int) $affected ) {
+				$message = $this->get_by_id( (int) $id );
+				if ( $message ) {
+					$claimed[] = $message;
+				}
+			}
+		}
+
+		return $claimed;
+	}
+
+	/**
+	 * Reclaim rows stuck in 'sending' past a threshold.
+	 *
+	 * Guards against a crash mid-send: rows left in 'sending' longer than
+	 * $threshold_minutes are flipped back to 'scheduled' so the next tick picks
+	 * them up again.
+	 *
+	 * @param int $threshold_minutes Minutes before a sending row is reclaimed.
+	 * @return int Number of rows reclaimed.
+	 */
+	public function reclaim_stuck( $threshold_minutes = 30 ) {
+		global $wpdb;
+
+		$cutoff = gmdate( 'Y-m-d H:i:s', strtotime( current_time( 'mysql' ) ) - ( $threshold_minutes * MINUTE_IN_SECONDS ) );
+
+		return (int) $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'scheduled' WHERE status = 'sending' AND updated_at < %s",
+				$this->get_table_name(),
+				$cutoff
+			)
+		);
+	}
+
+	/**
+	 * Cancel all still-scheduled messages for an event.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return int Number of rows canceled.
+	 */
+	public function cancel_for_event( $event_id ) {
+		global $wpdb;
+
+		return (int) $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'canceled' WHERE event_id = %d AND status = 'scheduled'",
+				$this->get_table_name(),
+				$event_id
+			)
+		);
+	}
+
+	/**
+	 * Delete a scheduled message by ID.
+	 *
+	 * @param int $id Message ID.
+	 * @return bool Success.
+	 */
+	public function delete( $id ) {
+		global $wpdb;
+
+		return $wpdb->delete(
+			$this->get_table_name(),
+			array( 'id' => $id ),
+			array( '%d' )
+		) !== false;
+	}
+}

--- a/fair-audience/src/Database/Schema.php
+++ b/fair-audience/src/Database/Schema.php
@@ -570,6 +570,49 @@ class Schema {
 	}
 
 	/**
+	 * Get SQL for creating the event scheduled messages table.
+	 *
+	 * Backs scheduled per-event mailings. Generalizes the ad-hoc
+	 * custom_mail_messages flow: the same recipient filter, templating, and
+	 * preview power scheduled sends. A row is claimed and sent by the
+	 * recurring cron once scheduled_for elapses.
+	 *
+	 * @return string SQL statement.
+	 */
+	public static function get_event_scheduled_messages_table_sql() {
+		global $wpdb;
+
+		$table_name      = $wpdb->prefix . 'fair_audience_event_scheduled_messages';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		return "CREATE TABLE $table_name (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			event_id BIGINT UNSIGNED NOT NULL COMMENT 'Denormalized for indexing / reschedule lookups',
+			event_date_id BIGINT UNSIGNED DEFAULT NULL COMMENT 'Anchor for event_date_* anchor types',
+			subject VARCHAR(255) NOT NULL,
+			body LONGTEXT NOT NULL,
+			anchor_type ENUM('event_date_start', 'event_date_end', 'sale_period_start', 'sale_period_end') NOT NULL,
+			anchor_ref_id BIGINT UNSIGNED DEFAULT NULL COMMENT 'Id of the anchor row (event_date id, or sale period id once #617 lands)',
+			offset_minutes INT NOT NULL DEFAULT 0 COMMENT 'Signed; negative = before anchor, positive = after',
+			recipients_filter LONGTEXT NOT NULL COMMENT 'JSON: {labels, group_ids, is_marketing}',
+			scheduled_for DATETIME DEFAULT NULL COMMENT 'Computed anchor_time + offset_minutes; recomputed on anchor change',
+			status ENUM('scheduled', 'sending', 'sent', 'canceled', 'failed') NOT NULL DEFAULT 'scheduled',
+			sent_count INT NOT NULL DEFAULT 0,
+			failed_count INT NOT NULL DEFAULT 0,
+			skipped_count INT NOT NULL DEFAULT 0,
+			sent_at DATETIME DEFAULT NULL,
+			last_error TEXT DEFAULT NULL,
+			created_by BIGINT UNSIGNED DEFAULT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY  (id),
+			KEY idx_status_scheduled_for (status, scheduled_for),
+			KEY idx_event_id (event_id),
+			KEY idx_anchor (anchor_type, anchor_ref_id)
+		) ENGINE=InnoDB $charset_collate;";
+	}
+
+	/**
 	 * Get SQL for creating the questionnaire submissions table.
 	 *
 	 * @return string SQL statement.

--- a/fair-audience/src/Hooks/ScheduledMessageHooks.php
+++ b/fair-audience/src/Hooks/ScheduledMessageHooks.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Scheduled Message Hooks
+ *
+ * Drives scheduled per-event mailings: a single recurring cron claims due
+ * messages and sends them, a reaper reclaims rows stuck mid-send, and anchor
+ * change / deletion hooks keep send times correct.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Hooks;
+
+use FairAudience\Database\ScheduledMessageRepository;
+use FairAudience\Database\ParticipantRepository;
+use FairAudience\Services\RecipientResolver;
+use FairAudience\Services\ScheduledMessageScheduler;
+use FairAudience\Services\EmailService;
+use FairAudience\Models\ScheduledMessage;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Hooks for the scheduled mailing sender and reschedule logic.
+ */
+class ScheduledMessageHooks {
+
+	/**
+	 * Cron hook name for the recurring sender.
+	 */
+	const CRON_HOOK = 'fair_audience_send_scheduled_messages';
+
+	/**
+	 * Max rows claimed (and sent) per cron tick.
+	 */
+	const BATCH_SIZE = 20;
+
+	/**
+	 * Minutes before a row stuck in 'sending' is reclaimed.
+	 */
+	const STUCK_THRESHOLD_MINUTES = 30;
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_filter( 'cron_schedules', array( static::class, 'add_cron_schedule' ) );
+
+		add_action( self::CRON_HOOK, array( static::class, 'run_due' ) );
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + MINUTE_IN_SECONDS, 'fair_audience_every_five_minutes', self::CRON_HOOK );
+		}
+
+		// Reschedule when the underlying anchor moves; cancel when it disappears.
+		add_action( 'fair_events_event_date_updated', array( static::class, 'handle_event_date_changed' ) );
+		add_action( 'fair_events_event_date_deleted', array( static::class, 'handle_event_date_deleted' ) );
+
+		// Cancel an event's scheduled messages when the event is deleted.
+		add_action( 'before_delete_post', array( static::class, 'handle_event_deleted' ) );
+	}
+
+	/**
+	 * Register the shared 5-minute cron schedule.
+	 *
+	 * Mirrors PaymentHooks::add_cron_schedule so the sender works even if that
+	 * hook set isn't active. Adding the same key twice is a no-op.
+	 *
+	 * @param array $schedules Existing schedules.
+	 * @return array
+	 */
+	public static function add_cron_schedule( $schedules ) {
+		if ( ! isset( $schedules['fair_audience_every_five_minutes'] ) ) {
+			$schedules['fair_audience_every_five_minutes'] = array(
+				'interval' => 5 * MINUTE_IN_SECONDS,
+				'display'  => __( 'Every 5 minutes (fair-audience)', 'fair-audience' ),
+			);
+		}
+		return $schedules;
+	}
+
+	/**
+	 * Cron tick: reclaim stuck rows, claim due rows, send each.
+	 */
+	public static function run_due() {
+		$repository = new ScheduledMessageRepository();
+
+		// Recover rows abandoned mid-send by a previous crashed tick.
+		$repository->reclaim_stuck( self::STUCK_THRESHOLD_MINUTES );
+
+		$claimed = $repository->claim_due( self::BATCH_SIZE );
+
+		$email_service = new EmailService();
+		$resolver      = new RecipientResolver();
+		$participants  = new ParticipantRepository();
+
+		foreach ( $claimed as $message ) {
+			self::send_message( $message, $email_service, $resolver, $participants );
+		}
+	}
+
+	/**
+	 * Resolve, render, and send one claimed message; record the outcome.
+	 *
+	 * @param ScheduledMessage      $message       Claimed message (status='sending').
+	 * @param EmailService          $email_service Mailer.
+	 * @param RecipientResolver     $resolver      Recipient resolver.
+	 * @param ParticipantRepository $participants  Participant lookup.
+	 */
+	private static function send_message( ScheduledMessage $message, EmailService $email_service, RecipientResolver $resolver, ParticipantRepository $participants ) {
+		$sent    = 0;
+		$failed  = 0;
+		$skipped = 0;
+
+		try {
+			$context    = self::build_context( $message );
+			$recipients = $resolver->resolve( $message->recipients_filter, $message->event_id );
+
+			foreach ( $recipients as $recipient ) {
+				if ( empty( $recipient['has_valid_email'] ) ) {
+					++$failed;
+					continue;
+				}
+
+				if ( ! empty( $recipient['would_skip_marketing'] ) ) {
+					++$skipped;
+					continue;
+				}
+
+				$participant = $participants->get_by_id( (int) $recipient['participant_id'] );
+				if ( ! $participant ) {
+					++$failed;
+					continue;
+				}
+
+				$success = $email_service->send_custom_mail_rendered(
+					$participant,
+					$message->subject,
+					$message->body,
+					(int) $message->event_date_id,
+					$context
+				);
+
+				if ( $success ) {
+					++$sent;
+				} else {
+					++$failed;
+				}
+			}
+
+			$message->sent_count    = $sent;
+			$message->failed_count  = $failed;
+			$message->skipped_count = $skipped;
+			$message->status        = 'sent';
+			$message->sent_at       = current_time( 'mysql' );
+			$message->last_error    = null;
+			$message->save();
+		} catch ( \Throwable $e ) {
+			$message->sent_count    = $sent;
+			$message->failed_count  = $failed;
+			$message->skipped_count = $skipped;
+			$message->status        = 'failed';
+			$message->last_error    = $e->getMessage();
+			$message->save();
+		}
+	}
+
+	/**
+	 * Build per-message placeholder context (event_name, event_date).
+	 *
+	 * @param ScheduledMessage $message Message.
+	 * @return array Context array.
+	 */
+	private static function build_context( ScheduledMessage $message ) {
+		$event_name = '';
+		$event      = get_post( $message->event_id );
+		if ( $event ) {
+			$event_name = $event->post_title;
+		}
+
+		$event_date = '';
+		if ( $message->event_date_id ) {
+			global $wpdb;
+			$table = $wpdb->prefix . 'fair_event_dates';
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$start = $wpdb->get_var(
+				$wpdb->prepare( 'SELECT start_datetime FROM %i WHERE id = %d', $table, $message->event_date_id )
+			);
+
+			if ( ! empty( $start ) ) {
+				$event_date = wp_date( 'Y-m-d H:i', strtotime( $start ) );
+			}
+		}
+
+		return array(
+			'event_name' => $event_name,
+			'event_date' => $event_date,
+		);
+	}
+
+	/**
+	 * Recompute send times for messages anchored to a moved event date.
+	 *
+	 * @param int $event_date_id Event date row ID.
+	 */
+	public static function handle_event_date_changed( $event_date_id ) {
+		$repository = new ScheduledMessageRepository();
+		$scheduler  = new ScheduledMessageScheduler();
+
+		foreach ( ScheduledMessageScheduler::EVENT_DATE_ANCHORS as $anchor_type ) {
+			$messages = $repository->get_scheduled_by_anchor( $anchor_type, (int) $event_date_id );
+			foreach ( $messages as $message ) {
+				$scheduler->recompute( $message );
+			}
+		}
+	}
+
+	/**
+	 * Cancel messages anchored to a deleted event date.
+	 *
+	 * @param int $event_date_id Event date row ID.
+	 */
+	public static function handle_event_date_deleted( $event_date_id ) {
+		$repository = new ScheduledMessageRepository();
+
+		foreach ( ScheduledMessageScheduler::EVENT_DATE_ANCHORS as $anchor_type ) {
+			$messages = $repository->get_scheduled_by_anchor( $anchor_type, (int) $event_date_id );
+			foreach ( $messages as $message ) {
+				$message->status = 'canceled';
+				$message->save();
+			}
+		}
+	}
+
+	/**
+	 * Cancel all scheduled messages for a deleted event.
+	 *
+	 * Fires for every post deletion; the targeted UPDATE simply matches nothing
+	 * when the deleted post is not an event with scheduled messages.
+	 *
+	 * @param int $post_id Post being deleted.
+	 */
+	public static function handle_event_deleted( $post_id ) {
+		$repository = new ScheduledMessageRepository();
+		$repository->cancel_for_event( (int) $post_id );
+	}
+}

--- a/fair-audience/src/Models/ScheduledMessage.php
+++ b/fair-audience/src/Models/ScheduledMessage.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Scheduled Message Model
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Models;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Scheduled per-event mailing model.
+ */
+class ScheduledMessage {
+
+	/**
+	 * Message ID.
+	 *
+	 * @var int|null
+	 */
+	public $id;
+
+	/**
+	 * Event post ID (denormalized for indexing / reschedule lookups).
+	 *
+	 * @var int
+	 */
+	public $event_id;
+
+	/**
+	 * Event date ID — anchor for event_date_* anchor types.
+	 *
+	 * @var int|null
+	 */
+	public $event_date_id;
+
+	/**
+	 * Email subject.
+	 *
+	 * @var string
+	 */
+	public $subject;
+
+	/**
+	 * Email body (HTML, supports placeholders).
+	 *
+	 * @var string
+	 */
+	public $body;
+
+	/**
+	 * Anchor type.
+	 *
+	 * One of event_date_start, event_date_end, sale_period_start,
+	 * sale_period_end.
+	 *
+	 * @var string
+	 */
+	public $anchor_type;
+
+	/**
+	 * Id of the anchor row (event_date id, or sale period id once #617 lands).
+	 *
+	 * @var int|null
+	 */
+	public $anchor_ref_id;
+
+	/**
+	 * Signed offset in minutes; negative = before anchor, positive = after.
+	 *
+	 * @var int
+	 */
+	public $offset_minutes;
+
+	/**
+	 * Recipient filter: {labels, group_ids, is_marketing}.
+	 *
+	 * @var array
+	 */
+	public $recipients_filter;
+
+	/**
+	 * Computed send time (anchor_time + offset_minutes), local time.
+	 *
+	 * @var string|null
+	 */
+	public $scheduled_for;
+
+	/**
+	 * Status: scheduled, sending, sent, canceled, failed.
+	 *
+	 * @var string
+	 */
+	public $status;
+
+	/**
+	 * Number of emails sent successfully.
+	 *
+	 * @var int
+	 */
+	public $sent_count;
+
+	/**
+	 * Number of emails that failed to send.
+	 *
+	 * @var int
+	 */
+	public $failed_count;
+
+	/**
+	 * Number of recipients skipped.
+	 *
+	 * @var int
+	 */
+	public $skipped_count;
+
+	/**
+	 * Sent timestamp.
+	 *
+	 * @var string|null
+	 */
+	public $sent_at;
+
+	/**
+	 * Last error message (set when status=failed).
+	 *
+	 * @var string|null
+	 */
+	public $last_error;
+
+	/**
+	 * Creator user ID.
+	 *
+	 * @var int|null
+	 */
+	public $created_by;
+
+	/**
+	 * Created timestamp.
+	 *
+	 * @var string
+	 */
+	public $created_at;
+
+	/**
+	 * Updated timestamp.
+	 *
+	 * @var string
+	 */
+	public $updated_at;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $data Optional data to populate.
+	 */
+	public function __construct( $data = array() ) {
+		if ( ! empty( $data ) ) {
+			$this->populate( $data );
+		}
+	}
+
+	/**
+	 * Populate from data array (DB row or input).
+	 *
+	 * @param array $data Data array.
+	 */
+	public function populate( $data ) {
+		$this->id             = isset( $data['id'] ) ? (int) $data['id'] : null;
+		$this->event_id       = isset( $data['event_id'] ) ? (int) $data['event_id'] : 0;
+		$this->event_date_id  = isset( $data['event_date_id'] ) && $data['event_date_id'] ? (int) $data['event_date_id'] : null;
+		$this->subject        = isset( $data['subject'] ) ? sanitize_text_field( $data['subject'] ) : '';
+		$this->body           = isset( $data['body'] ) ? wp_kses_post( $data['body'] ) : '';
+		$this->anchor_type    = isset( $data['anchor_type'] ) ? sanitize_key( $data['anchor_type'] ) : '';
+		$this->anchor_ref_id  = isset( $data['anchor_ref_id'] ) && $data['anchor_ref_id'] ? (int) $data['anchor_ref_id'] : null;
+		$this->offset_minutes = isset( $data['offset_minutes'] ) ? (int) $data['offset_minutes'] : 0;
+
+		if ( isset( $data['recipients_filter'] ) ) {
+			$this->recipients_filter = is_array( $data['recipients_filter'] )
+				? $data['recipients_filter']
+				: (array) json_decode( (string) $data['recipients_filter'], true );
+		} else {
+			$this->recipients_filter = array();
+		}
+
+		$this->scheduled_for = isset( $data['scheduled_for'] ) && $data['scheduled_for'] ? $data['scheduled_for'] : null;
+		$this->status        = isset( $data['status'] ) ? sanitize_key( $data['status'] ) : 'scheduled';
+		$this->sent_count    = isset( $data['sent_count'] ) ? (int) $data['sent_count'] : 0;
+		$this->failed_count  = isset( $data['failed_count'] ) ? (int) $data['failed_count'] : 0;
+		$this->skipped_count = isset( $data['skipped_count'] ) ? (int) $data['skipped_count'] : 0;
+		$this->sent_at       = isset( $data['sent_at'] ) && $data['sent_at'] ? $data['sent_at'] : null;
+		$this->last_error    = isset( $data['last_error'] ) && $data['last_error'] ? $data['last_error'] : null;
+		$this->created_by    = isset( $data['created_by'] ) && $data['created_by'] ? (int) $data['created_by'] : null;
+		$this->created_at    = isset( $data['created_at'] ) ? $data['created_at'] : '';
+		$this->updated_at    = isset( $data['updated_at'] ) ? $data['updated_at'] : '';
+	}
+
+	/**
+	 * Save to database (insert or update).
+	 *
+	 * @return bool Success.
+	 */
+	public function save() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_audience_event_scheduled_messages';
+
+		if ( empty( $this->subject ) || empty( $this->body ) || empty( $this->anchor_type ) ) {
+			return false;
+		}
+
+		$data = array(
+			'event_id'          => $this->event_id,
+			'event_date_id'     => $this->event_date_id,
+			'subject'           => $this->subject,
+			'body'              => $this->body,
+			'anchor_type'       => $this->anchor_type,
+			'anchor_ref_id'     => $this->anchor_ref_id,
+			'offset_minutes'    => $this->offset_minutes,
+			'recipients_filter' => wp_json_encode( (array) $this->recipients_filter ),
+			'scheduled_for'     => $this->scheduled_for,
+			'status'            => $this->status ? $this->status : 'scheduled',
+			'sent_count'        => $this->sent_count,
+			'failed_count'      => $this->failed_count,
+			'skipped_count'     => $this->skipped_count,
+			'sent_at'           => $this->sent_at,
+			'last_error'        => $this->last_error,
+			'created_by'        => $this->created_by,
+		);
+
+		$format = array( '%d', '%d', '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%d' );
+
+		if ( $this->id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result = $wpdb->update(
+				$table_name,
+				$data,
+				array( 'id' => $this->id ),
+				$format,
+				array( '%d' )
+			);
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$result = $wpdb->insert( $table_name, $data, $format );
+			if ( $result ) {
+				$this->id = $wpdb->insert_id;
+			}
+		}
+
+		return false !== $result;
+	}
+
+	/**
+	 * Delete from database.
+	 *
+	 * @return bool Success.
+	 */
+	public function delete() {
+		global $wpdb;
+
+		if ( ! $this->id ) {
+			return false;
+		}
+
+		$table_name = $wpdb->prefix . 'fair_audience_event_scheduled_messages';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->delete(
+			$table_name,
+			array( 'id' => $this->id ),
+			array( '%d' )
+		) !== false;
+	}
+}

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -23,6 +23,7 @@ use FairAudience\Services\AudienceSignupToken;
 use FairAudience\Services\ManageSubscriptionToken;
 use FairAudience\Services\ParticipantToken;
 use FairAudience\Services\FeePaymentToken;
+use FairAudience\Services\RecipientResolver;
 
 defined( 'WPINC' ) || die;
 
@@ -81,6 +82,13 @@ class EmailService {
 	private $active_extra_messages_cache = array();
 
 	/**
+	 * Recipient resolver instance.
+	 *
+	 * @var RecipientResolver
+	 */
+	private $recipient_resolver;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -90,6 +98,7 @@ class EmailService {
 		$this->event_participant_repository  = new EventParticipantRepository();
 		$this->participant_repository        = new ParticipantRepository();
 		$this->group_participant_repository  = new GroupParticipantRepository();
+		$this->recipient_resolver            = new RecipientResolver();
 	}
 
 	/**
@@ -114,13 +123,7 @@ class EmailService {
 	 * @return bool True if the participant can receive the email.
 	 */
 	private function can_receive_email( Participant $participant, string $email_type ): bool {
-		// Minimal emails are always allowed.
-		if ( EmailType::MINIMAL === $email_type ) {
-			return true;
-		}
-
-		// Marketing emails require explicit opt-in.
-		return 'marketing' === $participant->email_profile;
+		return $this->recipient_resolver->can_receive_email( $participant, $email_type );
 	}
 
 	/**
@@ -130,7 +133,7 @@ class EmailService {
 	 * @return bool True if the participant has a non-empty email.
 	 */
 	private function has_valid_email( Participant $participant ): bool {
-		return ! empty( $participant->email );
+		return $this->recipient_resolver->has_valid_email( $participant );
 	}
 
 	/**
@@ -140,19 +143,7 @@ class EmailService {
 	 * @return array Array of unique participant IDs.
 	 */
 	private function get_participant_ids_for_groups( $group_ids ) {
-		if ( empty( $group_ids ) ) {
-			return array();
-		}
-
-		$participant_ids = array();
-		foreach ( $group_ids as $group_id ) {
-			$members = $this->group_participant_repository->get_by_group( $group_id );
-			foreach ( $members as $member ) {
-				$participant_ids[] = $member->participant_id;
-			}
-		}
-
-		return array_unique( $participant_ids );
+		return $this->recipient_resolver->get_participant_ids_for_groups( $group_ids );
 	}
 
 	/**
@@ -1023,9 +1014,10 @@ class EmailService {
 	 * @param string      $content       Email content (HTML).
 	 * @param Participant $participant   Participant object.
 	 * @param int         $event_date_id Event date ID (0 if not linked to an event date).
+	 * @param array       $context       Per-message context: event_name, event_date.
 	 * @return string Processed content.
 	 */
-	private function replace_placeholders( $content, $participant, $event_date_id = 0 ) {
+	private function replace_placeholders( $content, $participant, $event_date_id = 0, $context = array() ) {
 		if ( false !== strpos( $content, '{photo_upload_url}' ) ) {
 			$token = ParticipantToken::generate( $participant->id, $event_date_id );
 			$url   = add_query_arg( 'participant_token', $token, home_url( '/' ) );
@@ -1040,6 +1032,25 @@ class EmailService {
 			$content = str_replace( '{manage_subscription_url}', esc_url( $url ), $content );
 		}
 
+		if ( false !== strpos( $content, '{unsubscribe_link}' ) ) {
+			$url     = ManageSubscriptionToken::get_url( $participant->id );
+			$content = str_replace( '{unsubscribe_link}', esc_url( $url ), $content );
+		}
+
+		if ( false !== strpos( $content, '{participant_name}' ) ) {
+			$content = str_replace( '{participant_name}', esc_html( $participant->name ), $content );
+		}
+
+		if ( false !== strpos( $content, '{event_name}' ) ) {
+			$event_name = isset( $context['event_name'] ) ? $context['event_name'] : '';
+			$content    = str_replace( '{event_name}', esc_html( $event_name ), $content );
+		}
+
+		if ( false !== strpos( $content, '{event_date}' ) ) {
+			$event_date = isset( $context['event_date'] ) ? $context['event_date'] : '';
+			$content    = str_replace( '{event_date}', esc_html( $event_date ), $content );
+		}
+
 		if ( preg_match_all( '/\{token_link_(\d+)\}/', $content, $matches ) ) {
 			foreach ( $matches[1] as $index => $post_id ) {
 				$url     = ParticipantToken::get_url( $participant->id, $event_date_id, (int) $post_id );
@@ -1048,6 +1059,119 @@ class EmailService {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Build the branded HTML email body wrapping custom-mail content.
+	 *
+	 * Shared by the ad-hoc custom-mail flow and scheduled event mailings.
+	 *
+	 * @param Participant $participant Participant the email greets.
+	 * @param string      $content     Inner HTML content (placeholders resolved).
+	 * @return string Full HTML document.
+	 */
+	private function build_custom_mail_html( $participant, $content ) {
+		$site_name               = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+		$manage_subscription_url = ManageSubscriptionToken::get_url( $participant->id );
+
+		return '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #333333; background-color: #f4f4f4;">
+	<table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f4;">
+		<tr>
+			<td align="center" style="padding: 20px 0;">
+				<table width="600" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+					<tr>
+						<td style="background-color: #0073aa; color: #ffffff; padding: 30px; border-radius: 8px 8px 0 0; text-align: center;">
+							<h1 style="margin: 0; font-size: 24px; font-weight: bold;">' . esc_html( $site_name ) . '</h1>
+						</td>
+					</tr>
+					<tr>
+						<td style="padding: 40px 30px;">
+							<p style="margin: 0 0 20px 0; font-size: 16px;">
+								' . sprintf(
+									/* translators: %s: participant first name */
+								esc_html__( 'Hi %s,', 'fair-audience' ),
+								'<strong>' . esc_html( $participant->name ) . '</strong>'
+							) . '
+							</p>
+							<div style="margin: 0 0 20px 0; font-size: 16px;">
+								' . wp_kses_post( $content ) . '
+							</div>
+							<p style="margin: 20px 0 0 0; font-size: 14px; color: #666666;">
+								' . sprintf(
+									/* translators: 1: line break, 2: site name */
+									esc_html__( 'Thanks,%1$sThe %2$s Team', 'fair-audience' ),
+									'<br>',
+									esc_html( $site_name )
+								) . '
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<td style="background-color: #f8f8f8; padding: 20px 30px; border-radius: 0 0 8px 8px; text-align: center; font-size: 12px; color: #666666;">
+							<p style="margin: 0;">
+								' . esc_html__( "Don't want to receive these emails?", 'fair-audience' ) . '
+								<a href="' . esc_url( $manage_subscription_url ) . '" style="color: #0073aa;">' . esc_html__( 'Manage your preferences', 'fair-audience' ) . '</a>
+							</p>
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+</body>
+</html>';
+	}
+
+	/**
+	 * Dispatch an HTML email, toggling the content-type filter around the send.
+	 *
+	 * @param string $to      Recipient email address.
+	 * @param string $subject Email subject.
+	 * @param string $message Full HTML body.
+	 * @return bool Whether wp_mail() accepted the message.
+	 */
+	private function dispatch_html_mail( $to, $subject, $message ) {
+		$content_type = static function () {
+			return 'text/html';
+		};
+
+		add_filter( 'wp_mail_content_type', $content_type );
+		$result = wp_mail( $to, $subject, $message );
+		remove_filter( 'wp_mail_content_type', $content_type );
+
+		return $result;
+	}
+
+	/**
+	 * Render and send a scheduled-message body to one participant.
+	 *
+	 * Resolves placeholders (including {event_name}/{event_date} from the
+	 * per-message context), wraps the content in the shared template, and
+	 * dispatches the email. Caller is responsible for recipient eligibility
+	 * (valid email, marketing consent).
+	 *
+	 * @param Participant $participant   Recipient.
+	 * @param string      $subject       Email subject.
+	 * @param string      $content       Body HTML with placeholders.
+	 * @param int         $event_date_id Event date ID for tokenized links.
+	 * @param array       $context       Per-message context: event_name, event_date.
+	 * @return bool Success.
+	 */
+	public function send_custom_mail_rendered( $participant, $subject, $content, $event_date_id = 0, $context = array() ) {
+		if ( ! $this->has_valid_email( $participant ) ) {
+			return false;
+		}
+
+		$content = $this->replace_placeholders( $content, $participant, $event_date_id, $context );
+		$message = $this->build_custom_mail_html( $participant, $content );
+
+		return $this->dispatch_html_mail( $participant->email, $subject, $message );
 	}
 
 	/**
@@ -1449,45 +1573,14 @@ class EmailService {
 	 * @return array List of recipient info arrays.
 	 */
 	public function preview_custom_mail_recipients( $event_id, $is_marketing = true, $labels = array( 'signed_up', 'collaborator' ), $group_ids = array() ) {
-		$recipients = array();
-
-		$event = get_post( $event_id );
-		if ( ! $event ) {
-			return $recipients;
-		}
-
-		$group_participant_ids = $this->get_participant_ids_for_groups( $group_ids );
-
-		$event_participants = $this->event_participant_repository->get_by_event( $event_id );
-
-		foreach ( $event_participants as $ep ) {
-			if ( ! in_array( $ep->label, $labels, true ) ) {
-				continue;
-			}
-
-			if ( ! empty( $group_ids ) && ! in_array( $ep->participant_id, $group_participant_ids, true ) ) {
-				continue;
-			}
-
-			$participant = $this->participant_repository->get_by_id( $ep->participant_id );
-			if ( ! $participant ) {
-				continue;
-			}
-
-			$would_skip_marketing = $is_marketing && ! $this->can_receive_email( $participant, EmailType::MARKETING );
-
-			$recipients[] = array(
-				'participant_id'       => $participant->id,
-				'name'                 => $participant->name,
-				'surname'              => $participant->surname,
-				'email'                => $participant->email,
-				'label'                => $ep->label,
-				'has_valid_email'      => $this->has_valid_email( $participant ),
-				'would_skip_marketing' => $would_skip_marketing,
-			);
-		}
-
-		return $recipients;
+		return $this->recipient_resolver->resolve(
+			array(
+				'labels'       => $labels,
+				'group_ids'    => $group_ids,
+				'is_marketing' => $is_marketing,
+			),
+			$event_id
+		);
 	}
 
 	/**
@@ -2293,30 +2386,13 @@ class EmailService {
 	 * @return array List of recipient info arrays.
 	 */
 	public function preview_custom_mail_recipients_all( $is_marketing = true, $group_ids = array() ) {
-		$recipients   = array();
-		$participants = $this->participant_repository->get_all();
-
-		$group_participant_ids = $this->get_participant_ids_for_groups( $group_ids );
-
-		foreach ( $participants as $participant ) {
-			if ( ! empty( $group_ids ) && ! in_array( $participant->id, $group_participant_ids, true ) ) {
-				continue;
-			}
-
-			$would_skip_marketing = $is_marketing && ! $this->can_receive_email( $participant, EmailType::MARKETING );
-
-			$recipients[] = array(
-				'participant_id'       => $participant->id,
-				'name'                 => $participant->name,
-				'surname'              => $participant->surname,
-				'email'                => $participant->email,
-				'label'                => '',
-				'has_valid_email'      => $this->has_valid_email( $participant ),
-				'would_skip_marketing' => $would_skip_marketing,
-			);
-		}
-
-		return $recipients;
+		return $this->recipient_resolver->resolve(
+			array(
+				'group_ids'    => $group_ids,
+				'is_marketing' => $is_marketing,
+			),
+			null
+		);
 	}
 
 	/**

--- a/fair-audience/src/Services/RecipientResolver.php
+++ b/fair-audience/src/Services/RecipientResolver.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Recipient Resolver
+ *
+ * Single source of truth for turning a recipient filter
+ * (`{labels, group_ids, is_marketing}`) into the list of recipients an email
+ * send would target. Used by both the ad-hoc custom-mail flow and scheduled
+ * event mailings so label/group/marketing logic lives in one place.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Services;
+
+use FairAudience\Database\EventParticipantRepository;
+use FairAudience\Database\ParticipantRepository;
+use FairAudience\Database\GroupParticipantRepository;
+use FairAudience\Models\Participant;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Resolves a recipient filter into recipient rows.
+ */
+class RecipientResolver {
+
+	/**
+	 * Event participant repository instance.
+	 *
+	 * @var EventParticipantRepository
+	 */
+	private $event_participant_repository;
+
+	/**
+	 * Participant repository instance.
+	 *
+	 * @var ParticipantRepository
+	 */
+	private $participant_repository;
+
+	/**
+	 * Group participant repository instance.
+	 *
+	 * @var GroupParticipantRepository
+	 */
+	private $group_participant_repository;
+
+	/**
+	 * Allowed participant labels for event-scoped sends.
+	 *
+	 * @var string[]
+	 */
+	const ALLOWED_LABELS = array( 'signed_up', 'collaborator', 'interested' );
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->event_participant_repository = new EventParticipantRepository();
+		$this->participant_repository       = new ParticipantRepository();
+		$this->group_participant_repository = new GroupParticipantRepository();
+	}
+
+	/**
+	 * Normalize a raw recipient filter into a predictable shape.
+	 *
+	 * Accepts the `previewRecipients` payload / stored `recipients_filter` JSON
+	 * and fills in defaults. Invalid labels are dropped.
+	 *
+	 * @param array $filter Raw filter array.
+	 * @return array{labels: string[], group_ids: int[], is_marketing: bool}
+	 */
+	public function normalize_filter( $filter ) {
+		$filter = is_array( $filter ) ? $filter : array();
+
+		$labels = isset( $filter['labels'] ) ? (array) $filter['labels'] : array( 'signed_up', 'collaborator' );
+		$labels = array_values( array_intersect( $labels, self::ALLOWED_LABELS ) );
+
+		$group_ids = isset( $filter['group_ids'] ) ? array_map( 'absint', (array) $filter['group_ids'] ) : array();
+
+		$is_marketing = ! isset( $filter['is_marketing'] ) || (bool) $filter['is_marketing'];
+
+		return array(
+			'labels'       => $labels,
+			'group_ids'    => $group_ids,
+			'is_marketing' => $is_marketing,
+		);
+	}
+
+	/**
+	 * Resolve a recipient filter into recipient rows.
+	 *
+	 * When `$event_id` is provided, recipients are the event participants whose
+	 * label is in the filter; otherwise the whole audience is considered
+	 * (labels do not apply). Group and marketing filters apply in both cases.
+	 *
+	 * @param array    $filter   Recipient filter (normalized or raw).
+	 * @param int|null $event_id Event post ID, or null/0 for the whole audience.
+	 * @return array[] Recipient rows: participant_id, name, surname, email,
+	 *                 label, has_valid_email, would_skip_marketing.
+	 */
+	public function resolve( $filter, $event_id = null ) {
+		$filter = $this->normalize_filter( $filter );
+
+		if ( ! empty( $event_id ) ) {
+			return $this->resolve_for_event( (int) $event_id, $filter );
+		}
+
+		return $this->resolve_for_audience( $filter );
+	}
+
+	/**
+	 * Resolve recipients scoped to a single event.
+	 *
+	 * @param int   $event_id Event post ID.
+	 * @param array $filter   Normalized filter.
+	 * @return array[] Recipient rows.
+	 */
+	private function resolve_for_event( $event_id, $filter ) {
+		$recipients = array();
+
+		if ( ! get_post( $event_id ) ) {
+			return $recipients;
+		}
+
+		$group_participant_ids = $this->get_participant_ids_for_groups( $filter['group_ids'] );
+		$event_participants    = $this->event_participant_repository->get_by_event( $event_id );
+
+		foreach ( $event_participants as $ep ) {
+			if ( ! in_array( $ep->label, $filter['labels'], true ) ) {
+				continue;
+			}
+
+			if ( ! empty( $filter['group_ids'] ) && ! in_array( $ep->participant_id, $group_participant_ids, true ) ) {
+				continue;
+			}
+
+			$participant = $this->participant_repository->get_by_id( $ep->participant_id );
+			if ( ! $participant ) {
+				continue;
+			}
+
+			$recipients[] = $this->build_row( $participant, $ep->label, $filter['is_marketing'] );
+		}
+
+		return $recipients;
+	}
+
+	/**
+	 * Resolve recipients across the whole audience (no event scope).
+	 *
+	 * @param array $filter Normalized filter.
+	 * @return array[] Recipient rows.
+	 */
+	private function resolve_for_audience( $filter ) {
+		$recipients            = array();
+		$participants          = $this->participant_repository->get_all();
+		$group_participant_ids = $this->get_participant_ids_for_groups( $filter['group_ids'] );
+
+		foreach ( $participants as $participant ) {
+			if ( ! empty( $filter['group_ids'] ) && ! in_array( $participant->id, $group_participant_ids, true ) ) {
+				continue;
+			}
+
+			$recipients[] = $this->build_row( $participant, '', $filter['is_marketing'] );
+		}
+
+		return $recipients;
+	}
+
+	/**
+	 * Build a single recipient row.
+	 *
+	 * @param Participant $participant  Participant object.
+	 * @param string      $label        Event-participant label ('' for audience).
+	 * @param bool        $is_marketing Whether the send is a marketing email.
+	 * @return array Recipient row.
+	 */
+	private function build_row( Participant $participant, $label, $is_marketing ) {
+		return array(
+			'participant_id'       => $participant->id,
+			'name'                 => $participant->name,
+			'surname'              => $participant->surname,
+			'email'                => $participant->email,
+			'label'                => $label,
+			'has_valid_email'      => $this->has_valid_email( $participant ),
+			'would_skip_marketing' => $is_marketing && ! $this->can_receive_email( $participant, EmailType::MARKETING ),
+		);
+	}
+
+	/**
+	 * Check if a participant can receive a specific type of email.
+	 *
+	 * @param Participant $participant The participant to check.
+	 * @param string      $email_type  EmailType::MINIMAL or EmailType::MARKETING.
+	 * @return bool True if the participant can receive the email.
+	 */
+	public function can_receive_email( Participant $participant, string $email_type ): bool {
+		if ( EmailType::MINIMAL === $email_type ) {
+			return true;
+		}
+
+		return 'marketing' === $participant->email_profile;
+	}
+
+	/**
+	 * Check if a participant has a valid email address.
+	 *
+	 * @param Participant $participant The participant to check.
+	 * @return bool True if the participant has a non-empty email.
+	 */
+	public function has_valid_email( Participant $participant ): bool {
+		return ! empty( $participant->email );
+	}
+
+	/**
+	 * Get unique participant IDs for an array of group IDs.
+	 *
+	 * @param array $group_ids Array of group IDs.
+	 * @return int[] Array of unique participant IDs.
+	 */
+	public function get_participant_ids_for_groups( $group_ids ) {
+		if ( empty( $group_ids ) ) {
+			return array();
+		}
+
+		$participant_ids = array();
+		foreach ( $group_ids as $group_id ) {
+			$members = $this->group_participant_repository->get_by_group( $group_id );
+			foreach ( $members as $member ) {
+				$participant_ids[] = $member->participant_id;
+			}
+		}
+
+		return array_unique( $participant_ids );
+	}
+}

--- a/fair-audience/src/Services/ScheduledMessageScheduler.php
+++ b/fair-audience/src/Services/ScheduledMessageScheduler.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Scheduled Message Scheduler
+ *
+ * Resolves the concrete send time for a scheduled message from its anchor
+ * (an event date's start/end) plus a signed minute offset. Shared by the REST
+ * controller (on create/edit) and the reschedule hooks (when an anchor moves).
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Services;
+
+use FairAudience\Models\ScheduledMessage;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Computes scheduled_for from an anchor + offset.
+ */
+class ScheduledMessageScheduler {
+
+	/**
+	 * Anchor types backed by an event date (supported in #606).
+	 */
+	const EVENT_DATE_ANCHORS = array( 'event_date_start', 'event_date_end' );
+
+	/**
+	 * Whether an anchor type is supported yet.
+	 *
+	 * Sale-period anchors (#617) are not resolvable until that work lands.
+	 *
+	 * @param string $anchor_type Anchor type.
+	 * @return bool True if supported.
+	 */
+	public static function is_supported_anchor( $anchor_type ) {
+		return in_array( $anchor_type, self::EVENT_DATE_ANCHORS, true );
+	}
+
+	/**
+	 * Compute the send time for an anchor + offset, in WP-local wall time.
+	 *
+	 * Returned string is comparable to current_time( 'mysql' ), the same frame
+	 * the cron picker uses. Returns null when the anchor row or its datetime is
+	 * missing, or the anchor type is unsupported.
+	 *
+	 * @param string $anchor_type    Anchor type.
+	 * @param int    $anchor_ref_id  Anchor row ID (event_date id for event_date_*).
+	 * @param int    $offset_minutes Signed offset in minutes.
+	 * @return string|null Computed datetime ('Y-m-d H:i:s') or null.
+	 */
+	public function compute_scheduled_for( $anchor_type, $anchor_ref_id, $offset_minutes ) {
+		if ( ! self::is_supported_anchor( $anchor_type ) ) {
+			return null;
+		}
+
+		$base = $this->get_event_date_anchor_time( $anchor_type, (int) $anchor_ref_id );
+		if ( empty( $base ) ) {
+			return null;
+		}
+
+		$dt = date_create( $base, wp_timezone() );
+		if ( false === $dt ) {
+			return null;
+		}
+
+		$offset_minutes = (int) $offset_minutes;
+		$sign           = $offset_minutes < 0 ? '-' : '+';
+		$dt->modify( $sign . abs( $offset_minutes ) . ' minutes' );
+
+		return $dt->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Recompute and persist scheduled_for for a message from its own anchor.
+	 *
+	 * @param ScheduledMessage $message Message to recompute.
+	 * @return bool Whether the save succeeded.
+	 */
+	public function recompute( ScheduledMessage $message ) {
+		$message->scheduled_for = $this->compute_scheduled_for(
+			$message->anchor_type,
+			$message->anchor_ref_id,
+			$message->offset_minutes
+		);
+
+		return $message->save();
+	}
+
+	/**
+	 * Read the start/end datetime of an event date.
+	 *
+	 * @param string $anchor_type   event_date_start or event_date_end.
+	 * @param int    $event_date_id Event date row ID.
+	 * @return string|null Datetime string, or null if not found.
+	 */
+	private function get_event_date_anchor_time( $anchor_type, $event_date_id ) {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'fair_event_dates';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT start_datetime, end_datetime FROM %i WHERE id = %d',
+				$table,
+				$event_date_id
+			),
+			ARRAY_A
+		);
+
+		if ( ! $row ) {
+			return null;
+		}
+
+		return 'event_date_end' === $anchor_type ? $row['end_datetime'] : $row['start_datetime'];
+	}
+}

--- a/fair-events/src/Admin/manage-event/AnchorOffsetPicker.js
+++ b/fair-events/src/Admin/manage-event/AnchorOffsetPicker.js
@@ -1,0 +1,211 @@
+/**
+ * Anchor + Offset Picker
+ *
+ * Composes an anchor type (event date start/end), which event date to anchor
+ * to (when the event has several), and a signed offset (value + unit +
+ * before/after) into the `{ anchor_type, anchor_ref_id, offset_minutes }` the
+ * scheduled-messages API expects. Shows the resulting send time as a preview.
+ *
+ * @package FairEvents
+ */
+
+import { SelectControl, RadioControl } from '@wordpress/components';
+import {
+	__experimentalNumberControl as NumberControl,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+const UNIT_MINUTES = {
+	minutes: 1,
+	hours: 60,
+	days: 1440,
+};
+
+/**
+ * Convert a value/unit/direction triple to signed offset minutes.
+ *
+ * @param {number} value     Offset magnitude.
+ * @param {string} unit      'minutes' | 'hours' | 'days'.
+ * @param {string} direction 'before' | 'after'.
+ * @return {number} Signed offset in minutes.
+ */
+export function toOffsetMinutes(value, unit, direction) {
+	const magnitude = Math.abs(parseInt(value, 10) || 0) * UNIT_MINUTES[unit];
+	return direction === 'before' ? -magnitude : magnitude;
+}
+
+/**
+ * Decompose signed offset minutes back into value/unit/direction, choosing the
+ * largest unit that divides evenly.
+ *
+ * @param {number} offsetMinutes Signed offset in minutes.
+ * @return {{value: number, unit: string, direction: string}} The triple.
+ */
+export function fromOffsetMinutes(offsetMinutes) {
+	const direction = offsetMinutes < 0 ? 'before' : 'after';
+	const abs = Math.abs(offsetMinutes);
+	let unit = 'minutes';
+	if (abs !== 0 && abs % UNIT_MINUTES.days === 0) {
+		unit = 'days';
+	} else if (abs !== 0 && abs % UNIT_MINUTES.hours === 0) {
+		unit = 'hours';
+	}
+	return { value: abs / UNIT_MINUTES[unit], unit, direction };
+}
+
+/**
+ * Compute the send time for a preview (best-effort, treats the stored datetime
+ * as wall-clock time — the server recomputes authoritatively).
+ *
+ * @param {Object} eventDate     Event date row with start_datetime/end_datetime.
+ * @param {string} anchorType    'event_date_start' | 'event_date_end'.
+ * @param {number} offsetMinutes Signed offset in minutes.
+ * @return {string} Formatted local datetime, or '' when unavailable.
+ */
+export function computeScheduledFor(eventDate, anchorType, offsetMinutes) {
+	if (!eventDate) {
+		return '';
+	}
+	const base =
+		anchorType === 'event_date_end'
+			? eventDate.end_datetime
+			: eventDate.start_datetime;
+	if (!base) {
+		return '';
+	}
+	const dt = new Date(base.replace(' ', 'T'));
+	if (Number.isNaN(dt.getTime())) {
+		return '';
+	}
+	dt.setMinutes(dt.getMinutes() + offsetMinutes);
+	const pad = (n) => String(n).padStart(2, '0');
+	return (
+		`${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())} ` +
+		`${pad(dt.getHours())}:${pad(dt.getMinutes())}`
+	);
+}
+
+/**
+ * Anchor + offset picker.
+ *
+ * @param {Object}   props            Component props.
+ * @param {Array}    props.eventDates  Event dates available as anchors.
+ * @param {string}   props.anchorType  Selected anchor type.
+ * @param {number}   props.anchorRefId Selected event date ID.
+ * @param {number}   props.offsetValue Offset magnitude.
+ * @param {string}   props.offsetUnit  Offset unit.
+ * @param {string}   props.direction   'before' | 'after'.
+ * @param {Function} props.onChange    Called with the changed field map.
+ * @param {boolean}  props.disabled    Whether inputs are disabled.
+ * @return {JSX.Element} The picker.
+ */
+export default function AnchorOffsetPicker({
+	eventDates,
+	anchorType,
+	anchorRefId,
+	offsetValue,
+	offsetUnit,
+	direction,
+	onChange,
+	disabled,
+}) {
+	const selectedDate = eventDates.find((d) => d.id === anchorRefId);
+	const offsetMinutes = toOffsetMinutes(offsetValue, offsetUnit, direction);
+	const preview = computeScheduledFor(
+		selectedDate,
+		anchorType,
+		offsetMinutes
+	);
+
+	return (
+		<div style={{ marginBottom: '16px' }}>
+			<SelectControl
+				label={__('Anchor', 'fair-events')}
+				value={anchorType}
+				options={[
+					{
+						label: __('Event date start', 'fair-events'),
+						value: 'event_date_start',
+					},
+					{
+						label: __('Event date end', 'fair-events'),
+						value: 'event_date_end',
+					},
+				]}
+				onChange={(value) => onChange({ anchorType: value })}
+				disabled={disabled}
+				__nextHasNoMarginBottom
+			/>
+
+			{eventDates.length > 1 && (
+				<SelectControl
+					label={__('Which date', 'fair-events')}
+					value={String(anchorRefId)}
+					options={eventDates.map((d) => ({
+						label: d.display_label || `#${d.id}`,
+						value: String(d.id),
+					}))}
+					onChange={(value) =>
+						onChange({ anchorRefId: parseInt(value, 10) })
+					}
+					disabled={disabled}
+					__nextHasNoMarginBottom
+				/>
+			)}
+
+			<HStack
+				alignment="flex-end"
+				spacing={3}
+				style={{ marginTop: '8px' }}
+			>
+				<NumberControl
+					label={__('Offset', 'fair-events')}
+					min={0}
+					value={offsetValue}
+					onChange={(value) =>
+						onChange({ offsetValue: parseInt(value, 10) || 0 })
+					}
+					disabled={disabled}
+					__nextHasNoMarginBottom
+				/>
+				<SelectControl
+					label={__('Unit', 'fair-events')}
+					value={offsetUnit}
+					options={[
+						{
+							label: __('minutes', 'fair-events'),
+							value: 'minutes',
+						},
+						{ label: __('hours', 'fair-events'), value: 'hours' },
+						{ label: __('days', 'fair-events'), value: 'days' },
+					]}
+					onChange={(value) => onChange({ offsetUnit: value })}
+					disabled={disabled}
+					__nextHasNoMarginBottom
+				/>
+				<RadioControl
+					selected={direction}
+					options={[
+						{ label: __('before', 'fair-events'), value: 'before' },
+						{ label: __('after', 'fair-events'), value: 'after' },
+					]}
+					onChange={(value) => onChange({ direction: value })}
+				/>
+			</HStack>
+
+			<p style={{ marginTop: '8px', color: '#666' }}>
+				{preview
+					? sprintf(
+							/* translators: %s: computed send date/time */
+							__('Will send around: %s', 'fair-events'),
+							preview
+					  )
+					: __(
+							'Send time will be computed from the chosen date.',
+							'fair-events'
+					  )}
+			</p>
+		</div>
+	);
+}

--- a/fair-events/src/Admin/manage-event/EventMailings.js
+++ b/fair-events/src/Admin/manage-event/EventMailings.js
@@ -1,0 +1,715 @@
+/**
+ * Event Mailings Tab
+ *
+ * Schedule and manage per-event mailings from the ManageEventApp. Mirrors the
+ * custom-mail page UX where it makes sense; scheduled sends intentionally drop
+ * the per-send skip list and immediate-send (stated in the form, not hidden).
+ * Data is owned by fair-audience and reached over its REST API.
+ *
+ * @package FairEvents
+ */
+
+import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	Button,
+	Spinner,
+	Notice,
+	TextControl,
+	CheckboxControl,
+	ToggleControl,
+	FormTokenField,
+	Modal,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import MailBodyEditor from './MailBodyEditor.js';
+import AnchorOffsetPicker, {
+	toOffsetMinutes,
+	fromOffsetMinutes,
+} from './AnchorOffsetPicker.js';
+import {
+	loadScheduledMessages,
+	loadEventDates,
+	loadGroups,
+	createScheduledMessage,
+	updateScheduledMessage,
+	cancelScheduledMessage,
+	previewDraftRecipients,
+} from './mailings-api.js';
+
+const LABEL_OPTIONS = [
+	{ key: 'signed_up', label: __('Registered', 'fair-events') },
+	{ key: 'interested', label: __('Interested', 'fair-events') },
+	{ key: 'collaborator', label: __('Collaborators', 'fair-events') },
+];
+
+const STATUS_COLORS = {
+	scheduled: '#2271b1',
+	sending: '#dba617',
+	sent: '#00a32a',
+	canceled: '#757575',
+	failed: '#d63638',
+};
+
+const emptyForm = (defaultAnchorRefId) => ({
+	editingId: null,
+	subject: '',
+	body: '',
+	anchorType: 'event_date_start',
+	anchorRefId: defaultAnchorRefId,
+	offsetValue: 1,
+	offsetUnit: 'days',
+	direction: 'before',
+	labels: { signed_up: true, interested: false, collaborator: false },
+	groupIds: [],
+	isMarketing: false,
+});
+
+/**
+ * Mailings tab.
+ *
+ * @param {Object} props             Component props.
+ * @param {number} props.eventId      Event post ID.
+ * @param {number} props.eventDateId  The event date currently being managed.
+ * @return {JSX.Element} The tab.
+ */
+export default function EventMailings({ eventId, eventDateId }) {
+	const [messages, setMessages] = useState([]);
+	const [eventDates, setEventDates] = useState([]);
+	const [groups, setGroups] = useState([]);
+	const [loading, setLoading] = useState(true);
+	const [notice, setNotice] = useState(null);
+	const [isSaving, setIsSaving] = useState(false);
+
+	const [form, setForm] = useState(emptyForm(eventDateId));
+
+	const [recipientCount, setRecipientCount] = useState(null);
+	const [recipientList, setRecipientList] = useState([]);
+	const [showRecipients, setShowRecipients] = useState(false);
+
+	const [cancelTarget, setCancelTarget] = useState(null);
+	const [detailMessage, setDetailMessage] = useState(null);
+
+	const updateForm = useCallback((patch) => {
+		setForm((prev) => ({ ...prev, ...patch }));
+	}, []);
+
+	const reloadMessages = useCallback(() => {
+		return loadScheduledMessages(eventId).then(setMessages);
+	}, [eventId]);
+
+	// Initial data load.
+	useEffect(() => {
+		let active = true;
+		Promise.all([
+			loadScheduledMessages(eventId),
+			loadEventDates(eventId),
+			loadGroups().catch(() => []),
+		])
+			.then(([msgs, dates, grps]) => {
+				if (!active) {
+					return;
+				}
+				setMessages(msgs);
+				setEventDates(dates);
+				setGroups(grps);
+				// Default the anchor to the managed date when present.
+				const hasManaged = dates.some((d) => d.id === eventDateId);
+				const fallback = dates.length > 0 ? dates[0].id : eventDateId;
+				updateForm({
+					anchorRefId: hasManaged ? eventDateId : fallback,
+				});
+			})
+			.catch(() => {
+				if (active) {
+					setNotice({
+						status: 'error',
+						message: __('Could not load mailings.', 'fair-events'),
+					});
+				}
+			})
+			.finally(() => active && setLoading(false));
+		return () => {
+			active = false;
+		};
+	}, [eventId, eventDateId, updateForm]);
+
+	const selectedLabels = useMemo(
+		() => LABEL_OPTIONS.filter((o) => form.labels[o.key]).map((o) => o.key),
+		[form.labels]
+	);
+
+	const recipientsFilter = useMemo(
+		() => ({
+			labels: selectedLabels,
+			group_ids: form.groupIds,
+			is_marketing: form.isMarketing,
+		}),
+		[selectedLabels, form.groupIds, form.isMarketing]
+	);
+
+	// Live recipient preview (debounced) whenever the filter changes.
+	useEffect(() => {
+		if (selectedLabels.length === 0) {
+			setRecipientCount(0);
+			setRecipientList([]);
+			return undefined;
+		}
+		const handle = setTimeout(() => {
+			previewDraftRecipients(eventId, recipientsFilter)
+				.then((list) => {
+					setRecipientCount(list.length);
+					setRecipientList(list);
+				})
+				.catch(() => {
+					setRecipientCount(null);
+					setRecipientList([]);
+				});
+		}, 400);
+		return () => clearTimeout(handle);
+	}, [eventId, recipientsFilter, selectedLabels.length]);
+
+	const resetForm = useCallback(() => {
+		const hasManaged = eventDates.some((d) => d.id === eventDateId);
+		const fallback = eventDates.length > 0 ? eventDates[0].id : eventDateId;
+		setForm(emptyForm(hasManaged ? eventDateId : fallback));
+	}, [eventDates, eventDateId]);
+
+	const startEdit = (message) => {
+		const decomposed = fromOffsetMinutes(message.offset_minutes);
+		const filter = message.recipients_filter || {};
+		const filterLabels = filter.labels || [];
+		setForm({
+			editingId: message.id,
+			subject: message.subject,
+			body: message.body,
+			anchorType: message.anchor_type,
+			anchorRefId: message.anchor_ref_id || message.event_date_id,
+			offsetValue: decomposed.value,
+			offsetUnit: decomposed.unit,
+			direction: decomposed.direction,
+			labels: {
+				signed_up: filterLabels.includes('signed_up'),
+				interested: filterLabels.includes('interested'),
+				collaborator: filterLabels.includes('collaborator'),
+			},
+			groupIds: filter.group_ids || [],
+			isMarketing: !!filter.is_marketing,
+		});
+		window.scrollTo({ top: 0, behavior: 'smooth' });
+	};
+
+	const duplicate = (message) => {
+		startEdit(message);
+		updateForm({ editingId: null });
+	};
+
+	const handleSubmit = (e) => {
+		e.preventDefault();
+		if (!form.subject.trim()) {
+			setNotice({
+				status: 'error',
+				message: __('Please enter a subject.', 'fair-events'),
+			});
+			return;
+		}
+		if (!form.body.trim()) {
+			setNotice({
+				status: 'error',
+				message: __('Please enter a body.', 'fair-events'),
+			});
+			return;
+		}
+		if (selectedLabels.length === 0) {
+			setNotice({
+				status: 'error',
+				message: __(
+					'Please select at least one recipient type.',
+					'fair-events'
+				),
+			});
+			return;
+		}
+
+		const payload = {
+			subject: form.subject.trim(),
+			body: form.body,
+			anchor_type: form.anchorType,
+			anchor_ref_id: form.anchorRefId,
+			offset_minutes: toOffsetMinutes(
+				form.offsetValue,
+				form.offsetUnit,
+				form.direction
+			),
+			recipients_filter: recipientsFilter,
+		};
+
+		setIsSaving(true);
+		setNotice(null);
+		const request = form.editingId
+			? updateScheduledMessage(form.editingId, payload)
+			: createScheduledMessage(eventId, payload);
+
+		request
+			.then(() => reloadMessages())
+			.then(() => {
+				setNotice({
+					status: 'success',
+					message: form.editingId
+						? __('Mailing updated.', 'fair-events')
+						: __('Mailing scheduled.', 'fair-events'),
+				});
+				resetForm();
+			})
+			.catch((err) => {
+				setNotice({
+					status: 'error',
+					message:
+						err?.message ||
+						__('Could not save the mailing.', 'fair-events'),
+				});
+			})
+			.finally(() => setIsSaving(false));
+	};
+
+	const confirmCancel = () => {
+		const id = cancelTarget.id;
+		setCancelTarget(null);
+		cancelScheduledMessage(id)
+			.then(() => reloadMessages())
+			.then(() =>
+				setNotice({
+					status: 'success',
+					message: __('Mailing canceled.', 'fair-events'),
+				})
+			)
+			.catch(() =>
+				setNotice({
+					status: 'error',
+					message: __('Could not cancel the mailing.', 'fair-events'),
+				})
+			);
+	};
+
+	if (loading) {
+		return (
+			<Card style={{ marginTop: '16px' }}>
+				<CardBody>
+					<Spinner />
+				</CardBody>
+			</Card>
+		);
+	}
+
+	const groupNameById = (id) => {
+		const match = groups.find((g) => g.id === id);
+		return match ? match.name : String(id);
+	};
+	const groupIdByName = (name) => {
+		const match = groups.find((g) => g.name === name);
+		return match ? match.id : null;
+	};
+
+	return (
+		<>
+			{notice && (
+				<Notice
+					status={notice.status}
+					onRemove={() => setNotice(null)}
+					style={{ marginTop: '16px' }}
+				>
+					{notice.message}
+				</Notice>
+			)}
+
+			{/* Schedule / edit form */}
+			<Card style={{ marginTop: '16px', marginBottom: '24px' }}>
+				<CardHeader>
+					<h2 style={{ margin: 0 }}>
+						{form.editingId
+							? __('Edit scheduled mailing', 'fair-events')
+							: __('Schedule new mailing', 'fair-events')}
+					</h2>
+				</CardHeader>
+				<CardBody>
+					<form onSubmit={handleSubmit}>
+						<TextControl
+							label={__('Subject', 'fair-events')}
+							value={form.subject}
+							onChange={(value) => updateForm({ subject: value })}
+							disabled={isSaving}
+							__nextHasNoMarginBottom
+						/>
+
+						<MailBodyEditor
+							value={form.body}
+							onChange={(value) => updateForm({ body: value })}
+							disabled={isSaving}
+						/>
+
+						<AnchorOffsetPicker
+							eventDates={eventDates}
+							anchorType={form.anchorType}
+							anchorRefId={form.anchorRefId}
+							offsetValue={form.offsetValue}
+							offsetUnit={form.offsetUnit}
+							direction={form.direction}
+							onChange={updateForm}
+							disabled={isSaving}
+						/>
+
+						<fieldset style={{ marginBottom: '16px' }}>
+							<legend style={{ fontWeight: 600 }}>
+								{__('Recipients', 'fair-events')}
+							</legend>
+							{LABEL_OPTIONS.map((opt) => (
+								<CheckboxControl
+									key={opt.key}
+									label={opt.label}
+									checked={form.labels[opt.key]}
+									onChange={(checked) =>
+										updateForm({
+											labels: {
+												...form.labels,
+												[opt.key]: checked,
+											},
+										})
+									}
+									disabled={isSaving}
+									__nextHasNoMarginBottom
+								/>
+							))}
+
+							{groups.length > 0 && (
+								<div style={{ marginTop: '8px' }}>
+									<FormTokenField
+										label={__(
+											'Limit to groups (optional)',
+											'fair-events'
+										)}
+										value={form.groupIds.map(groupNameById)}
+										suggestions={groups.map((g) => g.name)}
+										onChange={(names) =>
+											updateForm({
+												groupIds: names
+													.map(groupIdByName)
+													.filter(Boolean),
+											})
+										}
+										__nextHasNoMarginBottom
+									/>
+								</div>
+							)}
+
+							<ToggleControl
+								label={__(
+									'Marketing email (respect opt-out)',
+									'fair-events'
+								)}
+								checked={form.isMarketing}
+								onChange={(checked) =>
+									updateForm({ isMarketing: checked })
+								}
+								disabled={isSaving}
+								__nextHasNoMarginBottom
+							/>
+
+							<p style={{ color: '#666', marginTop: '4px' }}>
+								{recipientCount === null
+									? __(
+											'Recipient count unavailable.',
+											'fair-events'
+									  )
+									: sprintf(
+											/* translators: %d: recipient count */
+											__(
+												'%d recipient(s) match right now.',
+												'fair-events'
+											),
+											recipientCount
+									  )}{' '}
+								{recipientList.length > 0 && (
+									<Button
+										variant="link"
+										onClick={() =>
+											setShowRecipients((v) => !v)
+										}
+									>
+										{showRecipients
+											? __('Hide list', 'fair-events')
+											: __('View list', 'fair-events')}
+									</Button>
+								)}
+							</p>
+
+							{showRecipients && recipientList.length > 0 && (
+								<ul
+									style={{
+										maxHeight: '160px',
+										overflow: 'auto',
+										border: '1px solid #ddd',
+										padding: '8px 12px',
+										margin: 0,
+									}}
+								>
+									{recipientList.map((r) => (
+										<li key={r.participant_id}>
+											{r.name} {r.surname} &lt;
+											{r.email ||
+												__('no email', 'fair-events')}
+											&gt;
+											{r.would_skip_marketing &&
+												` — ${__(
+													'will skip (opted out)',
+													'fair-events'
+												)}`}
+										</li>
+									))}
+								</ul>
+							)}
+						</fieldset>
+
+						<p style={{ color: '#757575', fontStyle: 'italic' }}>
+							{__(
+								'Scheduled mailings send automatically at the computed time. There is no per-send skip list or immediate send here — use the Custom Mail page for ad-hoc sends.',
+								'fair-events'
+							)}
+						</p>
+
+						<HStack justify="flex-start" spacing={3}>
+							<Button
+								variant="primary"
+								type="submit"
+								isBusy={isSaving}
+								disabled={isSaving}
+							>
+								{form.editingId
+									? __('Update mailing', 'fair-events')
+									: __('Schedule mailing', 'fair-events')}
+							</Button>
+							{form.editingId && (
+								<Button
+									variant="tertiary"
+									onClick={resetForm}
+									disabled={isSaving}
+								>
+									{__('Cancel edit', 'fair-events')}
+								</Button>
+							)}
+						</HStack>
+					</form>
+				</CardBody>
+			</Card>
+
+			{/* Existing mailings */}
+			<Card>
+				<CardHeader>
+					<h2 style={{ margin: 0 }}>
+						{__('Scheduled & past mailings', 'fair-events')}
+					</h2>
+				</CardHeader>
+				<CardBody>
+					{messages.length === 0 ? (
+						<p>{__('No mailings yet.', 'fair-events')}</p>
+					) : (
+						<VStack spacing={3}>
+							{messages.map((m) => (
+								<div
+									key={m.id}
+									style={{
+										borderBottom: '1px solid #eee',
+										paddingBottom: '12px',
+									}}
+								>
+									<HStack justify="space-between">
+										<strong>{m.subject}</strong>
+										<span
+											style={{
+												color:
+													STATUS_COLORS[m.status] ||
+													'#333',
+												fontWeight: 600,
+												textTransform: 'capitalize',
+											}}
+										>
+											{m.status}
+										</span>
+									</HStack>
+									<div
+										style={{
+											color: '#666',
+											fontSize: '13px',
+										}}
+									>
+										{m.scheduled_for
+											? sprintf(
+													/* translators: %s: send date/time */
+													__(
+														'Sends: %s',
+														'fair-events'
+													),
+													m.scheduled_for
+											  )
+											: __(
+													'Send time pending',
+													'fair-events'
+											  )}
+										{m.status === 'sent' &&
+											sprintf(
+												/* translators: 1: sent, 2: failed, 3: skipped */
+												__(
+													' · sent %1$d, failed %2$d, skipped %3$d',
+													'fair-events'
+												),
+												m.sent_count,
+												m.failed_count,
+												m.skipped_count
+											)}
+									</div>
+
+									<HStack
+										justify="flex-start"
+										spacing={2}
+										style={{ marginTop: '6px' }}
+									>
+										{m.status === 'scheduled' && (
+											<>
+												<Button
+													variant="secondary"
+													isSmall
+													onClick={() => startEdit(m)}
+												>
+													{__('Edit', 'fair-events')}
+												</Button>
+												<Button
+													variant="tertiary"
+													isSmall
+													isDestructive
+													onClick={() =>
+														setCancelTarget(m)
+													}
+												>
+													{__(
+														'Cancel',
+														'fair-events'
+													)}
+												</Button>
+											</>
+										)}
+										{(m.status === 'sent' ||
+											m.status === 'failed' ||
+											m.status === 'canceled') && (
+											<Button
+												variant="secondary"
+												isSmall
+												onClick={() =>
+													setDetailMessage(m)
+												}
+											>
+												{__('View', 'fair-events')}
+											</Button>
+										)}
+										{m.status === 'failed' && (
+											<Button
+												variant="tertiary"
+												isSmall
+												onClick={() => duplicate(m)}
+											>
+												{__('Duplicate', 'fair-events')}
+											</Button>
+										)}
+									</HStack>
+								</div>
+							))}
+						</VStack>
+					)}
+				</CardBody>
+			</Card>
+
+			{cancelTarget && (
+				<Modal
+					title={__('Cancel mailing?', 'fair-events')}
+					onRequestClose={() => setCancelTarget(null)}
+				>
+					<p>
+						{sprintf(
+							/* translators: %s: mailing subject */
+							__(
+								'Cancel the scheduled mailing "%s"? It will not be sent.',
+								'fair-events'
+							),
+							cancelTarget.subject
+						)}
+					</p>
+					<HStack justify="flex-end" spacing={3}>
+						<Button
+							variant="tertiary"
+							onClick={() => setCancelTarget(null)}
+						>
+							{__('Keep it', 'fair-events')}
+						</Button>
+						<Button
+							variant="primary"
+							isDestructive
+							onClick={confirmCancel}
+						>
+							{__('Cancel mailing', 'fair-events')}
+						</Button>
+					</HStack>
+				</Modal>
+			)}
+
+			{detailMessage && (
+				<Modal
+					title={detailMessage.subject}
+					onRequestClose={() => setDetailMessage(null)}
+				>
+					<p style={{ color: '#666' }}>
+						{sprintf(
+							/* translators: 1: status, 2: send time */
+							__('Status: %1$s · %2$s', 'fair-events'),
+							detailMessage.status,
+							detailMessage.sent_at ||
+								detailMessage.scheduled_for ||
+								''
+						)}
+					</p>
+					{detailMessage.status === 'sent' && (
+						<p>
+							{sprintf(
+								/* translators: 1: sent, 2: failed, 3: skipped */
+								__(
+									'Sent %1$d · failed %2$d · skipped %3$d',
+									'fair-events'
+								),
+								detailMessage.sent_count,
+								detailMessage.failed_count,
+								detailMessage.skipped_count
+							)}
+						</p>
+					)}
+					{detailMessage.last_error && (
+						<Notice status="error" isDismissible={false}>
+							{detailMessage.last_error}
+						</Notice>
+					)}
+					<div
+						style={{
+							border: '1px solid #ddd',
+							padding: '12px',
+							marginTop: '12px',
+							maxHeight: '300px',
+							overflow: 'auto',
+						}}
+						// eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={{ __html: detailMessage.body }}
+					/>
+				</Modal>
+			)}
+		</>
+	);
+}

--- a/fair-events/src/Admin/manage-event/MailBodyEditor.js
+++ b/fair-events/src/Admin/manage-event/MailBodyEditor.js
@@ -1,0 +1,270 @@
+/**
+ * Mail Body Editor
+ *
+ * Controlled textarea for composing a scheduled-message body, with the same
+ * placeholder-insertion affordances as fair-audience's custom-mail page (photo
+ * upload link, manage-subscription link, tokenized page link) plus the
+ * per-recipient/per-message tokens scheduled mailings support. Copied rather
+ * than shared because the source lives in another plugin and pulls in page
+ * search + @wordpress/components.
+ *
+ * @package FairEvents
+ */
+
+import { useRef, useState } from '@wordpress/element';
+import { Button, TextControl, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Placeholder chips inserted as literal tokens (resolved per recipient/message
+ * at send time).
+ */
+const TOKEN_CHIPS = [
+	{ token: '{participant_name}', label: __('Name', 'fair-events') },
+	{ token: '{event_name}', label: __('Event name', 'fair-events') },
+	{ token: '{event_date}', label: __('Event date', 'fair-events') },
+	{ token: '{unsubscribe_link}', label: __('Unsubscribe', 'fair-events') },
+];
+
+/**
+ * Body editor with placeholder insertion.
+ *
+ * @param {Object}   props          Component props.
+ * @param {string}   props.value    Current body HTML.
+ * @param {Function} props.onChange Called with the next body HTML.
+ * @param {boolean}  props.disabled Whether inputs are disabled.
+ * @return {JSX.Element} The editor.
+ */
+export default function MailBodyEditor({ value, onChange, disabled }) {
+	const textareaRef = useRef(null);
+	const [pageSearch, setPageSearch] = useState('');
+	const [pageResults, setPageResults] = useState([]);
+	const [selectedPage, setSelectedPage] = useState(null);
+	const [isSearching, setIsSearching] = useState(false);
+
+	/**
+	 * Insert a snippet at the caret (or replace the selection) of the textarea.
+	 *
+	 * @param {string} snippet Text/HTML to insert.
+	 */
+	const insertAtCursor = (snippet) => {
+		const el = textareaRef.current;
+		if (!el) {
+			onChange(`${value}${snippet}`);
+			return;
+		}
+		const start = el.selectionStart ?? value.length;
+		const end = el.selectionEnd ?? value.length;
+		const next = value.slice(0, start) + snippet + value.slice(end);
+		onChange(next);
+		// Restore caret after the inserted snippet on the next tick.
+		requestAnimationFrame(() => {
+			el.focus();
+			const caret = start + snippet.length;
+			el.setSelectionRange(caret, caret);
+		});
+	};
+
+	/**
+	 * Insert a placeholder link, wrapping the current selection as link text.
+	 *
+	 * @param {string} placeholder Href placeholder, e.g. '{photo_upload_url}'.
+	 * @param {string} defaultText Link text when nothing is selected.
+	 */
+	const insertPlaceholderLink = (placeholder, defaultText) => {
+		const el = textareaRef.current;
+		let linkText = defaultText;
+		if (el) {
+			const selected = value.slice(el.selectionStart, el.selectionEnd);
+			if (selected) {
+				linkText = selected;
+			}
+		}
+		insertAtCursor(`<a href="${placeholder}">${linkText}</a>`);
+	};
+
+	/**
+	 * Search published pages for the token-link picker.
+	 *
+	 * @param {string} term Search term.
+	 */
+	const searchPages = (term) => {
+		setPageSearch(term);
+		setSelectedPage(null);
+		if (!term || term.length < 2) {
+			setPageResults([]);
+			return;
+		}
+		setIsSearching(true);
+		apiFetch({
+			path: `/wp/v2/pages?search=${encodeURIComponent(
+				term
+			)}&per_page=5&_fields=id,title`,
+		})
+			.then((results) => setPageResults(results || []))
+			.catch(() => setPageResults([]))
+			.finally(() => setIsSearching(false));
+	};
+
+	return (
+		<div style={{ marginBottom: '16px' }}>
+			<label
+				htmlFor="fair-events-mail-body"
+				style={{
+					display: 'block',
+					marginBottom: '8px',
+					fontWeight: '600',
+				}}
+			>
+				{__('Body', 'fair-events')}
+			</label>
+			<textarea
+				id="fair-events-mail-body"
+				ref={textareaRef}
+				rows={10}
+				style={{ width: '100%' }}
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				disabled={disabled}
+			/>
+
+			<div
+				style={{
+					marginTop: '8px',
+					display: 'flex',
+					flexWrap: 'wrap',
+					alignItems: 'center',
+					gap: '8px',
+				}}
+			>
+				<Button
+					variant="secondary"
+					isSmall
+					onClick={() =>
+						insertPlaceholderLink(
+							'{photo_upload_url}',
+							__('Upload photos', 'fair-events')
+						)
+					}
+					disabled={disabled}
+				>
+					{__('Insert photo upload link', 'fair-events')}
+				</Button>
+				<Button
+					variant="secondary"
+					isSmall
+					onClick={() =>
+						insertPlaceholderLink(
+							'{manage_subscription_url}',
+							__('Manage your preferences', 'fair-events')
+						)
+					}
+					disabled={disabled}
+				>
+					{__('Insert subscription link', 'fair-events')}
+				</Button>
+
+				<span
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '4px',
+						position: 'relative',
+					}}
+				>
+					<TextControl
+						placeholder={__('Search page…', 'fair-events')}
+						value={
+							selectedPage
+								? selectedPage.title.rendered
+								: pageSearch
+						}
+						onChange={searchPages}
+						disabled={disabled}
+						__nextHasNoMarginBottom
+						style={{ width: '180px', marginBottom: 0 }}
+					/>
+					{isSearching && <Spinner />}
+					{pageResults.length > 0 && !selectedPage && (
+						<ul
+							style={{
+								position: 'absolute',
+								top: '100%',
+								left: 0,
+								zIndex: 100,
+								background: '#fff',
+								border: '1px solid #ccc',
+								borderRadius: '2px',
+								listStyle: 'none',
+								margin: 0,
+								padding: 0,
+								maxHeight: '200px',
+								overflow: 'auto',
+								width: '280px',
+								boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
+							}}
+						>
+							{pageResults.map((page) => (
+								<li
+									key={page.id}
+									style={{
+										padding: '6px 10px',
+										cursor: 'pointer',
+									}}
+									onMouseDown={() => {
+										setSelectedPage(page);
+										setPageSearch('');
+										setPageResults([]);
+									}}
+								>
+									{page.title.rendered}
+								</li>
+							))}
+						</ul>
+					)}
+					<Button
+						variant="secondary"
+						isSmall
+						onClick={() => {
+							if (selectedPage) {
+								insertPlaceholderLink(
+									`{token_link_${selectedPage.id}}`,
+									selectedPage.title.rendered
+								);
+							}
+						}}
+						disabled={disabled || !selectedPage}
+					>
+						{__('Insert token link', 'fair-events')}
+					</Button>
+				</span>
+			</div>
+
+			<div
+				style={{
+					marginTop: '8px',
+					display: 'flex',
+					flexWrap: 'wrap',
+					alignItems: 'center',
+					gap: '6px',
+				}}
+			>
+				<span style={{ color: '#666', fontSize: '12px' }}>
+					{__('Insert token:', 'fair-events')}
+				</span>
+				{TOKEN_CHIPS.map((chip) => (
+					<Button
+						key={chip.token}
+						variant="tertiary"
+						isSmall
+						onClick={() => insertAtCursor(chip.token)}
+						disabled={disabled}
+					>
+						{chip.label}
+					</Button>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -39,6 +39,7 @@ import EventAudience from './EventAudience.js';
 import GroupRules from './GroupRules.js';
 import EventTickets from './EventTickets.js';
 import EventPhotos from './EventPhotos.js';
+import EventMailings from './EventMailings.js';
 import DuplicateEventWizard from './DuplicateEventWizard.js';
 import MergeEventWizard from './MergeEventWizard.js';
 import RecurrenceCalendar from './RecurrenceCalendar.js';
@@ -583,6 +584,10 @@ export default function ManageEventApp() {
 						{
 							name: 'audience',
 							title: __('Audience', 'fair-events'),
+						},
+						{
+							name: 'mailings',
+							title: __('Mailings', 'fair-events'),
 						},
 				  ]
 				: []),
@@ -1205,6 +1210,14 @@ export default function ManageEventApp() {
 								eventDateId={eventDateId}
 								audienceUrl={audienceUrl}
 								eventTitle={title}
+							/>
+						);
+					}
+					if (tab.name === 'mailings') {
+						return (
+							<EventMailings
+								eventId={eventDate.event_id}
+								eventDateId={eventDateId}
 							/>
 						);
 					}

--- a/fair-events/src/Admin/manage-event/mailings-api.js
+++ b/fair-events/src/Admin/manage-event/mailings-api.js
@@ -1,0 +1,116 @@
+/**
+ * REST client for scheduled per-event mailings.
+ *
+ * All calls hit fair-audience's scheduled-messages endpoints (the Mailings tab
+ * lives in fair-events but the data model is owned by fair-audience). Paths are
+ * hardcoded and start with '/' per the project's apiFetch conventions.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * List scheduled messages for an event.
+ *
+ * @param {number} eventId Event post ID.
+ * @return {Promise<Array>} Promise resolving to the message list.
+ */
+export function loadScheduledMessages(eventId) {
+	return apiFetch({
+		path: `/fair-audience/v1/events/${eventId}/scheduled-messages`,
+	});
+}
+
+/**
+ * List an event's dates for the anchor picker.
+ *
+ * @param {number} eventId Event post ID.
+ * @return {Promise<Array>} Promise resolving to the event-date list.
+ */
+export function loadEventDates(eventId) {
+	return apiFetch({
+		path: `/fair-audience/v1/events/${eventId}/event-dates`,
+	});
+}
+
+/**
+ * Create a scheduled message.
+ *
+ * @param {number} eventId Event post ID.
+ * @param {Object} data    Message payload.
+ * @return {Promise<Object>} Promise resolving to the created message.
+ */
+export function createScheduledMessage(eventId, data) {
+	return apiFetch({
+		path: `/fair-audience/v1/events/${eventId}/scheduled-messages`,
+		method: 'POST',
+		data,
+	});
+}
+
+/**
+ * Update a scheduled message (only while status=scheduled).
+ *
+ * @param {number} id   Message ID.
+ * @param {Object} data Message payload.
+ * @return {Promise<Object>} Promise resolving to the updated message.
+ */
+export function updateScheduledMessage(id, data) {
+	return apiFetch({
+		path: `/fair-audience/v1/scheduled-messages/${id}`,
+		method: 'PUT',
+		data,
+	});
+}
+
+/**
+ * Cancel a scheduled message (only while status=scheduled).
+ *
+ * @param {number} id Message ID.
+ * @return {Promise<Object>} Promise resolving to the canceled message.
+ */
+export function cancelScheduledMessage(id) {
+	return apiFetch({
+		path: `/fair-audience/v1/scheduled-messages/${id}`,
+		method: 'DELETE',
+	});
+}
+
+/**
+ * Resolve recipients for a stored message, as of now.
+ *
+ * @param {number} id Message ID.
+ * @return {Promise<Array>} Promise resolving to the recipient list.
+ */
+export function previewRecipients(id) {
+	return apiFetch({
+		path: `/fair-audience/v1/scheduled-messages/${id}/preview-recipients`,
+		method: 'POST',
+	});
+}
+
+/**
+ * Resolve recipients for an unsaved draft from a filter.
+ *
+ * @param {number} eventId          Event post ID.
+ * @param {Object} recipientsFilter Filter: { labels, group_ids, is_marketing }.
+ * @return {Promise<Array>} Promise resolving to the recipient list.
+ */
+export function previewDraftRecipients(eventId, recipientsFilter) {
+	return apiFetch({
+		path: `/fair-audience/v1/events/${eventId}/scheduled-messages/preview-recipients`,
+		method: 'POST',
+		data: { recipients_filter: recipientsFilter },
+	});
+}
+
+/**
+ * Load groups for the recipient filter.
+ *
+ * @return {Promise<Array>} Promise resolving to the group list.
+ */
+export function loadGroups() {
+	return apiFetch({ path: '/fair-audience/v1/custom-mail/groups' });
+}

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -738,6 +738,18 @@ class EventDates {
 			array( '%d' )
 		);
 
+		if ( false !== $result ) {
+			/**
+			 * Fires after an event date row is updated.
+			 *
+			 * Consumers (e.g. fair-audience scheduled mailings) recompute any
+			 * send times anchored to this date.
+			 *
+			 * @param int $id Event date row ID.
+			 */
+			do_action( 'fair_events_event_date_updated', (int) $id );
+		}
+
 		return $result !== false;
 	}
 
@@ -772,6 +784,18 @@ class EventDates {
 			array( 'id' => $id ),
 			array( '%d' )
 		);
+
+		if ( false !== $result ) {
+			/**
+			 * Fires after an event date row is deleted.
+			 *
+			 * Consumers (e.g. fair-audience scheduled mailings) cancel any
+			 * messages anchored to this date.
+			 *
+			 * @param int $id Event date row ID.
+			 */
+			do_action( 'fair_events_event_date_deleted', (int) $id );
+		}
 
 		return $result !== false;
 	}


### PR DESCRIPTION
## Summary

Scheduled per-event mailings, end to end. Organizers queue an email anchored to an event date's start/end with a signed minute offset; a recurring cron sends it once the computed time elapses. Managed from a new **Mailings** tab in the event admin.

- Closes #606
- Closes #607

## Backend (fair-audience)

- **Migration** — `wp_fair_audience_event_scheduled_messages` (table + the three indexes from #606), wired into activation and a `1.35.0` upgrade block.
- **`RecipientResolver`** — full extract of label/group/marketing filtering out of `EmailService`; preview methods and the eligibility helpers now delegate to it, so ad-hoc and scheduled sends resolve recipients identically.
- **`ScheduledMessage` model + repository** — atomic `claim_due` (per-row conditional `scheduled→sending`, so overlapping cron ticks can't double-send), `reclaim_stuck`, anchor/event lookups, cancel.
- **`ScheduledMessagesController`** — list/create/update/cancel, stored + draft `preview-recipients`, and a small `events/{id}/event-dates` read for the anchor picker. Edits/cancels gated to `status=scheduled` (409 otherwise); sale-period anchors rejected (400) until #617.
- **`ScheduledMessageScheduler`** — computes `scheduled_for` from anchor + offset in `wp_timezone()`, comparable to `current_time('mysql')`.
- **`ScheduledMessageHooks`** — single 5-min cron (reaper → claim → resolve → render → send → record counts), plus reschedule/cancel listeners on new `fair_events_event_date_updated` / `fair_events_event_date_deleted` hooks and an event-deletion cascade.
- **Shared renderer** — `EmailService::send_custom_mail_rendered` + new `{participant_name}`, `{event_name}`, `{event_date}`, `{unsubscribe_link}` placeholders.

## Frontend (fair-events)

- **Mailings tab** in `ManageEventApp` (gated on the audience integration): lists scheduled/sent/canceled/failed mailings; schedule form with subject, body editor (placeholder-insertion buttons copied from the custom-mail page), recipient label/group/marketing filters with a live count + "view list", and an anchor + offset picker that previews the send time.
- Edit / cancel act only on scheduled rows (cancel behind a confirm modal); sent/failed rows open a read-only detail view; failed rows can be duplicated.
- The form states plainly that scheduled sends drop the per-send skip list and immediate send (not hidden).

## Notes

- The issue's recipient labels map to the existing enum: UI "Registered" → `signed_up`.
- Cron-tick idempotency and reschedule-on-date-move aren't HTTP-triggerable, so they're covered by design (conditional claim / recompute) rather than the API spec — noted in the spec header.
- Changeset added (`fair-audience` + `fair-events`, minor).

## Test plan

- [x] `php -l` + phpcs clean on all changed/new PHP (pre-existing debt untouched)
- [x] Autoload + reflect all six new backend classes (namespaces, imports, cross-file refs resolve)
- [x] `npm run build` in fair-events compiles the new tab + components
- [ ] Playwright API spec `ScheduledMessagesController.api.spec.js` — not run locally (plugins inactive + no admin Application Password in this env)
- [ ] Manual: schedule a mailing, confirm live recipient count, edit/cancel, verify a sent mailing's counts and a failed mailing's error detail