### PR TITLE
Make budgets table readable on narrow screens

### DIFF
--- a/fair-payment/src/Admin/AdminPages.php
+++ b/fair-payment/src/Admin/AdminPages.php
@@ -251,6 +251,19 @@ class AdminPages {
 		);
 
 		wp_enqueue_style( 'wp-components' );
+
+		// Enqueue the page's stylesheet when one was emitted by the build.
+		// wp-scripts writes style-index.css when index.js imports a stylesheet.
+		$style_file_path = FAIR_PAYMENT_PLUGIN_DIR . 'build/admin/' . $page . '/style-index.css';
+
+		if ( file_exists( $style_file_path ) ) {
+			wp_enqueue_style(
+				'fair-payment-' . $page,
+				FAIR_PAYMENT_PLUGIN_URL . 'build/admin/' . $page . '/style-index.css',
+				array( 'wp-components' ),
+				$asset_file['version']
+			);
+		}
 	}
 
 	/**

--- a/fair-payment/src/Admin/budgets/BudgetsApp.js
+++ b/fair-payment/src/Admin/budgets/BudgetsApp.js
@@ -182,6 +182,14 @@ const BudgetsApp = () => {
 
 	return (
 		<div className="wrap fair-payment-budgets-page">
+			{/*
+			 * Anchor for WordPress admin notices. Core's common.js inserts
+			 * .notice elements right after `.wp-header-end` (or, lacking it,
+			 * after the first h1 — which here is buried in the card header,
+			 * making notices overlap it). Keeping this marker at the top of
+			 * the wrap pins notices to the top of the page.
+			 */}
+			<hr className="wp-header-end" />
 			<VStack spacing={4}>
 				{/* Unbudgeted Summary */}
 				<Card>
@@ -304,12 +312,22 @@ const BudgetsApp = () => {
 											);
 											return (
 												<tr key={budget.id}>
-													<td>
+													<td
+														data-label={__(
+															'Name',
+															'fair-payment'
+														)}
+													>
 														<strong>
 															{budget.name}
 														</strong>
 													</td>
-													<td>
+													<td
+														data-label={__(
+															'Description',
+															'fair-payment'
+														)}
+													>
 														{budget.description || (
 															<em>
 																{__(
@@ -319,7 +337,12 @@ const BudgetsApp = () => {
 															</em>
 														)}
 													</td>
-													<td>
+													<td
+														data-label={__(
+															'Balance',
+															'fair-payment'
+														)}
+													>
 														<span
 															style={{
 																color:
@@ -336,8 +359,16 @@ const BudgetsApp = () => {
 															)}
 														</span>
 													</td>
-													<td>
-														<HStack spacing={2}>
+													<td
+														data-label={__(
+															'Actions',
+															'fair-payment'
+														)}
+													>
+														<HStack
+															spacing={2}
+															className="fair-payment-budget-actions"
+														>
 															<Button
 																variant="secondary"
 																size="small"
@@ -384,7 +415,12 @@ const BudgetsApp = () => {
 										})}
 										{/* Unbudgeted row */}
 										<tr>
-											<td>
+											<td
+												data-label={__(
+													'Name',
+													'fair-payment'
+												)}
+											>
 												<em>
 													{__(
 														'Unbudgeted',
@@ -392,7 +428,12 @@ const BudgetsApp = () => {
 													)}
 												</em>
 											</td>
-											<td>
+											<td
+												data-label={__(
+													'Description',
+													'fair-payment'
+												)}
+											>
 												<em>
 													{__(
 														'Entries without a budget category',
@@ -400,7 +441,12 @@ const BudgetsApp = () => {
 													)}
 												</em>
 											</td>
-											<td>
+											<td
+												data-label={__(
+													'Balance',
+													'fair-payment'
+												)}
+											>
 												<span
 													style={{
 														color:
@@ -416,7 +462,12 @@ const BudgetsApp = () => {
 													)}
 												</span>
 											</td>
-											<td>
+											<td
+												data-label={__(
+													'Actions',
+													'fair-payment'
+												)}
+											>
 												<Button
 													variant="secondary"
 													size="small"
@@ -437,7 +488,12 @@ const BudgetsApp = () => {
 											<td colSpan={2}>
 												{__('Total', 'fair-payment')}
 											</td>
-											<td>
+											<td
+												data-label={__(
+													'Total',
+													'fair-payment'
+												)}
+											>
 												<span
 													style={{
 														color:

--- a/fair-payment/src/Admin/budgets/index.js
+++ b/fair-payment/src/Admin/budgets/index.js
@@ -8,6 +8,7 @@ import { createRoot } from '@wordpress/element';
  * Internal dependencies
  */
 import BudgetsApp from './BudgetsApp.js';
+import './style.scss';
 
 /**
  * Initialize the budgets page

--- a/fair-payment/src/Admin/budgets/style.scss
+++ b/fair-payment/src/Admin/budgets/style.scss
@@ -1,0 +1,93 @@
+/**
+ * Budgets admin page styles.
+ *
+ * The Budget Categories table uses the WordPress `fixed` table layout, which
+ * splits width evenly across columns. On narrow / mobile screens that forces
+ * the Name and Description text to wrap one character per line. Below the
+ * mobile breakpoint we drop the table grid and render each row as a stacked
+ * card with label/value pairs so the content stays readable.
+ *
+ * Everything is scoped under `.fair-payment-budgets-page` so other
+ * `wp-list-table`s in the admin are untouched, and lives inside a media query
+ * so the desktop layout is unchanged.
+ *
+ * The selectors deliberately stack `.wrap.fair-payment-budgets-page` and
+ * `.wp-list-table.widefat` to outweigh WordPress core's responsive list-table
+ * rules (`...td::before { content: attr(data-colname); }`, active below 782px),
+ * which would otherwise blank out our `data-label` text.
+ */
+
+.wrap.fair-payment-budgets-page {
+	@media screen and (max-width: 600px) {
+		.wp-list-table.widefat {
+			display: block;
+			border: none;
+
+			// Column headers are replaced by per-cell labels on mobile.
+			thead {
+				display: none;
+			}
+
+			tbody,
+			tfoot,
+			tr,
+			td {
+				display: block;
+			}
+
+			// Each row becomes a self-contained card.
+			tr {
+				margin: 0 0 1em;
+				padding: 0.25em 0.75em;
+				border: 1px solid #c3c4c7;
+				border-radius: 4px;
+				background: #fff;
+			}
+
+			td {
+				width: auto !important;
+				padding: 0.45em 0;
+				border: none;
+				text-align: right;
+
+				// Label/value pairs: the column name sits on the left,
+				// the value on the right, and long values wrap normally.
+				&[data-label] {
+					display: flex;
+					gap: 1em;
+					align-items: baseline;
+					justify-content: space-between;
+
+					&::before {
+						content: attr(data-label);
+						// Core's responsive list-table absolutely positions
+						// this pseudo-element; keep it in the flex flow so the
+						// label sits beside the value instead of over it.
+						position: static;
+						flex: 0 0 35%;
+						padding: 0;
+						text-align: left;
+						font-weight: 600;
+						color: #1e1e1e;
+					}
+				}
+			}
+
+			// The empty actions cell on the totals row and the spanning
+			// "Total" label cell would otherwise show as blank lines.
+			td:empty {
+				display: none;
+			}
+
+			tfoot td[colspan] {
+				display: none;
+			}
+
+			// Let the View / Edit / Delete buttons wrap and stay right-aligned.
+			.fair-payment-budget-actions {
+				flex-wrap: wrap;
+				justify-content: flex-end;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The Budget Categories table on the **fair-payment-budgets** admin page used WordPress' `fixed` table layout, which splits width evenly across columns. On phone-width viewports that forced the **Name** and **Description** text to wrap one character per line, making the table unreadable.

Below **600px** each row now renders as a stacked card with label/value pairs (Name, Description, Balance, Actions). Styles are scoped to `.fair-payment-budgets-page` so other admin list tables are untouched, and live entirely inside a media query so the desktop table is unchanged.

This also fixes a pre-existing glitch where WordPress admin notices (e.g. the Fair Platform Mollie warning) were injected into the card header and overlapped the "Budget Categories" title — they now stay pinned to the top of the page.

Closes #643

## Before / After (375px viewport)

| Before | After |
| --- | --- |
| ![Before – text wraps one character per line, notice overlaps header](https://github.com/marcin-wosinek/fair-event-plugins/blob/pr-assets/643/budgets-before.png?raw=true) | ![After – readable stacked cards, notice at top](https://github.com/marcin-wosinek/fair-event-plugins/blob/pr-assets/643/budgets-after.png?raw=true) |

Desktop (≥600px) — table layout unchanged, notice pinned to the top:

![Desktop table unchanged](https://github.com/marcin-wosinek/fair-event-plugins/blob/pr-assets/643/budgets-desktop.png?raw=true)

## Notes

- **Card labels vs. core:** WordPress core's responsive list-table CSS absolutely positions `td::before` and fills it from `data-colname` below 782px. The card labels use `data-label` instead, and the selectors stack `.wrap.fair-payment-budgets-page` + `.wp-list-table.widefat` (plus `position: static` on the pseudo-element) to outweigh those core rules without `!important`.
- **Notice placement:** core's `common.js` moves `.notice` elements to just after the first `h1` — which here is buried in the card header. Adding an invisible `<hr class="wp-header-end">` at the top of the wrap gives core a higher-priority anchor, so notices render at the top.
- **CSS delivery:** `enqueue_admin_page_script()` now also enqueues a page's built `style-index.css` when one exists, so any future admin page can ship styles by importing a stylesheet from its entry.
- Screenshots are hosted on the `pr-assets/643` branch (kept out of the code diff); that branch can be deleted after review.

## Test plan

- [x] `npm run build` succeeds in `fair-payment`
- [x] `phpcs` clean on `AdminPages.php` (only the pre-existing `error_log` warning)
- [x] Manual check at 375px: Name/Description/Balance/Actions and the Total row all readable as cards; admin notice at the top (screenshots above)
- [x] Manual check at 1280px: table layout unchanged, notice at the top