### PR TITLE
fair-payment: gate /payments/{id}/status with per-transaction access token

### DIFF
--- a/.changeset/fair-payment-status-access-token.md
+++ b/.changeset/fair-payment-status-access-token.md
@@ -1,0 +1,5 @@
+---
+"fair-payment": patch
+---
+
+Gate `/payments/{id}/status` with a per-transaction access token so transaction IDs cannot be enumerated. The token is generated at creation time, propagated through the Mollie redirect URL, and required for anonymous reads. Logged-in admins and the transaction's owner can still read without a token.

--- a/fair-payment/src/API/PaymentEndpoint.php
+++ b/fair-payment/src/API/PaymentEndpoint.php
@@ -86,12 +86,20 @@ class PaymentEndpoint extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_transaction_status' ),
-					'permission_callback' => '__return_true',
+					// Anonymous read is intentional (post-Mollie redirect flow); ownership is enforced
+					// by a per-transaction access token. Permission failures return WP_Error 404 to
+					// avoid confirming which transaction IDs exist.
+					'permission_callback' => array( $this, 'get_transaction_status_permissions_check' ),
 					'args'                => array(
 						'transaction_id' => array(
 							'required'          => true,
 							'type'              => 'integer',
 							'sanitize_callback' => 'absint',
+						),
+						'token'          => array(
+							'required'          => false,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
 				),
@@ -201,16 +209,6 @@ class PaymentEndpoint extends WP_REST_Controller {
 			)
 		);
 
-		// Prepare redirect URL.
-		$redirect_url = add_query_arg(
-			array(
-				'fair_payment_callback' => 'true',
-				'transaction_id'        => $transaction_id,
-				'post_id'               => $post_id,
-			),
-			$post_id ? get_permalink( $post_id ) : home_url()
-		);
-
 		if ( is_wp_error( $transaction_id ) ) {
 			$logger->log(
 				'transaction_creation_failed',
@@ -228,6 +226,21 @@ class PaymentEndpoint extends WP_REST_Controller {
 				array( 'status' => 500 )
 			);
 		}
+
+		// Load freshly created transaction so we can attach its access token to the
+		// post-Mollie redirect URL. The token gates the /status endpoint.
+		$transaction = Transaction::get_by_id( $transaction_id );
+
+		// Prepare redirect URL.
+		$redirect_url = add_query_arg(
+			array(
+				'fair_payment_callback' => 'true',
+				'transaction_id'        => $transaction_id,
+				'post_id'               => $post_id,
+				'token'                 => $transaction ? $transaction->access_token : '',
+			),
+			$post_id ? get_permalink( $post_id ) : home_url()
+		);
 
 		// Initiate payment immediately.
 		$payment = TransactionAPI::initiate_payment(
@@ -318,5 +331,60 @@ class PaymentEndpoint extends WP_REST_Controller {
 		);
 
 		return new WP_REST_Response( $response_data, 200 );
+	}
+
+	/**
+	 * Permission check for the transaction status endpoint.
+	 *
+	 * Returns a 404 WP_Error on any failure so anonymous callers cannot enumerate
+	 * transaction IDs by distinguishing missing rows from token mismatches.
+	 *
+	 * Allowed without a token:
+	 * - Site admins (manage_options) — support / debugging.
+	 * - The transaction's owner when logged in (user_id matches).
+	 *
+	 * Otherwise the request must carry a `token` query arg that constant-time
+	 * matches the row's access_token.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return true|WP_Error True if allowed, WP_Error (404) otherwise.
+	 */
+	public function get_transaction_status_permissions_check( WP_REST_Request $request ) {
+		$not_found = new WP_Error(
+			'transaction_not_found',
+			__( 'Transaction not found.', 'fair-payment' ),
+			array( 'status' => 404 )
+		);
+
+		$transaction = Transaction::get_by_id( $request->get_param( 'transaction_id' ) );
+
+		if ( ! $transaction ) {
+			return $not_found;
+		}
+
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		if (
+			is_user_logged_in()
+			&& ! empty( $transaction->user_id )
+			&& (int) $transaction->user_id === get_current_user_id()
+		) {
+			return true;
+		}
+
+		$provided = (string) $request->get_param( 'token' );
+		$expected = (string) ( $transaction->access_token ?? '' );
+
+		if ( '' === $expected || '' === $provided ) {
+			return $not_found;
+		}
+
+		if ( hash_equals( $expected, $provided ) ) {
+			return true;
+		}
+
+		return $not_found;
 	}
 }

--- a/fair-payment/src/API/TransactionAPI.php
+++ b/fair-payment/src/API/TransactionAPI.php
@@ -85,6 +85,7 @@ class TransactionAPI {
 			'webhook_url'       => '',
 			'checkout_url'      => '',
 			'metadata'          => $args['metadata'],
+			'access_token'      => wp_generate_password( 64, false ),
 		);
 
 		// Allow filtering of transaction data before creation.

--- a/fair-payment/src/Database/Schema.php
+++ b/fair-payment/src/Database/Schema.php
@@ -115,6 +115,7 @@ class Schema {
 			webhook_url text DEFAULT NULL,
 			checkout_url text DEFAULT NULL,
 			metadata longtext DEFAULT NULL,
+			access_token char(64) DEFAULT NULL,
 			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY  (id),
@@ -123,7 +124,8 @@ class Schema {
 			KEY user_id (user_id),
 			KEY participant_id (participant_id),
 			KEY post_id (post_id),
-			KEY event_date_id (event_date_id)
+			KEY event_date_id (event_date_id),
+			KEY access_token (access_token)
 		) $charset_collate;";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
@@ -166,9 +168,10 @@ class Schema {
 		self::migrate_to_v17();
 		self::migrate_to_v18();
 		self::migrate_to_v19();
+		self::migrate_to_v20();
 
 		// Store database version for future migrations.
-		update_option( 'fair_payment_db_version', '19.0' );
+		update_option( 'fair_payment_db_version', '20.0' );
 	}
 
 	/**
@@ -1053,6 +1056,71 @@ class Schema {
 
 		if ( version_compare( $current_version, '19.0', '<' ) ) {
 			self::create_api_tokens_table();
+		}
+	}
+
+	/**
+	 * Migrate database from v19.0 to v20.0
+	 *
+	 * Adds access_token column to transactions and backfills tokens for existing rows.
+	 * The token gates anonymous reads of the /payments/{id}/status endpoint so
+	 * transaction IDs cannot be enumerated. See issue #749.
+	 *
+	 * @return void
+	 */
+	public static function migrate_to_v20() {
+		global $wpdb;
+
+		$current_version = get_option( 'fair_payment_db_version', '1.0' );
+
+		if ( version_compare( $current_version, '20.0', '<' ) ) {
+			$table_name = self::get_payments_table_name();
+
+			$column_exists = $wpdb->get_results(
+				$wpdb->prepare(
+					'SHOW COLUMNS FROM %i LIKE %s',
+					$table_name,
+					'access_token'
+				)
+			);
+
+			if ( empty( $column_exists ) ) {
+				$wpdb->query(
+					$wpdb->prepare(
+						'ALTER TABLE %i ADD COLUMN access_token char(64) DEFAULT NULL AFTER metadata',
+						$table_name
+					)
+				);
+
+				$wpdb->query(
+					$wpdb->prepare(
+						'ALTER TABLE %i ADD KEY access_token (access_token)',
+						$table_name
+					)
+				);
+			}
+
+			// Backfill tokens for legacy rows so the status endpoint can enforce
+			// ownership uniformly. Old in-flight Mollie callback URLs will fail
+			// after this — acceptable since the post-redirect window is short.
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT id FROM %i WHERE access_token IS NULL',
+					$table_name
+				)
+			);
+
+			if ( ! empty( $rows ) ) {
+				foreach ( $rows as $row ) {
+					$wpdb->update(
+						$table_name,
+						array( 'access_token' => wp_generate_password( 64, false ) ),
+						array( 'id' => (int) $row->id ),
+						array( '%s' ),
+						array( '%d' )
+					);
+				}
+			}
 		}
 	}
 

--- a/fair-payment/src/Models/Transaction.php
+++ b/fair-payment/src/Models/Transaction.php
@@ -44,6 +44,7 @@ class Transaction {
 			'webhook_url'       => '',
 			'checkout_url'      => '',
 			'metadata'          => '',
+			'access_token'      => null,
 		);
 
 		$data = wp_parse_args( $data, $defaults );
@@ -79,8 +80,9 @@ class Transaction {
 				'webhook_url'       => $data['webhook_url'],
 				'checkout_url'      => $data['checkout_url'],
 				'metadata'          => $data['metadata'],
+				'access_token'      => $data['access_token'],
 			),
-			array( '%s', '%d', '%d', '%d', '%d', '%f', '%s', '%f', '%s', '%d', '%s', '%s', '%s', '%s', '%s' )
+			array( '%s', '%d', '%d', '%d', '%d', '%f', '%s', '%f', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
 		);
 
 		return $inserted ? $wpdb->insert_id : false;

--- a/fair-payment/src/payment-callback.js
+++ b/fair-payment/src/payment-callback.js
@@ -20,9 +20,10 @@ import './payment-callback.css';
 	}
 
 	function initializeCallback() {
-		// Get transaction_id from URL parameters
+		// Get transaction_id and token from URL parameters
 		const urlParams = new URLSearchParams(window.location.search);
 		const transactionId = urlParams.get('transaction_id');
+		const token = urlParams.get('token') || '';
 
 		if (!transactionId) {
 			console.error('Fair Payment: No transaction_id found in URL');
@@ -30,17 +31,24 @@ import './payment-callback.css';
 		}
 
 		// Fetch transaction status from API
-		fetchTransactionStatus(transactionId);
+		fetchTransactionStatus(transactionId, token);
 	}
 
 	/**
 	 * Fetch transaction status from REST API
 	 *
 	 * @param {string} transactionId Transaction ID
+	 * @param {string} token         Per-transaction access token from the redirect URL
 	 */
-	function fetchTransactionStatus(transactionId) {
+	function fetchTransactionStatus(transactionId, token) {
+		const path = token
+			? `/fair-payment/v1/payments/${transactionId}/status?token=${encodeURIComponent(
+					token
+			  )}`
+			: `/fair-payment/v1/payments/${transactionId}/status`;
+
 		apiFetch({
-			path: `/fair-payment/v1/payments/${transactionId}/status`,
+			path,
 			method: 'GET',
 		})
 			.then((response) => {


### PR DESCRIPTION
## Summary

- Closes #749. The status endpoint was registered with `__return_true`, so anyone could walk auto-increment transaction IDs and read amount, currency, description, Mollie payment ID, and status.
- Adds an `access_token` column (migration v20, backfills existing rows), generates a token at transaction creation via `wp_generate_password( 64, false )`, and propagates it through the post-Mollie redirect URL.
- Hardens `GET /payments/{id}/status`: new permission callback does a `hash_equals` compare; admins (`manage_options`) and the row's owner bypass the token; all auth failures return `WP_Error` 404 so IDs cannot be probed.
- Frontend (`payment-callback.js`) reads `token` from the URL and forwards it on the `apiFetch` path; assets rebuilt.

## Test plan

- [ ] `GET .../status` with no token → 404
- [ ] `GET .../status?token=wrong` → 404
- [ ] `GET .../status?token=<correct>` → 200 with expected fields
- [ ] Admin cookie session, no token → 200
- [ ] Logged-in owner (user_id match), no token → 200
- [ ] End-to-end Mollie test payment redirects back and the callback notification still renders
- [ ] Existing install upgrades cleanly: `migrate_to_v20` backfills every row's `access_token` and `fair_payment_db_version` reaches `20.0`