### PR TITLE
Make the Events post type optional

### DIFF
--- a/e2e/fair-events-admin-menu.spec.js
+++ b/e2e/fair-events-admin-menu.spec.js
@@ -7,8 +7,9 @@
  * decoupling — every page must mount its React root **whether or not the CPT is
  * registered**, and with the CPT on the menu must look unchanged.
  *
- * The CPT-off state is produced by the `fair_e2e_unregister_fair_event` toggle in
- * e2e/mu-plugins/fair-e2e-support.php (a stand-in for #655's real setting).
+ * The CPT-off state is produced by the real `fair_events_register_post_type`
+ * setting (#655): `wp option update fair_events_register_post_type 0`. This suite
+ * also asserts which menu elements appear/disappear based on that setting.
  *
  * Run: `npm run test:e2e -- fair-events-admin-menu`.
  */
@@ -79,14 +80,17 @@ async function expectRootMounts(page, slug, root) {
 	).toBeAttached({ timeout: 15000 });
 }
 
+/** CPT submenu link (the fair_event post list) lives under the top-level menu. */
+const CPT_LINK =
+	'#toplevel_page_fair-events-calendar a[href*="post_type=fair_event"]';
+/** Migration page link — a CPT-only affordance. */
+const MIGRATION_LINK =
+	'#toplevel_page_fair-events-calendar a[href*="page=fair-events-migration"]';
+
 test.describe('Fair Events admin menu — CPT registered (regression)', () => {
 	test.beforeAll(() => {
-		// Default state: CPT registered. Clear any leftover toggle.
-		try {
-			wpCli('option delete fair_e2e_unregister_fair_event');
-		} catch {
-			// Not set — fine.
-		}
+		// Default state: Events post type on.
+		wpCli('option update fair_events_register_post_type 1');
 	});
 
 	test('one top-level Fair Events menu, Calendar first and Settings last', async ({
@@ -112,6 +116,22 @@ test.describe('Fair Events admin menu — CPT registered (regression)', () => {
 		expect(labels[labels.length - 1]).toBe('Settings');
 	});
 
+	test('CPT-only menu items are present when the Events post type is on', async ({
+		page,
+	}) => {
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-calendar');
+
+		await expect(
+			page.locator(CPT_LINK),
+			'Events post type submenu link should be visible with the CPT on'
+		).toHaveCount(1);
+		await expect(
+			page.locator(MIGRATION_LINK).first(),
+			'Migrate Posts link should be visible with the CPT on'
+		).toBeVisible();
+	});
+
 	test('every page mounts its React root', async ({ page }) => {
 		await login(page);
 		for (const { slug, root } of PAGES) {
@@ -120,27 +140,24 @@ test.describe('Fair Events admin menu — CPT registered (regression)', () => {
 	});
 });
 
-test.describe('Fair Events admin menu — CPT unregistered', () => {
+test.describe('Fair Events admin menu — Events post type off', () => {
 	test.beforeAll(() => {
-		wpCli('option update fair_e2e_unregister_fair_event 1');
+		wpCli('option update fair_events_register_post_type 0');
 	});
 
 	test.afterAll(() => {
-		try {
-			wpCli('option delete fair_e2e_unregister_fair_event');
-		} catch {
-			// Already gone — fine.
-		}
+		// Restore the default so other suites see the CPT registered.
+		wpCli('option update fair_events_register_post_type 1');
 	});
 
-	test('top-level menu and every page still mount without the CPT', async ({
+	test('top-level menu and every non-CPT page still mount', async ({
 		page,
 	}) => {
 		await login(page);
 
 		await expect(
 			page.locator('#toplevel_page_fair-events-calendar'),
-			'top-level menu disappeared when the CPT was unregistered'
+			'top-level menu disappeared when the CPT was turned off'
 		).toHaveCount(1);
 
 		for (const { slug, root, cptOnly } of PAGES) {
@@ -149,5 +166,21 @@ test.describe('Fair Events admin menu — CPT unregistered', () => {
 			}
 			await expectRootMounts(page, slug, root);
 		}
+	});
+
+	test('CPT-only menu items are hidden when the Events post type is off', async ({
+		page,
+	}) => {
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-calendar');
+
+		await expect(
+			page.locator(CPT_LINK),
+			'Events post type submenu link should be gone with the CPT off'
+		).toHaveCount(0);
+		await expect(
+			page.locator(MIGRATION_LINK),
+			'Migration links should be gone with the CPT off'
+		).toHaveCount(0);
 	});
 });

--- a/e2e/mu-plugins/fair-e2e-support.php
+++ b/e2e/mu-plugins/fair-e2e-support.php
@@ -78,22 +78,3 @@ add_filter(
 	10,
 	2
 );
-
-/*
- * 4. Optionally unregister the fair_event CPT.
- *
- * Stand-in for the `fair_events_register_post_type` setting that arrives in #655,
- * so the admin menu's "CPT off" path can be exercised today. Runs on `init` at a
- * late priority (after FairEvents\Core\Plugin registers the CPT) so the admin
- * menu, built later on `admin_menu`, sees `post_type_exists( 'fair_event' )`
- * as false. Toggle with: `wp option update fair_e2e_unregister_fair_event 1`.
- */
-add_action(
-	'init',
-	static function () {
-		if ( get_option( 'fair_e2e_unregister_fair_event' ) && post_type_exists( 'fair_event' ) ) {
-			unregister_post_type( 'fair_event' );
-		}
-	},
-	99
-);

--- a/fair-events/__tests__/Settings/SettingsTest.php
+++ b/fair-events/__tests__/Settings/SettingsTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Settings Tests
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Settings;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Settings\Settings;
+
+/**
+ * Test enabled-post-types resolution and the Events CPT switch.
+ */
+class SettingsTest extends TestCase {
+	/**
+	 * Reset the stubbed option store before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$GLOBALS['_fair_test_options'] = array();
+	}
+
+	/**
+	 * Sanitizing no longer force-adds fair_event.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_drops_fair_event() {
+		$settings = new Settings();
+		$this->assertSame(
+			array( 'page' ),
+			$settings->sanitize_enabled_post_types( array( 'fair_event', 'page' ) )
+		);
+	}
+
+	/**
+	 * Sanitizing dedupes and drops empties.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_dedupes_and_filters() {
+		$settings = new Settings();
+		$this->assertSame(
+			array( 'post' ),
+			$settings->sanitize_enabled_post_types( array( 'post', 'post', '' ) )
+		);
+	}
+
+	/**
+	 * Non-array input sanitizes to an empty list.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_non_array_returns_empty() {
+		$settings = new Settings();
+		$this->assertSame( array(), $settings->sanitize_enabled_post_types( 'nope' ) );
+	}
+
+	/**
+	 * With the switch on, fair_event is present in the effective list.
+	 *
+	 * @return void
+	 */
+	public function test_get_enabled_includes_fair_event_when_switch_on() {
+		$GLOBALS['_fair_test_options']['fair_events_register_post_type'] = true;
+		$GLOBALS['_fair_test_options']['fair_events_enabled_post_types'] = array( 'page' );
+		$this->assertSame( array( 'fair_event', 'page' ), Settings::get_enabled_post_types() );
+	}
+
+	/**
+	 * With the switch off, fair_event is dropped from the effective list.
+	 *
+	 * @return void
+	 */
+	public function test_get_enabled_excludes_fair_event_when_switch_off() {
+		$GLOBALS['_fair_test_options']['fair_events_register_post_type'] = false;
+		$GLOBALS['_fair_test_options']['fair_events_enabled_post_types'] = array( 'fair_event', 'page' );
+		$this->assertSame( array( 'page' ), Settings::get_enabled_post_types() );
+	}
+
+	/**
+	 * With the switch off and no other type, fall back to page.
+	 *
+	 * @return void
+	 */
+	public function test_get_enabled_falls_back_to_page_when_off_and_empty() {
+		$GLOBALS['_fair_test_options']['fair_events_register_post_type'] = false;
+		$GLOBALS['_fair_test_options']['fair_events_enabled_post_types'] = array();
+		$this->assertSame( array( 'page' ), Settings::get_enabled_post_types() );
+	}
+
+	/**
+	 * Defaults (nothing stored) resolve to just the Events CPT.
+	 *
+	 * @return void
+	 */
+	public function test_get_enabled_defaults_to_fair_event() {
+		$this->assertSame( array( 'fair_event' ), Settings::get_enabled_post_types() );
+	}
+}

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -12,3 +12,32 @@ require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 if ( ! defined( 'WPINC' ) ) {
 	define( 'WPINC', 'wp-includes' );
 }
+
+// Minimal WordPress function stubs so pure settings logic can be unit tested
+// without a full WP bootstrap. Tests seed values via $GLOBALS['_fair_test_options'].
+if ( ! function_exists( 'sanitize_key' ) ) {
+	/**
+	 * Stub of WordPress sanitize_key().
+	 *
+	 * @param string $key Key to sanitize.
+	 * @return string Lowercased key stripped to [a-z0-9_-].
+	 */
+	function sanitize_key( $key ) {
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	/**
+	 * Stub of WordPress get_option() backed by $GLOBALS['_fair_test_options'].
+	 *
+	 * @param string $name          Option name.
+	 * @param mixed  $default_value  Value returned when the option is unset.
+	 * @return mixed Stored value or the default.
+	 */
+	function get_option( $name, $default_value = false ) {
+		$options = isset( $GLOBALS['_fair_test_options'] ) ? $GLOBALS['_fair_test_options'] : array();
+		return array_key_exists( $name, $options ) ? $options[ $name ] : $default_value;
+	}
+}

--- a/fair-events/src/Admin/settings/GeneralTab.js
+++ b/fair-events/src/Admin/settings/GeneralTab.js
@@ -7,6 +7,7 @@ import {
 	Button,
 	TextControl,
 	CheckboxControl,
+	ToggleControl,
 	PanelBody,
 	ExternalLink,
 	Card,
@@ -31,7 +32,8 @@ import CopyUrlButton from '../components/CopyUrlButton.js';
  */
 export default function GeneralTab({ onNotice }) {
 	const [slug, setSlug] = useState('');
-	const [enabledPostTypes, setEnabledPostTypes] = useState(['fair_event']);
+	const [enabledPostTypes, setEnabledPostTypes] = useState([]);
+	const [registerPostType, setRegisterPostType] = useState(true);
 	const [availablePostTypes, setAvailablePostTypes] = useState([]);
 	const [isLoading, setIsLoading] = useState(true);
 	const [isSaving, setIsSaving] = useState(false);
@@ -42,6 +44,7 @@ export default function GeneralTab({ onNotice }) {
 			.then(([settings, postTypes]) => {
 				setSlug(settings.slug);
 				setEnabledPostTypes(settings.enabledPostTypes);
+				setRegisterPostType(settings.registerPostType);
 
 				// Filter to get content post types that make sense for events.
 				// Exclude system types that shouldn't have event data.
@@ -85,11 +88,28 @@ export default function GeneralTab({ onNotice }) {
 
 	// Save settings.
 	const handleSave = () => {
+		const otherPostTypes = enabledPostTypes.filter(
+			(t) => t !== 'fair_event'
+		);
+
+		// With the Events post type off, at least one other type must be chosen.
+		if (!registerPostType && otherPostTypes.length === 0) {
+			onNotice({
+				status: 'error',
+				message: __(
+					'Select at least one post type, or enable the Events post type.',
+					'fair-events'
+				),
+			});
+			return;
+		}
+
 		setIsSaving(true);
 
 		saveSettings({
 			fair_events_slug: slug,
-			fair_events_enabled_post_types: enabledPostTypes,
+			fair_events_register_post_type: registerPostType,
+			fair_events_enabled_post_types: otherPostTypes,
 		})
 			.then(() => {
 				return loadGeneralSettings();
@@ -97,6 +117,7 @@ export default function GeneralTab({ onNotice }) {
 			.then((settings) => {
 				setSlug(settings.slug);
 				setEnabledPostTypes(settings.enabledPostTypes);
+				setRegisterPostType(settings.registerPostType);
 				onNotice({
 					status: 'success',
 					message: __('Settings saved successfully.', 'fair-events'),
@@ -148,19 +169,23 @@ export default function GeneralTab({ onNotice }) {
 					>
 						<p className="description">
 							{__(
-								'Select which post types can have event data (dates, location). The Events post type is always enabled.',
+								'Select which post types can have event data (dates, location).',
 								'fair-events'
 							)}
 						</p>
 
-						<CheckboxControl
-							label={__('Events', 'fair-events')}
-							checked={true}
-							disabled={true}
-							help={__(
-								'The Events post type is always enabled.',
+						<ToggleControl
+							label={__(
+								'Use the Events post type',
 								'fair-events'
 							)}
+							checked={registerPostType}
+							onChange={(value) => setRegisterPostType(value)}
+							help={__(
+								'Register the dedicated Events post type. Turn off to attach events only to the post types selected below.',
+								'fair-events'
+							)}
+							disabled={isSaving}
 						/>
 
 						{availablePostTypes.map((postType) => (

--- a/fair-events/src/Admin/settings/settings-api.js
+++ b/fair-events/src/Admin/settings/settings-api.js
@@ -28,9 +28,8 @@ export function loadGeneralSettings() {
 	return apiFetch({ path: '/wp/v2/settings' }).then((settings) => {
 		return {
 			slug: settings.fair_events_slug || 'fair-events',
-			enabledPostTypes: settings.fair_events_enabled_post_types || [
-				'fair_event',
-			],
+			enabledPostTypes: settings.fair_events_enabled_post_types || [],
+			registerPostType: settings.fair_events_register_post_type ?? true,
 		};
 	});
 }

--- a/fair-events/src/PostTypes/Event.php
+++ b/fair-events/src/PostTypes/Event.php
@@ -28,6 +28,24 @@ class Event {
 	 * @return void
 	 */
 	public static function register() {
+		// Skip the post type itself when the switch is off, but still register
+		// meta / meta box / admin columns below for the other enabled post types.
+		if ( Settings::should_register_post_type() ) {
+			self::register_post_type();
+		}
+
+		self::register_meta();
+		self::register_meta_box();
+		self::register_clone_support();
+		self::register_admin_columns();
+	}
+
+	/**
+	 * Register the fair_event post type with WordPress.
+	 *
+	 * @return void
+	 */
+	private static function register_post_type() {
 		$labels = array(
 			'name'                  => _x( 'Events', 'Post type general name', 'fair-events' ),
 			'singular_name'         => _x( 'Event', 'Post type singular name', 'fair-events' ),
@@ -81,11 +99,6 @@ class Event {
 		);
 
 		register_post_type( self::POST_TYPE, $args );
-
-		self::register_meta();
-		self::register_meta_box();
-		self::register_clone_support();
-		self::register_admin_columns();
 	}
 
 	/**

--- a/fair-events/src/Settings/Settings.php
+++ b/fair-events/src/Settings/Settings.php
@@ -23,6 +23,9 @@ class Settings {
 		add_action( 'add_option_fair_events_slug', array( $this, 'flush_rewrite_rules_on_slug_change' ), 10, 2 );
 		add_action( 'update_option_fair_events_slug', array( $this, 'flush_rewrite_rules_on_slug_change' ), 10, 2 );
 		add_action( 'delete_option_fair_events_slug', array( $this, 'flush_rewrite_rules_on_slug_change' ) );
+		// Toggling CPT registration changes which rewrite rules exist.
+		add_action( 'add_option_fair_events_register_post_type', array( $this, 'flush_rewrite_rules_on_slug_change' ) );
+		add_action( 'update_option_fair_events_register_post_type', array( $this, 'flush_rewrite_rules_on_slug_change' ) );
 		add_filter( 'rest_pre_update_setting', array( $this, 'handle_empty_slug_via_rest' ), 10, 3 );
 	}
 
@@ -59,9 +62,33 @@ class Settings {
 						'items' => array( 'type' => 'string' ),
 					),
 				),
-				'default'           => array( 'fair_event' ),
+				'default'           => array(),
 			)
 		);
+
+		// Register the Events post type toggle. This single switch controls both
+		// whether the fair_event CPT is registered and its membership in the
+		// enabled post types, so the two can never contradict each other.
+		register_setting(
+			'fair_events_settings',
+			'fair_events_register_post_type',
+			array(
+				'type'              => 'boolean',
+				'description'       => __( 'Register the Events post type', 'fair-events' ),
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'show_in_rest'      => true,
+				'default'           => true,
+			)
+		);
+	}
+
+	/**
+	 * Whether the fair_event custom post type should be registered.
+	 *
+	 * @return bool True when the Events post type is enabled.
+	 */
+	public static function should_register_post_type() {
+		return (bool) get_option( 'fair_events_register_post_type', true );
 	}
 
 	/**
@@ -70,7 +97,23 @@ class Settings {
 	 * @return array Array of post type slugs.
 	 */
 	public static function get_enabled_post_types() {
-		return get_option( 'fair_events_enabled_post_types', array( 'fair_event' ) );
+		$types = get_option( 'fair_events_enabled_post_types', array() );
+		if ( ! is_array( $types ) ) {
+			$types = array();
+		}
+
+		// fair_event membership is owned by the registration switch, never the
+		// stored list, so resolve it here regardless of how the options were saved.
+		$types = array_values( array_diff( $types, array( 'fair_event' ) ) );
+
+		if ( self::should_register_post_type() ) {
+			array_unshift( $types, 'fair_event' );
+		} elseif ( empty( $types ) ) {
+			// Guarantee at least one type so queries/blocks keep working with the CPT off.
+			$types = array( 'page' );
+		}
+
+		return array_values( array_unique( $types ) );
 	}
 
 	/**
@@ -81,16 +124,15 @@ class Settings {
 	 */
 	public function sanitize_enabled_post_types( $value ) {
 		if ( ! is_array( $value ) ) {
-			return array( 'fair_event' );
+			$value = array();
 		}
 
-		// Sanitize each post type slug
-		$sanitized = array_map( 'sanitize_key', $value );
+		// Sanitize each post type slug, dropping empties.
+		$sanitized = array_filter( array_map( 'sanitize_key', $value ) );
 
-		// Ensure fair_event is always included
-		if ( ! in_array( 'fair_event', $sanitized, true ) ) {
-			array_unshift( $sanitized, 'fair_event' );
-		}
+		// fair_event is never stored here; its membership is driven by the
+		// registration switch and resolved in get_enabled_post_types().
+		$sanitized = array_diff( $sanitized, array( 'fair_event' ) );
 
 		return array_values( array_unique( $sanitized ) );
 	}


### PR DESCRIPTION
## Summary

Closes #655.

Adds a single **"Use the Events post type"** switch (`fair_events_register_post_type`, default **on**) so a pages- or posts-only install never registers the `fair_event` CPT. The switch is the sole source of truth for both CPT registration and its membership in the enabled post types — resolved in `get_enabled_post_types()` so the two can never contradict regardless of option save order. Default installs keep the CPT, so behaviour is unchanged.

- `Settings.php`: new boolean setting + `should_register_post_type()`; `sanitize_enabled_post_types()` no longer force-adds `fair_event`; `get_enabled_post_types()` adds/drops `fair_event` per the switch and falls back to `['page']` when off and empty; flush rewrite rules when the switch changes.
- `Event::register()`: gates only `register_post_type()` on the switch; still registers meta, the Event Details meta box, and admin columns for the other enabled post types.
- Settings React page: replaces the always-on disabled "Events" checkbox with an interactive `ToggleControl`; guards against saving with the CPT off and no other type chosen.
- The admin menu adapts on its own — #656 already gates CPT-only affordances on `post_type_exists( 'fair_event' )`.

## Notes

- **Hidden-events admin notice deferred** to a follow-up. Turning the CPT off only stops registering it; existing `fair_event` posts stay in the DB and reappear when it's turned back on.
- **No sample-post seed to skip:** `Installer::install()` only runs `dbDelta` + migrations, so that acceptance-criteria item is already satisfied with no code change.
- Retired the `fair_e2e_unregister_fair_event` test stand-in (from #656) now that the real setting exists; the admin-menu e2e drives the real option instead.

## Test plan

- [x] PHPUnit: 15/15 pass, incl. 7 new in `__tests__/Settings/SettingsTest.php` (sanitize no longer forces `fair_event`; `get_enabled_post_types()` on/off/fallback/default).
- [x] e2e `fair-events-admin-menu.spec.js`: 5/5 pass against wp-env — asserts CPT submenu + Migration links visible when on, hidden when off; non-CPT pages still mount in both states.
- [x] `npm run build` (fair-events) succeeds; phpcs clean on changed lines.
- [ ] Manual: with CPT off + `page` enabled, the Event Details meta box appears on the Page editor and a page-backed event shows on the calendar/list/gallery.