### PR TITLE
Show conditional fields by event-option short name

### DIFF
--- a/e2e/mu-plugins/scripts/seed-conditional-signup.php
+++ b/e2e/mu-plugins/scripts/seed-conditional-signup.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Seed a published free event whose Event Signup nests a Conditional Section
+ * keyed on an event option's short name (issue #681).
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-conditional-signup.php
+ *
+ * Creates a fair_event post whose content is an event-signup block containing a
+ * fair-form-conditional (conditionSource=eventOption, short name "dinner") that
+ * wraps a short-text question. Adds one event date, an active sale period, a
+ * free ticket type + price, and a "dinner" ticket option carrying the short
+ * name. Prints a single `E2E_SEED:{json}` line the spec parses.
+ *
+ * @package FairEventsE2E
+ */
+
+use FairEvents\Models\EventDates;
+use FairEvents\Models\TicketSalePeriod;
+use FairEvents\Models\TicketType;
+use FairEvents\Models\TicketPrice;
+use FairEvents\Models\TicketOption;
+
+// Nested block content: the conditional reveals the "diet" question only when
+// the "dinner" option is selected.
+$content = implode(
+	"\n",
+	array(
+		'<!-- wp:fair-audience/event-signup -->',
+		'<!-- wp:fair-audience/fair-form-conditional {"conditionSource":"eventOption","conditionOptionShortName":"dinner","conditionOperator":"selected"} -->',
+		'<!-- wp:fair-audience/fair-form-short-text {"questionKey":"diet","questionText":"Dietary restrictions"} /-->',
+		'<!-- /wp:fair-audience/fair-form-conditional -->',
+		'<!-- /wp:fair-audience/event-signup -->',
+	)
+);
+
+$event_id = wp_insert_post(
+	array(
+		'post_type'    => 'fair_event',
+		'post_status'  => 'publish',
+		'post_title'   => 'E2E Conditional Signup ' . gmdate( 'YmdHis' ),
+		'post_content' => $content,
+	),
+	true
+);
+
+if ( is_wp_error( $event_id ) ) {
+	WP_CLI::error( 'Failed to create event: ' . $event_id->get_error_message() );
+}
+
+$event_date_id = EventDates::save_occurrence(
+	$event_id,
+	gmdate( 'Y-m-d H:i:s', strtotime( '+7 days' ) ),
+	gmdate( 'Y-m-d H:i:s', strtotime( '+7 days +2 hours' ) ),
+	false,
+	'single'
+);
+
+if ( ! $event_date_id ) {
+	WP_CLI::error( 'Failed to create event date.' );
+}
+
+$sale_period_id = TicketSalePeriod::create(
+	$event_date_id,
+	'Standard',
+	gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) ),
+	gmdate( 'Y-m-d H:i:s', strtotime( '+30 days' ) ),
+	0
+);
+
+if ( ! $sale_period_id ) {
+	WP_CLI::error( 'Failed to create sale period.' );
+}
+
+$ticket_type_id = TicketType::create( $event_date_id, 'General Admission', null, 0 );
+
+if ( ! $ticket_type_id ) {
+	WP_CLI::error( 'Failed to create ticket type.' );
+}
+
+if ( ! TicketPrice::create( $ticket_type_id, $sale_period_id, 0.0, null ) ) {
+	WP_CLI::error( 'Failed to create ticket price.' );
+}
+
+// The controlling option: short name "dinner" is what the conditional keys on.
+$option_id = TicketOption::create( $event_date_id, 'Dinner', 0.0, 0, 'dinner' );
+
+if ( ! $option_id ) {
+	WP_CLI::error( 'Failed to create ticket option.' );
+}
+
+echo 'E2E_SEED:' . wp_json_encode(
+	array(
+		'pageUrl'     => get_permalink( $event_id ),
+		'eventId'     => (int) $event_id,
+		'eventDateId' => (int) $event_date_id,
+		'optionId'    => (int) $option_id,
+		'shortName'   => 'dinner',
+	)
+) . "\n";

--- a/e2e/user-flows/conditional-signup-fields.spec.js
+++ b/e2e/user-flows/conditional-signup-fields.spec.js
@@ -1,0 +1,87 @@
+/**
+ * E2E: conditional signup fields keyed on an event option's short name (#681).
+ *
+ * Loads a public event whose Event Signup nests a Conditional Section
+ * (conditionSource=eventOption, short name "dinner") wrapping a "Dietary
+ * restrictions" question. Asserts the real frontend show/hide logic in
+ * shared/questionnaire.js: the question is hidden until the matching option
+ * checkbox is ticked, and hides again when it is unticked.
+ *
+ * Everything here is production code — the block render callbacks emit the
+ * data-option-short-name / data-condition-* attributes and the bundled
+ * frontend.js evaluates them. See e2e/README.md for the harness mechanics.
+ */
+
+import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+
+/**
+ * Run a WP-CLI command against the wp-env `tests` instance and return stdout.
+ *
+ * @param {string} args WP-CLI arguments (everything after `wp`).
+ * @return {string} Command stdout.
+ */
+function wpCli(args) {
+	return execSync(`npx wp-env run tests-cli wp ${args}`, {
+		cwd: process.cwd(),
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+}
+
+/**
+ * Run a seed/state eval-file script and parse its `MARKER:{json}` output.
+ *
+ * @param {string} file      Script filename under mu-plugins/scripts/.
+ * @param {string} marker    Output marker (e.g. 'E2E_SEED').
+ * @param {string} extraArgs Positional args passed to the script.
+ * @return {object} Parsed JSON payload.
+ */
+function runScript(file, marker, extraArgs = '') {
+	const out = wpCli(
+		`eval-file wp-content/mu-plugins/scripts/${file} ${extraArgs}`.trim()
+	);
+	const match = out.match(new RegExp(`${marker}:(\\{.*\\})`));
+	if (!match) {
+		throw new Error(`Expected ${marker} in WP-CLI output, got:\n${out}`);
+	}
+	return JSON.parse(match[1]);
+}
+
+let event;
+
+test.beforeAll(() => {
+	event = runScript('seed-conditional-signup.php', 'E2E_SEED');
+});
+
+test.describe('conditional signup fields by event-option short name', () => {
+	test('reveals the question only while the matching option is selected', async ({
+		page,
+	}) => {
+		await page.goto(event.pageUrl);
+
+		// Anonymous visitors get the registration form by default.
+		const form = page.locator('.fair-audience-signup-register');
+		await expect(form).toBeVisible();
+
+		const dinner = form.locator(
+			'input[name="ticket_option_ids[]"][data-option-short-name="dinner"]'
+		);
+		await expect(dinner).toHaveCount(1);
+
+		// The conditional wraps the "diet" question; it is display:none until
+		// the controlling option is checked.
+		const dietQuestion = form.locator('[data-question-key="diet"]');
+
+		// Hidden on load.
+		await expect(dietQuestion).toBeHidden();
+
+		// Selecting "dinner" reveals it.
+		await dinner.check();
+		await expect(dietQuestion).toBeVisible();
+
+		// Unselecting hides it again.
+		await dinner.uncheck();
+		await expect(dietQuestion).toBeHidden();
+	});
+});

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -457,10 +457,11 @@ if ( $pricing_event_date_id && class_exists( \FairEvents\Models\TicketOption::cl
 		}
 
 		$ticket_options_for_display[] = array(
-			'id'      => (int) $opt->id,
-			'name'    => $opt->name,
-			'price'   => $opt_price,
-			'is_full' => $is_full,
+			'id'         => (int) $opt->id,
+			'name'       => $opt->name,
+			'short_name' => $opt->short_name ?? null,
+			'price'      => $opt_price,
+			'is_full'    => $is_full,
 		);
 	}
 }
@@ -733,7 +734,7 @@ $render_ticket_options = static function () use ( $ticket_options_for_display, $
 			$classes .= ' fair-audience-ticket-option-full';
 		}
 		echo '<label class="' . esc_attr( $classes ) . '" for="' . $checkbox_id . '">';
-		echo '<input type="checkbox" name="ticket_option_ids[]" id="' . $checkbox_id . '" value="' . (int) $opt['id'] . '" data-option-price="' . esc_attr( number_format( $opt['price'], 2, '.', '' ) ) . '"';
+		echo '<input type="checkbox" name="ticket_option_ids[]" id="' . $checkbox_id . '" value="' . (int) $opt['id'] . '" data-option-price="' . esc_attr( number_format( $opt['price'], 2, '.', '' ) ) . '" data-option-short-name="' . esc_attr( $opt['short_name'] ?? '' ) . '"';
 		if ( $is_full ) {
 			echo ' disabled';
 		}
@@ -796,7 +797,7 @@ $render_add_activities = static function () use ( $addable_options, $has_addable
 			$classes .= ' fair-audience-ticket-option-full';
 		}
 		echo '<label class="' . esc_attr( $classes ) . '" for="' . $checkbox_id . '">';
-		echo '<input type="checkbox" name="add_option_ids[]" id="' . $checkbox_id . '" value="' . (int) $opt['id'] . '" data-option-price="' . esc_attr( number_format( $opt['price'], 2, '.', '' ) ) . '"';
+		echo '<input type="checkbox" name="add_option_ids[]" id="' . $checkbox_id . '" value="' . (int) $opt['id'] . '" data-option-price="' . esc_attr( number_format( $opt['price'], 2, '.', '' ) ) . '" data-option-short-name="' . esc_attr( $opt['short_name'] ?? '' ) . '"';
 		if ( $is_full ) {
 			echo ' disabled';
 		}

--- a/fair-audience/src/blocks/fair-form-conditional/block.json
+++ b/fair-audience/src/blocks/fair-form-conditional/block.json
@@ -14,6 +14,10 @@
 		"html": false
 	},
 	"attributes": {
+		"conditionSource": {
+			"type": "string",
+			"default": "question"
+		},
 		"conditionQuestionKey": {
 			"type": "string",
 			"default": ""
@@ -23,6 +27,10 @@
 			"default": "equals"
 		},
 		"conditionValue": {
+			"type": "string",
+			"default": ""
+		},
+		"conditionOptionShortName": {
 			"type": "string",
 			"default": ""
 		}

--- a/fair-audience/src/blocks/fair-form-conditional/editor.js
+++ b/fair-audience/src/blocks/fair-form-conditional/editor.js
@@ -33,6 +33,18 @@ const OPERATOR_OPTIONS = [
 	{ label: __('is not empty', 'fair-audience'), value: 'not_empty' },
 ];
 
+// Event options are boolean per checkbox, so they get a dedicated
+// selected/not-selected operator pair rather than reusing equals/contains.
+const EVENT_OPTION_OPERATOR_OPTIONS = [
+	{ label: __('is selected', 'fair-audience'), value: 'selected' },
+	{ label: __('is not selected', 'fair-audience'), value: 'not_selected' },
+];
+
+const SOURCE_OPTIONS = [
+	{ label: __('Question', 'fair-audience'), value: 'question' },
+	{ label: __('Event option', 'fair-audience'), value: 'eventOption' },
+];
+
 const OPTION_BLOCK_PARENTS = [
 	'fair-audience/fair-form-multiselect',
 	'fair-audience/fair-form-select-one',
@@ -70,28 +82,47 @@ function findQuestionBlocks(blocks) {
 
 registerBlockType('fair-audience/fair-form-conditional', {
 	edit: ({ attributes, setAttributes, clientId }) => {
-		const { conditionQuestionKey, conditionOperator, conditionValue } =
-			attributes;
+		const {
+			conditionSource,
+			conditionQuestionKey,
+			conditionOperator,
+			conditionValue,
+			conditionOptionShortName,
+		} = attributes;
 
-		const questionOptions = useSelect(
+		const { questionOptions, isEventSignup } = useSelect(
 			(select) => {
-				const { getBlockParents, getBlocks } =
+				const { getBlockParents, getBlocks, getBlock } =
 					select('core/block-editor');
 				const parents = getBlockParents(clientId);
-				// Find the fair-form parent (the topmost relevant parent).
+				// Find the nearest form-like parent: a Fair Form or an Event
+				// Signup (which accepts nested fair-form questions since #615).
 				const formParentId = parents.find((parentId) => {
-					const parentBlock =
-						select('core/block-editor').getBlock(parentId);
-					return parentBlock?.name === 'fair-audience/fair-form';
+					const parentBlock = getBlock(parentId);
+					return (
+						parentBlock?.name === 'fair-audience/fair-form' ||
+						parentBlock?.name === 'fair-audience/event-signup'
+					);
 				});
 				if (!formParentId) {
-					return [];
+					return { questionOptions: [], isEventSignup: false };
 				}
+				const formBlock = getBlock(formParentId);
 				const formBlocks = getBlocks(formParentId);
-				return findQuestionBlocks(formBlocks);
+				return {
+					questionOptions: findQuestionBlocks(formBlocks),
+					isEventSignup:
+						formBlock?.name === 'fair-audience/event-signup',
+				};
 			},
 			[clientId]
 		);
+
+		// The event-option source is only meaningful inside an Event Signup,
+		// whose runtime option checkboxes carry the short name. Outside one,
+		// keep the source on "question" regardless of the stored attribute.
+		const source = isEventSignup ? conditionSource : 'question';
+		const isEventOption = source === 'eventOption';
 
 		const questionSelectOptions = [
 			{
@@ -110,15 +141,30 @@ registerBlockType('fair-audience/fair-form-conditional', {
 		const hasOptions =
 			selectedQuestion?.options && selectedQuestion.options.length > 0;
 
-		const isConfigured = !!conditionQuestionKey;
+		// Keep the operator valid for the active source: the question
+		// operators (equals/…) and the event-option operators
+		// (selected/not_selected) are disjoint sets.
+		const eventOptionOperator =
+			conditionOperator === 'not_selected' ? 'not_selected' : 'selected';
 
-		const conditionLabel = isConfigured
-			? `${conditionQuestionKey} ${conditionOperator}${
-					conditionOperator !== 'not_empty'
-						? ` "${conditionValue}"`
-						: ''
-			  }`
-			: __('No condition set', 'fair-audience');
+		const isConfigured = isEventOption
+			? !!conditionOptionShortName
+			: !!conditionQuestionKey;
+
+		let conditionLabel;
+		if (!isConfigured) {
+			conditionLabel = __('No condition set', 'fair-audience');
+		} else if (isEventOption) {
+			conditionLabel = `${conditionOptionShortName} ${
+				eventOptionOperator === 'not_selected'
+					? __('is not selected', 'fair-audience')
+					: __('is selected', 'fair-audience')
+			}`;
+		} else {
+			conditionLabel = `${conditionQuestionKey} ${conditionOperator}${
+				conditionOperator !== 'not_empty' ? ` "${conditionValue}"` : ''
+			}`;
+		}
 
 		const blockProps = useBlockProps({
 			className: `fair-form-conditional-editor${
@@ -142,76 +188,133 @@ registerBlockType('fair-audience/fair-form-conditional', {
 					<PanelBody
 						title={__('Condition Settings', 'fair-audience')}
 					>
-						<SelectControl
-							label={__('Show when question', 'fair-audience')}
-							value={conditionQuestionKey}
-							options={questionSelectOptions}
-							onChange={(value) => {
-								const question = questionOptions.find(
-									(q) => q.key === value
-								);
-								const updates = {
-									conditionQuestionKey: value,
-									conditionValue: '',
-								};
-								if (
-									question?.blockName ===
-									'fair-audience/fair-form-multiselect'
-								) {
-									updates.conditionOperator = 'contains';
+						{isEventSignup && (
+							<SelectControl
+								label={__('Condition source', 'fair-audience')}
+								value={source}
+								options={SOURCE_OPTIONS}
+								onChange={(value) =>
+									setAttributes({
+										conditionSource: value,
+										// Reset the operator to one valid for the
+										// newly selected source.
+										conditionOperator:
+											value === 'eventOption'
+												? 'selected'
+												: 'equals',
+									})
 								}
-								setAttributes(updates);
-							}}
-						/>
-						<SelectControl
-							label={__('Operator', 'fair-audience')}
-							value={conditionOperator}
-							options={OPERATOR_OPTIONS}
-							onChange={(value) =>
-								setAttributes({ conditionOperator: value })
-							}
-						/>
-						{conditionOperator !== 'not_empty' &&
-							(hasOptions ? (
-								<SelectControl
-									label={__('Value', 'fair-audience')}
-									value={conditionValue}
-									options={[
-										{
-											label: __(
-												'— Select a value —',
-												'fair-audience'
-											),
-											value: '',
-										},
-										...selectedQuestion.options.map(
-											(opt) => ({
-												label: opt,
-												value: opt,
-											})
-										),
-									]}
-									onChange={(value) =>
-										setAttributes({
-											conditionValue: value,
-										})
-									}
-								/>
-							) : (
+							/>
+						)}
+						{isEventOption ? (
+							<>
 								<TextControl
-									label={__('Value', 'fair-audience')}
-									value={conditionValue}
+									label={__(
+										'Option short name',
+										'fair-audience'
+									)}
+									value={conditionOptionShortName}
 									onChange={(value) =>
 										setAttributes({
-											conditionValue: value,
+											conditionOptionShortName: value,
 										})
 									}
 									help={__(
-										'The value to compare against.',
+										"Enter the option's short name (set it in the event's Tickets tab). Options can't be listed here because they come from the selected event date at render time.",
 										'fair-audience'
 									)}
 								/>
-							))}
+								<SelectControl
+									label={__('Operator', 'fair-audience')}
+									value={eventOptionOperator}
+									options={EVENT_OPTION_OPERATOR_OPTIONS}
+									onChange={(value) =>
+										setAttributes({
+											conditionOperator: value,
+										})
+									}
+								/>
+							</>
+						) : (
+							<>
+								<SelectControl
+									label={__(
+										'Show when question',
+										'fair-audience'
+									)}
+									value={conditionQuestionKey}
+									options={questionSelectOptions}
+									onChange={(value) => {
+										const question = questionOptions.find(
+											(q) => q.key === value
+										);
+										const updates = {
+											conditionQuestionKey: value,
+											conditionValue: '',
+										};
+										if (
+											question?.blockName ===
+											'fair-audience/fair-form-multiselect'
+										) {
+											updates.conditionOperator =
+												'contains';
+										}
+										setAttributes(updates);
+									}}
+								/>
+								<SelectControl
+									label={__('Operator', 'fair-audience')}
+									value={conditionOperator}
+									options={OPERATOR_OPTIONS}
+									onChange={(value) =>
+										setAttributes({
+											conditionOperator: value,
+										})
+									}
+								/>
+								{conditionOperator !== 'not_empty' &&
+									(hasOptions ? (
+										<SelectControl
+											label={__('Value', 'fair-audience')}
+											value={conditionValue}
+											options={[
+												{
+													label: __(
+														'— Select a value —',
+														'fair-audience'
+													),
+													value: '',
+												},
+												...selectedQuestion.options.map(
+													(opt) => ({
+														label: opt,
+														value: opt,
+													})
+												),
+											]}
+											onChange={(value) =>
+												setAttributes({
+													conditionValue: value,
+												})
+											}
+										/>
+									) : (
+										<TextControl
+											label={__('Value', 'fair-audience')}
+											value={conditionValue}
+											onChange={(value) =>
+												setAttributes({
+													conditionValue: value,
+												})
+											}
+											help={__(
+												'The value to compare against.',
+												'fair-audience'
+											)}
+										/>
+									))}
+							</>
+						)}
 					</PanelBody>
 				</InspectorControls>
 

--- a/fair-audience/src/blocks/fair-form-conditional/render.php
+++ b/fair-audience/src/blocks/fair-form-conditional/render.php
@@ -14,22 +14,32 @@
 
 defined( 'WPINC' ) || die;
 
-$condition_question_key = $attributes['conditionQuestionKey'] ?? '';
-$condition_operator     = $attributes['conditionOperator'] ?? 'equals';
-$condition_value        = $attributes['conditionValue'] ?? '';
+$condition_source            = $attributes['conditionSource'] ?? 'question';
+$condition_question_key      = $attributes['conditionQuestionKey'] ?? '';
+$condition_operator          = $attributes['conditionOperator'] ?? 'equals';
+$condition_value             = $attributes['conditionValue'] ?? '';
+$condition_option_short_name = $attributes['conditionOptionShortName'] ?? '';
 
-// Don't render if no condition question key is set.
-if ( empty( $condition_question_key ) ) {
+// Don't render if the controlling reference is missing for the active source:
+// a question key for the question source, or an option short name for the
+// event-option source.
+if ( 'eventOption' === $condition_source ) {
+	if ( empty( $condition_option_short_name ) ) {
+		return '';
+	}
+} elseif ( empty( $condition_question_key ) ) {
 	return '';
 }
 
 $wrapper_attributes = get_block_wrapper_attributes(
 	array(
-		'class'                       => 'fair-form-conditional',
-		'data-fair-form-conditional'  => '',
-		'data-condition-question-key' => esc_attr( $condition_question_key ),
-		'data-condition-operator'     => esc_attr( $condition_operator ),
-		'data-condition-value'        => esc_attr( $condition_value ),
+		'class'                            => 'fair-form-conditional',
+		'data-fair-form-conditional'       => '',
+		'data-condition-source'            => esc_attr( $condition_source ),
+		'data-condition-question-key'      => esc_attr( $condition_question_key ),
+		'data-condition-operator'          => esc_attr( $condition_operator ),
+		'data-condition-value'             => esc_attr( $condition_value ),
+		'data-condition-option-short-name' => esc_attr( $condition_option_short_name ),
 	)
 );
 ?>

--- a/fair-audience/src/blocks/shared/__tests__/questionnaire.test.js
+++ b/fair-audience/src/blocks/shared/__tests__/questionnaire.test.js
@@ -1,0 +1,213 @@
+/**
+ * @jest-environment jsdom
+ */
+import { evaluateConditionals } from '../questionnaire.js';
+
+const VISIBLE = 'fair-form-conditional-visible';
+
+/**
+ * Build an option checkbox as the Event Signup render.php emits it.
+ *
+ * @param {Object}  opts            Checkbox config.
+ * @param {string}  opts.name       Field name (ticket_option_ids[] or add_option_ids[]).
+ * @param {string}  opts.shortName  data-option-short-name value.
+ * @param {boolean} opts.checked    Whether it starts checked.
+ * @return {string} The input markup.
+ */
+function optionCheckbox({ name, shortName, checked }) {
+	return `<input type="checkbox" name="${name}" value="1" data-option-short-name="${shortName}"${
+		checked ? ' checked' : ''
+	} />`;
+}
+
+/**
+ * Build a conditional section keyed on an event option.
+ *
+ * @param {Object} opts            Section config.
+ * @param {string} opts.shortName  conditionOptionShortName (omit for the empty case).
+ * @param {string} opts.operator   selected | not_selected.
+ * @param {string} opts.inner      Inner HTML.
+ * @return {string} The section markup.
+ */
+function eventOptionSection({
+	shortName = '',
+	operator = 'selected',
+	inner = '',
+}) {
+	return `<div data-fair-form-conditional data-condition-source="eventOption" data-condition-operator="${operator}" data-condition-option-short-name="${shortName}">${inner}</div>`;
+}
+
+/**
+ * Render markup into a detached <form> and run evaluateConditionals on it.
+ *
+ * @param {string} html Form inner HTML.
+ * @return {HTMLFormElement} The form element.
+ */
+function buildForm(html) {
+	const form = document.createElement('form');
+	form.innerHTML = html;
+	document.body.appendChild(form);
+	evaluateConditionals(form);
+	return form;
+}
+
+afterEach(() => {
+	document.body.innerHTML = '';
+});
+
+describe('evaluateConditionals — eventOption source', () => {
+	it('shows the section when the matching option is selected', () => {
+		const form = buildForm(
+			optionCheckbox({
+				name: 'ticket_option_ids[]',
+				shortName: 'dinner',
+				checked: true,
+			}) +
+				eventOptionSection({
+					shortName: 'dinner',
+					operator: 'selected',
+				})
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(true);
+	});
+
+	it('hides the section when the matching option is not selected', () => {
+		const form = buildForm(
+			optionCheckbox({
+				name: 'ticket_option_ids[]',
+				shortName: 'dinner',
+				checked: false,
+			}) +
+				eventOptionSection({
+					shortName: 'dinner',
+					operator: 'selected',
+				})
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(false);
+	});
+
+	it('inverts visibility for the not_selected operator', () => {
+		const form = buildForm(
+			optionCheckbox({
+				name: 'ticket_option_ids[]',
+				shortName: 'dinner',
+				checked: false,
+			}) +
+				eventOptionSection({
+					shortName: 'dinner',
+					operator: 'not_selected',
+				})
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(true);
+	});
+
+	it('matches options in the "add activities" fieldset too', () => {
+		const form = buildForm(
+			optionCheckbox({
+				name: 'add_option_ids[]',
+				shortName: 'dinner',
+				checked: true,
+			}) +
+				eventOptionSection({
+					shortName: 'dinner',
+					operator: 'selected',
+				})
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(true);
+	});
+
+	it('hides the section when the short name is empty', () => {
+		const form = buildForm(
+			optionCheckbox({
+				name: 'ticket_option_ids[]',
+				shortName: 'dinner',
+				checked: true,
+			}) + eventOptionSection({ shortName: '', operator: 'selected' })
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(false);
+	});
+
+	it('keeps an inner section hidden when its parent conditional is hidden, even if its option is selected', () => {
+		// Outer conditional is keyed on a different, unselected option, so it
+		// stays hidden; the inner one is keyed on a selected option but must
+		// remain hidden because of the hidden ancestor.
+		const form = buildForm(
+			optionCheckbox({
+				name: 'ticket_option_ids[]',
+				shortName: 'breakfast',
+				checked: false,
+			}) +
+				optionCheckbox({
+					name: 'ticket_option_ids[]',
+					shortName: 'dinner',
+					checked: true,
+				}) +
+				eventOptionSection({
+					shortName: 'breakfast',
+					operator: 'selected',
+					inner: eventOptionSection({
+						shortName: 'dinner',
+						operator: 'selected',
+					}),
+				})
+		);
+		const [outer, inner] = form.querySelectorAll(
+			'[data-fair-form-conditional]'
+		);
+		expect(outer.classList.contains(VISIBLE)).toBe(false);
+		expect(inner.classList.contains(VISIBLE)).toBe(false);
+	});
+
+	it('shows a nested section when both its option and its ancestor are visible', () => {
+		const form = buildForm(
+			optionCheckbox({
+				name: 'ticket_option_ids[]',
+				shortName: 'breakfast',
+				checked: true,
+			}) +
+				optionCheckbox({
+					name: 'ticket_option_ids[]',
+					shortName: 'dinner',
+					checked: true,
+				}) +
+				eventOptionSection({
+					shortName: 'breakfast',
+					operator: 'selected',
+					inner: eventOptionSection({
+						shortName: 'dinner',
+						operator: 'selected',
+					}),
+				})
+		);
+		const [outer, inner] = form.querySelectorAll(
+			'[data-fair-form-conditional]'
+		);
+		expect(outer.classList.contains(VISIBLE)).toBe(true);
+		expect(inner.classList.contains(VISIBLE)).toBe(true);
+	});
+});
+
+describe('evaluateConditionals — question source (regression)', () => {
+	it('still shows a question-keyed section when its answer matches', () => {
+		const form = buildForm(
+			`<div data-fair-form-question data-question-key="color" data-question-type="short_text"><input type="text" value="blue" /></div>` +
+				`<div data-fair-form-conditional data-condition-source="question" data-condition-question-key="color" data-condition-operator="equals" data-condition-value="blue"></div>`
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(true);
+	});
+
+	it('treats a missing conditionSource as the question source', () => {
+		const form = buildForm(
+			`<div data-fair-form-question data-question-key="color" data-question-type="short_text"><input type="text" value="red" /></div>` +
+				`<div data-fair-form-conditional data-condition-question-key="color" data-condition-operator="equals" data-condition-value="blue"></div>`
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(false);
+	});
+});

--- a/fair-audience/src/blocks/shared/questionnaire.js
+++ b/fair-audience/src/blocks/shared/questionnaire.js
@@ -58,13 +58,64 @@ function evaluateCondition(currentValue, operator, expectedValue) {
 }
 
 /**
- * Show/hide conditional sections based on their controlling question's value.
+ * Whether an event ticket option (identified by its short name) is currently
+ * checked, across both the main options and the post-signup "add activities"
+ * fieldsets.
+ *
+ * @param {HTMLElement} form      The form (or container) element.
+ * @param {string}      shortName The option's short name.
+ * @return {boolean} Whether a matching option checkbox is checked.
+ */
+function isEventOptionSelected(form, shortName) {
+	const escaped =
+		typeof CSS !== 'undefined' && CSS.escape
+			? CSS.escape(shortName)
+			: shortName;
+	return !!form.querySelector(
+		`input[name="ticket_option_ids[]"][data-option-short-name="${escaped}"]:checked,` +
+			`input[name="add_option_ids[]"][data-option-short-name="${escaped}"]:checked`
+	);
+}
+
+/**
+ * Resolve whether a conditional section keyed on an event option should show,
+ * honoring the selected/not_selected operator and an empty short name.
+ *
+ * @param {HTMLElement} form    The form (or container) element.
+ * @param {HTMLElement} section The conditional section element.
+ * @return {boolean} Whether the section's own condition is met.
+ */
+function evaluateEventOptionCondition(form, section) {
+	const shortName = section.dataset.conditionOptionShortName;
+	if (!shortName) {
+		return false;
+	}
+	const selected = isEventOptionSelected(form, shortName);
+	return section.dataset.conditionOperator === 'not_selected'
+		? !selected
+		: selected;
+}
+
+/**
+ * Show/hide conditional sections based on their controlling question's value
+ * (the default "question" source) or whether an event option is selected (the
+ * "eventOption" source).
  *
  * @param {HTMLElement} form The form (or container) element.
  */
 export function evaluateConditionals(form) {
 	const conditionals = form.querySelectorAll('[data-fair-form-conditional]');
 	conditionals.forEach((section) => {
+		if (section.dataset.conditionSource === 'eventOption') {
+			// A section nested inside a hidden conditional stays hidden
+			// regardless of its own condition.
+			const visible =
+				isQuestionVisible(section.parentElement) &&
+				evaluateEventOptionCondition(form, section);
+			section.classList.toggle('fair-form-conditional-visible', visible);
+			return;
+		}
+
 		const questionKey = section.dataset.conditionQuestionKey;
 		const operator = section.dataset.conditionOperator;
 		const expectedValue = section.dataset.conditionValue;


### PR DESCRIPTION
## Summary

Extends the **Conditional Section** block so that, inside an **Event Signup**, it can show/hide its inner fields based on whether an event ticket option is selected — keyed on the option's `short_name` (a stable, human-entered handle, since a form's options are runtime data the editor can't enumerate). Organizers can now reveal e.g. a "dietary restrictions" group only when the "dinner" option is checked.

Closes #681.

- **Event Signup checkboxes** now carry `data-option-short-name` on both the main `ticket_option_ids[]` and the post-signup `add_option_ids[]` fieldsets.
- **Conditional block** gains a Question / **Event option** source toggle (shown only inside an Event Signup), with a short-name field and an **is selected / is not selected** operator pair.
- The existing **Question** source is unchanged and now also resolves sibling questions nested inside an Event Signup (via #615).
- The shared frontend evaluator (`questionnaire.js`) branches on the condition source, matches both fieldsets, honors the empty-short-name guard, and re-uses the existing nested-visibility rules.

## Notes

- Per the issue's recommendations: dedicated `selected`/`not_selected` operators, both fieldsets count, empty short name renders nothing.
- Presentation logic only — no new REST surface or persisted input.
- The e2e seed (`seed-conditional-signup.php`) is mounted via the mu-plugins mapping, which applies on a fresh `wp-env start` (CI's `test:e2e:setup`). The equivalent show/hide behavior was verified manually against the running tests instance.

## Test plan

- [x] `npm run test:js` (fair-audience) — new jsdom unit test for `evaluateConditionals`' `eventOption` branch: selected/not_selected, both fieldsets, empty short name, nested (hidden ancestor + both-visible), plus question-source regression.
- [x] `npm run build` (fair-audience) — built assets confirmed live in the wp-env tests instance.
- [x] Manual browser check against a seeded event: the field is hidden on load, shown when "dinner" is checked, hidden again when unchecked.
- [x] phpcs — zero new violations introduced.
- [ ] `npm run test:e2e` (`conditional-signup-fields.spec.js`) on a fresh `test:e2e:setup`.