### PR TITLE
Exclude interested participants from Activity copy list

### DIFF
--- a/fair-events/src/Admin/manage-event/EventAudience.js
+++ b/fair-events/src/Admin/manage-event/EventAudience.js
@@ -879,7 +879,12 @@ export default function EventAudience({
 		return ticketOptions
 			.map((opt) => {
 				const names = filteredParticipants
-					.filter((p) => participantHasOption(p, opt))
+					.filter(
+						(p) =>
+							(p.label === 'signed_up' ||
+								p.label === 'collaborator') &&
+							participantHasOption(p, opt)
+					)
 					.map((p) => p.participant_name || '—')
 					.sort((a, b) => a.localeCompare(b));
 				return `*${opt.name}* (${names.length})\n${


### PR DESCRIPTION
The Activity button on the event-management audience tab copied names of every participant matching a ticket option, including those merely marked as interested. Restrict the list to participants whose label is signed_up or collaborator so only people actually attending are shown.