### PR TITLE
fair-events: visual & minor improvements

### DIFF
--- a/fair-events/src/Admin/calendar/CalendarApp.js
+++ b/fair-events/src/Admin/calendar/CalendarApp.js
@@ -5,7 +5,13 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
-import { Spinner, Notice } from '@wordpress/components';
+import {
+	Spinner,
+	Notice,
+	Card,
+	CardHeader,
+	CardBody,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { formatLocalDate, calculateLeadingDays } from 'fair-events-shared';
@@ -156,13 +162,6 @@ export default function CalendarApp() {
 		<div className="wrap fair-events-calendar-wrap">
 			<h1>{__('Events Calendar', 'fair-events')}</h1>
 
-			<CalendarHeader
-				currentDate={currentDate}
-				onPrevMonth={handlePrevMonth}
-				onNextMonth={handleNextMonth}
-				onToday={handleToday}
-			/>
-
 			{successNotice && (
 				<Notice
 					status="success"
@@ -188,20 +187,32 @@ export default function CalendarApp() {
 				</div>
 			)}
 
-			{loading ? (
-				<div className="fair-events-calendar-loading">
-					<Spinner />
-				</div>
-			) : (
-				<CalendarGrid
-					currentDate={currentDate}
-					events={events}
-					onAddEvent={handleAddEvent}
-					manageEventUrl={
-						window.fairEventsCalendarData?.manageEventUrl
-					}
-				/>
-			)}
+			<Card style={{ marginTop: '16px' }}>
+				<CardHeader>
+					<CalendarHeader
+						currentDate={currentDate}
+						onPrevMonth={handlePrevMonth}
+						onNextMonth={handleNextMonth}
+						onToday={handleToday}
+					/>
+				</CardHeader>
+				<CardBody className="fair-events-calendar-card-body">
+					{loading ? (
+						<div className="fair-events-calendar-loading">
+							<Spinner />
+						</div>
+					) : (
+						<CalendarGrid
+							currentDate={currentDate}
+							events={events}
+							onAddEvent={handleAddEvent}
+							manageEventUrl={
+								window.fairEventsCalendarData?.manageEventUrl
+							}
+						/>
+					)}
+				</CardBody>
+			</Card>
 
 			{modalDate && (
 				<QuickEventModal

--- a/fair-events/src/Admin/calendar/components/CalendarHeader.js
+++ b/fair-events/src/Admin/calendar/components/CalendarHeader.js
@@ -27,7 +27,7 @@ export default function CalendarHeader({
 				<Button variant="secondary" onClick={onPrevMonth}>
 					{__('Previous', 'fair-events')}
 				</Button>
-				<Button variant="secondary" onClick={onToday}>
+				<Button variant="primary" onClick={onToday}>
 					{__('Today', 'fair-events')}
 				</Button>
 				<Button variant="secondary" onClick={onNextMonth}>

--- a/fair-events/src/Admin/calendar/components/CalendarHeader.js
+++ b/fair-events/src/Admin/calendar/components/CalendarHeader.js
@@ -21,7 +21,8 @@ export default function CalendarHeader({
 	});
 
 	return (
-		<div className="fair-events-calendar-header">
+		<>
+			<h2 className="fair-events-calendar-title">{monthYear}</h2>
 			<div className="fair-events-calendar-nav">
 				<Button variant="secondary" onClick={onPrevMonth}>
 					{__('Previous', 'fair-events')}
@@ -33,7 +34,6 @@ export default function CalendarHeader({
 					{__('Next', 'fair-events')}
 				</Button>
 			</div>
-			<h2 className="fair-events-calendar-title">{monthYear}</h2>
-		</div>
+		</>
 	);
 }

--- a/fair-events/src/Admin/calendar/style.css
+++ b/fair-events/src/Admin/calendar/style.css
@@ -14,15 +14,7 @@
 	padding: 40px;
 }
 
-/* Header */
-.fair-events-calendar-header {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	margin-bottom: 20px;
-	padding: 10px 0;
-}
-
+/* Header (rendered inside CardHeader, so no outer spacing of its own) */
 .fair-events-calendar-nav {
 	display: flex;
 	gap: 8px;
@@ -34,11 +26,14 @@
 	font-weight: 600;
 }
 
-/* Calendar Grid */
+/* CardBody hugs the grid edges so the grid borders align with the Card */
+.fair-events-calendar-card-body {
+	padding: 0 !important;
+}
+
+/* Calendar Grid (sits inside a Card, so no outer border/radius of its own) */
 .fair-events-calendar-grid {
 	background: #fff;
-	border: 1px solid #c3c4c7;
-	border-radius: 4px;
 }
 
 .fair-events-calendar-weekdays {
@@ -207,7 +202,9 @@ a.fair-events-calendar-event:visited {
 	background: #0e4a78;
 }
 
-.fair-events-calendar-event-row .fair-events-calendar-destination-link .dashicons {
+.fair-events-calendar-event-row
+	.fair-events-calendar-destination-link
+	.dashicons {
 	font-size: 12px;
 	width: 12px;
 	height: 12px;
@@ -217,7 +214,8 @@ a.fair-events-calendar-event:visited {
 	border-radius: 3px;
 }
 
-.fair-events-calendar-event-row:has(.fair-events-calendar-destination-link) .fair-events-calendar-event {
+.fair-events-calendar-event-row:has(.fair-events-calendar-destination-link)
+	.fair-events-calendar-event {
 	border-radius: 3px 0 0 3px;
 }
 
@@ -245,7 +243,8 @@ a.fair-events-calendar-event:visited {
 	background: #8c6e1a;
 }
 
-.fair-events-calendar-event-row.link-type-external .fair-events-calendar-event:hover {
+.fair-events-calendar-event-row.link-type-external
+	.fair-events-calendar-event:hover {
 	background: #6e5614;
 }
 
@@ -253,7 +252,8 @@ a.fair-events-calendar-event:visited {
 	background: #646970;
 }
 
-.fair-events-calendar-event-row.link-type-unlinked .fair-events-calendar-event:hover {
+.fair-events-calendar-event-row.link-type-unlinked
+	.fair-events-calendar-event:hover {
 	background: #4e5157;
 }
 
@@ -265,12 +265,6 @@ a.fair-events-calendar-event:visited {
 
 /* Responsive */
 @media screen and (max-width: 782px) {
-	.fair-events-calendar-header {
-		flex-direction: column;
-		gap: 10px;
-		align-items: flex-start;
-	}
-
 	.fair-events-calendar-day {
 		min-height: 60px;
 	}

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -1178,7 +1178,10 @@ export default function ManageEventApp() {
 /* Let the tab bar wrap onto multiple rows instead of overflowing the
    viewport on narrow screens. Harmless on desktop, where the tabs fit on
    one row. */
-.fair-events-manage-event .components-tab-panel__tabs { flex-wrap: wrap; row-gap: 4px; }`}
+.fair-events-manage-event .components-tab-panel__tabs { flex-wrap: wrap; row-gap: 4px; }
+/* The 1.5px height of the active-tab indicator anti-aliases to a thin
+   darker top edge at 1x DPI. Round to 2px so the bar renders crisp. */
+.fair-events-manage-event .components-tab-panel__tabs-item.is-active::after { height: 2px; }`}
 			</style>
 			<h1>
 				{__('Manage Event', 'fair-events')}

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -1181,7 +1181,7 @@ export default function ManageEventApp() {
 .fair-events-manage-event .components-tab-panel__tabs { flex-wrap: wrap; row-gap: 4px; }
 /* The 1.5px height of the active-tab indicator anti-aliases to a thin
    darker top edge at 1x DPI. Round to 2px so the bar renders crisp. */
-.fair-events-manage-event .components-tab-panel__tabs-item.is-active::after { height: 2px; }`}
+.fair-events-manage-event .components-tab-panel__tabs-item.is-active::after { height: 2px; outline: none; }`}
 			</style>
 			<h1>
 				{__('Manage Event', 'fair-events')}

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -1162,6 +1162,7 @@ export default function ManageEventApp() {
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
+	margin-top: 16px;
 }
 .fair-events-manage-event .fair-events-event-details-columns {
 	display: grid;

--- a/fair-events/src/Admin/settings/FeaturesTab.js
+++ b/fair-events/src/Admin/settings/FeaturesTab.js
@@ -7,6 +7,7 @@ import {
 	Button,
 	ToggleControl,
 	Card,
+	CardHeader,
 	CardBody,
 	Notice,
 } from '@wordpress/components';
@@ -103,7 +104,7 @@ export default function FeaturesTab({ onNotice }) {
 
 	if (isLoading) {
 		return (
-			<Card>
+			<Card style={{ marginTop: '16px' }}>
 				<CardBody>
 					<p>{__('Loading features...', 'fair-events')}</p>
 				</CardBody>
@@ -114,7 +115,10 @@ export default function FeaturesTab({ onNotice }) {
 	const entries = Object.entries(registry);
 
 	return (
-		<Card>
+		<Card style={{ marginTop: '16px' }}>
+			<CardHeader>
+				<h2>{__('Feature Bundles', 'fair-events')}</h2>
+			</CardHeader>
 			<CardBody>
 				<p className="description">
 					{__(

--- a/fair-events/src/Admin/settings/GeneralTab.js
+++ b/fair-events/src/Admin/settings/GeneralTab.js
@@ -8,10 +8,11 @@ import {
 	TextControl,
 	CheckboxControl,
 	ToggleControl,
-	PanelBody,
 	ExternalLink,
 	Card,
+	CardHeader,
 	CardBody,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -135,7 +136,7 @@ export default function GeneralTab({ onNotice }) {
 
 	if (isLoading) {
 		return (
-			<Card>
+			<Card style={{ marginTop: '16px' }}>
 				<CardBody>
 					<p>{__('Loading settings...', 'fair-events')}</p>
 				</CardBody>
@@ -144,29 +145,37 @@ export default function GeneralTab({ onNotice }) {
 	}
 
 	return (
-		<Card>
-			<CardBody>
-				<form
-					onSubmit={(e) => {
-						e.preventDefault();
-						handleSave();
-					}}
-				>
-					<TextControl
-						label={__('Event URL Slug', 'fair-events')}
-						help={__(
-							'The URL slug used for event permalinks (e.g., /fair-events/event-name)',
-							'fair-events'
-						)}
-						value={slug}
-						onChange={(value) => setSlug(value)}
-						disabled={isSaving}
-					/>
+		<form
+			onSubmit={(e) => {
+				e.preventDefault();
+				handleSave();
+			}}
+		>
+			<VStack spacing={4} style={{ marginTop: '16px' }}>
+				<Card>
+					<CardHeader>
+						<h2>{__('Event URL Slug', 'fair-events')}</h2>
+					</CardHeader>
+					<CardBody>
+						<TextControl
+							label={__('Event URL Slug', 'fair-events')}
+							hideLabelFromVision
+							help={__(
+								'The URL slug used for event permalinks (e.g., /fair-events/event-name)',
+								'fair-events'
+							)}
+							value={slug}
+							onChange={(value) => setSlug(value)}
+							disabled={isSaving}
+						/>
+					</CardBody>
+				</Card>
 
-					<PanelBody
-						title={__('Enabled Post Types', 'fair-events')}
-						initialOpen={true}
-					>
+				<Card>
+					<CardHeader>
+						<h2>{__('Enabled Post Types', 'fair-events')}</h2>
+					</CardHeader>
+					<CardBody>
 						<p className="description">
 							{__(
 								'Select which post types can have event data (dates, location).',
@@ -204,12 +213,14 @@ export default function GeneralTab({ onNotice }) {
 								disabled={isSaving}
 							/>
 						))}
-					</PanelBody>
+					</CardBody>
+				</Card>
 
-					<PanelBody
-						title={__('Events API', 'fair-events')}
-						initialOpen={true}
-					>
+				<Card>
+					<CardHeader>
+						<h2>{__('Events API', 'fair-events')}</h2>
+					</CardHeader>
+					<CardBody>
 						<p className="description">
 							{__(
 								'Share your events with other Fair Events sites using the public JSON API.',
@@ -253,8 +264,10 @@ export default function GeneralTab({ onNotice }) {
 								'fair-events'
 							)}
 						</p>
-					</PanelBody>
+					</CardBody>
+				</Card>
 
+				<div>
 					<Button
 						variant="primary"
 						type="submit"
@@ -265,8 +278,8 @@ export default function GeneralTab({ onNotice }) {
 							? __('Saving...', 'fair-events')
 							: __('Save Settings', 'fair-events')}
 					</Button>
-				</form>
-			</CardBody>
-		</Card>
+				</div>
+			</VStack>
+		</form>
 	);
 }

--- a/fair-events/src/Admin/settings/SettingsApp.js
+++ b/fair-events/src/Admin/settings/SettingsApp.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { Notice, TabPanel } from '@wordpress/components';
 
 /**
@@ -21,6 +21,38 @@ import FeaturesTab from './FeaturesTab.js';
 export default function SettingsApp() {
 	const [notice, setNotice] = useState(null);
 
+	const tabs = useMemo(
+		() => [
+			{
+				name: 'general',
+				title: __('General', 'fair-events'),
+			},
+			{
+				name: 'features',
+				title: __('Features', 'fair-events'),
+			},
+		],
+		[]
+	);
+
+	const initialTab = useMemo(() => {
+		const urlTab = new URLSearchParams(window.location.search).get('tab');
+		if (tabs.some((t) => t.name === urlTab)) {
+			return urlTab;
+		}
+		return 'general';
+	}, [tabs]);
+
+	const handleTabSelect = useCallback((tabName) => {
+		const url = new URL(window.location.href);
+		if (tabName === 'general') {
+			url.searchParams.delete('tab');
+		} else {
+			url.searchParams.set('tab', tabName);
+		}
+		window.history.replaceState(null, '', url.toString());
+	}, []);
+
 	return (
 		<div className="wrap">
 			<h1>{__('Fair Events Settings', 'fair-events')}</h1>
@@ -38,16 +70,9 @@ export default function SettingsApp() {
 			<TabPanel
 				className="fair-events-settings-tabs"
 				activeClass="active-tab"
-				tabs={[
-					{
-						name: 'general',
-						title: __('General', 'fair-events'),
-					},
-					{
-						name: 'features',
-						title: __('Features', 'fair-events'),
-					},
-				]}
+				initialTabName={initialTab}
+				onSelect={handleTabSelect}
+				tabs={tabs}
 			>
 				{(tab) => (
 					<div style={{ marginTop: '1rem' }}>

--- a/fair-events/src/Admin/settings/SettingsApp.js
+++ b/fair-events/src/Admin/settings/SettingsApp.js
@@ -54,7 +54,12 @@ export default function SettingsApp() {
 	}, []);
 
 	return (
-		<div className="wrap">
+		<div className="wrap fair-events-settings">
+			<style>
+				{`/* The 1.5px height of the active-tab indicator anti-aliases to a thin
+   darker top edge at 1x DPI. Round to 2px so the bar renders crisp. */
+.fair-events-settings .components-tab-panel__tabs-item.is-active::after { height: 2px; }`}
+			</style>
 			<h1>{__('Fair Events Settings', 'fair-events')}</h1>
 
 			{notice && (

--- a/fair-events/src/Admin/settings/SettingsApp.js
+++ b/fair-events/src/Admin/settings/SettingsApp.js
@@ -58,7 +58,7 @@ export default function SettingsApp() {
 			<style>
 				{`/* The 1.5px height of the active-tab indicator anti-aliases to a thin
    darker top edge at 1x DPI. Round to 2px so the bar renders crisp. */
-.fair-events-settings .components-tab-panel__tabs-item.is-active::after { height: 2px; }`}
+.fair-events-settings .components-tab-panel__tabs-item.is-active::after { height: 2px; outline: none; }`}
 			</style>
 			<h1>{__('Fair Events Settings', 'fair-events')}</h1>
 

--- a/fair-events/src/Admin/venues/VenuesApp.js
+++ b/fair-events/src/Admin/venues/VenuesApp.js
@@ -282,69 +282,64 @@ const VenuesApp = () => {
 	};
 
 	return (
-		<div className="fair-events-venues-page">
-			<Card>
+		<div className="wrap fair-events-venues">
+			<h1>{__('Venues', 'fair-events')}</h1>
+
+			{error && (
+				<Notice
+					status="error"
+					isDismissible
+					onRemove={() => setError(null)}
+				>
+					{error}
+				</Notice>
+			)}
+
+			{success && (
+				<Notice
+					status="success"
+					isDismissible
+					onRemove={() => setSuccess(null)}
+				>
+					{success}
+				</Notice>
+			)}
+
+			<Card style={{ marginTop: '16px' }}>
 				<CardHeader>
-					<HStack justify="space-between">
-						<h1>{__('Venues', 'fair-events')}</h1>
-						<HStack spacing={2} expanded={false}>
-							{selectedVenues.size > 0 && (
-								<Button
-									variant="secondary"
-									onClick={handleExport}
-								>
-									{__('Export Selected', 'fair-events')}
-								</Button>
-							)}
-							<Button
-								variant="secondary"
-								onClick={() =>
-									document
-										.getElementById(
-											'fair-events-venue-import'
-										)
-										.click()
-								}
-								isBusy={isImporting}
-								disabled={isImporting}
-							>
-								{__('Import', 'fair-events')}
+					<h2>{__('All Venues', 'fair-events')}</h2>
+					<HStack spacing={2} expanded={false}>
+						{selectedVenues.size > 0 && (
+							<Button variant="secondary" onClick={handleExport}>
+								{__('Export Selected', 'fair-events')}
 							</Button>
-							<input
-								id="fair-events-venue-import"
-								type="file"
-								accept=".json"
-								style={{ display: 'none' }}
-								onChange={handleImport}
-							/>
-							<Button variant="primary" onClick={handleCreate}>
-								{__('Add New Venue', 'fair-events')}
-							</Button>
-						</HStack>
+						)}
+						<Button
+							variant="secondary"
+							onClick={() =>
+								document
+									.getElementById('fair-events-venue-import')
+									.click()
+							}
+							isBusy={isImporting}
+							disabled={isImporting}
+						>
+							{__('Import', 'fair-events')}
+						</Button>
+						<input
+							id="fair-events-venue-import"
+							type="file"
+							accept=".json"
+							style={{ display: 'none' }}
+							onChange={handleImport}
+						/>
+						<Button variant="primary" onClick={handleCreate}>
+							{__('Add New Venue', 'fair-events')}
+						</Button>
 					</HStack>
 				</CardHeader>
 				<CardBody>
 					<VStack spacing={4}>
-						{error && (
-							<Notice
-								status="error"
-								isDismissible
-								onRemove={() => setError(null)}
-							>
-								{error}
-							</Notice>
-						)}
-
-						{success && (
-							<Notice
-								status="success"
-								isDismissible
-								onRemove={() => setSuccess(null)}
-							>
-								{success}
-							</Notice>
-						)}
-
 						{loading && (
 							<div className="venues-loading">
 								<Spinner />


### PR DESCRIPTION
Collecting small visual / UX polish for fair-events. More changes coming on this branch.

## Summary
- Settings page now reflects the active tab in the URL (`?tab=features`) and restores it on reload, matching the manage-event page idiom.

## Test plan
- [ ] Open Fair Events → Settings, switch tabs, confirm URL updates and reload restores tab.
- [ ] Default tab (General) keeps URL clean (no `tab=` param).