### PR TITLE
Hide signup price until minimum activities reached (#644)

### DIFF
--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -144,17 +144,18 @@ const CSS_PREFIX = 'fair-audience-signup';
 	}
 
 	/**
-	 * Enforce the minimum-activities requirement by disabling the signup
-	 * and registration buttons until enough options are checked.  No-op
-	 * when the block has no minimum configured.
+	 * Compute the effective minimum number of activities for the block: the
+	 * event-date global baseline, possibly raised by the selected ticket type
+	 * (issue #625), capped at the number of options available so the requirement
+	 * is never impossible to satisfy.
 	 * @param {HTMLElement} block The block element
+	 * @return {number} The effective minimum (0 when no minimum applies)
 	 */
-	function updateMinActivitiesGate(block) {
-		// Event-date global baseline.
+	function getEffectiveMinimum(block) {
 		const globalMin = parseInt(block.dataset.minActivities || '0', 10);
 
-		// A selected ticket type can raise the requirement (issue #625); a value
-		// below the global is ignored because we take the max.
+		// A selected ticket type can raise the requirement; a value below the
+		// global is ignored because we take the max.
 		const selectedTicketType = block.querySelector(
 			'input[name="ticket_type_id"]:checked'
 		);
@@ -162,15 +163,21 @@ const CSS_PREFIX = 'fair-audience-signup';
 			? parseInt(selectedTicketType.dataset.minActivities || '0', 10)
 			: 0;
 
-		const optionInputs = block.querySelectorAll(
+		const optionCount = block.querySelectorAll(
 			'input[name="ticket_option_ids[]"]'
-		);
-		// Cap at the number of options available so the requirement is never
-		// impossible to satisfy.
-		const effectiveMin = Math.min(
-			Math.max(globalMin, typeMin),
-			optionInputs.length
-		);
+		).length;
+
+		return Math.min(Math.max(globalMin, typeMin), optionCount);
+	}
+
+	/**
+	 * Enforce the minimum-activities requirement by disabling the signup
+	 * and registration buttons until enough options are checked.  No-op
+	 * when the block has no minimum configured.
+	 * @param {HTMLElement} block The block element
+	 */
+	function updateMinActivitiesGate(block) {
+		const effectiveMin = getEffectiveMinimum(block);
 
 		// Keep the hint paragraph in sync with the effective minimum.
 		const hint = block.querySelector(
@@ -256,6 +263,26 @@ const CSS_PREFIX = 'fair-audience-signup';
 			block.dataset.registerBaseText ||
 			__('Register & Sign Up', 'fair-audience');
 
+		// Below the minimum-activities requirement the button is disabled and
+		// the price is meaningless, so show only the bare action label until the
+		// selection is valid (issue #644).
+		const effectiveMin = getEffectiveMinimum(block);
+		if (effectiveMin > 0 && checkedOptions.length < effectiveMin) {
+			const signupBtnBare = block.querySelector(
+				'.fair-audience-signup-button'
+			);
+			if (signupBtnBare) {
+				signupBtnBare.textContent = signupBaseText;
+			}
+			const submitBtnBare = block.querySelector(
+				'.fair-audience-signup-submit-button'
+			);
+			if (submitBtnBare) {
+				submitBtnBare.textContent = registerBaseText;
+			}
+			return;
+		}
+
 		let signupText, registerText;
 		if (total > 0) {
 			const formatted = total.toFixed(2);
@@ -280,6 +307,42 @@ const CSS_PREFIX = 'fair-audience-signup';
 	}
 
 	/**
+	 * Show or hide the per-option "(+price)" add-on tags. Tags reveal what
+	 * adding an option would cost and only appear once the minimum-activities
+	 * requirement is met, on options that are not yet checked (issue #644).
+	 * No-op when the block has no add-on tags (feature-inactive events).
+	 * @param {HTMLElement} block The block element
+	 */
+	function updateOptionAddons(block) {
+		// Scope to the signup options fieldset so the separate "add activities"
+		// fieldset (for already-signed-up viewers) is never touched.
+		const fieldset = block.querySelector('.fair-audience-ticket-options');
+		if (!fieldset) {
+			return;
+		}
+
+		const effectiveMin = getEffectiveMinimum(block);
+		const checkedCount = fieldset.querySelectorAll(
+			'input[name="ticket_option_ids[]"]:checked'
+		).length;
+		const meetsMin = effectiveMin === 0 || checkedCount >= effectiveMin;
+
+		const optionInputs = fieldset.querySelectorAll(
+			'input[name="ticket_option_ids[]"]'
+		);
+		optionInputs.forEach(function (input) {
+			const label = input.closest('label');
+			const addon = label
+				? label.querySelector('.fair-audience-ticket-option-addon')
+				: null;
+			if (!addon) {
+				return;
+			}
+			addon.style.display = meetsMin && !input.checked ? '' : 'none';
+		});
+	}
+
+	/**
 	 * Attach change listeners to ticket option checkboxes so the button total
 	 * stays in sync as the user checks/unchecks options.
 	 * @param {HTMLElement} block The block element
@@ -292,6 +355,7 @@ const CSS_PREFIX = 'fair-audience-signup';
 			radio.addEventListener('change', function () {
 				updateButtonTotal(block);
 				updateMinActivitiesGate(block);
+				updateOptionAddons(block);
 			});
 		});
 
@@ -302,10 +366,13 @@ const CSS_PREFIX = 'fair-audience-signup';
 			checkbox.addEventListener('change', function () {
 				updateButtonTotal(block);
 				updateMinActivitiesGate(block);
+				updateOptionAddons(block);
 			});
 		});
 
+		updateButtonTotal(block);
 		updateMinActivitiesGate(block);
+		updateOptionAddons(block);
 	}
 
 	/**

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -676,6 +676,13 @@ $render_ticket_options = static function () use ( $ticket_options_for_display, $
 	if ( ! $has_ticket_options ) {
 		return;
 	}
+	// When a minimum-activities requirement is in play (globally or because a
+	// ticket type can raise it), option prices are shown only past the minimum
+	// as a per-option "(+€X.XX)" add-on tag toggled by the frontend JS, instead
+	// of the always-on inline price. Feature-inactive events keep the inline
+	// price (today's behavior). See issue #644.
+	$feature_active = ( $minimum_activities > 0 || $any_ticket_type_min > 0 );
+
 	echo '<fieldset class="fair-audience-ticket-options">';
 	echo '<legend>' . esc_html__( 'Select activities', 'fair-audience' ) . '</legend>';
 	// Render the hint whenever a minimum is possible — either the event-date
@@ -705,7 +712,9 @@ $render_ticket_options = static function () use ( $ticket_options_for_display, $
 	}
 	foreach ( $ticket_options_for_display as $opt ) {
 		$opt_label = $opt['name'];
-		if ( $show_option_prices ) {
+		// Inline price only when the minimum-activities feature is inactive; the
+		// feature-active case uses the toggled "(+price)" tag emitted below.
+		if ( ! $feature_active && $show_option_prices ) {
 			if ( $opt['price'] > 0 ) {
 				$opt_label .= ' — €' . number_format_i18n( $opt['price'], 2 );
 			} elseif ( $opt['price'] < 0 ) {
@@ -730,6 +739,20 @@ $render_ticket_options = static function () use ( $ticket_options_for_display, $
 		}
 		echo ' /> ';
 		echo esc_html( $opt_label );
+		// Hidden add-on tag, revealed by frontend.js on unchecked options once
+		// the minimum is reached. Positive prices only (no "(+€0.00)").
+		if ( $feature_active && $show_option_prices && $opt['price'] > 0 ) {
+			printf(
+				'<span class="fair-audience-ticket-option-addon" style="display: none;"> %s</span>',
+				esc_html(
+					sprintf(
+						/* translators: %s: formatted add-on price */
+						__( '(+€%s)', 'fair-audience' ),
+						number_format_i18n( $opt['price'], 2 )
+					)
+				)
+			);
+		}
 		echo '</label>';
 	}
 	echo '</fieldset>';


### PR DESCRIPTION
## Summary

On the fair-audience **event-signup** block, events that require a minimum number of activities showed a running price on the signup button even while it was **disabled** below the minimum — misleading visitors about what they'd pay before making a valid selection.

For events that use the minimum-activities feature:
- **Below the minimum** → button shows only the bare action label (no price), matching its disabled state; options show no price.
- **At/above the minimum** → button shows the accumulating total, and each **unchosen** activity shows a `(+price)` add-on tag advertising what adding it would cost. Chosen activities show no tag (already in the total).

The `(+price)` tag **replaces** the inline `— €X.XX` option price for these events (no double price). Events **without** any minimum requirement are unchanged.

Closes #644.

## Changes

- **`render.php`** — when the minimum-activities feature is active (`$minimum_activities > 0 || $any_ticket_type_min > 0`), drop the inline option price and emit a hidden `<span class="fair-audience-ticket-option-addon">(+€X.XX)</span>` inside the label for positive-priced options. Feature-inactive events keep the inline price.
- **`frontend.js`** — extract `getEffectiveMinimum(block)`; suppress the button price in `updateButtonTotal` when below the minimum; add `updateOptionAddons(block)` (scoped to `.fair-audience-ticket-options`) to toggle tags on unchecked options once the minimum is met; wire both into the change handlers and into init so first paint is correct.

The min-activities gate and hint paragraph are unchanged. `npm run build` succeeds in `fair-audience`.

## Verification

Manual, against an event date with `minimum_activities = 2` and priced options:
1. **0–1 selected** → button disabled, no price; no `(+price)` tags; hint visible.
2. **2+ selected** → button enabled, shows total; every unchecked option shows `(+€X.XX)`; checked options show none.
3. **Switch ticket type** that raises the minimum → price/tags re-hide/re-show live.
4. **No-minimum event** → unchanged (inline prices, running total, no tags).
5. Clicking a `(+price)` tag still toggles its checkbox (tag is inside the `<label>`).