### PR TITLE
Fit Event meta box action buttons into sidebar width (#699)

### DIFF
--- a/.changeset/event-meta-box-action-buttons.md
+++ b/.changeset/event-meta-box-action-buttons.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fit the Event meta box action buttons into the available sidebar width: "Edit Full Details" and "Unlink from event" now share one row beneath the full-width "Save Event" button, so longer translated labels no longer wrap awkwardly.

--- a/fair-events/src/Admin/event-meta-box/EventEditForm.js
+++ b/fair-events/src/Admin/event-meta-box/EventEditForm.js
@@ -36,6 +36,8 @@ export default function EventEditForm({
 	manageEventUrl,
 	postId,
 	postType,
+	onUnlink,
+	unlinking,
 }) {
 	const [loading, setLoading] = useState(true);
 	const [saving, setSaving] = useState(false);
@@ -501,31 +503,38 @@ export default function EventEditForm({
 				</VStack>
 			)}
 
-			<Button
-				variant="primary"
-				onClick={handleSave}
-				isBusy={saving}
-				disabled={saving}
+			<div
 				style={{
-					width: '100%',
-					justifyContent: 'center',
+					display: 'flex',
+					gap: '8px',
+					flexWrap: 'wrap',
 				}}
 			>
-				{__('Save Event', 'fair-events')}
-			</Button>
-
-			{manageEventUrl && (
 				<Button
-					variant="secondary"
-					href={manageEventUrl}
-					style={{
-						width: '100%',
-						justifyContent: 'center',
-					}}
+					variant="primary"
+					onClick={handleSave}
+					isBusy={saving}
+					disabled={saving || unlinking}
 				>
-					{__('Edit Full Details', 'fair-events')}
+					{__('Save Event', 'fair-events')}
 				</Button>
-			)}
+				{manageEventUrl && (
+					<Button variant="secondary" href={manageEventUrl}>
+						{__('Edit Full Details', 'fair-events')}
+					</Button>
+				)}
+				{onUnlink && (
+					<Button
+						variant="tertiary"
+						isDestructive
+						onClick={onUnlink}
+						isBusy={unlinking}
+						disabled={saving || unlinking}
+					>
+						{__('Unlink from event', 'fair-events')}
+					</Button>
+				)}
+			</div>
 		</VStack>
 	);
 }

--- a/fair-events/src/Admin/event-meta-box/EventMetaBox.js
+++ b/fair-events/src/Admin/event-meta-box/EventMetaBox.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import { Button, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
@@ -120,30 +120,14 @@ export default function EventMetaBox({
 	// For fair_event posts or linked posts: show edit form.
 	if (isLinked) {
 		return (
-			<>
-				<EventEditForm
-					eventDateId={eventDateId}
-					manageEventUrl={manageEventUrl}
-					postId={postId}
-					postType={postType}
-				/>
-				{!isFairEvent && (
-					<Button
-						variant="tertiary"
-						isDestructive
-						onClick={handleUnlink}
-						isBusy={unlinking}
-						disabled={unlinking}
-						style={{
-							width: '100%',
-							justifyContent: 'center',
-							marginTop: '8px',
-						}}
-					>
-						{__('Unlink from event', 'fair-events')}
-					</Button>
-				)}
-			</>
+			<EventEditForm
+				eventDateId={eventDateId}
+				manageEventUrl={manageEventUrl}
+				postId={postId}
+				postType={postType}
+				onUnlink={!isFairEvent ? handleUnlink : undefined}
+				unlinking={unlinking}
+			/>
 		);
 	}
 

--- a/fair-events/src/Admin/event-meta-box/__tests__/EventEditForm.test.jsx
+++ b/fair-events/src/Admin/event-meta-box/__tests__/EventEditForm.test.jsx
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import EventEditForm from '../EventEditForm.js';
+
+jest.mock('@wordpress/api-fetch');
+
+jest.mock('../store.js', () => ({ STORE_NAME: 'fair-events/event-data' }));
+
+jest.mock('@wordpress/data', () => {
+	const stub = () => stub;
+	return new Proxy(
+		{
+			useDispatch: () => ({ setEventData: jest.fn() }),
+			useSelect: () => ({}),
+		},
+		{
+			get(target, prop) {
+				if (prop in target) return target[prop];
+				return stub;
+			},
+		}
+	);
+});
+
+const eventDate = {
+	id: 42,
+	start_datetime: '2026-06-10 10:00:00',
+	end_datetime: '2026-06-10 11:00:00',
+	all_day: false,
+	venue_id: null,
+	rrule: null,
+};
+
+beforeEach(() => {
+	apiFetch.mockImplementation(({ path, method }) => {
+		if (path === '/fair-events/v1/venues') {
+			return Promise.resolve([]);
+		}
+		if (path.startsWith('/fair-events/v1/event-dates/') && !method) {
+			return Promise.resolve(eventDate);
+		}
+		return Promise.resolve({});
+	});
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+const renderForm = async (props = {}) => {
+	render(
+		<EventEditForm
+			eventDateId={42}
+			manageEventUrl="/wp-admin/admin.php?page=fair-events-manage-event&event_date_id=42"
+			postId={1}
+			postType="post"
+			{...props}
+		/>
+	);
+	await waitFor(() =>
+		expect(
+			screen.getByRole('button', { name: 'Save Event' })
+		).toBeInTheDocument()
+	);
+};
+
+describe('EventEditForm secondary actions', () => {
+	it('renders Edit Full Details and Unlink when onUnlink is provided', async () => {
+		await renderForm({ onUnlink: jest.fn(), unlinking: false });
+		expect(
+			screen.getByRole('link', { name: 'Edit Full Details' })
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'Unlink from event' })
+		).toBeInTheDocument();
+		expect(console).toHaveWarned();
+	});
+
+	it('hides Unlink when onUnlink is not provided (fair_event post)', async () => {
+		await renderForm({
+			postType: 'fair_event',
+			onUnlink: undefined,
+		});
+		expect(
+			screen.getByRole('link', { name: 'Edit Full Details' })
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Unlink from event' })
+		).not.toBeInTheDocument();
+	});
+
+	it('calls onUnlink when Unlink is clicked', async () => {
+		const onUnlink = jest.fn();
+		await renderForm({ onUnlink, unlinking: false });
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Unlink from event' })
+		);
+		expect(onUnlink).toHaveBeenCalledTimes(1);
+	});
+
+	it('disables Save and Unlink while unlinking is in flight', async () => {
+		await renderForm({ onUnlink: jest.fn(), unlinking: true });
+		expect(
+			screen.getByRole('button', { name: 'Save Event' })
+		).toBeDisabled();
+		expect(
+			screen.getByRole('button', { name: 'Unlink from event' })
+		).toBeDisabled();
+	});
+});


### PR DESCRIPTION
## Summary

- Lifts the destructive "Unlink from event" action into `EventEditForm` and renders it alongside "Edit Full Details" in an `HStack` beneath the full-width "Save Event" button, so long translated labels no longer force each action onto its own row.
- "Save Event" and "Unlink" both disable while either save or unlink is in flight.
- Drops the inline `marginTop` on Unlink in favor of the surrounding `VStack`/`HStack` spacing.

Closes #699.

## Test plan

- [x] `npm test` in `fair-events/` passes (new component test covers: linked non-`fair_event` post renders both secondary actions, `fair_event` post hides Unlink, clicking Unlink calls handler, both buttons disable while `unlinking` is true).
- [x] `npm run build` in `fair-events/` produces clean assets.
- [ ] Manually verify in the Gutenberg sidebar at default width that nothing wraps in English and `es_ES`.