### PR TITLE
Fix fair-events Plugin Check: direct-access, LIKE wildcards, i18n (batches 1-3)

### DIFF
--- a/fair-events/src/API/EventDuplicationController.php
+++ b/fair-events/src/API/EventDuplicationController.php
@@ -7,6 +7,8 @@
 
 namespace FairEvents\API;
 
+defined( 'ABSPATH' ) || die;
+
 use FairEvents\Core\Plugin;
 use FairEvents\Models\EventDates;
 use WP_REST_Controller;

--- a/fair-events/src/Admin/CopyEventPage.php
+++ b/fair-events/src/Admin/CopyEventPage.php
@@ -7,6 +7,8 @@
 
 namespace FairEvents\Admin;
 
+defined( 'ABSPATH' ) || die;
+
 use FairEvents\Models\EventDates;
 use FairEvents\PostTypes\Event;
 

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -533,8 +533,9 @@ class Installer {
 		// Check if column already exists.
 		$column_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'participant_id'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'participant_id' )
 			)
 		);
 
@@ -578,8 +579,9 @@ class Installer {
 		// Check if occurrence_type column already exists.
 		$occurrence_type_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'occurrence_type'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'occurrence_type' )
 			)
 		);
 
@@ -604,8 +606,9 @@ class Installer {
 		// Check if master_id column already exists.
 		$master_id_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'master_id'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'master_id' )
 			)
 		);
 
@@ -641,8 +644,9 @@ class Installer {
 		// Check if rrule column already exists.
 		$rrule_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'rrule'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'rrule' )
 			)
 		);
 
@@ -716,8 +720,9 @@ class Installer {
 		// Check if venue_id column already exists.
 		$venue_id_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'venue_id'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'venue_id' )
 			)
 		);
 
@@ -753,8 +758,9 @@ class Installer {
 		// Check if google_maps_link column already exists.
 		$google_maps_link_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'google_maps_link'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'google_maps_link' )
 			)
 		);
 
@@ -770,8 +776,9 @@ class Installer {
 		// Check if latitude column already exists.
 		$latitude_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'latitude'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'latitude' )
 			)
 		);
 
@@ -787,8 +794,9 @@ class Installer {
 		// Check if longitude column already exists.
 		$longitude_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'longitude'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'longitude' )
 			)
 		);
 
@@ -804,8 +812,9 @@ class Installer {
 		// Check if facebook_page_link column already exists.
 		$facebook_page_link_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'facebook_page_link'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'facebook_page_link' )
 			)
 		);
 
@@ -832,8 +841,9 @@ class Installer {
 		// Check if instagram_handle column already exists.
 		$instagram_handle_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'instagram_handle'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'instagram_handle' )
 			)
 		);
 
@@ -889,8 +899,9 @@ class Installer {
 		// Check if title column already exists.
 		$title_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'title'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'title' )
 			)
 		);
 
@@ -906,8 +917,9 @@ class Installer {
 		// Check if external_url column already exists.
 		$external_url_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'external_url'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'external_url' )
 			)
 		);
 
@@ -923,8 +935,9 @@ class Installer {
 		// Check if link_type column already exists.
 		$link_type_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'link_type'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'link_type' )
 			)
 		);
 
@@ -959,8 +972,9 @@ class Installer {
 		// Check if website_url column already exists.
 		$website_url_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'website_url'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'website_url' )
 			)
 		);
 
@@ -987,8 +1001,9 @@ class Installer {
 		// Check if page_id column already exists.
 		$page_id_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'page_id'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'page_id' )
 			)
 		);
 
@@ -1015,8 +1030,9 @@ class Installer {
 		// Check if capacity column already exists.
 		$capacity_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'capacity'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'capacity' )
 			)
 		);
 
@@ -1043,8 +1059,9 @@ class Installer {
 		// Check if exdates column already exists.
 		$exdates_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'exdates'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'exdates' )
 			)
 		);
 
@@ -1071,8 +1088,9 @@ class Installer {
 		// Check if event_date_id column already exists.
 		$column_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'event_date_id'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'event_date_id' )
 			)
 		);
 
@@ -1120,8 +1138,9 @@ class Installer {
 
 		$column_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'signup_price'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'signup_price' )
 			)
 		);
 
@@ -1147,8 +1166,9 @@ class Installer {
 
 		$column_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'seats_per_ticket'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'seats_per_ticket' )
 			)
 		);
 
@@ -1174,8 +1194,9 @@ class Installer {
 
 		$column_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'invitation_only'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'invitation_only' )
 			)
 		);
 
@@ -1201,8 +1222,9 @@ class Installer {
 
 		$column_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'short_name'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'short_name' )
 			)
 		);
 
@@ -1228,8 +1250,9 @@ class Installer {
 
 		$column_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'discounted_price'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'discounted_price' )
 			)
 		);
 
@@ -1255,8 +1278,9 @@ class Installer {
 
 		$column_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'capacity'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'capacity' )
 			)
 		);
 
@@ -1282,8 +1306,9 @@ class Installer {
 
 		$column_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'derive_price_from_sale_period'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'derive_price_from_sale_period' )
 			)
 		);
 
@@ -1309,8 +1334,9 @@ class Installer {
 
 		$column_exists = $wpdb->get_results(
 			$wpdb->prepare(
-				"SHOW COLUMNS FROM %i LIKE 'minimum_activities'",
-				$table_name
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'minimum_activities' )
 			)
 		);
 

--- a/fair-events/src/blocks/event-proposal/render.php
+++ b/fair-events/src/blocks/event-proposal/render.php
@@ -14,7 +14,7 @@ defined( 'WPINC' ) || die;
 // Get block attributes
 $enable_categories  = $attributes['enableCategories'] ?? true;
 $enable_description = $attributes['enableDescription'] ?? true;
-$submit_button_text = __( $attributes['submitButtonText'] ?? 'Submit Event Proposal', 'fair-events' );
+$submit_button_text = $attributes['submitButtonText'] ?? __( 'Submit Event Proposal', 'fair-events' );
 
 // Check if user is logged in
 $is_logged_in = is_user_logged_in();


### PR DESCRIPTION
## Summary

fair-events Plugin Check cleanup (#669). This PR covers the first three
low-risk batches; the remaining batches (output escaping,
`date()`→`gmdate()`, PhotoDownloadController) land separately.

**Batch 1 — direct file access protection.** Add the repo-standard
`defined( 'ABSPATH' ) || die;` guard after the namespace in the two files
flagged for `missing_direct_file_access_protection`:
- `src/API/EventDuplicationController.php`
- `src/Admin/CopyEventPage.php`

**Batch 2 — `Installer.php` LIKE wildcards.** The column-existence checks
hardcoded the LIKE operand (`LikeWildcardsInQuery`). Underscores in the
column names are SQL LIKE single-char wildcards, so the literal also
over-matched in principle. Now passed through a `%s` placeholder wrapped in
`$wpdb->esc_like()` for a literal match. Applied to all 26 checks (the 19
flagged plus 7 wildcard-free names) so the file uses one uniform pattern.

**Batch 3 — event-proposal i18n.** `__()` was called on a runtime
expression (`$attributes['submitButtonText'] ?? 'Submit Event Proposal'`),
which the i18n tooling cannot extract (`NonSingularStringLiteralText`) and
which makes no sense for a user-supplied label. Now only the literal default
is translated, with the attribute value as the fallback.

Refs #669

## Notes

- `build/` is gitignored and regenerated by the deploy pipeline, so the
  `build/blocks/event-proposal/render.php` row in the report resolves
  automatically once `src/` is fixed. Verified locally with `npm run build`.
- `phpcs` surfaces pre-existing, **unrelated** "inline comments must end in
  full-stops" findings in the touched files. They are not in the Plugin
  Check report and are left untouched here.

## Test plan

- [x] `phpcs` no longer reports `missing_direct_file_access_protection` (Batch 1 files)
- [x] `phpcs` no longer reports `LikeWildcardsInQuery` in `Installer.php`
- [x] `phpcs` no longer reports `NonSingularStringLiteralText` in event-proposal `render.php` (src + rebuilt build)
- [ ] Migrations still detect existing columns correctly (esc_like matches the underscore literally)
- [ ] Custom submit-button label still renders verbatim; default label still translatable
