### PR TITLE
ci: publish plugins to WordPress.org SVN on tag release

### DIFF
--- a/.github/workflows/publish-to-svn.yml
+++ b/.github/workflows/publish-to-svn.yml
@@ -1,0 +1,126 @@
+name: Publish to WordPress.org SVN
+
+permissions:
+    contents: read
+
+on:
+    workflow_dispatch:
+        inputs:
+            plugin:
+                description: Plugin to publish
+                required: true
+                type: choice
+                options:
+                    - fair-events
+                    - fair-audience
+                    - fair-timetable
+            version:
+                description: Version to publish (semver, e.g. 1.2.3)
+                required: true
+                type: string
+            dry_run:
+                description: Dry run (skip svn ci, only print svn status)
+                required: true
+                type: boolean
+                default: true
+
+jobs:
+    publish:
+        name: Publish ${{ inputs.plugin }} ${{ inputs.version }}
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Validate version input
+              run: |
+                  if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                      echo "::error::version '${{ inputs.version }}' is not valid semver (expected MAJOR.MINOR.PATCH)"
+                      exit 1
+                  fi
+
+            - name: Checkout tag ${{ inputs.plugin }}@${{ inputs.version }}
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ inputs.plugin }}@${{ inputs.version }}
+                  fetch-depth: 1
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # 2.37.0
+              with:
+                  php-version: '8.3'
+                  extensions: mbstring, intl, zip
+                  coverage: none
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: '24'
+
+            - name: Install Subversion
+              run: sudo apt-get update && sudo apt-get install -y subversion
+
+            - name: Install npm dependencies
+              run: npm ci --prefer-offline
+
+            - name: Install production PHP dependencies in all plugins
+              run: npm run composer:install:prod
+
+            - name: Install WP-CLI
+              run: |
+                  curl -L -o wp-cli.phar https://github.com/wp-cli/wp-cli/releases/download/v2.12.0/wp-cli-2.12.0.phar
+                  echo "be928f6b8ca1e8dfb9d2f4b75a13aa4aee0896f8a9a0a1c45cd5d2c98605e6172e6d014dda2e27f88c98befc16c040cbb2bd1bfa121510ea5cdf5f6a30fe8832  wp-cli.phar" | sha512sum -c -
+                  chmod +x wp-cli.phar
+                  sudo mv wp-cli.phar /usr/local/bin/wp
+                  wp --info
+
+            - name: Install WP-CLI dist-archive command
+              env:
+                  COMPOSER_HOME: ${{ runner.temp }}/wp-cli-composer
+              run: |
+                  if ! wp dist-archive --help >/dev/null 2>&1; then
+                      for attempt in 1 2 3; do
+                          echo "Installing dist-archive-command (attempt ${attempt})..."
+                          wp package install wp-cli/dist-archive-command:^3.1 && break
+                          echo "Attempt ${attempt} failed; retrying in 15s..."
+                          sleep 15
+                      done
+                  fi
+                  wp dist-archive --help
+
+            - name: Build plugin assets
+              run: npm run build -w ${{ inputs.plugin }}
+
+            - name: Checkout WordPress.org SVN repo
+              run: npm run svn:checkout -w ${{ inputs.plugin }}
+
+            - name: Create SVN tag from dist archive
+              env:
+                  COMPOSER_HOME: ${{ runner.temp }}/wp-cli-composer
+              run: npm run svn:tag:${{ inputs.plugin }}
+
+            - name: Refresh trunk and assets
+              run: npm run svn:copy -w ${{ inputs.plugin }}
+
+            - name: Stage SVN changes
+              working-directory: ${{ inputs.plugin }}/svn
+              run: |
+                  svn add --force trunk assets "tags/${{ inputs.version }}"
+                  echo "=== svn status ==="
+                  svn status
+
+            - name: Commit to WordPress.org SVN
+              if: ${{ inputs.dry_run == false }}
+              working-directory: ${{ inputs.plugin }}/svn
+              env:
+                  SVN_USER: ${{ secrets.WPORG_SVN_USERNAME }}
+                  SVN_PASS: ${{ secrets.WPORG_SVN_PASSWORD }}
+              run: |
+                  svn ci \
+                      -m "Release ${{ inputs.plugin }} ${{ inputs.version }}" \
+                      --username "$SVN_USER" \
+                      --password "$SVN_PASS" \
+                      --non-interactive \
+                      --no-auth-cache
+
+            - name: Dry-run notice
+              if: ${{ inputs.dry_run == true }}
+              run: echo "::notice::dry_run=true — skipped 'svn ci'. Re-run with dry_run=false to publish."

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -152,3 +152,37 @@ Each deployed plugin gets a `.deploy-version` file (written into the extracted p
 
 The CI deploy path remains the canonical/recommended flow — local deploy is an additional, opt-in escape hatch.
 
+## Publishing to WordPress.org SVN
+
+The `.github/workflows/publish-to-svn.yml` workflow publishes a tagged release of a plugin to its [WordPress.org SVN repository](https://plugins.svn.wordpress.org/). It replaces the previous laptop-only flow that ran `npm run svn:checkout` / `svn:tag:*` / `svn:copy` by hand.
+
+### Trigger
+
+Manual only — **Actions → Publish to WordPress.org SVN → Run workflow**. Inputs:
+
+- `plugin` — one of `fair-events`, `fair-audience`, `fair-timetable`.
+- `version` — semver string (e.g. `1.2.3`). Validated against `^[0-9]+\.[0-9]+\.[0-9]+$`; the workflow fails fast on anything else.
+- `dry_run` — defaults to `true`. When `true`, the workflow performs every step except the final `svn ci` and prints `svn status` so you can confirm the staged changes.
+
+The workflow checks out the matching git tag (`<plugin>@<version>`) so the build matches the released commit, not whatever is on `main`.
+
+### Required secrets
+
+Configure these as **repository secrets** (Settings → Secrets and variables → Actions):
+
+- `WPORG_SVN_USERNAME` — WordPress.org committer username.
+- `WPORG_SVN_PASSWORD` — committer password (or app password, if configured on wordpress.org).
+
+The password is only exposed as an env var on the `svn ci` step; it is never passed through workflow `with:` inputs.
+
+### Typical flow
+
+1. Merge a Changesets release PR. This produces a git tag like `fair-events@1.2.3` (see [RELEASES.md](./RELEASES.md)).
+2. Run the workflow with `plugin=fair-events`, `version=1.2.3`, `dry_run=true`.
+3. Inspect the `svn status` output in the job log. Confirm the new `tags/<version>/` directory and any updated `trunk/` / `assets/` files look right.
+4. Re-run with `dry_run=false` to commit to wordpress.org.
+
+### Optional hardening
+
+The commit step can be gated behind a dedicated GitHub Environment (e.g. `wordpress.org`) with required reviewers. Add `environment: wordpress.org` to the `publish` job and move the two secrets onto that environment if you want a second-pair-of-eyes prompt before the live commit.
+

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -81,6 +81,7 @@ This allows you to easily track releases for each plugin individually.
 3. **Commit and push** to `main`
 4. **GitHub Action** creates release PR
 5. **Merge PR** → Automatic tag creation: `fair-events@1.1.0`
+6. **Publish to wordpress.org** → Run the [Publish to WordPress.org SVN](./DEPLOYMENT.md#publishing-to-wordpressorg-svn) workflow with the new tag (dry-run first, then live)
 
 ## ⚙️ WordPress Plugin Header Sync
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-to-svn.yml`, a manual `workflow_dispatch` workflow that checks out a `<plugin>@<version>` git tag, builds the plugin, and runs the existing `svn:checkout` / `svn:tag:<plugin>` / `svn:copy` scripts to publish to `https://plugins.svn.wordpress.org/<slug>`.
- Inputs: `plugin` (choice of `fair-events` / `fair-audience` / `fair-timetable`), `version` (semver, regex-validated), `dry_run` (boolean, default `true` — skips the final `svn ci` but still prints `svn status`).
- Credentials come from new repo secrets `WPORG_SVN_USERNAME` / `WPORG_SVN_PASSWORD` and are only exposed as env on the `svn ci` step.
- Documents the inputs, secrets, and dry-run flow under a new "Publishing to WordPress.org SVN" section in `DEPLOYMENT.md`, and links to it from the example release flow in `RELEASES.md`.

Closes #698.

## Test plan

- [ ] Add `WPORG_SVN_USERNAME` and `WPORG_SVN_PASSWORD` as repository secrets.
- [ ] Trigger the workflow from the Actions tab with `plugin=fair-events`, `version=<existing tag>`, `dry_run=true`; confirm the job is green and the `svn status` step shows a new `tags/<version>/` plus updated `trunk/` and `assets/`.
- [ ] Confirm the workflow rejects a malformed `version` input (e.g. `1.2`, `v1.2.3`, `1.2.3-beta`).
- [ ] Run once with `dry_run=false` and verify the new tag appears under `https://plugins.svn.wordpress.org/fair-events/tags/`.