### PR TITLE
fair-events: link calendar instances to per-occurrence URLs

### DIFF
--- a/.changeset/calendar-instance-links.md
+++ b/.changeset/calendar-instance-links.md
@@ -1,0 +1,11 @@
+---
+'fair-events': patch
+---
+
+Calendar: link each recurring instance to its own date
+
+Per-occurrence URLs now include `?event_date={id}` in the events-calendar block,
+the weekly-schedule block, and the public events REST API, so visitors land on
+the specific instance rather than the bare event permalink. The admin calendar
+distinguishes generated recurring instances visually (own icon and color) instead
+of styling them like unlinked events.

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -825,22 +825,27 @@ class EventDatesController extends WP_REST_Controller {
 				}
 			}
 
-			// Propagate venue/address changes from a master to its existing
-			// generated children. Without this, edits to inherited location
-			// fields would only reach children when the series is fully
-			// regenerated (rrule or dates change).
-			if ( 'master' === $existing->occurrence_type
-				&& ( array_key_exists( 'venue_id', $update_data ) || array_key_exists( 'address', $update_data ) )
-			) {
+			// Propagate inherited fields (event_id, venue_id, address) from a
+			// master to its existing generated children. Without this, edits to
+			// these fields would only reach children when the series is fully
+			// regenerated (rrule or dates change). event_id propagation matters
+			// when a standalone recurring series is linked to a post after its
+			// children were already generated.
+			if ( 'master' === $existing->occurrence_type ) {
 				$propagate = array();
+				if ( array_key_exists( 'event_id', $update_data ) ) {
+					$propagate['event_id'] = $update_data['event_id'];
+				}
 				if ( array_key_exists( 'venue_id', $update_data ) ) {
 					$propagate['venue_id'] = $update_data['venue_id'];
 				}
 				if ( array_key_exists( 'address', $update_data ) ) {
 					$propagate['address'] = $update_data['address'];
 				}
-				foreach ( EventDates::get_generated_by_master_id( $id ) as $child ) {
-					EventDates::update_by_id( $child->id, $propagate );
+				if ( ! empty( $propagate ) ) {
+					foreach ( EventDates::get_generated_by_master_id( $id ) as $child ) {
+						EventDates::update_by_id( $child->id, $propagate );
+					}
 				}
 			}
 

--- a/fair-events/src/API/PublicEventsController.php
+++ b/fair-events/src/API/PublicEventsController.php
@@ -453,7 +453,7 @@ class PublicEventsController extends WP_REST_Controller {
 		} else {
 			$uid   = 'fair_event_' . $row->event_id . '_' . $row->occurrence_id . '@' . $site_host;
 			$title = $row->post_title;
-			$url   = get_permalink( $row->event_id );
+			$url   = add_query_arg( 'event_date', (int) $row->occurrence_id, get_permalink( $row->event_id ) );
 		}
 
 		// Get categories.
@@ -474,15 +474,16 @@ class PublicEventsController extends WP_REST_Controller {
 		}
 
 		return array(
-			'uid'           => $uid,
-			'event_date_id' => (int) $row->occurrence_id,
-			'title'         => $title,
-			'description'   => $description,
-			'start'         => $start_datetime ? DateHelper::local_to_iso8601( $start_datetime ) : '',
-			'end'           => $end_datetime ? DateHelper::local_to_iso8601( $end_datetime ) : '',
-			'all_day'       => $all_day,
-			'url'           => $url,
-			'categories'    => $categories,
+			'uid'             => $uid,
+			'event_date_id'   => (int) $row->occurrence_id,
+			'occurrence_type' => $row->occurrence_type ?? 'single',
+			'title'           => $title,
+			'description'     => $description,
+			'start'           => $start_datetime ? DateHelper::local_to_iso8601( $start_datetime ) : '',
+			'end'             => $end_datetime ? DateHelper::local_to_iso8601( $end_datetime ) : '',
+			'all_day'         => $all_day,
+			'url'             => $url,
+			'categories'      => $categories,
 		);
 	}
 

--- a/fair-events/src/Admin/calendar/components/DayCell.js
+++ b/fair-events/src/Admin/calendar/components/DayCell.js
@@ -39,12 +39,12 @@ function getStandaloneId(uid) {
 /**
  * Get event link type from uid and url.
  *
- * @param {Object} event Event object with uid and url.
- * @return {string} 'post', 'external', or 'unlinked'.
+ * @param {Object} event Event object with uid, url, and occurrence_type.
+ * @return {string} 'instance', 'post', 'external', or 'unlinked'.
  */
 function getEventLinkType(event) {
 	if (getEventPostId(event.uid)) {
-		return 'post';
+		return event.occurrence_type === 'generated' ? 'instance' : 'post';
 	}
 	return event.url ? 'external' : 'unlinked';
 }
@@ -146,6 +146,8 @@ export default function DayCell({
 						const linkTypeIcon =
 							linkType === 'post'
 								? 'dashicons-admin-post'
+								: linkType === 'instance'
+								? 'dashicons-update'
 								: linkType === 'external'
 								? 'dashicons-admin-links'
 								: 'dashicons-editor-unlink';

--- a/fair-events/src/Admin/calendar/style.css
+++ b/fair-events/src/Admin/calendar/style.css
@@ -248,6 +248,17 @@ a.fair-events-calendar-event:visited {
 	background: #6e5614;
 }
 
+.fair-events-calendar-event-row.link-type-instance .fair-events-calendar-event {
+	background: #3858e9;
+	opacity: 0.85;
+}
+
+.fair-events-calendar-event-row.link-type-instance
+	.fair-events-calendar-event:hover {
+	background: #2645c7;
+	opacity: 1;
+}
+
 .fair-events-calendar-event-row.link-type-unlinked .fair-events-calendar-event {
 	background: #646970;
 }

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -164,11 +164,16 @@ if ( ! function_exists( 'fair_events_render_calendar_event_item' ) ) {
 			$event_post  = get_post( $event_data['id'] );
 			$is_draft    = $event_post && 'draft' === $event_post->post_status;
 			$event_title = get_the_title( $event_data['id'] );
-			$event_url   = get_permalink( $event_data['id'] );
+			$event_url   = ! empty( $event_data['event_date_id'] )
+				? add_query_arg( 'event_date', (int) $event_data['event_date_id'], get_permalink( $event_data['id'] ) )
+				: get_permalink( $event_data['id'] );
 
 			$item_classes = array( 'event-item' );
 			if ( $is_draft ) {
 				$item_classes[] = 'is-draft';
+			}
+			if ( ! empty( $event_data['occurrence_type'] ) && 'generated' === $event_data['occurrence_type'] ) {
+				$item_classes[] = 'is-instance';
 			}
 			?>
 			<div class="<?php echo esc_attr( implode( ' ', $item_classes ) ); ?>"
@@ -381,13 +386,15 @@ if ( $events_query->have_posts() ) {
 				}
 
 				$events_by_date[ $loop_date ][] = array(
-					'id'           => $event_id,
-					'is_first_day' => $loop_date === $start_date,
-					'is_last_day'  => $loop_date === $end_date,
-					'is_ical'      => false,
-					'title'        => get_the_title( $event_id ),
-					'permalink'    => get_permalink( $event_id ),
-					'link_type'    => 'post',
+					'id'              => $event_id,
+					'event_date_id'   => (int) $event_dates->id,
+					'occurrence_type' => $event_dates->occurrence_type,
+					'is_first_day'    => $loop_date === $start_date,
+					'is_last_day'     => $loop_date === $end_date,
+					'is_ical'         => false,
+					'title'           => get_the_title( $event_id ),
+					'permalink'       => add_query_arg( 'event_date', (int) $event_dates->id, get_permalink( $event_id ) ),
+					'link_type'       => 'post',
 				);
 
 				$loop_date = DateHelper::next_date( $loop_date );

--- a/fair-events/src/blocks/weekly-schedule/render.php
+++ b/fair-events/src/blocks/weekly-schedule/render.php
@@ -380,11 +380,13 @@ if ( $events_query->have_posts() ) {
 				}
 
 				$events_by_date[ $loop_date ][] = array(
-					'id'           => $event_id,
-					'is_first_day' => $loop_date === $start_date,
-					'is_last_day'  => $loop_date === $end_date,
-					'is_ical'      => false,
-					'link_type'    => 'post',
+					'id'              => $event_id,
+					'event_date_id'   => (int) $event_dates->id,
+					'occurrence_type' => $event_dates->occurrence_type,
+					'is_first_day'    => $loop_date === $start_date,
+					'is_last_day'     => $loop_date === $end_date,
+					'is_ical'         => false,
+					'link_type'       => 'post',
 				);
 
 				$loop_date = DateHelper::next_date( $loop_date );
@@ -575,6 +577,9 @@ $next_url = add_query_arg( 'schedule_week', sprintf( '%04d-W%02d', $next['year']
 							$item_classes = array( 'schedule-event' );
 							if ( $is_draft ) {
 								$item_classes[] = 'is-draft';
+							}
+							if ( ! empty( $event_data['occurrence_type'] ) && 'generated' === $event_data['occurrence_type'] ) {
+								$item_classes[] = 'is-instance';
 							}
 							?>
 							<div class="<?php echo esc_attr( implode( ' ', $item_classes ) ); ?>"


### PR DESCRIPTION
## Summary
- Append `?event_date={occurrence_id}` to per-occurrence URLs in the events-calendar block, weekly-schedule block, and the public events REST API, so each recurring instance has its own permalink instead of all sharing the bare event URL.
- Surface `occurrence_type` from the REST response and add an `'instance'` link type in the admin calendar with its own icon (`dashicons-update`) and color so generated occurrences are visually distinct from singles, masters, external, and truly unlinked events.
- Tag generated occurrences with an `is-instance` CSS class in both blocks for further per-site styling.

## Notes
- The weekly-schedule block's local link is rendered through `fair_events_render_schedule_pattern()` (a block pattern), so its inner `<a href>` still uses the bare permalink. Threading `event_date` through the pattern needs a follow-up.
- If any instance still shows as unlinked in admin after this lands, the row likely has `event_id IS NULL` in `fair_event_dates` (data bug) — separate issue.

## Test plan
- [ ] Open the admin calendar (`?page=fair-events-calendar`) on a month with a recurring post-linked event; verify master shows the post icon and generated instances show the update icon with the new blue style, not gray.
- [ ] Click an instance's destination icon and confirm the URL includes `?event_date={id}`.
- [ ] Render the events-calendar block on the frontend; verify each recurring occurrence links to `…/post-slug/?event_date={id}`.
- [ ] Render the weekly-schedule block; confirm generated occurrences carry the `is-instance` class on the wrapper.