### PR TITLE
Resolve Event Info editor linkage by post ID

### DIFF
--- a/fair-events/src/blocks/event-info/components/EditComponent.js
+++ b/fair-events/src/blocks/event-info/components/EditComponent.js
@@ -2,17 +2,19 @@
  * WordPress dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 import ServerSideRender from '@wordpress/server-side-render';
 
 /**
- * Internal dependencies — import store to ensure it is registered
- */
-import { STORE_NAME } from '../../../Admin/event-meta-box/store.js';
-
-/**
- * Edit component for Event Info block
+ * Edit component for Event Info block.
+ *
+ * Linkage is resolved the same way the server does (by post ID, not post type):
+ * an event-date is linked to this post if its primary `event_id` matches, or if
+ * the post appears in the date's junction-linked posts. This mirrors
+ * SelectedOccurrence::resolve() in render.php, so the editor preview matches the
+ * published output for any enabled post type — including pages.
  *
  * @param {Object} props            - Component props
  * @param {Object} props.attributes - Block attributes
@@ -21,23 +23,48 @@ import { STORE_NAME } from '../../../Admin/event-meta-box/store.js';
  */
 export default function EditComponent({ attributes, context }) {
 	const blockProps = useBlockProps();
-	const { postId, postType } = context;
+	const { postId } = context;
 
-	const eventData = useSelect(
-		(select) => {
-			if (postType !== 'fair_event' || !postId) {
-				return null;
-			}
-			return select(STORE_NAME).getEventData();
-		},
-		[postId, postType]
-	);
+	// null = still resolving, true/false = resolved linkage.
+	const [linked, setLinked] = useState(null);
 
-	const isLinked = eventData && eventData.id;
+	useEffect(() => {
+		if (!postId) {
+			setLinked(false);
+			return undefined;
+		}
+
+		let cancelled = false;
+		const currentPostId = parseInt(postId, 10);
+
+		apiFetch({ path: '/fair-events/v1/event-dates?include_linked=true' })
+			.then((eventDates) => {
+				if (cancelled) {
+					return;
+				}
+				const isLinked = (eventDates || []).some(
+					(ed) =>
+						ed.event_id === currentPostId ||
+						(ed.linked_posts || []).some(
+							(p) => p.id === currentPostId
+						)
+				);
+				setLinked(isLinked);
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setLinked(false);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [postId]);
 
 	return (
 		<div {...blockProps}>
-			{isLinked ? (
+			{linked === null ? null : linked ? (
 				<ServerSideRender
 					block="fair-events/event-info"
 					attributes={attributes}

--- a/fair-events/src/blocks/event-info/components/__tests__/EditComponent.test.jsx
+++ b/fair-events/src/blocks/event-info/components/__tests__/EditComponent.test.jsx
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import EditComponent from '../EditComponent.js';
+
+jest.mock('@wordpress/api-fetch');
+
+// useBlockProps needs the editor's block context, which jsdom doesn't provide;
+// stub it to a plain spread so we can render the component in isolation.
+jest.mock('@wordpress/block-editor', () => ({
+	useBlockProps: () => ({}),
+}));
+
+// ServerSideRender hits the REST API for a live render; stub it to a marker so
+// we can assert "the preview rendered" without a server.
+jest.mock(
+	'@wordpress/server-side-render',
+	() => () => <div data-testid="ssr" />,
+	{
+		virtual: true,
+	}
+);
+
+const PLACEHOLDER = 'Event Info block is disabled';
+
+// A single, non-recurring event whose primary post is id 16 (a page).
+const primaryLinked = {
+	id: 11,
+	event_id: 16,
+	linked_posts: [{ id: 16, is_primary: true }],
+};
+
+// An event linked to post 42 only through the junction table (event_id is a
+// different fair_event post), so it is NOT the primary event_id.
+const junctionLinked = {
+	id: 12,
+	event_id: 99,
+	linked_posts: [
+		{ id: 99, is_primary: true },
+		{ id: 42, is_primary: false },
+	],
+};
+
+const renderBlock = (postId, postType) =>
+	render(<EditComponent attributes={{}} context={{ postId, postType }} />);
+
+describe('EventInfo EditComponent', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('shows the preview for a page linked as the primary event_id', async () => {
+		apiFetch.mockResolvedValue([primaryLinked, junctionLinked]);
+
+		renderBlock(16, 'page');
+
+		await waitFor(() =>
+			expect(screen.getByTestId('ssr')).toBeInTheDocument()
+		);
+		expect(screen.queryByText(PLACEHOLDER, { exact: false })).toBeNull();
+		expect(apiFetch).toHaveBeenCalledWith({
+			path: '/fair-events/v1/event-dates?include_linked=true',
+		});
+	});
+
+	it('shows the preview for a page linked only via the junction table', async () => {
+		apiFetch.mockResolvedValue([primaryLinked, junctionLinked]);
+
+		renderBlock(42, 'page');
+
+		await waitFor(() =>
+			expect(screen.getByTestId('ssr')).toBeInTheDocument()
+		);
+	});
+
+	it('shows the placeholder when the post is not linked to any event', async () => {
+		apiFetch.mockResolvedValue([primaryLinked, junctionLinked]);
+
+		renderBlock(7, 'page');
+
+		await waitFor(() =>
+			expect(
+				screen.getByText(PLACEHOLDER, { exact: false })
+			).toBeInTheDocument()
+		);
+		expect(screen.queryByTestId('ssr')).toBeNull();
+	});
+
+	it('still renders the preview for a linked fair_event post (no regression)', async () => {
+		apiFetch.mockResolvedValue([primaryLinked]);
+
+		renderBlock(16, 'fair_event');
+
+		await waitFor(() =>
+			expect(screen.getByTestId('ssr')).toBeInTheDocument()
+		);
+	});
+
+	it('shows the placeholder when the lookup fails', async () => {
+		apiFetch.mockRejectedValue(new Error('network'));
+
+		renderBlock(16, 'page');
+
+		await waitFor(() =>
+			expect(
+				screen.getByText(PLACEHOLDER, { exact: false })
+			).toBeInTheDocument()
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Closes #657.

The **Event Info block** rendered correctly on the front end for any post linked to an event, but its **editor preview** was gated on the `fair_event` post type (and read linkage from the meta-box Redux store). On a **page** linked to an event, the editor showed "Event Info block is disabled — no event is linked to this post." even though the published page rendered the date/venue fine.

`EditComponent` now resolves linkage the same way the server does (`render.php` / `SelectedOccurrence::resolve()`): it fetches `/fair-events/v1/event-dates?include_linked=true` and matches the current `postId` against the primary `event_id` **or** the junction-linked posts (`linked_posts[].id`), regardless of post type, then defers to `ServerSideRender`. The `postType !== 'fair_event'` guard and the meta-box store dependency are removed.

## Notes

- **Editor-only** change; `render.php` was already correct and is untouched.
- Also fixes **junction-linked** posts (linked via `fair_event_date_posts`, not as the primary `event_id`), which the meta-box auto-detect never matched.
- Adds one editor-time `apiFetch` per block instance (the meta box already makes the same call). Not deduped across multiple blocks on one page — acceptable for an editor preview.
- The editor previews the default/master occurrence (no `?event_date=<id>` arg), matching an un-parametrized page view.
- Verified against the live env: page `/test/` (post 16) is linked to event-date 11 (primary + junction); the endpoint returns `event_id: 16` and `linked_posts: [{ id: 16, … }]`, so both match paths hit it.

## Test plan

- [x] `npx jest EditComponent` — new component test passes (5 cases: primary-linked page, junction-linked page, not linked, `fair_event` no-regression, lookup failure).
- [x] Full `jest` suite green (17/17).
- [x] `npm run build` succeeds; built `editor.js` contains the new lookup.
- [ ] Manual: Event Info block on a page linked to an event shows the preview (not the placeholder) in the editor; an unlinked page still shows the placeholder; `fair_event` editor preview unchanged.