### PR TITLE
Add Statistics tab to event management page

### DIFF
--- a/fair-events/jest.config.cjs
+++ b/fair-events/jest.config.cjs
@@ -1,0 +1,17 @@
+module.exports = {
+	preset: '@wordpress/jest-preset-default',
+	testEnvironment: 'jsdom',
+	testMatch: ['**/?(*.)+(test).[jt]s?(x)'],
+	testPathIgnorePatterns: ['/node_modules/', '/vendor/', '/build/', '/e2e/'],
+	transform: {
+		'^.+\\.[jt]sx?$': [
+			'babel-jest',
+			{
+				presets: [
+					['@babel/preset-env', { targets: { node: 'current' } }],
+					['@babel/preset-react', { runtime: 'automatic' }],
+				],
+			},
+		],
+	},
+};

--- a/fair-events/package.json
+++ b/fair-events/package.json
@@ -46,12 +46,15 @@
 		"@wordpress/i18n": "^6.2.0",
 		"calendar-link": "^2.11.0",
 		"fair-events-shared": "*",
-		"react-easy-crop": "^5.5.6"
+		"react-easy-crop": "^5.5.6",
+		"recharts": "^2.12.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.28.3",
 		"@babel/preset-env": "^7.28.3",
 		"@playwright/test": "^1.40.0",
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/react": "^14.3.1",
 		"@wordpress/scripts": "^31.2.0",
 		"babel-jest": "^30.0.5",
 		"dotenv": "^16.3.1",

--- a/fair-events/src/Admin/manage-event/EventStatistics.js
+++ b/fair-events/src/Admin/manage-event/EventStatistics.js
@@ -1,0 +1,290 @@
+import { useState, useEffect, useMemo } from '@wordpress/element';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	Notice,
+	Spinner,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	ResponsiveContainer,
+	BarChart,
+	Bar,
+	XAxis,
+	YAxis,
+	Tooltip,
+	CartesianGrid,
+} from 'recharts';
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const BAR_COLOR = '#3858e9'; // WordPress admin blue.
+
+// WordPress stores datetimes as "YYYY-MM-DD HH:MM:SS"; Safari/strict parsers
+// reject the space, so normalise it to an ISO-ish "T" before constructing Date.
+function parseDate(value) {
+	if (!value) return NaN;
+	return new Date(String(value).replace(' ', 'T')).getTime();
+}
+
+// People per activity: one row per distinct ticket option, counting how many
+// confirmed participants picked it. ticket_option_ids / ticket_option_names are
+// parallel arrays on each participant row. Sorted by count descending.
+export function peoplePerActivity(participants) {
+	const counts = new Map();
+	participants.forEach((p) => {
+		const ids = Array.isArray(p.ticket_option_ids)
+			? p.ticket_option_ids
+			: [];
+		const names = Array.isArray(p.ticket_option_names)
+			? p.ticket_option_names
+			: [];
+		ids.forEach((id, i) => {
+			const name = names[i] || `#${id}`;
+			counts.set(name, (counts.get(name) || 0) + 1);
+		});
+	});
+	return Array.from(counts.entries())
+		.map(([name, count]) => ({ name, count }))
+		.sort((a, b) => b.count - a.count);
+}
+
+// Activities-per-person histogram: how many people picked 0 activities, 1, 2, …
+// The range is filled continuously from the smallest to the largest observed
+// count so the histogram has no gaps.
+export function activityCountDistribution(participants) {
+	const buckets = new Map();
+	participants.forEach((p) => {
+		const n = Array.isArray(p.ticket_option_ids)
+			? p.ticket_option_ids.length
+			: 0;
+		buckets.set(n, (buckets.get(n) || 0) + 1);
+	});
+	if (!buckets.size) return [];
+	const keys = Array.from(buckets.keys());
+	const min = Math.min(...keys);
+	const max = Math.max(...keys);
+	const result = [];
+	for (let i = min; i <= max; i++) {
+		result.push({ activities: i, people: buckets.get(i) || 0 });
+	}
+	return result;
+}
+
+// Sales lead time: confirmed tickets bucketed per day by how many days before
+// the event they were created. Returned furthest-out first (descending daysOut)
+// with a continuous day range so the axis reads as a timeline toward the event.
+export function salesLeadTime(participants, eventDate) {
+	const eventTime = parseDate(eventDate);
+	if (Number.isNaN(eventTime)) return [];
+	const buckets = new Map();
+	participants.forEach((p) => {
+		const createdTime = parseDate(p.created_at);
+		if (Number.isNaN(createdTime)) return;
+		const daysOut = Math.max(
+			0,
+			Math.floor((eventTime - createdTime) / MS_PER_DAY)
+		);
+		buckets.set(daysOut, (buckets.get(daysOut) || 0) + 1);
+	});
+	if (!buckets.size) return [];
+	const max = Math.max(...buckets.keys());
+	const result = [];
+	for (let d = max; d >= 0; d--) {
+		result.push({ daysOut: d, count: buckets.get(d) || 0 });
+	}
+	return result;
+}
+
+function ChartCard({ title, children }) {
+	return (
+		<Card style={{ marginTop: '16px' }}>
+			<CardHeader>
+				<h3 style={{ margin: 0 }}>{title}</h3>
+			</CardHeader>
+			<CardBody>{children}</CardBody>
+		</Card>
+	);
+}
+
+export default function EventStatistics({ eventDateId }) {
+	const [participants, setParticipants] = useState([]);
+	const [eventDate, setEventDate] = useState(null);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		if (!eventDateId) {
+			setLoading(false);
+			return;
+		}
+		setLoading(true);
+		Promise.all([
+			apiFetch({
+				path: `/fair-audience/v1/event-dates/${eventDateId}/participants`,
+			}).catch(() => []),
+			apiFetch({
+				path: `/fair-audience/v1/event-dates/${eventDateId}`,
+			}).catch(() => null),
+		])
+			.then(([participantData, eventInfo]) => {
+				setParticipants(
+					Array.isArray(participantData) ? participantData : []
+				);
+				setEventDate(eventInfo?.event_date || null);
+			})
+			.finally(() => setLoading(false));
+	}, [eventDateId]);
+
+	const confirmed = useMemo(
+		() => participants.filter((p) => p.label === 'signed_up'),
+		[participants]
+	);
+	const excludedCount = participants.length - confirmed.length;
+
+	const activityData = useMemo(
+		() => peoplePerActivity(confirmed),
+		[confirmed]
+	);
+	const distributionData = useMemo(
+		() => activityCountDistribution(confirmed),
+		[confirmed]
+	);
+	const leadTimeData = useMemo(
+		() => salesLeadTime(confirmed, eventDate),
+		[confirmed, eventDate]
+	);
+
+	if (loading) {
+		return (
+			<div style={{ padding: '24px', textAlign: 'center' }}>
+				<Spinner />
+			</div>
+		);
+	}
+
+	if (confirmed.length === 0) {
+		return (
+			<Notice status="info" isDismissible={false}>
+				{__(
+					'No confirmed participants yet. Statistics appear once people sign up.',
+					'fair-events'
+				)}
+			</Notice>
+		);
+	}
+
+	return (
+		<div>
+			<Notice status="info" isDismissible={false}>
+				{sprintf(
+					/* translators: %d: number of excluded participant rows. */
+					__(
+						'Confirmed participants only (signed up). %d excluded (pending payment, interested, collaborators).',
+						'fair-events'
+					),
+					excludedCount
+				)}
+			</Notice>
+
+			<ChartCard title={__('People per activity', 'fair-events')}>
+				{activityData.length === 0 ? (
+					<p>
+						{__(
+							'No activities recorded for confirmed participants.',
+							'fair-events'
+						)}
+					</p>
+				) : (
+					<ResponsiveContainer
+						width="100%"
+						height={Math.max(120, activityData.length * 44)}
+					>
+						<BarChart
+							data={activityData}
+							layout="vertical"
+							margin={{ left: 24, right: 24 }}
+						>
+							<CartesianGrid strokeDasharray="3 3" />
+							<XAxis type="number" allowDecimals={false} />
+							<YAxis type="category" dataKey="name" width={160} />
+							<Tooltip />
+							<Bar
+								dataKey="count"
+								name={__('People', 'fair-events')}
+								fill={BAR_COLOR}
+							/>
+						</BarChart>
+					</ResponsiveContainer>
+				)}
+			</ChartCard>
+
+			<ChartCard title={__('Activities per person', 'fair-events')}>
+				<ResponsiveContainer width="100%" height={280}>
+					<BarChart
+						data={distributionData}
+						margin={{ left: 8, right: 24 }}
+					>
+						<CartesianGrid strokeDasharray="3 3" />
+						<XAxis
+							dataKey="activities"
+							allowDecimals={false}
+							label={{
+								value: __('Activities', 'fair-events'),
+								position: 'insideBottom',
+								offset: -4,
+							}}
+						/>
+						<YAxis allowDecimals={false} />
+						<Tooltip />
+						<Bar
+							dataKey="people"
+							name={__('People', 'fair-events')}
+							fill={BAR_COLOR}
+						/>
+					</BarChart>
+				</ResponsiveContainer>
+			</ChartCard>
+
+			<ChartCard title={__('Sales lead time', 'fair-events')}>
+				{leadTimeData.length === 0 ? (
+					<p>
+						{__(
+							'Lead time is unavailable (missing event date or signup timestamps).',
+							'fair-events'
+						)}
+					</p>
+				) : (
+					<ResponsiveContainer width="100%" height={280}>
+						<BarChart
+							data={leadTimeData}
+							margin={{ left: 8, right: 24 }}
+						>
+							<CartesianGrid strokeDasharray="3 3" />
+							<XAxis
+								dataKey="daysOut"
+								allowDecimals={false}
+								reversed
+								label={{
+									value: __(
+										'Days before event',
+										'fair-events'
+									),
+									position: 'insideBottom',
+									offset: -4,
+								}}
+							/>
+							<YAxis allowDecimals={false} />
+							<Tooltip />
+							<Bar
+								dataKey="count"
+								name={__('Tickets', 'fair-events')}
+								fill={BAR_COLOR}
+							/>
+						</BarChart>
+					</ResponsiveContainer>
+				)}
+			</ChartCard>
+		</div>
+	);
+}

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -40,6 +40,7 @@ import GroupRules from './GroupRules.js';
 import EventTickets from './EventTickets.js';
 import EventPhotos from './EventPhotos.js';
 import EventMailings from './EventMailings.js';
+import EventStatistics from './EventStatistics.js';
 import DuplicateEventWizard from './DuplicateEventWizard.js';
 import MergeEventWizard from './MergeEventWizard.js';
 import RecurrenceCalendar from './RecurrenceCalendar.js';
@@ -588,6 +589,10 @@ export default function ManageEventApp() {
 						{
 							name: 'mailings',
 							title: __('Mailings', 'fair-events'),
+						},
+						{
+							name: 'statistics',
+							title: __('Statistics', 'fair-events'),
 						},
 				  ]
 				: []),
@@ -1218,6 +1223,14 @@ export default function ManageEventApp() {
 							<EventMailings
 								eventId={eventDate.event_id}
 								eventDateId={eventDateId}
+							/>
+						);
+					}
+					if (tab.name === 'statistics') {
+						return (
+							<EventStatistics
+								eventDateId={eventDateId}
+								eventId={eventDate.event_id}
 							/>
 						);
 					}

--- a/fair-events/src/Admin/manage-event/__tests__/EventStatistics.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventStatistics.test.jsx
@@ -1,0 +1,203 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import EventStatistics, {
+	peoplePerActivity,
+	activityCountDistribution,
+	salesLeadTime,
+} from '../EventStatistics.js';
+
+jest.mock('@wordpress/api-fetch');
+
+// recharts needs ResizeObserver / a sized container that jsdom doesn't provide,
+// and renders SVG internals that aren't this component's concern. Stub the
+// chart primitives so the test can focus on our headings, notice, and states.
+jest.mock('recharts', () => {
+	const Passthrough = ({ children }) => <div>{children}</div>;
+	const Empty = () => null;
+	return {
+		ResponsiveContainer: Passthrough,
+		BarChart: Passthrough,
+		Bar: Empty,
+		XAxis: Empty,
+		YAxis: Empty,
+		Tooltip: Empty,
+		CartesianGrid: Empty,
+	};
+});
+
+const signedUp = (overrides) => ({
+	label: 'signed_up',
+	ticket_option_ids: [],
+	ticket_option_names: [],
+	created_at: null,
+	...overrides,
+});
+
+describe('peoplePerActivity', () => {
+	it('counts confirmed participants per ticket option, sorted desc', () => {
+		const participants = [
+			signedUp({
+				ticket_option_ids: [1, 2],
+				ticket_option_names: ['Yoga', 'Acro'],
+			}),
+			signedUp({
+				ticket_option_ids: [1],
+				ticket_option_names: ['Yoga'],
+			}),
+			signedUp({
+				ticket_option_ids: [1, 3],
+				ticket_option_names: ['Yoga', 'Thai'],
+			}),
+		];
+		expect(peoplePerActivity(participants)).toEqual([
+			{ name: 'Yoga', count: 3 },
+			{ name: 'Acro', count: 1 },
+			{ name: 'Thai', count: 1 },
+		]);
+	});
+
+	it('falls back to #id when a name is missing', () => {
+		const participants = [
+			signedUp({ ticket_option_ids: [7], ticket_option_names: [] }),
+		];
+		expect(peoplePerActivity(participants)).toEqual([
+			{ name: '#7', count: 1 },
+		]);
+	});
+
+	it('returns [] for no participants', () => {
+		expect(peoplePerActivity([])).toEqual([]);
+	});
+});
+
+describe('activityCountDistribution', () => {
+	it('buckets people by number of activities, continuous range', () => {
+		const participants = [
+			signedUp({ ticket_option_ids: [1] }), // 1 activity
+			signedUp({ ticket_option_ids: [1, 2] }), // 2 activities
+			signedUp({ ticket_option_ids: [1, 2, 3] }), // 3 activities
+			signedUp({ ticket_option_ids: [4, 5, 6] }), // 3 activities
+		];
+		expect(activityCountDistribution(participants)).toEqual([
+			{ activities: 1, people: 1 },
+			{ activities: 2, people: 1 },
+			{ activities: 3, people: 2 },
+		]);
+	});
+
+	it('fills gaps in the range with zero', () => {
+		const participants = [
+			signedUp({ ticket_option_ids: [1] }), // 1
+			signedUp({ ticket_option_ids: [1, 2, 3] }), // 3
+		];
+		expect(activityCountDistribution(participants)).toEqual([
+			{ activities: 1, people: 1 },
+			{ activities: 2, people: 0 },
+			{ activities: 3, people: 1 },
+		]);
+	});
+});
+
+describe('salesLeadTime', () => {
+	const eventDate = '2026-06-15 00:00:00';
+
+	it('buckets confirmed tickets by whole days before the event, desc', () => {
+		const participants = [
+			signedUp({ created_at: '2026-06-01 00:00:00' }), // 14 days out
+			signedUp({ created_at: '2026-06-14 00:00:00' }), // 1 day out
+			signedUp({ created_at: '2026-06-14 12:00:00' }), // 0 days out
+		];
+		expect(salesLeadTime(participants, eventDate)).toEqual([
+			{ daysOut: 14, count: 1 },
+			{ daysOut: 13, count: 0 },
+			{ daysOut: 12, count: 0 },
+			{ daysOut: 11, count: 0 },
+			{ daysOut: 10, count: 0 },
+			{ daysOut: 9, count: 0 },
+			{ daysOut: 8, count: 0 },
+			{ daysOut: 7, count: 0 },
+			{ daysOut: 6, count: 0 },
+			{ daysOut: 5, count: 0 },
+			{ daysOut: 4, count: 0 },
+			{ daysOut: 3, count: 0 },
+			{ daysOut: 2, count: 0 },
+			{ daysOut: 1, count: 1 },
+			{ daysOut: 0, count: 1 },
+		]);
+	});
+
+	it('ignores rows with missing/unparseable created_at', () => {
+		const participants = [
+			signedUp({ created_at: null }),
+			signedUp({ created_at: '2026-06-14 00:00:00' }), // 1 day out
+		];
+		expect(salesLeadTime(participants, eventDate)).toEqual([
+			{ daysOut: 1, count: 1 },
+			{ daysOut: 0, count: 0 },
+		]);
+	});
+
+	it('returns [] when the event date is missing', () => {
+		expect(
+			salesLeadTime([signedUp({ created_at: eventDate })], null)
+		).toEqual([]);
+	});
+});
+
+describe('EventStatistics component', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	function mockApi(participants, eventDate = '2026-06-15 00:00:00') {
+		apiFetch.mockImplementation((opts) => {
+			if (opts.path.endsWith('/participants')) {
+				return Promise.resolve(participants);
+			}
+			return Promise.resolve({ event_date: eventDate });
+		});
+	}
+
+	it('renders the three views and the exclusion note', async () => {
+		mockApi([
+			signedUp({
+				ticket_option_ids: [1],
+				ticket_option_names: ['Yoga'],
+				created_at: '2026-06-10 00:00:00',
+			}),
+			// Excluded rows: not signed_up.
+			{ label: 'pending_payment', ticket_option_ids: [1] },
+			{ label: 'interested', ticket_option_ids: [] },
+		]);
+
+		render(<EventStatistics eventDateId={42} />);
+
+		await waitFor(() =>
+			expect(screen.getByText('People per activity')).toBeInTheDocument()
+		);
+		expect(screen.getByText('Activities per person')).toBeInTheDocument();
+		expect(screen.getByText('Sales lead time')).toBeInTheDocument();
+		// 2 of the 3 rows are excluded (pending_payment + interested).
+		// getAllByText: WordPress Notice mirrors its text into an a11y live region.
+		expect(screen.getAllByText(/2 excluded/).length).toBeGreaterThan(0);
+	});
+
+	it('shows an empty-state when there are no confirmed participants', async () => {
+		mockApi([{ label: 'interested', ticket_option_ids: [] }]);
+
+		render(<EventStatistics eventDateId={42} />);
+
+		await waitFor(() =>
+			expect(
+				screen.getAllByText(/No confirmed participants yet/).length
+			).toBeGreaterThan(0)
+		);
+		expect(
+			screen.queryByText('People per activity')
+		).not.toBeInTheDocument();
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3109,12 +3109,15 @@
 				"@wordpress/i18n": "^6.2.0",
 				"calendar-link": "^2.11.0",
 				"fair-events-shared": "*",
-				"react-easy-crop": "^5.5.6"
+				"react-easy-crop": "^5.5.6",
+				"recharts": "^2.12.0"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.28.3",
 				"@babel/preset-env": "^7.28.3",
 				"@playwright/test": "^1.40.0",
+				"@testing-library/jest-dom": "^6.9.1",
+				"@testing-library/react": "^14.3.1",
 				"@wordpress/scripts": "^31.2.0",
 				"babel-jest": "^30.0.5",
 				"dotenv": "^16.3.1",
@@ -13231,6 +13234,69 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/d3-array": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-color": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-ease": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-interpolate": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+			"integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-color": "*"
+			}
+		},
+		"node_modules/@types/d3-path": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+			"integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-scale": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-time": "*"
+			}
+		},
+		"node_modules/@types/d3-shape": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+			"integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-path": "*"
+			}
+		},
+		"node_modules/@types/d3-time": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-timer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+			"license": "MIT"
+		},
 		"node_modules/@types/eslint": {
 			"version": "9.6.1",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -13549,6 +13615,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
 			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -13559,6 +13626,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
@@ -20378,6 +20446,127 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/d3-array": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+			"license": "ISC",
+			"dependencies": {
+				"internmap": "1 - 2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-color": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-ease": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-format": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+			"integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-interpolate": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-scale": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.10.0 - 3",
+				"d3-format": "1 - 3",
+				"d3-interpolate": "1.2.0 - 3",
+				"d3-time": "2.1.1 - 3",
+				"d3-time-format": "2 - 4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-shape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time-format": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-time": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/damerau-levenshtein": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -20541,6 +20730,12 @@
 			"version": "10.6.0",
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
 			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"license": "MIT"
+		},
+		"node_modules/decimal.js-light": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+			"integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
 			"license": "MIT"
 		},
 		"node_modules/decompress-response": {
@@ -20986,6 +21181,16 @@
 			"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/dom-helpers": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^3.0.2"
+			}
 		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
@@ -22488,6 +22693,15 @@
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
 			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/fast-equals": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+			"integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/fast-fifo": {
 			"version": "1.3.2",
@@ -24281,6 +24495,15 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/internmap": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/interpret": {
@@ -31552,6 +31775,21 @@
 				}
 			}
 		},
+		"node_modules/react-smooth": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+			"integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-equals": "^5.0.1",
+				"prop-types": "^15.8.1",
+				"react-transition-group": "^4.4.5"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
 		"node_modules/react-style-singleton": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -31572,6 +31810,22 @@
 				"@types/react": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/react-transition-group": {
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+			"integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
+			},
+			"peerDependencies": {
+				"react": ">=16.6.0",
+				"react-dom": ">=16.6.0"
 			}
 		},
 		"node_modules/read-cache": {
@@ -31751,6 +32005,39 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/recharts": {
+			"version": "2.15.4",
+			"resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+			"integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+			"deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+			"license": "MIT",
+			"dependencies": {
+				"clsx": "^2.0.0",
+				"eventemitter3": "^4.0.1",
+				"lodash": "^4.17.21",
+				"react-is": "^18.3.1",
+				"react-smooth": "^4.0.4",
+				"recharts-scale": "^0.4.4",
+				"tiny-invariant": "^1.3.1",
+				"victory-vendor": "^36.6.8"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/recharts-scale": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+			"integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+			"license": "MIT",
+			"dependencies": {
+				"decimal.js-light": "^2.4.1"
 			}
 		},
 		"node_modules/rechoir": {
@@ -34751,6 +35038,12 @@
 			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
 			"license": "MIT"
 		},
+		"node_modules/tiny-invariant": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+			"integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+			"license": "MIT"
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -35588,6 +35881,28 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/victory-vendor": {
+			"version": "36.9.2",
+			"resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+			"integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+			"license": "MIT AND ISC",
+			"dependencies": {
+				"@types/d3-array": "^3.0.3",
+				"@types/d3-ease": "^3.0.0",
+				"@types/d3-interpolate": "^3.0.1",
+				"@types/d3-scale": "^4.0.2",
+				"@types/d3-shape": "^3.1.0",
+				"@types/d3-time": "^3.0.0",
+				"@types/d3-timer": "^3.0.0",
+				"d3-array": "^3.1.6",
+				"d3-ease": "^3.0.1",
+				"d3-interpolate": "^3.0.1",
+				"d3-scale": "^4.0.2",
+				"d3-shape": "^3.1.0",
+				"d3-time": "^3.0.0",
+				"d3-timer": "^3.0.1"
 			}
 		},
 		"node_modules/w3c-xmlserializer": {


### PR DESCRIPTION
## Summary

Adds a **Statistics** tab to the manage-event page (shown alongside Audience) that summarizes participation and sales for the current event date. All three views are computed client-side from the existing `/fair-audience/v1/event-dates/{id}/participants` endpoint — no new backend route. Closes #641.

- **People per activity** — confirmed sign-ups per ticket option (horizontal bars).
- **Activities per person** — histogram of how many activities each person picked.
- **Sales lead time** — tickets created per day, bucketed by days before the event.

Only confirmed (`signed_up`) participants are counted; a visible note reports how many rows were excluded (pending payment / interested / collaborators).

## Notes

- **Charting:** uses `recharts` (new `fair-events` dependency). Per the issue this establishes the approach #638 can reuse. The manage-event bundle grows to ~547 KiB (trips webpack's 244 KiB perf warning) — lazy-loading the tab with `import()` is a possible follow-up if load time matters.
- **Test infra:** `fair-events` had no JS test setup, so this adds `jest.config.cjs` (mirroring fair-payment) and the two `@testing-library/*` devDeps; everything else was already hoisted at the repo root.
- **Scope (v1):** single `event_date_id` only; recurring-event aggregation and a dedicated SQL aggregation endpoint are deferred (the single-date dataset is small enough to aggregate in the browser).
- No PHP changes — the participants endpoint is already `is_user_logged_in`-gated.

## Test plan

- [x] `npm test` in `fair-events` — 12 passing (10 new: 3 helper-maths suites + render/empty-state, plus the existing example test).
- [x] `npm run build` in `fair-events` — succeeds; `.asset.php` confirms `react`/`react-jsx-runtime` are externalized (no duplicate react-dom bundled).
- [ ] Manual: open manage-event for a date with confirmed participants; confirm the Statistics tab appears next to Audience, the three views show sane numbers, and the exclusion count matches (total − signed_up).