### PR TITLE
Let logged-in unlinked users self-register on Event Signup (#684)

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -2202,6 +2202,11 @@ class EventSignupController extends WP_REST_Controller {
 					'email'         => $email,
 					'email_profile' => $keep_informed ? 'marketing' : 'minimal',
 					'status'        => $keep_informed ? 'pending' : 'confirmed',
+					// Link to the WP account when the caller is logged in.
+					// Only set on new-participant creation — never claim an
+					// existing-email participant for the current WP user, the
+					// email_recognized branch above guards that case.
+					'wp_user_id'    => $wp_user_id ? $wp_user_id : null,
 				)
 			);
 

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -162,9 +162,24 @@ if ( $is_valid_post_type ) {
 		$participant = $participant_repository->get_by_user_id( $user_id );
 		if ( $participant ) {
 			$state = 'linked';
-		} else {
-			$state = 'not_linked';
 		}
+		// Else: leave $state as 'anonymous' so the visitor falls through to
+		// the self-service registration form. The new participant is linked
+		// to the WP account in EventSignupController::register_and_signup,
+		// so the next page load resolves to 'linked'.
+	}
+
+	// Pre-fill the register form from the WP account when the visitor is
+	// logged in but has no participant yet. Fields remain editable. We
+	// deliberately don't set $has_session_prefill — the "Not you? Start
+	// fresh" button is for cookie-based identity, not WP auth.
+	if ( $user_id && null === $participant ) {
+		$wp_user                 = wp_get_current_user();
+		$session_prefill_name    = $wp_user->first_name
+			? (string) $wp_user->first_name
+			: (string) $wp_user->display_name;
+		$session_prefill_surname = (string) $wp_user->last_name;
+		$session_prefill_email   = (string) $wp_user->user_email;
 	}
 
 	// Check if already signed up (prefer event_date_id if available).
@@ -879,7 +894,9 @@ $wrapper_attributes = get_block_wrapper_attributes(
 );
 ?>
 
-<?php if ( ! $is_valid_post_type ) : ?>
+<?php
+if ( ! $is_valid_post_type ) :
+	?>
 <p class="fair-audience-event-signup-error">
 	<?php echo esc_html__( 'This block can only be used on event pages.', 'fair-audience' ); ?>
 </p>
@@ -1092,16 +1109,11 @@ $wrapper_attributes = get_block_wrapper_attributes(
 			<div class="fair-audience-signup-message" style="display: none;"></div>
 		</div>
 
-	<?php elseif ( 'not_linked' === $state ) : ?>
-		<!-- Logged in but no linked participant -->
-		<div class="fair-audience-signup-not-linked">
-			<p><?php echo esc_html__( 'Your WordPress account is not linked to a participant profile. Please contact the site administrator.', 'fair-audience' ); ?></p>
-		</div>
-
 	<?php else : ?>
-		<!-- Anonymous: show tabs with forms -->
+		<!-- Anonymous (or logged-in but unlinked): self-service form. -->
 		<div class="fair-audience-signup-anonymous">
 			<?php $render_occurrence_picker(); ?>
+			<?php if ( ! $user_id ) : ?>
 			<div class="fair-audience-signup-tabs">
 				<button type="button" class="fair-audience-signup-tab active" data-tab="register">
 					<?php echo esc_html__( "I'm new", 'fair-audience' ); ?>
@@ -1110,6 +1122,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 					<?php echo esc_html__( 'I have an account', 'fair-audience' ); ?>
 				</button>
 			</div>
+			<?php endif; ?>
 
 			<!-- Registration form (new participant) -->
 			<form class="fair-audience-signup-form fair-audience-signup-register" data-tab-content="register">
@@ -1181,7 +1194,10 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				<div class="fair-audience-signup-message" style="display: none;"></div>
 			</form>
 
-			<!-- Request link form (existing participant) -->
+			<!-- Request link form (existing participant). Hidden for
+				logged-in users — they're already authenticated, so the
+				resume-by-email path is redundant. -->
+			<?php if ( ! $user_id ) : ?>
 			<form class="fair-audience-signup-form fair-audience-signup-request-link" data-tab-content="request-link" style="display: none;">
 				<p class="fair-audience-signup-info">
 					<?php echo esc_html__( 'Enter your email to receive a signup link.', 'fair-audience' ); ?>
@@ -1207,6 +1223,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 
 				<div class="fair-audience-signup-message" style="display: none;"></div>
 			</form>
+			<?php endif; ?>
 		</div>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
Closes #684.

## Problem

When a logged-in WP user has no linked participant profile, the Event
Signup block hits a dead-end notice — *"Your WordPress account is not
linked to a participant profile. Please contact the site administrator."*
Anonymous visitors can already self-register; an authenticated visitor —
a stronger identity — was worse off.

## Change

Route unlinked logged-in users through the same self-service form as
anonymous visitors, prefilled from their WP account, and link the new
participant to their WP user on creation so the next page load resolves
to `linked`.

### `fair-audience/src/blocks/event-signup/render.php`

- Drop the `not_linked` state and its dead-end branch.
- Prefill register-form name/email from `wp_get_current_user()`
  (`first_name` → fall back to `display_name`; `last_name` passes
  through; `user_email`). Fields stay editable. No *"Not you?"* button —
  that affordance is for cookie-based identity, not WP auth.
- Hide the *"I have an account"* tab and the request-link form for
  logged-in users; the resume-by-email path is meaningless once
  authenticated.

### `fair-audience/src/API/EventSignupController.php`

- Set `wp_user_id` on the new `Participant` when the caller is logged in.
- **Only on new-participant creation.** The existing `email_recognized`
  branch is unchanged: if an unlinked logged-in user types an email that
  matches a *different* existing participant and the browser session
  doesn't already hold them, the controller still sends a resume link
  rather than letting the WP account silently claim that participant.

## Acceptance criteria

- [x] Logged-in unlinked user sees the self-service signup form.
- [x] Form is prefilled from the WP account and remains editable.
- [x] Completing registration sets `wp_user_id`; reload shows `linked` state.
- [x] Typing a different existing participant's email still routes through
      `email_recognized` (no silent linking).
- [x] No regression for `linked`, `with_token`, or anonymous flows.
- [ ] API spec + e2e per TESTING.md — to follow once the event-seeding
      harness from the Basic QC milestone lands.

## Test plan (manual)

1. Log in as a fresh WP user with no participant row → register form
   appears, prefilled with WP name + email.
2. Submit → reload → `linked` greeting + "Cancel signup". Verify
   `wp_user_id` is set on the row.
3. Log out → anonymous flow unchanged.
4. Log in as a user already linked → `linked` flow unchanged.
5. Log in as user A, type user B's email → `email_recognized` resume
   link, no auto-link.