### PR TITLE
fair-payment: guard simple-payment render.php against direct access

### DIFF
--- a/.changeset/fair-payment-render-direct-access.md
+++ b/.changeset/fair-payment-render-direct-access.md
@@ -1,0 +1,5 @@
+---
+'fair-payment': patch
+---
+
+Add `defined( 'ABSPATH' ) || exit;` guard to the simple-payment block's `render.php` so Plugin Check's `missing_direct_file_access_protection` error is cleared.

--- a/fair-payment/src/blocks/simple-payment/render.php
+++ b/fair-payment/src/blocks/simple-payment/render.php
@@ -9,6 +9,8 @@
  * @var WP_Block $block      Block instance.
  */
 
+defined( 'ABSPATH' ) || exit;
+
 $amount          = isset( $attributes['amount'] ) ? $attributes['amount'] : '10';
 $currency        = isset( $attributes['currency'] ) ? $attributes['currency'] : 'EUR';
 $description     = isset( $attributes['description'] ) ? $attributes['description'] : '';


### PR DESCRIPTION
## Summary
- Add `defined( 'ABSPATH' ) || exit;` to `fair-payment/src/blocks/simple-payment/render.php` to clear Plugin Check's `missing_direct_file_access_protection` error (also reported against the built `build/blocks/simple-payment/render.php`, which is generated from this source).
- Add a patch changeset.

## Test plan
- [ ] Run `npm run build` in `fair-payment/` and confirm `build/blocks/simple-payment/render.php` contains the guard
- [ ] Run Plugin Check against a clean fair-payment build — no `missing_direct_file_access_protection` errors
- [ ] Render a Simple Payment block on the frontend and confirm output is unchanged