### PR TITLE
Replace subscription-link button with event-page link in mail editors

### DIFF
--- a/fair-audience/src/Admin/custom-mail/CustomMail.js
+++ b/fair-audience/src/Admin/custom-mail/CustomMail.js
@@ -594,18 +594,26 @@ export default function CustomMail() {
 									isSmall
 									onClick={() =>
 										insertPlaceholderLink(
-											'{manage_subscription_url}',
+											'{event_page_url}',
 											__(
-												'Manage your preferences',
+												'Open event page',
 												'fair-audience'
 											)
 										)
 									}
-									disabled={isSending}
+									disabled={isSending || !eventDateId}
 									style={{ marginLeft: '8px' }}
+									title={
+										!eventDateId
+											? __(
+													'Select an event below to enable this link.',
+													'fair-audience'
+											  )
+											: undefined
+									}
 								>
 									{__(
-										'Insert subscription link',
+										'Insert event page link',
 										'fair-audience'
 									)}
 								</Button>

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -1032,6 +1032,18 @@ class EmailService {
 			$content = str_replace( '{manage_subscription_url}', esc_url( $url ), $content );
 		}
 
+		if ( false !== strpos( $content, '{event_page_url}' ) ) {
+			$post_id = 0;
+			if ( $event_date_id > 0 && class_exists( \FairEvents\Models\EventDates::class ) ) {
+				$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+				if ( $event_date && ! empty( $event_date->event_id ) ) {
+					$post_id = (int) $event_date->event_id;
+				}
+			}
+			$url     = ParticipantToken::get_url( $participant->id, $event_date_id, $post_id );
+			$content = str_replace( '{event_page_url}', esc_url( $url ), $content );
+		}
+
 		if ( false !== strpos( $content, '{unsubscribe_link}' ) ) {
 			$url     = ManageSubscriptionToken::get_url( $participant->id );
 			$content = str_replace( '{unsubscribe_link}', esc_url( $url ), $content );

--- a/fair-events/src/Admin/manage-event/MailBodyEditor.js
+++ b/fair-events/src/Admin/manage-event/MailBodyEditor.js
@@ -156,13 +156,13 @@ export default function MailBodyEditor({ value, onChange, disabled }) {
 					isSmall
 					onClick={() =>
 						insertPlaceholderLink(
-							'{manage_subscription_url}',
-							__('Manage your preferences', 'fair-events')
+							'{event_page_url}',
+							__('Open event page', 'fair-events')
 						)
 					}
 					disabled={disabled}
 				>
-					{__('Insert subscription link', 'fair-events')}
+					{__('Insert event page link', 'fair-events')}
 				</Button>
 
 				<span


### PR DESCRIPTION
## Why

In the fair-events manage-event mailings tab and the fair-audience custom mail page, the 'Insert subscription link' button inserted `{manage_subscription_url}` — a link to the preferences page. For event-related mailings that's rarely what you want; the useful link is the event page itself with a `participant_token`, so the recipient arrives already identified (signup state, photo upload, signups list all work).

## What

- New `{event_page_url}` placeholder resolved in `EmailService::replace_placeholders`. Looks up the event date → `event_id` (post) via `FairEvents\\Models\\EventDates`, then `ParticipantToken::get_url(participant, event_date_id, post_id)`. Falls back to `home_url('/')` + token if the event post can't be resolved (mirrors the existing `{photo_upload_url}` fallback).
- `MailBodyEditor.js` (fair-events): button repurposed; always enabled (the tab is always in event context).
- `CustomMail.js` (fair-audience): button repurposed; disabled until the Event select has a value, with a tooltip explaining why.

## Compatibility

`{manage_subscription_url}` is still resolved server-side, so existing drafts and scheduled mailings that reference it keep working.

## Test plan

- Open `/wp-admin/admin.php?page=fair-audience-custom-mail`: button is disabled with a tooltip until an event is selected; once selected, inserting it produces `<a href="{event_page_url}">Open event page</a>`. Send a mail and confirm the rendered link points at the event permalink with `?participant_token=…`.
- Open the manage-event mailings tab: button is always enabled, inserts the same placeholder, and resolves at send time.