### PR TITLE
Wrap manage-event tab bar on narrow screens

### DIFF
--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -1155,7 +1155,11 @@ export default function ManageEventApp() {
 				{`.fair-events-manage-event .components-card > div:first-child { height: auto; }
 .fair-events-manage-event .components-card__body > * { max-width: 600px; }
 .fair-events-manage-event .fair-events-tickets .components-card__body > * { max-width: none; }
-.fair-events-manage-event .fair-events-photos .components-card__body > * { max-width: none; }`}
+.fair-events-manage-event .fair-events-photos .components-card__body > * { max-width: none; }
+/* Let the tab bar wrap onto multiple rows instead of overflowing the
+   viewport on narrow screens. Harmless on desktop, where the tabs fit on
+   one row. */
+.fair-events-manage-event .components-tab-panel__tabs { flex-wrap: wrap; row-gap: 4px; }`}
 			</style>
 			<h1>
 				{__('Manage Event', 'fair-events')}


### PR DESCRIPTION
## Summary

The event management page (`fair-events-manage-event`) renders its eleven tabs as a single horizontal `TabPanel` row. On a phone-width viewport the later tabs (Photos → Admin) were clipped off-screen with no way to reach them.

The fix adds `flex-wrap: wrap` (plus a small `row-gap`) to the tab list, scoped under `.fair-events-manage-event`, so tabs flow onto multiple rows when they don't fit. It's a no-op on desktop, where all tabs still sit on one row.

I added it to the page's **existing scoped inline `<style>` block** rather than introducing a new stylesheet + webpack/enqueue plumbing — the issue's "no stylesheet exists" note is slightly out of date, and extending the in-place pattern keeps the change to one line of CSS.

Closes #642

## Before / After (375px — viewport frame)

| Before | After |
| --- | --- |
| ![Before – only 5 of 11 tabs visible, rest clipped](https://github.com/marcin-wosinek/fair-event-plugins/blob/pr-assets/642/tabs-before-mobile.png?raw=true) | ![After – all tabs wrap onto 3 rows](https://github.com/marcin-wosinek/fair-event-plugins/blob/pr-assets/642/tabs-after-mobile.png?raw=true) |

Tablet (768px):

| Before | After |
| --- | --- |
| ![Before tablet](https://github.com/marcin-wosinek/fair-event-plugins/blob/pr-assets/642/tabs-before-tablet.png?raw=true) | ![After tablet – tabs wrap to 2 rows](https://github.com/marcin-wosinek/fair-event-plugins/blob/pr-assets/642/tabs-after-tablet.png?raw=true) |

Desktop (1280px) — unchanged, single row:

![Desktop unchanged](https://github.com/marcin-wosinek/fair-event-plugins/blob/pr-assets/642/tabs-after-desktop.png?raw=true)

## Notes

- **Accessibility:** the change is pure CSS and doesn't touch the DOM, so `TabPanel`'s roving-tabindex, arrow-key navigation, and aria roles are unaffected. The active-tab indicator (blue underline) renders correctly on the wrapped rows (visible in the after shots).
- **Robust to growth:** the issue notes the tab count keeps growing (Statistics was since added). Unconditional wrap handles any count at any width without a breakpoint to tune.
- Screenshots live on the `pr-assets/642` branch (kept out of the code diff); deletable after review.

## Test plan

- [x] `npm run build` succeeds in `fair-events`
- [x] 375px: all 11 tabs reachable, none clipped (screenshots)
- [x] 768px: tabs wrap to 2 rows
- [x] 1280px: layout unchanged, single row
- [x] Active-tab indicator preserved on wrapped rows