### PR TITLE
fair-payment: clear PHPCS WordPress-standard backlog

### DIFF
--- a/fair-payment/src/API/ConnectionController.php
+++ b/fair-payment/src/API/ConnectionController.php
@@ -42,7 +42,7 @@ class ConnectionController extends \WP_REST_Controller {
 	 */
 	public function test_connection() {
 		try {
-			// Check if OAuth is configured
+			// Check if OAuth is configured.
 			if ( ! get_option( 'fair_payment_mollie_connected', false ) ) {
 				return new \WP_Error(
 					'not_connected',
@@ -51,17 +51,17 @@ class ConnectionController extends \WP_REST_Controller {
 				);
 			}
 
-			// Get current token expiration
+			// Get current token expiration.
 			$token_expires = get_option( 'fair_payment_mollie_token_expires', 0 );
 
-			// Try to create payment handler (will trigger token refresh if needed)
+			// Try to create payment handler (will trigger token refresh if needed).
 			$handler = new MolliePaymentHandler();
 
-			// If we get here, connection is working
+			// If we get here, connection is working.
 			$new_token_expires = get_option( 'fair_payment_mollie_token_expires', 0 );
 			$new_expires_at    = $new_token_expires > 0 ? gmdate( 'Y-m-d H:i:s', $new_token_expires ) : 'unknown';
 
-			// Check if token was refreshed
+			// Check if token was refreshed.
 			$was_refreshed = $new_token_expires !== $token_expires;
 
 			return new \WP_REST_Response(

--- a/fair-payment/src/API/ConnectionController.php
+++ b/fair-payment/src/API/ConnectionController.php
@@ -53,9 +53,6 @@ class ConnectionController extends \WP_REST_Controller {
 
 			// Get current token expiration
 			$token_expires = get_option( 'fair_payment_mollie_token_expires', 0 );
-			$expires_at    = $token_expires > 0 ? gmdate( 'Y-m-d H:i:s', $token_expires ) : 'unknown';
-
-			error_log( '[Fair Payment] Test connection called. Token expires at: ' . $expires_at );
 
 			// Try to create payment handler (will trigger token refresh if needed)
 			$handler = new MolliePaymentHandler();
@@ -81,8 +78,10 @@ class ConnectionController extends \WP_REST_Controller {
 			);
 
 		} catch ( \Exception $e ) {
-			error_log( '[Fair Payment] Test connection failed with exception: ' . $e->getMessage() );
-			error_log( '[Fair Payment] Exception trace: ' . $e->getTraceAsString() );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payment] Test connection failed: ' . $e->getMessage() . "\n" . $e->getTraceAsString() );
+			}
 
 			return new \WP_Error(
 				'connection_failed',

--- a/fair-payment/src/API/FinancialEntryController.php
+++ b/fair-payment/src/API/FinancialEntryController.php
@@ -998,6 +998,7 @@ class FinancialEntryController extends WP_REST_Controller {
 				$link = self::get_transaction_link( $transaction );
 				if ( '' !== $link['event_url'] || null !== $link['event_date_id'] ) {
 					global $wpdb;
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- writing a back-link onto our own table; no caching layer.
 					$wpdb->update(
 						\FairPayment\Database\Schema::get_financial_entries_table_name(),
 						array(

--- a/fair-payment/src/API/PaymentEndpoint.php
+++ b/fair-payment/src/API/PaymentEndpoint.php
@@ -106,10 +106,10 @@ class PaymentEndpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object or error.
 	 */
 	public function create_payment( WP_REST_Request $request ) {
-		// TODO: Implement different behavior for logged-in vs anonymous users
-		// - Logged-in users: Track in user profile
-		// - Anonymous users: Require email
-		// See: REST_API_BACKEND.md for implementation guidance
+		// TODO: Implement different behavior for logged-in vs anonymous users.
+		// - Logged-in users: Track in user profile.
+		// - Anonymous users: Require email.
+		// See: REST_API_BACKEND.md for implementation guidance.
 
 		$logger = new PaymentLogRepository();
 

--- a/fair-payment/src/API/TransactionAPI.php
+++ b/fair-payment/src/API/TransactionAPI.php
@@ -425,7 +425,9 @@ class TransactionAPI {
 			'amount'            => $to_amount( $payment->amount ?? null ),
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Mollie API field.
 			'settlement_amount' => $to_amount( $payment->settlementAmount ?? null ),
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Mollie API field.
 			'application_fee'   => isset( $payment->applicationFee->amount )
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Mollie API field.
 				? $to_amount( $payment->applicationFee->amount )
 				: null,
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Mollie API field.
@@ -467,9 +469,11 @@ class TransactionAPI {
 				++$debug['scanned'];
 
 				if ( isset( $txn->context->paymentId ) && $txn->context->paymentId === $payment->id ) {
-					$debug['match_found']    = true;
-					$debug['deductions']     = isset( $txn->deductions ) ? (array) $txn->deductions : null;
-					$debug['result_amount']  = isset( $txn->resultAmount ) ? (array) $txn->resultAmount : null;
+					$debug['match_found'] = true;
+					$debug['deductions']  = isset( $txn->deductions ) ? (array) $txn->deductions : null;
+					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Mollie API field.
+					$debug['result_amount'] = isset( $txn->resultAmount ) ? (array) $txn->resultAmount : null;
+					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Mollie API field.
 					$debug['initial_amount'] = isset( $txn->initialAmount ) ? (array) $txn->initialAmount : null;
 
 					if ( isset( $txn->deductions->value ) ) {

--- a/fair-payment/src/API/TransactionAPI.php
+++ b/fair-payment/src/API/TransactionAPI.php
@@ -385,8 +385,10 @@ class TransactionAPI {
 
 			$transaction->sync_debug = self::build_mollie_debug( $payment );
 		} catch ( \Exception $e ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( 'Fair Payment sync error: ' . $e->getMessage() );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'Fair Payment sync error: ' . $e->getMessage() );
+			}
 
 			if ( $force ) {
 				return new \WP_Error(
@@ -500,8 +502,10 @@ class TransactionAPI {
 			}
 		} catch ( \Exception $e ) {
 			$debug['error'] = $e->getMessage();
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( 'Fair Payment balance lookup error: ' . $e->getMessage() );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'Fair Payment balance lookup error: ' . $e->getMessage() );
+			}
 		}
 
 		return $debug;
@@ -632,7 +636,10 @@ class TransactionAPI {
 		try {
 			$key_date = new \DateTimeImmutable( $event_date->start_datetime, $tz );
 		} catch ( \Exception $e ) {
-			error_log( '[Fair Payment] Invalid event start_datetime for event_date #' . (int) $transaction->event_date_id . ': ' . $e->getMessage() );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payment] Invalid event start_datetime for event_date #' . (int) $transaction->event_date_id . ': ' . $e->getMessage() );
+			}
 			return array();
 		}
 

--- a/fair-payment/src/API/TransactionsController.php
+++ b/fair-payment/src/API/TransactionsController.php
@@ -296,15 +296,18 @@ class TransactionsController extends WP_REST_Controller {
 		$fields = array();
 
 		if ( null !== $request->get_param( 'participant_id' ) ) {
-			$fields['participant_id'] = $request->get_param( 'participant_id' ) ?: null;
+			$participant_id           = $request->get_param( 'participant_id' );
+			$fields['participant_id'] = $participant_id ? $participant_id : null;
 		}
 
 		if ( null !== $request->get_param( 'user_id' ) ) {
-			$fields['user_id'] = $request->get_param( 'user_id' ) ?: null;
+			$user_id           = $request->get_param( 'user_id' );
+			$fields['user_id'] = $user_id ? $user_id : null;
 		}
 
 		if ( null !== $request->get_param( 'post_id' ) ) {
-			$fields['post_id'] = $request->get_param( 'post_id' ) ?: null;
+			$post_id           = $request->get_param( 'post_id' );
+			$fields['post_id'] = $post_id ? $post_id : null;
 		}
 
 		if ( empty( $fields ) ) {

--- a/fair-payment/src/Admin/AdminPages.php
+++ b/fair-payment/src/Admin/AdminPages.php
@@ -236,7 +236,10 @@ class AdminPages {
 		$asset_file_path = FAIR_PAYMENT_PLUGIN_DIR . 'build/admin/' . $page . '/index.asset.php';
 
 		if ( ! file_exists( $asset_file_path ) ) {
-			error_log( 'Fair Payment: Asset file not found at ' . $asset_file_path );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'Fair Payment: Asset file not found at ' . $asset_file_path );
+			}
 			return;
 		}
 

--- a/fair-payment/src/Admin/MigrationNotice.php
+++ b/fair-payment/src/Admin/MigrationNotice.php
@@ -28,26 +28,26 @@ class MigrationNotice {
 	 * @return void
 	 */
 	public function show_migration_notice() {
-		// Only show on admin pages
+		// Only show on admin pages.
 		if ( ! is_admin() ) {
 			return;
 		}
 
-		// Only show on Fair Event Plugins admin pages
+		// Only show on Fair Event Plugins admin pages.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$current_page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
 		if ( empty( $current_page ) || strpos( $current_page, 'fair' ) !== 0 ) {
 			return;
 		}
 
-		// Check if user has API keys configured
+		// Check if user has API keys configured.
 		$has_api_keys = ! empty( get_option( 'fair_payment_test_api_key' ) ) ||
 						! empty( get_option( 'fair_payment_live_api_key' ) );
 
-		// Check if OAuth is connected
+		// Check if OAuth is connected.
 		$has_oauth = get_option( 'fair_payment_mollie_connected', false );
 
-		// Show notice only if API keys exist but OAuth is not connected
+		// Show notice only if API keys exist but OAuth is not connected.
 		if ( $has_api_keys && ! $has_oauth ) {
 			$this->render_migration_notice();
 		}

--- a/fair-payment/src/Core/Plugin.php
+++ b/fair-payment/src/Core/Plugin.php
@@ -76,7 +76,7 @@ class Plugin {
 	 * @return void
 	 */
 	public function register_blocks() {
-		// Register simple-payment block from build directory
+		// Register simple-payment block from build directory.
 		register_block_type(
 			FAIR_PAYMENT_PLUGIN_DIR . 'build/blocks/simple-payment'
 		);

--- a/fair-payment/src/Database/PaymentLogRepository.php
+++ b/fair-payment/src/Database/PaymentLogRepository.php
@@ -193,6 +193,7 @@ class PaymentLogRepository {
 
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $where joins clauses already individually prepared above.
 				"SELECT * FROM %i{$where} ORDER BY id DESC LIMIT %d OFFSET %d",
 				$table_name,
 				(int) $args['limit'],

--- a/fair-payment/src/Database/Schema.php
+++ b/fair-payment/src/Database/Schema.php
@@ -3,6 +3,8 @@
  * Database schema for Fair Payment
  *
  * @package FairPayment
+ *
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery -- schema migrations and uninstall drops legitimately bypass dbDelta and caching.
  */
 
 namespace FairPayment\Database;
@@ -372,7 +374,6 @@ class Schema {
 			$table_name = self::get_payments_table_name();
 
 			// Check if payment_initiated_at column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -383,7 +384,6 @@ class Schema {
 
 			// Add payment_initiated_at column if it doesn't exist.
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN payment_initiated_at datetime DEFAULT NULL AFTER status',
@@ -393,7 +393,6 @@ class Schema {
 			}
 
 			// Update existing transactions: if they have mollie_payment_id, set status to 'pending_payment'.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->query(
 				$wpdb->prepare(
 					"UPDATE %i
@@ -421,7 +420,6 @@ class Schema {
 			$table_name = self::get_payments_table_name();
 
 			// Check if testmode column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -432,7 +430,6 @@ class Schema {
 
 			// Add testmode column if it doesn't exist.
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN testmode tinyint(1) NOT NULL DEFAULT 1 AFTER payment_initiated_at',
@@ -444,7 +441,6 @@ class Schema {
 				$current_mode = get_option( 'fair_payment_mode', 'test' );
 				$testmode     = ( 'live' === $current_mode ) ? 0 : 1;
 
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 				$wpdb->query(
 					$wpdb->prepare(
 						'UPDATE %i SET testmode = %d WHERE mollie_payment_id != %s',
@@ -473,7 +469,6 @@ class Schema {
 			$table_name = self::get_payments_table_name();
 
 			// Check if application_fee column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -484,7 +479,6 @@ class Schema {
 
 			// Add application_fee column if it doesn't exist.
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN application_fee decimal(10,2) DEFAULT NULL AFTER currency',
@@ -511,7 +505,6 @@ class Schema {
 			$table_name = self::get_payments_table_name();
 
 			// Check if old platform_fee_amount column exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$old_column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -521,7 +514,6 @@ class Schema {
 			);
 
 			// Check if new application_fee column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$new_column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -532,7 +524,6 @@ class Schema {
 
 			// Rename column if old exists and new doesn't.
 			if ( ! empty( $old_column_exists ) && empty( $new_column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i CHANGE COLUMN platform_fee_amount application_fee decimal(10,2) DEFAULT NULL',
@@ -577,7 +568,6 @@ class Schema {
 			$table_name = self::get_financial_entries_table_name();
 
 			// Check if external_reference column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -588,7 +578,6 @@ class Schema {
 
 			// Add external_reference column if it doesn't exist.
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN external_reference varchar(255) DEFAULT NULL AFTER transaction_id',
@@ -597,7 +586,6 @@ class Schema {
 				);
 
 				// Add unique index on external_reference.
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD UNIQUE KEY external_reference (external_reference)',
@@ -624,7 +612,6 @@ class Schema {
 			$table_name = self::get_financial_entries_table_name();
 
 			// Check if import_source column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -635,7 +622,6 @@ class Schema {
 
 			// Add import_source column if it doesn't exist.
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN import_source varchar(255) DEFAULT NULL AFTER external_reference',
@@ -645,7 +631,6 @@ class Schema {
 			}
 
 			// Check if imported_at column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$imported_at_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -656,7 +641,6 @@ class Schema {
 
 			// Add imported_at column if it doesn't exist.
 			if ( empty( $imported_at_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN imported_at datetime DEFAULT NULL AFTER import_source',
@@ -683,7 +667,6 @@ class Schema {
 			$table_name = self::get_financial_entries_table_name();
 
 			// Check if parent_entry_id column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -694,7 +677,6 @@ class Schema {
 
 			// Add parent_entry_id column if it doesn't exist.
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN parent_entry_id bigint(20) UNSIGNED DEFAULT NULL AFTER import_source',
@@ -703,7 +685,6 @@ class Schema {
 				);
 
 				// Add index on parent_entry_id.
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD KEY parent_entry_id (parent_entry_id)',
@@ -730,7 +711,6 @@ class Schema {
 			$table_name = self::get_financial_entries_table_name();
 
 			// Check if event_url column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -741,7 +721,6 @@ class Schema {
 
 			// Add event_url column if it doesn't exist.
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN event_url varchar(500) DEFAULT NULL AFTER parent_entry_id',
@@ -750,7 +729,6 @@ class Schema {
 				);
 
 				// Add index on event_url.
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD KEY event_url (event_url)',
@@ -777,7 +755,6 @@ class Schema {
 			$table_name = self::get_financial_entries_table_name();
 
 			// Check if event_date_id column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -788,7 +765,6 @@ class Schema {
 
 			// Add event_date_id column if it doesn't exist.
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN event_date_id bigint(20) UNSIGNED DEFAULT NULL AFTER event_url',
@@ -797,7 +773,6 @@ class Schema {
 				);
 
 				// Add index on event_date_id.
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD KEY event_date_id (event_date_id)',
@@ -824,7 +799,6 @@ class Schema {
 			$table_name = self::get_payments_table_name();
 
 			// Check if mollie_fee column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -835,7 +809,6 @@ class Schema {
 
 			// Add mollie_fee column if it doesn't exist.
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN mollie_fee decimal(10,2) DEFAULT NULL AFTER application_fee',
@@ -862,7 +835,6 @@ class Schema {
 			$table_name = self::get_payments_table_name();
 
 			// Check if event_date_id column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -873,7 +845,6 @@ class Schema {
 
 			// Add event_date_id column if it doesn't exist.
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN event_date_id bigint(20) UNSIGNED DEFAULT NULL AFTER post_id',
@@ -882,7 +853,6 @@ class Schema {
 				);
 
 				// Add index on event_date_id.
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD KEY event_date_id (event_date_id)',
@@ -913,7 +883,6 @@ class Schema {
 			$entries_table  = self::get_financial_entries_table_name();
 
 			// Migrate existing 1:1 matches into the junction table.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->query(
 				$wpdb->prepare(
 					'INSERT IGNORE INTO %i (entry_id, transaction_id) SELECT id, transaction_id FROM %i WHERE transaction_id IS NOT NULL',
@@ -941,7 +910,6 @@ class Schema {
 			$table_name = self::get_payments_table_name();
 
 			// Check if participant_id column already exists.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -952,7 +920,6 @@ class Schema {
 
 			// Add participant_id column if it doesn't exist.
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN participant_id bigint(20) UNSIGNED DEFAULT NULL AFTER user_id',
@@ -961,7 +928,6 @@ class Schema {
 				);
 
 				// Add index on participant_id.
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD KEY participant_id (participant_id)',
@@ -993,7 +959,6 @@ class Schema {
 		if ( version_compare( $current_version, '16.0', '<' ) ) {
 			$table_name = self::get_payments_table_name();
 
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$rows = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT id, metadata FROM %i WHERE event_date_id IS NULL AND metadata IS NOT NULL AND metadata != ''",
@@ -1008,7 +973,6 @@ class Schema {
 						continue;
 					}
 
-					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 					$wpdb->update(
 						$table_name,
 						array( 'event_date_id' => (int) $metadata['event_date_id'] ),
@@ -1036,7 +1000,6 @@ class Schema {
 		if ( version_compare( $current_version, '17.0', '<' ) ) {
 			$table_name = self::get_financial_entries_table_name();
 
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$column_exists = $wpdb->get_results(
 				$wpdb->prepare(
 					'SHOW COLUMNS FROM %i LIKE %s',
@@ -1046,7 +1009,6 @@ class Schema {
 			);
 
 			if ( empty( $column_exists ) ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD COLUMN participant_id bigint(20) UNSIGNED DEFAULT NULL AFTER event_date_id',
@@ -1054,7 +1016,6 @@ class Schema {
 					)
 				);
 
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 				$wpdb->query(
 					$wpdb->prepare(
 						'ALTER TABLE %i ADD KEY participant_id (participant_id)',
@@ -1112,31 +1073,24 @@ class Schema {
 		$api_tokens_table         = self::get_api_tokens_table_name();
 
 		// Drop API tokens table (standalone, no FK references).
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $api_tokens_table ) );
 
 		// Drop log table (references transactions but only via informational FK, drop first).
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $log_table ) );
 
 		// Drop entry-transaction junction table first (references both entries and transactions).
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $entry_transactions_table ) );
 
 		// Drop financial entries (references transactions and budgets).
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $financial_entries_table ) );
 
 		// Drop budgets table.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $budgets_table ) );
 
 		// Drop line items (foreign key reference to transactions).
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $line_items_table ) );
 
 		// Drop transactions table.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $transactions_table ) );
 
 		delete_option( 'fair_payment_db_version' );

--- a/fair-payment/src/Models/EntryTransaction.php
+++ b/fair-payment/src/Models/EntryTransaction.php
@@ -144,9 +144,10 @@ class EntryTransaction {
 
 		$placeholders = implode( ',', array_fill( 0, count( $transaction_ids ), '%d' ) );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic placeholder count matches array size.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic placeholder count matches array size.
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is a generated string of %d placeholders only.
 				"SELECT transaction_id, entry_id FROM %i WHERE transaction_id IN ($placeholders) ORDER BY id ASC",
 				array_merge( array( $table_name ), array_map( 'intval', $transaction_ids ) )
 			)

--- a/fair-payment/src/Models/FinancialEntry.php
+++ b/fair-payment/src/Models/FinancialEntry.php
@@ -3,6 +3,8 @@
  * Financial Entry model for Fair Payment
  *
  * @package FairPayment
+ *
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery -- model layer reads/writes a custom table directly; caching is left to callers.
  */
 
 namespace FairPayment\Models;
@@ -258,9 +260,10 @@ class FinancialEntry {
 
 		// When filtering by a specific budget, event_url, or event_date_id, include child entries matching that filter.
 		// Otherwise, exclude child entries (they are shown under their parent).
-		if ( ( ! empty( $filters['budget_id'] ) && 'none' !== $filters['budget_id'] ) || ! empty( $filters['event_url'] ) || ! empty( $filters['event_date_id'] ) ) {
-			// No parent_entry_id restriction — filter will match both parents and children.
-		} else {
+		$include_children = ( ! empty( $filters['budget_id'] ) && 'none' !== $filters['budget_id'] )
+			|| ! empty( $filters['event_url'] )
+			|| ! empty( $filters['event_date_id'] );
+		if ( ! $include_children ) {
 			$where_clauses[] = 'parent_entry_id IS NULL';
 		}
 
@@ -301,6 +304,7 @@ class FinancialEntry {
 		if ( ! empty( $filters['unmatched'] ) ) {
 			$junction_table  = Schema::get_entry_transactions_table_name();
 			$where_clauses[] = $wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- $table_name comes from Schema::get_*_table_name() and is not user input.
 				'NOT EXISTS (SELECT 1 FROM %i WHERE entry_id = ' . $table_name . '.id)',
 				$junction_table
 			);
@@ -314,7 +318,7 @@ class FinancialEntry {
 		// Get total count.
 		$count_sql = $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $table_name );
 		if ( ! empty( $where_values ) ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- placeholder count is dynamic (one per $where_values entry).
 			$count_sql .= ' ' . $wpdb->prepare( str_replace( '%i', '%%i', $where_sql ), ...$where_values );
 		} elseif ( ! empty( $where_sql ) ) {
 			$count_sql .= ' ' . $where_sql;
@@ -332,7 +336,7 @@ class FinancialEntry {
 		// Get entries.
 		$query = $wpdb->prepare( 'SELECT * FROM %i', $table_name );
 		if ( ! empty( $where_values ) ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- placeholder count is dynamic (one per $where_values entry).
 			$query .= ' ' . $wpdb->prepare( str_replace( '%i', '%%i', $where_sql ), ...$where_values );
 		} elseif ( ! empty( $where_sql ) ) {
 			$query .= ' ' . $where_sql;
@@ -343,7 +347,7 @@ class FinancialEntry {
 			: 'entry_date';
 		$order           = ! empty( $filters['order'] ) && 'asc' === strtolower( $filters['order'] ) ? 'ASC' : 'DESC';
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order is validated against an ASC/DESC allowlist above.
 		$query .= $wpdb->prepare( " ORDER BY %i $order, id DESC LIMIT %d OFFSET %d", $orderby, $per_page, $offset );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
@@ -418,6 +422,7 @@ class FinancialEntry {
 		if ( ! empty( $filters['unmatched'] ) ) {
 			$junction_table  = Schema::get_entry_transactions_table_name();
 			$where_clauses[] = $wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- $table_name comes from Schema::get_*_table_name() and is not user input.
 				'NOT EXISTS (SELECT 1 FROM %i WHERE entry_id = ' . $table_name . '.id)',
 				$junction_table
 			);
@@ -431,7 +436,7 @@ class FinancialEntry {
 		// Get cost total.
 		$cost_sql = $wpdb->prepare( 'SELECT COALESCE(SUM(amount), 0) FROM %i', $table_name );
 		if ( ! empty( $where_values ) ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- placeholder count is dynamic (one per $where_values entry).
 			$cost_where = $wpdb->prepare( str_replace( '%i', '%%i', $where_sql ), ...$where_values );
 			$cost_sql  .= ' ' . $cost_where . " AND entry_type = 'cost'";
 		} elseif ( ! empty( $where_sql ) ) {
@@ -445,7 +450,7 @@ class FinancialEntry {
 		// Get income total.
 		$income_sql = $wpdb->prepare( 'SELECT COALESCE(SUM(amount), 0) FROM %i', $table_name );
 		if ( ! empty( $where_values ) ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- placeholder count is dynamic (one per $where_values entry).
 			$income_where = $wpdb->prepare( str_replace( '%i', '%%i', $where_sql ), ...$where_values );
 			$income_sql  .= ' ' . $income_where . " AND entry_type = 'income'";
 		} elseif ( ! empty( $where_sql ) ) {
@@ -525,6 +530,8 @@ class FinancialEntry {
 	 * @param string|null $description    Entry description.
 	 * @param int|null    $budget_id      Budget ID.
 	 * @param int|null    $transaction_id Transaction ID.
+	 * @param string|null $event_url      Event URL.
+	 * @param int|null    $event_date_id  Event date ID.
 	 * @return int|false The entry ID on success, false on failure.
 	 */
 	public static function create( $amount, $entry_type, $entry_date, $description = null, $budget_id = null, $transaction_id = null, $event_url = null, $event_date_id = null ) {
@@ -569,6 +576,8 @@ class FinancialEntry {
 	 * @param string|null $description    Entry description.
 	 * @param int|null    $budget_id      Budget ID.
 	 * @param int|null    $transaction_id Transaction ID.
+	 * @param string|null $event_url      Event URL.
+	 * @param int|null    $event_date_id  Event date ID.
 	 * @return bool True on success, false on failure.
 	 */
 	public static function update( $id, $amount, $entry_type, $entry_date, $description = null, $budget_id = null, $transaction_id = null, $event_url = null, $event_date_id = null ) {
@@ -1045,6 +1054,7 @@ class FinancialEntry {
 	 * @param string|null $description       Transfer description.
 	 * @param string|null $event_url         Event URL.
 	 * @param int|null    $event_date_id     Event date ID.
+	 * @param int|null    $participant_id    Participant ID.
 	 * @return int|false The parent entry ID on success, false on failure.
 	 */
 	public static function create_transfer( $amount, $entry_date, $source_budget_id, $target_budget_id, $description = null, $event_url = null, $event_date_id = null, $participant_id = null ) {
@@ -1134,6 +1144,7 @@ class FinancialEntry {
 	 * @param string|null $description       Transfer description.
 	 * @param string|null $event_url         Event URL.
 	 * @param int|null    $event_date_id     Event date ID.
+	 * @param int|null    $participant_id    Participant ID.
 	 * @return bool True on success, false on failure.
 	 */
 	public static function update_transfer( $id, $amount, $entry_date, $source_budget_id, $target_budget_id, $description = null, $event_url = null, $event_date_id = null, $participant_id = null ) {

--- a/fair-payment/src/Models/LineItem.php
+++ b/fair-payment/src/Models/LineItem.php
@@ -3,6 +3,8 @@
  * LineItem Model
  *
  * @package FairPayment
+ *
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery -- model layer reads/writes a custom table directly; caching is left to callers.
  */
 
 namespace FairPayment\Models;

--- a/fair-payment/src/Models/Transaction.php
+++ b/fair-payment/src/Models/Transaction.php
@@ -3,6 +3,8 @@
  * Transaction Model
  *
  * @package FairPayment
+ *
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery -- model layer reads/writes a custom table directly; caching is left to callers.
  */
 
 namespace FairPayment\Models;
@@ -259,6 +261,7 @@ class Transaction {
 
 		$ids = $wpdb->get_col(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $where is an AND-join of clauses already individually run through $wpdb->prepare() above.
 				"SELECT id FROM %i WHERE {$where} ORDER BY created_at DESC",
 				$table_name
 			)
@@ -344,6 +347,7 @@ class Transaction {
 
 		return $wpdb->get_results(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $where joins clauses already prepared above; $orderby/$order are validated against allowlists.
 				"SELECT * FROM %i{$where} ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
 				$table_name,
 				$args['limit'],
@@ -392,6 +396,7 @@ class Transaction {
 
 		return (int) $wpdb->get_var(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $where joins clauses already prepared above.
 				"SELECT COUNT(*) FROM %i{$where}",
 				$table_name
 			)

--- a/fair-payment/src/OAuth/SiteIdManager.php
+++ b/fair-payment/src/OAuth/SiteIdManager.php
@@ -26,8 +26,8 @@ class SiteIdManager {
 		$site_id = get_option( 'fair_payment_mollie_site_id' );
 
 		if ( empty( $site_id ) ) {
-			// Generate unique ID from home URL and absolute path
-			// This ensures the ID remains stable across requests
+			// Generate unique ID from home URL and absolute path.
+			// This ensures the ID remains stable across requests.
 			$site_id = hash( 'sha256', home_url() . ABSPATH );
 			update_option( 'fair_payment_mollie_site_id', $site_id );
 		}

--- a/fair-payment/src/Payment/MolliePaymentHandler.php
+++ b/fair-payment/src/Payment/MolliePaymentHandler.php
@@ -30,7 +30,7 @@ class MolliePaymentHandler {
 	public function __construct() {
 		$this->mollie = new MollieApiClient();
 
-		// Prefer OAuth if connected, otherwise fall back to API keys
+		// Prefer OAuth if connected, otherwise fall back to API keys.
 		if ( get_option( 'fair_payment_mollie_connected', false ) ) {
 			$this->set_access_token();
 		} else {
@@ -42,6 +42,7 @@ class MolliePaymentHandler {
 	 * Set API key based on mode
 	 *
 	 * @return void
+	 * @throws \Exception If no API key is configured.
 	 */
 	private function set_api_key() {
 		$mode = get_option( 'fair_payment_mode', 'test' );
@@ -53,7 +54,7 @@ class MolliePaymentHandler {
 		}
 
 		if ( empty( $api_key ) ) {
-			throw new \Exception( __( 'Mollie API key is not configured.', 'fair-payment' ) );
+			throw new \Exception( esc_html__( 'Mollie API key is not configured.', 'fair-payment' ) );
 		}
 
 		$this->mollie->setApiKey( $api_key );
@@ -72,7 +73,7 @@ class MolliePaymentHandler {
 		$access_token = $this->get_valid_access_token();
 
 		if ( empty( $access_token ) ) {
-			throw new \Exception( __( 'Mollie is not connected. Please connect your Mollie account in settings.', 'fair-payment' ) );
+			throw new \Exception( esc_html__( 'Mollie is not connected. Please connect your Mollie account in settings.', 'fair-payment' ) );
 		}
 
 		$this->mollie->setAccessToken( $access_token );
@@ -89,12 +90,12 @@ class MolliePaymentHandler {
 		$token   = get_option( 'fair_payment_mollie_access_token' );
 		$expires = get_option( 'fair_payment_mollie_token_expires', 0 );
 
-		// Token valid if not expired (5 min buffer)
+		// Token valid if not expired (5 min buffer).
 		if ( $token && time() < ( $expires - 300 ) ) {
 			return $token;
 		}
 
-		// Expired - refresh it
+		// Expired - refresh it.
 		return $this->refresh_access_token();
 	}
 
@@ -180,18 +181,18 @@ class MolliePaymentHandler {
 	 * @return string|false Profile ID or false if unavailable.
 	 */
 	private function get_profile_id() {
-		// Not needed for API key authentication
+		// Not needed for API key authentication.
 		if ( ! get_option( 'fair_payment_mollie_connected', false ) ) {
 			return false;
 		}
 
-		// Check cached profile ID
+		// Check cached profile ID.
 		$profile_id = get_option( 'fair_payment_mollie_profile_id' );
 		if ( ! empty( $profile_id ) ) {
 			return $profile_id;
 		}
 
-		// Fetch current profile from Mollie
+		// Fetch current profile from Mollie.
 		try {
 			$profile = $this->mollie->profiles->get( 'me' );
 			if ( $profile && ! empty( $profile->id ) ) {
@@ -213,7 +214,7 @@ class MolliePaymentHandler {
 	 *
 	 * @param array $args Payment arguments.
 	 * @return array Payment data including mollie_payment_id and checkout_url.
-	 * @throws ApiException If payment creation fails.
+	 * @throws \Exception If the underlying Mollie call fails.
 	 */
 	public function create_payment( $args ) {
 		$defaults = array(
@@ -257,19 +258,19 @@ class MolliePaymentHandler {
 				);
 			}
 
-			// Add profile ID for OAuth authentication
+			// Add profile ID for OAuth authentication.
 			$profile_id = $this->get_profile_id();
 			if ( $profile_id ) {
 				$payment_data['profileId'] = $profile_id;
 			}
 
-			// Set test mode based on settings (required for OAuth)
+			// Set test mode based on settings (required for OAuth).
 			$mode                     = get_option( 'fair_payment_mode', 'test' );
 			$payment_data['testmode'] = ( 'live' === $mode ) ? false : true;
 
 			// Build a method allowlist when callers want to suppress specific methods.
 			// Mollie has no "exclude" parameter; the supported way is to pass `method`
-			// as an allowlist. We fetch the currently active set so the allowlist
+			// as an allowlist. We fetch the currently active set so the allowlist.
 			// stays in sync with the merchant's Mollie configuration.
 			if ( ! empty( $args['disable_methods'] ) && is_array( $args['disable_methods'] ) ) {
 				$allowed = $this->build_method_allowlist(
@@ -324,8 +325,8 @@ class MolliePaymentHandler {
 				'status'            => $payment->status,
 			);
 		} catch ( ApiException $e ) {
-			// At this point Mollie may or may not have created the payment — we never
-			// got a confirmed response. Log the request payload so an admin can search
+			// At this point Mollie may or may not have created the payment — we never.
+			// got a confirmed response. Log the request payload so an admin can search.
 			// the Mollie dashboard for an orphan payment.
 			$logger->log(
 				'mollie_call_failed',
@@ -343,10 +344,12 @@ class MolliePaymentHandler {
 				)
 			);
 			throw new \Exception(
-				sprintf(
-					/* translators: %s: error message */
-					__( 'Failed to create payment: %s', 'fair-payment' ),
-					$e->getMessage()
+				esc_html(
+					sprintf(
+						/* translators: %s: error message */
+						__( 'Failed to create payment: %s', 'fair-payment' ),
+						$e->getMessage()
+					)
 				)
 			);
 		}
@@ -392,7 +395,7 @@ class MolliePaymentHandler {
 			$allowed[] = $method->id;
 		}
 
-		// If filtering left us with nothing, fall back to letting Mollie show
+		// If filtering left us with nothing, fall back to letting Mollie show.
 		// all enabled methods rather than passing an empty allowlist.
 		if ( count( $allowed ) === count( $methods ) || empty( $allowed ) ) {
 			return array();
@@ -407,17 +410,19 @@ class MolliePaymentHandler {
 	 * @param string $mollie_payment_id Mollie payment ID.
 	 * @param array  $options Options for retrieving payment (e.g., testmode).
 	 * @return object Payment object from Mollie.
-	 * @throws ApiException If payment retrieval fails.
+	 * @throws \Exception If the underlying Mollie call fails.
 	 */
 	public function get_payment( $mollie_payment_id, $options = array() ) {
 		try {
 			return $this->mollie->payments->get( $mollie_payment_id, $options );
 		} catch ( ApiException $e ) {
 			throw new \Exception(
-				sprintf(
-					/* translators: %s: error message */
-					__( 'Failed to retrieve payment: %s', 'fair-payment' ),
-					$e->getMessage()
+				esc_html(
+					sprintf(
+						/* translators: %s: error message */
+						__( 'Failed to retrieve payment: %s', 'fair-payment' ),
+						$e->getMessage()
+					)
 				)
 			);
 		}
@@ -440,10 +445,12 @@ class MolliePaymentHandler {
 			return $this->mollie->balanceTransactions->iteratorForPrimary( $parameters );
 		} catch ( ApiException $e ) {
 			throw new \Exception(
-				sprintf(
-					/* translators: %s: error message */
-					__( 'Failed to list balance transactions: %s', 'fair-payment' ),
-					$e->getMessage()
+				esc_html(
+					sprintf(
+						/* translators: %s: error message */
+						__( 'Failed to list balance transactions: %s', 'fair-payment' ),
+						$e->getMessage()
+					)
 				)
 			);
 		}
@@ -458,12 +465,12 @@ class MolliePaymentHandler {
 	 * @return bool True if OAuth is connected or API key is set.
 	 */
 	public static function is_configured() {
-		// Check OAuth connection first
+		// Check OAuth connection first.
 		if ( get_option( 'fair_payment_mollie_connected', false ) ) {
 			return true;
 		}
 
-		// Fall back to API key check
+		// Fall back to API key check.
 		$mode = get_option( 'fair_payment_mode', 'test' );
 
 		if ( 'live' === $mode ) {

--- a/fair-payment/src/Payment/MolliePaymentHandler.php
+++ b/fair-payment/src/Payment/MolliePaymentHandler.php
@@ -106,17 +106,16 @@ class MolliePaymentHandler {
 	 * @return string|false New access token or false if refresh failed.
 	 */
 	private function refresh_access_token() {
-		error_log( '[Fair Payment] Token refresh started' );
-
 		$refresh_token = get_option( 'fair_payment_mollie_refresh_token' );
 
 		if ( empty( $refresh_token ) ) {
-			error_log( '[Fair Payment] Token refresh failed: No refresh token found in database' );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payment] Token refresh failed: No refresh token found in database' );
+			}
 			update_option( 'fair_payment_mollie_connected', false );
 			return false;
 		}
-
-		error_log( '[Fair Payment] Sending refresh request to fair-event-plugins.com with token: ' . substr( $refresh_token, 0, 15 ) . '...' );
 
 		$response = wp_remote_post(
 			'https://fair-event-plugins.com/oauth/refresh',
@@ -127,49 +126,48 @@ class MolliePaymentHandler {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			error_log( '[Fair Payment] Token refresh failed: HTTP error - ' . $response->get_error_message() );
-			error_log( '[Fair Payment] Error code: ' . $response->get_error_code() );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payment] Token refresh failed: HTTP error - ' . $response->get_error_message() . ' (code: ' . $response->get_error_code() . ')' );
+			}
 			return false;
 		}
 
-		$http_code     = wp_remote_retrieve_response_code( $response );
 		$response_body = wp_remote_retrieve_body( $response );
-
-		error_log( '[Fair Payment] OAuth server responded with HTTP ' . $http_code );
-		error_log( '[Fair Payment] Response body: ' . $response_body );
-
-		$body = json_decode( $response_body, true );
+		$body          = json_decode( $response_body, true );
 
 		if ( json_last_error() !== JSON_ERROR_NONE ) {
-			error_log( '[Fair Payment] Token refresh failed: Invalid JSON response - ' . json_last_error_msg() );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payment] Token refresh failed: Invalid JSON response - ' . json_last_error_msg() );
+			}
 			return false;
 		}
 
 		if ( empty( $body['success'] ) ) {
 			update_option( 'fair_payment_mollie_connected', false );
-			$error_message = isset( $body['message'] ) ? $body['message'] : 'Unknown error';
-			error_log( '[Fair Payment] Token refresh failed: Server returned success=false - ' . $error_message );
-			error_log( '[Fair Payment] Full response: ' . wp_json_encode( $body ) );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				$error_message = isset( $body['message'] ) ? $body['message'] : 'Unknown error';
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payment] Token refresh failed: Server returned success=false - ' . $error_message );
+			}
 			return false;
 		}
 
-		// Verify required keys exist in response (nested under data.data)
+		// Verify required keys exist in response (nested under data.data).
 		if ( ! isset( $body['data']['data']['access_token'] ) || ! isset( $body['data']['data']['expires_in'] ) ) {
 			update_option( 'fair_payment_mollie_connected', false );
-			error_log( '[Fair Payment] Token refresh failed: Missing required fields in response' );
-			error_log( '[Fair Payment] Has data.data.access_token: ' . ( isset( $body['data']['data']['access_token'] ) ? 'yes' : 'no' ) );
-			error_log( '[Fair Payment] Has data.data.expires_in: ' . ( isset( $body['data']['data']['expires_in'] ) ? 'yes' : 'no' ) );
-			error_log( '[Fair Payment] Full response: ' . wp_json_encode( $body ) );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payment] Token refresh failed: Missing required fields in response' );
+			}
 			return false;
 		}
 
-		// Store new token
 		$new_token  = $body['data']['data']['access_token'];
 		$expires_in = $body['data']['data']['expires_in'];
 		update_option( 'fair_payment_mollie_access_token', $new_token );
 		update_option( 'fair_payment_mollie_token_expires', time() + $expires_in );
-
-		error_log( '[Fair Payment] Token refresh successful. New token: ' . substr( $new_token, 0, 15 ) . '... (expires in ' . $expires_in . ' seconds)' );
 
 		return $new_token;
 	}
@@ -201,7 +199,10 @@ class MolliePaymentHandler {
 				return $profile->id;
 			}
 		} catch ( \Exception $e ) {
-			error_log( 'Failed to fetch Mollie profile: ' . $e->getMessage() );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'Failed to fetch Mollie profile: ' . $e->getMessage() );
+			}
 		}
 
 		return false;
@@ -375,7 +376,10 @@ class MolliePaymentHandler {
 
 			$methods = $this->mollie->methods->allActive( $parameters );
 		} catch ( ApiException $e ) {
-			error_log( '[Fair Payment] Failed to list Mollie methods for filter: ' . $e->getMessage() );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payment] Failed to list Mollie methods for filter: ' . $e->getMessage() );
+			}
 			return array();
 		}
 

--- a/fair-payment/src/Services/TelegramService.php
+++ b/fair-payment/src/Services/TelegramService.php
@@ -60,7 +60,10 @@ class TelegramService {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			error_log( '[Fair Payment] Telegram send failed: ' . $response->get_error_message() );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payment] Telegram send failed: ' . $response->get_error_message() );
+			}
 			return $response;
 		}
 
@@ -70,7 +73,10 @@ class TelegramService {
 
 		if ( $code < 200 || $code >= 300 || empty( $data['ok'] ) ) {
 			$description = is_array( $data ) && ! empty( $data['description'] ) ? $data['description'] : 'HTTP ' . $code;
-			error_log( '[Fair Payment] Telegram send returned non-OK: ' . $description );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payment] Telegram send returned non-OK: ' . $description );
+			}
 			return new \WP_Error(
 				'fair_payment_telegram_api_error',
 				$description,

--- a/fair-payment/src/Settings/Settings.php
+++ b/fair-payment/src/Settings/Settings.php
@@ -28,7 +28,7 @@ class Settings {
 	 * @return void
 	 */
 	public function register_settings() {
-		// Test API Key
+		// Test API Key.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_test_api_key',
@@ -41,7 +41,7 @@ class Settings {
 			)
 		);
 
-		// Live API Key
+		// Live API Key.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_live_api_key',
@@ -54,7 +54,7 @@ class Settings {
 			)
 		);
 
-		// Mode (test or live)
+		// Mode (test or live).
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_mode',
@@ -67,7 +67,7 @@ class Settings {
 			)
 		);
 
-		// Organization ID
+		// Organization ID.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_organization_id',
@@ -80,7 +80,7 @@ class Settings {
 			)
 		);
 
-		// OAuth Access Token
+		// OAuth Access Token.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_mollie_access_token',
@@ -98,7 +98,7 @@ class Settings {
 			)
 		);
 
-		// OAuth Refresh Token
+		// OAuth Refresh Token.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_mollie_refresh_token',
@@ -116,7 +116,7 @@ class Settings {
 			)
 		);
 
-		// OAuth Token Expiration
+		// OAuth Token Expiration.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_mollie_token_expires',
@@ -134,7 +134,7 @@ class Settings {
 			)
 		);
 
-		// OAuth Site ID
+		// OAuth Site ID.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_mollie_site_id',
@@ -152,7 +152,7 @@ class Settings {
 			)
 		);
 
-		// OAuth Connection Status
+		// OAuth Connection Status.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_mollie_connected',
@@ -170,7 +170,7 @@ class Settings {
 			)
 		);
 
-		// Enable Budgets Feature
+		// Enable Budgets Feature.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_enable_budgets',
@@ -183,7 +183,7 @@ class Settings {
 			)
 		);
 
-		// Mollie Profile ID (cached for OAuth)
+		// Mollie Profile ID (cached for OAuth).
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_mollie_profile_id',
@@ -196,7 +196,7 @@ class Settings {
 			)
 		);
 
-		// Disable bank transfer when close to event date
+		// Disable bank transfer when close to event date.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_disable_banktransfer_near_date',
@@ -209,7 +209,7 @@ class Settings {
 			)
 		);
 
-		// Bank transfer cutoff in working days
+		// Bank transfer cutoff in working days.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_banktransfer_threshold_days',
@@ -222,7 +222,7 @@ class Settings {
 			)
 		);
 
-		// Telegram: enabled
+		// Telegram: enabled.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_telegram_enabled',
@@ -235,7 +235,7 @@ class Settings {
 			)
 		);
 
-		// Telegram: bot token (sensitive — edit context only)
+		// Telegram: bot token (sensitive — edit context only).
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_telegram_bot_token',
@@ -253,7 +253,7 @@ class Settings {
 			)
 		);
 
-		// Telegram: chat IDs (comma-separated)
+		// Telegram: chat IDs (comma-separated).
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_telegram_chat_ids',
@@ -266,7 +266,7 @@ class Settings {
 			)
 		);
 
-		// Telegram: message template
+		// Telegram: message template.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_telegram_template',
@@ -279,7 +279,7 @@ class Settings {
 			)
 		);
 
-		// Telegram: include PII placeholders
+		// Telegram: include PII placeholders.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_telegram_include_pii',

--- a/fair-payment/src/blocks/simple-payment/render.php
+++ b/fair-payment/src/blocks/simple-payment/render.php
@@ -9,15 +9,16 @@
  * @var WP_Block $block      Block instance.
  */
 
-$amount      = isset( $attributes['amount'] ) ? $attributes['amount'] : '10';
-$currency    = isset( $attributes['currency'] ) ? $attributes['currency'] : 'EUR';
-$description = isset( $attributes['description'] ) ? $attributes['description'] : '';
-$post_id     = get_the_ID();
+$amount          = isset( $attributes['amount'] ) ? $attributes['amount'] : '10';
+$currency        = isset( $attributes['currency'] ) ? $attributes['currency'] : 'EUR';
+$description     = isset( $attributes['description'] ) ? $attributes['description'] : '';
+$current_post_id = get_the_ID();
 
-// Check if payment callback (return from payment gateway).
+// Read-only flags from URL params signalling a return from the payment gateway. No state change; nonce not applicable.
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $is_callback = isset( $_GET['fair_payment_callback'] ) && 'true' === $_GET['fair_payment_callback'];
 
-// Check if payment redirect with success message.
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $show_success = isset( $_GET['payment_redirect'] ) && '1' === $_GET['payment_redirect'];
 
 // Check if Mollie is configured.
@@ -26,7 +27,12 @@ $is_configured = \FairPayment\Payment\MolliePaymentHandler::is_configured();
 $block_id = 'fair-payment-' . wp_unique_id();
 ?>
 
-<div <?php echo get_block_wrapper_attributes( array( 'id' => $block_id ) ); ?>>
+<div 
+<?php
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() returns pre-escaped HTML attributes.
+	echo get_block_wrapper_attributes( array( 'id' => $block_id ) );
+?>
+>
 	<div class="fair-payment-block">
 		<?php if ( $is_callback ) : ?>
 			<div class="fair-payment-callback">
@@ -57,7 +63,7 @@ $block_id = 'fair-payment-' . wp_unique_id();
 					data-amount="<?php echo esc_attr( $amount ); ?>"
 					data-currency="<?php echo esc_attr( $currency ); ?>"
 					data-description="<?php echo esc_attr( $description ); ?>"
-					data-post-id="<?php echo esc_attr( $post_id ); ?>"
+					data-post-id="<?php echo esc_attr( $current_post_id ); ?>"
 				>
 					<?php esc_html_e( 'Pay Now', 'fair-payment' ); ?>
 				</button>


### PR DESCRIPTION
## Summary

- Clears the `fair-payment` PHPCS backlog against the project's `WordPress` ruleset: `vendor/bin/phpcs fair-payment/src fair-payment/fair-payment.php` now exits 0 (was 82 errors / 84 warnings / 166 sniff violations).
- Removes/guards 24 stray `error_log()` calls — chatty progress logs in Mollie token refresh and connection-test deleted; real error-path logs wrapped in `WP_DEBUG` guards with justified `phpcs:ignore`.
- Adopts the sibling-plugin pattern of file-level `phpcs:disable WordPress.DB.DirectDatabaseQuery` on `Schema.php` and the model layer (Transaction, FinancialEntry, LineItem) where direct table access is the design. Inline `phpcs:ignore` covers SQL fragments that are already prepared (joined `$where`, allowlisted `$orderby`/`$order`, dynamic `%d` placeholders for `IN`).
- Wraps exception messages thrown to user-facing surfaces in `esc_html` / `esc_html__`. Marks `get_block_wrapper_attributes()` output as pre-escaped. Suppresses `NonceVerification.Recommended` on the read-only return-from-gateway URL flags in `blocks/simple-payment/render.php`.
- Renames the local `$post_id` in the block render to `$current_post_id` to stop clobbering the WordPress global; the rendered HTML attribute `data-post-id` (read by the view JS) is unchanged.
- Adds missing `@throws` tags and trailing punctuation on inline comments flagged by `Squiz.Commenting.InlineComment`.

Closes #735.

## Test plan

- [x] `vendor/bin/phpcs fair-payment/src fair-payment/fair-payment.php` exits 0 with no errors and no warnings.
- [x] `npm test --workspace=fair-payment` passes (11/11).
- [x] `npm run build` in `fair-payment/` succeeds; block `render.php` regenerates with the new local-variable name.
- [ ] Manual: open a published page with a simple-payment block and confirm the payment button still posts via `apiFetch` and redirects to Mollie (the `data-post-id` attribute is unchanged so view.js is unaffected).