### PR TITLE
Use gmdate() in events-calendar render (batch 5 of #669)

### DIFF
--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -230,8 +230,8 @@ if ( ! preg_match( '/^\d{4}$/', $current_year ) || $current_year < 1900 || $curr
 
 // Calculate grid structure early (needed for query range)
 $first_day_of_month_ts = strtotime( "{$current_year}-{$current_month}-01" );
-$days_in_month         = (int) date( 't', $first_day_of_month_ts );
-$first_weekday         = (int) date( 'w', $first_day_of_month_ts ); // 0=Sunday, 6=Saturday
+$days_in_month         = (int) gmdate( 't', $first_day_of_month_ts );
+$first_weekday         = (int) gmdate( 'w', $first_day_of_month_ts ); // 0=Sunday, 6=Saturday
 
 // Adjust for Monday start (startOfWeek attribute)
 if ( 1 === $start_of_week ) {
@@ -243,9 +243,9 @@ $total_cells     = $leading_blanks + $days_in_month;
 $trailing_blanks = ( 0 === $total_cells % 7 ) ? 0 : 7 - ( $total_cells % 7 );
 
 // Calculate extended query range including adjacent month days
-$query_start          = date( 'Y-m-d 00:00:00', strtotime( "-{$leading_blanks} days", $first_day_of_month_ts ) );
+$query_start          = gmdate( 'Y-m-d 00:00:00', strtotime( "-{$leading_blanks} days", $first_day_of_month_ts ) );
 $last_day_of_month_ts = strtotime( "{$current_year}-{$current_month}-{$days_in_month}" );
-$query_end            = date( 'Y-m-d 23:59:59', strtotime( "+{$trailing_blanks} days", $last_day_of_month_ts ) );
+$query_end            = gmdate( 'Y-m-d 23:59:59', strtotime( "+{$trailing_blanks} days", $last_day_of_month_ts ) );
 
 // Keep original month boundaries for display logic
 $month_start = "{$current_year}-{$current_month}-01";
@@ -461,15 +461,15 @@ $next_month_timestamp = strtotime( '+1 month', $first_day_of_month_ts );
 
 $prev_url = add_query_arg(
 	array(
-		'calendar_month' => date( 'm', $prev_month_timestamp ),
-		'calendar_year'  => date( 'Y', $prev_month_timestamp ),
+		'calendar_month' => gmdate( 'm', $prev_month_timestamp ),
+		'calendar_year'  => gmdate( 'Y', $prev_month_timestamp ),
 	)
 );
 
 $next_url = add_query_arg(
 	array(
-		'calendar_month' => date( 'm', $next_month_timestamp ),
-		'calendar_year'  => date( 'Y', $next_month_timestamp ),
+		'calendar_month' => gmdate( 'm', $next_month_timestamp ),
+		'calendar_year'  => gmdate( 'Y', $next_month_timestamp ),
 	)
 );
 
@@ -522,8 +522,8 @@ $today = current_time( 'Y-m-d' );
 			for ( $i = 0; $i < $leading_blanks; $i++ ) :
 				$day_offset   = $leading_blanks - $i;
 				$date_ts      = strtotime( "-{$day_offset} days", $first_day_of_month_ts );
-				$current_date = date( 'Y-m-d', $date_ts );
-				$day_num      = date( 'j', $date_ts );
+				$current_date = gmdate( 'Y-m-d', $date_ts );
+				$day_num      = gmdate( 'j', $date_ts );
 				$day_events   = $events_by_date[ $current_date ] ?? array();
 				$is_past      = strtotime( $current_date ) < strtotime( $today );
 
@@ -595,8 +595,8 @@ $today = current_time( 'Y-m-d' );
 			for ( $i = 0; $i < $trailing_blanks; $i++ ) :
 				$day_offset   = $i + 1;
 				$date_ts      = strtotime( "+{$day_offset} days", $last_day_of_month_ts );
-				$current_date = date( 'Y-m-d', $date_ts );
-				$day_num      = date( 'j', $date_ts );
+				$current_date = gmdate( 'Y-m-d', $date_ts );
+				$day_num      = gmdate( 'j', $date_ts );
 				$day_events   = $events_by_date[ $current_date ] ?? array();
 				$is_past      = strtotime( $current_date ) < strtotime( $today );
 


### PR DESCRIPTION
## Summary

Batch 5 of #669 — resolves the `WordPress.DateTime.RestrictedFunctions` Plugin Check findings (12×) in `events-calendar/render.php` by swapping `date()` for `gmdate()`. `Refs #669` (one of several batches; does not close the ticket).

Per the ticket, each call was classified individually rather than blanket-replaced. **All twelve operate on UTC-anchored timestamps** (built with `strtotime("Y-m-d")`) and produce civil-date or machine values:

| Lines | Call | Purpose |
|---|---|---|
| 233, 234 | `date('t'/'w', $first_day_of_month_ts)` | days-in-month / first weekday (grid structure) |
| 246, 248 | `date('Y-m-d H:i:s', …)` | DB query-range boundary strings |
| 464, 465, 471, 472 | `date('m'/'Y', prev/next_month_ts)` | prev/next-month navigation URL params |
| 525, 526, 598, 599 | `date('Y-m-d'/'j', $date_ts)` | leading/trailing grid-cell civil date (events-by-date key) + day number |

## Why `gmdate()`, not `wp_date()`

WordPress fixes PHP's default timezone to **UTC**, so `date()` and `gmdate()` already returned identical output here — this change is **behaviour-preserving** and just makes the calls immune to `date_default_timezone_set()`.

`wp_date()` would be **wrong** for every one of these: the timestamps are UTC-midnight *civil-date anchors*, so applying the site's UTC offset would shift them across day boundaries (e.g. midnight-UTC May 1 → Apr 30 evening in US zones), corrupting the grid weekday, day numbers, and `events_by_date` keys.

The genuinely display-facing values were already correct and are left untouched: localized weekday labels use `wp_date('D', …)`, the month title uses `date_i18n('F Y', …)`, and "today" uses `current_time('Y-m-d')`.

## Notes

- `build/` is gitignored, so only the `src/` change is committed; `build/` was regenerated via `npm run build` and verified byte-identical to `src/`.
- Branched off `main` (independent of the open Batch 4 PR #675); the `date()` lines don't overlap Batch 4's escaping lines, so the two merge cleanly.

## Test plan

- [x] `vendor/bin/phpcs --sniffs=WordPress.DateTime.RestrictedFunctions` → exit 0 (was 12 errors).
- [x] No bare `date()` calls remain; `php -l` clean.
- [x] `npm run build` regenerates `build/` identical to the fixed `src/`.
- [ ] Manual smoke on the dev site at a **non-UTC** timezone: calendar grid weekday alignment, day numbers, today/past highlighting, and prev/next navigation all correct across a month boundary.
