### PR TITLE
Let signed-up users add activities to their subscription

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -258,6 +258,47 @@ class EventSignupController extends WP_REST_Controller {
 			)
 		);
 
+		// POST /fair-audience/v1/event-signup/add-activities
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/add-activities',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'add_activities' ),
+					'permission_callback' => array( $this, 'create_signup_permissions_check' ),
+					'args'                => array(
+						'event_id'          => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+						'event_date_id'     => array(
+							'type'              => 'integer',
+							'required'          => false,
+							'sanitize_callback' => 'absint',
+						),
+						'ticket_option_ids' => array(
+							'type'     => 'array',
+							'required' => true,
+							'items'    => array( 'type' => 'integer' ),
+						),
+						'participant_token' => array(
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'invitation_token'  => array(
+							'type'              => 'string',
+							'required'          => false,
+							'default'           => '',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+
 		// POST /fair-audience/v1/event-signup/register
 		register_rest_route(
 			$this->namespace,
@@ -577,6 +618,252 @@ class EventSignupController extends WP_REST_Controller {
 				'success' => true,
 				'message' => __( 'You have successfully signed up for the event!', 'fair-audience' ),
 				'status'  => 'signed_up',
+			)
+		);
+	}
+
+	/**
+	 * Add one or more activity options to an existing (already signed-up)
+	 * subscription. Free additions attach immediately; priced additions route
+	 * the buyer through payment for just the delta and only attach on success
+	 * (see PaymentHooks::handle_activities_added_paid).
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	public function add_activities( $request ) {
+		$event_id          = $request->get_param( 'event_id' );
+		$participant_token = $request->get_param( 'participant_token' );
+		$invitation_token  = $request->get_param( 'invitation_token' ) ?: '';
+		$user_id           = get_current_user_id();
+		$raw_option_ids    = $request->get_param( 'ticket_option_ids' ) ?: array();
+
+		// Validate event exists.
+		$event = get_post( $event_id );
+		if ( ! $event || ! \FairEvents\Database\EventRepository::is_event( $event ) ) {
+			return new WP_Error(
+				'invalid_event',
+				__( 'Event not found.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Resolve event_date_id.
+		$event_date_id = $request->get_param( 'event_date_id' ) ?: 0;
+		if ( empty( $event_date_id ) && class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_dates_obj = \FairEvents\Models\EventDates::get_by_event_id( $event_id );
+			if ( $event_dates_obj ) {
+				$event_date_id = (int) $event_dates_obj->id;
+			}
+		}
+
+		// Resolve participant from token or logged-in user.
+		$participant = null;
+		if ( ! empty( $participant_token ) ) {
+			$token_data = ParticipantToken::verify( $participant_token );
+			if ( $token_data ) {
+				$participant = $this->participant_repository->get_by_id( $token_data['participant_id'] );
+			}
+		} elseif ( $user_id ) {
+			$participant = $this->participant_repository->get_by_user_id( $user_id );
+		}
+
+		if ( ! $participant ) {
+			return new WP_Error(
+				'no_participant',
+				__( 'Could not find your participant profile.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// The subscription must already exist and be signed up — adding
+		// activities to a non-existent or pending signup is out of scope.
+		if ( $event_date_id ) {
+			$existing = $this->event_participant_repository->get_by_event_date_and_participant(
+				$event_date_id,
+				$participant->id
+			);
+		} else {
+			$existing = $this->event_participant_repository->get_by_event_and_participant(
+				$event_id,
+				$participant->id
+			);
+		}
+
+		if ( ! $existing || 'signed_up' !== $existing->label ) {
+			return new WP_Error(
+				'not_signed_up',
+				__( 'You need an active signup before you can add activities.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Validate the requested options (exist for the event date, have capacity).
+		$requested = $this->load_valid_options( $event_date_id, $raw_option_ids );
+
+		// Drop options already on the subscription — the duplicate-add guard.
+		$already_ids = $this->event_participant_repository->get_option_ids_for_event_participant( (int) $existing->id );
+		$new_options = array_values(
+			array_filter(
+				$requested,
+				static function ( $opt ) use ( $already_ids ) {
+					return ! in_array( (int) $opt->id, $already_ids, true );
+				}
+			)
+		);
+
+		if ( empty( $new_options ) ) {
+			return new WP_Error(
+				'no_new_activities',
+				__( 'No new activities to add.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$paid_response = $this->maybe_start_addon_payment( $event_id, $event_date_id, $participant, $existing, $user_id, $new_options, $invitation_token );
+		if ( null !== $paid_response ) {
+			if ( ! is_wp_error( $paid_response ) ) {
+				AudienceSession::set( (int) $participant->id );
+			}
+			return $paid_response;
+		}
+
+		// Free path: attach immediately and notify.
+		$this->save_participant_options( (int) $existing->id, $new_options );
+
+		$new_option_ids = array_map( static fn( $opt ) => (int) $opt->id, $new_options );
+		do_action( 'fair_audience_event_activities_added', $existing, null, $new_option_ids );
+
+		AudienceSession::set( (int) $participant->id );
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'status'  => 'activities_added',
+				'message' => __( 'Your activities have been added!', 'fair-audience' ),
+			)
+		);
+	}
+
+	/**
+	 * Start the paid flow for added activities when the new options carry a
+	 * positive total. Returns null for the free path so the caller can attach
+	 * immediately.
+	 *
+	 * Unlike maybe_start_paid_signup, this never mutates the existing
+	 * (signed_up) row: the subscription stays valid regardless of whether the
+	 * add-on payment succeeds. The selected option IDs ride along on the
+	 * transaction metadata; PaymentHooks attaches them only once Mollie
+	 * confirms the payment.
+	 *
+	 * @param int                                   $event_id          Event post ID.
+	 * @param int                                   $event_date_id     Event date ID.
+	 * @param \FairAudience\Models\Participant      $participant       Participant adding activities.
+	 * @param \FairAudience\Models\EventParticipant $event_participant Existing signed-up row.
+	 * @param int                                   $user_id           Current WP user ID (0 for anonymous).
+	 * @param array                                 $new_options       New TicketOption objects to add.
+	 * @param string                                $invitation_token  Optional invitation token.
+	 * @return \WP_REST_Response|\WP_Error|null Response/error on paid path, null on free path.
+	 */
+	private function maybe_start_addon_payment( $event_id, $event_date_id, $participant, $event_participant, $user_id, $new_options, $invitation_token = '' ) {
+		$best_discount_rule = null;
+		if ( $event_date_id && class_exists( \FairEvents\Services\EventSignupPricing::class ) ) {
+			$best_discount_rule = \FairEvents\Services\EventSignupPricing::resolve_best_discount_rule(
+				$event_date_id,
+				$participant->id
+			);
+		}
+
+		$invitation_inviter_id = $this->resolve_invitation_inviter_id( $invitation_token, $event_date_id );
+
+		$line_items   = array();
+		$total_amount = 0;
+		foreach ( $new_options as $opt ) {
+			$opt_price     = $this->compute_option_price( $opt, $event_date_id, $invitation_inviter_id, $best_discount_rule );
+			$total_amount += $opt_price;
+			if ( 0.0 !== (float) $opt_price ) {
+				$line_items[] = array(
+					'name'     => $opt->name,
+					'quantity' => 1,
+					'amount'   => $opt_price,
+				);
+			}
+		}
+
+		if ( $total_amount <= 0 ) {
+			return null;
+		}
+
+		if ( ! class_exists( \FairPayment\API\TransactionAPI::class ) ) {
+			return new WP_Error(
+				'payment_unavailable',
+				__( 'Paid activities are not available because the payment plugin is missing.', 'fair-audience' ),
+				array( 'status' => 503 )
+			);
+		}
+
+		$description = sprintf(
+			/* translators: %s: event title */
+			__( 'Added activities for %s', 'fair-audience' ),
+			get_the_title( $event_id )
+		);
+
+		$new_option_ids = array_map( static fn( $opt ) => (int) $opt->id, $new_options );
+
+		$transaction_id = \FairPayment\API\TransactionAPI::create_transaction(
+			$line_items,
+			array(
+				'currency'      => 'EUR',
+				'description'   => $description,
+				'post_id'       => $event_id,
+				'event_date_id' => $event_date_id,
+				'user_id'       => $user_id ? $user_id : null,
+				'metadata'      => array(
+					'source'               => 'fair-audience-activity-addon',
+					'event_date_id'        => $event_date_id,
+					'event_participant_id' => (int) $event_participant->id,
+					'participant_id'       => (int) $participant->id,
+					'ticket_option_ids'    => $new_option_ids,
+				),
+			)
+		);
+
+		if ( is_wp_error( $transaction_id ) ) {
+			return $transaction_id;
+		}
+
+		$redirect_url = add_query_arg(
+			array(
+				'fair_payment_callback' => 'true',
+				'fair_signup_tx'        => $transaction_id,
+				'fst_sig'               => \FairAudience\Services\TransactionAccessToken::generate(
+					(int) $transaction_id,
+					(int) $participant->id
+				),
+			),
+			get_permalink( $event_id )
+		);
+
+		$payment = \FairPayment\API\TransactionAPI::initiate_payment(
+			$transaction_id,
+			array(
+				'redirect_url' => $redirect_url,
+			)
+		);
+
+		if ( is_wp_error( $payment ) ) {
+			return $payment;
+		}
+
+		return rest_ensure_response(
+			array(
+				'success'        => true,
+				'status'         => 'payment_required',
+				'message'        => __( 'Redirecting to payment…', 'fair-audience' ),
+				'checkout_url'   => $payment['checkout_url'],
+				'transaction_id' => $transaction_id,
+				'amount'         => $total_amount,
+				'currency'       => 'EUR',
 			)
 		);
 	}
@@ -932,32 +1219,12 @@ class EventSignupController extends WP_REST_Controller {
 	/**
 	 * Insert rows into fair_audience_event_participant_options.
 	 *
-	 * phpcs:disable WordPress.DB.DirectDatabaseQuery
-	 *
 	 * @param int   $event_participant_id Event participant record ID.
 	 * @param array $option_items         Array of TicketOption objects.
 	 * @return void
 	 */
 	private function save_participant_options( $event_participant_id, $option_items ) {
-		global $wpdb;
-
-		if ( empty( $option_items ) ) {
-			return;
-		}
-
-		$table_name = $wpdb->prefix . 'fair_audience_event_participant_options';
-
-		foreach ( $option_items as $option ) {
-			$wpdb->replace(
-				$table_name,
-				array(
-					'event_participant_id' => $event_participant_id,
-					'ticket_option_id'     => $option->id,
-					'ticket_option_name'   => $option->name,
-				),
-				array( '%d', '%d', '%s' )
-			);
-		}
+		$this->event_participant_repository->add_options( $event_participant_id, $option_items );
 	}
 
 	/**
@@ -1360,7 +1627,16 @@ class EventSignupController extends WP_REST_Controller {
 		}
 
 		$metadata = ! empty( $old_transaction->metadata ) ? json_decode( $old_transaction->metadata, true ) : array();
-		if ( empty( $metadata['source'] ) || 'fair-audience-signup' !== $metadata['source'] ) {
+		$source   = $metadata['source'] ?? '';
+
+		// Added-activities add-ons retry along a separate path: the base signup
+		// row must not be touched, so they don't go through the row-mutation
+		// logic below.
+		if ( 'fair-audience-activity-addon' === $source ) {
+			return $this->retry_addon_payment( $old_transaction, $metadata );
+		}
+
+		if ( 'fair-audience-signup' !== $source ) {
 			return new WP_Error(
 				'invalid_retry_source',
 				__( 'This payment is not retriable from this endpoint.', 'fair-audience' ),
@@ -1515,6 +1791,147 @@ class EventSignupController extends WP_REST_Controller {
 
 		$event_participant->transaction_id = (int) $new_transaction_id;
 		$event_participant->save();
+
+		$redirect_url = add_query_arg(
+			array(
+				'fair_payment_callback' => 'true',
+				'fair_signup_tx'        => $new_transaction_id,
+				'fst_sig'               => \FairAudience\Services\TransactionAccessToken::generate(
+					(int) $new_transaction_id,
+					(int) $participant_id
+				),
+			),
+			get_permalink( $event_id )
+		);
+
+		$payment = \FairPayment\API\TransactionAPI::initiate_payment(
+			$new_transaction_id,
+			array(
+				'redirect_url' => $redirect_url,
+			)
+		);
+
+		if ( is_wp_error( $payment ) ) {
+			return $payment;
+		}
+
+		return rest_ensure_response(
+			array(
+				'success'        => true,
+				'status'         => 'payment_required',
+				'message'        => __( 'Redirecting to payment…', 'fair-audience' ),
+				'checkout_url'   => $payment['checkout_url'],
+				'transaction_id' => (int) $new_transaction_id,
+				'amount'         => $old_transaction->amount,
+				'currency'       => $old_transaction->currency,
+			)
+		);
+	}
+
+	/**
+	 * Retry a failed added-activities (add-on) payment. Mirrors the original
+	 * line items into a fresh transaction without touching the still-valid
+	 * signed_up row. The activities only attach once Mollie confirms (see
+	 * PaymentHooks::handle_activities_added_paid), so a previously failed
+	 * attempt left nothing attached.
+	 *
+	 * @param object $old_transaction The failed/expired add-on transaction.
+	 * @param array  $metadata        Decoded metadata from the old transaction.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	private function retry_addon_payment( $old_transaction, $metadata ) {
+		$transaction_id       = (int) $old_transaction->id;
+		$event_id             = isset( $metadata['post_id'] ) ? (int) $metadata['post_id'] : (int) $old_transaction->post_id;
+		$event_date_id        = isset( $metadata['event_date_id'] ) ? (int) $metadata['event_date_id'] : (int) $old_transaction->event_date_id;
+		$participant_id       = isset( $metadata['participant_id'] ) ? (int) $metadata['participant_id'] : (int) $old_transaction->participant_id;
+		$event_participant_id = isset( $metadata['event_participant_id'] ) ? (int) $metadata['event_participant_id'] : 0;
+		$option_ids           = isset( $metadata['ticket_option_ids'] ) && is_array( $metadata['ticket_option_ids'] )
+			? array_map( 'intval', $metadata['ticket_option_ids'] )
+			: array();
+		$user_id              = isset( $old_transaction->user_id ) ? (int) $old_transaction->user_id : 0;
+
+		if ( ! $event_id || ! $participant_id || ! $event_participant_id || empty( $option_ids ) ) {
+			return new WP_Error(
+				'invalid_retry_state',
+				__( 'This payment is missing context needed to retry.', 'fair-audience' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$event = get_post( $event_id );
+		if ( ! $event ) {
+			return new WP_Error(
+				'invalid_event',
+				__( 'Event not found.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$event_participant = $this->event_participant_repository->get_by_id( $event_participant_id );
+		if ( ! $event_participant || 'signed_up' !== $event_participant->label ) {
+			return new WP_Error(
+				'not_signed_up',
+				__( 'Your signup is no longer active.', 'fair-audience' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		// Already attached (e.g. the original payment landed after all)? Nothing
+		// to retry.
+		$already_ids   = $this->event_participant_repository->get_option_ids_for_event_participant( $event_participant_id );
+		$remaining_ids = array_values( array_diff( $option_ids, $already_ids ) );
+		if ( empty( $remaining_ids ) ) {
+			return rest_ensure_response(
+				array(
+					'success' => true,
+					'status'  => 'activities_added',
+					'message' => __( 'These activities are already on your signup.', 'fair-audience' ),
+				)
+			);
+		}
+
+		// Rebuild line items from the original transaction so the retry charges
+		// exactly what the buyer agreed to.
+		$old_line_items = \FairPayment\Models\LineItem::get_by_transaction_id( $transaction_id );
+		if ( empty( $old_line_items ) ) {
+			return new WP_Error(
+				'invalid_retry_state',
+				__( 'Original line items could not be loaded.', 'fair-audience' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$line_items = array();
+		foreach ( $old_line_items as $li ) {
+			$line_items[] = array(
+				'name'     => (string) $li->name,
+				'quantity' => isset( $li->quantity ) ? (int) $li->quantity : 1,
+				'amount'   => (float) $li->unit_amount,
+			);
+		}
+
+		$new_transaction_id = \FairPayment\API\TransactionAPI::create_transaction(
+			$line_items,
+			array(
+				'currency'      => $old_transaction->currency,
+				'description'   => $old_transaction->description,
+				'post_id'       => $event_id,
+				'event_date_id' => $event_date_id,
+				'user_id'       => $user_id ? $user_id : null,
+				'metadata'      => array(
+					'source'                  => 'fair-audience-activity-addon',
+					'event_date_id'           => $event_date_id,
+					'event_participant_id'    => $event_participant_id,
+					'participant_id'          => $participant_id,
+					'ticket_option_ids'       => $option_ids,
+					'retry_of_transaction_id' => $transaction_id,
+				),
+			)
+		);
+
+		if ( is_wp_error( $new_transaction_id ) ) {
+			return $new_transaction_id;
+		}
 
 		$redirect_url = add_query_arg(
 			array(

--- a/fair-audience/src/API/__tests__/EventSignupAddActivities.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupAddActivities.api.spec.js
@@ -1,0 +1,217 @@
+/**
+ * Playwright API tests for the add-activities endpoint on EventSignupController
+ * (issue #611): POST /fair-audience/v1/event-signup/add-activities.
+ *
+ * The endpoint resolves the acting participant from the logged-in user, so the
+ * suite links a participant to the admin WP user (Application Password creds)
+ * and tears it down afterwards. A free (price 0) activity is used so the happy
+ * path attaches immediately without routing through Mollie — the paid delta
+ * flow is covered by manual verification.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+async function createEvent(api, title) {
+	const res = await api.post('/wp-json/wp/v2/fair_event', {
+		headers: authHeaders,
+		data: { title, status: 'publish' },
+	});
+	expect(res.ok()).toBeTruthy();
+	const eventId = (await res.json()).id;
+
+	const eventsRes = await api.get('/wp-json/fair-audience/v1/events', {
+		headers: authHeaders,
+		params: { per_page: 100 },
+	});
+	expect(eventsRes.ok()).toBeTruthy();
+	const match = (await eventsRes.json()).find((e) => e.event_id === eventId);
+	expect(match, 'event-date row for the test event').toBeTruthy();
+	return { eventId, eventDateId: match.event_date_id };
+}
+
+test.describe('EventSignupController add-activities', () => {
+	let api;
+	let adminUserId;
+	let participantId;
+	let signedUpEvent;
+	let otherEvent;
+	let freeOptionId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const meRes = await api.get('/wp-json/wp/v2/users/me', {
+			headers: authHeaders,
+		});
+		expect(meRes.ok()).toBeTruthy();
+		adminUserId = (await meRes.json()).id;
+
+		// Participant linked to the admin user so the add-activities endpoint
+		// resolves to it from the logged-in session.
+		const partRes = await api.post(
+			'/wp-json/fair-audience/v1/participants',
+			{
+				headers: authHeaders,
+				data: {
+					name: 'Add Activities Tester',
+					email: uniqueEmail('add-activities'),
+					wp_user_id: adminUserId,
+				},
+			}
+		);
+		expect(
+			partRes.ok(),
+			'admin must not be pre-linked to a participant'
+		).toBeTruthy();
+		participantId = (await partRes.json()).id;
+
+		signedUpEvent = await createEvent(
+			api,
+			`Add Activities Signed ${Date.now()}`
+		);
+		otherEvent = await createEvent(
+			api,
+			`Add Activities Other ${Date.now()}`
+		);
+
+		// Sign the participant up for the first event.
+		const linkRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${signedUpEvent.eventDateId}/participants/batch`,
+			{
+				headers: authHeaders,
+				data: { participant_ids: [participantId], label: 'signed_up' },
+			}
+		);
+		expect(linkRes.ok()).toBeTruthy();
+
+		// Add a free activity option on the signed-up event date.
+		const ticketsRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${signedUpEvent.eventDateId}/tickets`,
+			{
+				headers: authHeaders,
+				data: { options: [{ name: 'Free Workshop', price: 0 }] },
+			}
+		);
+		expect(ticketsRes.ok()).toBeTruthy();
+		const config = await ticketsRes.json();
+		const option = (config.options || []).find(
+			(o) => o.name === 'Free Workshop'
+		);
+		expect(option, 'created free option').toBeTruthy();
+		freeOptionId = option.id;
+	});
+
+	test.afterAll(async () => {
+		if (participantId) {
+			await api.delete(
+				`/wp-json/fair-audience/v1/participants/${participantId}`,
+				{ headers: authHeaders }
+			);
+		}
+		for (const ev of [signedUpEvent, otherEvent]) {
+			if (ev?.eventId) {
+				await api.delete(`/wp-json/wp/v2/fair_event/${ev.eventId}`, {
+					headers: authHeaders,
+					params: { force: 'true' },
+				});
+			}
+		}
+		await api.dispose();
+	});
+
+	test('unauthenticated request is rejected', async () => {
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/event-signup/add-activities',
+			{
+				data: {
+					event_id: signedUpEvent.eventId,
+					ticket_option_ids: [freeOptionId],
+				},
+			}
+		);
+		expect(res.status()).toBe(401);
+	});
+
+	test('unknown event returns 404', async () => {
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/event-signup/add-activities',
+			{
+				headers: authHeaders,
+				data: { event_id: 99999999, ticket_option_ids: [freeOptionId] },
+			}
+		);
+		expect(res.status()).toBe(404);
+	});
+
+	test('adding to an event the participant is not signed up for is rejected', async () => {
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/event-signup/add-activities',
+			{
+				headers: authHeaders,
+				data: {
+					event_id: otherEvent.eventId,
+					ticket_option_ids: [freeOptionId],
+				},
+			}
+		);
+		expect(res.status()).toBe(400);
+		expect((await res.json()).code).toBe('not_signed_up');
+	});
+
+	test('free activity is added immediately and reflected on the subscription', async () => {
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/event-signup/add-activities',
+			{
+				headers: authHeaders,
+				data: {
+					event_id: signedUpEvent.eventId,
+					ticket_option_ids: [freeOptionId],
+				},
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		expect((await res.json()).status).toBe('activities_added');
+
+		const listRes = await api.get(
+			`/wp-json/fair-audience/v1/event-dates/${signedUpEvent.eventDateId}/participants`,
+			{ headers: authHeaders }
+		);
+		expect(listRes.ok()).toBeTruthy();
+		const row = (await listRes.json()).find(
+			(p) => p.participant_id === participantId
+		);
+		expect(row).toBeTruthy();
+		expect(row.ticket_option_ids).toContain(freeOptionId);
+	});
+
+	test('re-adding the same activity is rejected by the duplicate guard', async () => {
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/event-signup/add-activities',
+			{
+				headers: authHeaders,
+				data: {
+					event_id: signedUpEvent.eventId,
+					ticket_option_ids: [freeOptionId],
+				},
+			}
+		);
+		expect(res.status()).toBe(400);
+		expect((await res.json()).code).toBe('no_new_activities');
+	});
+});

--- a/fair-audience/src/Database/EventParticipantRepository.php
+++ b/fair-audience/src/Database/EventParticipantRepository.php
@@ -430,6 +430,84 @@ class EventParticipantRepository {
 	}
 
 	/**
+	 * Find an event participant row by its primary key.
+	 *
+	 * @param int $id Event participant row ID.
+	 * @return EventParticipant|null Relationship or null.
+	 */
+	public function get_by_id( $id ) {
+		global $wpdb;
+
+		$result = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE id = %d LIMIT 1',
+				$this->get_table_name(),
+				$id
+			),
+			ARRAY_A
+		);
+
+		return $result ? new EventParticipant( $result ) : null;
+	}
+
+	/**
+	 * Get the ticket option IDs currently attached to an event participant.
+	 *
+	 * @param int $event_participant_id Event participant row ID.
+	 * @return int[] Attached ticket option IDs.
+	 */
+	public function get_option_ids_for_event_participant( $event_participant_id ) {
+		global $wpdb;
+
+		$options_table = $wpdb->prefix . 'fair_audience_event_participant_options';
+
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				'SELECT ticket_option_id FROM %i WHERE event_participant_id = %d',
+				$options_table,
+				$event_participant_id
+			)
+		);
+
+		return array_map( 'intval', (array) $ids );
+	}
+
+	/**
+	 * Attach ticket options to an event participant. Idempotent: uses REPLACE
+	 * so re-attaching an existing option only refreshes its snapshotted name.
+	 *
+	 * @param int   $event_participant_id Event participant row ID.
+	 * @param array $options              Array of objects/arrays with `id` and `name`.
+	 * @return void
+	 */
+	public function add_options( $event_participant_id, $options ) {
+		global $wpdb;
+
+		if ( empty( $options ) ) {
+			return;
+		}
+
+		$options_table = $wpdb->prefix . 'fair_audience_event_participant_options';
+
+		foreach ( $options as $option ) {
+			$option_id   = is_array( $option ) ? ( $option['id'] ?? 0 ) : ( $option->id ?? 0 );
+			$option_name = is_array( $option ) ? ( $option['name'] ?? '' ) : ( $option->name ?? '' );
+			if ( ! $option_id ) {
+				continue;
+			}
+			$wpdb->replace(
+				$options_table,
+				array(
+					'event_participant_id' => (int) $event_participant_id,
+					'ticket_option_id'     => (int) $option_id,
+					'ticket_option_name'   => (string) $option_name,
+				),
+				array( '%d', '%d', '%s' )
+			);
+		}
+	}
+
+	/**
 	 * Delete pending_payment rows whose payment_expires_at has passed.
 	 *
 	 * @return int Number of rows deleted.

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -30,9 +30,11 @@ class PaymentHooks {
 		add_action( 'fair_payment_failed', array( static::class, 'handle_payment_failed' ), 10, 2 );
 		add_action( 'fair_payment_paid', array( static::class, 'handle_signup_paid' ), 10, 2 );
 		add_action( 'fair_payment_failed', array( static::class, 'handle_signup_failed' ), 10, 2 );
+		add_action( 'fair_payment_paid', array( static::class, 'handle_activities_added_paid' ), 10, 2 );
 
 		add_action( 'fair_audience_event_signup_paid', array( static::class, 'send_signup_confirmation_email' ), 10, 2 );
 		add_action( 'fair_audience_event_signup_failed', array( static::class, 'send_signup_payment_failed_email' ), 10, 2 );
+		add_action( 'fair_audience_event_activities_added', array( static::class, 'send_activities_added_email' ), 10, 3 );
 
 		add_filter( 'fair_payment_resolve_participant_id', array( static::class, 'resolve_participant_id' ), 10, 2 );
 		add_filter( 'fair_payment_prepare_participant', array( static::class, 'prepare_participant' ), 10, 2 );
@@ -452,6 +454,98 @@ class PaymentHooks {
 	}
 
 	/**
+	 * Attach added activities to an existing signed-up subscription once Mollie
+	 * confirms the add-on payment. The base signup row is never touched: a
+	 * failed add-on simply leaves nothing attached.
+	 *
+	 * Idempotent — Mollie retries the webhook, so a per-transaction transient
+	 * guards against attaching (and emailing) twice.
+	 *
+	 * @param object $payment     Mollie payment object.
+	 * @param object $transaction Transaction row from fair-payment.
+	 */
+	public static function handle_activities_added_paid( $payment, $transaction ) {
+		$metadata = ! empty( $transaction->metadata ) ? json_decode( $transaction->metadata, true ) : array();
+		if ( empty( $metadata['source'] ) || 'fair-audience-activity-addon' !== $metadata['source'] ) {
+			return;
+		}
+
+		$dedupe_key = 'fair_audience_activities_added_' . (int) $transaction->id;
+		if ( get_transient( $dedupe_key ) ) {
+			return;
+		}
+
+		$event_participant_id = isset( $metadata['event_participant_id'] ) ? (int) $metadata['event_participant_id'] : 0;
+		$option_ids           = isset( $metadata['ticket_option_ids'] ) && is_array( $metadata['ticket_option_ids'] )
+			? array_map( 'intval', $metadata['ticket_option_ids'] )
+			: array();
+
+		if ( ! $event_participant_id || empty( $option_ids ) ) {
+			return;
+		}
+
+		$repo              = new EventParticipantRepository();
+		$event_participant = $repo->get_by_id( $event_participant_id );
+		if ( ! $event_participant || 'signed_up' !== $event_participant->label ) {
+			return;
+		}
+
+		// Resolve option names from the live ticket_options table, keyed by id.
+		$options = self::resolve_option_rows( $option_ids );
+		if ( empty( $options ) ) {
+			return;
+		}
+
+		set_transient( $dedupe_key, 1, DAY_IN_SECONDS );
+
+		$repo->add_options( $event_participant_id, $options );
+
+		do_action( 'fair_audience_event_activities_added', $event_participant, $transaction, $option_ids );
+	}
+
+	/**
+	 * Load ticket option id + name rows for the given IDs, preserving order.
+	 *
+	 * @param int[] $option_ids Ticket option IDs.
+	 * @return array[] Array of [ 'id' => int, 'name' => string ].
+	 */
+	private static function resolve_option_rows( $option_ids ) {
+		global $wpdb;
+
+		$option_ids = array_values( array_filter( array_map( 'intval', $option_ids ) ) );
+		if ( empty( $option_ids ) ) {
+			return array();
+		}
+
+		$placeholders = implode( ', ', array_fill( 0, count( $option_ids ), '%d' ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT id, name FROM {$wpdb->prefix}fair_events_ticket_options WHERE id IN ( $placeholders )",
+				...$option_ids
+			)
+		);
+
+		$names_by_id = array();
+		foreach ( (array) $rows as $row ) {
+			$names_by_id[ (int) $row->id ] = (string) $row->name;
+		}
+
+		$options = array();
+		foreach ( $option_ids as $id ) {
+			if ( isset( $names_by_id[ $id ] ) ) {
+				$options[] = array(
+					'id'   => $id,
+					'name' => $names_by_id[ $id ],
+				);
+			}
+		}
+
+		return $options;
+	}
+
+	/**
 	 * Send confirmation email to buyer after paid event signup.
 	 *
 	 * @param object $event_participant EventParticipant row.
@@ -486,6 +580,34 @@ class PaymentHooks {
 
 		$email_service = new EmailService();
 		$email_service->send_signup_payment_confirmation( $participant, $event, $transaction, $option_names );
+	}
+
+	/**
+	 * Send a confirmation email after activities are added to an existing
+	 * subscription. Lists only the newly added activities.
+	 *
+	 * @param object      $event_participant EventParticipant row.
+	 * @param object|null $transaction      Transaction row (null for free adds).
+	 * @param int[]       $added_option_ids  IDs of the activities that were added.
+	 */
+	public static function send_activities_added_email( $event_participant, $transaction, $added_option_ids ) {
+		$participant_repo = new ParticipantRepository();
+		$participant      = $participant_repo->get_by_id( (int) $event_participant->participant_id );
+
+		if ( ! $participant ) {
+			return;
+		}
+
+		$event = get_post( $event_participant->event_id );
+		if ( ! $event ) {
+			return;
+		}
+
+		$option_rows = self::resolve_option_rows( (array) $added_option_ids );
+		$added_names = array_map( static fn( $row ) => $row['name'], $option_rows );
+
+		$email_service = new EmailService();
+		$email_service->send_activities_added_confirmation( $participant, $event, $transaction, $added_names );
 	}
 
 	/**

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -2244,6 +2244,142 @@ class EmailService {
 	}
 
 	/**
+	 * Send a confirmation email after activities are added to an existing
+	 * subscription. Lists the newly added activities and (for paid adds) the
+	 * amount paid for them.
+	 *
+	 * @param Participant   $participant       Participant who added activities.
+	 * @param \WP_Post|null $event             Event post object (nullable).
+	 * @param object|null   $transaction       Transaction row (null for free adds).
+	 * @param array         $added_option_names Names of the activities that were added.
+	 * @return bool Success.
+	 */
+	public function send_activities_added_confirmation( Participant $participant, $event, $transaction = null, $added_option_names = array() ): bool {
+		if ( ! $this->has_valid_email( $participant ) ) {
+			return false;
+		}
+
+		$site_name   = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+		$event_title = $event ? $event->post_title : __( 'Event', 'fair-audience' );
+
+		$subject = sprintf(
+			/* translators: %s: event title */
+			__( 'Activities added — %s', 'fair-audience' ),
+			$event_title
+		);
+
+		$amount   = isset( $transaction->amount ) ? (float) $transaction->amount : 0;
+		$currency = ! empty( $transaction->currency ) ? $transaction->currency : 'EUR';
+
+		$payment_html = '';
+		if ( $amount > 0 ) {
+			$payment_html = '
+							<table style="width: 100%; border-collapse: collapse; margin: 0 0 20px 0;">
+								<tr>
+									<td style="padding: 8px 0; border-bottom: 1px solid #eee; font-weight: bold;">' . esc_html__( 'Amount paid:', 'fair-audience' ) . '</td>
+									<td style="padding: 8px 0; border-bottom: 1px solid #eee;">' . esc_html( number_format( $amount, 2 ) . ' ' . $currency ) . '</td>
+								</tr>
+							</table>';
+		}
+
+		$options_html = '';
+		if ( ! empty( $added_option_names ) ) {
+			$options_list = '';
+			foreach ( $added_option_names as $name ) {
+				$options_list .= '<li style="padding: 4px 0;">' . esc_html( $name ) . '</li>';
+			}
+			$options_html = '
+							<p style="margin: 0 0 8px 0; font-size: 16px; font-weight: bold;">' . esc_html__( 'Activities added:', 'fair-audience' ) . '</p>
+							<ul style="margin: 0 0 20px 20px; padding: 0;">' . $options_list . '</ul>';
+		}
+
+		$message = '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #333333; background-color: #f4f4f4;">
+	<table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f4;">
+		<tr>
+			<td align="center" style="padding: 20px 0;">
+				<table width="600" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+					<!-- Header -->
+					<tr>
+						<td style="background-color: #0073aa; color: #ffffff; padding: 30px; border-radius: 8px 8px 0 0; text-align: center;">
+							<h1 style="margin: 0; font-size: 24px; font-weight: bold;">' . esc_html( $event_title ) . '</h1>
+						</td>
+					</tr>
+
+					<!-- Content -->
+					<tr>
+						<td style="padding: 40px 30px;">
+							<p style="margin: 0 0 20px 0; font-size: 16px;">
+								' . sprintf(
+									/* translators: %s: participant first name */
+								esc_html__( 'Hi %s,', 'fair-audience' ),
+								'<strong>' . esc_html( $participant->name ) . '</strong>'
+							) . '
+							</p>
+
+							<p style="margin: 0 0 20px 0; font-size: 16px;">
+								' . sprintf(
+									/* translators: %s: event title */
+								esc_html__( 'The following activities have been added to your signup for %s.', 'fair-audience' ),
+								'<strong>' . esc_html( $event_title ) . '</strong>'
+							) . '
+							</p>
+
+							' . $options_html . '
+
+							' . $payment_html . '
+
+							<p style="margin: 20px 0 0 0; font-size: 14px; color: #666666;">
+								' . sprintf(
+									/* translators: 1: line break, 2: site name */
+								esc_html__( 'See you there!%1$sThe %2$s Team', 'fair-audience' ),
+								'<br>',
+								esc_html( $site_name )
+							) . '
+							</p>
+						</td>
+					</tr>
+
+					<!-- Footer -->
+					<tr>
+						<td style="background-color: #f8f8f8; padding: 20px 30px; border-radius: 0 0 8px 8px; text-align: center; font-size: 12px; color: #666666;">
+							<p style="margin: 0;">
+								' . esc_html( $site_name ) . '
+							</p>
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+</body>
+</html>';
+
+		add_filter(
+			'wp_mail_content_type',
+			function () {
+				return 'text/html';
+			}
+		);
+
+		$result = wp_mail( $participant->email, $subject, $message );
+
+		remove_filter(
+			'wp_mail_content_type',
+			function () {
+				return 'text/html';
+			}
+		);
+
+		return $result;
+	}
+
+	/**
 	 * Send payment-failure email with a resume link.
 	 *
 	 * Fires for Mollie failed/cancelled/expired transitions on signup

--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -88,6 +88,10 @@ const CSS_PREFIX = 'fair-audience-signup';
 			});
 		});
 
+		// Wire the "add activities" section (issue #611) for signed-up viewers.
+		// No-op when the section isn't rendered (nothing left to add).
+		wireAddActivities(block);
+
 		// When a recurrence picker is present, the user can switch between
 		// signed-up and not-signed-up occurrences inline — initialise the
 		// authenticated form even if the default selection is signed up.
@@ -818,6 +822,150 @@ const CSS_PREFIX = 'fair-audience-signup';
 				showNotification(errorMessage, 'error');
 			})
 			.finally(function () {
+				restoreButton();
+			});
+	}
+
+	/**
+	 * Wire the "add activities" section shown to a signed-up viewer: keep the
+	 * Add button's total in sync with the checked options and submit on click.
+	 * No-op when the section isn't present.
+	 * @param {HTMLElement} block The block element
+	 */
+	function wireAddActivities(block) {
+		const section = block.querySelector('.fair-audience-add-activities');
+		if (!section) {
+			return;
+		}
+		const button = section.querySelector(
+			'.fair-audience-add-activities-button'
+		);
+		if (!button) {
+			return;
+		}
+		const checkboxes = section.querySelectorAll(
+			'input[name="add_option_ids[]"]'
+		);
+
+		const baseText = __('Add activities', 'fair-audience');
+		const updateButton = function () {
+			let total = 0;
+			let anyChecked = false;
+			checkboxes.forEach(function (cb) {
+				if (cb.checked) {
+					anyChecked = true;
+					total += parseFloat(cb.dataset.optionPrice || 0);
+				}
+			});
+			button.disabled = !anyChecked;
+			button.textContent =
+				total > 0 ? baseText + ' — €' + total.toFixed(2) : baseText;
+		};
+
+		checkboxes.forEach(function (cb) {
+			cb.addEventListener('change', updateButton);
+		});
+		button.addEventListener('click', function () {
+			submitAddActivities(block, this);
+		});
+
+		updateButton();
+	}
+
+	/**
+	 * Submit the add-activities request. Redirects to checkout when the added
+	 * activities are priced; otherwise reloads to reflect the updated list.
+	 * @param {HTMLElement} block The block element
+	 * @param {HTMLElement} button The add-activities button
+	 */
+	function submitAddActivities(block, button) {
+		const eventId = parseInt(block.dataset.eventId, 10);
+		const eventDateId = block.dataset.eventDateId
+			? parseInt(block.dataset.eventDateId, 10)
+			: null;
+		const token = block.dataset.participantToken || '';
+		const section = block.querySelector('.fair-audience-add-activities');
+		const messageContainer = block.querySelector(
+			'.fair-audience-signup-message'
+		);
+
+		const checked = section.querySelectorAll(
+			'input[name="add_option_ids[]"]:checked'
+		);
+		if (checked.length === 0) {
+			return;
+		}
+
+		const requestData = {
+			event_id: eventId,
+			ticket_option_ids: Array.from(checked).map((i) =>
+				parseInt(i.value, 10)
+			),
+		};
+		if (eventDateId) {
+			requestData.event_date_id = eventDateId;
+		}
+		if (token) {
+			requestData.participant_token = token;
+		}
+		const invitationToken = block.dataset.invitationToken || '';
+		if (invitationToken) {
+			requestData.invitation_token = invitationToken;
+		}
+
+		const restoreButton = setButtonLoading(
+			button,
+			__('Adding…', 'fair-audience')
+		);
+
+		apiFetch({
+			path: '/fair-audience/v1/event-signup/add-activities',
+			method: 'POST',
+			data: requestData,
+		})
+			.then(function (response) {
+				// Paid add: redirect to Mollie checkout for the delta.
+				if (
+					response &&
+					response.status === 'payment_required' &&
+					response.checkout_url
+				) {
+					window.location = response.checkout_url;
+					return;
+				}
+				if (response && response.success) {
+					showNotification(
+						response.message ||
+							__(
+								'Your activities have been added!',
+								'fair-audience'
+							),
+						'success'
+					);
+					// Reload so the list reflects the just-added activities.
+					window.location.reload();
+					return;
+				}
+				restoreButton();
+			})
+			.catch(function (error) {
+				console.error('Add activities error:', error);
+				const errorMessage = extractErrorMessage(
+					error,
+					__(
+						'Failed to add activities. Please try again.',
+						'fair-audience'
+					)
+				);
+				if (messageContainer) {
+					showMessage(
+						messageContainer,
+						errorMessage,
+						'error',
+						CSS_PREFIX
+					);
+				}
+				showNotification(errorMessage, 'error');
 				restoreButton();
 			});
 	}

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -534,9 +534,8 @@ if ( $is_signed_up && $participant && ! empty( $event_date_id ) && isset( $event
 				$current_activity_names[] = $opt['name'];
 				continue;
 			}
-			if ( ! empty( $opt['is_full'] ) ) {
-				continue;
-			}
+			// Full options are kept in the list but rendered disabled, so the
+			// section stays discoverable and explains why they can't be added.
 			$addable_options[] = $opt;
 		}
 	}
@@ -759,9 +758,21 @@ $render_add_activities = static function () use ( $addable_options, $has_addable
 				$opt_label .= ' — ' . __( 'free', 'fair-audience' );
 			}
 		}
+		$is_full = ! empty( $opt['is_full'] );
+		if ( $is_full ) {
+			$opt_label .= ' — ' . __( 'full', 'fair-audience' );
+		}
 		$checkbox_id = esc_attr( $form_id ) . '-add-opt-' . (int) $opt['id'];
-		echo '<label class="fair-audience-ticket-option-item" for="' . $checkbox_id . '">';
-		echo '<input type="checkbox" name="add_option_ids[]" id="' . $checkbox_id . '" value="' . (int) $opt['id'] . '" data-option-price="' . esc_attr( number_format( $opt['price'], 2, '.', '' ) ) . '" /> ';
+		$classes     = 'fair-audience-ticket-option-item';
+		if ( $is_full ) {
+			$classes .= ' fair-audience-ticket-option-full';
+		}
+		echo '<label class="' . esc_attr( $classes ) . '" for="' . $checkbox_id . '">';
+		echo '<input type="checkbox" name="add_option_ids[]" id="' . $checkbox_id . '" value="' . (int) $opt['id'] . '" data-option-price="' . esc_attr( number_format( $opt['price'], 2, '.', '' ) ) . '"';
+		if ( $is_full ) {
+			echo ' disabled';
+		}
+		echo ' /> ';
 		echo esc_html( $opt_label );
 		echo '</label>';
 	}

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -511,6 +511,23 @@ $has_priced_options = ! empty(
 	)
 );
 
+// Activities the signed-up viewer can still add: every (non-full) option for
+// this event date that isn't already on their subscription (issue #611).
+$addable_options = array();
+if ( $is_signed_up && $participant && $has_ticket_options && ! empty( $event_date_id ) && isset( $event_participant_repository ) ) {
+	$signed_row = $event_participant_repository->get_by_event_date_and_participant( (int) $event_date_id, (int) $participant->id );
+	if ( $signed_row ) {
+		$selected_option_ids = $event_participant_repository->get_option_ids_for_event_participant( (int) $signed_row->id );
+		foreach ( $ticket_options_for_display as $opt ) {
+			if ( ! empty( $opt['is_full'] ) || in_array( (int) $opt['id'], $selected_option_ids, true ) ) {
+				continue;
+			}
+			$addable_options[] = $opt;
+		}
+	}
+}
+$has_addable_options = ! empty( $addable_options );
+
 // Resolve effective signup price for the current viewer so we can reflect it
 // in the button label.
 // null = no price configured at all → keep the default button text
@@ -701,6 +718,43 @@ $render_ticket_options = static function () use ( $ticket_options_for_display, $
 		echo esc_html( $opt_label );
 		echo '</label>';
 	}
+	echo '</fieldset>';
+};
+
+/**
+ * Render the "add activities" checkbox fieldset shown to a signed-up viewer,
+ * listing only the activities they don't yet have (issue #611). No-op when
+ * there's nothing left to add. The Add button total is kept in sync by the
+ * frontend JS from the checked options' data-option-price.
+ */
+$render_add_activities = static function () use ( $addable_options, $has_addable_options, $form_id, $show_option_prices ) {
+	if ( ! $has_addable_options ) {
+		return;
+	}
+	echo '<fieldset class="fair-audience-add-activities">';
+	echo '<legend>' . esc_html__( 'Add activities', 'fair-audience' ) . '</legend>';
+	foreach ( $addable_options as $opt ) {
+		$opt_label = $opt['name'];
+		if ( $show_option_prices ) {
+			if ( $opt['price'] > 0 ) {
+				$opt_label .= ' — €' . number_format_i18n( $opt['price'], 2 );
+			} elseif ( $opt['price'] < 0 ) {
+				$opt_label .= ' — -€' . number_format_i18n( abs( $opt['price'] ), 2 );
+			} else {
+				$opt_label .= ' — ' . __( 'free', 'fair-audience' );
+			}
+		}
+		$checkbox_id = esc_attr( $form_id ) . '-add-opt-' . (int) $opt['id'];
+		echo '<label class="fair-audience-ticket-option-item" for="' . $checkbox_id . '">';
+		echo '<input type="checkbox" name="add_option_ids[]" id="' . $checkbox_id . '" value="' . (int) $opt['id'] . '" data-option-price="' . esc_attr( number_format( $opt['price'], 2, '.', '' ) ) . '" /> ';
+		echo esc_html( $opt_label );
+		echo '</label>';
+	}
+	echo '<div class="wp-block-button">';
+	echo '<button type="button" class="wp-block-button__link wp-element-button fair-audience-add-activities-button" disabled>';
+	echo esc_html__( 'Add activities', 'fair-audience' );
+	echo '</button>';
+	echo '</div>';
 	echo '</fieldset>';
 };
 
@@ -939,6 +993,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				<div class="fair-audience-signup-status fair-audience-signup-status-success">
 					<p><?php echo esc_html__( 'You are signed up for this date.', 'fair-audience' ); ?></p>
 				</div>
+				<?php $render_add_activities(); ?>
 				<div class="wp-block-button fair-audience-unsignup-button-wrap">
 					<button type="button" class="wp-block-button__link wp-element-button fair-audience-unsignup-button is-style-outline">
 						<?php echo esc_html__( 'Cancel signup', 'fair-audience' ); ?>

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -511,15 +511,30 @@ $has_priced_options = ! empty(
 	)
 );
 
-// Activities the signed-up viewer can still add: every (non-full) option for
-// this event date that isn't already on their subscription (issue #611).
-$addable_options = array();
-if ( $is_signed_up && $participant && $has_ticket_options && ! empty( $event_date_id ) && isset( $event_participant_repository ) ) {
+// For a signed-up viewer, summarise their current registration (ticket type +
+// chosen activities) and compute which activities they can still add — every
+// non-full option for this event date that isn't already on their
+// subscription (issue #611).
+$addable_options        = array();
+$current_activity_names = array();
+$current_ticket_label   = '';
+if ( $is_signed_up && $participant && ! empty( $event_date_id ) && isset( $event_participant_repository ) ) {
 	$signed_row = $event_participant_repository->get_by_event_date_and_participant( (int) $event_date_id, (int) $participant->id );
 	if ( $signed_row ) {
+		if ( ! empty( $signed_row->ticket_type_id ) && class_exists( \FairEvents\Models\TicketType::class ) ) {
+			$current_ticket_type = \FairEvents\Models\TicketType::get_by_id( (int) $signed_row->ticket_type_id );
+			if ( $current_ticket_type ) {
+				$current_ticket_label = (string) $current_ticket_type->name;
+			}
+		}
+
 		$selected_option_ids = $event_participant_repository->get_option_ids_for_event_participant( (int) $signed_row->id );
 		foreach ( $ticket_options_for_display as $opt ) {
-			if ( ! empty( $opt['is_full'] ) || in_array( (int) $opt['id'], $selected_option_ids, true ) ) {
+			if ( in_array( (int) $opt['id'], $selected_option_ids, true ) ) {
+				$current_activity_names[] = $opt['name'];
+				continue;
+			}
+			if ( ! empty( $opt['is_full'] ) ) {
 				continue;
 			}
 			$addable_options[] = $opt;
@@ -965,24 +980,32 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		$form_class = 'with_token' === $state
 			? 'fair-audience-signup-token-form'
 			: 'fair-audience-signup-linked-form';
-		$greeting   = 'with_token' === $state
-			? sprintf(
+		if ( $is_signed_up ) {
+			$greeting = sprintf(
+				/* translators: %s: participant name */
+				__( 'Hi %s! Here is your registration for this event.', 'fair-audience' ),
+				$participant->name
+			);
+		} elseif ( 'with_token' === $state ) {
+			$greeting = sprintf(
 				/* translators: %s: participant name */
 				__( 'Hi %s! Click the button below to sign up for this event.', 'fair-audience' ),
 				$participant->name
-			)
-			: sprintf(
+			);
+		} else {
+			$greeting = sprintf(
 				/* translators: %s: participant name */
 				__( 'Hi %s! You can sign up for this event.', 'fair-audience' ),
 				$participant->name
 			);
+		}
 		?>
 		<div class="<?php echo esc_attr( $form_class ); ?>">
 			<p class="fair-audience-signup-greeting"><?php echo esc_html( $greeting ); ?></p>
 			<?php $render_occurrence_picker(); ?>
-			<?php $render_ticket_types(); ?>
-			<?php $render_ticket_options(); ?>
 			<div class="fair-audience-signup-action-signup"<?php echo $is_signed_up ? ' style="display: none;"' : ''; ?>>
+				<?php $render_ticket_types(); ?>
+				<?php $render_ticket_options(); ?>
 				<div class="wp-block-button">
 					<button type="button" class="wp-block-button__link wp-element-button fair-audience-signup-button" data-action="signup">
 						<?php echo esc_html( $signup_button_text ); ?>
@@ -993,6 +1016,27 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				<div class="fair-audience-signup-status fair-audience-signup-status-success">
 					<p><?php echo esc_html__( 'You are signed up for this date.', 'fair-audience' ); ?></p>
 				</div>
+				<?php if ( '' !== $current_ticket_label ) : ?>
+					<p class="fair-audience-signup-current-ticket">
+						<?php
+						printf(
+							/* translators: %s: ticket type name */
+							esc_html__( 'Your ticket: %s', 'fair-audience' ),
+							'<strong>' . esc_html( $current_ticket_label ) . '</strong>'
+						);
+						?>
+					</p>
+				<?php endif; ?>
+				<?php if ( ! empty( $current_activity_names ) ) : ?>
+					<div class="fair-audience-signup-current-activities">
+						<p><?php echo esc_html__( 'Your activities:', 'fair-audience' ); ?></p>
+						<ul>
+							<?php foreach ( $current_activity_names as $current_activity_name ) : ?>
+								<li><?php echo esc_html( $current_activity_name ); ?></li>
+							<?php endforeach; ?>
+						</ul>
+					</div>
+				<?php endif; ?>
 				<?php $render_add_activities(); ?>
 				<div class="wp-block-button fair-audience-unsignup-button-wrap">
 					<button type="button" class="wp-block-button__link wp-element-button fair-audience-unsignup-button is-style-outline">


### PR DESCRIPTION
Closes #611.

After signing up for an event, participants couldn't go back and add an activity option (workshop, catering, etc.) they skipped — they had to contact the organizer or sign up again. This lets a signed-up user add activities to their existing subscription, paying only for the delta when those activities are priced.

## Behavior
- From the resume link (or while logged in), a signed-up viewer sees an **Add activities** fieldset listing only the options they don't yet have (and that aren't full).
- Free additions attach immediately.
- Priced additions route through Mollie checkout for **just the delta**; the activities attach **only on confirmed payment**, so a failed/cancelled payment attaches nothing.
- No duplicate signup is created — the existing `signed_up` row is never mutated.
- A dedicated "Activities added" confirmation email lists the newly added activities.

## Changes
- **REST** `POST /fair-audience/v1/event-signup/add-activities` (`add_activities()`): resolves participant via resume token or logged-in user, requires an active `signed_up` subscription (`not_signed_up` otherwise), drops already-owned options (`no_new_activities` guard), free vs. paid split.
- **Paid completion** `PaymentHooks::handle_activities_added_paid` on `fair_payment_paid` for `source=fair-audience-activity-addon`; transient-guarded against Mollie webhook retries; fires `fair_audience_event_activities_added`.
- **Retry** `retry_payment()` gains an add-on branch (`retry_addon_payment()`) that rebuilds the delta transaction without touching the signed-up row.
- **Email** `EmailService::send_activities_added_confirmation()`.
- **UI** server-rendered fieldset in the signup block + `wireAddActivities()`/`submitAddActivities()` in `frontend.js` (live total, redirect for paid, reload for free).
- **Repo helpers** `get_by_id()`, `get_option_ids_for_event_participant()`, `add_options()`.

## Out of scope (per issue)
Removing activities, changing ticket type / base signup, refunds for downgrades.

## Testing
- New Playwright API spec `EventSignupAddActivities.api.spec.js`: unauthenticated, unknown event, not-signed-up, free add (+ verifying attachment), duplicate guard.
- Validated the live code path locally via internal `rest_do_request` and direct hook invocation: free add attaches / duplicate rejected / not-signed-up rejected; paid hook attaches once, idempotent on webhook retry, base signup stays `signed_up`.
- `npm run build` (fair-audience), `jest`, and `phpcs` all clean.

## Note
The paid delta + confirmation email path exercises Mollie, so it's covered by manual test-mode verification rather than the automated specs.