### PR TITLE
Publish: reuse CI-built ZIP in publish-to-svn

### DIFF
--- a/.github/workflows/publish-to-svn.yml
+++ b/.github/workflows/publish-to-svn.yml
@@ -43,13 +43,6 @@ jobs:
                   ref: ${{ inputs.plugin }}@${{ inputs.version }}
                   fetch-depth: 1
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # 2.37.0
-              with:
-                  php-version: '8.3'
-                  extensions: mbstring, intl, zip
-                  coverage: none
-
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
@@ -61,10 +54,42 @@ jobs:
             - name: Install npm dependencies
               run: npm ci --prefer-offline
 
+            # Prefer the ZIP CI already built, stamped and tested (the
+            # `build-<version>` release asset) over rebuilding from the source
+            # tag. Ships exactly what CI tested and sidesteps the stale source
+            # header bug (#728). Falls back to a source rebuild when no matching
+            # release asset exists. See #729.
+            - name: Try to reuse pre-built release artifact
+              id: reuse
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  mkdir -p dist
+                  if gh release download "build-${{ inputs.version }}" \
+                      --repo "$GITHUB_REPOSITORY" \
+                      --pattern "${{ inputs.plugin }}.${{ inputs.version }}.zip" \
+                      --dir dist; then
+                      echo "reuse=true" >> "$GITHUB_OUTPUT"
+                      echo "::notice::Reusing ${{ inputs.plugin }}.${{ inputs.version }}.zip from release build-${{ inputs.version }}."
+                  else
+                      echo "reuse=false" >> "$GITHUB_OUTPUT"
+                      echo "::notice::No matching release asset; rebuilding ${{ inputs.plugin }} ${{ inputs.version }} from source."
+                  fi
+
+            - name: Setup PHP
+              if: ${{ steps.reuse.outputs.reuse != 'true' }}
+              uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # 2.37.0
+              with:
+                  php-version: '8.3'
+                  extensions: mbstring, intl, zip
+                  coverage: none
+
             - name: Install production PHP dependencies in all plugins
+              if: ${{ steps.reuse.outputs.reuse != 'true' }}
               run: npm run composer:install:prod
 
             - name: Install WP-CLI
+              if: ${{ steps.reuse.outputs.reuse != 'true' }}
               run: |
                   curl -L -o wp-cli.phar https://github.com/wp-cli/wp-cli/releases/download/v2.12.0/wp-cli-2.12.0.phar
                   echo "be928f6b8ca1e8dfb9d2f4b75a13aa4aee0896f8a9a0a1c45cd5d2c98605e6172e6d014dda2e27f88c98befc16c040cbb2bd1bfa121510ea5cdf5f6a30fe8832  wp-cli.phar" | sha512sum -c -
@@ -73,6 +98,7 @@ jobs:
                   wp --info
 
             - name: Install WP-CLI dist-archive command
+              if: ${{ steps.reuse.outputs.reuse != 'true' }}
               env:
                   COMPOSER_HOME: ${{ runner.temp }}/wp-cli-composer
               run: |
@@ -87,6 +113,7 @@ jobs:
                   wp dist-archive --help
 
             - name: Build plugin assets
+              if: ${{ steps.reuse.outputs.reuse != 'true' }}
               run: npm run build -w ${{ inputs.plugin }}
 
             - name: Checkout WordPress.org SVN repo
@@ -95,10 +122,23 @@ jobs:
             - name: Create SVN tag from dist archive
               env:
                   COMPOSER_HOME: ${{ runner.temp }}/wp-cli-composer
+                  SVN_TAG_REUSE_ZIP: ${{ steps.reuse.outputs.reuse == 'true' && '1' || '0' }}
               run: npm run svn:tag:${{ inputs.plugin }}
 
+            # Rebuild path: refresh trunk + assets from source. Reuse path: trunk
+            # is already populated from the extracted build by svn:tag, so only
+            # the wordpress.org assets (banners/screenshots) need copying.
             - name: Refresh trunk and assets
+              if: ${{ steps.reuse.outputs.reuse != 'true' }}
               run: npm run svn:copy -w ${{ inputs.plugin }}
+
+            - name: Refresh assets
+              if: ${{ steps.reuse.outputs.reuse == 'true' }}
+              working-directory: ${{ inputs.plugin }}
+              run: |
+                  if [ -d assets ]; then
+                      cp assets/* svn/assets/
+                  fi
 
             - name: Stage SVN changes
               working-directory: ${{ inputs.plugin }}/svn

--- a/scripts/svn-tag.cjs
+++ b/scripts/svn-tag.cjs
@@ -54,37 +54,55 @@ console.log(`Creating SVN tag for ${pluginName} version ${version}...`);
 const distDir = path.join(__dirname, '..', 'dist');
 const zipFile = path.join(distDir, `${pluginName}.${version}.zip`);
 const tagDir = path.join(svnDir, 'tags', version);
+const trunkDir = path.join(svnDir, 'trunk');
+
+// Reuse mode: when SVN_TAG_REUSE_ZIP=1, ship the pre-built dist ZIP that CI
+// already created, stamped and tested (the `build-<version>` release asset)
+// instead of rebuilding it from the source tag. This ships exactly what CI
+// tested and sidesteps the stale source-tag header bug (#728). See ticket #729.
+const reuseZip = process.env.SVN_TAG_REUSE_ZIP === '1';
+
+const composerJsonPath = path.join(pluginDir, 'composer.json');
 
 try {
-	// 1. Install production-only dependencies
-	const composerJsonPath = path.join(pluginDir, 'composer.json');
-	if (fs.existsSync(composerJsonPath)) {
-		console.log(
-			'Installing production dependencies (--no-dev) in plugin...'
-		);
-		try {
-			execSync('composer install --no-dev --optimize-autoloader', {
-				cwd: pluginDir,
-				stdio: 'inherit',
-			});
-		} catch (error) {
-			console.warn(
-				'Warning: composer install failed, continuing anyway...'
+	if (reuseZip) {
+		if (!fs.existsSync(zipFile)) {
+			console.error(
+				`Error: SVN_TAG_REUSE_ZIP=1 but no pre-built archive found at ${zipFile}`
 			);
+			process.exit(1);
 		}
-	}
+		console.log(`Reusing pre-built dist archive: ${zipFile}`);
+	} else {
+		// 1. Install production-only dependencies
+		if (fs.existsSync(composerJsonPath)) {
+			console.log(
+				'Installing production dependencies (--no-dev) in plugin...'
+			);
+			try {
+				execSync('composer install --no-dev --optimize-autoloader', {
+					cwd: pluginDir,
+					stdio: 'inherit',
+				});
+			} catch (error) {
+				console.warn(
+					'Warning: composer install failed, continuing anyway...'
+				);
+			}
+		}
 
-	// 2. Always rebuild dist archive to ensure .distignore is respected
-	if (fs.existsSync(zipFile)) {
-		console.log('Removing old dist archive to ensure fresh build...');
-		fs.unlinkSync(zipFile);
-	}
+		// 2. Always rebuild dist archive to ensure .distignore is respected
+		if (fs.existsSync(zipFile)) {
+			console.log('Removing old dist archive to ensure fresh build...');
+			fs.unlinkSync(zipFile);
+		}
 
-	console.log('Creating dist archive...');
-	execSync(`wp dist-archive ${pluginName} dist --create-target-dir`, {
-		cwd: path.join(__dirname, '..'),
-		stdio: 'inherit',
-	});
+		console.log('Creating dist archive...');
+		execSync(`wp dist-archive ${pluginName} dist --create-target-dir`, {
+			cwd: path.join(__dirname, '..'),
+			stdio: 'inherit',
+		});
+	}
 
 	// 2. Create tags directory if it doesn't exist
 	if (!fs.existsSync(tagDir)) {
@@ -118,8 +136,37 @@ try {
 		console.log('Moved files to tag root');
 	}
 
-	// 5. Restore dev dependencies for local development
-	if (fs.existsSync(composerJsonPath)) {
+	// 5. In reuse mode, also populate trunk/ from the same extracted build so
+	// trunk matches exactly what we tag (includes build/, honours .distignore).
+	// This resolves the src-vs-build trunk concern from #727. In the rebuild
+	// path, trunk is still refreshed from source by the `svn:copy` step.
+	if (reuseZip) {
+		console.log('Refreshing trunk/ from the extracted build...');
+		if (fs.existsSync(trunkDir)) {
+			for (const entry of fs.readdirSync(trunkDir)) {
+				if (entry === '.svn') {
+					continue;
+				}
+				fs.rmSync(path.join(trunkDir, entry), {
+					recursive: true,
+					force: true,
+				});
+			}
+		} else {
+			fs.mkdirSync(trunkDir, { recursive: true });
+		}
+		for (const entry of fs.readdirSync(tagDir)) {
+			fs.cpSync(
+				path.join(tagDir, entry),
+				path.join(trunkDir, entry),
+				{ recursive: true }
+			);
+		}
+	}
+
+	// 6. Restore dev dependencies for local development (only the rebuild path
+	// switches to --no-dev; reuse mode never touched composer).
+	if (!reuseZip && fs.existsSync(composerJsonPath)) {
 		console.log('\nRestoring dev dependencies for local development...');
 		try {
 			execSync('composer install', {
@@ -141,9 +188,8 @@ try {
 } catch (error) {
 	console.error('Error:', error.message);
 
-	// Try to restore dev dependencies even on error
-	const composerJsonPath = path.join(pluginDir, 'composer.json');
-	if (fs.existsSync(composerJsonPath)) {
+	// Try to restore dev dependencies even on error (rebuild path only).
+	if (!reuseZip && fs.existsSync(composerJsonPath)) {
 		console.log('\nRestoring dev dependencies...');
 		try {
 			execSync('composer install', {


### PR DESCRIPTION
## Summary

`Closes #729`

`publish-to-svn.yml` rebuilt each plugin from the source tag (`composer install` → `npm run build` → `wp dist-archive`) even though CI had already built, stamped, tested and released the **exact** same artifact as the `build-<version>` release asset. Rebuilding from the source tag re-introduces the stale-header bug (#728), because the source tag still carries the pre-stamp `Version`.

This PR reuses CI's pre-built ZIP when it's available, and only rebuilds from source as a fallback.

## What changed

- **`publish-to-svn.yml`**
  - New step tries `gh release download build-<version> --pattern '<plugin>.<version>.zip' --dir dist`. Sets `reuse=true/false`.
  - PHP / Composer-prod / WP-CLI / dist-archive-install / `npm run build` steps now run **only** on the fallback path (`reuse != 'true'`), so the reuse path is much leaner.
  - `svn:tag` step passes `SVN_TAG_REUSE_ZIP=1` on the reuse path.
  - Trunk/assets: rebuild path keeps `svn:copy` (trunk + assets from source); reuse path copies only the wordpress.org `assets/` (trunk is populated from the build by `svn:tag`).

- **`scripts/svn-tag.cjs`**
  - `SVN_TAG_REUSE_ZIP=1` mode: skip the `composer install` / delete / `wp dist-archive` rebuild and use the existing `dist/<plugin>.<version>.zip` as-is (errors if it's missing).
  - In reuse mode, also mirror the extracted build into `trunk/` (preserving `.svn`) so trunk matches the tag and includes `build/` — resolves the src-vs-build trunk concern in #727.
  - Composer dev-dep restore is skipped in reuse mode (it never touched composer).

## Verification

Local smoke test of the reuse path with a synthetic `fair-events.<ver>.zip` (clean header) and a fake svn working copy:
- `tags/<ver>/` contains `build/` and `fair-events.php` with the **clean** header — confirming the #728 header bug is bypassed.
- `trunk/` keeps its `.svn`, drops stale content, and mirrors the tag.

Fallback path (no matching release asset) is unchanged behaviour.