### PR TITLE
fair-events: address field when Venues feature is off

### DIFF
--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -314,6 +314,12 @@ class EventDatesController extends WP_REST_Controller {
 				'type'        => array( 'integer', 'null' ),
 				'required'    => false,
 			),
+			'address'        => array(
+				'description'       => __( 'Free-text address (used when Venues feature is disabled).', 'fair-events' ),
+				'type'              => array( 'string', 'null' ),
+				'required'          => false,
+				'sanitize_callback' => 'sanitize_textarea_field',
+			),
 			'link_type'      => array(
 				'description' => __( 'Link type (post, external, none).', 'fair-events' ),
 				'type'        => 'string',
@@ -738,6 +744,11 @@ class EventDatesController extends WP_REST_Controller {
 
 		if ( $request->has_param( 'venue_id' ) ) {
 			$update_data['venue_id'] = $request->get_param( 'venue_id' );
+		}
+
+		if ( $request->has_param( 'address' ) ) {
+			$address                = $request->get_param( 'address' );
+			$update_data['address'] = ( null === $address || '' === $address ) ? null : $address;
 		}
 
 		$link_type = $request->get_param( 'link_type' );
@@ -1330,6 +1341,7 @@ class EventDatesController extends WP_REST_Controller {
 			'occurrence_type' => $event_date->occurrence_type,
 			'master_id'       => $event_date->master_id,
 			'venue_id'        => $event_date->venue_id,
+			'address'         => $event_date->address,
 			'link_type'       => $event_date->link_type,
 			'external_url'    => $event_date->external_url,
 			'display_url'     => $event_date->get_display_url(),

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -825,6 +825,25 @@ class EventDatesController extends WP_REST_Controller {
 				}
 			}
 
+			// Propagate venue/address changes from a master to its existing
+			// generated children. Without this, edits to inherited location
+			// fields would only reach children when the series is fully
+			// regenerated (rrule or dates change).
+			if ( 'master' === $existing->occurrence_type
+				&& ( array_key_exists( 'venue_id', $update_data ) || array_key_exists( 'address', $update_data ) )
+			) {
+				$propagate = array();
+				if ( array_key_exists( 'venue_id', $update_data ) ) {
+					$propagate['venue_id'] = $update_data['venue_id'];
+				}
+				if ( array_key_exists( 'address', $update_data ) ) {
+					$propagate['address'] = $update_data['address'];
+				}
+				foreach ( EventDates::get_generated_by_master_id( $id ) as $child ) {
+					EventDates::update_by_id( $child->id, $propagate );
+				}
+			}
+
 			// When linking a standalone event to a post, copy categories to post taxonomy.
 			if ( $newly_linked ) {
 				$standalone_cat_ids = $this->get_standalone_category_ids( $id );

--- a/fair-events/src/Admin/event-meta-box/EventEditForm.js
+++ b/fair-events/src/Admin/event-meta-box/EventEditForm.js
@@ -38,6 +38,7 @@ export default function EventEditForm({
 	postType,
 	onUnlink,
 	unlinking,
+	venuesEnabled = false,
 }) {
 	const [loading, setLoading] = useState(true);
 	const [saving, setSaving] = useState(false);
@@ -52,6 +53,7 @@ export default function EventEditForm({
 	const [endDate, setEndDate] = useState('');
 	const [endTime, setEndTime] = useState('');
 	const [venueId, setVenueId] = useState('');
+	const [address, setAddress] = useState('');
 
 	// Recurrence state.
 	const [recurrenceEnabled, setRecurrenceEnabled] = useState(false);
@@ -64,7 +66,9 @@ export default function EventEditForm({
 
 	useEffect(() => {
 		loadEventDate();
-		loadVenues();
+		if (venuesEnabled) {
+			loadVenues();
+		}
 	}, [eventDateId]);
 
 	const loadEventDate = async () => {
@@ -100,6 +104,7 @@ export default function EventEditForm({
 	const populateForm = (data) => {
 		setAllDay(data.all_day || false);
 		setVenueId(data.venue_id ? String(data.venue_id) : '');
+		setAddress(data.address || '');
 
 		if (data.start_datetime) {
 			const [sDate, sTime] = data.start_datetime.split(' ');
@@ -291,7 +296,12 @@ export default function EventEditForm({
 					start_datetime: startDate ? startDatetime : null,
 					end_datetime: endDatetime,
 					all_day: allDay,
-					venue_id: venueId ? parseInt(venueId, 10) : null,
+					venue_id: venuesEnabled
+						? venueId
+							? parseInt(venueId, 10)
+							: null
+						: undefined,
+					address: venuesEnabled ? undefined : address,
 					rrule: buildRRule(),
 				},
 			});
@@ -328,6 +338,7 @@ export default function EventEditForm({
 			end_datetime: endDatetime,
 			all_day: allDay,
 			venue_id: venueId ? parseInt(venueId, 10) : null,
+			address,
 			rrule: buildRRule(),
 			occurrence_type: recurrenceEnabled ? 'master' : 'single',
 		});
@@ -338,6 +349,7 @@ export default function EventEditForm({
 		endTime,
 		allDay,
 		venueId,
+		address,
 		recurrenceEnabled,
 		recurrenceFrequency,
 		recurrenceEndType,
@@ -424,12 +436,20 @@ export default function EventEditForm({
 				/>
 			)}
 
-			<SelectControl
-				label={__('Venue', 'fair-events')}
-				value={venueId}
-				options={venueOptions}
-				onChange={setVenueId}
-			/>
+			{venuesEnabled ? (
+				<SelectControl
+					label={__('Venue', 'fair-events')}
+					value={venueId}
+					options={venueOptions}
+					onChange={setVenueId}
+				/>
+			) : (
+				<TextControl
+					label={__('Address', 'fair-events')}
+					value={address}
+					onChange={setAddress}
+				/>
+			)}
 
 			<CheckboxControl
 				label={__('Repeat this event', 'fair-events')}

--- a/fair-events/src/Admin/event-meta-box/EventMetaBox.js
+++ b/fair-events/src/Admin/event-meta-box/EventMetaBox.js
@@ -25,7 +25,9 @@ export default function EventMetaBox({
 	postType,
 	eventDateId: initialEventDateId,
 	manageEventUrl: initialManageEventUrl,
+	enabledFeatures = {},
 }) {
+	const venuesEnabled = !!enabledFeatures.venues;
 	const [eventDateId, setEventDateId] = useState(initialEventDateId || 0);
 	const [manageEventUrl, setManageEventUrl] = useState(
 		initialManageEventUrl || ''
@@ -127,6 +129,7 @@ export default function EventMetaBox({
 				postType={postType}
 				onUnlink={!isFairEvent ? handleUnlink : undefined}
 				unlinking={unlinking}
+				venuesEnabled={venuesEnabled}
 			/>
 		);
 	}

--- a/fair-events/src/Admin/event-meta-box/index.js
+++ b/fair-events/src/Admin/event-meta-box/index.js
@@ -16,7 +16,8 @@ domReady(() => {
 	}
 
 	const config = window.fairEventsMetaBox || {};
-	const { postId, postType, eventDateId, manageEventUrl } = config;
+	const { postId, postType, eventDateId, manageEventUrl, enabledFeatures } =
+		config;
 
 	const root = createRoot(container);
 	root.render(
@@ -25,6 +26,7 @@ domReady(() => {
 			postType={postType}
 			eventDateId={eventDateId}
 			manageEventUrl={manageEventUrl}
+			enabledFeatures={enabledFeatures || {}}
 		/>
 	);
 });

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -60,6 +60,7 @@ export default function ManageEventApp() {
 		window.fairEventsManageEventData?.enabledFeatures || {};
 	const galleriesEnabled = !!enabledFeatures.galleries;
 	const ticketingEnabled = !!enabledFeatures.ticketing;
+	const venuesEnabled = !!enabledFeatures.venues;
 
 	const [eventDate, setEventDate] = useState(null);
 	const [loading, setLoading] = useState(true);
@@ -76,6 +77,7 @@ export default function ManageEventApp() {
 	const [endDate, setEndDate] = useState('');
 	const [endTime, setEndTime] = useState('');
 	const [venueId, setVenueId] = useState('');
+	const [address, setAddress] = useState('');
 	const [linkType, setLinkType] = useState('none');
 	const [externalUrl, setExternalUrl] = useState('');
 	const [categories, setCategories] = useState([]);
@@ -115,7 +117,9 @@ export default function ManageEventApp() {
 			return;
 		}
 		loadEventDate();
-		loadVenues();
+		if (venuesEnabled) {
+			loadVenues();
+		}
 		loadCategories();
 	}, []);
 
@@ -162,6 +166,7 @@ export default function ManageEventApp() {
 		setLinkType(data.link_type || 'none');
 		setExternalUrl(data.external_url || '');
 		setVenueId(data.venue_id ? String(data.venue_id) : '');
+		setAddress(data.address || '');
 		setCategories(data.categories?.map((c) => c.id) || []);
 
 		if (data.start_datetime) {
@@ -347,7 +352,12 @@ export default function ManageEventApp() {
 					start_datetime: startDatetime,
 					end_datetime: endDatetime,
 					all_day: allDay,
-					venue_id: venueId ? parseInt(venueId, 10) : null,
+					venue_id: venuesEnabled
+						? venueId
+							? parseInt(venueId, 10)
+							: null
+						: undefined,
+					address: venuesEnabled ? undefined : address,
 					link_type: linkType,
 					external_url: linkType === 'external' ? externalUrl : null,
 					rrule: buildRRule(),
@@ -783,12 +793,20 @@ export default function ManageEventApp() {
 									__experimentalExpandOnFocus
 								/>
 
-								<SelectControl
-									label={__('Venue', 'fair-events')}
-									value={venueId}
-									options={venueOptions}
-									onChange={setVenueId}
-								/>
+								{venuesEnabled ? (
+									<SelectControl
+										label={__('Venue', 'fair-events')}
+										value={venueId}
+										options={venueOptions}
+										onChange={setVenueId}
+									/>
+								) : (
+									<TextControl
+										label={__('Address', 'fair-events')}
+										value={address}
+										onChange={setAddress}
+									/>
+								)}
 							</VStack>
 						</div>
 					</CardBody>

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -219,6 +219,11 @@ class Installer {
 			self::migrate_to_3_11_0();
 		}
 
+		// Run migration if upgrading from pre-3.12.0 (add address column to event_dates).
+		if ( version_compare( $current_version, '3.12.0', '<' ) ) {
+			self::migrate_to_3_12_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -345,6 +350,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.11.0', '<' ) ) {
 				self::migrate_to_3_11_0();
+			}
+
+			if ( version_compare( $current_version, '3.12.0', '<' ) ) {
+				self::migrate_to_3_12_0();
 			}
 
 			// Install/update tables
@@ -1381,6 +1390,38 @@ class Installer {
 			$wpdb->query(
 				$wpdb->prepare(
 					'ALTER TABLE %i DROP COLUMN theme_image_id',
+					$table_name
+				)
+			);
+		}
+	}
+
+	/**
+	 * Migrate to version 3.12.0 - Add address column to event_dates table.
+	 *
+	 * Used as a fallback location for an event's address when the Venues
+	 * feature bundle is disabled, so editors get a simple inline field
+	 * instead of the venue dropdown.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_12_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_event_dates';
+
+		$column_exists = $wpdb->get_results(
+			$wpdb->prepare(
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'address' )
+			)
+		);
+
+		if ( empty( $column_exists ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD COLUMN address TEXT DEFAULT NULL AFTER signup_price',
 					$table_name
 				)
 			);

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.11.0';
+	const DB_VERSION = '3.12.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -48,6 +48,7 @@ class Schema {
 			link_type VARCHAR(20) NOT NULL DEFAULT 'post',
 			capacity INT UNSIGNED DEFAULT NULL,
 			signup_price DECIMAL(10,2) DEFAULT NULL,
+			address TEXT DEFAULT NULL,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY (id),

--- a/fair-events/src/Hooks/CalendarButtonHooks.php
+++ b/fair-events/src/Hooks/CalendarButtonHooks.php
@@ -101,7 +101,9 @@ class CalendarButtonHooks {
 		$url         = get_permalink( $post_id );
 		$description = get_the_excerpt( $post_id );
 
-		// Get location from venue if available, otherwise fall back to event_location meta.
+		// Get location from venue if available, otherwise fall back to the
+		// event date's inline address (used when Venues is disabled), then
+		// the legacy event_location post meta.
 		$location = '';
 		if ( ! empty( $event_dates->venue_id ) ) {
 			$venue = Venue::get_by_id( $event_dates->venue_id );
@@ -113,7 +115,10 @@ class CalendarButtonHooks {
 			}
 		}
 
-		// Fall back to event_location meta if no venue location.
+		if ( empty( $location ) && ! empty( $event_dates->address ) ) {
+			$location = $event_dates->address;
+		}
+
 		if ( empty( $location ) ) {
 			$location = get_post_meta( $post_id, 'event_location', true );
 		}

--- a/fair-events/src/Hooks/CalendarButtonHooks.php
+++ b/fair-events/src/Hooks/CalendarButtonHooks.php
@@ -102,8 +102,7 @@ class CalendarButtonHooks {
 		$description = get_the_excerpt( $post_id );
 
 		// Get location from venue if available, otherwise fall back to the
-		// event date's inline address (used when Venues is disabled), then
-		// the legacy event_location post meta.
+		// event date's inline address (used when Venues is disabled).
 		$location = '';
 		if ( ! empty( $event_dates->venue_id ) ) {
 			$venue = Venue::get_by_id( $event_dates->venue_id );
@@ -117,10 +116,6 @@ class CalendarButtonHooks {
 
 		if ( empty( $location ) && ! empty( $event_dates->address ) ) {
 			$location = $event_dates->address;
-		}
-
-		if ( empty( $location ) ) {
-			$location = get_post_meta( $post_id, 'event_location', true );
 		}
 
 		// Get RRULE if available.

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -122,6 +122,13 @@ class EventDates {
 	public $signup_price;
 
 	/**
+	 * Free-text address (used when the Venues feature bundle is disabled).
+	 *
+	 * @var string|null
+	 */
+	public $address;
+
+	/**
 	 * Get event dates by event ID
 	 *
 	 * Checks the direct event_id column first (primary post), then falls back
@@ -190,6 +197,7 @@ class EventDates {
 		$event_dates->link_type       = $result->link_type ?? 'post';
 		$event_dates->capacity        = isset( $result->capacity ) && null !== $result->capacity ? (int) $result->capacity : null;
 		$event_dates->signup_price    = isset( $result->signup_price ) && null !== $result->signup_price ? (float) $result->signup_price : null;
+		$event_dates->address         = isset( $result->address ) ? $result->address : null;
 
 		return $event_dates;
 	}
@@ -705,6 +713,7 @@ class EventDates {
 			'link_type'       => '%s',
 			'capacity'        => '%d',
 			'signup_price'    => '%f',
+			'address'         => '%s',
 		);
 
 		$update_data   = array();

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -911,9 +911,10 @@ class EventDates {
 			'external_url'    => $data['external_url'] ?? null,
 			'link_type'       => $data['link_type'] ?? 'none',
 			'venue_id'        => $data['venue_id'] ?? null,
+			'address'         => $data['address'] ?? null,
 		);
 
-		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d' );
+		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%s' );
 
 		$result = $wpdb->insert( $table_name, $insert_data, $format );
 

--- a/fair-events/src/PostTypes/Event.php
+++ b/fair-events/src/PostTypes/Event.php
@@ -104,7 +104,7 @@ class Event {
 	/**
 	 * Register custom meta fields for all enabled post types
 	 *
-	 * Only registers event_location (legacy, used by CalendarButtonHooks as fallback).
+	 * Only registers event_location (legacy, still read by OpenGraphHooks as a fallback).
 	 * Event dates are now stored exclusively in the fair_event_dates custom table.
 	 *
 	 * @return void

--- a/fair-events/src/PostTypes/Event.php
+++ b/fair-events/src/PostTypes/Event.php
@@ -190,10 +190,11 @@ class Event {
 			'fair-events-event-meta-box',
 			'fairEventsMetaBox',
 			array(
-				'postId'         => $post_id,
-				'postType'       => $screen->post_type,
-				'eventDateId'    => $event_date_id,
-				'manageEventUrl' => $manage_event_url,
+				'postId'          => $post_id,
+				'postType'        => $screen->post_type,
+				'eventDateId'     => $event_date_id,
+				'manageEventUrl'  => $manage_event_url,
+				'enabledFeatures' => \FairEvents\Core\Features::public_map(),
 			)
 		);
 

--- a/fair-events/src/Services/RecurrenceService.php
+++ b/fair-events/src/Services/RecurrenceService.php
@@ -359,6 +359,7 @@ class RecurrenceService {
 					'link_type'      => $master->link_type,
 					'external_url'   => $master->external_url,
 					'venue_id'       => $master->venue_id,
+					'address'        => $master->address,
 				)
 			);
 

--- a/fair-events/src/blocks/event-info/render.php
+++ b/fair-events/src/blocks/event-info/render.php
@@ -190,5 +190,11 @@ if ( $is_recurring ) {
 				</div>
 			<?php endif; ?>
 		</div>
+	<?php elseif ( ! empty( $event_dates->address ) ) : ?>
+		<div class="wp-block-fair-events-event-info__venue">
+			<div class="wp-block-fair-events-event-info__venue-address">
+				<?php echo nl2br( esc_html( $event_dates->address ) ); ?>
+			</div>
+		</div>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary

- When the `venues` feature bundle is disabled, the Manage Event page and the post meta box swap the venue dropdown for a plain Address text input.
- Address is stored in a new `address TEXT` column on `fair_event_dates` (migration 3.12.0). Existing `venue_id` references are preserved so re-enabling Venues restores the prior selection.
- Meta box now receives the resolved feature map (`enabledFeatures`) from PHP so it can make the swap client-side without an extra REST call.

## Test plan

- [ ] With `venues` disabled (default), visit `wp-admin/admin.php?page=fair-events-manage-event&event_date_id=…` → see Address input instead of Venue dropdown; save persists across reload.
- [ ] With `venues` disabled, on a linked post edit screen, the Event Details meta box shows Address input; save and verify persistence.
- [ ] Enable `venues` (define `FAIR_EVENTS_FEATURE_VENUES` or toggle in Settings) → both UIs show the Venue dropdown again, and previously-selected venue is still set.
- [ ] Plugin reactivation (or hitting `Installer::maybe_upgrade()`) adds the `address` column without errors.