### PR TITLE
Fix payment_expires_at timezone parsing in audience tab

### DIFF
--- a/.changeset/fix-payment-expires-at-timezone.md
+++ b/.changeset/fix-payment-expires-at-timezone.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix `payment_expires_at` being parsed as local time in the Manage Event audience tab, which falsely flagged in-progress payment holds as expired on non-UTC browsers (e.g. CEST).

--- a/fair-events/src/Admin/manage-event/EventAudience.js
+++ b/fair-events/src/Admin/manage-event/EventAudience.js
@@ -24,13 +24,27 @@ const LABEL_DISPLAY = {
 	interested: __('Interested', 'fair-events'),
 };
 
+// payment_expires_at is stored as UTC via PHP gmdate() in the form
+// "YYYY-MM-DD HH:MM:SS" (no timezone suffix). new Date() parses that shape as
+// *local* time on most engines, which on non-UTC servers shifts the expiry by
+// the local offset and falsely flags in-progress holds as expired. Normalize
+// to ISO-8601 with a trailing "Z" so it is interpreted as UTC.
+const parsePaymentExpiresAt = (iso) => {
+	if (!iso) return NaN;
+	const normalized =
+		typeof iso === 'string' && !/[zZ]|[+-]\d{2}:?\d{2}$/.test(iso)
+			? iso.replace(' ', 'T') + 'Z'
+			: iso;
+	return new Date(normalized).getTime();
+};
+
 // A pending_payment row is "stale" once its hold has lapsed: capacity counters
 // stop including it (matching the registration block) and the row needs admin
 // triage — confirm (cash payment etc.) or cancel.
 const isStalePendingPayment = (p) => {
 	if (!p || p.label !== 'pending_payment') return false;
 	if (!p.payment_expires_at) return true;
-	return new Date(p.payment_expires_at).getTime() <= Date.now();
+	return parsePaymentExpiresAt(p.payment_expires_at) <= Date.now();
 };
 
 // Whether a participant currently occupies a seat for capacity purposes.
@@ -908,10 +922,10 @@ export default function EventAudience({
 
 	const formatExpiredAgo = (iso) => {
 		if (!iso) return __('no expiry set', 'fair-events');
-		const ts = new Date(iso).getTime();
+		const ts = parsePaymentExpiresAt(iso);
 		if (Number.isNaN(ts)) return iso;
 		const diffMs = Date.now() - ts;
-		if (diffMs < 0) return new Date(iso).toLocaleString();
+		if (diffMs < 0) return new Date(ts).toLocaleString();
 		const minutes = Math.floor(diffMs / 60000);
 		if (minutes < 60) {
 			/* translators: %d: number of minutes */


### PR DESCRIPTION
## Problem

On https://acroyoga-club.es the Manage Event → Audience tab surfaced in-progress payment holds under **Pendiente de revisión** as `expirado hace 1 h`, even though the 15-minute hold had not yet lapsed.

## Cause

`payment_expires_at` is stored as UTC via PHP `gmdate()` and returned by `/fair-audience/v1/event-dates/{id}/participants` as a bare `YYYY-MM-DD HH:MM:SS` string with no timezone marker. `new Date(...)` parses that shape as **local** time on most engines, so on a CEST (UTC+2) browser the expiry instant landed 2 hours earlier than reality — holds created minutes ago appeared expired an hour ago.

## Fix

In `fair-events/src/Admin/manage-event/EventAudience.js`, add `parsePaymentExpiresAt()` that normalizes the value to ISO-8601 with a trailing `Z` before constructing the `Date`, and route both `isStalePendingPayment` and `formatExpiredAgo` through it.

The frontend signup block (`render.php`) uses PHP `strtotime()`, which evaluates the unsuffixed UTC string against PHP's default timezone (UTC under WordPress) and already matches `time()` correctly — only the JS admin side was affected.