### PR TITLE
Add opt-in imgbb upload mode to screenshot helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,9 @@
 # Get your key from: https://console.anthropic.com/settings/keys
 # Cost: $0.80/$4.00 per 1M tokens (input/output)
 #ANTHROPIC_API_KEY=sk-ant-...
+
+# imgbb API key for the screenshot helper's `--upload imgbb` mode
+# (npm run screenshot -- … --upload imgbb). Get a free key at
+# https://api.imgbb.com/. Public host: only used when you opt in with
+# --upload; synthetic data only. Uploads default to a 30-day expiry.
+#IMGBB_API_KEY=...

--- a/TESTING.md
+++ b/TESTING.md
@@ -185,12 +185,43 @@ login + `WP_BASE_URL` convention; defaults to the dev wp-env on `:8888`,
 npm run screenshot -- "/wp-admin/admin.php?page=fair-payment-budgets" mobile budgets-mobile.png
 
 # dimensions: desktop | tablet | mobile | WIDTHxHEIGHT (e.g. 414x900)
-# options: --viewport (visible area only), --wait <ms>, --wait-for <selector>, --no-login
+# options: --viewport (visible area only), --wait <ms>, --wait-for <selector>,
+#          --no-login, --upload imgbb, --expiry <seconds>
 ```
 
 The file is written **relative to the current working directory**, so run it
 from wherever you want the image. Point it elsewhere with
 `WP_BASE_URL=http://localhost:8889 npm run screenshot -- …`.
+
+#### Embedding in a PR (`--upload imgbb`)
+
+To turn a capture into a PR-embeddable link in one command, add
+`--upload imgbb`. The local PNG is still written; the upload is **in addition**
+to it. The script prints the public URL and a paste-ready markdown snippet:
+
+```bash
+npm run screenshot -- "/" desktop home.png --no-login --upload imgbb
+# Saved desktop (1280x900) screenshot of http://localhost:8888/
+#   → /…/home.png
+# Uploaded: https://i.ibb.co/abc123/home.png
+# Markdown:  ![home](https://i.ibb.co/abc123/home.png)
+```
+
+**Setup**: get a free API key at <https://api.imgbb.com/> and add it to the repo
+`.env` as `IMGBB_API_KEY=<key>` (gitignored — never commit it). Without it the
+command errors and exits non-zero rather than silently skipping the upload.
+
+Uploads default to a **30-day expiry** so stale PR images self-clean; override
+with `--expiry <seconds>` (imgbb accepts `60`–`15552000`; `0` keeps it
+indefinitely).
+
+> ⚠️ **Public exposure, synthetic data only.** imgbb is a public host: anyone
+> with the link can view the image and GitHub caches it via camo. Admin captures
+> can leak participant names, emails, or finance figures — only upload
+> synthetic/demo pages. For real-data screenshots keep using the `pr-assets/<n>`
+> branch + authenticated `…?raw=true` embeds. imgbb is also not a durable
+> archive (hence the default expiry), so for long-lived PRs prefer the
+> `pr-assets` branch or a manual GitHub drag-drop attachment.
 
 ### Plugin Check reporting (`e2e/plugin-check.spec.js`)
 

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -26,12 +26,22 @@
  *   --wait <ms>         Extra settle time after load (default 600)
  *   --wait-for <sel>    Wait for a CSS selector before capturing
  *   --no-login          Skip the wp-login step (for public pages)
+ *   --upload <target>   After saving, upload the PNG and print a public URL +
+ *                       markdown snippet. Currently supports `imgbb` (needs
+ *                       IMGBB_API_KEY in .env). Opt-in: the local file is
+ *                       always written; upload is in addition to it. imgbb is
+ *                       PUBLIC — synthetic/demo data only.
+ *   --expiry <seconds>  Upload TTL for hosts that support it (default 2592000
+ *                       = 30 days; 0 keeps it indefinitely). imgbb accepts
+ *                       60–15552000.
  *
  * Examples:
  *   node scripts/screenshot.js "/wp-admin/admin.php?page=fair-payment-budgets" mobile budgets-mobile.png
  *   WP_BASE_URL=http://localhost:8889 node scripts/screenshot.js "/" desktop home.png --no-login
+ *   node scripts/screenshot.js "/" desktop home.png --no-login --upload imgbb
  */
 
+import { readFile } from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { chromium } from '@playwright/test';
@@ -55,9 +65,114 @@ const PRESETS = {
 	mobile: { width: 375, height: 812, deviceScaleFactor: 2 },
 };
 
+/** Default upload TTL: 30 days, so stale PR screenshots self-clean. */
+const DEFAULT_EXPIRY = 2592000;
+
+/**
+ * Upload a PNG buffer to imgbb and return the public link.
+ *
+ * Mirrors the shape of InstagramPostsController::upload_image() — POST the
+ * image to a host, read the public URL back, surface the API error body on
+ * failure. imgbb takes the API key (and optional expiration) as query params
+ * and the image as a base64 form field. Unlike imgur it still issues free API
+ * keys, which is why this replaces the imgur design from #653.
+ *
+ * @param {Buffer} buffer PNG bytes.
+ * @param {number} expiry Seconds until imgbb deletes it (0 = keep forever).
+ * @returns {Promise<string>} The public `i.ibb.co` link.
+ */
+async function uploadToImgbb(buffer, expiry) {
+	const apiKey = process.env.IMGBB_API_KEY;
+	if (!apiKey) {
+		throw new Error(
+			'IMGBB_API_KEY is not set. Add it to the repo .env as ' +
+				'`IMGBB_API_KEY=<your key>` (get a free key at ' +
+				'https://api.imgbb.com/). Never commit the key.'
+		);
+	}
+
+	const params = new URLSearchParams({ key: apiKey });
+	if (expiry > 0) {
+		params.set('expiration', String(expiry));
+	}
+
+	const form = new FormData();
+	form.append('image', buffer.toString('base64'));
+
+	const response = await fetch(`https://api.imgbb.com/1/upload?${params}`, {
+		method: 'POST',
+		body: form,
+	});
+
+	const text = await response.text();
+	let data;
+	try {
+		data = JSON.parse(text);
+	} catch {
+		data = null;
+	}
+
+	if (!response.ok || !data?.data?.url) {
+		throw new Error(
+			`imgbb upload failed (HTTP ${response.status}).\n${text}`
+		);
+	}
+
+	return data.data.url;
+}
+
+/**
+ * Swappable upload targets. A future durable/private host (S3, Cloudinary)
+ * slots in here behind `--upload <target>` without touching the CLI. `public`
+ * gates the exposure warning.
+ */
+const UPLOADERS = {
+	imgbb: { label: 'imgbb', public: true, upload: uploadToImgbb },
+};
+
+/**
+ * Read the just-written PNG, hand it to the selected uploader, and print the
+ * public URL plus a paste-ready markdown snippet. Throws on an unknown target
+ * or upload failure — the caller turns that into a non-zero exit, but the
+ * local PNG is already on disk by then.
+ */
+async function uploadScreenshot(target, outFile, expiry) {
+	const uploader = UPLOADERS[target];
+	if (!uploader) {
+		throw new Error(
+			`unknown --upload target "${target}". Supported: ${Object.keys(
+				UPLOADERS
+			).join(', ')}`
+		);
+	}
+
+	if (uploader.public) {
+		console.error(
+			`\n⚠️  Uploading to ${uploader.label}, a PUBLIC host: anyone with the ` +
+				'link can view it and GitHub caches it. Upload synthetic/demo data ' +
+				'only — admin captures can leak participant names, emails, or finance ' +
+				'figures. For real-data pages keep using the pr-assets branch.\n'
+		);
+	}
+
+	const buffer = await readFile(outFile);
+	const link = await uploader.upload(buffer, expiry);
+	const alt = path.basename(outFile, path.extname(outFile));
+
+	console.log(`Uploaded: ${link}`);
+	console.log(`Markdown:  ![${alt}](${link})`);
+}
+
 function parseArgs(argv) {
 	const positional = [];
-	const opts = { fullPage: true, wait: 600, waitFor: null, login: true };
+	const opts = {
+		fullPage: true,
+		wait: 600,
+		waitFor: null,
+		login: true,
+		upload: null,
+		expiry: DEFAULT_EXPIRY,
+	};
 
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i];
@@ -73,6 +188,12 @@ function parseArgs(argv) {
 				break;
 			case '--wait-for':
 				opts.waitFor = argv[++i];
+				break;
+			case '--upload':
+				opts.upload = argv[++i];
+				break;
+			case '--expiry':
+				opts.expiry = Number(argv[++i]);
 				break;
 			default:
 				positional.push(arg);
@@ -110,7 +231,10 @@ function usage(message) {
 			`  <dimensions>: ${Object.keys(PRESETS).join(
 				' | '
 			)} | WIDTHxHEIGHT\n` +
-			'  options: --viewport, --wait <ms>, --wait-for <selector>, --no-login'
+			'  options: --viewport, --wait <ms>, --wait-for <selector>, --no-login,\n' +
+			`           --upload <${Object.keys(UPLOADERS).join(
+				' | '
+			)}>, --expiry <seconds>`
 	);
 	process.exit(1);
 }
@@ -140,6 +264,16 @@ async function main() {
 	const viewport = resolveViewport(dimensions);
 	if (!viewport) {
 		usage(`unknown dimensions "${dimensions}"`);
+	}
+
+	// Validate the upload target before launching the browser so a typo fails
+	// fast instead of after a full capture.
+	if (opts.upload && !UPLOADERS[opts.upload]) {
+		usage(
+			`unknown --upload target "${opts.upload}". Supported: ${Object.keys(
+				UPLOADERS
+			).join(', ')}`
+		);
 	}
 
 	const outFile = path.resolve(process.cwd(), filename);
@@ -177,6 +311,12 @@ async function main() {
 		);
 	} finally {
 		await browser.close();
+	}
+
+	// Upload last, with the browser already closed and the PNG on disk: an
+	// upload failure exits non-zero but never costs the local file.
+	if (opts.upload) {
+		await uploadScreenshot(opts.upload, outFile, opts.expiry);
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds an opt-in `--upload imgbb` mode to `scripts/screenshot.js`: after writing the screenshot it uploads the PNG to imgbb and prints the public URL plus a paste-ready markdown snippet, so a capture becomes a PR-embeddable link in one command.
- Upload is **in addition to** the local file — omitting `--upload` leaves the existing flow byte-for-byte unchanged.
- Uploads default to a **30-day expiry** (`--expiry <seconds>` to override; `0` keeps indefinitely) so stale PR images self-clean.
- `IMGBB_API_KEY` is read from the repo `.env` (documented in `.env.example`); a missing key produces a clear error and non-zero exit rather than silently skipping.
- The uploader sits behind a small swappable `UPLOADERS` registry, so a durable/private host (S3, Cloudinary) can be added behind `--upload <target>` later without reworking the CLI.

Closes #672.

## Notes

- **Why imgbb, not imgur:** #653 proposed this against imgur but was closed *not planned* — imgur no longer issues new API client IDs. imgbb still hands out free keys and supports per-upload expiration, so it keeps the same base64-POST-read-`data.url` shape that mirrors `InstagramPostsController::upload_image()`.
- **Public-data caveat:** imgbb is a public host. A stderr warning fires before any upload and `TESTING.md` documents synthetic-data-only use — admin captures can leak participant names/emails/finance figures, so the `pr-assets/<n>` branch remains the default for real-data pages. imgbb is also not a durable archive (hence the default expiry).
- The upload runs after the browser closes and the PNG is on disk, so an upload failure exits non-zero but never costs the local file.

## Test plan

- [x] `node --check scripts/screenshot.js` passes.
- [x] Usage output lists `--upload <imgbb>, --expiry <seconds>`.
- [x] A bad target (`--upload badhost`) fails fast before launching the browser with a clear error.
- [ ] With `IMGBB_API_KEY` set: `npm run screenshot -- "/" desktop home.png --no-login --upload imgbb` writes `home.png` and prints an `i.ibb.co` URL + markdown snippet. *(Needs a real key — not run in CI.)*
- [ ] With `IMGBB_API_KEY` unset: same command errors with a clear message and non-zero exit, but `home.png` is still written.
