### PR TITLE
Give fair-* admin menus unique string positions (#751)

### DIFF
--- a/.changeset/move-admin-menus-below-core.md
+++ b/.changeset/move-admin-menus-below-core.md
@@ -5,8 +5,8 @@
 'fair-platform': patch
 ---
 
-Move admin menus below core WordPress menus
+Group admin menus with string positions to avoid overwriting core menus
 
-Each plugin's top-level admin menu now registers in the `>= 80` range (string
-positions `80.1`–`83.1`) so they sit below Settings instead of crowding the core
-Pages/Comments group, per wp.org plugin review feedback.
+Each plugin's top-level admin menu now registers with a unique string decimal
+position (`20.1`–`20.4`) so the four menus cluster together in order without
+colliding with each other or with core WordPress menu items.

--- a/.changeset/move-admin-menus-below-core.md
+++ b/.changeset/move-admin-menus-below-core.md
@@ -1,0 +1,12 @@
+---
+'fair-events': patch
+'fair-payment': patch
+'fair-audience': patch
+'fair-platform': patch
+---
+
+Move admin menus below core WordPress menus
+
+Each plugin's top-level admin menu now registers in the `>= 80` range (string
+positions `80.1`–`83.1`) so they sit below Settings instead of crowding the core
+Pages/Comments group, per wp.org plugin review feedback.

--- a/fair-audience/src/Admin/AdminHooks.php
+++ b/fair-audience/src/Admin/AdminHooks.php
@@ -156,7 +156,7 @@ class AdminHooks {
 			'fair-audience',
 			array( $this, 'render_timeline_page' ),
 			'dashicons-groups',
-			22
+			'82.1'
 		);
 
 		// Override first submenu item label (same slug as parent).

--- a/fair-audience/src/Admin/AdminHooks.php
+++ b/fair-audience/src/Admin/AdminHooks.php
@@ -156,7 +156,7 @@ class AdminHooks {
 			'fair-audience',
 			array( $this, 'render_timeline_page' ),
 			'dashicons-groups',
-			'82.1'
+			'20.3'
 		);
 
 		// Override first submenu item label (same slug as parent).

--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -92,7 +92,7 @@ class AdminPages {
 			$parent,
 			array( $this, 'render_calendar_page' ),
 			'dashicons-calendar-alt',
-			'80.1'
+			'20.1'
 		);
 
 		// Calendar landing submenu. Registering a submenu whose slug matches the

--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -92,7 +92,7 @@ class AdminPages {
 			$parent,
 			array( $this, 'render_calendar_page' ),
 			'dashicons-calendar-alt',
-			20
+			'80.1'
 		);
 
 		// Calendar landing submenu. Registering a submenu whose slug matches the

--- a/fair-events/src/PostTypes/Event.php
+++ b/fair-events/src/PostTypes/Event.php
@@ -91,7 +91,7 @@ class Event {
 			'capability_type'    => 'post',
 			'has_archive'        => true,
 			'hierarchical'       => false,
-			'menu_position'      => '80.1',
+			'menu_position'      => '20.1',
 			'menu_icon'          => 'dashicons-calendar-alt',
 			'supports'           => array( 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'custom-fields' ),
 			'show_in_rest'       => true,

--- a/fair-events/src/PostTypes/Event.php
+++ b/fair-events/src/PostTypes/Event.php
@@ -91,7 +91,7 @@ class Event {
 			'capability_type'    => 'post',
 			'has_archive'        => true,
 			'hierarchical'       => false,
-			'menu_position'      => 20,
+			'menu_position'      => '80.1',
 			'menu_icon'          => 'dashicons-calendar-alt',
 			'supports'           => array( 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'custom-fields' ),
 			'show_in_rest'       => true,

--- a/fair-payment/src/Admin/AdminPages.php
+++ b/fair-payment/src/Admin/AdminPages.php
@@ -37,7 +37,7 @@ class AdminPages {
 			'fair-payment-transactions',
 			array( $this, 'render_transactions_page' ),
 			'dashicons-money-alt',
-			'81.1'
+			'20.2'
 		);
 
 		// Transactions submenu (duplicate to rename main menu item).

--- a/fair-payment/src/Admin/AdminPages.php
+++ b/fair-payment/src/Admin/AdminPages.php
@@ -37,7 +37,7 @@ class AdminPages {
 			'fair-payment-transactions',
 			array( $this, 'render_transactions_page' ),
 			'dashicons-money-alt',
-			21
+			'81.1'
 		);
 
 		// Transactions submenu (duplicate to rename main menu item).

--- a/fair-platform/src/Admin/AdminHooks.php
+++ b/fair-platform/src/Admin/AdminHooks.php
@@ -39,7 +39,7 @@ class AdminHooks {
 			'fair-platform-settings',
 			array( $this, 'render_settings_page' ),
 			'dashicons-admin-plugins',
-			23
+			'83.1'
 		);
 
 		add_submenu_page(

--- a/fair-platform/src/Admin/AdminHooks.php
+++ b/fair-platform/src/Admin/AdminHooks.php
@@ -39,7 +39,7 @@ class AdminHooks {
 			'fair-platform-settings',
 			array( $this, 'render_settings_page' ),
 			'dashicons-admin-plugins',
-			'83.1'
+			'20.4'
 		);
 
 		add_submenu_page(


### PR DESCRIPTION
## Summary
- Assign each of fair-events, fair-payment, fair-audience, fair-platform a unique string decimal `menu_position` (`20.1`–`20.4`) so the four top-level menus cluster together in order without overwriting each other or core WordPress menu items.
- Match the fair-events `event` CPT `menu_position` to the Calendar entry (`20.1`) so the CPT does not resurface at a separate slot.
- Add a changeset patch-bumping all four plugins.

Using string positions avoids the integer-collision problem (where two menus sharing the same integer position can clobber each other) while keeping the menus in their familiar location near Pages.

Closes #751.

## Test plan
- [ ] `docker compose up`, activate all four plugins, confirm the Fair menus render in order: Fair Events, Fair Payment, Fair Audience, Fair Platform.
- [ ] Confirm none of the four entries overwrites another.
- [ ] Deactivate/reactivate fair-events and confirm no duplicate top-level `event` CPT entry appears.