### PR TITLE
Remove Questionnaire Responses summary card from Manage Event

### DIFF
--- a/fair-events/src/Admin/manage-event/EventAudience.js
+++ b/fair-events/src/Admin/manage-event/EventAudience.js
@@ -52,8 +52,6 @@ export default function EventAudience({
 	const [loadingParticipants, setLoadingParticipants] = useState(true);
 	const [ticketOptions, setTicketOptions] = useState([]);
 	const [ticketTypes, setTicketTypes] = useState([]);
-	const [questionnaireSummary, setQuestionnaireSummary] = useState(null);
-	const [loadingQuestionnaire, setLoadingQuestionnaire] = useState(true);
 	const [formsSummary, setFormsSummary] = useState([]);
 	const [loadingForms, setLoadingForms] = useState(true);
 
@@ -178,45 +176,6 @@ export default function EventAudience({
 				);
 			})
 			.catch(() => setInvitedGroups([]));
-	}, [eventDateId]);
-
-	useEffect(() => {
-		if (!eventDateId) {
-			setLoadingQuestionnaire(false);
-			return;
-		}
-		apiFetch({
-			path: `/fair-audience/v1/questionnaire-responses?event_date_id=${eventDateId}`,
-		})
-			.then((data) => {
-				if (!data || data.length === 0) {
-					setQuestionnaireSummary(null);
-				} else {
-					const questions = new Map();
-					data.forEach((submission) => {
-						(submission.answers || []).forEach((answer) => {
-							if (!questions.has(answer.question_key)) {
-								questions.set(answer.question_key, {
-									text: answer.question_text,
-									type: answer.question_type,
-									counts: {},
-								});
-							}
-							const q = questions.get(answer.question_key);
-							const val = answer.answer_value || '';
-							q.counts[val] = (q.counts[val] || 0) + 1;
-						});
-					});
-					setQuestionnaireSummary({
-						totalResponses: data.length,
-						questions: Array.from(questions.values()),
-					});
-				}
-			})
-			.catch(() => {
-				setQuestionnaireSummary(null);
-			})
-			.finally(() => setLoadingQuestionnaire(false));
 	}, [eventDateId]);
 
 	const filteredParticipants = useMemo(() => {
@@ -1665,55 +1624,6 @@ export default function EventAudience({
 						</div>
 					) : (
 						<p>{__('No form submissions yet.', 'fair-events')}</p>
-					)}
-				</CardBody>
-			</Card>
-
-			<Card style={{ marginTop: '16px' }}>
-				<CardHeader>
-					<h2>{__('Questionnaire Responses', 'fair-events')}</h2>
-				</CardHeader>
-				<CardBody>
-					{loadingQuestionnaire ? (
-						<Spinner />
-					) : questionnaireSummary ? (
-						<VStack spacing={3}>
-							<p>
-								{__('Total responses:', 'fair-events')}{' '}
-								<strong>
-									{questionnaireSummary.totalResponses}
-								</strong>
-							</p>
-							{questionnaireSummary.questions.map((q) => (
-								<div key={q.text}>
-									<p>
-										<strong>{q.text}</strong>
-									</p>
-									<ul style={{ margin: '4px 0 0 20px' }}>
-										{Object.entries(q.counts).map(
-											([value, count]) => (
-												<li key={value}>
-													{value || '—'}: {count}
-												</li>
-											)
-										)}
-									</ul>
-								</div>
-							))}
-							<Button
-								variant="secondary"
-								href={`admin.php?page=fair-audience-questionnaire-responses&event_date_id=${eventDateId}`}
-							>
-								{__('View All Responses', 'fair-events')}
-							</Button>
-						</VStack>
-					) : (
-						<p>
-							{__(
-								'No questionnaire responses yet.',
-								'fair-events'
-							)}
-						</p>
 					)}
 				</CardBody>
 			</Card>


### PR DESCRIPTION
## Summary

Removes the **Questionnaire Responses** summary card from the Manage Event → Audience admin page (`fair-events/src/Admin/manage-event/EventAudience.js`). The card showed a total-responses count and a per-question answer-value breakdown — duplicating the standalone Questionnaire Responses page (still reachable from the **Forms** card and the events list) with little added value.

## What changed

Removed the card and all of its now-dead supporting code:
- the render block (Total responses / per-question counts / "View All Responses"),
- the `useEffect` that fetched `/fair-audience/v1/questionnaire-responses` and built the summary,
- the `questionnaireSummary` / `loadingQuestionnaire` state.

## Not touched

- The **Forms** card directly above it (forms-summary table).
- The standalone Questionnaire Responses page and its REST endpoints — still used by the Forms card's "View Responses" links and the events-list action.

## Testing

- `npm run build` in `fair-events` compiles cleanly (warnings only).
- No leftover references to the removed state; `VStack`/`Spinner`/`Button` imports remain in use.

Note: the removed UI strings still linger in the fair-events `.po`/`.pot` files; those regenerate via `npm run makepot` at release, so they weren't hand-edited.