### PR TITLE
fair-payment: bump Requires at least to 6.2 for %i support

### DIFF
--- a/.changeset/fair-payment-requires-6-2.md
+++ b/.changeset/fair-payment-requires-6-2.md
@@ -1,0 +1,5 @@
+---
+'fair-payment': patch
+---
+
+Bump minimum WordPress version to 6.2 so the `%i` identifier placeholder used in `$wpdb->prepare()` is supported on the declared floor, clearing Plugin Check `UnsupportedIdentifierPlaceholder` errors before publishing.

--- a/fair-payment/fair-payment.php
+++ b/fair-payment/fair-payment.php
@@ -4,6 +4,7 @@
  * Plugin URI: https://fair-event-plugins.com
  * Description: Simple payment block for WordPress
  * Version: 1.3.1
+ * Requires at least: 6.2
  * Author: Fair Event Plugins
  * Author URI: https://fair-event-plugins.com
  * License: GPL-2.0-or-later

--- a/fair-payment/readme.txt
+++ b/fair-payment/readme.txt
@@ -1,7 +1,7 @@
 === Fair Payment ===
 Contributors: faireventplugins
 Tags: payment, gutenberg, block
-Requires at least: 6.0
+Requires at least: 6.2
 Tested up to: 7.0
 Stable tag: 1.3.1
 Requires PHP: 7.4


### PR DESCRIPTION
## Summary
- Bump `Requires at least` to **6.2** in `fair-payment/readme.txt` and add the missing `Requires at least: 6.2` line to the `fair-payment.php` plugin header.
- `%i` identifier placeholders in `$wpdb->prepare()` only landed in WP 6.2; declaring 6.0 caused Plugin Check to flag ~85 `WordPress.DB.PreparedSQLPlaceholders.UnsupportedIdentifierPlaceholder` errors. Raising the floor is the recommended fix per the ticket — `%i` is the correct pattern and stays as-is.
- Adds a patch changeset for `fair-payment`.

The other two Plugin Check findings (`.deploy-version` hidden file, `stable_tag_mismatch`) are local-deploy artifacts of `scripts/deploy-local.js`, not source issues — verifying the SVN publish flow stays clean is tracked separately on the ticket.

Closes #738

## Test plan
- [ ] Build fair-payment cleanly (not via `deploy-local.js`) and run Plugin Check — no `UnsupportedIdentifierPlaceholder` errors
- [ ] Confirm plugin header shows `Requires at least: 6.2` on the Plugins screen