### PR TITLE
Decouple Fair Events admin menu from the fair_event CPT

### DIFF
--- a/e2e/fair-events-admin-menu.spec.js
+++ b/e2e/fair-events-admin-menu.spec.js
@@ -1,0 +1,153 @@
+/**
+ * Fair Events admin menu / asset-enqueue regression (#656).
+ *
+ * The admin menu and its asset enqueuing used to assume the `fair_event` CPT:
+ * pages were submenus of `edit.php?post_type=fair_event` and the enqueue logic
+ * matched parent-derived hook names (`fair_event_page_*`). This suite guards the
+ * decoupling — every page must mount its React root **whether or not the CPT is
+ * registered**, and with the CPT on the menu must look unchanged.
+ *
+ * The CPT-off state is produced by the `fair_e2e_unregister_fair_event` toggle in
+ * e2e/mu-plugins/fair-e2e-support.php (a stand-in for #655's real setting).
+ *
+ * Run: `npm run test:e2e -- fair-events-admin-menu`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+/** Run a WP-CLI command against the wp-env `tests` instance. */
+function wpCli(args) {
+	return execSync(`npx wp-env run tests-cli wp ${args}`, {
+		cwd: process.cwd(),
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+}
+
+/** Every Fair Events admin page and its React root element id. */
+const PAGES = [
+	{ slug: 'fair-events-calendar', root: 'fair-events-calendar-root' },
+	{ slug: 'fair-events-all-events', root: 'fair-events-all-events-root' },
+	{ slug: 'fair-events-sources', root: 'fair-events-sources-root' },
+	{ slug: 'fair-events-venues', root: 'fair-events-venues-root' },
+	{ slug: 'fair-events-manage-event', root: 'fair-events-manage-event-root' },
+	{ slug: 'fair-events-source-view', root: 'fair-events-source-view-root' },
+	{
+		slug: 'fair-events-manage-invitations',
+		root: 'fair-events-manage-invitations-root',
+	},
+	{ slug: 'fair-events-settings', root: 'fair-events-settings-root' },
+	// Migration pages only register when the CPT exists.
+	{
+		slug: 'fair-events-migration',
+		root: 'fair-events-migration-root',
+		cptOnly: true,
+	},
+	{
+		slug: 'fair-events-migration-summary',
+		root: 'fair-events-migration-summary-root',
+		cptOnly: true,
+	},
+];
+
+async function login(page) {
+	await page.goto('/wp-login.php');
+	await page.fill('#user_login', ADMIN_USER);
+	await page.fill('#user_pass', ADMIN_PASSWORD);
+	await page.click('#wp-submit');
+	await expect(page).toHaveURL(/\/wp-admin\/?/);
+}
+
+/**
+ * Assert a page's React root is present AND something mounted into it. An empty
+ * root with no children is the exact failure mode of a broken enqueue (the page
+ * renders `<div id="…-root">` but no JS loads).
+ */
+async function expectRootMounts(page, slug, root) {
+	await page.goto(`/wp-admin/admin.php?page=${slug}`);
+	await expect(
+		page.locator(`#${root}`),
+		`${slug}: React root element missing`
+	).toBeAttached();
+	await expect(
+		page.locator(`#${root} > *`).first(),
+		`${slug}: root is empty — admin bundle did not load`
+	).toBeAttached({ timeout: 15000 });
+}
+
+test.describe('Fair Events admin menu — CPT registered (regression)', () => {
+	test.beforeAll(() => {
+		// Default state: CPT registered. Clear any leftover toggle.
+		try {
+			wpCli('option delete fair_e2e_unregister_fair_event');
+		} catch {
+			// Not set — fine.
+		}
+	});
+
+	test('one top-level Fair Events menu, Calendar first and Settings last', async ({
+		page,
+	}) => {
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-calendar');
+
+		const topLevel = page.locator('#toplevel_page_fair-events-calendar');
+		await expect(
+			topLevel,
+			'expected a single self-owned top-level menu'
+		).toHaveCount(1);
+		await expect(topLevel.locator('.wp-menu-name').first()).toContainText(
+			'Fair Events'
+		);
+
+		const labels = (await topLevel.locator('.wp-submenu a').allInnerTexts())
+			.map((t) => t.trim())
+			.filter(Boolean);
+
+		expect(labels[0]).toBe('Calendar');
+		expect(labels[labels.length - 1]).toBe('Settings');
+	});
+
+	test('every page mounts its React root', async ({ page }) => {
+		await login(page);
+		for (const { slug, root } of PAGES) {
+			await expectRootMounts(page, slug, root);
+		}
+	});
+});
+
+test.describe('Fair Events admin menu — CPT unregistered', () => {
+	test.beforeAll(() => {
+		wpCli('option update fair_e2e_unregister_fair_event 1');
+	});
+
+	test.afterAll(() => {
+		try {
+			wpCli('option delete fair_e2e_unregister_fair_event');
+		} catch {
+			// Already gone — fine.
+		}
+	});
+
+	test('top-level menu and every page still mount without the CPT', async ({
+		page,
+	}) => {
+		await login(page);
+
+		await expect(
+			page.locator('#toplevel_page_fair-events-calendar'),
+			'top-level menu disappeared when the CPT was unregistered'
+		).toHaveCount(1);
+
+		for (const { slug, root, cptOnly } of PAGES) {
+			if (cptOnly) {
+				continue;
+			}
+			await expectRootMounts(page, slug, root);
+		}
+	});
+});

--- a/e2e/mu-plugins/fair-e2e-support.php
+++ b/e2e/mu-plugins/fair-e2e-support.php
@@ -78,3 +78,22 @@ add_filter(
 	10,
 	2
 );
+
+/*
+ * 4. Optionally unregister the fair_event CPT.
+ *
+ * Stand-in for the `fair_events_register_post_type` setting that arrives in #655,
+ * so the admin menu's "CPT off" path can be exercised today. Runs on `init` at a
+ * late priority (after FairEvents\Core\Plugin registers the CPT) so the admin
+ * menu, built later on `admin_menu`, sees `post_type_exists( 'fair_event' )`
+ * as false. Toggle with: `wp option update fair_e2e_unregister_fair_event 1`.
+ */
+add_action(
+	'init',
+	static function () {
+		if ( get_option( 'fair_e2e_unregister_fair_event' ) && post_type_exists( 'fair_event' ) ) {
+			unregister_post_type( 'fair_event' );
+		}
+	},
+	99
+);

--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -14,6 +14,51 @@ defined( 'WPINC' ) || die;
  */
 class AdminPages {
 	/**
+	 * Map of page slug => admin page hook name, captured at registration.
+	 *
+	 * WordPress derives admin page hook names from the parent slug, so the
+	 * enqueue logic must look them up here rather than hardcoding strings like
+	 * `fair_event_page_*` (which break the moment the parent slug changes).
+	 *
+	 * @var array<string,string>
+	 */
+	private $page_hooks = array();
+
+	/**
+	 * The top-level menu slug all Fair Events pages parent under.
+	 *
+	 * Single source of truth shared by the submenu registrations, the menu
+	 * reorder logic, and internal links — independent of the `fair_event` CPT.
+	 *
+	 * @return string
+	 */
+	private function get_menu_parent_slug() {
+		return 'fair-events-calendar';
+	}
+
+	/**
+	 * URL for creating a new event.
+	 *
+	 * Points at the `fair_event` CPT when it is registered (today's default),
+	 * otherwise the first enabled post type's add-new screen.
+	 *
+	 * @return string
+	 */
+	private function get_new_event_url() {
+		if ( post_type_exists( 'fair_event' ) ) {
+			return admin_url( 'post-new.php?post_type=fair_event' );
+		}
+
+		foreach ( \FairEvents\Settings\Settings::get_enabled_post_types() as $slug ) {
+			if ( post_type_exists( $slug ) ) {
+				return admin_url( 'post-new.php?post_type=' . $slug );
+			}
+		}
+
+		return admin_url( 'post-new.php' );
+	}
+
+	/**
 	 * Initialize admin pages
 	 *
 	 * @return void
@@ -33,9 +78,30 @@ class AdminPages {
 	 * @return void
 	 */
 	public function register_admin_pages() {
-		// Calendar page
+		$parent = $this->get_menu_parent_slug();
+
+		// Self-owned top-level menu, independent of the fair_event CPT. The
+		// landing page is Calendar (works with or without the CPT). add_menu_page
+		// auto-creates a first submenu duplicating the parent slug, labelled with
+		// the menu title; reorder_admin_menu() relabels it to "Calendar".
+		$this->page_hooks['fair-events-calendar'] = add_menu_page(
+			__( 'Events Calendar', 'fair-events' ),
+			// Not translatable - "Fair Events" is the brand name.
+			'Fair Events',
+			'edit_posts',
+			$parent,
+			array( $this, 'render_calendar_page' ),
+			'dashicons-calendar-alt',
+			20
+		);
+
+		// Calendar landing submenu. Registering a submenu whose slug matches the
+		// parent gives the first row a proper "Calendar" label (the add_menu_page
+		// entry above is otherwise labelled with the brand name) without creating
+		// a second top-level entry. Not captured in $page_hooks: the active hook
+		// for this page is the top-level toplevel_page_* from add_menu_page().
 		add_submenu_page(
-			'edit.php?post_type=fair_event',
+			$parent,
 			__( 'Events Calendar', 'fair-events' ),
 			__( 'Calendar', 'fair-events' ),
 			'edit_posts',
@@ -44,8 +110,8 @@ class AdminPages {
 		);
 
 		// All Events page
-		add_submenu_page(
-			'edit.php?post_type=fair_event',
+		$this->page_hooks['fair-events-all-events'] = add_submenu_page(
+			$parent,
 			__( 'All Events', 'fair-events' ),
 			__( 'All Events', 'fair-events' ),
 			'edit_posts',
@@ -54,8 +120,8 @@ class AdminPages {
 		);
 
 		// Settings page
-		add_submenu_page(
-			'edit.php?post_type=fair_event',
+		$this->page_hooks['fair-events-settings'] = add_submenu_page(
+			$parent,
 			__( 'Fair Events Settings', 'fair-events' ),
 			__( 'Settings', 'fair-events' ),
 			'manage_options',
@@ -63,29 +129,32 @@ class AdminPages {
 			array( $this, 'render_settings_page' )
 		);
 
-		// Migration page
-		add_submenu_page(
-			'edit.php?post_type=fair_event',
-			__( 'Migrate Posts to Events', 'fair-events' ),
-			__( 'Migrate Posts', 'fair-events' ),
-			'manage_options',
-			'fair-events-migration',
-			array( $this, 'render_migration_page' )
-		);
+		// Migration pages only make sense when the CPT exists (migration targets it).
+		if ( post_type_exists( 'fair_event' ) ) {
+			// Migration page
+			$this->page_hooks['fair-events-migration'] = add_submenu_page(
+				$parent,
+				__( 'Migrate Posts to Events', 'fair-events' ),
+				__( 'Migrate Posts', 'fair-events' ),
+				'manage_options',
+				'fair-events-migration',
+				array( $this, 'render_migration_page' )
+			);
 
-		// Migration Summary page
-		add_submenu_page(
-			'edit.php?post_type=fair_event',
-			__( 'Migration Summary', 'fair-events' ),
-			__( 'Migration Summary', 'fair-events' ),
-			'manage_options',
-			'fair-events-migration-summary',
-			array( $this, 'render_migration_summary_page' )
-		);
+			// Migration Summary page
+			$this->page_hooks['fair-events-migration-summary'] = add_submenu_page(
+				$parent,
+				__( 'Migration Summary', 'fair-events' ),
+				__( 'Migration Summary', 'fair-events' ),
+				'manage_options',
+				'fair-events-migration-summary',
+				array( $this, 'render_migration_summary_page' )
+			);
+		}
 
 		// Event Sources page
-		add_submenu_page(
-			'edit.php?post_type=fair_event',
+		$this->page_hooks['fair-events-sources'] = add_submenu_page(
+			$parent,
 			__( 'Event Sources', 'fair-events' ),
 			__( 'Event Sources', 'fair-events' ),
 			'manage_options',
@@ -94,8 +163,8 @@ class AdminPages {
 		);
 
 		// Venues page
-		add_submenu_page(
-			'edit.php?post_type=fair_event',
+		$this->page_hooks['fair-events-venues'] = add_submenu_page(
+			$parent,
 			__( 'Venues', 'fair-events' ),
 			__( 'Venues', 'fair-events' ),
 			'manage_options',
@@ -104,7 +173,7 @@ class AdminPages {
 		);
 
 		// Manage Event page (hidden from menu, accessed via calendar)
-		$manage_hookname = add_submenu_page(
+		$this->page_hooks['fair-events-manage-event'] = add_submenu_page(
 			'', // Hidden from menu (empty string instead of null for PHP 8.1+ compatibility)
 			__( 'Manage Event', 'fair-events' ),
 			__( 'Manage Event', 'fair-events' ),
@@ -114,7 +183,7 @@ class AdminPages {
 		);
 
 		// Source View page (hidden from menu, accessed via sources list)
-		$source_view_hookname = add_submenu_page(
+		$this->page_hooks['fair-events-source-view'] = add_submenu_page(
 			'', // Hidden from menu (empty string instead of null for PHP 8.1+ compatibility)
 			__( 'View Source', 'fair-events' ),
 			__( 'View Source', 'fair-events' ),
@@ -124,7 +193,7 @@ class AdminPages {
 		);
 
 		// Manage Invitations page (hidden from menu, accessed via tickets tab)
-		$invitations_hookname = add_submenu_page(
+		$this->page_hooks['fair-events-manage-invitations'] = add_submenu_page(
 			'', // Hidden from menu (empty string instead of null for PHP 8.1+ compatibility)
 			__( 'Manage Invitations', 'fair-events' ),
 			__( 'Manage Invitations', 'fair-events' ),
@@ -134,7 +203,7 @@ class AdminPages {
 		);
 
 		// Copy Event page (hidden from menu, accessed via row action)
-		$copy_hookname = add_submenu_page(
+		$this->page_hooks['fair-events-copy'] = add_submenu_page(
 			'', // Hidden from menu (empty string instead of null for PHP 8.1+ compatibility)
 			__( 'Copy Event', 'fair-events' ),
 			__( 'Copy Event', 'fair-events' ),
@@ -144,13 +213,13 @@ class AdminPages {
 		);
 
 		// Set page titles for hidden pages to prevent strip_tags() deprecation warning.
-		$this->set_hidden_page_title( $manage_hookname, __( 'Manage Event', 'fair-events' ) );
-		$this->set_hidden_page_title( $source_view_hookname, __( 'View Source', 'fair-events' ) );
-		$this->set_hidden_page_title( $invitations_hookname, __( 'Manage Invitations', 'fair-events' ) );
-		$this->set_hidden_page_title( $copy_hookname, __( 'Copy Event', 'fair-events' ) );
+		$this->set_hidden_page_title( $this->page_hooks['fair-events-manage-event'], __( 'Manage Event', 'fair-events' ) );
+		$this->set_hidden_page_title( $this->page_hooks['fair-events-source-view'], __( 'View Source', 'fair-events' ) );
+		$this->set_hidden_page_title( $this->page_hooks['fair-events-manage-invitations'], __( 'Manage Invitations', 'fair-events' ) );
+		$this->set_hidden_page_title( $this->page_hooks['fair-events-copy'], __( 'Copy Event', 'fair-events' ) );
 
 		// Handle copy event form submission before page render
-		add_action( 'load-' . $copy_hookname, array( $this, 'handle_copy_event_submission' ) );
+		add_action( 'load-' . $this->page_hooks['fair-events-copy'], array( $this, 'handle_copy_event_submission' ) );
 	}
 
 	/**
@@ -182,8 +251,16 @@ class AdminPages {
 	 * @return void
 	 */
 	public function enqueue_admin_scripts( $hook ) {
+		// Resolve the current page to our slug via the captured hook map, so
+		// enqueuing is immune to the parent-derived hook prefix (which differs
+		// between CPT-on and CPT-off). Bail on any non-Fair-Events page.
+		$slug = array_search( $hook, $this->page_hooks, true );
+		if ( false === $slug ) {
+			return;
+		}
+
 		// Calendar page
-		if ( 'fair_event_page_fair-events-calendar' === $hook ) {
+		if ( 'fair-events-calendar' === $slug ) {
 			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/calendar/index.asset.php';
 
 			wp_enqueue_script(
@@ -203,7 +280,7 @@ class AdminPages {
 
 			$calendar_data = array(
 				'startOfWeek'    => (int) get_option( 'start_of_week', 1 ),
-				'newEventUrl'    => admin_url( 'post-new.php?post_type=fair_event' ),
+				'newEventUrl'    => $this->get_new_event_url(),
 				'editEventUrl'   => admin_url( 'post.php?action=edit&post=' ),
 				'manageEventUrl' => admin_url( 'admin.php?page=fair-events-manage-event' ),
 			);
@@ -229,7 +306,7 @@ class AdminPages {
 		}
 
 		// All Events page
-		if ( 'fair_event_page_fair-events-all-events' === $hook ) {
+		if ( 'fair-events-all-events' === $slug ) {
 			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/all-events/index.asset.php';
 
 			wp_enqueue_script(
@@ -259,7 +336,7 @@ class AdminPages {
 		}
 
 		// Event Sources page
-		if ( 'fair_event_page_fair-events-sources' === $hook ) {
+		if ( 'fair-events-sources' === $slug ) {
 			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/sources/index.asset.php';
 
 			wp_enqueue_script(
@@ -290,7 +367,7 @@ class AdminPages {
 		}
 
 		// Migration page
-		if ( 'fair_event_page_fair-events-migration' === $hook ) {
+		if ( 'fair-events-migration' === $slug ) {
 			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/migration/index.asset.php';
 
 			wp_enqueue_script(
@@ -312,7 +389,7 @@ class AdminPages {
 		}
 
 		// Migration Summary page
-		if ( 'fair_event_page_fair-events-migration-summary' === $hook ) {
+		if ( 'fair-events-migration-summary' === $slug ) {
 			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/migration-summary/index.asset.php';
 
 			wp_enqueue_script(
@@ -333,8 +410,8 @@ class AdminPages {
 			return;
 		}
 
-		// Source View page (hidden pages use 'admin_page_' prefix).
-		if ( 'admin_page_fair-events-source-view' === $hook ) {
+		// Source View page
+		if ( 'fair-events-source-view' === $slug ) {
 			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/source-view/index.asset.php';
 
 			wp_enqueue_script(
@@ -378,8 +455,8 @@ class AdminPages {
 			return;
 		}
 
-		// Manage Invitations page (hidden pages use 'admin_page_' prefix).
-		if ( 'admin_page_fair-events-manage-invitations' === $hook ) {
+		// Manage Invitations page
+		if ( 'fair-events-manage-invitations' === $slug ) {
 			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/manage-invitations/index.asset.php';
 
 			wp_enqueue_script(
@@ -421,8 +498,8 @@ class AdminPages {
 			return;
 		}
 
-		// Manage Event page (hidden pages use 'admin_page_' prefix).
-		if ( 'admin_page_fair-events-manage-event' === $hook ) {
+		// Manage Event page
+		if ( 'fair-events-manage-event' === $slug ) {
 			wp_enqueue_media();
 
 			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/manage-event/index.asset.php';
@@ -486,7 +563,7 @@ class AdminPages {
 		}
 
 		// Venues page
-		if ( 'fair_event_page_fair-events-venues' === $hook ) {
+		if ( 'fair-events-venues' === $slug ) {
 			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/venues/index.asset.php';
 
 			wp_enqueue_script(
@@ -507,14 +584,14 @@ class AdminPages {
 			return;
 		}
 
-		// Only load on Fair Events admin pages.
-		if ( 'fair_event_page_fair-events-settings' !== $hook ) {
+		// Settings page (the only remaining slug at this point).
+		if ( 'fair-events-settings' !== $slug ) {
 			return;
 		}
 
 		$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/settings/index.asset.php';
 
-		if ( 'fair_event_page_fair-events-settings' === $hook ) {
+		if ( 'fair-events-settings' === $slug ) {
 			wp_enqueue_script(
 				'fair-events-settings',
 				FAIR_EVENTS_PLUGIN_URL . 'build/admin/settings/index.js',
@@ -682,7 +759,7 @@ class AdminPages {
 	public function reorder_admin_menu() {
 		global $submenu;
 
-		$parent_slug = 'edit.php?post_type=fair_event';
+		$parent_slug = $this->get_menu_parent_slug();
 
 		if ( ! isset( $submenu[ $parent_slug ] ) ) {
 			return;
@@ -843,6 +920,11 @@ class AdminPages {
 	public function add_copy_button_to_admin_bar( $wp_admin_bar ) {
 		// Only show on event edit pages in admin
 		if ( ! is_admin() ) {
+			return;
+		}
+
+		// Copy targets the fair_event CPT; nothing to copy when it's not registered.
+		if ( ! post_type_exists( 'fair_event' ) ) {
 			return;
 		}
 

--- a/fair-events/src/Admin/CopyEventPage.php
+++ b/fair-events/src/Admin/CopyEventPage.php
@@ -389,7 +389,7 @@ class CopyEventPage {
 						class="button button-primary"
 						value="<?php esc_attr_e( 'Create Copy', 'fair-events' ); ?>"
 					/>
-					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=fair_event' ) ); ?>" class="button">
+					<a href="<?php echo esc_url( post_type_exists( 'fair_event' ) ? admin_url( 'edit.php?post_type=fair_event' ) : admin_url( 'admin.php?page=fair-events-all-events' ) ); ?>" class="button">
 						<?php esc_html_e( 'Cancel', 'fair-events' ); ?>
 					</a>
 				</p>

--- a/fair-events/src/PostTypes/Event.php
+++ b/fair-events/src/PostTypes/Event.php
@@ -64,7 +64,10 @@ class Event {
 			'public'             => true,
 			'publicly_queryable' => true,
 			'show_ui'            => true,
-			'show_in_menu'       => true,
+			// Nest under the self-owned Fair Events menu (AdminPages) instead of
+			// creating a second top-level entry. The menu is registered
+			// independently of this CPT so it survives the CPT being turned off.
+			'show_in_menu'       => 'fair-events-calendar',
 			'query_var'          => true,
 			'rewrite'            => array( 'slug' => $slug ),
 			'capability_type'    => 'post',


### PR DESCRIPTION
## Summary

The Fair Events admin menu *was* the `fair_event` CPT's own menu — every page was a submenu of `edit.php?post_type=fair_event`, and asset enqueuing matched parent-derived hook names (`fair_event_page_*`). Turn the CPT off (the goal of follow-up #655) and the whole menu and all admin JS would vanish.

This decouples the menu so it stands on its own:
- A **self-owned top-level "Fair Events" menu** (Calendar landing, same label/icon/position), independent of the CPT; all pages parent under it. When the CPT is registered it nests under the same menu via `show_in_menu` (no duplicate top-level).
- Asset enqueuing resolves the current page through a captured **`slug => hookname` map** instead of hardcoded `fair_event_page_*` / `admin_page_*` strings — immune to the parent-slug change in both CPT-on and CPT-off states.
- CPT-only affordances (Migrate Posts / Migration Summary, the new-event link, admin-bar Copy) are gated on `post_type_exists( 'fair_event' )`; the parent slug flows through one `get_menu_parent_slug()` helper.

This is **1 of 3** (before #655 makes the CPT optional and #654 adds the flag registry). It changes the *wiring*, not the visible result, while the CPT stays on.

Closes #656

## Before / After (CPT registered)

| Before (`main`) | After |
| --- | --- |
| ![before](https://github.com/marcin-wosinek/fair-event-plugins/blob/pr-assets/656/menu-before.png?raw=true) | ![after CPT on](https://github.com/marcin-wosinek/fair-event-plugins/blob/pr-assets/656/menu-after-cpt-on.png?raw=true) |

**CPT unregistered** — the menu and every page survive (this is the whole point):

![after CPT off](https://github.com/marcin-wosinek/fair-event-plugins/blob/pr-assets/656/menu-after-cpt-off.png?raw=true)

## Note on menu parity (decided during review)

Nesting the CPT via `show_in_menu => 'fair-events-calendar'` keeps its **Event Posts** list but **not** the core-generated **Add New Event Post / Categories / Tags** submenus — WordPress doesn't carry those under a string parent. We deliberately **accepted the streamlined menu** (those three drop off) rather than re-adding them manually; the plugin's primary UX is Calendar / All Events / Manage Event, and events are still fully editable via Event Posts. This is the one intentional deviation from "byte-for-byte unchanged".

## Tests

New `e2e/fair-events-admin-menu.spec.js` (root harness):
- **CPT registered:** single top-level menu, Calendar first / Settings last, and every page mounts its React root.
- **CPT unregistered:** top-level menu present and every non-CPT page still mounts — driven by a test-only `fair_e2e_unregister_fair_event` toggle in `e2e/mu-plugins/fair-e2e-support.php` (stand-in for #655's setting).

## Test plan

- [x] `npm run build` in `fair-events`
- [x] `npm run test:e2e -- fair-events-admin-menu` — 3 passed
- [x] Manual: menu + every page render with CPT on (`:8890`) and with the CPT toggled off
- [x] `phpcs` — no new violations beyond the file's pre-existing inline-comment style (phpcs isn't CI-gated)

Screenshots live on the `pr-assets/656` branch (kept out of the code diff); deletable after review.