### PR TITLE
Escape block render output in fair-events (batch 4 of #669)

### DIFF
--- a/fair-events/src/Admin/MediaLibraryHooks.php
+++ b/fair-events/src/Admin/MediaLibraryHooks.php
@@ -127,7 +127,7 @@ class MediaLibraryHooks {
 			$label = $ed->title ?: $ed->start_datetime;
 			printf(
 				'<option value="%d"%s>%s</option>',
-				$ed->id,
+				absint( $ed->id ),
 				selected( $selected, (int) $ed->id, false ),
 				esc_html( $label )
 			);

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -106,9 +106,9 @@ if ( ! function_exists( 'fair_events_render_calendar_event_item' ) ) {
 
 		if ( $is_ical ) {
 			// iCal event rendering
-			$event_title = esc_html( $event_data['title'] );
+			$event_title = $event_data['title'];
 			$event_url   = $event_data['permalink'] ?? '';
-			$event_desc  = esc_attr( $event_data['description'] ?? '' );
+			$event_desc  = $event_data['description'] ?? '';
 
 			$item_classes = array( 'event-item', 'is-ical' );
 			?>
@@ -118,21 +118,21 @@ if ( ! function_exists( 'fair_events_render_calendar_event_item' ) ) {
 				<?php if ( ! empty( $event_url ) ) : ?>
 					<a href="<?php echo esc_url( $event_url ); ?>"
 						class="ical-event-title"
-						title="<?php echo $event_desc; ?>"
+						title="<?php echo esc_attr( $event_desc ); ?>"
 						target="_blank"
 						rel="noopener noreferrer">
-						<?php echo $event_title; ?>
+						<?php echo esc_html( $event_title ); ?>
 					</a>
 				<?php else : ?>
-					<span class="ical-event-title" title="<?php echo $event_desc; ?>">
-						<?php echo $event_title; ?>
+					<span class="ical-event-title" title="<?php echo esc_attr( $event_desc ); ?>">
+						<?php echo esc_html( $event_title ); ?>
 					</span>
 				<?php endif; ?>
 			</div>
 			<?php
 		} elseif ( $is_standalone ) {
 			// Standalone event rendering (external/unlinked)
-			$event_title = esc_html( $event_data['title'] ?? '' );
+			$event_title = $event_data['title'] ?? '';
 			$event_url   = $event_data['permalink'] ?? '';
 			$link_type   = $event_data['link_type'] ?? 'none';
 			$is_external = 'external' === $link_type;
@@ -152,10 +152,10 @@ if ( ! function_exists( 'fair_events_render_calendar_event_item' ) ) {
 						class="event-title"
 						target="_blank"
 						rel="noopener noreferrer">
-						<?php echo $event_title; ?>
+						<?php echo esc_html( $event_title ); ?>
 					</a>
 				<?php else : ?>
-					<span class="event-title"><?php echo $event_title; ?></span>
+					<span class="event-title"><?php echo esc_html( $event_title ); ?></span>
 				<?php endif; ?>
 			</div>
 			<?php

--- a/fair-events/src/blocks/events-list/render.php
+++ b/fair-events/src/blocks/events-list/render.php
@@ -366,7 +366,7 @@ if ( ! empty( $event_source_slugs ) && is_array( $event_source_slugs ) ) {
 					$bg_color_value = 'var(--wp--preset--color--' . esc_attr( $event_color ) . ')';
 				}
 
-				$event_style = 'style="--event-bg-color: ' . esc_attr( $bg_color_value ) . '; --event-text-color: #ffffff;"';
+				$event_style = '--event-bg-color: ' . $bg_color_value . '; --event-text-color: #ffffff;';
 			} elseif ( 'standalone' === $event_type ) {
 				// Standalone event (external/unlinked)
 				$event_classes[] = 'is-standalone';
@@ -382,7 +382,7 @@ if ( ! empty( $event_source_slugs ) && is_array( $event_source_slugs ) ) {
 			}
 
 			// Open event wrapper
-			echo '<div class="' . esc_attr( implode( ' ', $event_classes ) ) . '" ' . $event_style . '>';
+			echo '<div class="' . esc_attr( implode( ' ', $event_classes ) ) . '"' . ( '' !== $event_style ? ' style="' . esc_attr( $event_style ) . '"' : '' ) . '>';
 
 			if ( 'ical' === $event_type ) {
 				// Create a temporary context for pattern rendering

--- a/fair-events/src/blocks/weekly-schedule/render.php
+++ b/fair-events/src/blocks/weekly-schedule/render.php
@@ -521,30 +521,30 @@ $next_url = add_query_arg( 'schedule_week', sprintf( '%04d-W%02d', $next['year']
 						<?php if ( $event_data['is_ical'] ) : ?>
 							<?php
 							// iCal event rendering
-							$event_title = esc_html( $event_data['title'] );
+							$event_title = $event_data['title'];
 							$event_url   = $event_data['permalink'] ?? '';
-							$event_desc  = esc_attr( $event_data['description'] ?? '' );
+							$event_desc  = $event_data['description'] ?? '';
 							?>
 							<div class="schedule-event is-ical"
 								data-event-id="<?php echo esc_attr( $event_data['id'] ); ?>"
 								style="--event-bg-color: <?php echo esc_attr( $event_data['color'] ); ?>; --event-text-color: #ffffff;">
 								<?php if ( ! empty( $event_url ) ) : ?>
 									<a href="<?php echo esc_url( $event_url ); ?>"
-										title="<?php echo $event_desc; ?>"
+										title="<?php echo esc_attr( $event_desc ); ?>"
 										target="_blank"
 										rel="noopener noreferrer">
-										<?php echo $event_title; ?>
+										<?php echo esc_html( $event_title ); ?>
 									</a>
 								<?php else : ?>
-									<span title="<?php echo $event_desc; ?>">
-										<?php echo $event_title; ?>
+									<span title="<?php echo esc_attr( $event_desc ); ?>">
+										<?php echo esc_html( $event_title ); ?>
 									</span>
 								<?php endif; ?>
 							</div>
 						<?php elseif ( ! empty( $event_data['is_standalone'] ) ) : ?>
 							<?php
 							// Standalone event rendering (external/unlinked)
-							$event_title  = esc_html( $event_data['title'] ?? '' );
+							$event_title  = $event_data['title'] ?? '';
 							$event_url    = $event_data['url'] ?? '';
 							$is_external  = 'external' === $event_data['link_type'];
 							$item_classes = array( 'schedule-event', 'is-standalone' );
@@ -561,10 +561,10 @@ $next_url = add_query_arg( 'schedule_week', sprintf( '%04d-W%02d', $next['year']
 									<a href="<?php echo esc_url( $event_url ); ?>"
 										target="_blank"
 										rel="noopener noreferrer">
-										<?php echo $event_title; ?>
+										<?php echo esc_html( $event_title ); ?>
 									</a>
 								<?php else : ?>
-									<span><?php echo $event_title; ?></span>
+									<span><?php echo esc_html( $event_title ); ?></span>
 								<?php endif; ?>
 							</div>
 						<?php else : ?>
@@ -580,7 +580,13 @@ $next_url = add_query_arg( 'schedule_week', sprintf( '%04d-W%02d', $next['year']
 							<div class="<?php echo esc_attr( implode( ' ', $item_classes ) ); ?>"
 								data-event-id="<?php echo esc_attr( $event_data['id'] ); ?>"
 								style="--event-bg-color: <?php echo esc_attr( $bg_color_value ); ?>; --event-text-color: <?php echo esc_attr( $text_color_value ); ?>;">
-								<?php echo fair_events_render_schedule_pattern( $display_pattern, $event_data['id'] ); ?>
+								<?php
+								// fair_events_render_schedule_pattern() returns already-rendered,
+								// trusted block markup from render_block() (plus injected event-time
+								// data attributes); escaping it would corrupt the HTML output.
+								// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								echo fair_events_render_schedule_pattern( $display_pattern, $event_data['id'] );
+								?>
 							</div>
 						<?php endif; ?>
 					<?php endforeach; ?>


### PR DESCRIPTION
## Summary

Batch 4 of #669 — output escaping (the `WordPress.Security.EscapeOutput` findings) in fair-events, clearing the bulk of the Plugin Check security errors blocking a clean WordPress.org submission. `Refs #669` (one of several batches; does not close the ticket).

Scoped to the four files the ticket lists. In the block renderers the values were being **pre-escaped at assignment** and then echoed raw — safe at runtime, but the sniff escapes at the *point of output*, and adding escaping on top of the pre-escaped value would double-encode (`&amp;amp;`). The fix moves escaping to the echo:

- **events-calendar/render.php** — `$event_title` → `esc_html()`, `$event_desc` (in `title="…"`) → `esc_attr()` at each echo; assignment no longer pre-escapes (6 spots).
- **weekly-schedule/render.php** — same treatment for `$event_title`/`$event_desc`. Line 583 `fair_events_render_schedule_pattern()` returns already-rendered, trusted `render_block()` markup (with injected `data-event-time` attributes); `wp_kses_post()` would strip those, so it carries a **documented `phpcs:ignore`** with the rationale.
- **events-list/render.php:385** — store the inline style as a raw CSS value and `esc_attr()` it at the echo (the whole `style="…"` attribute string can't itself be passed to `esc_attr`).
- **Admin/MediaLibraryHooks.php:130** — wrap the option id in `absint()`.

## Notes

- **Output is unchanged** — every value is now escaped exactly once, same as before; this is a sniff-compliance change, not a behavior change.
- **`build/` is gitignored**, so only `src/` changes are committed. `build/` was regenerated locally via `npm run build` and verified identical to the fixed `src/`.
- **Out of scope:** the remaining phpcs errors in these files (inline-comment punctuation, missing doc comments, `date()` → `gmdate()` [Batch 5], short ternaries, nonce/unslash) belong to other batches or the repo's broader ruleset and are intentionally untouched here.

## Test plan

- [x] `vendor/bin/phpcs --sniffs=WordPress.Security.EscapeOutput` on all four files → exit 0 (was 15 errors).
- [x] `php -l` clean on all four files.
- [x] No new sniff violations introduced at the edited lines.
- [x] `npm run build` regenerates `build/` matching the fixed `src/`.
- [ ] Manual smoke: calendar / weekly-schedule / events-list blocks render identically on the dev site.
