### PR TITLE
Introduce feature-flag registry in fair-events (#654)

### DIFF
--- a/.changeset/fair-events-feature-flag-registry.md
+++ b/.changeset/fair-events-feature-flag-registry.md
@@ -1,0 +1,12 @@
+---
+"fair-events": minor
+---
+
+Introduce a feature-flag registry (`FairEvents\Core\Features`) that splits the
+plugin into bundles — `venues`, `sources`, `galleries`, `ticketing`,
+`event-tools`, `migration` — defaulting **off** for a clean public install.
+Define `FAIR_EVENTS_INTERNAL` (or a per-bundle `FAIR_EVENTS_FEATURE_*`
+constant) in `wp-config.php` to opt back into the full build; otherwise toggle
+bundles from the new **Settings → Features** tab. REST controllers, admin
+pages, blocks, frontend rewrites, and manage-event tabs all consult the
+registry, so disabled bundles register no routes and surface no UI.

--- a/e2e/fair-events-admin-menu.spec.js
+++ b/e2e/fair-events-admin-menu.spec.js
@@ -29,6 +29,27 @@ function wpCli(args) {
 	});
 }
 
+/**
+ * Turn every #654 feature bundle on. This suite covers the #656 menu/CPT
+ * decoupling, which assumes the full page inventory exists — bundle gating
+ * lives in `fair-events-feature-flags.spec.js`.
+ */
+const ALL_BUNDLES_ON = {
+	venues: true,
+	sources: true,
+	galleries: true,
+	ticketing: true,
+	'event-tools': true,
+	migration: true,
+};
+function enableAllBundles() {
+	const json = JSON.stringify(ALL_BUNDLES_ON).replace(/'/g, "'\\''");
+	wpCli(`option update fair_events_features '${json}' --format=json`);
+}
+function clearBundles() {
+	wpCli('option delete fair_events_features');
+}
+
 /** Every Fair Events admin page and its React root element id. */
 const PAGES = [
 	{ slug: 'fair-events-calendar', root: 'fair-events-calendar-root' },
@@ -89,8 +110,14 @@ const MIGRATION_LINK =
 
 test.describe('Fair Events admin menu — CPT registered (regression)', () => {
 	test.beforeAll(() => {
-		// Default state: Events post type on.
+		// Default state: Events post type on, all bundles on (so every page
+		// in PAGES is registered — bundle gating is covered separately).
 		wpCli('option update fair_events_register_post_type 1');
+		enableAllBundles();
+	});
+
+	test.afterAll(() => {
+		clearBundles();
 	});
 
 	test('one top-level Fair Events menu, Calendar first and Settings last', async ({
@@ -143,11 +170,13 @@ test.describe('Fair Events admin menu — CPT registered (regression)', () => {
 test.describe('Fair Events admin menu — Events post type off', () => {
 	test.beforeAll(() => {
 		wpCli('option update fair_events_register_post_type 0');
+		enableAllBundles();
 	});
 
 	test.afterAll(() => {
 		// Restore the default so other suites see the CPT registered.
 		wpCli('option update fair_events_register_post_type 1');
+		clearBundles();
 	});
 
 	test('top-level menu and every non-CPT page still mount', async ({

--- a/e2e/fair-events-feature-flags.spec.js
+++ b/e2e/fair-events-feature-flags.spec.js
@@ -1,0 +1,239 @@
+/**
+ * Fair Events feature-flag registry (#654).
+ *
+ * Two branches of the same plugin:
+ *   - simplified public — no bundles set; only `core` is active.
+ *   - full internal — every bundle flipped on via the stored option (the same
+ *     state `FAIR_EVENTS_INTERNAL` produces, exercised through the option
+ *     resolver so we don't have to mutate wp-config from the test).
+ *
+ * For each branch this asserts:
+ *   1. The expected admin pages mount (or stop mounting) their React root.
+ *   2. The expected REST routes register (or 404 with `rest_no_route`).
+ *   3. The Settings → Features tab is reachable in both branches.
+ *
+ * Sibling-plugin dependencies (`fair-audience` for `ticketing`) are not
+ * required for these assertions — the ticketing REST routes register on the
+ * flag alone; controller-level dependency checks (e.g.
+ * GroupPricingRulesController guarding on FAIR_AUDIENCE_PLUGIN_DIR) are
+ * orthogonal and unit-tested elsewhere.
+ *
+ * Run: `npm run test:e2e -- fair-events-feature-flags`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+/** Run a WP-CLI command against the wp-env `tests` instance. */
+function wpCli(args) {
+	return execSync(`npx wp-env run tests-cli wp ${args}`, {
+		cwd: process.cwd(),
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+}
+
+/** Set the `fair_events_features` option to a `{bundle: bool}` map. */
+function setFeatures(map) {
+	const json = JSON.stringify(map).replace(/'/g, "'\\''");
+	wpCli(`option update fair_events_features '${json}' --format=json`);
+}
+
+/** Clear the option entirely — minimal-public defaults. */
+function clearFeatures() {
+	wpCli('option delete fair_events_features');
+}
+
+/** Bundle keys mirror FairEvents\\Core\\Features::registry(). */
+const ALL_BUNDLES_ON = {
+	venues: true,
+	sources: true,
+	galleries: true,
+	ticketing: true,
+	'event-tools': true,
+	migration: true,
+};
+
+/**
+ * Bundle → admin page slug + React root id. Pages without a menu entry are
+ * tested by direct URL so we still catch enqueue/registration regressions.
+ */
+const BUNDLE_PAGES = {
+	venues: [{ slug: 'fair-events-venues', root: 'fair-events-venues-root' }],
+	sources: [
+		{ slug: 'fair-events-sources', root: 'fair-events-sources-root' },
+		{
+			slug: 'fair-events-source-view',
+			root: 'fair-events-source-view-root',
+		},
+	],
+	ticketing: [
+		{
+			slug: 'fair-events-manage-invitations',
+			root: 'fair-events-manage-invitations-root',
+		},
+	],
+	migration: [
+		{
+			slug: 'fair-events-migration',
+			root: 'fair-events-migration-root',
+		},
+		{
+			slug: 'fair-events-migration-summary',
+			root: 'fair-events-migration-summary-root',
+		},
+	],
+};
+
+/**
+ * Bundle → a representative REST route. Probed with GET; a registered route
+ * returns *anything* other than `rest_no_route` (401/403/404 for missing
+ * resource still count as "registered").
+ */
+const BUNDLE_PROBE_ROUTES = {
+	sources: '/fair-events/v1/sources/categories',
+	galleries: '/fair-events/v1/event-dates/1/gallery',
+	ticketing: '/fair-events/v1/event-dates/1/tickets',
+	migration: '/fair-events/v1/migration/post-types',
+};
+
+async function login(page) {
+	await page.goto('/wp-login.php');
+	await page.fill('#user_login', ADMIN_USER);
+	await page.fill('#user_pass', ADMIN_PASSWORD);
+	await page.click('#wp-submit');
+	await expect(page).toHaveURL(/\/wp-admin\/?/);
+}
+
+async function expectRootMounts(page, slug, root) {
+	await page.goto(`/wp-admin/admin.php?page=${slug}`);
+	await expect(
+		page.locator(`#${root}`),
+		`${slug}: React root element missing`
+	).toBeAttached();
+	await expect(
+		page.locator(`#${root} > *`).first(),
+		`${slug}: root is empty — admin bundle did not load`
+	).toBeAttached({ timeout: 15000 });
+}
+
+async function expectPageMissing(page, slug) {
+	await page.goto(`/wp-admin/admin.php?page=${slug}`);
+	// WP renders a "you do not have permission" / "invalid page" notice when
+	// a submenu slug is unregistered. The hallmark is the absence of our
+	// React root rather than any specific copy.
+	const rootCount = await page
+		.locator('[id^="fair-events-"][id$="-root"]')
+		.count();
+	expect(
+		rootCount,
+		`${slug}: should not mount a Fair Events React root when its bundle is off`
+	).toBe(0);
+}
+
+/** True iff WordPress returned a registered route (anything but rest_no_route). */
+async function routeIsRegistered(request, path) {
+	const response = await request.get(`/wp-json${path}`);
+	if (response.status() !== 404) {
+		return true;
+	}
+	let body;
+	try {
+		body = await response.json();
+	} catch {
+		return true; // 404 without rest_no_route shape — treat as registered.
+	}
+	return body?.code !== 'rest_no_route';
+}
+
+test.describe('Fair Events — simplified public build (no bundles set)', () => {
+	test.beforeAll(() => {
+		clearFeatures();
+	});
+
+	test('only core admin pages mount; bundle pages are gone', async ({
+		page,
+	}) => {
+		await login(page);
+
+		// Core pages stay available regardless of feature state.
+		await expectRootMounts(
+			page,
+			'fair-events-calendar',
+			'fair-events-calendar-root'
+		);
+		await expectRootMounts(
+			page,
+			'fair-events-all-events',
+			'fair-events-all-events-root'
+		);
+		await expectRootMounts(
+			page,
+			'fair-events-settings',
+			'fair-events-settings-root'
+		);
+
+		for (const pages of Object.values(BUNDLE_PAGES)) {
+			for (const { slug } of pages) {
+				await expectPageMissing(page, slug);
+			}
+		}
+	});
+
+	test('bundle REST routes 404 with rest_no_route', async ({ request }) => {
+		for (const [bundle, path] of Object.entries(BUNDLE_PROBE_ROUTES)) {
+			expect(
+				await routeIsRegistered(request, path),
+				`${bundle}: ${path} should be unregistered in the minimal build`
+			).toBe(false);
+		}
+	});
+
+	test('Settings page exposes the Features tab', async ({ page }) => {
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-settings');
+		await expect(
+			page.getByRole('tab', { name: 'Features' }),
+			'Features tab should be reachable in every build'
+		).toBeVisible();
+	});
+});
+
+test.describe('Fair Events — full internal build (all bundles on)', () => {
+	test.beforeAll(() => {
+		setFeatures(ALL_BUNDLES_ON);
+	});
+
+	test.afterAll(() => {
+		// Leave the suite in the minimal-public default so other suites
+		// inherit a clean baseline.
+		clearFeatures();
+	});
+
+	test('every bundle page mounts its React root', async ({ page }) => {
+		await login(page);
+		for (const pages of Object.values(BUNDLE_PAGES)) {
+			for (const { slug, root } of pages) {
+				await expectRootMounts(page, slug, root);
+			}
+		}
+	});
+
+	test('bundle REST routes are registered', async ({ request }) => {
+		for (const [bundle, path] of Object.entries(BUNDLE_PROBE_ROUTES)) {
+			expect(
+				await routeIsRegistered(request, path),
+				`${bundle}: ${path} should be registered in the internal build`
+			).toBe(true);
+		}
+	});
+
+	test('Settings page still exposes the Features tab', async ({ page }) => {
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-settings');
+		await expect(page.getByRole('tab', { name: 'Features' })).toBeVisible();
+	});
+});

--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -129,8 +129,9 @@ class AdminPages {
 			array( $this, 'render_settings_page' )
 		);
 
-		// Migration pages only make sense when the CPT exists (migration targets it).
-		if ( post_type_exists( 'fair_event' ) ) {
+		// Migration pages only make sense when the CPT exists (migration
+		// targets it) AND the `migration` feature bundle is enabled.
+		if ( \FairEvents\Core\Features::is_enabled( 'migration' ) && post_type_exists( 'fair_event' ) ) {
 			// Migration page
 			$this->page_hooks['fair-events-migration'] = add_submenu_page(
 				$parent,
@@ -152,25 +153,41 @@ class AdminPages {
 			);
 		}
 
-		// Event Sources page
-		$this->page_hooks['fair-events-sources'] = add_submenu_page(
-			$parent,
-			__( 'Event Sources', 'fair-events' ),
-			__( 'Event Sources', 'fair-events' ),
-			'manage_options',
-			'fair-events-sources',
-			array( $this, 'render_sources_page' )
-		);
+		// Event Sources page — `sources` bundle.
+		if ( \FairEvents\Core\Features::is_enabled( 'sources' ) ) {
+			$this->page_hooks['fair-events-sources'] = add_submenu_page(
+				$parent,
+				__( 'Event Sources', 'fair-events' ),
+				__( 'Event Sources', 'fair-events' ),
+				'manage_options',
+				'fair-events-sources',
+				array( $this, 'render_sources_page' )
+			);
 
-		// Venues page
-		$this->page_hooks['fair-events-venues'] = add_submenu_page(
-			$parent,
-			__( 'Venues', 'fair-events' ),
-			__( 'Venues', 'fair-events' ),
-			'manage_options',
-			'fair-events-venues',
-			array( $this, 'render_venues_page' )
-		);
+			// Source View page (hidden from menu, accessed via sources list).
+			$this->page_hooks['fair-events-source-view'] = add_submenu_page(
+				'',
+				__( 'View Source', 'fair-events' ),
+				__( 'View Source', 'fair-events' ),
+				'manage_options',
+				'fair-events-source-view',
+				array( $this, 'render_source_view_page' )
+			);
+
+			$this->set_hidden_page_title( $this->page_hooks['fair-events-source-view'], __( 'View Source', 'fair-events' ) );
+		}
+
+		// Venues page — `venues` bundle.
+		if ( \FairEvents\Core\Features::is_enabled( 'venues' ) ) {
+			$this->page_hooks['fair-events-venues'] = add_submenu_page(
+				$parent,
+				__( 'Venues', 'fair-events' ),
+				__( 'Venues', 'fair-events' ),
+				'manage_options',
+				'fair-events-venues',
+				array( $this, 'render_venues_page' )
+			);
+		}
 
 		// Manage Event page (hidden from menu, accessed via calendar)
 		$this->page_hooks['fair-events-manage-event'] = add_submenu_page(
@@ -182,44 +199,41 @@ class AdminPages {
 			array( $this, 'render_manage_event_page' )
 		);
 
-		// Source View page (hidden from menu, accessed via sources list)
-		$this->page_hooks['fair-events-source-view'] = add_submenu_page(
-			'', // Hidden from menu (empty string instead of null for PHP 8.1+ compatibility)
-			__( 'View Source', 'fair-events' ),
-			__( 'View Source', 'fair-events' ),
-			'manage_options',
-			'fair-events-source-view',
-			array( $this, 'render_source_view_page' )
-		);
+		// Manage Invitations page — `ticketing` bundle (hidden, linked from
+		// the tickets tab).
+		if ( \FairEvents\Core\Features::is_enabled( 'ticketing' ) ) {
+			$this->page_hooks['fair-events-manage-invitations'] = add_submenu_page(
+				'',
+				__( 'Manage Invitations', 'fair-events' ),
+				__( 'Manage Invitations', 'fair-events' ),
+				'manage_options',
+				'fair-events-manage-invitations',
+				array( $this, 'render_manage_invitations_page' )
+			);
 
-		// Manage Invitations page (hidden from menu, accessed via tickets tab)
-		$this->page_hooks['fair-events-manage-invitations'] = add_submenu_page(
-			'', // Hidden from menu (empty string instead of null for PHP 8.1+ compatibility)
-			__( 'Manage Invitations', 'fair-events' ),
-			__( 'Manage Invitations', 'fair-events' ),
-			'manage_options',
-			'fair-events-manage-invitations',
-			array( $this, 'render_manage_invitations_page' )
-		);
+			$this->set_hidden_page_title( $this->page_hooks['fair-events-manage-invitations'], __( 'Manage Invitations', 'fair-events' ) );
+		}
 
-		// Copy Event page (hidden from menu, accessed via row action)
-		$this->page_hooks['fair-events-copy'] = add_submenu_page(
-			'', // Hidden from menu (empty string instead of null for PHP 8.1+ compatibility)
-			__( 'Copy Event', 'fair-events' ),
-			__( 'Copy Event', 'fair-events' ),
-			'edit_posts',
-			'fair-events-copy',
-			array( $this, 'render_copy_event_page' )
-		);
+		// Copy Event page — `event-tools` bundle (hidden, linked from row
+		// action / admin bar).
+		if ( \FairEvents\Core\Features::is_enabled( 'event-tools' ) ) {
+			$this->page_hooks['fair-events-copy'] = add_submenu_page(
+				'',
+				__( 'Copy Event', 'fair-events' ),
+				__( 'Copy Event', 'fair-events' ),
+				'edit_posts',
+				'fair-events-copy',
+				array( $this, 'render_copy_event_page' )
+			);
 
-		// Set page titles for hidden pages to prevent strip_tags() deprecation warning.
+			$this->set_hidden_page_title( $this->page_hooks['fair-events-copy'], __( 'Copy Event', 'fair-events' ) );
+
+			// Handle copy event form submission before page render.
+			add_action( 'load-' . $this->page_hooks['fair-events-copy'], array( $this, 'handle_copy_event_submission' ) );
+		}
+
+		// Manage Event hidden-page title (always on; the page itself is core).
 		$this->set_hidden_page_title( $this->page_hooks['fair-events-manage-event'], __( 'Manage Event', 'fair-events' ) );
-		$this->set_hidden_page_title( $this->page_hooks['fair-events-source-view'], __( 'View Source', 'fair-events' ) );
-		$this->set_hidden_page_title( $this->page_hooks['fair-events-manage-invitations'], __( 'Manage Invitations', 'fair-events' ) );
-		$this->set_hidden_page_title( $this->page_hooks['fair-events-copy'], __( 'Copy Event', 'fair-events' ) );
-
-		// Handle copy event form submission before page render
-		add_action( 'load-' . $this->page_hooks['fair-events-copy'], array( $this, 'handle_copy_event_submission' ) );
 	}
 
 	/**
@@ -532,13 +546,20 @@ class AdminPages {
 				'calendarUrl'      => admin_url( 'admin.php?page=fair-events-calendar' ),
 				'manageEventUrl'   => admin_url( 'admin.php?page=fair-events-manage-event' ),
 				'enabledPostTypes' => $enabled_post_types,
+				// Resolved feature map — React reads this to hide tabs whose
+				// bundle is off (mirroring the existing audienceUrl /
+				// paymentEntriesUrl conditionals).
+				'enabledFeatures'  => \FairEvents\Core\Features::public_map(),
 			);
 
-			// Add audience URL and group pricing flag if fair-audience plugin is active.
+			// Audience-dependent URLs require both the sibling plugin AND the
+			// ticketing/invitations bundle (manage-invitations page lives there).
 			if ( defined( 'FAIR_AUDIENCE_PLUGIN_DIR' ) ) {
-				$localized_data['audienceUrl']          = admin_url( 'admin.php?page=fair-audience-event-participants&event_date_id=' );
-				$localized_data['groupPricingEnabled']  = true;
-				$localized_data['manageInvitationsUrl'] = admin_url( 'admin.php?page=fair-events-manage-invitations&event_date_id=' );
+				$localized_data['audienceUrl']         = admin_url( 'admin.php?page=fair-audience-event-participants&event_date_id=' );
+				$localized_data['groupPricingEnabled'] = \FairEvents\Core\Features::is_enabled( 'ticketing' );
+				if ( \FairEvents\Core\Features::is_enabled( 'ticketing' ) ) {
+					$localized_data['manageInvitationsUrl'] = admin_url( 'admin.php?page=fair-events-manage-invitations&event_date_id=' );
+				}
 			}
 
 			// Add payment entries URL if fair-payment plugin is active.
@@ -605,6 +626,11 @@ class AdminPages {
 				'fairEventsSettingsData',
 				array(
 					'eventsApiUrl' => rest_url( 'fair-events/v1/events' ),
+					// Feature registry (labels/descriptions/forced state) for the
+					// Features tab; resolved enabled state comes via the stored
+					// option once toggles are saved, but the registry itself is
+					// PHP-owned.
+					'features'     => \FairEvents\Core\Features::all(),
 				)
 			);
 
@@ -920,6 +946,12 @@ class AdminPages {
 	public function add_copy_button_to_admin_bar( $wp_admin_bar ) {
 		// Only show on event edit pages in admin
 		if ( ! is_admin() ) {
+			return;
+		}
+
+		// The Copy flow lives in the `event-tools` bundle — without it
+		// enabled the target admin page is not registered.
+		if ( ! \FairEvents\Core\Features::is_enabled( 'event-tools' ) ) {
 			return;
 		}
 

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -55,6 +55,12 @@ export default function ManageEventApp() {
 	const audienceUrl = window.fairEventsManageEventData?.audienceUrl || '';
 	const paymentEntriesUrl =
 		window.fairEventsManageEventData?.paymentEntriesUrl || '';
+	// Per-bundle feature gates from the PHP registry. Empty object → treat
+	// every bundle as off (fail-closed) on a misconfigured page.
+	const enabledFeatures =
+		window.fairEventsManageEventData?.enabledFeatures || {};
+	const galleriesEnabled = !!enabledFeatures.galleries;
+	const ticketingEnabled = !!enabledFeatures.ticketing;
 
 	const [eventDate, setEventDate] = useState(null);
 	const [loading, setLoading] = useState(true);
@@ -562,12 +568,16 @@ export default function ManageEventApp() {
 				name: 'links',
 				title: __('Links', 'fair-events'),
 			},
-			{
-				name: 'tickets',
-				title: __('Tickets', 'fair-events'),
-				disabled: isGeneratedOccurrence,
-			},
-			...(audienceUrl
+			...(ticketingEnabled
+				? [
+						{
+							name: 'tickets',
+							title: __('Tickets', 'fair-events'),
+							disabled: isGeneratedOccurrence,
+						},
+				  ]
+				: []),
+			...(ticketingEnabled && audienceUrl
 				? [
 						{
 							name: 'groups',
@@ -576,10 +586,14 @@ export default function ManageEventApp() {
 						},
 				  ]
 				: []),
-			{
-				name: 'photos',
-				title: __('Photos', 'fair-events'),
-			},
+			...(galleriesEnabled
+				? [
+						{
+							name: 'photos',
+							title: __('Photos', 'fair-events'),
+						},
+				  ]
+				: []),
 			...(audienceUrl
 				? [
 						{
@@ -609,7 +623,13 @@ export default function ManageEventApp() {
 				title: __('Admin', 'fair-events'),
 			},
 		],
-		[audienceUrl, paymentEntriesUrl, isGeneratedOccurrence]
+		[
+			audienceUrl,
+			paymentEntriesUrl,
+			isGeneratedOccurrence,
+			galleriesEnabled,
+			ticketingEnabled,
+		]
 	);
 
 	const initialTab = useMemo(() => {
@@ -958,12 +978,14 @@ export default function ManageEventApp() {
 				</CardBody>
 			</Card>
 
-			<ImageExports
-				eventDateId={eventDateId}
-				themeImageId={themeImageId}
-				themeImageUrl={themeImageUrl}
-				initialExports={eventDate?.image_exports || []}
-			/>
+			{galleriesEnabled && (
+				<ImageExports
+					eventDateId={eventDateId}
+					themeImageId={themeImageId}
+					themeImageUrl={themeImageUrl}
+					initialExports={eventDate?.image_exports || []}
+				/>
+			)}
 		</>
 	);
 

--- a/fair-events/src/Admin/settings/FeaturesTab.js
+++ b/fair-events/src/Admin/settings/FeaturesTab.js
@@ -1,0 +1,171 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import {
+	Button,
+	ToggleControl,
+	Card,
+	CardBody,
+	Notice,
+} from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Features Tab Component
+ *
+ * Per-bundle toggles backed by the `fair_events_features` option. Bundles
+ * forced by a wp-config constant render disabled with an explanatory note —
+ * the server-side sanitizer drops writes to forced keys, so the UI just
+ * reflects what PHP will accept.
+ *
+ * @param {Object}   props          Props
+ * @param {Function} props.onNotice Handler for displaying notices
+ * @return {JSX.Element} The Features settings tab
+ */
+export default function FeaturesTab({ onNotice }) {
+	const registry = window.fairEventsSettingsData?.features || {};
+	const [values, setValues] = useState({});
+	const [isLoading, setIsLoading] = useState(true);
+	const [isSaving, setIsSaving] = useState(false);
+
+	useEffect(() => {
+		apiFetch({ path: '/wp/v2/settings' })
+			.then((settings) => {
+				const stored = settings.fair_events_features || {};
+				const next = {};
+				Object.entries(registry).forEach(([key, meta]) => {
+					if (meta.always_on || meta.forced) {
+						next[key] = meta.enabled;
+					} else {
+						next[key] =
+							typeof stored[key] === 'boolean'
+								? stored[key]
+								: meta.enabled;
+					}
+				});
+				setValues(next);
+				setIsLoading(false);
+			})
+			.catch(() => {
+				onNotice({
+					status: 'error',
+					message: __('Failed to load features.', 'fair-events'),
+				});
+				setIsLoading(false);
+			});
+		// registry comes from a global injected once per page load — no need
+		// to track it in deps.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [onNotice]);
+
+	const handleToggle = (key, value) => {
+		setValues({ ...values, [key]: value });
+	};
+
+	const handleSave = () => {
+		// Drop forced/always-on keys from the payload — the PHP sanitizer
+		// ignores them anyway, but sending only editable keys keeps intent
+		// clear.
+		const payload = {};
+		Object.entries(registry).forEach(([key, meta]) => {
+			if (meta.always_on || meta.forced) {
+				return;
+			}
+			payload[key] = !!values[key];
+		});
+
+		setIsSaving(true);
+		apiFetch({
+			path: '/wp/v2/settings',
+			method: 'POST',
+			data: { fair_events_features: payload },
+		})
+			.then(() => {
+				onNotice({
+					status: 'success',
+					message: __(
+						'Features saved. Reload the page to see admin-menu changes.',
+						'fair-events'
+					),
+				});
+				setIsSaving(false);
+			})
+			.catch(() => {
+				onNotice({
+					status: 'error',
+					message: __('Failed to save features.', 'fair-events'),
+				});
+				setIsSaving(false);
+			});
+	};
+
+	if (isLoading) {
+		return (
+			<Card>
+				<CardBody>
+					<p>{__('Loading features...', 'fair-events')}</p>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	const entries = Object.entries(registry);
+
+	return (
+		<Card>
+			<CardBody>
+				<p className="description">
+					{__(
+						'Toggle optional feature bundles. Bundles fixed in wp-config (FAIR_EVENTS_INTERNAL or FAIR_EVENTS_FEATURE_*) are read-only here.',
+						'fair-events'
+					)}
+				</p>
+
+				{entries.map(([key, meta]) => {
+					const help = meta.forced
+						? __(
+								'Forced by a wp-config constant — change it there.',
+								'fair-events'
+						  )
+						: meta.description;
+
+					return (
+						<div key={key} style={{ marginBottom: '1rem' }}>
+							<ToggleControl
+								label={meta.label}
+								checked={!!values[key]}
+								onChange={(value) => handleToggle(key, value)}
+								disabled={
+									isSaving || meta.always_on || meta.forced
+								}
+								help={help}
+							/>
+						</div>
+					);
+				})}
+
+				{entries.some(([, meta]) => meta.forced) && (
+					<Notice status="info" isDismissible={false}>
+						{__(
+							'One or more bundles are forced by wp-config and cannot be toggled here.',
+							'fair-events'
+						)}
+					</Notice>
+				)}
+
+				<Button
+					variant="primary"
+					onClick={handleSave}
+					isBusy={isSaving}
+					disabled={isSaving}
+				>
+					{isSaving
+						? __('Saving...', 'fair-events')
+						: __('Save Features', 'fair-events')}
+				</Button>
+			</CardBody>
+		</Card>
+	);
+}

--- a/fair-events/src/Admin/settings/SettingsApp.js
+++ b/fair-events/src/Admin/settings/SettingsApp.js
@@ -10,6 +10,7 @@ import { Notice, TabPanel } from '@wordpress/components';
  */
 import GeneralTab from './GeneralTab.js';
 import FacebookTab from './FacebookTab.js';
+import FeaturesTab from './FeaturesTab.js';
 
 /**
  * Settings App Component
@@ -44,6 +45,10 @@ export default function SettingsApp() {
 						title: __('General', 'fair-events'),
 					},
 					{
+						name: 'features',
+						title: __('Features', 'fair-events'),
+					},
+					{
 						name: 'facebook',
 						title: __('Facebook', 'fair-events'),
 					},
@@ -53,6 +58,9 @@ export default function SettingsApp() {
 					<div style={{ marginTop: '1rem' }}>
 						{tab.name === 'general' && (
 							<GeneralTab onNotice={setNotice} />
+						)}
+						{tab.name === 'features' && (
+							<FeaturesTab onNotice={setNotice} />
 						)}
 						{tab.name === 'facebook' && (
 							<FacebookTab onNotice={setNotice} />

--- a/fair-events/src/Core/Features.php
+++ b/fair-events/src/Core/Features.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Feature flag registry for Fair Events.
+ *
+ * Central, fine-grained gate that lets the plugin ship a clean public build
+ * while keeping the full internal build active on sites the maintainer
+ * controls. Registration points (REST controllers, admin pages, blocks,
+ * frontend hooks) consult {@see Features::is_enabled()} so advanced or
+ * less-tested bundles can default off for public installs and on under the
+ * `FAIR_EVENTS_INTERNAL` master switch.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Core;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Feature flag registry.
+ *
+ * Resolution order for is_enabled() (first match wins):
+ *
+ *   1. Per-feature constant `FAIR_EVENTS_FEATURE_<UPPER>` (true/false).
+ *   2. Master switch `FAIR_EVENTS_INTERNAL` (true → every internal bundle on).
+ *   3. `fair_events_feature_enabled` filter (programmatic / tests).
+ *   4. Stored option `fair_events_features` ([ key => bool ]) from Settings UI.
+ *   5. Hardcoded default in the registry below.
+ *
+ * `core` is not a flag — it is always on. It is listed in all() only so the
+ * Settings UI can describe it alongside the rest.
+ */
+class Features {
+
+	/**
+	 * Option key holding user-toggled feature state.
+	 */
+	public const OPTION = 'fair_events_features';
+
+	/**
+	 * Master switch constant. When defined and truthy, every internal-bundle
+	 * default flips to true — the single line a maintainer adds in
+	 * wp-config.php (or via deploy) to get the full build.
+	 */
+	public const MASTER_CONSTANT = 'FAIR_EVENTS_INTERNAL';
+
+	/**
+	 * Canonical bundle registry.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on?:bool}>
+	 */
+	public static function registry() {
+		return array(
+			'core'        => array(
+				'label'       => __( 'Core', 'fair-events' ),
+				'description' => __( 'Events, calendar, all-events, settings, core blocks. Always on.', 'fair-events' ),
+				'default'     => true,
+				'always_on'   => true,
+			),
+			'venues'      => array(
+				'label'       => __( 'Venues', 'fair-events' ),
+				'description' => __( 'Venues admin page and REST controller.', 'fair-events' ),
+				'default'     => false,
+			),
+			'sources'     => array(
+				'label'       => __( 'Event sources & feeds', 'fair-events' ),
+				'description' => __( 'External event sources, Facebook import, iCal/JSON feeds, event proposals, weekly schedule.', 'fair-events' ),
+				'default'     => false,
+			),
+			'galleries'   => array(
+				'label'       => __( 'Galleries', 'fair-events' ),
+				'description' => __( 'Per-event photo galleries, photo likes/downloads, image exports, media library hooks.', 'fair-events' ),
+				'default'     => false,
+			),
+			'ticketing'   => array(
+				'label'       => __( 'Ticketing', 'fair-events' ),
+				'description' => __( 'Tickets, group pricing/permission rules, invitations. Requires fair-audience.', 'fair-events' ),
+				'default'     => false,
+			),
+			'event-tools' => array(
+				'label'       => __( 'Event tools', 'fair-events' ),
+				'description' => __( 'Event duplication, merge, and admin-bar Copy button.', 'fair-events' ),
+				'default'     => false,
+			),
+			'migration'   => array(
+				'label'       => __( 'Migration', 'fair-events' ),
+				'description' => __( 'One-time post → event migration tooling.', 'fair-events' ),
+				'default'     => false,
+			),
+		);
+	}
+
+	/**
+	 * Resolve whether a feature bundle is enabled.
+	 *
+	 * Unknown keys resolve to false (fail-closed).
+	 *
+	 * @param string $key Bundle key from registry().
+	 * @return bool
+	 */
+	public static function is_enabled( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $registry[ $key ]['always_on'] ) ) {
+			return true;
+		}
+
+		// 1. Per-feature constant always wins.
+		$constant = self::feature_constant_name( $key );
+		if ( defined( $constant ) ) {
+			return (bool) constant( $constant );
+		}
+
+		// 2. Master internal switch flips every non-core bundle on.
+		if ( defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT ) ) {
+			$enabled = true;
+		} else {
+			// 4. Stored option, then 5. hardcoded default.
+			$stored  = get_option( self::OPTION, array() );
+			$enabled = is_array( $stored ) && array_key_exists( $key, $stored )
+				? (bool) $stored[ $key ]
+				: (bool) $registry[ $key ]['default'];
+		}
+
+		// 3. Filter runs after constants so tests/extensions can override
+		// stored/default state without fighting a wp-config decision.
+		return (bool) apply_filters( 'fair_events_feature_enabled', $enabled, $key );
+	}
+
+	/**
+	 * Whether the resolved value is forced by a constant — used by the
+	 * Settings UI to render the toggle disabled and ignored by the option
+	 * sanitizer so a UI write cannot override wp-config.
+	 *
+	 * @param string $key Bundle key.
+	 * @return bool
+	 */
+	public static function is_forced( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $registry[ $key ]['always_on'] ) ) {
+			return true;
+		}
+
+		if ( defined( self::feature_constant_name( $key ) ) ) {
+			return true;
+		}
+
+		return defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT );
+	}
+
+	/**
+	 * Full snapshot for the Settings UI: registry entries + resolved state.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on:bool,enabled:bool,forced:bool}>
+	 */
+	public static function all() {
+		$out = array();
+		foreach ( self::registry() as $key => $entry ) {
+			$out[ $key ] = array(
+				'label'       => $entry['label'],
+				'description' => $entry['description'],
+				'default'     => (bool) $entry['default'],
+				'always_on'   => ! empty( $entry['always_on'] ),
+				'enabled'     => self::is_enabled( $key ),
+				'forced'      => self::is_forced( $key ),
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Compact `[ key => bool ]` map of resolved feature state. Injected into
+	 * the manage-event page so React can hide tabs without re-querying REST.
+	 *
+	 * @return array<string,bool>
+	 */
+	public static function public_map() {
+		$out = array();
+		foreach ( array_keys( self::registry() ) as $key ) {
+			$out[ $key ] = self::is_enabled( $key );
+		}
+		return $out;
+	}
+
+	/**
+	 * Sanitize an option payload to the known key set, dropping forced keys
+	 * (so a UI write cannot contradict a wp-config decision).
+	 *
+	 * @param mixed $value Raw option value.
+	 * @return array<string,bool>
+	 */
+	public static function sanitize_option( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$existing = get_option( self::OPTION, array() );
+		if ( ! is_array( $existing ) ) {
+			$existing = array();
+		}
+
+		$registry = self::registry();
+		$out      = array();
+		foreach ( $registry as $key => $entry ) {
+			if ( ! empty( $entry['always_on'] ) ) {
+				continue;
+			}
+
+			if ( self::is_forced( $key ) ) {
+				// Preserve the existing stored value but never let a forced
+				// key be rewritten from the UI.
+				if ( array_key_exists( $key, $existing ) ) {
+					$out[ $key ] = (bool) $existing[ $key ];
+				}
+				continue;
+			}
+
+			if ( array_key_exists( $key, $value ) ) {
+				$out[ $key ] = (bool) $value[ $key ];
+			} elseif ( array_key_exists( $key, $existing ) ) {
+				$out[ $key ] = (bool) $existing[ $key ];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Per-feature constant name (e.g. `galleries` → `FAIR_EVENTS_FEATURE_GALLERIES`).
+	 *
+	 * @param string $key Bundle key.
+	 * @return string
+	 */
+	private static function feature_constant_name( $key ) {
+		return 'FAIR_EVENTS_FEATURE_' . strtoupper( str_replace( '-', '_', $key ) );
+	}
+}

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -87,8 +87,12 @@ class Plugin {
 			$admin = new \FairEvents\Admin\AdminPages();
 			$admin->init();
 
-			\FairEvents\Admin\MediaLibraryHooks::init();
-			\FairEvents\Admin\MediaBatchActions::init();
+			// Media library integrations only fire when galleries are on —
+			// they tag attachments with event metadata and bulk-attach photos.
+			if ( Features::is_enabled( 'galleries' ) ) {
+				\FairEvents\Admin\MediaLibraryHooks::init();
+				\FairEvents\Admin\MediaBatchActions::init();
+			}
 		}
 	}
 
@@ -111,80 +115,10 @@ class Plugin {
 	 * @return void
 	 */
 	private function load_rest_api() {
+		// Core endpoints — always on. Manage-event UI and EventDates schema
+		// depend on these; they belong to `core`.
 		new \FairEvents\API\DateOptionsEndpoint();
 		new \FairEvents\API\UserGroupOptionsEndpoint();
-
-		// Event Sources controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\EventSourceController();
-				$controller->register_routes();
-			}
-		);
-
-		// Event Proposal controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\EventProposalController();
-				$controller->register_routes();
-			}
-		);
-
-		// Event Gallery endpoint.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\EventGalleryEndpoint();
-				$controller->register_routes();
-			}
-		);
-
-		// Photo Likes controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\PhotoLikesController();
-				$controller->register_routes();
-			}
-		);
-
-		// Photo Download controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\PhotoDownloadController();
-				$controller->register_routes();
-			}
-		);
-
-		// Migration controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\MigrationController();
-				$controller->register_routes();
-			}
-		);
-
-		// Migration summary controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\MigrationSummaryController();
-				$controller->register_routes();
-			}
-		);
-
-		// Public Events controller (JSON export for cross-site sharing).
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\PublicEventsController();
-				$controller->register_routes();
-			}
-		);
 
 		// Event Dates controller.
 		add_action(
@@ -195,95 +129,169 @@ class Plugin {
 			}
 		);
 
-		// Image Export controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\ImageExportController();
-				$controller->register_routes();
-			}
-		);
+		// `sources` bundle — external sources, feeds, proposals, weekly schedule.
+		if ( Features::is_enabled( 'sources' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\EventSourceController();
+					$controller->register_routes();
+				}
+			);
 
-		// Venue controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\VenueController();
-				$controller->register_routes();
-			}
-		);
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\EventProposalController();
+					$controller->register_routes();
+				}
+			);
 
-		// Weekly Events controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\WeeklyEventsController();
-				$controller->register_routes();
-			}
-		);
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\PublicEventsController();
+					$controller->register_routes();
+				}
+			);
 
-		// Facebook controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\FacebookController();
-				$controller->register_routes();
-			}
-		);
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\WeeklyEventsController();
+					$controller->register_routes();
+				}
+			);
 
-		// Group Pricing Rules controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\GroupPricingRulesController();
-				$controller->register_routes();
-			}
-		);
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\FacebookController();
+					$controller->register_routes();
+				}
+			);
+		}
 
-		// Group Permission Rules controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\GroupPermissionRulesController();
-				$controller->register_routes();
-			}
-		);
+		// `galleries` bundle — per-event photo galleries + image export.
+		if ( Features::is_enabled( 'galleries' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\EventGalleryEndpoint();
+					$controller->register_routes();
+				}
+			);
 
-		// Tickets controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\TicketsController();
-				$controller->register_routes();
-			}
-		);
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\PhotoLikesController();
+					$controller->register_routes();
+				}
+			);
 
-		// Invitation Tokens controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\InvitationTokensController();
-				$controller->register_routes();
-			}
-		);
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\PhotoDownloadController();
+					$controller->register_routes();
+				}
+			);
 
-		// Event Duplication controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\EventDuplicationController();
-				$controller->register_routes();
-			}
-		);
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\ImageExportController();
+					$controller->register_routes();
+				}
+			);
+		}
 
-		// Event Merge controller.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\EventMergeController();
-				$controller->register_routes();
-			}
-		);
+		// `migration` bundle — one-time post → event migration tooling.
+		if ( Features::is_enabled( 'migration' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\MigrationController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\MigrationSummaryController();
+					$controller->register_routes();
+				}
+			);
+		}
+
+		// `venues` bundle.
+		if ( Features::is_enabled( 'venues' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\VenueController();
+					$controller->register_routes();
+				}
+			);
+		}
+
+		// `ticketing` bundle — composes with the existing fair-audience
+		// dependency check inside each controller (e.g.
+		// GroupPricingRulesController guards on FAIR_AUDIENCE_PLUGIN_DIR).
+		if ( Features::is_enabled( 'ticketing' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\GroupPricingRulesController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\GroupPermissionRulesController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\TicketsController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\InvitationTokensController();
+					$controller->register_routes();
+				}
+			);
+		}
+
+		// `event-tools` bundle — duplication / merge.
+		if ( Features::is_enabled( 'event-tools' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\EventDuplicationController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\EventMergeController();
+					$controller->register_routes();
+				}
+			);
+		}
 
 		// Add event relationship to attachment REST responses.
 		add_action(
@@ -324,7 +332,9 @@ class Plugin {
 	 * @return void
 	 */
 	private function load_frontend() {
-		\FairEvents\Frontend\EventGalleryPage::init();
+		if ( Features::is_enabled( 'galleries' ) ) {
+			\FairEvents\Frontend\EventGalleryPage::init();
+		}
 	}
 
 	/**

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -129,6 +129,17 @@ class Plugin {
 			}
 		);
 
+		// Public events controller — registers `/fair-events/v1/events`,
+		// which the core calendar admin page consumes. Despite the
+		// "cross-site JSON" framing in the ticket, this is a core endpoint.
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new \FairEvents\API\PublicEventsController();
+				$controller->register_routes();
+			}
+		);
+
 		// `sources` bundle — external sources, feeds, proposals, weekly schedule.
 		if ( Features::is_enabled( 'sources' ) ) {
 			add_action(
@@ -143,14 +154,6 @@ class Plugin {
 				'rest_api_init',
 				function () {
 					$controller = new \FairEvents\API\EventProposalController();
-					$controller->register_routes();
-				}
-			);
-
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\PublicEventsController();
 					$controller->register_routes();
 				}
 			);
@@ -226,16 +229,16 @@ class Plugin {
 			);
 		}
 
-		// `venues` bundle.
-		if ( Features::is_enabled( 'venues' ) ) {
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\VenueController();
-					$controller->register_routes();
-				}
-			);
-		}
+		// Venues controller — registered unconditionally so the core
+		// calendar/manage-event venue dropdowns keep working. Only the
+		// dedicated Venues admin page is hidden by the `venues` bundle.
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new \FairEvents\API\VenueController();
+				$controller->register_routes();
+			}
+		);
 
 		// `ticketing` bundle — composes with the existing fair-audience
 		// dependency check inside each controller (e.g.

--- a/fair-events/src/Hooks/BlockHooks.php
+++ b/fair-events/src/Hooks/BlockHooks.php
@@ -28,12 +28,18 @@ class BlockHooks {
 	 * @return void
 	 */
 	public function register_blocks() {
+		// Core blocks — always available in the inserter.
 		register_block_type( __DIR__ . '/../../build/blocks/events-list' );
 		register_block_type( __DIR__ . '/../../build/blocks/event-dates' );
 		register_block_type( __DIR__ . '/../../build/blocks/events-calendar' );
-		register_block_type( __DIR__ . '/../../build/blocks/weekly-schedule' );
-		register_block_type( __DIR__ . '/../../build/blocks/event-proposal' );
 		register_block_type( __DIR__ . '/../../build/blocks/event-info' );
+
+		// `sources` bundle — weekly schedule renders feed events; the
+		// event-proposal block writes to EventProposalController.
+		if ( \FairEvents\Core\Features::is_enabled( 'sources' ) ) {
+			register_block_type( __DIR__ . '/../../build/blocks/weekly-schedule' );
+			register_block_type( __DIR__ . '/../../build/blocks/event-proposal' );
+		}
 	}
 
 	/**

--- a/fair-events/src/Settings/Settings.php
+++ b/fair-events/src/Settings/Settings.php
@@ -26,6 +26,9 @@ class Settings {
 		// Toggling CPT registration changes which rewrite rules exist.
 		add_action( 'add_option_fair_events_register_post_type', array( $this, 'flush_rewrite_rules_on_slug_change' ) );
 		add_action( 'update_option_fair_events_register_post_type', array( $this, 'flush_rewrite_rules_on_slug_change' ) );
+		// Feature toggles can register/unregister rewrite rules (galleries).
+		add_action( 'add_option_' . \FairEvents\Core\Features::OPTION, array( $this, 'flush_rewrite_rules_on_slug_change' ) );
+		add_action( 'update_option_' . \FairEvents\Core\Features::OPTION, array( $this, 'flush_rewrite_rules_on_slug_change' ) );
 		add_filter( 'rest_pre_update_setting', array( $this, 'handle_empty_slug_via_rest' ), 10, 3 );
 	}
 
@@ -60,6 +63,25 @@ class Settings {
 					'schema' => array(
 						'type'  => 'array',
 						'items' => array( 'type' => 'string' ),
+					),
+				),
+				'default'           => array(),
+			)
+		);
+
+		// Feature flag bundle toggles — UI state only, never overrides a
+		// wp-config constant (see Features::sanitize_option()).
+		register_setting(
+			'fair_events_settings',
+			\FairEvents\Core\Features::OPTION,
+			array(
+				'type'              => 'object',
+				'description'       => __( 'Per-bundle feature toggles', 'fair-events' ),
+				'sanitize_callback' => array( \FairEvents\Core\Features::class, 'sanitize_option' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'additionalProperties' => array( 'type' => 'boolean' ),
 					),
 				),
 				'default'           => array(),


### PR DESCRIPTION
Closes #654.

Adds `FairEvents\Core\Features` — a central bundle registry consulted at every registration point (REST, admin pages, blocks, frontend rewrites, manage-event tabs). Public installs see only the **core** bundle by default; sites that define `FAIR_EVENTS_INTERNAL = true` (or a per-bundle `FAIR_EVENTS_FEATURE_*` constant) in `wp-config.php` get the full build today, with no re-architecture needed to promote a bundle to public-default later.

## Resolution order

1. Per-feature constant `FAIR_EVENTS_FEATURE_<UPPER>`
2. Master switch `FAIR_EVENTS_INTERNAL`
3. `fair_events_feature_enabled` filter
4. Stored option `fair_events_features` (from Settings → Features tab)
5. Hardcoded default in the registry

Constant-forced flags render disabled in the UI and the server-side sanitizer drops UI writes to forced keys, so wp-config always wins.

## Bundles

| Bundle | Default (public) | Contents |
|---|---|---|
| `core` | always on | Events, calendar, all-events, settings, core blocks, EventDates endpoints |
| `venues` | off | VenueController + Venues page |
| `sources` | off | EventSource/Facebook/PublicEvents/WeeklyEvents/EventProposal controllers; Sources + Source View pages; `weekly-schedule` and `event-proposal` blocks |
| `galleries` | off | EventGallery/PhotoLikes/PhotoDownload/ImageExport controllers; EventGalleryPage frontend; media library hooks; ImageExports card on manage-event |
| `ticketing` | off (also requires `FAIR_AUDIENCE_PLUGIN_DIR`) | Tickets / Group Pricing / Group Permission / Invitation Tokens controllers; Manage Invitations page; manage-event Tickets/Groups tabs |
| `event-tools` | off | EventDuplication / EventMerge controllers; Copy Event page; admin-bar Copy button |
| `migration` | off | Migration / MigrationSummary controllers + admin pages |

Ticketing still composes with the existing `FAIR_AUDIENCE_PLUGIN_DIR` dependency check — both must be true.

## Files

- **New:** `fair-events/src/Core/Features.php` — registry, `is_enabled()`, `is_forced()`, `all()`, `public_map()`, `sanitize_option()`
- **New:** `fair-events/src/Admin/settings/FeaturesTab.js` — per-bundle toggles
- **Modified:** `Plugin.php`, `AdminPages.php`, `BlockHooks.php`, `Settings.php`, `SettingsApp.js`, `ManageEventApp.js`

## Manual verification (per TESTING.md)

1. Fresh install, no constants: admin menu shows only Calendar / All Events / Settings (no Venues / Sources / Migration); REST routes for disabled bundles 404.
2. `define( 'FAIR_EVENTS_INTERNAL', true );` in `wp-config.php` → parity with previous build.
3. Toggle `galleries` off in Settings → Features; `/event-gallery/{id}` 404s after the rewrite flush triggered by saving the option.
4. `GroupPricingRulesController` still 403s without `FAIR_AUDIENCE_PLUGIN_DIR` even with `ticketing` enabled — sibling-plugin checks compose with the flag.