### PR TITLE
Scope event mailings to event date instead of event

### DIFF
--- a/fair-audience/fair-audience.php
+++ b/fair-audience/fair-audience.php
@@ -73,7 +73,7 @@ function fair_audience_activate() {
 	dbDelta( \FairAudience\Database\Schema::get_event_scheduled_messages_table_sql() );
 
 	// Update database version.
-	update_option( 'fair_audience_db_version', '1.35.0' );
+	update_option( 'fair_audience_db_version', '1.36.0' );
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\\fair_audience_activate' );
 
@@ -650,6 +650,71 @@ function fair_audience_maybe_upgrade_db() {
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( \FairAudience\Database\Schema::get_event_scheduled_messages_table_sql() );
 		update_option( 'fair_audience_db_version', '1.35.0' );
+	}
+
+	if ( version_compare( $db_version, '1.36.0', '<' ) ) {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'fair_audience_event_scheduled_messages';
+
+		// Re-scope scheduled mailings from the event (post) to the event date.
+		// MySQL 8 (unlike MariaDB) has no IF [NOT] EXISTS for columns/indexes,
+		// so each schema change is guarded with an information_schema check.
+
+		// Backfill event_date_id from the anchor where missing; anchor_ref_id has
+		// always held the event-date id, so it is a safe source for legacy rows.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			"UPDATE {$table_name}
+			 SET event_date_id = anchor_ref_id
+			 WHERE event_date_id IS NULL AND anchor_ref_id IS NOT NULL"
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$wpdb->query(
+			"ALTER TABLE {$table_name}
+			 MODIFY COLUMN event_date_id BIGINT UNSIGNED NOT NULL COMMENT 'Event date the mailing is scoped to'"
+		);
+
+		$has_event_id_index = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM information_schema.STATISTICS
+				 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s AND INDEX_NAME = %s',
+				$table_name,
+				'idx_event_id'
+			)
+		);
+		if ( $has_event_id_index ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+			$wpdb->query( "ALTER TABLE {$table_name} DROP INDEX idx_event_id" );
+		}
+
+		$has_event_id_column = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM information_schema.COLUMNS
+				 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s AND COLUMN_NAME = %s',
+				$table_name,
+				'event_id'
+			)
+		);
+		if ( $has_event_id_column ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+			$wpdb->query( "ALTER TABLE {$table_name} DROP COLUMN event_id" );
+		}
+
+		$has_event_date_index = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM information_schema.STATISTICS
+				 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s AND INDEX_NAME = %s',
+				$table_name,
+				'idx_event_date_id'
+			)
+		);
+		if ( ! $has_event_date_index ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+			$wpdb->query( "ALTER TABLE {$table_name} ADD INDEX idx_event_date_id (event_date_id)" );
+		}
+
+		update_option( 'fair_audience_db_version', '1.36.0' );
 	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_audience_maybe_upgrade_db' );

--- a/fair-audience/src/API/ScheduledMessagesController.php
+++ b/fair-audience/src/API/ScheduledMessagesController.php
@@ -19,7 +19,7 @@ use WP_Error;
 defined( 'WPINC' ) || die;
 
 /**
- * REST API controller for scheduled per-event mailings.
+ * REST API controller for scheduled per-event-date mailings.
  */
 class ScheduledMessagesController extends WP_REST_Controller {
 
@@ -66,7 +66,7 @@ class ScheduledMessagesController extends WP_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/events/(?P<event_id>[\d]+)/scheduled-messages',
+			'/event-dates/(?P<event_date_id>[\d]+)/scheduled-messages',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -84,19 +84,7 @@ class ScheduledMessagesController extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/events/(?P<event_id>[\d]+)/event-dates',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_event_dates' ),
-					'permission_callback' => array( $this, 'admin_permissions_check' ),
-				),
-			)
-		);
-
-		register_rest_route(
-			$this->namespace,
-			'/events/(?P<event_id>[\d]+)/scheduled-messages/preview-recipients',
+			'/event-dates/(?P<event_date_id>[\d]+)/scheduled-messages/preview-recipients',
 			array(
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
@@ -198,14 +186,14 @@ class ScheduledMessagesController extends WP_REST_Controller {
 	}
 
 	/**
-	 * List scheduled messages for an event.
+	 * List scheduled messages for an event date.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response Response object.
 	 */
 	public function get_items( $request ) {
-		$event_id = (int) $request->get_param( 'event_id' );
-		$messages = $this->repository->get_by_event( $event_id );
+		$event_date_id = (int) $request->get_param( 'event_date_id' );
+		$messages      = $this->repository->get_by_event_date( $event_date_id );
 
 		$data = array_map(
 			function ( $message ) {
@@ -218,26 +206,21 @@ class ScheduledMessagesController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Create a scheduled message for an event.
+	 * Create a scheduled message for an event date.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response|WP_Error Response object.
 	 */
 	public function create_item( $request ) {
-		$event_id = (int) $request->get_param( 'event_id' );
+		$event_date_id = (int) $request->get_param( 'event_date_id' );
 
-		if ( ! get_post( $event_id ) ) {
-			return new WP_Error( 'invalid_event', __( 'Event not found.', 'fair-audience' ), array( 'status' => 404 ) );
-		}
-
-		$anchor = $this->validate_anchor( $request, $event_id );
+		$anchor = $this->validate_anchor( $request, $event_date_id );
 		if ( is_wp_error( $anchor ) ) {
 			return $anchor;
 		}
 
 		$message                    = new ScheduledMessage();
-		$message->event_id          = $event_id;
-		$message->event_date_id     = $anchor['event_date_id'];
+		$message->event_date_id     = $event_date_id;
 		$message->subject           = $request->get_param( 'subject' );
 		$message->body              = wp_kses_post( $request->get_param( 'body' ) );
 		$message->anchor_type       = $request->get_param( 'anchor_type' );
@@ -279,12 +262,11 @@ class ScheduledMessagesController extends WP_REST_Controller {
 			);
 		}
 
-		$anchor = $this->validate_anchor( $request, $message->event_id );
+		$anchor = $this->validate_anchor( $request, $message->event_date_id );
 		if ( is_wp_error( $anchor ) ) {
 			return $anchor;
 		}
 
-		$message->event_date_id     = $anchor['event_date_id'];
 		$message->subject           = $request->get_param( 'subject' );
 		$message->body              = wp_kses_post( $request->get_param( 'body' ) );
 		$message->anchor_type       = $request->get_param( 'anchor_type' );
@@ -342,49 +324,9 @@ class ScheduledMessagesController extends WP_REST_Controller {
 			return new WP_Error( 'not_found', __( 'Scheduled message not found.', 'fair-audience' ), array( 'status' => 404 ) );
 		}
 
-		$recipients = $this->resolver->resolve( $message->recipients_filter, $message->event_id );
+		$recipients = $this->resolver->resolve_by_event_date( $message->recipients_filter, $message->event_date_id );
 
 		return rest_ensure_response( $recipients );
-	}
-
-	/**
-	 * List an event's dates for the anchor picker.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return \WP_REST_Response Response object.
-	 */
-	public function get_event_dates( $request ) {
-		global $wpdb;
-
-		$event_id = (int) $request->get_param( 'event_id' );
-		$table    = $wpdb->prefix . 'fair_event_dates';
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				'SELECT id, start_datetime, end_datetime, all_day FROM %i WHERE event_id = %d ORDER BY start_datetime ASC',
-				$table,
-				$event_id
-			),
-			ARRAY_A
-		);
-
-		$data = array_map(
-			static function ( $row ) {
-				$start_display = empty( $row['start_datetime'] ) ? '' : wp_date( 'Y-m-d H:i', strtotime( $row['start_datetime'] ) );
-
-				return array(
-					'id'             => (int) $row['id'],
-					'start_datetime' => $row['start_datetime'],
-					'end_datetime'   => $row['end_datetime'],
-					'all_day'        => ! empty( $row['all_day'] ),
-					'display_label'  => $start_display,
-				);
-			},
-			$rows
-		);
-
-		return rest_ensure_response( $data );
 	}
 
 	/**
@@ -394,10 +336,10 @@ class ScheduledMessagesController extends WP_REST_Controller {
 	 * @return \WP_REST_Response Response object.
 	 */
 	public function preview_draft_recipients( $request ) {
-		$event_id = (int) $request->get_param( 'event_id' );
-		$filter   = $request->get_param( 'recipients_filter' );
+		$event_date_id = (int) $request->get_param( 'event_date_id' );
+		$filter        = $request->get_param( 'recipients_filter' );
 
-		$recipients = $this->resolver->resolve( $filter, $event_id );
+		$recipients = $this->resolver->resolve_by_event_date( $filter, $event_date_id );
 
 		return rest_ensure_response( $recipients );
 	}
@@ -405,16 +347,16 @@ class ScheduledMessagesController extends WP_REST_Controller {
 	/**
 	 * Validate the anchor for a create/update request.
 	 *
-	 * Rejects sale-period anchors (until #617) and verifies the referenced
-	 * event date belongs to the event.
+	 * Rejects sale-period anchors (until #617). A mailing is scoped to one event
+	 * date, so the anchor always refers to that date: the anchor row is forced to
+	 * the scoping event date and verified to exist.
 	 *
-	 * @param WP_REST_Request $request  Request object.
-	 * @param int             $event_id Event post ID.
+	 * @param WP_REST_Request $request       Request object.
+	 * @param int             $event_date_id Event date the mailing is scoped to.
 	 * @return array|WP_Error {anchor_ref_id, event_date_id} or error.
 	 */
-	private function validate_anchor( $request, $event_id ) {
-		$anchor_type   = $request->get_param( 'anchor_type' );
-		$anchor_ref_id = (int) $request->get_param( 'anchor_ref_id' );
+	private function validate_anchor( $request, $event_date_id ) {
+		$anchor_type = $request->get_param( 'anchor_type' );
 
 		if ( ! ScheduledMessageScheduler::is_supported_anchor( $anchor_type ) ) {
 			return new WP_Error(
@@ -428,22 +370,21 @@ class ScheduledMessagesController extends WP_REST_Controller {
 		$table = $wpdb->prefix . 'fair_event_dates';
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$event_date = $wpdb->get_row(
-			$wpdb->prepare( 'SELECT id, event_id FROM %i WHERE id = %d', $table, $anchor_ref_id ),
-			ARRAY_A
+		$exists = $wpdb->get_var(
+			$wpdb->prepare( 'SELECT id FROM %i WHERE id = %d', $table, $event_date_id )
 		);
 
-		if ( ! $event_date || (int) $event_date['event_id'] !== $event_id ) {
+		if ( ! $exists ) {
 			return new WP_Error(
-				'invalid_anchor',
-				__( 'The chosen event date does not belong to this event.', 'fair-audience' ),
-				array( 'status' => 400 )
+				'invalid_event_date',
+				__( 'Event date not found.', 'fair-audience' ),
+				array( 'status' => 404 )
 			);
 		}
 
 		return array(
-			'anchor_ref_id' => $anchor_ref_id,
-			'event_date_id' => $anchor_ref_id,
+			'anchor_ref_id' => $event_date_id,
+			'event_date_id' => $event_date_id,
 		);
 	}
 
@@ -456,7 +397,6 @@ class ScheduledMessagesController extends WP_REST_Controller {
 	private function prepare_message( $message ) {
 		return array(
 			'id'                => $message->id,
-			'event_id'          => $message->event_id,
 			'event_date_id'     => $message->event_date_id,
 			'subject'           => $message->subject,
 			'body'              => $message->body,

--- a/fair-audience/src/API/__tests__/ScheduledMessagesController.api.spec.js
+++ b/fair-audience/src/API/__tests__/ScheduledMessagesController.api.spec.js
@@ -1,10 +1,10 @@
 /**
  * Playwright API tests for the ScheduledMessagesController.
  *
- * Exercises the scheduled per-event mailing endpoints against a live WordPress
- * instance:
- *   GET/POST  /fair-audience/v1/events/{event_id}/scheduled-messages
- *   POST      /fair-audience/v1/events/{event_id}/scheduled-messages/preview-recipients
+ * Exercises the scheduled per-event-date mailing endpoints against a live
+ * WordPress instance:
+ *   GET/POST  /fair-audience/v1/event-dates/{event_date_id}/scheduled-messages
+ *   POST      /fair-audience/v1/event-dates/{event_date_id}/scheduled-messages/preview-recipients
  *   PUT/DELETE /fair-audience/v1/scheduled-messages/{id}
  *   POST      /fair-audience/v1/scheduled-messages/{id}/preview-recipients
  *
@@ -147,7 +147,7 @@ test.describe('ScheduledMessagesController', () => {
 
 	test('unauthenticated create is rejected', async () => {
 		const res = await api.post(
-			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages`,
 			{ data: baseMessage(eventDateId) }
 		);
 		expect(res.status()).toBeGreaterThanOrEqual(401);
@@ -156,7 +156,7 @@ test.describe('ScheduledMessagesController', () => {
 
 	test('create schedules a message with a computed send time', async () => {
 		const res = await api.post(
-			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages`,
 			{ headers: authHeaders, data: baseMessage(eventDateId) }
 		);
 		expect(res.status()).toBe(200);
@@ -176,7 +176,7 @@ test.describe('ScheduledMessagesController', () => {
 
 	test('sale-period anchors are rejected until #617', async () => {
 		const res = await api.post(
-			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages`,
 			{
 				headers: authHeaders,
 				data: baseMessage(eventDateId, {
@@ -187,26 +187,18 @@ test.describe('ScheduledMessagesController', () => {
 		expect(res.status()).toBe(400);
 	});
 
-	test('anchor from a different event is rejected', async () => {
-		const otherEventId = await publishEvent(
-			api,
-			`Other Event ${Date.now()}`
-		);
-		const otherDateId = await resolveEventDateId(api, otherEventId);
-
+	test('create on a nonexistent event date is rejected', async () => {
 		const res = await api.post(
-			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
-			{ headers: authHeaders, data: baseMessage(otherDateId) }
+			`/wp-json/fair-audience/v1/event-dates/999999999/scheduled-messages`,
+			{ headers: authHeaders, data: baseMessage(999999999) }
 		);
-		expect(res.status()).toBe(400);
-
-		await deleteEvent(api, otherEventId);
+		expect(res.status()).toBe(404);
 	});
 
 	test('list, edit, preview, and cancel lifecycle', async () => {
 		// Create.
 		const createRes = await api.post(
-			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages`,
 			{ headers: authHeaders, data: baseMessage(eventDateId) }
 		);
 		expect(createRes.ok()).toBeTruthy();
@@ -215,7 +207,7 @@ test.describe('ScheduledMessagesController', () => {
 
 		// List includes it.
 		const listRes = await api.get(
-			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages`,
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages`,
 			{ headers: authHeaders }
 		);
 		expect(listRes.ok()).toBeTruthy();
@@ -277,7 +269,7 @@ test.describe('ScheduledMessagesController', () => {
 
 	test('draft preview honors label filters without saving', async () => {
 		const res = await api.post(
-			`/wp-json/fair-audience/v1/events/${eventId}/scheduled-messages/preview-recipients`,
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages/preview-recipients`,
 			{
 				headers: authHeaders,
 				data: {
@@ -296,22 +288,28 @@ test.describe('ScheduledMessagesController', () => {
 		expect(ids).not.toContain(signedUpId);
 	});
 
-	test('deleting the event cancels its scheduled messages', async () => {
+	test('deleting the event date cancels its scheduled messages', async () => {
 		const tempEventId = await publishEvent(api, `Temp Event ${Date.now()}`);
 		const tempDateId = await resolveEventDateId(api, tempEventId);
 
 		const createRes = await api.post(
-			`/wp-json/fair-audience/v1/events/${tempEventId}/scheduled-messages`,
+			`/wp-json/fair-audience/v1/event-dates/${tempDateId}/scheduled-messages`,
 			{ headers: authHeaders, data: baseMessage(tempDateId) }
 		);
 		expect(createRes.ok()).toBeTruthy();
 		const messageId = (await createRes.json()).id;
 
-		// Force-delete the event post; before_delete_post cascades the cancel.
-		await deleteEvent(api, tempEventId);
+		// Delete the event date; fair_events_event_date_deleted cascades the
+		// cancel onto its anchored mailings.
+		const delRes = await api.delete(
+			`/wp-json/fair-events/v1/event-dates/${tempDateId}`,
+			{ headers: authHeaders }
+		);
+		expect(delRes.ok()).toBeTruthy();
 
+		// The message row survives the date deletion but is now canceled.
 		const listRes = await api.get(
-			`/wp-json/fair-audience/v1/events/${tempEventId}/scheduled-messages`,
+			`/wp-json/fair-audience/v1/event-dates/${tempDateId}/scheduled-messages`,
 			{ headers: authHeaders }
 		);
 		expect(listRes.ok()).toBeTruthy();
@@ -319,8 +317,10 @@ test.describe('ScheduledMessagesController', () => {
 		const message = list.find((m) => m.id === messageId);
 		expect(
 			message,
-			'scheduled message row survives event deletion'
+			'scheduled message row survives event-date deletion'
 		).toBeTruthy();
 		expect(message.status).toBe('canceled');
+
+		await deleteEvent(api, tempEventId);
 	});
 });

--- a/fair-audience/src/Database/ScheduledMessageRepository.php
+++ b/fair-audience/src/Database/ScheduledMessageRepository.php
@@ -50,19 +50,19 @@ class ScheduledMessageRepository {
 	}
 
 	/**
-	 * Get all scheduled messages for an event, newest first.
+	 * Get all scheduled messages for an event date, newest first.
 	 *
-	 * @param int $event_id Event post ID.
+	 * @param int $event_date_id Event date ID.
 	 * @return ScheduledMessage[] Array of messages.
 	 */
-	public function get_by_event( $event_id ) {
+	public function get_by_event_date( $event_date_id ) {
 		global $wpdb;
 
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
-				'SELECT * FROM %i WHERE event_id = %d ORDER BY created_at DESC',
+				'SELECT * FROM %i WHERE event_date_id = %d ORDER BY created_at DESC',
 				$this->get_table_name(),
-				$event_id
+				$event_date_id
 			),
 			ARRAY_A
 		);
@@ -185,19 +185,19 @@ class ScheduledMessageRepository {
 	}
 
 	/**
-	 * Cancel all still-scheduled messages for an event.
+	 * Cancel all still-scheduled messages for an event date.
 	 *
-	 * @param int $event_id Event post ID.
+	 * @param int $event_date_id Event date ID.
 	 * @return int Number of rows canceled.
 	 */
-	public function cancel_for_event( $event_id ) {
+	public function cancel_for_event_date( $event_date_id ) {
 		global $wpdb;
 
 		return (int) $wpdb->query(
 			$wpdb->prepare(
-				"UPDATE %i SET status = 'canceled' WHERE event_id = %d AND status = 'scheduled'",
+				"UPDATE %i SET status = 'canceled' WHERE event_date_id = %d AND status = 'scheduled'",
 				$this->get_table_name(),
-				$event_id
+				$event_date_id
 			)
 		);
 	}

--- a/fair-audience/src/Database/Schema.php
+++ b/fair-audience/src/Database/Schema.php
@@ -587,15 +587,14 @@ class Schema {
 
 		return "CREATE TABLE $table_name (
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-			event_id BIGINT UNSIGNED NOT NULL COMMENT 'Denormalized for indexing / reschedule lookups',
-			event_date_id BIGINT UNSIGNED DEFAULT NULL COMMENT 'Anchor for event_date_* anchor types',
+			event_date_id BIGINT UNSIGNED NOT NULL COMMENT 'Event date the mailing is scoped to',
 			subject VARCHAR(255) NOT NULL,
 			body LONGTEXT NOT NULL,
 			anchor_type ENUM('event_date_start', 'event_date_end', 'sale_period_start', 'sale_period_end') NOT NULL,
 			anchor_ref_id BIGINT UNSIGNED DEFAULT NULL COMMENT 'Id of the anchor row (event_date id, or sale period id once #617 lands)',
-			offset_minutes INT NOT NULL DEFAULT 0 COMMENT 'Signed; negative = before anchor, positive = after',
+			offset_minutes INT NOT NULL DEFAULT 0 COMMENT 'Signed offset, negative = before anchor, positive = after',
 			recipients_filter LONGTEXT NOT NULL COMMENT 'JSON: {labels, group_ids, is_marketing}',
-			scheduled_for DATETIME DEFAULT NULL COMMENT 'Computed anchor_time + offset_minutes; recomputed on anchor change',
+			scheduled_for DATETIME DEFAULT NULL COMMENT 'Computed anchor_time + offset_minutes, recomputed on anchor change',
 			status ENUM('scheduled', 'sending', 'sent', 'canceled', 'failed') NOT NULL DEFAULT 'scheduled',
 			sent_count INT NOT NULL DEFAULT 0,
 			failed_count INT NOT NULL DEFAULT 0,
@@ -607,7 +606,7 @@ class Schema {
 			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY  (id),
 			KEY idx_status_scheduled_for (status, scheduled_for),
-			KEY idx_event_id (event_id),
+			KEY idx_event_date_id (event_date_id),
 			KEY idx_anchor (anchor_type, anchor_ref_id)
 		) ENGINE=InnoDB $charset_collate;";
 	}

--- a/fair-audience/src/Hooks/ScheduledMessageHooks.php
+++ b/fair-audience/src/Hooks/ScheduledMessageHooks.php
@@ -52,11 +52,11 @@ class ScheduledMessageHooks {
 		}
 
 		// Reschedule when the underlying anchor moves; cancel when it disappears.
+		// A mailing is scoped to a single event date, so deleting that date
+		// (which fires for every date when the parent event is deleted) cancels
+		// its mailings — no separate post-deletion hook is needed.
 		add_action( 'fair_events_event_date_updated', array( static::class, 'handle_event_date_changed' ) );
 		add_action( 'fair_events_event_date_deleted', array( static::class, 'handle_event_date_deleted' ) );
-
-		// Cancel an event's scheduled messages when the event is deleted.
-		add_action( 'before_delete_post', array( static::class, 'handle_event_deleted' ) );
 	}
 
 	/**
@@ -113,7 +113,7 @@ class ScheduledMessageHooks {
 
 		try {
 			$context    = self::build_context( $message );
-			$recipients = $resolver->resolve( $message->recipients_filter, $message->event_id );
+			$recipients = $resolver->resolve_by_event_date( $message->recipients_filter, $message->event_date_id );
 
 			foreach ( $recipients as $recipient ) {
 				if ( empty( $recipient['has_valid_email'] ) ) {
@@ -172,23 +172,30 @@ class ScheduledMessageHooks {
 	 */
 	private static function build_context( ScheduledMessage $message ) {
 		$event_name = '';
-		$event      = get_post( $message->event_id );
-		if ( $event ) {
-			$event_name = $event->post_title;
-		}
-
 		$event_date = '';
+
 		if ( $message->event_date_id ) {
 			global $wpdb;
 			$table = $wpdb->prefix . 'fair_event_dates';
 
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$start = $wpdb->get_var(
-				$wpdb->prepare( 'SELECT start_datetime FROM %i WHERE id = %d', $table, $message->event_date_id )
+			$row = $wpdb->get_row(
+				$wpdb->prepare( 'SELECT start_datetime, event_id FROM %i WHERE id = %d', $table, $message->event_date_id ),
+				ARRAY_A
 			);
 
-			if ( ! empty( $start ) ) {
-				$event_date = wp_date( 'Y-m-d H:i', strtotime( $start ) );
+			if ( $row ) {
+				if ( ! empty( $row['start_datetime'] ) ) {
+					$event_date = wp_date( 'Y-m-d H:i', strtotime( $row['start_datetime'] ) );
+				}
+
+				// Resolve the event name from the date's linked post, when present.
+				if ( ! empty( $row['event_id'] ) ) {
+					$event = get_post( (int) $row['event_id'] );
+					if ( $event ) {
+						$event_name = $event->post_title;
+					}
+				}
 			}
 		}
 
@@ -230,18 +237,5 @@ class ScheduledMessageHooks {
 				$message->save();
 			}
 		}
-	}
-
-	/**
-	 * Cancel all scheduled messages for a deleted event.
-	 *
-	 * Fires for every post deletion; the targeted UPDATE simply matches nothing
-	 * when the deleted post is not an event with scheduled messages.
-	 *
-	 * @param int $post_id Post being deleted.
-	 */
-	public static function handle_event_deleted( $post_id ) {
-		$repository = new ScheduledMessageRepository();
-		$repository->cancel_for_event( (int) $post_id );
 	}
 }

--- a/fair-audience/src/Models/ScheduledMessage.php
+++ b/fair-audience/src/Models/ScheduledMessage.php
@@ -22,16 +22,9 @@ class ScheduledMessage {
 	public $id;
 
 	/**
-	 * Event post ID (denormalized for indexing / reschedule lookups).
+	 * Event date ID — the event date this mailing is scoped to.
 	 *
 	 * @var int
-	 */
-	public $event_id;
-
-	/**
-	 * Event date ID — anchor for event_date_* anchor types.
-	 *
-	 * @var int|null
 	 */
 	public $event_date_id;
 
@@ -156,9 +149,9 @@ class ScheduledMessage {
 	 * @param array $data Optional data to populate.
 	 */
 	public function __construct( $data = array() ) {
-		if ( ! empty( $data ) ) {
-			$this->populate( $data );
-		}
+		// Always populate so numeric/status fields get their defaults (0 / 'scheduled')
+		// instead of null; an empty array yields a fully-initialized blank record.
+		$this->populate( $data );
 	}
 
 	/**
@@ -168,8 +161,7 @@ class ScheduledMessage {
 	 */
 	public function populate( $data ) {
 		$this->id             = isset( $data['id'] ) ? (int) $data['id'] : null;
-		$this->event_id       = isset( $data['event_id'] ) ? (int) $data['event_id'] : 0;
-		$this->event_date_id  = isset( $data['event_date_id'] ) && $data['event_date_id'] ? (int) $data['event_date_id'] : null;
+		$this->event_date_id  = isset( $data['event_date_id'] ) ? (int) $data['event_date_id'] : 0;
 		$this->subject        = isset( $data['subject'] ) ? sanitize_text_field( $data['subject'] ) : '';
 		$this->body           = isset( $data['body'] ) ? wp_kses_post( $data['body'] ) : '';
 		$this->anchor_type    = isset( $data['anchor_type'] ) ? sanitize_key( $data['anchor_type'] ) : '';
@@ -206,12 +198,11 @@ class ScheduledMessage {
 
 		$table_name = $wpdb->prefix . 'fair_audience_event_scheduled_messages';
 
-		if ( empty( $this->subject ) || empty( $this->body ) || empty( $this->anchor_type ) ) {
+		if ( empty( $this->subject ) || empty( $this->body ) || empty( $this->anchor_type ) || empty( $this->event_date_id ) ) {
 			return false;
 		}
 
 		$data = array(
-			'event_id'          => $this->event_id,
 			'event_date_id'     => $this->event_date_id,
 			'subject'           => $this->subject,
 			'body'              => $this->body,
@@ -229,7 +220,7 @@ class ScheduledMessage {
 			'created_by'        => $this->created_by,
 		);
 
-		$format = array( '%d', '%d', '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%d' );
+		$format = array( '%d', '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%d' );
 
 		if ( $this->id ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/fair-audience/src/Services/RecipientResolver.php
+++ b/fair-audience/src/Services/RecipientResolver.php
@@ -110,6 +110,22 @@ class RecipientResolver {
 	}
 
 	/**
+	 * Resolve a recipient filter scoped to a single event date.
+	 *
+	 * Recipients are the participants of that specific date whose label is in
+	 * the filter; group and marketing filters apply as usual.
+	 *
+	 * @param array $filter        Recipient filter (normalized or raw).
+	 * @param int   $event_date_id Event date ID.
+	 * @return array[] Recipient rows.
+	 */
+	public function resolve_by_event_date( $filter, $event_date_id ) {
+		$filter = $this->normalize_filter( $filter );
+
+		return $this->resolve_for_event_date( (int) $event_date_id, $filter );
+	}
+
+	/**
 	 * Resolve recipients scoped to a single event.
 	 *
 	 * @param int   $event_id Event post ID.
@@ -123,8 +139,38 @@ class RecipientResolver {
 			return $recipients;
 		}
 
+		$event_participants = $this->event_participant_repository->get_by_event( $event_id );
+
+		return $this->rows_from_event_participants( $event_participants, $filter );
+	}
+
+	/**
+	 * Resolve recipients scoped to a single event date.
+	 *
+	 * @param int   $event_date_id Event date ID.
+	 * @param array $filter        Normalized filter.
+	 * @return array[] Recipient rows.
+	 */
+	private function resolve_for_event_date( $event_date_id, $filter ) {
+		if ( empty( $event_date_id ) ) {
+			return array();
+		}
+
+		$event_participants = $this->event_participant_repository->get_by_event_date( $event_date_id );
+
+		return $this->rows_from_event_participants( $event_participants, $filter );
+	}
+
+	/**
+	 * Build recipient rows from a set of event-participant relationships.
+	 *
+	 * @param object[] $event_participants Event-participant rows (have label, participant_id).
+	 * @param array    $filter             Normalized filter.
+	 * @return array[] Recipient rows.
+	 */
+	private function rows_from_event_participants( $event_participants, $filter ) {
+		$recipients            = array();
 		$group_participant_ids = $this->get_participant_ids_for_groups( $filter['group_ids'] );
-		$event_participants    = $this->event_participant_repository->get_by_event( $event_id );
 
 		foreach ( $event_participants as $ep ) {
 			if ( ! in_array( $ep->label, $filter['labels'], true ) ) {

--- a/fair-events/src/Admin/manage-event/EventMailings.js
+++ b/fair-events/src/Admin/manage-event/EventMailings.js
@@ -33,7 +33,6 @@ import AnchorOffsetPicker, {
 } from './AnchorOffsetPicker.js';
 import {
 	loadScheduledMessages,
-	loadEventDates,
 	loadGroups,
 	createScheduledMessage,
 	updateScheduledMessage,
@@ -72,18 +71,42 @@ const emptyForm = (defaultAnchorRefId) => ({
 /**
  * Mailings tab.
  *
- * @param {Object} props             Component props.
- * @param {number} props.eventId      Event post ID.
- * @param {number} props.eventDateId  The event date currently being managed.
+ * Mailings are scoped to the single event date being managed; the anchor is
+ * always that date (start or end), so there is no cross-date picker.
+ *
+ * @param {Object} props               Component props.
+ * @param {number} props.eventDateId    The event date being managed.
+ * @param {string} props.startDatetime  The date's start datetime (for the send-time preview).
+ * @param {string} props.endDatetime    The date's end datetime (for the send-time preview).
+ * @param {boolean} props.allDay         Whether the date is all-day.
  * @return {JSX.Element} The tab.
  */
-export default function EventMailings({ eventId, eventDateId }) {
+export default function EventMailings({
+	eventDateId,
+	startDatetime,
+	endDatetime,
+	allDay,
+}) {
 	const [messages, setMessages] = useState([]);
-	const [eventDates, setEventDates] = useState([]);
 	const [groups, setGroups] = useState([]);
 	const [loading, setLoading] = useState(true);
 	const [notice, setNotice] = useState(null);
 	const [isSaving, setIsSaving] = useState(false);
+
+	// The single date this tab manages, shaped for AnchorOffsetPicker. With one
+	// entry the picker hides its "which date" dropdown and just uses it for the
+	// send-time preview.
+	const eventDates = useMemo(
+		() => [
+			{
+				id: eventDateId,
+				start_datetime: startDatetime,
+				end_datetime: endDatetime,
+				all_day: allDay,
+			},
+		],
+		[eventDateId, startDatetime, endDatetime, allDay]
+	);
 
 	const [form, setForm] = useState(emptyForm(eventDateId));
 
@@ -99,30 +122,22 @@ export default function EventMailings({ eventId, eventDateId }) {
 	}, []);
 
 	const reloadMessages = useCallback(() => {
-		return loadScheduledMessages(eventId).then(setMessages);
-	}, [eventId]);
+		return loadScheduledMessages(eventDateId).then(setMessages);
+	}, [eventDateId]);
 
 	// Initial data load.
 	useEffect(() => {
 		let active = true;
 		Promise.all([
-			loadScheduledMessages(eventId),
-			loadEventDates(eventId),
+			loadScheduledMessages(eventDateId),
 			loadGroups().catch(() => []),
 		])
-			.then(([msgs, dates, grps]) => {
+			.then(([msgs, grps]) => {
 				if (!active) {
 					return;
 				}
 				setMessages(msgs);
-				setEventDates(dates);
 				setGroups(grps);
-				// Default the anchor to the managed date when present.
-				const hasManaged = dates.some((d) => d.id === eventDateId);
-				const fallback = dates.length > 0 ? dates[0].id : eventDateId;
-				updateForm({
-					anchorRefId: hasManaged ? eventDateId : fallback,
-				});
 			})
 			.catch(() => {
 				if (active) {
@@ -136,7 +151,7 @@ export default function EventMailings({ eventId, eventDateId }) {
 		return () => {
 			active = false;
 		};
-	}, [eventId, eventDateId, updateForm]);
+	}, [eventDateId]);
 
 	const selectedLabels = useMemo(
 		() => LABEL_OPTIONS.filter((o) => form.labels[o.key]).map((o) => o.key),
@@ -160,7 +175,7 @@ export default function EventMailings({ eventId, eventDateId }) {
 			return undefined;
 		}
 		const handle = setTimeout(() => {
-			previewDraftRecipients(eventId, recipientsFilter)
+			previewDraftRecipients(eventDateId, recipientsFilter)
 				.then((list) => {
 					setRecipientCount(list.length);
 					setRecipientList(list);
@@ -171,13 +186,11 @@ export default function EventMailings({ eventId, eventDateId }) {
 				});
 		}, 400);
 		return () => clearTimeout(handle);
-	}, [eventId, recipientsFilter, selectedLabels.length]);
+	}, [eventDateId, recipientsFilter, selectedLabels.length]);
 
 	const resetForm = useCallback(() => {
-		const hasManaged = eventDates.some((d) => d.id === eventDateId);
-		const fallback = eventDates.length > 0 ? eventDates[0].id : eventDateId;
-		setForm(emptyForm(hasManaged ? eventDateId : fallback));
-	}, [eventDates, eventDateId]);
+		setForm(emptyForm(eventDateId));
+	}, [eventDateId]);
 
 	const startEdit = (message) => {
 		const decomposed = fromOffsetMinutes(message.offset_minutes);
@@ -252,7 +265,7 @@ export default function EventMailings({ eventId, eventDateId }) {
 		setNotice(null);
 		const request = form.editingId
 			? updateScheduledMessage(form.editingId, payload)
-			: createScheduledMessage(eventId, payload);
+			: createScheduledMessage(eventDateId, payload);
 
 		request
 			.then(() => reloadMessages())

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -1221,8 +1221,10 @@ export default function ManageEventApp() {
 					if (tab.name === 'mailings') {
 						return (
 							<EventMailings
-								eventId={eventDate.event_id}
 								eventDateId={eventDateId}
+								startDatetime={eventDate.start_datetime}
+								endDatetime={eventDate.end_datetime}
+								allDay={eventDate.all_day}
 							/>
 						);
 					}

--- a/fair-events/src/Admin/manage-event/mailings-api.js
+++ b/fair-events/src/Admin/manage-event/mailings-api.js
@@ -12,39 +12,27 @@
 import apiFetch from '@wordpress/api-fetch';
 
 /**
- * List scheduled messages for an event.
+ * List scheduled messages for an event date.
  *
- * @param {number} eventId Event post ID.
+ * @param {number} eventDateId Event date ID.
  * @return {Promise<Array>} Promise resolving to the message list.
  */
-export function loadScheduledMessages(eventId) {
+export function loadScheduledMessages(eventDateId) {
 	return apiFetch({
-		path: `/fair-audience/v1/events/${eventId}/scheduled-messages`,
-	});
-}
-
-/**
- * List an event's dates for the anchor picker.
- *
- * @param {number} eventId Event post ID.
- * @return {Promise<Array>} Promise resolving to the event-date list.
- */
-export function loadEventDates(eventId) {
-	return apiFetch({
-		path: `/fair-audience/v1/events/${eventId}/event-dates`,
+		path: `/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages`,
 	});
 }
 
 /**
  * Create a scheduled message.
  *
- * @param {number} eventId Event post ID.
- * @param {Object} data    Message payload.
+ * @param {number} eventDateId Event date ID.
+ * @param {Object} data        Message payload.
  * @return {Promise<Object>} Promise resolving to the created message.
  */
-export function createScheduledMessage(eventId, data) {
+export function createScheduledMessage(eventDateId, data) {
 	return apiFetch({
-		path: `/fair-audience/v1/events/${eventId}/scheduled-messages`,
+		path: `/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages`,
 		method: 'POST',
 		data,
 	});
@@ -94,13 +82,13 @@ export function previewRecipients(id) {
 /**
  * Resolve recipients for an unsaved draft from a filter.
  *
- * @param {number} eventId          Event post ID.
+ * @param {number} eventDateId      Event date ID.
  * @param {Object} recipientsFilter Filter: { labels, group_ids, is_marketing }.
  * @return {Promise<Array>} Promise resolving to the recipient list.
  */
-export function previewDraftRecipients(eventId, recipientsFilter) {
+export function previewDraftRecipients(eventDateId, recipientsFilter) {
 	return apiFetch({
-		path: `/fair-audience/v1/events/${eventId}/scheduled-messages/preview-recipients`,
+		path: `/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages/preview-recipients`,
 		method: 'POST',
 		data: { recipients_filter: recipientsFilter },
 	});


### PR DESCRIPTION
## Summary

The Mailings tab keyed every API request on the **event (WP post) id**. On an event date with no linked post, `event_id` was `null`, so the tab fired requests to `/events//scheduled-messages` and got a string of 404s. Production only worked because every date there happens to be linked to a post.

This re-scopes scheduled mailings to the **event date** the manage-event page already operates on, so the feature no longer depends on a linked post.

## Changes

**Behavior**
- Recipients now resolve to **that date's participants** (consistent with the Audience tab) via `RecipientResolver::resolve_by_event_date`.
- The anchor is always the managed date — the cross-date picker and its endpoint are removed.
- Cancellation cascades from **event-date deletion** (`fair_events_event_date_deleted`) instead of post deletion.

**API**
- Routes move to `/fair-audience/v1/event-dates/{event_date_id}/scheduled-messages` (+ `/preview-recipients`).
- `/scheduled-messages/{id}` PUT/DELETE and stored-preview are unchanged.

**Data model**
- Drop the `event_id` column (model, schema, repository).
- New guarded `1.36.0` migration backfills `event_date_id` from `anchor_ref_id`, then drops the column/index and adds `idx_event_date_id`. Guards use `information_schema` because **MySQL 8 has no `IF [NOT] EXISTS` for columns/indexes** (MariaDB-only).

**Latent bugs fixed (surfaced on MySQL 8)**
- Semicolons inside column `COMMENT` strings broke `dbDelta`, so the table was never created. This is why it was missing on fresh installs.
- `new ScheduledMessage()` left `NOT NULL` counters null because the constructor skipped `populate()`; strict mode then rejected inserts.

## Testing

- Migration verified on MySQL 8.0.45: table creates, `event_id` gone, `event_date_id NOT NULL`, `idx_event_date_id` present.
- Full REST lifecycle (create / list / edit / cancel / draft preview / 404 on missing date) verified via `WP_REST_Server::dispatch`.
- Updated `ScheduledMessagesController.api.spec.js` to the new routes (not executed in this session — run `npm run test:api` before merge).
- `npm run build` (fair-events) and `npm run test-unit-js` pass.

## Deploy note

On migration, existing rows are backfilled from `anchor_ref_id` (which has always held the event-date id) before `event_id` is dropped, so they survive as event-date-scoped.