### PR TITLE
Source event date from event-dates table for statistics

### DIFF
--- a/fair-audience/src/API/EventParticipantsController.php
+++ b/fair-audience/src/API/EventParticipantsController.php
@@ -1175,8 +1175,13 @@ class EventParticipantsController extends WP_REST_Controller {
 			);
 		}
 
-		// Get event date metadata.
-		$event_date = get_post_meta( $event_id, 'event_start', true );
+		// Get event date metadata. Prefer the authoritative start_datetime from
+		// the fair_event_dates row; fall back to legacy post meta for events
+		// whose meta predates the event-dates table.
+		$event_date = $event_date_obj->start_datetime;
+		if ( empty( $event_date ) ) {
+			$event_date = get_post_meta( $event_id, 'event_start', true );
+		}
 		if ( empty( $event_date ) ) {
 			$event_date = get_post_meta( $event_id, 'event_date', true );
 		}


### PR DESCRIPTION
## Summary

The manage-event **Statistics** tab showed "Lead time is unavailable (missing event date or signup timestamps)" for some events even when they had participants with valid signup timestamps.

Root cause: the event-info endpoint (`GET /fair-audience/v1/event-dates/{id}`) sourced the event date from the legacy `event_start` / `event_date` **post meta**, not from the `fair_event_dates` table. For events whose meta predates that table (older or imported events), the meta is empty, so the frontend received no date and `salesLeadTime()` bailed out.

This change makes `get_event()` prefer the authoritative `start_datetime` from the already-resolved event-dates row, falling back to post meta only when the table value is empty.

## Notes

- PHP-only change; no asset build required.
- The sibling list endpoint `get_events()` has the same post-meta-first pattern (it already loads an event-dates object too). The calendar list works today because that meta is populated for the events shown there, so I left it out of this PR to keep the fix scoped. Worth a follow-up for consistency.

## Test plan

- [ ] Open the Statistics tab for an event whose `event_start`/`event_date` post meta is empty but which has a `fair_event_dates` row with a `start_datetime` — the "Sales lead time" chart now renders instead of the "unavailable" message.
- [ ] Confirm events that rely on post meta (no/empty table `start_datetime`) still show their date via the fallback.