### PR TITLE
Add E2E test for ticket purchase confirmation + marketing opt-in

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,5 +6,8 @@
 		"./fair-events",
 		"./fair-audience",
 		"./fair-platform"
-	]
+	],
+	"mappings": {
+		"wp-content/mu-plugins": "./e2e/mu-plugins"
+	}
 }

--- a/TESTING.md
+++ b/TESTING.md
@@ -620,6 +620,14 @@ WP_BASE_URL=http://localhost:8889 npm run test:e2e   # override base URL
 3. For admin flows, log in via `/wp-login.php` with `WP_ADMIN_USER` /
    `WP_ADMIN_PASSWORD` (default `admin` / `password`). See `e2e/smoke.spec.js`.
 
+### Capturing email & intercepting external services
+
+Specs that need to assert on outgoing mail, or drive flows that hit external
+services (e.g. Mollie payments), rely on a test-only support layer mounted into
+wp-env from `e2e/mu-plugins/` (mail is captured via `pre_wp_mail`; Mollie's HTTP
+transport is replaced by a double, with no change to plugin code). See
+[`e2e/README.md`](./e2e/README.md) for how it works and how to reuse it.
+
 ### CI
 
 `.github/workflows/e2e.yml` runs on PRs touching plugin source, `e2e/`,

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,112 @@
+# E2E harness internals
+
+This directory holds the repo-root Playwright suite that runs against the
+isolated `@wordpress/env` instance (`:8889`). The general harness — how to run
+specs, ports, CI — is documented in [`TESTING.md`](../TESTING.md#isolated-e2e-harness-wordpress-env).
+This file documents the **test-only support layer** that lets specs drive flows
+which normally depend on external services (payments, email), without touching
+any production plugin code.
+
+## Layout
+
+```
+e2e/
+├── smoke.spec.js                         # harness sanity check
+├── user-flows/                           # functional specs
+│   └── ticket-purchase-confirmation.spec.js
+└── mu-plugins/                           # mounted into wp-env only (see .wp-env.json)
+    ├── fair-e2e-support.php              # auto-loaded mu-plugin (mail capture + Mollie test creds + loads the double)
+    ├── lib/
+    │   └── mollie-http-double.php        # fake Mollie HTTP transport
+    └── scripts/                          # WP-CLI eval-file helpers (NOT auto-loaded — subdir)
+        ├── seed-paid-event.php
+        └── signup-state.php
+```
+
+`.wp-env.json` maps `wp-content/mu-plugins` → `./e2e/mu-plugins`, so this code
+loads **only** inside the Playwright wp-env instance. It is never shipped to
+production and never mounted by the dev `docker compose` stack. Anything dropped
+directly in `mu-plugins/` is auto-loaded by WordPress; helper scripts live in the
+`scripts/` subdirectory precisely so they are **not** auto-loaded and only run
+when invoked via `wp eval-file`.
+
+## Capturing email
+
+We assert on outgoing mail without sending it. `fair-e2e-support.php` hooks
+`pre_wp_mail` and returns `true` (short-circuiting `wp_mail()`), recording each
+message — recipient, subject, body — into the `fair_e2e_captured_mail` option.
+Specs read it back via WP-CLI (`signup-state.php` filters it down to the buyer's
+mail). No real mail leaves the host, and no MailHog/Mailpit container is needed.
+
+## Intercepting Mollie (the key decision)
+
+Driving a *real* purchase in the isolated env is the hard part, and we
+explicitly **do not modify the fair-payment Mollie integration to make it
+testable**. The constraints that rule out the obvious approaches:
+
+- The Mollie PHP SDK talks to the network through a raw-cURL adapter that pins
+  TLS to a bundled CA (`CURLOPT_SSL_VERIFYPEER` + bundled `cacert.pem`), so a
+  DNS/hosts-level MITM of `api.mollie.com` cannot work.
+- The SDK is constructed inline (`new MollieApiClient()`), with no hook to
+  redirect its endpoint.
+- Mollie's hosted checkout page and its payment webhook are unreachable from
+  `localhost:8889`.
+- Playwright `page.route` only sees browser traffic — it cannot intercept the
+  server-side `create_payment` cURL call.
+
+The clean interception point is the SDK's HTTP transport itself.
+`lib/mollie-http-double.php` pre-declares
+`Mollie\Api\HttpAdapter\CurlMollieHttpAdapter` (the exact class the SDK's adapter
+picker instantiates) **before** the vendored `final` class autoloads, so PHP
+never loads the real one. The double returns canned responses; the rest of the
+SDK — URL building, response decoding, resource hydration — and **all** of the
+fair-payment / fair-audience purchase code run unchanged.
+
+Canned behaviour, enough to complete a purchase:
+
+| Request | Response |
+| --- | --- |
+| `POST /v2/payments` | payment `status: open`, `checkout` link = the request's `redirectUrl` |
+| `GET /v2/payments/{id}` | the same payment, `status: paid` |
+| `GET /v2/methods` | empty list (no method allowlist applied) |
+| `GET /v2/balances…` | empty list (fee capture finds nothing) |
+
+`fair-e2e-support.php` also forces `fair_payment_mode = test` and supplies a
+syntactically valid dummy API key via `pre_option_*` filters, so the real
+`MolliePaymentHandler` validates and runs against the double.
+
+### How a test purchase flows end to end
+
+1. The spec fills and submits the public event-signup form (real REST call to
+   `register_and_signup`), which sets `email_profile` from the "Keep me
+   informed" checkbox and creates a `pending_payment` signup + transaction.
+2. `initiate_payment` → the double returns an `open` payment whose checkout link
+   is the signup **callback URL** (`?fair_payment_callback=true&fair_signup_tx=…`).
+3. The frontend redirects the browser there. `event-signup/render.php` calls the
+   real `fair_payment_sync_transaction_status`, which fetches the payment → the
+   double returns `paid`.
+4. That fires the real `fair_payment_paid` → `handle_signup_paid` →
+   `fair_audience_event_signup_paid` → `send_signup_confirmation_email` chain.
+   The email is captured; the signup row flips to `signed_up`.
+
+No separate "simulate the webhook" step is needed — the production sync-on-
+redirect path does it.
+
+## WP-CLI helper scripts
+
+Run against the tests instance, e.g.:
+
+```bash
+npx wp-env run tests-cli wp eval-file wp-content/mu-plugins/scripts/seed-paid-event.php
+npx wp-env run tests-cli wp eval-file wp-content/mu-plugins/scripts/signup-state.php buyer@example.test 12
+```
+
+Each prints a single `MARKER:{json}` line (`E2E_SEED`, `E2E_STATE`) that the
+spec parses.
+
+- **`seed-paid-event.php`** — creates a published `fair_event` (with the
+  event-signup block in its content), an event date, an active sale period, one
+  paid ticket type, and its price. Emits the event permalink + ids.
+- **`signup-state.php <email> <event_date_id>`** — reports the participant's
+  `email_profile`/`status`, the event-participant `label`, and the mail captured
+  for that buyer.

--- a/e2e/mu-plugins/fair-e2e-support.php
+++ b/e2e/mu-plugins/fair-e2e-support.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Plugin Name: Fair Events E2E Support
+ * Description: Test-only helpers loaded ONLY inside the Playwright wp-env
+ *              instance (mounted via the `mappings` entry in .wp-env.json).
+ *              Never shipped to production and never mounted by the dev
+ *              `docker compose` stack.
+ *
+ * It does three things, all confined to the test environment:
+ *
+ *   1. Captures outgoing mail into the `fair_e2e_captured_mail` option instead
+ *      of sending it, so specs can assert on subject/recipient/body and no real
+ *      mail leaves the host.
+ *   2. Forces fair-payment into Mollie "test" mode with a dummy key, so the
+ *      production Mollie code path runs without a real API key.
+ *   3. Pre-declares a fake Mollie HTTP transport (see lib/mollie-http-double.php)
+ *      so every Mollie API call returns canned responses. This keeps ALL of the
+ *      real fair-payment / fair-audience purchase code in play while making the
+ *      "payment" deterministic and offline.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/*
+ * 1. Intercept the Mollie HTTP transport.
+ *
+ * Declared at mu-plugin load time — before fair-payment's Composer autoloader
+ * gets a chance to load the vendored CurlMollieHttpAdapter — so the SDK's
+ * adapter picker instantiates our double instead. The real MollieApiClient
+ * (URL building, response parsing, resource hydration) is untouched.
+ */
+require_once __DIR__ . '/lib/mollie-http-double.php';
+
+/*
+ * 2. Force fair-payment into test mode with a syntactically valid dummy key.
+ *
+ * MollieApiClient::setApiKey() requires `^(live|test)_\w{30,}$`. The double
+ * ignores the key, but the real handler still validates it before use, so it
+ * must look real.
+ */
+add_filter(
+	'pre_option_fair_payment_test_api_key',
+	static function () {
+		return 'test_' . str_repeat( 'e', 30 );
+	}
+);
+add_filter(
+	'pre_option_fair_payment_mode',
+	static function () {
+		return 'test';
+	}
+);
+
+/*
+ * 3. Capture mail instead of sending it.
+ *
+ * Returning a non-null value from `pre_wp_mail` short-circuits wp_mail() (so
+ * nothing is dispatched) and becomes its return value. We log each message to
+ * an option the specs read via WP-CLI.
+ */
+add_filter(
+	'pre_wp_mail',
+	static function ( $short_circuit, $atts ) {
+		$log   = get_option( 'fair_e2e_captured_mail', array() );
+		$log[] = array(
+			'to'      => isset( $atts['to'] ) ? $atts['to'] : '',
+			'subject' => isset( $atts['subject'] ) ? $atts['subject'] : '',
+			'body'    => isset( $atts['message'] ) ? $atts['message'] : '',
+			'headers' => isset( $atts['headers'] ) ? $atts['headers'] : '',
+			'time'    => time(),
+		);
+		update_option( 'fair_e2e_captured_mail', $log, false );
+
+		return true;
+	},
+	10,
+	2
+);

--- a/e2e/mu-plugins/lib/mollie-http-double.php
+++ b/e2e/mu-plugins/lib/mollie-http-double.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Fake Mollie HTTP transport for E2E tests.
+ *
+ * The Mollie PHP SDK's adapter picker does `new CurlMollieHttpAdapter()` when no
+ * HTTP client is injected. By declaring that exact class here — before the
+ * vendored `final class` is autoloaded — every Mollie API call is served by this
+ * double instead of hitting the network. The rest of the SDK (URL building,
+ * response decoding, resource hydration) and ALL of the fair-payment /
+ * fair-audience code runs unchanged.
+ *
+ * Canned behaviour, enough to drive the ticket-purchase flow:
+ *   - POST /v2/payments        -> a payment in status "open" whose checkout link
+ *                                 points straight back at the redirectUrl, so the
+ *                                 buyer lands on the signup callback page.
+ *   - GET  /v2/payments/{id}   -> the same payment in status "paid", so the
+ *                                 callback page's sync pulls "paid" and the real
+ *                                 fair_payment_paid -> signup-confirmation chain
+ *                                 fires.
+ *   - GET  /v2/methods         -> empty list (method allowlist stays unset).
+ *   - GET  /v2/balances...     -> empty list (fee capture finds nothing).
+ *
+ * @package FairEventsE2E
+ */
+
+namespace Mollie\Api\HttpAdapter;
+
+// If the real adapter somehow loaded first, don't redeclare.
+if ( class_exists( __NAMESPACE__ . '\\CurlMollieHttpAdapter', false ) ) {
+	return;
+}
+
+/**
+ * Drop-in stand-in for the SDK's cURL adapter. Intentionally does not implement
+ * MollieHttpAdapterInterface (the interface may not be autoloadable this early);
+ * the SDK only calls send()/versionString() and enforces no type.
+ */
+class CurlMollieHttpAdapter {
+
+	/**
+	 * Serve a canned response for a Mollie API request.
+	 *
+	 * @param string       $http_method HTTP verb.
+	 * @param string       $url         Full request URL.
+	 * @param string|array $headers     Request headers (ignored).
+	 * @param string       $http_body   JSON request body.
+	 * @return \stdClass|null Decoded response body, or null for no content.
+	 */
+	public function send( $http_method, $url, $headers, $http_body ) {
+		$path    = (string) \wp_parse_url( $url, PHP_URL_PATH );
+		$payload = ! empty( $http_body ) ? \json_decode( $http_body, true ) : array();
+		$payload = \is_array( $payload ) ? $payload : array();
+
+		// Create payment: POST /v2/payments
+		if ( 'POST' === \strtoupper( $http_method ) && \preg_match( '#/payments/?$#', $path ) ) {
+			return $this->payment_response( $payload, 'open' );
+		}
+
+		// Get single payment: GET /v2/payments/{id}
+		if ( \preg_match( '#/payments/([^/]+)$#', $path, $m ) ) {
+			return $this->payment_response( $payload, 'paid', $m[1] );
+		}
+
+		// Payment methods allowlist lookup: GET /v2/methods
+		if ( \preg_match( '#/methods#', $path ) ) {
+			return $this->objectify(
+				array(
+					'count'     => 0,
+					'_embedded' => array( 'methods' => array() ),
+					'_links'    => new \stdClass(),
+				)
+			);
+		}
+
+		// Balance / balance-transactions lookup used by fee capture.
+		if ( \preg_match( '#/balances|/balance-transactions#', $path ) ) {
+			return $this->objectify(
+				array(
+					'count'     => 0,
+					'_embedded' => array( 'balance_transactions' => array() ),
+					'_links'    => array( 'next' => null ),
+				)
+			);
+		}
+
+		return new \stdClass();
+	}
+
+	/**
+	 * The version string the SDK uses to build its User-Agent header.
+	 *
+	 * @return string
+	 */
+	public function versionString() {
+		return 'FairEventsE2EMock/1.0';
+	}
+
+	/**
+	 * Build a Mollie payment response object.
+	 *
+	 * @param array       $payload Decoded request body (create only).
+	 * @param string      $status  Payment status to report.
+	 * @param string|null $id      Existing payment id (get) or null to mint one.
+	 * @return \stdClass
+	 */
+	private function payment_response( $payload, $status, $id = null ) {
+		$id           = $id ? $id : 'tr_' . \strtoupper( \substr( \md5( \uniqid( '', true ) ), 0, 10 ) );
+		$redirect_url = isset( $payload['redirectUrl'] ) ? $payload['redirectUrl'] : \home_url( '/' );
+		$amount       = isset( $payload['amount'] ) && \is_array( $payload['amount'] )
+			? $payload['amount']
+			: array(
+				'currency' => 'EUR',
+				'value'    => '0.00',
+			);
+
+		$data = array(
+			'resource'    => 'payment',
+			'id'          => $id,
+			'mode'        => 'test',
+			'status'      => $status,
+			'amount'      => $amount,
+			'description' => isset( $payload['description'] ) ? $payload['description'] : 'E2E payment',
+			'metadata'    => isset( $payload['metadata'] ) ? $payload['metadata'] : new \stdClass(),
+			'createdAt'   => \gmdate( 'c' ),
+			'_links'      => array(
+				'checkout' => array(
+					'href' => $redirect_url,
+					'type' => 'text/html',
+				),
+			),
+		);
+
+		if ( 'paid' === $status ) {
+			$data['paidAt'] = \gmdate( 'c' );
+		}
+
+		return $this->objectify( $data );
+	}
+
+	/**
+	 * Convert a nested array into the nested stdClass the SDK expects from a
+	 * decoded JSON body.
+	 *
+	 * @param array $data Response data.
+	 * @return \stdClass
+	 */
+	private function objectify( $data ) {
+		return \json_decode( \json_encode( $data ) );
+	}
+}

--- a/e2e/mu-plugins/scripts/seed-paid-event.php
+++ b/e2e/mu-plugins/scripts/seed-paid-event.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Seed a published paid event for the ticket-purchase E2E spec.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-paid-event.php
+ *
+ * Creates a fair_event post (with the event-signup block in its content), a
+ * single event date, an active sale period, one paid ticket type, and its
+ * price. Prints a single `E2E_SEED:{json}` line the spec parses for the event
+ * permalink and ids.
+ *
+ * @package FairEventsE2E
+ */
+
+use FairEvents\Models\EventDates;
+use FairEvents\Models\TicketSalePeriod;
+use FairEvents\Models\TicketType;
+use FairEvents\Models\TicketPrice;
+
+$price = 25.00;
+
+$event_id = wp_insert_post(
+	array(
+		'post_type'    => 'fair_event',
+		'post_status'  => 'publish',
+		'post_title'   => 'E2E Paid Event ' . gmdate( 'YmdHis' ),
+		'post_content' => '<!-- wp:fair-audience/event-signup /-->',
+	),
+	true
+);
+
+if ( is_wp_error( $event_id ) ) {
+	WP_CLI::error( 'Failed to create event: ' . $event_id->get_error_message() );
+}
+
+$event_date_id = EventDates::save_occurrence(
+	$event_id,
+	gmdate( 'Y-m-d H:i:s', strtotime( '+7 days' ) ),
+	gmdate( 'Y-m-d H:i:s', strtotime( '+7 days +2 hours' ) ),
+	false,
+	'single'
+);
+
+if ( ! $event_date_id ) {
+	WP_CLI::error( 'Failed to create event date.' );
+}
+
+$sale_period_id = TicketSalePeriod::create(
+	$event_date_id,
+	'Standard',
+	gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) ),
+	gmdate( 'Y-m-d H:i:s', strtotime( '+30 days' ) ),
+	0
+);
+
+if ( ! $sale_period_id ) {
+	WP_CLI::error( 'Failed to create sale period.' );
+}
+
+$ticket_type_id = TicketType::create( $event_date_id, 'General Admission', null, 0 );
+
+if ( ! $ticket_type_id ) {
+	WP_CLI::error( 'Failed to create ticket type.' );
+}
+
+if ( ! TicketPrice::create( $ticket_type_id, $sale_period_id, $price, null ) ) {
+	WP_CLI::error( 'Failed to create ticket price.' );
+}
+
+echo 'E2E_SEED:' . wp_json_encode(
+	array(
+		'pageUrl'      => get_permalink( $event_id ),
+		'eventId'      => (int) $event_id,
+		'eventDateId'  => (int) $event_date_id,
+		'ticketTypeId' => (int) $ticket_type_id,
+		'price'        => $price,
+	)
+) . "\n";

--- a/e2e/mu-plugins/scripts/signup-state.php
+++ b/e2e/mu-plugins/scripts/signup-state.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Report a buyer's signup state for the ticket-purchase E2E spec.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/signup-state.php <email> <event_date_id>
+ *
+ * Prints a single `E2E_STATE:{json}` line with the participant's marketing
+ * profile, the event-participant label, and the mail captured for this buyer,
+ * so the spec can assert that consent was recorded only when opted in, that
+ * payment flipped the row to signed_up, and that the confirmation email was
+ * delivered.
+ *
+ * @package FairEventsE2E
+ */
+
+use FairAudience\Database\ParticipantRepository;
+use FairAudience\Database\EventParticipantRepository;
+
+$email         = isset( $args[0] ) ? $args[0] : '';
+$event_date_id = isset( $args[1] ) ? (int) $args[1] : 0;
+
+if ( empty( $email ) ) {
+	WP_CLI::error( 'Usage: signup-state.php <email> <event_date_id>' );
+}
+
+$participant = ( new ParticipantRepository() )->get_by_email( $email );
+
+if ( ! $participant ) {
+	echo 'E2E_STATE:' . wp_json_encode( array( 'found' => false ) ) . "\n";
+	return;
+}
+
+$label = null;
+if ( $event_date_id ) {
+	$event_participant = ( new EventParticipantRepository() )->get_by_event_date_and_participant(
+		$event_date_id,
+		$participant->id
+	);
+	$label             = $event_participant ? $event_participant->label : null;
+}
+
+// Mail addressed to this buyer, captured by fair-e2e-support.php.
+$mail = array();
+foreach ( get_option( 'fair_e2e_captured_mail', array() ) as $entry ) {
+	$recipients = (array) ( $entry['to'] ?? array() );
+	if ( in_array( $email, $recipients, true ) ) {
+		$mail[] = array(
+			'to'      => $entry['to'] ?? '',
+			'subject' => $entry['subject'] ?? '',
+		);
+	}
+}
+
+echo 'E2E_STATE:' . wp_json_encode(
+	array(
+		'found'         => true,
+		'email_profile' => $participant->email_profile,
+		'status'        => $participant->status,
+		'label'         => $label,
+		'mail'          => $mail,
+	)
+) . "\n";

--- a/e2e/user-flows/ticket-purchase-confirmation.spec.js
+++ b/e2e/user-flows/ticket-purchase-confirmation.spec.js
@@ -1,0 +1,142 @@
+/**
+ * E2E: ticket purchase → confirmation email + marketing opt-in.
+ *
+ * Buys a paid ticket through the public event-signup block against the isolated
+ * wp-env instance and asserts the buyer-facing outcome:
+ *   - the purchase confirmation email is delivered (both opt-in cases), and
+ *   - marketing consent (email_profile = 'marketing') is recorded ONLY when the
+ *     buyer ticks "Keep me informed".
+ *
+ * No real Mollie call or outbound mail happens. A test-only mu-plugin
+ * (e2e/mu-plugins/) swaps the Mollie HTTP transport for a double that returns a
+ * paid payment, and captures wp_mail into an option. Everything else — the
+ * registration controller, the fair_payment_paid → signup-confirmation hook
+ * chain, the email rendering — is the real production code. See
+ * e2e/README.md for the mechanics.
+ */
+
+import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+
+/**
+ * Run a WP-CLI command against the wp-env `tests` instance and return stdout.
+ *
+ * @param {string} args WP-CLI arguments (everything after `wp`).
+ * @return {string} Command stdout.
+ */
+function wpCli(args) {
+	return execSync(`npx wp-env run tests-cli wp ${args}`, {
+		cwd: process.cwd(),
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+}
+
+/**
+ * Run a seed/state eval-file script and parse its `MARKER:{json}` output.
+ *
+ * @param {string} file      Script filename under mu-plugins/scripts/.
+ * @param {string} marker    Output marker (e.g. 'E2E_SEED').
+ * @param {string} extraArgs Positional args passed to the script.
+ * @return {object} Parsed JSON payload.
+ */
+function runScript(file, marker, extraArgs = '') {
+	const out = wpCli(
+		`eval-file wp-content/mu-plugins/scripts/${file} ${extraArgs}`.trim()
+	);
+	const match = out.match(new RegExp(`${marker}:(\\{.*\\})`));
+	if (!match) {
+		throw new Error(`Expected ${marker} in WP-CLI output, got:\n${out}`);
+	}
+	return JSON.parse(match[1]);
+}
+
+/** Clear captured mail so each scenario starts clean. */
+function resetCapturedMail() {
+	try {
+		wpCli('option delete fair_e2e_captured_mail');
+	} catch {
+		// Option may not exist yet — nothing to clear.
+	}
+}
+
+let event;
+
+test.beforeAll(() => {
+	event = runScript('seed-paid-event.php', 'E2E_SEED');
+});
+
+const scenarios = [
+	{
+		name: 'records marketing consent when the buyer opts in',
+		optIn: true,
+		expectedProfile: 'marketing',
+	},
+	{
+		name: 'does not record marketing consent when the buyer opts out',
+		optIn: false,
+		expectedProfile: 'minimal',
+	},
+];
+
+test.describe('ticket purchase confirmation', () => {
+	for (const scenario of scenarios) {
+		test(scenario.name, async ({ page }) => {
+			resetCapturedMail();
+			const email = `buyer.${
+				scenario.optIn ? 'optin' : 'optout'
+			}.${Date.now()}@example.test`;
+
+			// Public event page renders the signup block; the "I'm new"
+			// registration form is shown by default for anonymous visitors.
+			await page.goto(event.pageUrl);
+			const form = page.locator('.fair-audience-signup-register');
+			await expect(form).toBeVisible();
+
+			// One paid ticket type is seeded and auto-selected; assert it carries
+			// a positive price so the paid path (not the free path) is exercised.
+			const ticket = form.locator('input[name="ticket_type_id"]');
+			await ticket.check();
+			expect(
+				Number(await ticket.getAttribute('data-ticket-price'))
+			).toBeGreaterThan(0);
+
+			await form.locator('input[name="signup_name"]').fill('E2E Buyer');
+			await form.locator('input[name="signup_email"]').fill(email);
+			if (scenario.optIn) {
+				await form
+					.locator('input[name="signup_keep_informed"]')
+					.check();
+			}
+
+			// Submit → register REST call returns payment_required with a
+			// checkout_url that (via the Mollie double) points back at the signup
+			// callback page, where sync pulls "paid" and fires the real chain.
+			await form.locator('.fair-audience-signup-submit-button').click();
+			await page.waitForURL(/fair_payment_callback=true/);
+			await expect(
+				page.getByText('Payment confirmed', { exact: false })
+			).toBeVisible();
+
+			// Server-side assertions: consent recorded per opt-in, row signed up,
+			// and the confirmation email captured for this buyer.
+			const state = runScript(
+				'signup-state.php',
+				'E2E_STATE',
+				`${email} ${event.eventDateId}`
+			);
+
+			expect(state.found).toBe(true);
+			expect(state.label).toBe('signed_up');
+			expect(state.email_profile).toBe(scenario.expectedProfile);
+
+			const confirmation = state.mail.find((m) =>
+				m.subject.includes('Signup confirmed')
+			);
+			expect(
+				confirmation,
+				'a "Signup confirmed" email should be captured for the buyer'
+			).toBeTruthy();
+		});
+	}
+});


### PR DESCRIPTION
## What

Adds a Playwright E2E spec (`e2e/user-flows/ticket-purchase-confirmation.spec.js`) covering the **ticket purchase → confirmation email** flow with marketing opt-in, per #623.

The spec buys a paid ticket through the public event-signup block against the isolated wp-env instance and asserts, parametrized over opt-in / opt-out:

- the **purchase confirmation email** is delivered to the buyer in both cases (it's transactional), and
- marketing consent (`email_profile = marketing`) is recorded **only** when the buyer ticks "Keep me informed".

The signup row reaches `signed_up` and the page shows "Payment confirmed".

## How payment is driven offline (no plugin code changed)

Mollie's hosted checkout and webhook are unreachable from `localhost:8889`, the SDK pins TLS to a bundled CA (so no network MITM), and it's constructed inline (no endpoint hook). Rather than add a production seam, the interception lives entirely in a **test-only support layer** mounted into wp-env via `.wp-env.json` `mappings` (`e2e/mu-plugins/`, never shipped, never mounted by the dev `docker compose` stack):

- `fair-e2e-support.php` — captures `wp_mail` via `pre_wp_mail` into an option; forces `fair_payment_mode = test` + a dummy key via `pre_option_*`; loads the double.
- `lib/mollie-http-double.php` — pre-declares `Mollie\Api\HttpAdapter\CurlMollieHttpAdapter` before the vendored `final` class autoloads, so the SDK's picker uses it. Returns `open` (checkout link = signup callback URL) on create and `paid` on lookup.

The browser lands on the callback page, where the **existing** `fair_payment_sync_transaction_status` pulls "paid" and fires the **real** `fair_payment_paid → handle_signup_paid → fair_audience_event_signup_paid → send_signup_confirmation_email` chain. No webhook, secret, or simulate step needed. Full mechanics in `e2e/README.md`.

WP-CLI `eval-file` helpers seed a paid event and read back signup state + captured mail.

## Test plan

- `npm run test:e2e` → `4 passed` (smoke + both purchase scenarios) against a clean wp-env.
- Opt-in yields `marketing`, opt-out yields `minimal`; both capture the "Signup confirmed —" email; `pre_wp_mail` short-circuits so nothing leaves the host.

## Note

Seeding surfaced a latent bug: inserting a `fair_event` triggers `FairEvents\Core\Plugin::auto_create_event_date`, which attempts an event-date row with a null `start_datetime` (logged DB error). It doesn't affect the test, but is worth a follow-up.