### PR TITLE
Gate per-ticket-type minimum activities behind a setting

### DIFF
--- a/.changeset/gate-min-activities-setting.md
+++ b/.changeset/gate-min-activities-setting.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Hide the per-ticket-type "Min. activities" field behind a new "Per-ticket-type minimum activities" setting in the ticket Configuración panel (off by default). When the setting is off, every ticket type uses the event-wide minimum; turning it on reveals the per-type input, which still only ever raises the global.

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -45,6 +45,7 @@ export default function EventTickets({
 		show_seats_per_ticket: false,
 		activity_collaborator_discount: false,
 		minimum_activities: 0,
+		show_ticket_type_minimum_activities: false,
 	});
 	const [options, setOptions] = useState([]);
 	const [loading, setLoading] = useState(!initialData);
@@ -1285,14 +1286,15 @@ export default function EventTickets({
 															)}
 														</th>
 													)}
-													{options.length > 0 && (
-														<th>
-															{__(
-																'Min. activities',
-																'fair-events'
-															)}
-														</th>
-													)}
+													{settings.show_ticket_type_minimum_activities &&
+														options.length > 0 && (
+															<th>
+																{__(
+																	'Min. activities',
+																	'fair-events'
+																)}
+															</th>
+														)}
 													{salePeriods.map(
 														(period, pIndex) => {
 															const isContinuous =
@@ -1530,43 +1532,44 @@ export default function EventTickets({
 																	/>
 																</td>
 															)}
-															{options.length >
-																0 && (
-																<td>
-																	<TextControl
-																		type="number"
-																		min="0"
-																		placeholder="0"
-																		value={String(
-																			type.minimum_activities ||
-																				0
-																		)}
-																		onChange={(
-																			v
-																		) =>
-																			updateTicketType(
-																				tIndex,
-																				'minimum_activities',
-																				v !==
-																					''
-																					? Math.max(
-																							0,
-																							parseInt(
-																								v,
-																								10
-																							) ||
-																								0
-																					  )
-																					: 0
-																			)
-																		}
-																		help={__(
-																			'Only raises the event-wide minimum for this ticket type. Leave 0 to inherit.',
-																			'fair-events'
-																		)}
-																	/>
-																</td>
-															)}
+															{settings.show_ticket_type_minimum_activities &&
+																options.length >
+																	0 && (
+																	<td>
+																		<TextControl
+																			type="number"
+																			min="0"
+																			placeholder="0"
+																			value={String(
+																				type.minimum_activities ||
+																					0
+																			)}
+																			onChange={(
+																				v
+																			) =>
+																				updateTicketType(
+																					tIndex,
+																					'minimum_activities',
+																					v !==
+																						''
+																						? Math.max(
+																								0,
+																								parseInt(
+																									v,
+																									10
+																								) ||
+																									0
+																						  )
+																						: 0
+																				)
+																			}
+																			help={__(
+																				'Only raises the event-wide minimum for this ticket type. Leave 0 to inherit.',
+																				'fair-events'
+																			)}
+																		/>
+																	</td>
+																)}
 															{salePeriods.map(
 																(
 																	period,
@@ -1726,7 +1729,13 @@ export default function EventTickets({
 															(settings.show_seats_per_ticket
 																? 1
 																: 0) +
-															(hasGroups ? 2 : 0)
+															(hasGroups
+																? 2
+																: 0) +
+															(settings.show_ticket_type_minimum_activities &&
+															options.length > 0
+																? 1
+																: 0)
 														}
 													>
 														<Button
@@ -2372,6 +2381,26 @@ export default function EventTickets({
 									setSettings((prev) => ({
 										...prev,
 										show_seats_per_ticket: value,
+									}))
+								}
+							/>
+							<CheckboxControl
+								label={__(
+									'Per-ticket-type minimum activities',
+									'fair-events'
+								)}
+								help={__(
+									'Show a Min. activities input on each ticket type to require more activities than the event-wide minimum (it only ever raises it). When off, every ticket type uses the event-wide minimum.',
+									'fair-events'
+								)}
+								checked={
+									settings.show_ticket_type_minimum_activities
+								}
+								onChange={(value) =>
+									setSettings((prev) => ({
+										...prev,
+										show_ticket_type_minimum_activities:
+											value,
 									}))
 								}
 							/>

--- a/fair-events/src/Models/EventDateSetting.php
+++ b/fair-events/src/Models/EventDateSetting.php
@@ -66,13 +66,14 @@ class EventDateSetting {
 	 * Settings at their default value do not need a DB row.
 	 */
 	const DEFAULTS = array(
-		'continues_pricing_period'          => '1',
-		'unlimited_tickets_in_price_period' => '1',
-		'show_ticket_type_capacity'         => '0',
-		'multiple_pricing_periods'          => '0',
-		'show_seats_per_ticket'             => '0',
-		'activity_collaborator_discount'    => '0',
-		'minimum_activities'                => '0',
+		'continues_pricing_period'            => '1',
+		'unlimited_tickets_in_price_period'   => '1',
+		'show_ticket_type_capacity'           => '0',
+		'multiple_pricing_periods'            => '0',
+		'show_seats_per_ticket'               => '0',
+		'activity_collaborator_discount'      => '0',
+		'minimum_activities'                  => '0',
+		'show_ticket_type_minimum_activities' => '0',
 	);
 
 	/**


### PR DESCRIPTION
## Summary

The per-ticket-type **Min. activities** field (added in #625) is now hidden unless a new **Per-ticket-type minimum activities** toggle is enabled in the ticket Configuración panel — off by default, alongside the existing per-ticket-type capacity and seats toggles.

When the setting is off, every ticket type uses the event-wide minimum. Turning it on reveals the per-type input, which (unchanged) only ever raises the global minimum.

Refs #625

## Changes

- `EventDateSetting::DEFAULTS` — register `show_ticket_type_minimum_activities` (default `'0'`); the settings layer's allowlist requires it.
- `EventTickets.js` — new toggle in the Configuración panel; the Min. activities column header, per-type input cell, and footer colspan now all key off `settings.show_ticket_type_minimum_activities` (still also requiring the event to have activity options).

## Notes

- UI-gating only, mirroring the sibling capacity/seats toggles: any stored per-type value is preserved and still enforced server-side. The feature is brand new (unreleased), so default-off means no event silently loses a configured value.
- Changeset added (`fair-events`, patch — refines the still-unreleased #625 feature).

## Test plan

- [x] `php -l` + phpcs clean on `EventDateSetting.php`
- [x] `npm run build` in fair-events compiles
- [ ] Manual: open a ticketed event with activity options → Min. activities field hidden; enable the new toggle in Configuración → column + per-type input appear; set a value, save, reload → persists; disable → hidden again