### PR TITLE
Drop the per-event-date theme image

### DIFF
--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -327,11 +327,6 @@ class EventDatesController extends WP_REST_Controller {
 				'required'          => false,
 				'sanitize_callback' => 'esc_url_raw',
 			),
-			'theme_image_id' => array(
-				'description' => __( 'Theme image attachment ID.', 'fair-events' ),
-				'type'        => array( 'integer', 'null' ),
-				'required'    => false,
-			),
 			'signup_price'   => array(
 				'description' => __( 'Signup price (null = free).', 'fair-events' ),
 				'type'        => array( 'number', 'null' ),
@@ -753,11 +748,6 @@ class EventDatesController extends WP_REST_Controller {
 		$external_url = $request->get_param( 'external_url' );
 		if ( null !== $external_url ) {
 			$update_data['external_url'] = $external_url;
-		}
-
-		$theme_image_id = $request->get_param( 'theme_image_id' );
-		if ( null !== $theme_image_id ) {
-			$update_data['theme_image_id'] = $theme_image_id ? absint( $theme_image_id ) : null;
 		}
 
 		if ( $request->has_param( 'signup_price' ) ) {
@@ -1344,10 +1334,6 @@ class EventDatesController extends WP_REST_Controller {
 			'external_url'    => $event_date->external_url,
 			'display_url'     => $event_date->get_display_url(),
 			'rrule'           => $event_date->rrule,
-			'theme_image_id'  => $event_date->theme_image_id ? (int) $event_date->theme_image_id : null,
-			'theme_image_url' => $event_date->theme_image_id
-				? wp_get_attachment_image_url( $event_date->theme_image_id, 'full' )
-				: null,
 			'signup_price'    => null !== $event_date->signup_price ? (float) $event_date->signup_price : null,
 		);
 

--- a/fair-events/src/Admin/manage-event/DuplicateEventWizard.js
+++ b/fair-events/src/Admin/manage-event/DuplicateEventWizard.js
@@ -63,14 +63,6 @@ export default function DuplicateEventWizard({
 	const [recurrenceCount, setRecurrenceCount] = useState(10);
 	const [recurrenceUntil, setRecurrenceUntil] = useState('');
 
-	// Image state
-	const [themeImageId, setThemeImageId] = useState(
-		sourceEventDate.theme_image_id || null
-	);
-	const [themeImageUrl, setThemeImageUrl] = useState(
-		sourceEventDate.theme_image_url || null
-	);
-
 	// Links state
 	const [linksOption, setLinksOption] = useState('clone');
 
@@ -384,28 +376,6 @@ export default function DuplicateEventWizard({
 		return ruleParts.join(';');
 	};
 
-	const handleSelectImage = () => {
-		const frame = window.wp.media({
-			title: __('Select Theme Image', 'fair-events'),
-			button: { text: __('Use this image', 'fair-events') },
-			multiple: false,
-			library: { type: 'image' },
-		});
-
-		frame.on('select', () => {
-			const attachment = frame.state().get('selection').first().toJSON();
-			setThemeImageId(attachment.id);
-			setThemeImageUrl(attachment.url);
-		});
-
-		frame.open();
-	};
-
-	const handleRemoveImage = () => {
-		setThemeImageId(null);
-		setThemeImageUrl(null);
-	};
-
 	// Build new start datetime string
 	const getNewStartDatetime = () => {
 		if (allDay) return `${startDate} 00:00:00`;
@@ -447,18 +417,7 @@ export default function DuplicateEventWizard({
 			setNewEventDateId(createdEventDateId);
 			setCompletedSteps((prev) => [...prev, 'create']);
 
-			// Step 2: Set theme image
-			if (themeImageId) {
-				setProgress(__('Setting theme image…', 'fair-events'));
-				await apiFetch({
-					path: `/fair-events/v1/event-dates/${createdEventDateId}`,
-					method: 'PUT',
-					data: { theme_image_id: themeImageId },
-				});
-			}
-			setCompletedSteps((prev) => [...prev, 'image']);
-
-			// Step 3: Handle links
+			// Step 2: Handle links
 			const linkedPosts = sourceEventDate.linked_posts || [];
 			if (linksOption === 'clone' && linkedPosts.length > 0) {
 				setProgress(__('Cloning posts…', 'fair-events'));
@@ -597,10 +556,6 @@ export default function DuplicateEventWizard({
 				name: 'event-details',
 				title: __('Event Details', 'fair-events'),
 			},
-			{
-				name: 'images',
-				title: __('Images', 'fair-events'),
-			},
 		];
 		if (linkedPosts.length > 0) {
 			s.push({
@@ -633,8 +588,6 @@ export default function DuplicateEventWizard({
 		switch (currentStep.name) {
 			case 'event-details':
 				return renderEventDetailsTab();
-			case 'images':
-				return renderImagesTab();
 			case 'links':
 				return renderLinksTab();
 			case 'tickets':
@@ -930,49 +883,6 @@ export default function DuplicateEventWizard({
 								)}
 							</VStack>
 						)}
-					</VStack>
-				</CardBody>
-			</Card>
-		);
-	}
-
-	function renderImagesTab() {
-		return (
-			<Card style={{ marginTop: '16px' }}>
-				<CardHeader>
-					<h2>{__('Theme Image', 'fair-events')}</h2>
-				</CardHeader>
-				<CardBody>
-					<VStack spacing={4}>
-						{themeImageUrl && (
-							<img
-								src={themeImageUrl}
-								alt={__('Theme image preview', 'fair-events')}
-								style={{
-									maxWidth: '300px',
-									height: 'auto',
-								}}
-							/>
-						)}
-						<HStack spacing={2}>
-							<Button
-								variant="secondary"
-								onClick={handleSelectImage}
-							>
-								{themeImageId
-									? __('Change Image', 'fair-events')
-									: __('Select Image', 'fair-events')}
-							</Button>
-							{themeImageId && (
-								<Button
-									variant="tertiary"
-									isDestructive
-									onClick={handleRemoveImage}
-								>
-									{__('Remove Image', 'fair-events')}
-								</Button>
-							)}
-						</HStack>
 					</VStack>
 				</CardBody>
 			</Card>
@@ -1275,7 +1185,6 @@ function hasTicketData(data) {
 function getNextStep(completedSteps) {
 	const allSteps = [
 		'create',
-		'image',
 		'links',
 		'tickets',
 		'collaborators',

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -78,8 +78,6 @@ export default function ManageEventApp() {
 	const [venueId, setVenueId] = useState('');
 	const [linkType, setLinkType] = useState('none');
 	const [externalUrl, setExternalUrl] = useState('');
-	const [themeImageId, setThemeImageId] = useState(null);
-	const [themeImageUrl, setThemeImageUrl] = useState(null);
 	const [categories, setCategories] = useState([]);
 	const [availableCategories, setAvailableCategories] = useState([]);
 
@@ -164,8 +162,6 @@ export default function ManageEventApp() {
 		setLinkType(data.link_type || 'none');
 		setExternalUrl(data.external_url || '');
 		setVenueId(data.venue_id ? String(data.venue_id) : '');
-		setThemeImageId(data.theme_image_id || null);
-		setThemeImageUrl(data.theme_image_url || null);
 		setCategories(data.categories?.map((c) => c.id) || []);
 
 		if (data.start_datetime) {
@@ -354,7 +350,6 @@ export default function ManageEventApp() {
 					venue_id: venueId ? parseInt(venueId, 10) : null,
 					link_type: linkType,
 					external_url: linkType === 'external' ? externalUrl : null,
-					theme_image_id: themeImageId,
 					rrule: buildRRule(),
 					categories,
 				},
@@ -485,28 +480,6 @@ export default function ManageEventApp() {
 		}
 	};
 
-	const handleSelectImage = () => {
-		const frame = window.wp.media({
-			title: __('Select Theme Image', 'fair-events'),
-			button: { text: __('Use this image', 'fair-events') },
-			multiple: false,
-			library: { type: 'image' },
-		});
-
-		frame.on('select', () => {
-			const attachment = frame.state().get('selection').first().toJSON();
-			setThemeImageId(attachment.id);
-			setThemeImageUrl(attachment.url);
-		});
-
-		frame.open();
-	};
-
-	const handleRemoveImage = () => {
-		setThemeImageId(null);
-		setThemeImageUrl(null);
-	};
-
 	const handleToggleExdate = async (date) => {
 		setTogglingExdate(date);
 		setError(null);
@@ -558,10 +531,6 @@ export default function ManageEventApp() {
 			{
 				name: 'event-details',
 				title: __('Event Details', 'fair-events'),
-			},
-			{
-				name: 'images',
-				title: __('Images', 'fair-events'),
 			},
 			...(ticketingEnabled
 				? [
@@ -983,49 +952,6 @@ export default function ManageEventApp() {
 		</>
 	);
 
-	const renderImagesTab = () => (
-		<>
-			<Card>
-				<CardHeader>
-					<h2>{__('Theme Image', 'fair-events')}</h2>
-				</CardHeader>
-				<CardBody>
-					<VStack spacing={4}>
-						{themeImageUrl && (
-							<img
-								src={themeImageUrl}
-								alt={__('Theme image preview', 'fair-events')}
-								style={{
-									maxWidth: '300px',
-									height: 'auto',
-								}}
-							/>
-						)}
-						<HStack spacing={2}>
-							<Button
-								variant="secondary"
-								onClick={handleSelectImage}
-							>
-								{themeImageId
-									? __('Change Image', 'fair-events')
-									: __('Select Image', 'fair-events')}
-							</Button>
-							{themeImageId && (
-								<Button
-									variant="tertiary"
-									isDestructive
-									onClick={handleRemoveImage}
-								>
-									{__('Remove Image', 'fair-events')}
-								</Button>
-							)}
-						</HStack>
-					</VStack>
-				</CardBody>
-			</Card>
-		</>
-	);
-
 	const renderLinksTab = () => (
 		<Card className="fair-events-event-details-card">
 			<CardHeader>
@@ -1284,9 +1210,6 @@ export default function ManageEventApp() {
 				onSelect={handleTabSelect}
 			>
 				{(tab) => {
-					if (tab.name === 'images') {
-						return renderImagesTab();
-					}
 					if (tab.name === 'tickets') {
 						return (
 							<EventTickets
@@ -1433,7 +1356,7 @@ export default function ManageEventApp() {
 					}
 					isBusy={saving}
 					disabled={
-						activeTab === 'event-details' || activeTab === 'images'
+						activeTab === 'event-details'
 							? saving || !title
 							: saving
 					}

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -214,6 +214,11 @@ class Installer {
 			self::migrate_to_3_10_0();
 		}
 
+		// Run migration if upgrading from pre-3.11.0 (drop theme_image_id from event_dates).
+		if ( version_compare( $current_version, '3.11.0', '<' ) ) {
+			self::migrate_to_3_11_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -336,6 +341,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.10.0', '<' ) ) {
 				self::migrate_to_3_10_0();
+			}
+
+			if ( version_compare( $current_version, '3.11.0', '<' ) ) {
+				self::migrate_to_3_11_0();
 			}
 
 			// Install/update tables
@@ -1344,6 +1353,34 @@ class Installer {
 			$wpdb->query(
 				$wpdb->prepare(
 					'ALTER TABLE %i ADD COLUMN minimum_activities INT UNSIGNED NOT NULL DEFAULT 0 AFTER invitation_only',
+					$table_name
+				)
+			);
+		}
+	}
+
+	/**
+	 * Migrate to version 3.11.0 - Drop theme_image_id column from event_dates table.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_11_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_event_dates';
+
+		$column_exists = $wpdb->get_results(
+			$wpdb->prepare(
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'theme_image_id' )
+			)
+		);
+
+		if ( ! empty( $column_exists ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i DROP COLUMN theme_image_id',
 					$table_name
 				)
 			);

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.10.0';
+	const DB_VERSION = '3.11.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -46,7 +46,6 @@ class Schema {
 			title VARCHAR(255) DEFAULT NULL,
 			external_url TEXT DEFAULT NULL,
 			link_type VARCHAR(20) NOT NULL DEFAULT 'post',
-			theme_image_id BIGINT UNSIGNED DEFAULT NULL,
 			capacity INT UNSIGNED DEFAULT NULL,
 			signup_price DECIMAL(10,2) DEFAULT NULL,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/fair-events/src/Hooks/OpenGraphHooks.php
+++ b/fair-events/src/Hooks/OpenGraphHooks.php
@@ -63,7 +63,7 @@ class OpenGraphHooks {
 		$this->output_meta_tag( 'og:type', 'website' );
 		$this->output_meta_tag( 'og:site_name', get_bloginfo( 'name' ) );
 
-		$image_url = $this->get_image_url( $post_id, $event_date );
+		$image_url = $this->get_image_url( $post_id );
 		if ( $image_url ) {
 			$this->output_meta_tag( 'og:image', $image_url );
 		}
@@ -107,7 +107,7 @@ class OpenGraphHooks {
 		}
 
 		$post      = get_post( $post_id );
-		$image_url = $this->get_image_url( $post_id, $event_date );
+		$image_url = $this->get_image_url( $post_id );
 
 		$this->output_name_meta_tag( 'twitter:card', $image_url ? 'summary_large_image' : 'summary' );
 		$this->output_name_meta_tag( 'twitter:title', $this->get_title( $post, $event_date ) );
@@ -165,7 +165,7 @@ class OpenGraphHooks {
 			$data['description'] = $description;
 		}
 
-		$image_url = $this->get_image_url( $post_id, $event_date );
+		$image_url = $this->get_image_url( $post_id );
 		if ( $image_url ) {
 			$data['image'] = $image_url;
 		}
@@ -267,31 +267,17 @@ class OpenGraphHooks {
 	/**
 	 * Get the image URL for OG tag
 	 *
-	 * Checks theme_image_id first, then falls back to post featured image.
-	 *
-	 * @param int        $post_id    Post ID.
-	 * @param EventDates $event_date Event date object.
+	 * @param int $post_id Post ID.
 	 * @return string|null Image URL or null.
 	 */
-	private function get_image_url( $post_id, $event_date ) {
-		// Try theme image first.
-		if ( ! empty( $event_date->theme_image_id ) ) {
-			$url = wp_get_attachment_url( $event_date->theme_image_id );
-			if ( $url ) {
-				return $url;
-			}
-		}
-
-		// Fall back to post featured image.
+	private function get_image_url( $post_id ) {
 		$thumbnail_id = get_post_thumbnail_id( $post_id );
-		if ( $thumbnail_id ) {
-			$url = wp_get_attachment_url( $thumbnail_id );
-			if ( $url ) {
-				return $url;
-			}
+		if ( ! $thumbnail_id ) {
+			return null;
 		}
 
-		return null;
+		$url = wp_get_attachment_url( $thumbnail_id );
+		return $url ? $url : null;
 	}
 
 	/**

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -108,13 +108,6 @@ class EventDates {
 	public $link_type = 'post';
 
 	/**
-	 * Theme image attachment ID
-	 *
-	 * @var int|null
-	 */
-	public $theme_image_id;
-
-	/**
 	 * Event capacity
 	 *
 	 * @var int|null
@@ -195,7 +188,6 @@ class EventDates {
 		$event_dates->title           = $result->title ?? null;
 		$event_dates->external_url    = $result->external_url ?? null;
 		$event_dates->link_type       = $result->link_type ?? 'post';
-		$event_dates->theme_image_id  = isset( $result->theme_image_id ) && $result->theme_image_id ? (int) $result->theme_image_id : null;
 		$event_dates->capacity        = isset( $result->capacity ) && null !== $result->capacity ? (int) $result->capacity : null;
 		$event_dates->signup_price    = isset( $result->signup_price ) && null !== $result->signup_price ? (float) $result->signup_price : null;
 
@@ -711,7 +703,6 @@ class EventDates {
 			'title'           => '%s',
 			'external_url'    => '%s',
 			'link_type'       => '%s',
-			'theme_image_id'  => '%d',
 			'capacity'        => '%d',
 			'signup_price'    => '%f',
 		);
@@ -911,10 +902,9 @@ class EventDates {
 			'external_url'    => $data['external_url'] ?? null,
 			'link_type'       => $data['link_type'] ?? 'none',
 			'venue_id'        => $data['venue_id'] ?? null,
-			'theme_image_id'  => $data['theme_image_id'] ?? null,
 		);
 
-		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%d' );
+		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d' );
 
 		$result = $wpdb->insert( $table_name, $insert_data, $format );
 

--- a/fair-events/src/Services/RecurrenceService.php
+++ b/fair-events/src/Services/RecurrenceService.php
@@ -359,7 +359,6 @@ class RecurrenceService {
 					'link_type'      => $master->link_type,
 					'external_url'   => $master->external_url,
 					'venue_id'       => $master->venue_id,
-					'theme_image_id' => $master->theme_image_id,
 				)
 			);
 


### PR DESCRIPTION
## Summary
- Open Graph / Twitter / JSON-LD tags now read the linked post's featured image directly, removing the `theme_image_id` override path.
- Removes the Images tab in Manage Event and the Images step in the Duplicate Event wizard, plus the REST field, model property, and `theme_image_id` column (migration `3.11.0` drops it).

## Test plan
- [ ] Manage Event page no longer shows an Images tab; existing event edits still save.
- [ ] Duplicate Event wizard skips the image step and completes successfully.
- [ ] Visiting a singular event post renders `og:image` / `twitter:image` from the post's featured image (and is omitted when the post has none).
- [ ] Upgrade from a previous version applies migration `3.11.0` and the `theme_image_id` column is gone from `wp_fair_event_dates`.