### PR TITLE
Stack activity Name and Short name in one column

### DIFF
--- a/.changeset/activity-name-single-column.md
+++ b/.changeset/activity-name-single-column.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Stack the activity option Name and Short name inputs in a single column (one above the other) instead of two side-by-side columns, narrowing the activity options table.

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -1811,12 +1811,6 @@ export default function EventTickets({
 												</th>
 												<th>
 													{__(
-														'Short name',
-														'fair-events'
-													)}
-												</th>
-												<th>
-													{__(
 														'Price (EUR)',
 														'fair-events'
 													)}
@@ -1861,69 +1855,79 @@ export default function EventTickets({
 												return (
 													<tr key={index}>
 														<td>
-															<TextControl
-																placeholder={__(
-																	'Activity name',
-																	'fair-events'
-																)}
-																value={
-																	option.name ||
-																	''
-																}
-																onChange={(
-																	v
-																) => {
-																	const updated =
-																		[
-																			...options,
-																		];
-																	updated[
-																		index
-																	] = {
-																		...updated[
+															<VStack spacing={2}>
+																<TextControl
+																	label={__(
+																		'Name',
+																		'fair-events'
+																	)}
+																	hideLabelFromVision
+																	placeholder={__(
+																		'Activity name',
+																		'fair-events'
+																	)}
+																	value={
+																		option.name ||
+																		''
+																	}
+																	onChange={(
+																		v
+																	) => {
+																		const updated =
+																			[
+																				...options,
+																			];
+																		updated[
 																			index
-																		],
-																		name: v,
-																	};
-																	setOptions(
-																		updated
-																	);
-																}}
-																__nextHasNoMarginBottom
-															/>
-														</td>
-														<td>
-															<TextControl
-																placeholder={__(
-																	'Short name',
-																	'fair-events'
-																)}
-																value={
-																	option.short_name ||
-																	''
-																}
-																onChange={(
-																	v
-																) => {
-																	const updated =
-																		[
-																			...options,
-																		];
-																	updated[
-																		index
-																	] = {
-																		...updated[
+																		] = {
+																			...updated[
+																				index
+																			],
+																			name: v,
+																		};
+																		setOptions(
+																			updated
+																		);
+																	}}
+																	__nextHasNoMarginBottom
+																/>
+																<TextControl
+																	label={__(
+																		'Short name',
+																		'fair-events'
+																	)}
+																	hideLabelFromVision
+																	placeholder={__(
+																		'Short name',
+																		'fair-events'
+																	)}
+																	value={
+																		option.short_name ||
+																		''
+																	}
+																	onChange={(
+																		v
+																	) => {
+																		const updated =
+																			[
+																				...options,
+																			];
+																		updated[
 																			index
-																		],
-																		short_name:
-																			v,
-																	};
-																	setOptions(
-																		updated
-																	);
-																}}
-																__nextHasNoMarginBottom
-															/>
+																		] = {
+																			...updated[
+																				index
+																			],
+																			short_name:
+																				v,
+																		};
+																		setOptions(
+																			updated
+																		);
+																	}}
+																	__nextHasNoMarginBottom
+																/>
+															</VStack>
 														</td>
 														<td>
 															<TextControl


### PR DESCRIPTION
## Summary

In the activity options table, the **Name** and **Short name** inputs were two side-by-side columns. They're now a single column with the inputs stacked (Name above Short name), narrowing the table and grouping the two related fields — matching the requested layout.

## Changes

- `EventTickets.js` — drop the separate "Short name" column header; render both `TextControl`s in one `<td>` inside a `VStack`. Each input keeps an accessible label via `hideLabelFromVision` (placeholders unchanged), so screen readers still distinguish them once the placeholder is gone.

## Test plan

- [x] `npm run build` in fair-events compiles
- [ ] Manual: open a ticketed event with activity options → Name and Short name appear stacked in one column; both edit and save correctly