### PR TITLE
Use ticket option short names in Telegram sale notifications

### DIFF
--- a/.changeset/telegram-activities-short-name.md
+++ b/.changeset/telegram-activities-short-name.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": patch
+---
+
+Use ticket option short names in Telegram sale notifications. Falls back to the full name and then to the snapshot name when no short name is set, so existing configurations keep working unchanged.

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -175,16 +175,22 @@ class PaymentHooks {
 				}
 			}
 
-			// Activities — the ticket options selected at signup.
+			// Activities — the ticket options selected at signup. Telegram
+			// notifications stay readable on mobile, so prefer the curated
+			// `short_name` when set; fall back to the full `name`, then the
+			// snapshot `epo.ticket_option_name` for options whose row was
+			// deleted after signup.
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$option_names = $wpdb->get_col(
 				$wpdb->prepare(
-					"SELECT COALESCE(NULLIF(topt.name, ''), epo.ticket_option_name)
+					"SELECT COALESCE(NULLIF(topt.short_name, ''), NULLIF(topt.name, ''), epo.ticket_option_name)
 					FROM {$wpdb->prefix}fair_audience_event_participant_options epo
 					LEFT JOIN {$wpdb->prefix}fair_events_ticket_options topt
 						ON topt.id = epo.ticket_option_id
 					WHERE epo.event_participant_id = %d
-						AND ( ( topt.name IS NOT NULL AND topt.name != '' ) OR epo.ticket_option_name != '' )",
+						AND ( ( topt.short_name IS NOT NULL AND topt.short_name != '' )
+							OR ( topt.name IS NOT NULL AND topt.name != '' )
+							OR epo.ticket_option_name != '' )",
 					(int) $event_participant->id
 				)
 			);


### PR DESCRIPTION
## Problem

Telegram sale notifications render the buyer's selected activities, but on multi-activity events the full ticket option names quickly outgrow what's readable on a phone. Real-world example from acroyoga-club.es:

> Activities: 11:00 Taller icarians con Alberto y Lidia, 12:30 Taller de flow: Side Star Infinity con Ignasi y Andrea, 15:30 Taller whips con Alberto y Lidia

## Change

`fair-audience`'s `enrich_notification_context()` (the filter that fills the Telegram template's \`activities\` slot) now selects:

\`\`\`sql
COALESCE(NULLIF(topt.short_name, ''), NULLIF(topt.name, ''), epo.ticket_option_name)
\`\`\`

So an option with a configured \`short_name\` shortens the Telegram line; options without one keep producing the current output, and snapshotted \`epo.ticket_option_name\` is still the final fallback for rows whose ticket option was deleted after signup.

## Scope

- Telegram path only (\`fair_payment_notification_context\` is consumed solely by fair-payment's \`NotificationHooks\`). Confirmation/added-activities emails build their activity list through a separate path and are unaffected.
- No schema change — \`short_name\` already exists on \`fair_events_ticket_options\` (migration 3.6.0).
- Rollout is incremental: until a site fills in \`short_name\` values, the message looks identical to before.