### PR TITLE
fair-timetable: wire into release tooling

### DIFF
--- a/.changeset/fair-timetable-release-wiring.md
+++ b/.changeset/fair-timetable-release-wiring.md
@@ -1,0 +1,5 @@
+---
+"fair-timetable": patch
+---
+
+Wire fair-timetable into release tooling: stamp build version in PHP header during CI build, and include `languages/` in the SVN trunk copy so bundled translations ship to WordPress.org.

--- a/fair-timetable/package.json
+++ b/fair-timetable/package.json
@@ -27,7 +27,7 @@
 		"playwright:run": "playwright test --headed",
 		"playwright:up": "playwright test --headed --ui",
 		"svn:checkout": "svn co https://plugins.svn.wordpress.org/fair-timetable svn",
-		"svn:copy": "cp -r readme.txt fair-timetable.php src package* composer* CHANGELOG.md svn/trunk; cp assets/* svn/assets"
+		"svn:copy": "cp -r readme.txt fair-timetable.php src package* composer* languages CHANGELOG.md svn/trunk; cp assets/* svn/assets"
 	},
 	"dependencies": {
 		"@fortawesome/fontawesome-free": "^7.0.0",

--- a/scripts/stamp-build-version.js
+++ b/scripts/stamp-build-version.js
@@ -25,6 +25,7 @@ const pluginFiles = [
 	'fair-payment/fair-payment.php',
 	'fair-platform/fair-platform.php',
 	'fair-audience/fair-audience.php',
+	'fair-timetable/fair-timetable.php',
 ];
 
 const versionRegex = /(\*?\s*Version:\s*)([0-9]+\.[0-9]+\.[0-9]+[^\s*]*)/gi;


### PR DESCRIPTION
## Summary

Refs #727 — closes two of the concrete gaps that prevent a `fair-timetable` release from flowing cleanly through the Changesets → build → WordPress.org SVN pipeline.

- Add `fair-timetable/fair-timetable.php` to `scripts/stamp-build-version.js` so CI build artifacts get the `git describe --tags` version stamped into the PHP header (was shipping with a stale `Version: 0.6.1`).
- Add `languages` to fair-timetable's `svn:copy`, matching fair-events / fair-audience / fair-platform, so bundled translations land in trunk on publish.

Gap #3 from the ticket (PHP header version on a Changesets release) is already covered by `scripts/sync-wp-versions.js::updatePluginHeaderVersion`, which rewrites the header `Version:` line for every plugin listed (fair-timetable is in the list). No code change needed.

Remaining ticket work — running the publish chain end-to-end as a dry run, the wordpress.org slug approval check, and the `0.6.1 → 1.0.0` decision — is operational and tracked in #727.

## Test plan

- [ ] CI build green
- [ ] Manually inspect `npm run dist-archive:fair-timetable` output: PHP header `Version:` reflects `git describe`
- [ ] Manually run `fair-timetable` `svn:copy` against a checkout and confirm `svn/trunk/languages/` is populated