### PR TITLE
Include custom signup answers in signup confirmation email

### DIFF
--- a/.changeset/signup-email-custom-answers.md
+++ b/.changeset/signup-email-custom-answers.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": patch
+---
+
+Include the attendee's custom signup question answers in the signup confirmation email (free and paid signups). File-upload answers render as a link to the attachment; multiselect answers render as a readable list. Answer formatting is shared with the form-confirmation and form-notification emails.

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -645,7 +645,7 @@ class EventSignupController extends WP_REST_Controller {
 		$this->snapshot_options_on_signup( $event_date_id, $participant->id, $option_items );
 
 		$option_names = array_map( fn( $o ) => $o->name, $option_items );
-		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names );
+		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names, (int) $event_date_id );
 
 		AudienceSession::set( (int) $participant->id );
 
@@ -2282,7 +2282,7 @@ class EventSignupController extends WP_REST_Controller {
 		$this->snapshot_options_on_signup( $event_date_id, $participant->id, $option_items );
 
 		$option_names = array_map( fn( $o ) => $o->name, $option_items );
-		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names );
+		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names, (int) $event_date_id );
 
 		if ( $is_new_participant ) {
 			AudienceSession::set( (int) $participant->id );

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -579,7 +579,7 @@ class PaymentHooks {
 		);
 
 		$email_service = new EmailService();
-		$email_service->send_signup_payment_confirmation( $participant, $event, $transaction, $option_names );
+		$email_service->send_signup_payment_confirmation( $participant, $event, $transaction, $option_names, (int) $event_participant->event_date_id );
 	}
 
 	/**

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -17,6 +17,8 @@ use FairAudience\Database\ExtraMessageRepository;
 use FairAudience\Database\FeeRepository;
 use FairAudience\Database\FeePaymentRepository;
 use FairAudience\Database\FeeAuditLogRepository;
+use FairAudience\Database\QuestionnaireSubmissionRepository;
+use FairAudience\Database\QuestionnaireAnswerRepository;
 use FairAudience\Models\Participant;
 use FairAudience\Services\EmailType;
 use FairAudience\Services\AudienceSignupToken;
@@ -763,23 +765,7 @@ class EmailService {
 			$site_name
 		);
 
-		// Build answers table rows.
-		$answers_html = '';
-		foreach ( $answers as $answer ) {
-			$question_text = esc_html( $answer['question_text'] ?? '' );
-			$answer_value  = $answer['answer_value'] ?? '';
-
-			// Checkbox values are JSON-encoded arrays — display comma-separated.
-			$decoded = json_decode( $answer_value, true );
-			if ( is_array( $decoded ) ) {
-				$answer_value = implode( ', ', $decoded );
-			}
-
-			$answers_html .= '<tr>
-				<td style="padding: 8px 12px; border-bottom: 1px solid #eeeeee; font-weight: bold; vertical-align: top; width: 40%;">' . $question_text . '</td>
-				<td style="padding: 8px 12px; border-bottom: 1px solid #eeeeee;">' . esc_html( $answer_value ) . '</td>
-			</tr>';
-		}
+		$answers_html = $this->render_answer_rows( $answers );
 
 		// Build HTML message body.
 		$message = '<!DOCTYPE html>
@@ -1866,26 +1852,7 @@ class EmailService {
 			<td style="padding: 8px 12px; border-bottom: 1px solid #eeeeee;"><a href="mailto:' . esc_attr( $submitter_email ) . '" style="color: #0073aa;">' . esc_html( $submitter_email ) . '</a></td>
 		</tr>';
 
-		// Build answers table rows.
-		$answers_html = '';
-		foreach ( $answers as $answer ) {
-			if ( 'file_upload' === ( $answer['question_type'] ?? '' ) ) {
-				continue;
-			}
-
-			$question_text = esc_html( $answer['question_text'] ?? '' );
-			$answer_value  = $answer['answer_value'] ?? '';
-
-			$decoded = json_decode( $answer_value, true );
-			if ( is_array( $decoded ) ) {
-				$answer_value = implode( ', ', $decoded );
-			}
-
-			$answers_html .= '<tr>
-				<td style="padding: 8px 12px; border-bottom: 1px solid #eeeeee; font-weight: bold; vertical-align: top; width: 40%;">' . $question_text . '</td>
-				<td style="padding: 8px 12px; border-bottom: 1px solid #eeeeee;">' . esc_html( $answer_value ) . '</td>
-			</tr>';
-		}
+		$answers_html = $this->render_answer_rows( $answers );
 
 		$context_html = '';
 		if ( ! empty( $page_title ) ) {
@@ -1966,6 +1933,66 @@ class EmailService {
 	}
 
 	/**
+	 * Render questionnaire answers as `<tr>` rows for the email tables.
+	 *
+	 * Shared by signup-answers, form-confirmation, form-notification and signup
+	 * confirmation emails so the formatting stays in one place.
+	 *
+	 * Accepts both array-shaped answers (as produced by the REST request) and
+	 * QuestionnaireAnswer model objects (as returned by the repository).
+	 * `multiselect` values arrive JSON-encoded — those are decoded to a
+	 * comma-joined list. `file_upload` values are the attachment ID; resolve
+	 * to a clickable link when possible, otherwise render the raw value.
+	 *
+	 * @param array $answers Array of answer arrays or QuestionnaireAnswer objects.
+	 * @return string `<tr>...</tr>` markup, or '' when nothing renderable.
+	 */
+	private function render_answer_rows( array $answers ): string {
+		$rows = '';
+		foreach ( $answers as $answer ) {
+			$question_text = is_object( $answer ) ? ( $answer->question_text ?? '' ) : ( $answer['question_text'] ?? '' );
+			$question_type = is_object( $answer ) ? ( $answer->question_type ?? '' ) : ( $answer['question_type'] ?? '' );
+			$answer_value  = is_object( $answer ) ? ( $answer->answer_value ?? '' ) : ( $answer['answer_value'] ?? '' );
+
+			if ( 'file_upload' === $question_type ) {
+				$value_html = '';
+				if ( is_numeric( $answer_value ) ) {
+					$attachment_id  = (int) $answer_value;
+					$attachment_url = wp_get_attachment_url( $attachment_id );
+					if ( $attachment_url ) {
+						$label      = get_the_title( $attachment_id );
+						$value_html = '<a href="' . esc_url( $attachment_url ) . '" style="color: #0073aa;">'
+							. esc_html( $label ? $label : basename( $attachment_url ) )
+							. '</a>';
+					}
+				}
+				if ( '' === $value_html ) {
+					// No resolvable attachment — skip rather than show a stray ID.
+					continue;
+				}
+
+				$rows .= '<tr>
+					<td style="padding: 8px 12px; border-bottom: 1px solid #eeeeee; font-weight: bold; vertical-align: top; width: 40%;">' . esc_html( $question_text ) . '</td>
+					<td style="padding: 8px 12px; border-bottom: 1px solid #eeeeee;">' . $value_html . '</td>
+				</tr>';
+				continue;
+			}
+
+			$decoded = json_decode( (string) $answer_value, true );
+			if ( is_array( $decoded ) ) {
+				$answer_value = implode( ', ', $decoded );
+			}
+
+			$rows .= '<tr>
+				<td style="padding: 8px 12px; border-bottom: 1px solid #eeeeee; font-weight: bold; vertical-align: top; width: 40%;">' . esc_html( $question_text ) . '</td>
+				<td style="padding: 8px 12px; border-bottom: 1px solid #eeeeee;">' . esc_html( $answer_value ) . '</td>
+			</tr>';
+		}
+
+		return $rows;
+	}
+
+	/**
 	 * Send form submission confirmation email to the submitter.
 	 *
 	 * @param Participant $participant Participant who submitted the form.
@@ -1994,26 +2021,7 @@ class EmailService {
 			$site_name
 		);
 
-		// Build answers table rows.
-		$answers_html = '';
-		foreach ( $answers as $answer ) {
-			if ( 'file_upload' === ( $answer['question_type'] ?? '' ) ) {
-				continue;
-			}
-
-			$question_text = esc_html( $answer['question_text'] ?? '' );
-			$answer_value  = $answer['answer_value'] ?? '';
-
-			$decoded = json_decode( $answer_value, true );
-			if ( is_array( $decoded ) ) {
-				$answer_value = implode( ', ', $decoded );
-			}
-
-			$answers_html .= '<tr>
-				<td style="padding: 8px 12px; border-bottom: 1px solid #eeeeee; font-weight: bold; vertical-align: top; width: 40%;">' . $question_text . '</td>
-				<td style="padding: 8px 12px; border-bottom: 1px solid #eeeeee;">' . esc_html( $answer_value ) . '</td>
-			</tr>';
-		}
+		$answers_html = $this->render_answer_rows( $answers );
 
 		$context_html = '';
 		if ( ! empty( $page_title ) ) {
@@ -2123,12 +2131,16 @@ class EmailService {
 	/**
 	 * Send signup confirmation email to the participant.
 	 *
-	 * @param Participant   $participant Participant who signed up.
-	 * @param \WP_Post|null $event       Event post object (nullable).
-	 * @param object|null   $transaction Transaction row from fair-payment (null for free signups).
+	 * @param Participant   $participant   Participant who signed up.
+	 * @param \WP_Post|null $event         Event post object (nullable).
+	 * @param object|null   $transaction   Transaction row from fair-payment (null for free signups).
+	 * @param array         $option_names  Names of the selected ticket-activity options.
+	 * @param int           $event_date_id Event date ID — used to load the signup
+	 *                                     questionnaire answers so they can be
+	 *                                     included in the email. Pass 0 to skip.
 	 * @return bool Success.
 	 */
-	public function send_signup_payment_confirmation( Participant $participant, $event, $transaction = null, $option_names = array() ): bool {
+	public function send_signup_payment_confirmation( Participant $participant, $event, $transaction = null, $option_names = array(), int $event_date_id = 0 ): bool {
 		if ( ! $this->has_valid_email( $participant ) ) {
 			return false;
 		}
@@ -2165,6 +2177,31 @@ class EmailService {
 			$options_html = '
 							<p style="margin: 0 0 8px 0; font-size: 16px; font-weight: bold;">' . esc_html__( 'Selected options:', 'fair-audience' ) . '</p>
 							<ul style="margin: 0 0 20px 20px; padding: 0;">' . $options_list . '</ul>';
+		}
+
+		// Custom signup question answers (Event Signup questionnaire submission).
+		$answers_html = '';
+		if ( $event_date_id > 0 ) {
+			$submission_repo = new QuestionnaireSubmissionRepository();
+			$submissions     = $submission_repo->get_by_filters(
+				array(
+					'participant_id' => (int) $participant->id,
+					'event_date_id'  => $event_date_id,
+					'title'          => __( 'Event Signup', 'fair-audience' ),
+				)
+			);
+
+			if ( ! empty( $submissions ) ) {
+				$answer_repo = new QuestionnaireAnswerRepository();
+				$rows_html   = $this->render_answer_rows( $answer_repo->get_by_submission( $submissions[0]->id ) );
+				if ( '' !== $rows_html ) {
+					$answers_html = '
+							<p style="margin: 0 0 8px 0; font-size: 16px; font-weight: bold;">' . esc_html__( 'Your answers:', 'fair-audience' ) . '</p>
+							<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0 0 20px 0; border: 1px solid #eeeeee; border-radius: 4px;">'
+						. $rows_html
+						. '</table>';
+				}
+			}
 		}
 
 		$message = '<!DOCTYPE html>
@@ -2209,6 +2246,8 @@ class EmailService {
 							' . $payment_html . '
 
 							' . $options_html . '
+
+							' . $answers_html . '
 
 							<p style="margin: 20px 0 0 0; font-size: 14px; color: #666666;">
 								' . sprintf(


### PR DESCRIPTION
Closes #685

## Summary

The Event Signup block collects custom question answers (#615), but they were never echoed back in the signup confirmation email — only the selected ticket-activity options were. This PR fixes that for both free and paid signups, mirroring the Fair Form confirmation flow.

## Changes

- **`EmailService::render_answer_rows()`** — new private helper that produces the `<tr>` rows used by the email answer tables. Accepts both array-shaped answers (from the REST request) and `QuestionnaireAnswer` model objects (from the repository). `multiselect` JSON values are flattened to a comma-joined list; `file_upload` answers now resolve to a clickable link via `wp_get_attachment_url()` instead of being skipped.
- **`send_form_confirmation()`, `send_form_notification()`, `send_audience_signup_answers_email()`** — refactored to call the shared helper. Functional change: file uploads are now rendered as a link rather than dropped from the form emails.
- **`send_signup_payment_confirmation()`** — new optional `int $event_date_id = 0` parameter. When provided, the method loads the "Event Signup" `QuestionnaireSubmission` for `participant_id` + `event_date_id` (same lookup used by `EventParticipantsController::get_signup_answers_by_participant()`) and appends a "Your answers:" table after the "Selected options" block. No section is emitted when there is no submission.
- **Call sites updated** to pass `event_date_id`:
  - `EventSignupController::create_signup()` (free)
  - `EventSignupController::register_and_signup()` (free)
  - `PaymentHooks::send_signup_confirmation_email()` (paid, post Mollie webhook)

## Acceptance criteria

- [x] Custom question answers (question text + value) appear next to the existing ticket options.
- [x] Works for free signups (create + register flows) and paid signups.
- [x] `file_upload` answers render as a link; `multiselect` answers render as a readable list.
- [x] No "Your answers" block appears when the signup has no custom questions.
- [x] Answer formatting shared with `send_form_confirmation` — single `render_answer_rows()` helper.
- [ ] Automated test coverage — **not added.** There is no PHP test harness for `EmailService` in this plugin, and existing email methods are uncovered. The renderer is exercised manually via the WP-CLI `eval-file` recipe in `TESTING.md`. Happy to add a Playwright API-level smoke test if desired.

## Notes / follow-ups

- The admin notification path for signups (analogous to `send_form_notification`) does not exist today and is out of scope here — call out in #685.
- File-upload rendering in the **form-confirmation** email is now consistent with the new signup behavior (link instead of skip). This is the intended unification per the issue; flag in review if the form-email change should instead stay gated.