### PR TITLE
Support custom question fields in Event Signup block (#615)

### DIFF
--- a/fair-audience/src/API/EventParticipantsController.php
+++ b/fair-audience/src/API/EventParticipantsController.php
@@ -9,6 +9,8 @@ namespace FairAudience\API;
 
 use FairAudience\Database\EventParticipantRepository;
 use FairAudience\Database\ParticipantRepository;
+use FairAudience\Database\QuestionnaireSubmissionRepository;
+use FairAudience\Database\QuestionnaireAnswerRepository;
 use FairAudience\Models\EmailConsentLog;
 use FairAudience\Services\EmailService;
 use WP_REST_Controller;
@@ -417,39 +419,101 @@ class EventParticipantsController extends WP_REST_Controller {
 			OBJECT_K
 		);
 
+		// Custom question answers captured during signup (Event Signup block).
+		// Stored as questionnaire submissions keyed by participant + event date,
+		// indexed here so each signup row can carry its answers inline.
+		$participant_questionnaire = $this->get_signup_answers_by_participant( $event_date_id );
+
 		$items = array_map(
-			function ( $ep ) use ( $likes_data, $ticket_type_names, $participant_option_names, $participant_option_ids ) {
+			function ( $ep ) use ( $likes_data, $ticket_type_names, $participant_option_names, $participant_option_ids, $participant_questionnaire ) {
 				$participant = $this->participant_repo->get_by_id( $ep->participant_id );
 				return array(
-					'id'                   => $ep->id,
-					'participant_id'       => $ep->participant_id,
-					'event_date_id'        => $ep->event_date_id,
-					'participant_name'     => $participant ? $participant->name . ' ' . $participant->surname : '',
-					'name'                 => $participant ? $participant->name : '',
-					'surname'              => $participant ? $participant->surname : '',
-					'participant_email'    => $participant ? $participant->email : '',
-					'email_profile'        => $participant ? $participant->email_profile : '',
-					'instagram'            => $participant ? $participant->instagram : '',
-					'label'                => $ep->label,
-					'ticket_type_id'       => $ep->ticket_type_id ? (int) $ep->ticket_type_id : null,
-					'ticket_type_name'     => $ep->ticket_type_id && isset( $ticket_type_names[ $ep->ticket_type_id ] )
+					'id'                    => $ep->id,
+					'participant_id'        => $ep->participant_id,
+					'event_date_id'         => $ep->event_date_id,
+					'participant_name'      => $participant ? $participant->name . ' ' . $participant->surname : '',
+					'name'                  => $participant ? $participant->name : '',
+					'surname'               => $participant ? $participant->surname : '',
+					'participant_email'     => $participant ? $participant->email : '',
+					'email_profile'         => $participant ? $participant->email_profile : '',
+					'instagram'             => $participant ? $participant->instagram : '',
+					'label'                 => $ep->label,
+					'ticket_type_id'        => $ep->ticket_type_id ? (int) $ep->ticket_type_id : null,
+					'ticket_type_name'      => $ep->ticket_type_id && isset( $ticket_type_names[ $ep->ticket_type_id ] )
 						? $ticket_type_names[ $ep->ticket_type_id ]
 						: null,
-					'attended_at'          => $ep->attended_at,
-					'created_at'           => $ep->created_at,
-					'payment_expires_at'   => $ep->payment_expires_at,
-					'photo_likes_received' => isset( $likes_data[ $ep->participant_id ] )
+					'attended_at'           => $ep->attended_at,
+					'created_at'            => $ep->created_at,
+					'payment_expires_at'    => $ep->payment_expires_at,
+					'photo_likes_received'  => isset( $likes_data[ $ep->participant_id ] )
 						? (int) $likes_data[ $ep->participant_id ]->likes_count
 						: 0,
-					'ticket_option_names'  => $participant_option_names[ $ep->id ] ?? array(),
-					'ticket_option_ids'    => $participant_option_ids[ $ep->id ] ?? array(),
-					'admin_comment'        => isset( $ep->admin_comment ) && null !== $ep->admin_comment ? $ep->admin_comment : '',
+					'ticket_option_names'   => $participant_option_names[ $ep->id ] ?? array(),
+					'ticket_option_ids'     => $participant_option_ids[ $ep->id ] ?? array(),
+					'admin_comment'         => isset( $ep->admin_comment ) && null !== $ep->admin_comment ? $ep->admin_comment : '',
+					'questionnaire_answers' => $participant_questionnaire[ $ep->participant_id ] ?? array(),
 				);
 			},
 			$event_participants
 		);
 
 		return rest_ensure_response( $items );
+	}
+
+	/**
+	 * Build a map of participant ID → custom question answers for the signups
+	 * on an event date. Answers come from "Event Signup" questionnaire
+	 * submissions (created by the Event Signup block). File-upload answers gain
+	 * a resolved URL, mirroring QuestionnaireResponsesController.
+	 *
+	 * @param int $event_date_id Event date ID.
+	 * @return array Map of participant_id => array of answer arrays.
+	 */
+	private function get_signup_answers_by_participant( $event_date_id ) {
+		$submission_repo = new QuestionnaireSubmissionRepository();
+		$answer_repo     = new QuestionnaireAnswerRepository();
+
+		$submissions = $submission_repo->get_by_filters(
+			array(
+				'event_date_id' => $event_date_id,
+				'title'         => __( 'Event Signup', 'fair-audience' ),
+			)
+		);
+
+		$by_participant = array();
+		foreach ( $submissions as $submission ) {
+			// One signup submission per participant; get_by_filters orders by
+			// created_at DESC, so the first seen is the newest — keep that.
+			if ( isset( $by_participant[ $submission->participant_id ] ) ) {
+				continue;
+			}
+
+			$answers_data = array();
+			foreach ( $answer_repo->get_by_submission( $submission->id ) as $answer ) {
+				$answer_item = array(
+					'question_key'  => $answer->question_key,
+					'question_text' => $answer->question_text,
+					'question_type' => $answer->question_type,
+					'answer_value'  => $answer->answer_value,
+				);
+
+				if ( 'file_upload' === $answer->question_type && is_numeric( $answer->answer_value ) ) {
+					$attachment_id  = (int) $answer->answer_value;
+					$attachment_url = wp_get_attachment_url( $attachment_id );
+					if ( $attachment_url ) {
+						$answer_item['file_url'] = $attachment_url;
+						$mime                    = get_post_mime_type( $attachment_id );
+						$answer_item['is_image'] = $mime && 0 === strpos( $mime, 'image/' );
+					}
+				}
+
+				$answers_data[] = $answer_item;
+			}
+
+			$by_participant[ $submission->participant_id ] = $answers_data;
+		}
+
+		return $by_participant;
 	}
 
 	/**

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -14,6 +14,7 @@ use FairAudience\Models\Participant;
 use FairAudience\Services\AudienceSession;
 use FairAudience\Services\EmailService;
 use FairAudience\Services\ParticipantToken;
+use FairAudience\Services\QuestionnaireService;
 use WP_REST_Controller;
 use WP_REST_Server;
 use WP_REST_Request;
@@ -70,6 +71,13 @@ class EventSignupController extends WP_REST_Controller {
 	private $token_repository;
 
 	/**
+	 * Questionnaire service instance.
+	 *
+	 * @var QuestionnaireService
+	 */
+	private $questionnaire_service;
+
+	/**
 	 * Rate limit: max requests per email per hour.
 	 */
 	const RATE_LIMIT_MAX = 3;
@@ -87,6 +95,7 @@ class EventSignupController extends WP_REST_Controller {
 		$this->event_participant_repository = new EventParticipantRepository();
 		$this->email_service                = new EmailService();
 		$this->token_repository             = new EmailConfirmationTokenRepository();
+		$this->questionnaire_service        = new QuestionnaireService();
 	}
 
 	/**
@@ -133,35 +142,42 @@ class EventSignupController extends WP_REST_Controller {
 					'callback'            => array( $this, 'create_signup' ),
 					'permission_callback' => array( $this, 'create_signup_permissions_check' ),
 					'args'                => array(
-						'event_id'          => array(
+						'event_id'              => array(
 							'type'              => 'integer',
 							'required'          => true,
 							'sanitize_callback' => 'absint',
 						),
-						'event_date_id'     => array(
+						'event_date_id'         => array(
 							'type'              => 'integer',
 							'required'          => false,
 							'sanitize_callback' => 'absint',
 						),
-						'ticket_type_id'    => array(
+						'ticket_type_id'        => array(
 							'type'              => 'integer',
 							'required'          => false,
 							'sanitize_callback' => 'absint',
 						),
-						'ticket_option_ids' => array(
+						'ticket_option_ids'     => array(
 							'type'  => 'array',
 							'items' => array( 'type' => 'integer' ),
 						),
-						'participant_token' => array(
+						'participant_token'     => array(
 							'type'              => 'string',
 							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',
 						),
-						'invitation_token'  => array(
+						'invitation_token'      => array(
 							'type'              => 'string',
 							'required'          => false,
 							'default'           => '',
 							'sanitize_callback' => 'sanitize_text_field',
+						),
+						// No 'type' declared: a JSON string sent via FormData would
+						// otherwise be mangled. The QuestionnaireService parse/sanitize
+						// helpers handle both raw JSON strings and decoded arrays.
+						'questionnaire_answers' => array(
+							'required' => false,
+							'default'  => array(),
 						),
 					),
 				),
@@ -309,37 +325,37 @@ class EventSignupController extends WP_REST_Controller {
 					'callback'            => array( $this, 'register_and_signup' ),
 					'permission_callback' => '__return_true',
 					'args'                => array(
-						'event_id'          => array(
+						'event_id'              => array(
 							'type'              => 'integer',
 							'required'          => true,
 							'sanitize_callback' => 'absint',
 						),
-						'event_date_id'     => array(
+						'event_date_id'         => array(
 							'type'              => 'integer',
 							'required'          => false,
 							'sanitize_callback' => 'absint',
 						),
-						'ticket_type_id'    => array(
+						'ticket_type_id'        => array(
 							'type'              => 'integer',
 							'required'          => false,
 							'sanitize_callback' => 'absint',
 						),
-						'ticket_option_ids' => array(
+						'ticket_option_ids'     => array(
 							'type'  => 'array',
 							'items' => array( 'type' => 'integer' ),
 						),
-						'name'              => array(
+						'name'                  => array(
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => 'sanitize_text_field',
 						),
-						'surname'           => array(
+						'surname'               => array(
 							'type'              => 'string',
 							'required'          => false,
 							'default'           => '',
 							'sanitize_callback' => 'sanitize_text_field',
 						),
-						'email'             => array(
+						'email'                 => array(
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => 'sanitize_email',
@@ -347,17 +363,24 @@ class EventSignupController extends WP_REST_Controller {
 								return is_email( $value );
 							},
 						),
-						'keep_informed'     => array(
+						'keep_informed'         => array(
 							'type'              => 'boolean',
 							'required'          => false,
 							'default'           => false,
 							'sanitize_callback' => 'rest_sanitize_boolean',
 						),
-						'invitation_token'  => array(
+						'invitation_token'      => array(
 							'type'              => 'string',
 							'required'          => false,
 							'default'           => '',
 							'sanitize_callback' => 'sanitize_text_field',
+						),
+						// No 'type' declared: a JSON string sent via FormData would
+						// otherwise be mangled. The QuestionnaireService parse/sanitize
+						// helpers handle both raw JSON strings and decoded arrays.
+						'questionnaire_answers' => array(
+							'required' => false,
+							'default'  => array(),
 						),
 					),
 				),
@@ -541,6 +564,12 @@ class EventSignupController extends WP_REST_Controller {
 			);
 		}
 
+		// Parse and validate custom question answers before any mutation.
+		$questionnaire_answers = $this->prepare_questionnaire_answers( $request );
+		if ( is_wp_error( $questionnaire_answers ) ) {
+			return $questionnaire_answers;
+		}
+
 		// Validate ticket type group restrictions (and invitation tokens for invitation-only types).
 		$group_error = $this->validate_ticket_type_group_restriction( $ticket_type_id, $participant->id, $invitation_token );
 		if ( is_wp_error( $group_error ) ) {
@@ -584,6 +613,13 @@ class EventSignupController extends WP_REST_Controller {
 		$min_error = $this->validate_minimum_activities( $event_date_id, $option_items, $ticket_type_id );
 		if ( is_wp_error( $min_error ) ) {
 			return $min_error;
+		}
+
+		// Persist custom question answers up front so they survive the paid
+		// flow (the signup row may be only pending_payment at this point).
+		$save_error = $this->save_signup_questionnaire( $request, $questionnaire_answers, $participant->id, $event_date_id, $event_id );
+		if ( is_wp_error( $save_error ) ) {
+			return $save_error;
 		}
 
 		$paid_response = $this->maybe_start_paid_signup( $event_id, $event_date_id, $participant, $existing, $user_id, $ticket_type_id, $option_items, $invitation_token );
@@ -1225,6 +1261,57 @@ class EventSignupController extends WP_REST_Controller {
 	 */
 	private function save_participant_options( $event_participant_id, $option_items ) {
 		$this->event_participant_repository->add_options( $event_participant_id, $option_items );
+	}
+
+	/**
+	 * Parse and sanitize the custom question answers from a signup request.
+	 *
+	 * Validation runs before any signup mutation so bad input (e.g. malformed
+	 * phone numbers) is rejected with a 400 without creating a participant or
+	 * signup row.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array|WP_Error Sanitized answers, or WP_Error on invalid input.
+	 */
+	private function prepare_questionnaire_answers( $request ) {
+		$answers = $this->questionnaire_service->parse_answers( $request->get_param( 'questionnaire_answers' ) );
+		return $this->questionnaire_service->sanitize_answers( $answers );
+	}
+
+	/**
+	 * Process uploads for and persist the custom question answers tied to a
+	 * signup. Answers are stored as a questionnaire submission keyed by
+	 * participant + event date (title "Event Signup"), so they survive the
+	 * paid-signup flow and surface in the admin signups list and Form Answers
+	 * view. The save is idempotent per participant + event date.
+	 *
+	 * @param WP_REST_Request $request        Request object.
+	 * @param array           $answers        Sanitized answers.
+	 * @param int             $participant_id Participant ID.
+	 * @param int             $event_date_id  Event date ID.
+	 * @param int             $event_id       Event post ID.
+	 * @return void|WP_Error WP_Error on file-upload failure.
+	 */
+	private function save_signup_questionnaire( $request, $answers, $participant_id, $event_date_id, $event_id ) {
+		// Nothing to persist for signups without custom questions — avoids
+		// creating empty submissions (and any regression for plain signups).
+		if ( empty( $answers ) ) {
+			return;
+		}
+
+		$answers = $this->questionnaire_service->process_file_uploads( $request, $answers, $event_date_id, $participant_id );
+		if ( is_wp_error( $answers ) ) {
+			return $answers;
+		}
+
+		$this->questionnaire_service->save_answers(
+			$participant_id,
+			$answers,
+			$event_date_id,
+			$event_id,
+			__( 'Event Signup', 'fair-audience' ),
+			true
+		);
 	}
 
 	/**
@@ -2022,6 +2109,12 @@ class EventSignupController extends WP_REST_Controller {
 			);
 		}
 
+		// Parse and validate custom question answers before any mutation.
+		$questionnaire_answers = $this->prepare_questionnaire_answers( $request );
+		if ( is_wp_error( $questionnaire_answers ) ) {
+			return $questionnaire_answers;
+		}
+
 		// Logged-in WP users with a linked participant get to skip the email
 		// lookup entirely. Their wp_user_id is a stronger identity than the
 		// typed email — typing someone else's email shouldn't let them sign
@@ -2157,6 +2250,13 @@ class EventSignupController extends WP_REST_Controller {
 		$min_error = $this->validate_minimum_activities( $event_date_id, $option_items, $ticket_type_id );
 		if ( is_wp_error( $min_error ) ) {
 			return $min_error;
+		}
+
+		// Persist custom question answers up front so they survive the paid
+		// flow (the signup row may be only pending_payment at this point).
+		$save_error = $this->save_signup_questionnaire( $request, $questionnaire_answers, $participant->id, $event_date_id, $event_id );
+		if ( is_wp_error( $save_error ) ) {
+			return $save_error;
 		}
 
 		$paid_response = $this->maybe_start_paid_signup( $event_id, $event_date_id, $participant, $existing, $wp_user_id, $ticket_type_id, $option_items, $invitation_token );

--- a/fair-audience/src/API/FairFormController.php
+++ b/fair-audience/src/API/FairFormController.php
@@ -10,11 +10,9 @@ namespace FairAudience\API;
 use FairAudience\Database\ParticipantRepository;
 use FairAudience\Database\ParticipantCategoryRepository;
 use FairAudience\Database\EmailConfirmationTokenRepository;
-use FairAudience\Database\QuestionnaireSubmissionRepository;
-use FairAudience\Database\QuestionnaireAnswerRepository;
 use FairAudience\Models\Participant;
-use FairAudience\Models\QuestionnaireSubmission;
 use FairAudience\Services\EmailService;
+use FairAudience\Services\QuestionnaireService;
 use WP_REST_Controller;
 use WP_REST_Server;
 use WP_REST_Request;
@@ -50,18 +48,11 @@ class FairFormController extends WP_REST_Controller {
 	private $participant_repository;
 
 	/**
-	 * Questionnaire submission repository instance.
+	 * Questionnaire service instance.
 	 *
-	 * @var QuestionnaireSubmissionRepository
+	 * @var QuestionnaireService
 	 */
-	private $submission_repository;
-
-	/**
-	 * Questionnaire answer repository instance.
-	 *
-	 * @var QuestionnaireAnswerRepository
-	 */
-	private $answer_repository;
+	private $questionnaire_service;
 
 	/**
 	 * Participant category repository instance.
@@ -99,8 +90,7 @@ class FairFormController extends WP_REST_Controller {
 	 */
 	public function __construct() {
 		$this->participant_repository = new ParticipantRepository();
-		$this->submission_repository  = new QuestionnaireSubmissionRepository();
-		$this->answer_repository      = new QuestionnaireAnswerRepository();
+		$this->questionnaire_service  = new QuestionnaireService();
 		$this->category_repository    = new ParticipantCategoryRepository();
 		$this->token_repository       = new EmailConfirmationTokenRepository();
 		$this->email_service          = new EmailService();
@@ -184,26 +174,6 @@ class FairFormController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Allowed MIME types for file uploads.
-	 *
-	 * @var array
-	 */
-	const ALLOWED_FILE_TYPES = array(
-		'image/jpeg',
-		'image/png',
-		'image/gif',
-		'image/webp',
-		'application/pdf',
-		'application/msword',
-		'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-	);
-
-	/**
-	 * Maximum file size in bytes (20 MB).
-	 */
-	const MAX_FILE_SIZE = 20 * 1024 * 1024;
-
-	/**
 	 * Handle form submission.
 	 *
 	 * @param WP_REST_Request $request Request object.
@@ -217,43 +187,14 @@ class FairFormController extends WP_REST_Controller {
 		$event_date_id = $request->get_param( 'event_date_id' );
 		$post_id       = $request->get_param( 'post_id' );
 
-		// Handle questionnaire_answers: may be JSON string when sent via FormData.
-		// WP REST API may wrap the string in an array, so check both cases.
-		$questionnaire_answers = $request->get_param( 'questionnaire_answers' );
-		$questionnaire_answers = $this->parse_questionnaire_answers( $questionnaire_answers );
-
-		// Sanitize each answer.
-		$valid_types = array( 'radio', 'checkbox', 'short_text', 'long_text', 'select', 'number', 'date', 'multiselect', 'file_upload', 'phone' );
-		$sanitized   = array();
-		foreach ( $questionnaire_answers as $answer ) {
-			if ( ! is_array( $answer ) ) {
-				continue;
-			}
-			$question_type = in_array( $answer['question_type'] ?? '', $valid_types, true ) ? $answer['question_type'] : 'short_text';
-			$answer_value  = sanitize_text_field( $answer['answer_value'] ?? '' );
-			$question_text = sanitize_text_field( $answer['question_text'] ?? '' );
-
-			if ( 'phone' === $question_type && '' !== $answer_value && ! preg_match( '/^\+[1-9][0-9]{6,14}$/', $answer_value ) ) {
-				return new WP_Error(
-					'invalid_phone',
-					sprintf(
-						/* translators: %s: question text */
-						__( 'Please enter a valid phone number with country code (e.g. +49170...) for: %s', 'fair-audience' ),
-						$question_text
-					),
-					array( 'status' => 400 )
-				);
-			}
-
-			$sanitized[] = array(
-				'question_key'  => sanitize_key( $answer['question_key'] ?? '' ),
-				'question_text' => $question_text,
-				'question_type' => $question_type,
-				'answer_value'  => $answer_value,
-				'display_order' => (int) ( $answer['display_order'] ?? 0 ),
-			);
+		// Parse and sanitize questionnaire_answers (may be a JSON string when sent via FormData).
+		$questionnaire_answers = $this->questionnaire_service->parse_answers(
+			$request->get_param( 'questionnaire_answers' )
+		);
+		$questionnaire_answers = $this->questionnaire_service->sanitize_answers( $questionnaire_answers );
+		if ( is_wp_error( $questionnaire_answers ) ) {
+			return $questionnaire_answers;
 		}
-		$questionnaire_answers = $sanitized;
 
 		// Validate email.
 		if ( ! is_email( $email ) ) {
@@ -330,14 +271,20 @@ class FairFormController extends WP_REST_Controller {
 		}
 
 		// Process file uploads and update answer values with attachment IDs.
-		$file_result = $this->process_file_uploads( $request, $questionnaire_answers, $event_date_id, $participant->id );
+		$file_result = $this->questionnaire_service->process_file_uploads( $request, $questionnaire_answers, $event_date_id, $participant->id );
 		if ( is_wp_error( $file_result ) ) {
 			return $file_result;
 		}
 		$questionnaire_answers = $file_result;
 
 		// Save questionnaire answers.
-		$this->save_questionnaire_answers( $participant->id, $questionnaire_answers, $event_date_id, $post_id );
+		$this->questionnaire_service->save_answers(
+			$participant->id,
+			$questionnaire_answers,
+			$event_date_id,
+			$post_id,
+			__( 'Fair Form', 'fair-audience' )
+		);
 
 		// Send confirmation email to the submitter (deferred so a slow mail
 		// transport can't make this request time out).
@@ -364,161 +311,6 @@ class FairFormController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Process file uploads from the request and update answer values.
-	 *
-	 * @param WP_REST_Request $request        Request object.
-	 * @param array           $answers        Questionnaire answers to update.
-	 * @param int             $event_date_id  Optional event date ID to link images to.
-	 * @param int             $participant_id Participant ID to set as photo author.
-	 * @return array|WP_Error Updated answers array or error.
-	 */
-	private function process_file_uploads( $request, $answers, $event_date_id = 0, $participant_id = 0 ) {
-		$files = $request->get_file_params();
-		if ( empty( $files ) ) {
-			return $answers;
-		}
-
-		// Required for wp_handle_upload().
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-		require_once ABSPATH . 'wp-admin/includes/image.php';
-		require_once ABSPATH . 'wp-admin/includes/media.php';
-
-		foreach ( $answers as $index => &$answer ) {
-			if ( 'file_upload' !== ( $answer['question_type'] ?? '' ) ) {
-				continue;
-			}
-
-			$file_key = 'fair_form_file_' . ( $answer['question_key'] ?? '' );
-			if ( ! isset( $files[ $file_key ] ) ) {
-				$answer['answer_value'] = '';
-				continue;
-			}
-
-			$file = $files[ $file_key ];
-
-			// Validate upload error.
-			if ( UPLOAD_ERR_OK !== $file['error'] ) {
-				return new WP_Error(
-					'upload_error',
-					__( 'File upload failed. Please try again.', 'fair-audience' ),
-					array( 'status' => 400 )
-				);
-			}
-
-			// Validate file size.
-			if ( $file['size'] > self::MAX_FILE_SIZE ) {
-				return new WP_Error(
-					'file_too_large',
-					__( 'File is too large.', 'fair-audience' ),
-					array( 'status' => 400 )
-				);
-			}
-
-			// Validate MIME type.
-			$file_type = wp_check_filetype( $file['name'] );
-			if ( empty( $file_type['type'] ) || ! in_array( $file_type['type'], self::ALLOWED_FILE_TYPES, true ) ) {
-				return new WP_Error(
-					'invalid_file_type',
-					__( 'File type not allowed.', 'fair-audience' ),
-					array( 'status' => 400 )
-				);
-			}
-
-			// Upload file.
-			$upload = wp_handle_upload(
-				$file,
-				array(
-					'test_form' => false,
-					'test_type' => true,
-				)
-			);
-
-			if ( isset( $upload['error'] ) ) {
-				return new WP_Error(
-					'upload_failed',
-					$upload['error'],
-					array( 'status' => 500 )
-				);
-			}
-
-			// Create attachment in media library.
-			$attachment_data = array(
-				'post_mime_type' => $upload['type'],
-				'post_title'     => sanitize_file_name( $file['name'] ),
-				'post_content'   => '',
-				'post_status'    => 'inherit',
-			);
-
-			$attachment_id = wp_insert_attachment( $attachment_data, $upload['file'] );
-			if ( is_wp_error( $attachment_id ) ) {
-				return new WP_Error(
-					'attachment_failed',
-					__( 'Failed to save uploaded file.', 'fair-audience' ),
-					array( 'status' => 500 )
-				);
-			}
-
-			// Generate attachment metadata (thumbnails, etc.).
-			$attachment_metadata = wp_generate_attachment_metadata( $attachment_id, $upload['file'] );
-			wp_update_attachment_metadata( $attachment_id, $attachment_metadata );
-
-			// Link image to event if event_date_id is set and fair-events plugin is active.
-			if ( $event_date_id > 0 && class_exists( '\FairEvents\Database\EventPhotoRepository' ) ) {
-				$photo_repo = new \FairEvents\Database\EventPhotoRepository();
-				$photo_repo->set_event_date( $attachment_id, $event_date_id );
-			}
-
-			// Set participant as photo author.
-			if ( $participant_id > 0 ) {
-				$photo_participant_repo = new \FairAudience\Database\PhotoParticipantRepository();
-				$photo_participant_repo->set_author( $attachment_id, $participant_id );
-			}
-
-			// Store attachment ID as the answer value.
-			$answer['answer_value'] = (string) $attachment_id;
-		}
-
-		return $answers;
-	}
-
-	/**
-	 * Save questionnaire answers for a participant.
-	 *
-	 * @param int   $participant_id Participant ID.
-	 * @param array $answers        Questionnaire answers from request.
-	 * @param int   $event_date_id  Optional event date ID.
-	 * @param int   $post_id        Optional post ID.
-	 * @return int Submission ID, or 0 on failure.
-	 */
-	private function save_questionnaire_answers( $participant_id, $answers, $event_date_id = 0, $post_id = 0 ) {
-		$submission_data = array(
-			'participant_id' => $participant_id,
-			'title'          => __( 'Fair Form', 'fair-audience' ),
-		);
-
-		if ( $event_date_id > 0 ) {
-			$submission_data['event_date_id'] = $event_date_id;
-		}
-
-		if ( $post_id > 0 ) {
-			$submission_data['post_id'] = $post_id;
-		}
-
-		$submission = new QuestionnaireSubmission();
-		$submission->populate( $submission_data );
-
-		if ( ! $submission->save() ) {
-			return 0;
-		}
-
-		if ( ! empty( $answers ) ) {
-			$this->answer_repository->save_answers( $submission->id, $answers );
-		}
-
-		return $submission->id;
-	}
-
-	/**
 	 * Parse mailing_category_ids from various formats.
 	 *
 	 * When sent via FormData, the IDs arrive as a JSON string.
@@ -537,28 +329,6 @@ class FairFormController extends WP_REST_Controller {
 
 		if ( is_array( $raw ) ) {
 			return array_map( 'intval', $raw );
-		}
-
-		return array();
-	}
-
-	/**
-	 * Parse questionnaire_answers from various formats.
-	 *
-	 * When sent via FormData, the answers arrive as a JSON string.
-	 * When sent via a JSON request body, they arrive as a decoded array.
-	 *
-	 * @param mixed $raw Raw questionnaire_answers value.
-	 * @return array Parsed answers array.
-	 */
-	private function parse_questionnaire_answers( $raw ) {
-		if ( is_string( $raw ) ) {
-			$decoded = json_decode( $raw, true );
-			return is_array( $decoded ) ? $decoded : array();
-		}
-
-		if ( is_array( $raw ) ) {
-			return $raw;
 		}
 
 		return array();

--- a/fair-audience/src/Admin/event-participants/EventParticipants.js
+++ b/fair-audience/src/Admin/event-participants/EventParticipants.js
@@ -26,12 +26,74 @@ const DEFAULT_VIEW = {
 	},
 	search: '',
 	filters: [],
-	fields: ['name', 'role', 'photo_likes'],
+	fields: ['name', 'role', 'photo_likes', 'questions'],
 };
 
 const DEFAULT_LAYOUTS = {
 	table: {},
 };
+
+/**
+ * Format a single questionnaire answer value for display.
+ *
+ * @param {Object} answer The answer record.
+ * @return {string} Human-readable value.
+ */
+function formatAnswerValue(answer) {
+	if (answer.question_type === 'multiselect') {
+		try {
+			const values = JSON.parse(answer.answer_value);
+			if (Array.isArray(values)) {
+				return values.join(', ');
+			}
+		} catch (e) {
+			// Fall through to the raw value.
+		}
+	}
+	return answer.answer_value || '';
+}
+
+/**
+ * Render the custom question answers captured during signup as a compact list.
+ *
+ * @param {Array} answers Answer records from the REST response.
+ * @return {JSX.Element|null} The rendered list, or null when there are none.
+ */
+function renderQuestionnaireAnswers(answers) {
+	if (!answers || answers.length === 0) {
+		return null;
+	}
+
+	return (
+		<dl
+			className="fair-audience-signup-answers"
+			style={{ margin: 0, fontSize: '12px' }}
+		>
+			{answers.map((answer, index) => (
+				<div
+					key={answer.question_key || index}
+					className="fair-audience-signup-answer"
+					style={{ marginBottom: '4px' }}
+				>
+					<dt style={{ fontWeight: 600 }}>{answer.question_text}</dt>
+					<dd style={{ margin: 0 }}>
+						{answer.file_url ? (
+							<a
+								href={answer.file_url}
+								target="_blank"
+								rel="noreferrer"
+							>
+								{__('View file', 'fair-audience')}
+							</a>
+						) : (
+							formatAnswerValue(answer)
+						)}
+					</dd>
+				</div>
+			))}
+		</dl>
+	);
+}
 
 export default function EventParticipants() {
 	const [participants, setParticipants] = useState([]);
@@ -588,6 +650,15 @@ export default function EventParticipants() {
 				),
 				enableSorting: true,
 				getValue: ({ item }) => item.photo_likes_received || 0,
+			},
+			{
+				id: 'questions',
+				label: __('Questions', 'fair-audience'),
+				render: ({ item }) =>
+					renderQuestionnaireAnswers(item.questionnaire_answers),
+				enableSorting: false,
+				getValue: ({ item }) =>
+					(item.questionnaire_answers || []).length,
 			},
 		],
 		[]

--- a/fair-audience/src/Services/QuestionnaireService.php
+++ b/fair-audience/src/Services/QuestionnaireService.php
@@ -1,0 +1,319 @@
+<?php
+/**
+ * Questionnaire Service
+ *
+ * Shared logic for handling `fair-form-*` question answers submitted through
+ * either the Fair Form block or the Event Signup block: parsing, sanitizing,
+ * file-upload handling, and persistence into the questionnaire submission /
+ * answer tables.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Services;
+
+use FairAudience\Database\QuestionnaireSubmissionRepository;
+use FairAudience\Database\QuestionnaireAnswerRepository;
+use FairAudience\Models\QuestionnaireSubmission;
+use WP_REST_Request;
+use WP_Error;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Service for processing and persisting questionnaire answers.
+ */
+class QuestionnaireService {
+
+	/**
+	 * Allowed MIME types for file uploads.
+	 *
+	 * @var array
+	 */
+	const ALLOWED_FILE_TYPES = array(
+		'image/jpeg',
+		'image/png',
+		'image/gif',
+		'image/webp',
+		'application/pdf',
+		'application/msword',
+		'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+	);
+
+	/**
+	 * Maximum file size in bytes (20 MB).
+	 */
+	const MAX_FILE_SIZE = 20 * 1024 * 1024;
+
+	/**
+	 * Valid question types.
+	 *
+	 * @var array
+	 */
+	const VALID_TYPES = array( 'radio', 'checkbox', 'short_text', 'long_text', 'select', 'number', 'date', 'multiselect', 'file_upload', 'phone' );
+
+	/**
+	 * Questionnaire submission repository instance.
+	 *
+	 * @var QuestionnaireSubmissionRepository
+	 */
+	private $submission_repository;
+
+	/**
+	 * Questionnaire answer repository instance.
+	 *
+	 * @var QuestionnaireAnswerRepository
+	 */
+	private $answer_repository;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->submission_repository = new QuestionnaireSubmissionRepository();
+		$this->answer_repository     = new QuestionnaireAnswerRepository();
+	}
+
+	/**
+	 * Parse the raw `questionnaire_answers` request value into an array.
+	 *
+	 * When sent via FormData the answers arrive as a JSON string; when sent via
+	 * a JSON request body they arrive as a decoded array.
+	 *
+	 * @param mixed $raw Raw questionnaire_answers value.
+	 * @return array Parsed answers array.
+	 */
+	public function parse_answers( $raw ) {
+		if ( is_string( $raw ) ) {
+			$decoded = json_decode( $raw, true );
+			return is_array( $decoded ) ? $decoded : array();
+		}
+
+		if ( is_array( $raw ) ) {
+			return $raw;
+		}
+
+		return array();
+	}
+
+	/**
+	 * Sanitize and validate parsed answers.
+	 *
+	 * @param array $answers Parsed answers.
+	 * @return array|WP_Error Sanitized answers, or WP_Error on invalid input.
+	 */
+	public function sanitize_answers( $answers ) {
+		$sanitized = array();
+
+		foreach ( $answers as $answer ) {
+			if ( ! is_array( $answer ) ) {
+				continue;
+			}
+
+			$question_type = in_array( $answer['question_type'] ?? '', self::VALID_TYPES, true ) ? $answer['question_type'] : 'short_text';
+			$answer_value  = sanitize_text_field( $answer['answer_value'] ?? '' );
+			$question_text = sanitize_text_field( $answer['question_text'] ?? '' );
+
+			if ( 'phone' === $question_type && '' !== $answer_value && ! preg_match( '/^\+[1-9][0-9]{6,14}$/', $answer_value ) ) {
+				return new WP_Error(
+					'invalid_phone',
+					sprintf(
+						/* translators: %s: question text */
+						__( 'Please enter a valid phone number with country code (e.g. +49170...) for: %s', 'fair-audience' ),
+						$question_text
+					),
+					array( 'status' => 400 )
+				);
+			}
+
+			$sanitized[] = array(
+				'question_key'  => sanitize_key( $answer['question_key'] ?? '' ),
+				'question_text' => $question_text,
+				'question_type' => $question_type,
+				'answer_value'  => $answer_value,
+				'display_order' => (int) ( $answer['display_order'] ?? 0 ),
+			);
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Process file uploads from the request and update answer values with the
+	 * resulting attachment IDs.
+	 *
+	 * @param WP_REST_Request $request        Request object.
+	 * @param array           $answers        Questionnaire answers to update.
+	 * @param int             $event_date_id  Optional event date ID to link images to.
+	 * @param int             $participant_id Participant ID to set as photo author.
+	 * @return array|WP_Error Updated answers array or error.
+	 */
+	public function process_file_uploads( $request, $answers, $event_date_id = 0, $participant_id = 0 ) {
+		$files = $request->get_file_params();
+		if ( empty( $files ) ) {
+			return $answers;
+		}
+
+		// Required for wp_handle_upload().
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+
+		foreach ( $answers as $index => &$answer ) {
+			if ( 'file_upload' !== ( $answer['question_type'] ?? '' ) ) {
+				continue;
+			}
+
+			$file_key = 'fair_form_file_' . ( $answer['question_key'] ?? '' );
+			if ( ! isset( $files[ $file_key ] ) ) {
+				$answer['answer_value'] = '';
+				continue;
+			}
+
+			$file = $files[ $file_key ];
+
+			// Validate upload error.
+			if ( UPLOAD_ERR_OK !== $file['error'] ) {
+				return new WP_Error(
+					'upload_error',
+					__( 'File upload failed. Please try again.', 'fair-audience' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			// Validate file size.
+			if ( $file['size'] > self::MAX_FILE_SIZE ) {
+				return new WP_Error(
+					'file_too_large',
+					__( 'File is too large.', 'fair-audience' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			// Validate MIME type.
+			$file_type = wp_check_filetype( $file['name'] );
+			if ( empty( $file_type['type'] ) || ! in_array( $file_type['type'], self::ALLOWED_FILE_TYPES, true ) ) {
+				return new WP_Error(
+					'invalid_file_type',
+					__( 'File type not allowed.', 'fair-audience' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			// Upload file.
+			$upload = wp_handle_upload(
+				$file,
+				array(
+					'test_form' => false,
+					'test_type' => true,
+				)
+			);
+
+			if ( isset( $upload['error'] ) ) {
+				return new WP_Error(
+					'upload_failed',
+					$upload['error'],
+					array( 'status' => 500 )
+				);
+			}
+
+			// Create attachment in media library.
+			$attachment_data = array(
+				'post_mime_type' => $upload['type'],
+				'post_title'     => sanitize_file_name( $file['name'] ),
+				'post_content'   => '',
+				'post_status'    => 'inherit',
+			);
+
+			$attachment_id = wp_insert_attachment( $attachment_data, $upload['file'] );
+			if ( is_wp_error( $attachment_id ) ) {
+				return new WP_Error(
+					'attachment_failed',
+					__( 'Failed to save uploaded file.', 'fair-audience' ),
+					array( 'status' => 500 )
+				);
+			}
+
+			// Generate attachment metadata (thumbnails, etc.).
+			$attachment_metadata = wp_generate_attachment_metadata( $attachment_id, $upload['file'] );
+			wp_update_attachment_metadata( $attachment_id, $attachment_metadata );
+
+			// Link image to event if event_date_id is set and fair-events plugin is active.
+			if ( $event_date_id > 0 && class_exists( '\FairEvents\Database\EventPhotoRepository' ) ) {
+				$photo_repo = new \FairEvents\Database\EventPhotoRepository();
+				$photo_repo->set_event_date( $attachment_id, $event_date_id );
+			}
+
+			// Set participant as photo author.
+			if ( $participant_id > 0 ) {
+				$photo_participant_repo = new \FairAudience\Database\PhotoParticipantRepository();
+				$photo_participant_repo->set_author( $attachment_id, $participant_id );
+			}
+
+			// Store attachment ID as the answer value.
+			$answer['answer_value'] = (string) $attachment_id;
+		}
+
+		return $answers;
+	}
+
+	/**
+	 * Save questionnaire answers for a participant.
+	 *
+	 * @param int    $participant_id Participant ID.
+	 * @param array  $answers        Questionnaire answers to persist.
+	 * @param int    $event_date_id  Optional event date ID.
+	 * @param int    $post_id        Optional post ID.
+	 * @param string $title          Submission title (e.g. "Fair Form", "Event Signup").
+	 * @param bool   $reuse_existing When true, an existing submission with the same
+	 *                               participant, event date and title is reused
+	 *                               (its answers replaced) instead of inserting a
+	 *                               new one. Keeps re-submits/payment retries idempotent.
+	 * @return int Submission ID, or 0 on failure.
+	 */
+	public function save_answers( $participant_id, $answers, $event_date_id = 0, $post_id = 0, $title = '', $reuse_existing = false ) {
+		$title = '' !== $title ? $title : __( 'Fair Form', 'fair-audience' );
+
+		$submission = null;
+
+		if ( $reuse_existing && $event_date_id > 0 ) {
+			$existing = $this->submission_repository->get_by_filters(
+				array(
+					'participant_id' => $participant_id,
+					'event_date_id'  => $event_date_id,
+					'title'          => $title,
+				)
+			);
+			if ( ! empty( $existing ) ) {
+				$submission = $existing[0];
+			}
+		}
+
+		if ( null === $submission ) {
+			$submission_data = array(
+				'participant_id' => $participant_id,
+				'title'          => $title,
+			);
+
+			if ( $event_date_id > 0 ) {
+				$submission_data['event_date_id'] = $event_date_id;
+			}
+
+			if ( $post_id > 0 ) {
+				$submission_data['post_id'] = $post_id;
+			}
+
+			$submission = new QuestionnaireSubmission();
+			$submission->populate( $submission_data );
+
+			if ( ! $submission->save() ) {
+				return 0;
+			}
+		}
+
+		// save_answers() atomically replaces any existing answers for the submission.
+		$this->answer_repository->save_answers( $submission->id, $answers );
+
+		return $submission->id;
+	}
+}

--- a/fair-audience/src/blocks/event-signup/editor.css
+++ b/fair-audience/src/blocks/event-signup/editor.css
@@ -4,11 +4,79 @@
 
 .fair-audience-event-signup {
 	margin: 2rem 0;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	padding: 16px;
 }
 
-/* Prevent interaction with SSR form in editor */
-.fair-audience-event-signup input,
-.fair-audience-event-signup button,
-.fair-audience-event-signup .wp-block-button__link {
+.fair-audience-event-signup-editor-header {
+	margin-bottom: 12px;
+	padding-bottom: 8px;
+	border-bottom: 1px solid #eee;
+}
+
+.fair-audience-event-signup-editor-label {
+	font-weight: 600;
+	font-size: 14px;
+	color: #1e1e1e;
+}
+
+.fair-audience-event-signup-editor-fields {
+	margin-bottom: 12px;
+	padding: 12px;
+	background: #f9f9f9;
+	border-radius: 4px;
+}
+
+.fair-audience-event-signup-editor-field {
+	margin-bottom: 8px;
+}
+
+.fair-audience-event-signup-editor-field:last-child {
+	margin-bottom: 0;
+}
+
+.fair-audience-event-signup-editor-field label {
+	display: block;
+	font-size: 13px;
+	margin-bottom: 4px;
+}
+
+.fair-audience-event-signup-editor-field input {
+	width: 100%;
+	padding: 4px 8px;
+	border: 1px solid #ddd;
+	border-radius: 2px;
+	background: #fff;
+	pointer-events: none;
+}
+
+.fair-audience-event-signup-editor-note {
+	margin: 0 0 12px;
+	font-size: 12px;
+	font-style: italic;
+	color: #757575;
+}
+
+.fair-audience-event-signup-editor-questions-label {
+	font-weight: 600;
+	font-size: 13px;
+	color: #1e1e1e;
+	margin-bottom: 4px;
+}
+
+.fair-audience-event-signup-questions {
+	min-height: 40px;
+	margin: 4px 0 16px;
+	padding: 8px;
+	border: 1px dashed #ccc;
+	border-radius: 4px;
+}
+
+.fair-audience-event-signup-editor-footer {
+	margin-top: 12px;
+}
+
+.fair-audience-event-signup-editor-footer .wp-block-button__link {
 	pointer-events: none;
 }

--- a/fair-audience/src/blocks/event-signup/editor.js
+++ b/fair-audience/src/blocks/event-signup/editor.js
@@ -2,7 +2,12 @@ import './style.css';
 import './editor.css';
 
 import { registerBlockType } from '@wordpress/blocks';
-import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls,
+	InnerBlocks,
+} from '@wordpress/block-editor';
 import {
 	PanelBody,
 	TextControl,
@@ -10,7 +15,25 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import ServerSideRender from '@wordpress/server-side-render';
+
+// Custom question blocks that can be nested inside the signup form. Mirrors the
+// Fair Form block's set (see fair-form/editor.js) so organizers collect the same
+// extra information during event registration. `fair-form-option` is omitted
+// because it is a child of the select/radio/multiselect blocks, not a top-level
+// question.
+const ALLOWED_BLOCKS = [
+	'core/heading',
+	'core/paragraph',
+	'core/list',
+	'fair-audience/fair-form-short-text',
+	'fair-audience/fair-form-long-text',
+	'fair-audience/fair-form-phone',
+	'fair-audience/fair-form-select-one',
+	'fair-audience/fair-form-radio',
+	'fair-audience/fair-form-multiselect',
+	'fair-audience/fair-form-file-upload',
+	'fair-audience/fair-form-conditional',
+];
 
 registerBlockType('fair-audience/event-signup', {
 	edit: ({ attributes, setAttributes }) => {
@@ -27,6 +50,14 @@ registerBlockType('fair-audience/event-signup', {
 		const blockProps = useBlockProps({
 			className: 'fair-audience-event-signup',
 		});
+
+		const innerBlocksProps = useInnerBlocksProps(
+			{ className: 'fair-audience-event-signup-questions' },
+			{
+				allowedBlocks: ALLOWED_BLOCKS,
+				renderAppender: InnerBlocks.ButtonBlockAppender,
+			}
+		);
 
 		return (
 			<>
@@ -139,15 +170,61 @@ registerBlockType('fair-audience/event-signup', {
 				</InspectorControls>
 
 				<div {...blockProps}>
-					<ServerSideRender
-						block="fair-audience/event-signup"
-						attributes={attributes}
-					/>
+					<div className="fair-audience-event-signup-editor-header">
+						<span className="fair-audience-event-signup-editor-label">
+							{__('Event Signup', 'fair-audience')}
+						</span>
+					</div>
+					<div className="fair-audience-event-signup-editor-fields">
+						<div className="fair-audience-event-signup-editor-field">
+							<label>{__('First Name', 'fair-audience')} *</label>
+							<input type="text" disabled />
+						</div>
+						<div className="fair-audience-event-signup-editor-field">
+							<label>{__('Surname', 'fair-audience')}</label>
+							<input type="text" disabled />
+						</div>
+						<div className="fair-audience-event-signup-editor-field">
+							<label>{__('Email', 'fair-audience')} *</label>
+							<input type="email" disabled />
+						</div>
+					</div>
+					<p className="fair-audience-event-signup-editor-note">
+						{__(
+							'Ticket types, activity options and pricing are rendered on the published page based on the event.',
+							'fair-audience'
+						)}
+					</p>
+					<div className="fair-audience-event-signup-editor-questions-label">
+						{__('Custom questions', 'fair-audience')}
+					</div>
+					<div {...innerBlocksProps} />
+					<div className="fair-audience-event-signup-editor-footer">
+						<div className="wp-block-button">
+							<button
+								className="wp-block-button__link wp-element-button"
+								disabled
+							>
+								{registerButtonText ||
+									__('Register & Sign Up', 'fair-audience')}
+							</button>
+						</div>
+					</div>
 				</div>
 			</>
 		);
 	},
 	save: () => {
-		return null; // Dynamic block, rendered via PHP
+		// Dynamic block (rendered via render.php), but the nested question
+		// blocks must be serialized so render.php receives them as $content.
+		return <InnerBlocks.Content />;
 	},
+	deprecated: [
+		{
+			// Previously a pure dynamic block with no saved markup. Existing
+			// instances have no inner blocks, so migrating them to the
+			// InnerBlocks.Content save is a no-op that avoids block recovery.
+			save: () => null,
+		},
+	],
 });

--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -9,6 +9,13 @@ import {
 	onDomReady,
 	wireNotYouButton,
 } from '../shared/form-utils.js';
+import {
+	collectQuestionAnswers,
+	validateQuestions,
+	hasFileUploads,
+	appendQuestionFiles,
+	setupQuestionnaire,
+} from '../shared/questionnaire.js';
 
 /**
  * Frontend JavaScript for Fair Audience Event Signup
@@ -412,6 +419,7 @@ const CSS_PREFIX = 'fair-audience-signup';
 			'.fair-audience-signup-register'
 		);
 		if (registerForm) {
+			setupQuestionnaire(registerForm);
 			registerForm.addEventListener('submit', function (e) {
 				e.preventDefault();
 				submitRegistration(block, registerForm);
@@ -437,6 +445,13 @@ const CSS_PREFIX = 'fair-audience-signup';
 	function initializeAuthenticatedBlock(block) {
 		initializeOptionTotals(block);
 
+		const signupAction = block.querySelector(
+			'.fair-audience-signup-action-signup'
+		);
+		if (signupAction) {
+			setupQuestionnaire(signupAction);
+		}
+
 		const signupButton = block.querySelector(
 			'.fair-audience-signup-button'
 		);
@@ -446,6 +461,50 @@ const CSS_PREFIX = 'fair-audience-signup';
 				submitSignup(block, this);
 			});
 		}
+	}
+
+	/**
+	 * Build apiFetch options for a signup request, attaching the custom
+	 * question answers. When the scope has pending file uploads the request is
+	 * sent as multipart FormData (matching the Fair Form convention), otherwise
+	 * as JSON.
+	 *
+	 * @param {string}      path                The REST path.
+	 * @param {Object}      requestData         Scalar/array signup fields.
+	 * @param {Array}       questionnaireAnswers Collected question answers.
+	 * @param {HTMLElement} scope               Element containing the question blocks.
+	 * @return {Object} apiFetch options.
+	 */
+	function buildSignupFetch(path, requestData, questionnaireAnswers, scope) {
+		if (!hasFileUploads(scope)) {
+			return {
+				path,
+				method: 'POST',
+				data: {
+					...requestData,
+					questionnaire_answers: questionnaireAnswers,
+				},
+			};
+		}
+
+		const formData = new FormData();
+		Object.keys(requestData).forEach(function (key) {
+			const value = requestData[key];
+			if (Array.isArray(value)) {
+				value.forEach((v) => formData.append(key + '[]', v));
+			} else if (typeof value === 'boolean') {
+				formData.append(key, value ? '1' : '0');
+			} else if (value !== null && value !== undefined) {
+				formData.append(key, value);
+			}
+		});
+		formData.append(
+			'questionnaire_answers',
+			JSON.stringify(questionnaireAnswers)
+		);
+		appendQuestionFiles(scope, formData);
+
+		return { path, method: 'POST', body: formData };
 	}
 
 	/**
@@ -500,6 +559,13 @@ const CSS_PREFIX = 'fair-audience-signup';
 			return;
 		}
 
+		// Validate custom question blocks (required/phone/file constraints).
+		const questionError = validateQuestions(form);
+		if (questionError) {
+			showMessage(messageContainer, questionError, 'error', CSS_PREFIX);
+			return;
+		}
+
 		// Build request data
 		const requestData = {
 			event_id: eventId,
@@ -536,6 +602,9 @@ const CSS_PREFIX = 'fair-audience-signup';
 			);
 		}
 
+		// Collect custom question answers.
+		const questionnaireAnswers = collectQuestionAnswers(form);
+
 		// Disable button and show loading state
 		const restoreButton = setButtonLoading(
 			submitButton,
@@ -543,11 +612,14 @@ const CSS_PREFIX = 'fair-audience-signup';
 		);
 
 		// Submit to API
-		apiFetch({
-			path: '/fair-audience/v1/event-signup/register',
-			method: 'POST',
-			data: requestData,
-		})
+		apiFetch(
+			buildSignupFetch(
+				'/fair-audience/v1/event-signup/register',
+				requestData,
+				questionnaireAnswers,
+				form
+			)
+		)
 			.then(function (response) {
 				if (response.success) {
 					// Paid signup: redirect to Mollie checkout.
@@ -788,6 +860,19 @@ const CSS_PREFIX = 'fair-audience-signup';
 			);
 		}
 
+		// Custom questions live inside the signup action container.
+		const questionScope =
+			block.querySelector('.fair-audience-signup-action-signup') || block;
+
+		// Validate custom question blocks (required/phone/file constraints).
+		const questionError = validateQuestions(questionScope);
+		if (questionError) {
+			showMessage(messageContainer, questionError, 'error', CSS_PREFIX);
+			return;
+		}
+
+		const questionnaireAnswers = collectQuestionAnswers(questionScope);
+
 		// Disable button and show loading state
 		const restoreButton = setButtonLoading(
 			button,
@@ -795,11 +880,14 @@ const CSS_PREFIX = 'fair-audience-signup';
 		);
 
 		// Submit to API
-		apiFetch({
-			path: '/fair-audience/v1/event-signup',
-			method: 'POST',
-			data: requestData,
-		})
+		apiFetch(
+			buildSignupFetch(
+				'/fair-audience/v1/event-signup',
+				requestData,
+				questionnaireAnswers,
+				questionScope
+			)
+		)
 			.then(function (response) {
 				if (response.success) {
 					// Paid signup: redirect to Mollie checkout.

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -1045,6 +1045,11 @@ $wrapper_attributes = get_block_wrapper_attributes(
 			<div class="fair-audience-signup-action-signup"<?php echo $is_signed_up ? ' style="display: none;"' : ''; ?>>
 				<?php $render_ticket_types(); ?>
 				<?php $render_ticket_options(); ?>
+				<?php if ( '' !== trim( $content ) ) : ?>
+					<div class="fair-audience-signup-questions">
+						<?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner blocks content is already escaped by WordPress. ?>
+					</div>
+				<?php endif; ?>
 				<div class="wp-block-button">
 					<button type="button" class="wp-block-button__link wp-element-button fair-audience-signup-button" data-action="signup">
 						<?php echo esc_html( $signup_button_text ); ?>
@@ -1153,6 +1158,12 @@ $wrapper_attributes = get_block_wrapper_attributes(
 						<?php echo esc_html__( 'Keep me informed about future events', 'fair-audience' ); ?>
 					</label>
 				</p>
+
+				<?php if ( '' !== trim( $content ) ) : ?>
+					<div class="fair-audience-signup-questions">
+						<?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner blocks content is already escaped by WordPress. ?>
+					</div>
+				<?php endif; ?>
 
 				<?php if ( $has_session_prefill ) : ?>
 				<button type="button" class="fair-audience-not-you">

--- a/fair-audience/src/blocks/fair-form-conditional/block.json
+++ b/fair-audience/src/blocks/fair-form-conditional/block.json
@@ -9,7 +9,7 @@
 	"description": "Show or hide a group of fields based on an answer to a previous question",
 	"keywords": ["conditional", "show", "hide", "section", "logic"],
 	"textdomain": "fair-audience",
-	"parent": ["fair-audience/fair-form"],
+	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
 	"supports": {
 		"html": false
 	},

--- a/fair-audience/src/blocks/fair-form-file-upload/block.json
+++ b/fair-audience/src/blocks/fair-form-file-upload/block.json
@@ -9,7 +9,7 @@
 	"description": "A file upload question for Fair Form",
 	"keywords": ["question", "file", "upload", "image"],
 	"textdomain": "fair-audience",
-	"parent": ["fair-audience/fair-form"],
+	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
 	"supports": {
 		"html": false
 	},

--- a/fair-audience/src/blocks/fair-form-long-text/block.json
+++ b/fair-audience/src/blocks/fair-form-long-text/block.json
@@ -9,7 +9,7 @@
 	"description": "A long text (textarea) question for Fair Form",
 	"keywords": ["question", "textarea", "long text"],
 	"textdomain": "fair-audience",
-	"parent": ["fair-audience/fair-form"],
+	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
 	"supports": {
 		"html": false
 	},

--- a/fair-audience/src/blocks/fair-form-multiselect/block.json
+++ b/fair-audience/src/blocks/fair-form-multiselect/block.json
@@ -9,7 +9,7 @@
 	"description": "A multiple-choice checkbox question for Fair Form",
 	"keywords": ["question", "checkbox", "multiselect", "multiple"],
 	"textdomain": "fair-audience",
-	"parent": ["fair-audience/fair-form"],
+	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
 	"supports": {
 		"html": false
 	},

--- a/fair-audience/src/blocks/fair-form-phone/block.json
+++ b/fair-audience/src/blocks/fair-form-phone/block.json
@@ -9,7 +9,7 @@
 	"description": "A phone number input question with enforced country code for Fair Form",
 	"keywords": ["question", "phone", "tel"],
 	"textdomain": "fair-audience",
-	"parent": ["fair-audience/fair-form"],
+	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
 	"supports": {
 		"html": false
 	},

--- a/fair-audience/src/blocks/fair-form-radio/block.json
+++ b/fair-audience/src/blocks/fair-form-radio/block.json
@@ -9,7 +9,7 @@
 	"description": "A single-choice radio button question for Fair Form",
 	"keywords": ["question", "radio", "choice", "button"],
 	"textdomain": "fair-audience",
-	"parent": ["fair-audience/fair-form"],
+	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
 	"supports": {
 		"html": false
 	},

--- a/fair-audience/src/blocks/fair-form-select-one/block.json
+++ b/fair-audience/src/blocks/fair-form-select-one/block.json
@@ -9,7 +9,7 @@
 	"description": "A single-choice question (select or radio) for Fair Form",
 	"keywords": ["question", "select", "radio", "choice"],
 	"textdomain": "fair-audience",
-	"parent": ["fair-audience/fair-form"],
+	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
 	"supports": {
 		"html": false
 	},

--- a/fair-audience/src/blocks/fair-form-short-text/block.json
+++ b/fair-audience/src/blocks/fair-form-short-text/block.json
@@ -9,7 +9,7 @@
 	"description": "A short text input question for Fair Form",
 	"keywords": ["question", "text", "input"],
 	"textdomain": "fair-audience",
-	"parent": ["fair-audience/fair-form"],
+	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
 	"supports": {
 		"html": false
 	},

--- a/fair-audience/src/blocks/fair-form/frontend.js
+++ b/fair-audience/src/blocks/fair-form/frontend.js
@@ -7,6 +7,13 @@ import {
 	setButtonLoading,
 	onDomReady,
 } from '../shared/form-utils.js';
+import {
+	collectQuestionAnswers,
+	validateQuestions,
+	hasFileUploads,
+	appendQuestionFiles,
+	setupQuestionnaire,
+} from '../shared/questionnaire.js';
 
 onDomReady(initializeFairForms);
 
@@ -21,172 +28,8 @@ function setupFormSubmission(form) {
 		submitForm(form);
 	});
 
-	// Set up file upload previews.
-	const fileInputs = form.querySelectorAll(
-		'[data-question-type="file_upload"] input[type="file"]'
-	);
-	fileInputs.forEach((input) => {
-		input.addEventListener('change', () => handleFilePreview(input));
-	});
-
-	// Evaluate conditionals on load and on any input change.
-	evaluateConditionals(form);
-	form.addEventListener('input', () => evaluateConditionals(form));
-	form.addEventListener('change', () => evaluateConditionals(form));
-}
-
-function handleFilePreview(input) {
-	const wrapper = input.closest('[data-fair-form-question]');
-	// Remove existing preview.
-	const existing = wrapper.querySelector('.fair-form-file-preview');
-	if (existing) {
-		existing.remove();
-	}
-
-	if (!input.files || input.files.length === 0) {
-		return;
-	}
-
-	const file = input.files[0];
-	if (!file.type.startsWith('image/')) {
-		return;
-	}
-
-	const preview = document.createElement('div');
-	preview.className = 'fair-form-file-preview';
-
-	const img = document.createElement('img');
-	img.alt = file.name;
-	img.src = URL.createObjectURL(file);
-	img.onload = () => URL.revokeObjectURL(img.src);
-
-	preview.appendChild(img);
-	wrapper.appendChild(preview);
-}
-
-function getQuestionValue(questionEl) {
-	const questionType = questionEl.dataset.questionType;
-
-	if (questionType === 'multiselect') {
-		const checked = questionEl.querySelectorAll(
-			'input[type="checkbox"]:checked'
-		);
-		return JSON.stringify(Array.from(checked).map((cb) => cb.value));
-	}
-
-	const input = questionEl.querySelector(
-		'input:checked, select, input, textarea'
-	);
-	return input ? input.value : '';
-}
-
-function evaluateCondition(currentValue, operator, expectedValue) {
-	switch (operator) {
-		case 'equals':
-			return currentValue === expectedValue;
-		case 'not_equals':
-			return currentValue !== expectedValue;
-		case 'contains':
-			return currentValue.includes(expectedValue);
-		case 'not_empty':
-			return currentValue.trim() !== '';
-		default:
-			return false;
-	}
-}
-
-function evaluateConditionals(form) {
-	const conditionals = form.querySelectorAll('[data-fair-form-conditional]');
-	conditionals.forEach((section) => {
-		const questionKey = section.dataset.conditionQuestionKey;
-		const operator = section.dataset.conditionOperator;
-		const expectedValue = section.dataset.conditionValue;
-
-		const questionEl = form.querySelector(
-			`[data-fair-form-question][data-question-key="${questionKey}"]`
-		);
-		if (!questionEl) {
-			section.classList.remove('fair-form-conditional-visible');
-			return;
-		}
-
-		// If the question itself is inside a hidden conditional, hide this section too.
-		if (!isQuestionVisible(questionEl)) {
-			section.classList.remove('fair-form-conditional-visible');
-			return;
-		}
-
-		const currentValue = getQuestionValue(questionEl);
-		const visible = evaluateCondition(
-			currentValue,
-			operator,
-			expectedValue
-		);
-		section.classList.toggle('fair-form-conditional-visible', visible);
-	});
-}
-
-function isQuestionVisible(el) {
-	const conditional = el.closest('[data-fair-form-conditional]');
-	if (!conditional) {
-		return true;
-	}
-	if (!conditional.classList.contains('fair-form-conditional-visible')) {
-		return false;
-	}
-	// Check parent conditionals (nested case).
-	return isQuestionVisible(conditional.parentElement);
-}
-
-function collectQuestionAnswers(form) {
-	const questionElements = form.querySelectorAll('[data-fair-form-question]');
-	const answers = [];
-
-	questionElements.forEach((el, index) => {
-		// Skip questions inside hidden conditional sections.
-		if (!isQuestionVisible(el)) {
-			return;
-		}
-
-		const questionType = el.dataset.questionType;
-		let answerValue = '';
-
-		if (questionType === 'file_upload') {
-			// File uploads are handled separately via FormData.
-			// Store a placeholder that will be replaced with attachment ID by the server.
-			const fileInput = el.querySelector('input[type="file"]');
-			answerValue =
-				fileInput && fileInput.files.length > 0
-					? '__file_pending__'
-					: '';
-		} else if (questionType === 'multiselect') {
-			// Collect all checked checkboxes and JSON-encode.
-			const checked = el.querySelectorAll(
-				'input[type="checkbox"]:checked'
-			);
-			const values = Array.from(checked).map((cb) => cb.value);
-			answerValue = JSON.stringify(values);
-		} else {
-			// For select, radio, text, textarea - get value from first input/select/textarea.
-			const input = el.querySelector(
-				'input:checked, select, input, textarea'
-			);
-			if (!input) {
-				return;
-			}
-			answerValue = input.value;
-		}
-
-		answers.push({
-			question_key: el.dataset.questionKey,
-			question_text: el.dataset.questionText,
-			question_type: questionType,
-			answer_value: answerValue,
-			display_order: index,
-		});
-	});
-
-	return answers;
+	// Wire up file previews and conditional logic for nested questions.
+	setupQuestionnaire(form);
 }
 
 function validateForm(form) {
@@ -207,111 +50,8 @@ function validateForm(form) {
 		return __('Please enter a valid email address.', 'fair-audience');
 	}
 
-	// Validate required questions (skip those inside hidden conditional sections).
-	const requiredQuestions = form.querySelectorAll(
-		'[data-fair-form-question][data-required="1"]'
-	);
-	for (const el of requiredQuestions) {
-		if (!isQuestionVisible(el)) {
-			continue;
-		}
-
-		const questionType = el.dataset.questionType;
-		let hasValue = false;
-
-		if (questionType === 'file_upload') {
-			const fileInput = el.querySelector('input[type="file"]');
-			hasValue = fileInput && fileInput.files.length > 0;
-		} else if (questionType === 'multiselect') {
-			hasValue =
-				el.querySelectorAll('input[type="checkbox"]:checked').length >
-				0;
-		} else if (el.querySelector('input[type="radio"]')) {
-			hasValue = !!el.querySelector('input[type="radio"]:checked');
-		} else {
-			const input = el.querySelector('input, textarea, select');
-			hasValue = input && input.value.trim() !== '';
-		}
-
-		if (!hasValue) {
-			const questionText = el.dataset.questionText || '';
-			return (
-				__('Please answer the required question: ', 'fair-audience') +
-				questionText
-			);
-		}
-	}
-
-	// Validate phone questions (E.164 format with country code).
-	const phoneQuestions = form.querySelectorAll(
-		'[data-fair-form-question][data-question-type="phone"]'
-	);
-	for (const el of phoneQuestions) {
-		if (!isQuestionVisible(el)) {
-			continue;
-		}
-		const input = el.querySelector('input[type="tel"]');
-		const value = input ? input.value.trim() : '';
-		if (!value) {
-			continue;
-		}
-		if (!/^\+[1-9]\d{6,14}$/.test(value)) {
-			const questionText = el.dataset.questionText || '';
-			return (
-				__(
-					'Please enter a valid phone number with country code (e.g. +49170...): ',
-					'fair-audience'
-				) + questionText
-			);
-		}
-	}
-
-	// Validate file upload constraints (size and type), skip hidden ones.
-	const fileUploadQuestions = form.querySelectorAll(
-		'[data-fair-form-question][data-question-type="file_upload"]'
-	);
-	for (const el of fileUploadQuestions) {
-		if (!isQuestionVisible(el)) {
-			continue;
-		}
-		const fileInput = el.querySelector('input[type="file"]');
-		if (!fileInput || fileInput.files.length === 0) {
-			continue;
-		}
-
-		const file = fileInput.files[0];
-		const maxSizeMB = parseInt(el.dataset.maxFileSize, 10) || 5;
-		const maxSizeBytes = maxSizeMB * 1024 * 1024;
-
-		if (file.size > maxSizeBytes) {
-			const questionText = el.dataset.questionText || '';
-			return (
-				questionText +
-				': ' +
-				__('File is too large. Maximum size is ', 'fair-audience') +
-				maxSizeMB +
-				' MB.'
-			);
-		}
-	}
-
-	return null;
-}
-
-function hasFileUploads(form) {
-	const fileQuestions = form.querySelectorAll(
-		'[data-fair-form-question][data-question-type="file_upload"]'
-	);
-	for (const el of fileQuestions) {
-		if (!isQuestionVisible(el)) {
-			continue;
-		}
-		const fileInput = el.querySelector('input[type="file"]');
-		if (fileInput && fileInput.files.length > 0) {
-			return true;
-		}
-	}
-	return false;
+	// Validate the nested question blocks (required/phone/file constraints).
+	return validateQuestions(form);
 }
 
 function submitForm(form) {
@@ -388,22 +128,8 @@ function submitForm(form) {
 			formData.append('notification_email', notificationEmail);
 		}
 
-		// Append file inputs (skip hidden ones).
-		const fileQuestions = form.querySelectorAll(
-			'[data-fair-form-question][data-question-type="file_upload"]'
-		);
-		fileQuestions.forEach((el) => {
-			if (!isQuestionVisible(el)) {
-				return;
-			}
-			const fileInput = el.querySelector('input[type="file"]');
-			if (fileInput && fileInput.files.length > 0) {
-				formData.append(
-					'fair_form_file_' + el.dataset.questionKey,
-					fileInput.files[0]
-				);
-			}
-		});
+		// Append selected files (skip hidden questions).
+		appendQuestionFiles(form, formData);
 
 		fetchOptions = {
 			path: '/fair-audience/v1/fair-form-submit',

--- a/fair-audience/src/blocks/shared/questionnaire.js
+++ b/fair-audience/src/blocks/shared/questionnaire.js
@@ -1,0 +1,379 @@
+/**
+ * Shared frontend logic for `fair-form-*` question blocks.
+ *
+ * Both the Fair Form block and the Event Signup block nest the same question
+ * blocks as inner blocks. Each question self-identifies on the frontend through
+ * data attributes emitted by its `render.php`
+ * (`data-fair-form-question`, `data-question-key/-text/-type`, `data-required`,
+ * `data-max-file-size`, and `data-condition-*` on conditional sections). The
+ * helpers here read those attributes, so they work unchanged for any container
+ * that renders the question blocks.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Read the current value of a question element.
+ *
+ * @param {HTMLElement} questionEl Question wrapper element.
+ * @return {string} The value (JSON-encoded array for multiselect).
+ */
+export function getQuestionValue(questionEl) {
+	const questionType = questionEl.dataset.questionType;
+
+	if (questionType === 'multiselect') {
+		const checked = questionEl.querySelectorAll(
+			'input[type="checkbox"]:checked'
+		);
+		return JSON.stringify(Array.from(checked).map((cb) => cb.value));
+	}
+
+	const input = questionEl.querySelector(
+		'input:checked, select, input, textarea'
+	);
+	return input ? input.value : '';
+}
+
+/**
+ * Evaluate a single conditional rule.
+ *
+ * @param {string} currentValue  The current answer value.
+ * @param {string} operator      Comparison operator.
+ * @param {string} expectedValue The value to compare against.
+ * @return {boolean} Whether the condition is met.
+ */
+function evaluateCondition(currentValue, operator, expectedValue) {
+	switch (operator) {
+		case 'equals':
+			return currentValue === expectedValue;
+		case 'not_equals':
+			return currentValue !== expectedValue;
+		case 'contains':
+			return currentValue.includes(expectedValue);
+		case 'not_empty':
+			return currentValue.trim() !== '';
+		default:
+			return false;
+	}
+}
+
+/**
+ * Show/hide conditional sections based on their controlling question's value.
+ *
+ * @param {HTMLElement} form The form (or container) element.
+ */
+export function evaluateConditionals(form) {
+	const conditionals = form.querySelectorAll('[data-fair-form-conditional]');
+	conditionals.forEach((section) => {
+		const questionKey = section.dataset.conditionQuestionKey;
+		const operator = section.dataset.conditionOperator;
+		const expectedValue = section.dataset.conditionValue;
+
+		const questionEl = form.querySelector(
+			`[data-fair-form-question][data-question-key="${questionKey}"]`
+		);
+		if (!questionEl) {
+			section.classList.remove('fair-form-conditional-visible');
+			return;
+		}
+
+		// If the controlling question is itself inside a hidden conditional,
+		// hide this section too.
+		if (!isQuestionVisible(questionEl)) {
+			section.classList.remove('fair-form-conditional-visible');
+			return;
+		}
+
+		const currentValue = getQuestionValue(questionEl);
+		const visible = evaluateCondition(
+			currentValue,
+			operator,
+			expectedValue
+		);
+		section.classList.toggle('fair-form-conditional-visible', visible);
+	});
+}
+
+/**
+ * Determine whether a question is currently visible (not inside a hidden
+ * conditional section, accounting for nesting).
+ *
+ * @param {HTMLElement} el Question wrapper or conditional section element.
+ * @return {boolean} Whether the element is visible.
+ */
+export function isQuestionVisible(el) {
+	const conditional = el.closest('[data-fair-form-conditional]');
+	if (!conditional) {
+		return true;
+	}
+	if (!conditional.classList.contains('fair-form-conditional-visible')) {
+		return false;
+	}
+	// Check parent conditionals (nested case).
+	return isQuestionVisible(conditional.parentElement);
+}
+
+/**
+ * Collect answers from all visible question blocks within a form.
+ *
+ * @param {HTMLElement} form The form (or container) element.
+ * @return {Array<Object>} Answers ready for the `questionnaire_answers` payload.
+ */
+export function collectQuestionAnswers(form) {
+	const questionElements = form.querySelectorAll('[data-fair-form-question]');
+	const answers = [];
+
+	questionElements.forEach((el, index) => {
+		// Skip questions inside hidden conditional sections.
+		if (!isQuestionVisible(el)) {
+			return;
+		}
+
+		const questionType = el.dataset.questionType;
+		let answerValue = '';
+
+		if (questionType === 'file_upload') {
+			// File uploads are handled separately via FormData. Store a
+			// placeholder that the server replaces with the attachment ID.
+			const fileInput = el.querySelector('input[type="file"]');
+			answerValue =
+				fileInput && fileInput.files.length > 0
+					? '__file_pending__'
+					: '';
+		} else if (questionType === 'multiselect') {
+			// Collect all checked checkboxes and JSON-encode.
+			const checked = el.querySelectorAll(
+				'input[type="checkbox"]:checked'
+			);
+			const values = Array.from(checked).map((cb) => cb.value);
+			answerValue = JSON.stringify(values);
+		} else {
+			// For select, radio, text, textarea - get value from first
+			// input/select/textarea.
+			const input = el.querySelector(
+				'input:checked, select, input, textarea'
+			);
+			if (!input) {
+				return;
+			}
+			answerValue = input.value;
+		}
+
+		answers.push({
+			question_key: el.dataset.questionKey,
+			question_text: el.dataset.questionText,
+			question_type: questionType,
+			answer_value: answerValue,
+			display_order: index,
+		});
+	});
+
+	return answers;
+}
+
+/**
+ * Validate the nested question blocks within a form.
+ *
+ * Checks required questions (respecting conditional visibility), phone format
+ * (E.164), and file-upload size limits. The caller is responsible for any
+ * non-question fields (name/email).
+ *
+ * @param {HTMLElement} form The form (or container) element.
+ * @return {string|null} An error message, or null when valid.
+ */
+export function validateQuestions(form) {
+	// Validate required questions (skip those inside hidden conditional sections).
+	const requiredQuestions = form.querySelectorAll(
+		'[data-fair-form-question][data-required="1"]'
+	);
+	for (const el of requiredQuestions) {
+		if (!isQuestionVisible(el)) {
+			continue;
+		}
+
+		const questionType = el.dataset.questionType;
+		let hasValue = false;
+
+		if (questionType === 'file_upload') {
+			const fileInput = el.querySelector('input[type="file"]');
+			hasValue = fileInput && fileInput.files.length > 0;
+		} else if (questionType === 'multiselect') {
+			hasValue =
+				el.querySelectorAll('input[type="checkbox"]:checked').length >
+				0;
+		} else if (el.querySelector('input[type="radio"]')) {
+			hasValue = !!el.querySelector('input[type="radio"]:checked');
+		} else {
+			const input = el.querySelector('input, textarea, select');
+			hasValue = input && input.value.trim() !== '';
+		}
+
+		if (!hasValue) {
+			const questionText = el.dataset.questionText || '';
+			return (
+				__('Please answer the required question: ', 'fair-audience') +
+				questionText
+			);
+		}
+	}
+
+	// Validate phone questions (E.164 format with country code).
+	const phoneQuestions = form.querySelectorAll(
+		'[data-fair-form-question][data-question-type="phone"]'
+	);
+	for (const el of phoneQuestions) {
+		if (!isQuestionVisible(el)) {
+			continue;
+		}
+		const input = el.querySelector('input[type="tel"]');
+		const value = input ? input.value.trim() : '';
+		if (!value) {
+			continue;
+		}
+		if (!/^\+[1-9]\d{6,14}$/.test(value)) {
+			const questionText = el.dataset.questionText || '';
+			return (
+				__(
+					'Please enter a valid phone number with country code (e.g. +49170...): ',
+					'fair-audience'
+				) + questionText
+			);
+		}
+	}
+
+	// Validate file upload constraints (size), skip hidden ones.
+	const fileUploadQuestions = form.querySelectorAll(
+		'[data-fair-form-question][data-question-type="file_upload"]'
+	);
+	for (const el of fileUploadQuestions) {
+		if (!isQuestionVisible(el)) {
+			continue;
+		}
+		const fileInput = el.querySelector('input[type="file"]');
+		if (!fileInput || fileInput.files.length === 0) {
+			continue;
+		}
+
+		const file = fileInput.files[0];
+		const maxSizeMB = parseInt(el.dataset.maxFileSize, 10) || 5;
+		const maxSizeBytes = maxSizeMB * 1024 * 1024;
+
+		if (file.size > maxSizeBytes) {
+			const questionText = el.dataset.questionText || '';
+			return (
+				questionText +
+				': ' +
+				__('File is too large. Maximum size is ', 'fair-audience') +
+				maxSizeMB +
+				' MB.'
+			);
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Whether the form has any pending file uploads in visible questions.
+ *
+ * @param {HTMLElement} form The form (or container) element.
+ * @return {boolean} True when at least one file is selected.
+ */
+export function hasFileUploads(form) {
+	const fileQuestions = form.querySelectorAll(
+		'[data-fair-form-question][data-question-type="file_upload"]'
+	);
+	for (const el of fileQuestions) {
+		if (!isQuestionVisible(el)) {
+			continue;
+		}
+		const fileInput = el.querySelector('input[type="file"]');
+		if (fileInput && fileInput.files.length > 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Append selected files from visible file-upload questions to a FormData
+ * object, keyed as `fair_form_file_{question_key}` (the convention the server
+ * expects).
+ *
+ * @param {HTMLElement} form     The form (or container) element.
+ * @param {FormData}    formData The FormData to append to.
+ */
+export function appendQuestionFiles(form, formData) {
+	const fileQuestions = form.querySelectorAll(
+		'[data-fair-form-question][data-question-type="file_upload"]'
+	);
+	fileQuestions.forEach((el) => {
+		if (!isQuestionVisible(el)) {
+			return;
+		}
+		const fileInput = el.querySelector('input[type="file"]');
+		if (fileInput && fileInput.files.length > 0) {
+			formData.append(
+				'fair_form_file_' + el.dataset.questionKey,
+				fileInput.files[0]
+			);
+		}
+	});
+}
+
+/**
+ * Render an image preview for a selected file inside its question wrapper.
+ *
+ * @param {HTMLInputElement} input The file input element.
+ */
+export function handleFilePreview(input) {
+	const wrapper = input.closest('[data-fair-form-question]');
+	if (!wrapper) {
+		return;
+	}
+	// Remove existing preview.
+	const existing = wrapper.querySelector('.fair-form-file-preview');
+	if (existing) {
+		existing.remove();
+	}
+
+	if (!input.files || input.files.length === 0) {
+		return;
+	}
+
+	const file = input.files[0];
+	if (!file.type.startsWith('image/')) {
+		return;
+	}
+
+	const preview = document.createElement('div');
+	preview.className = 'fair-form-file-preview';
+
+	const img = document.createElement('img');
+	img.alt = file.name;
+	img.src = URL.createObjectURL(file);
+	img.onload = () => URL.revokeObjectURL(img.src);
+
+	preview.appendChild(img);
+	wrapper.appendChild(preview);
+}
+
+/**
+ * Wire up question behavior on a form: file previews and conditional logic.
+ *
+ * @param {HTMLElement} form The form (or container) element.
+ */
+export function setupQuestionnaire(form) {
+	// Set up file upload previews.
+	const fileInputs = form.querySelectorAll(
+		'[data-question-type="file_upload"] input[type="file"]'
+	);
+	fileInputs.forEach((input) => {
+		input.addEventListener('change', () => handleFilePreview(input));
+	});
+
+	// Evaluate conditionals on load and on any input change.
+	evaluateConditionals(form);
+	form.addEventListener('input', () => evaluateConditionals(form));
+	form.addEventListener('change', () => evaluateConditionals(form));
+}


### PR DESCRIPTION
## Summary

Closes #615. The **Event Signup** block (`fair-audience/event-signup`) now accepts the same `fair-form-*` question inner blocks as **Fair Form**, so organizers can collect extra info (dietary needs, t-shirt size, guests, etc.) during event registration instead of maintaining a separate Fair Form. Answers are persisted using the existing questionnaire storage — no new schema.

## What changed

**Shared logic (reuse, no duplication)**
- `blocks/shared/questionnaire.js` *(new)* — question collection/validation/conditional/file-preview logic, extracted from `fair-form/frontend.js` (which now imports it).
- `Services/QuestionnaireService.php` *(new)* — parse/sanitize/file-upload/persist logic, extracted from `FairFormController` (which now delegates). Adds an idempotent "reuse existing submission" mode keyed by participant + event date + title.

**Event Signup block**
- Editor: replaced ServerSideRender with a static mockup + an editable **InnerBlocks** region (allowed blocks = the `fair-form-*` question set per the issue). `save` returns `<InnerBlocks.Content />` with a `deprecated` entry so existing blocks migrate without recovery prompts.
- `render.php`: injects the rendered questions into the authenticated signup form and the anonymous register form (not the request-link form).
- `frontend.js`: validates + collects answers and submits them; switches to multipart `FormData` when file-upload questions have files.

**Backend persistence**
- `EventSignupController`: registers a `questionnaire_answers` arg on the signup + register routes, validates up front (400 on bad input), and persists answers (title "Event Signup") **before** the paid-signup branch so they survive `pending_payment`; idempotent on re-submit/retry.

**Admin**
- `EventParticipantsController::get_items()` attaches each signup's answers; `EventParticipants.js` shows them in a new "Questions" column. They also appear in the existing Form Answers view + Markdown export automatically.

## Acceptance criteria

- [x] All `fair-form-*` question blocks insertable inside Event Signup (phone included; mailing-signup left out as out-of-scope for signups).
- [x] Frontend submission stores answers alongside the signup (free and paid paths).
- [x] Required-field validation for nested questions.
- [x] Answers visible in the admin signups view and included in exports.
- [x] No regression for Event Signup forms without custom fields (empty `$content` → no submission).

## Testing

- `npm run build` — webpack compiles cleanly (only asset-size warnings); shared logic bundled into the event-signup frontend.
- `npm run test:js` — passing.
- `phpcs` — new files clean; modified files add zero new violations vs. the committed baseline.

**Still needs manual verification in a live WP environment** (`docker compose up` + editor/browser): inserting question blocks, submitting free/paid signups end-to-end, confirming persisted rows, and the admin display.

## Note for reviewers

`fair-form-phone` is included in the allowed blocks because #615 lists it explicitly, even though Fair Form's own block currently omits it. `fair-form-mailing-signup` is intentionally excluded (signups already have a keep-informed opt-in).