### PR TITLE
Keep activity price tag inline with its name

### DIFF
--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -738,6 +738,10 @@ $render_ticket_options = static function () use ( $ticket_options_for_display, $
 			echo ' disabled';
 		}
 		echo ' /> ';
+		// Name + add-on tag share one inline span so the "(+price)" flows with
+		// the (potentially wrapping) activity name instead of being stranded on
+		// its own line by the flex layout.
+		echo '<span class="fair-audience-ticket-option-text">';
 		echo esc_html( $opt_label );
 		// Hidden add-on tag, revealed by frontend.js on unchecked options once
 		// the minimum is reached. Positive prices only (no "(+€0.00)").
@@ -753,6 +757,7 @@ $render_ticket_options = static function () use ( $ticket_options_for_display, $
 				)
 			);
 		}
+		echo '</span>';
 		echo '</label>';
 	}
 	echo '</fieldset>';

--- a/fair-audience/src/blocks/event-signup/style.css
+++ b/fair-audience/src/blocks/event-signup/style.css
@@ -173,7 +173,6 @@
 	margin-top: 24px;
 }
 
-
 /* Cancel signup button */
 .fair-audience-unsignup-button-wrap {
 	margin-top: 15px;
@@ -217,6 +216,16 @@
 	height: 18px;
 	cursor: pointer;
 	flex-shrink: 0;
+}
+
+/* Name + "(+price)" tag live in one flex item so the price wraps with the
+   name as a single text flow rather than landing on its own line. */
+.fair-audience-ticket-option-text {
+	min-width: 0;
+}
+
+.fair-audience-ticket-option-addon {
+	white-space: nowrap;
 }
 
 .fair-audience-ticket-option-full {


### PR DESCRIPTION
## Summary

- Fixes the signup activity rows where the `(+€X,XX)` price tag jumped to its own line (appearing right-aligned/centered) whenever the activity name was long enough to wrap.

The row (`.fair-audience-ticket-option-item`) is a flexbox. The activity name was a bare text node (one flex item) and the price tag a separate `<span>` flex item, so once the name wrapped to two lines flex stranded the price on its own line. Wrapping the name and tag in a single inline `<span class="fair-audience-ticket-option-text">` makes them one flex item, so the price now flows inline and wraps together with the name.

## Notes

- `frontend.js` still locates the tag via `label.querySelector('.fair-audience-ticket-option-addon')` (descendant search), so the reveal-on-minimum-reached behaviour is unchanged.
- `min-width: 0` on the text span lets it shrink/wrap inside the flex row; `white-space: nowrap` on the addon keeps the price itself from breaking mid-number.

## Test plan

- [ ] On an event-signup block with the minimum-activities feature active, view an activity whose name wraps to two lines and confirm the `(+price)` tag sits inline at the end of the wrapped name rather than on its own line.
- [ ] Confirm the price tag still appears/hides correctly as the activity minimum is reached.
- [ ] Verify short activity names render unchanged.