### PR TITLE
Gate textdomain + script translations behind bundled-translations flag (#750)

### DIFF
--- a/.changeset/gate-textdomain-bundled-translations.md
+++ b/.changeset/gate-textdomain-bundled-translations.md
@@ -1,0 +1,13 @@
+---
+"fair-events": patch
+"fair-payment": patch
+"fair-audience": patch
+"fair-platform": patch
+"fair-timetable": patch
+---
+
+Default to WordPress.org language packs; gate `load_plugin_textdomain()` and the
+`wp_set_script_translations()` path behind a new per-plugin `bundled-translations`
+feature flag (resolved through the same constant / master / filter / option /
+default chain as the existing Fair Events features). The flag is exposed in
+each plugin's Settings → Features tab (or Features submenu) and defaults to off.

--- a/ADDING_NEW_PLUGIN.md
+++ b/ADDING_NEW_PLUGIN.md
@@ -259,11 +259,29 @@ WordPress generates translation JSON hashes based on **source file paths** but l
 - **PHP translations**: `languages/` directory (`.pot`, `.po`, `.mo`)
 - **JavaScript translations**: `build/languages/` directory (`.json` files)
 
-**Important**: PHP `.mo` files bundled in the plugin's `languages/` directory require `load_plugin_textdomain()` to be loaded. Add it in `Plugin::init()`:
+**Default behaviour**: rely on the WordPress.org language pack — do **not** call
+`load_plugin_textdomain()` unconditionally, and call
+`wp_set_script_translations( $handle, '{slug}' )` without a path argument.
+
+**Opt-in `bundled-translations` flag**: register `bundled-translations` in the
+plugin's `Core\Features` registry (default `false`). Gate the textdomain and
+script-translation paths behind the flag:
+
 ```php
-load_plugin_textdomain( 'plugin-name', false, 'plugin-name/languages' );
+add_action( 'init', function () {
+    if ( Features::is_enabled( 'bundled-translations' ) ) {
+        load_plugin_textdomain( 'plugin-name', false, 'plugin-name/languages' );
+    }
+} );
+
+wp_set_script_translations(
+    $handle,
+    'plugin-name',
+    Features::script_translations_path() // null unless the flag is on
+);
 ```
-JavaScript translations require `wp_set_script_translations()` pointing to `build/languages/`.
+
+See [I18N_SETUP.md](./I18N_SETUP.md) for the resolution order and Settings UI.
 
 ## Versioning and Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,10 +116,16 @@ deferred loading because the event may already have fired. Example:
 
 ### i18n — see [I18N_SETUP.md](./I18N_SETUP.md)
 
-- PHP `.mo` files live in `languages/`; JS `.json` files in `build/languages/`.
-  `wp_set_script_translations()` must point at `build/languages/`.
-- Every plugin calls `load_plugin_textdomain()` in `Plugin::init()` — required
-  to load the bundled `.mo` files.
+- **Default:** rely on WordPress.org language packs. Do **not** call
+  `load_plugin_textdomain()`. Call
+  `wp_set_script_translations( $handle, '{slug}' )` without a path argument so
+  core resolves JSON from `wp-content/languages/plugins/`.
+- **Opt-in (`bundled-translations` feature flag):** when the flag is on, gate
+  `load_plugin_textdomain( '{slug}', false, '{slug}/languages' )` behind
+  `Features::is_enabled( 'bundled-translations' )` and pass
+  `Features::script_translations_path()` as the third argument of
+  `wp_set_script_translations()` — it returns the bundled `build/languages/`
+  path when on, `null` when off.
 
 ### Testing — see [TESTING.md](./TESTING.md)
 

--- a/I18N_SETUP.md
+++ b/I18N_SETUP.md
@@ -80,22 +80,57 @@ npm run makemo      # Generate .mo files (PHP)
 npm run build       # Builds JS and runs makejson (generates JSON with correct hashes)
 ```
 
-## `load_plugin_textdomain()` Required for Bundled Translations
+## Default: WordPress.org language packs (no `load_plugin_textdomain()`)
 
-`load_plugin_textdomain()` **IS REQUIRED** to load `.mo` files bundled in the
-plugin's own `languages/` directory. WordPress only auto-loads translations from
-`wp-content/languages/plugins/` (downloaded from translate.wordpress.org).
+Since WordPress 4.6, core auto-loads language packs for plugins hosted on
+WordPress.org under the plugin slug (`wp-content/languages/plugins/{slug}-{locale}.mo`
+/ `.json`). Since WP 6.7 it does so just-in-time. Calling
+`load_plugin_textdomain()` is unnecessary for the standard case and was flagged
+by the WordPress.org plugin review team.
 
-**Pattern** (add in `Plugin::init` or equivalent):
+For each of our plugins, the **default** is therefore:
+
+- No `load_plugin_textdomain()` call.
+- `wp_set_script_translations( $handle, '{slug}' )` is called **without a path
+  argument**, so core resolves the JSON from the language-pack location.
+
+Translated strings come from `wp-content/languages/plugins/` once the locale's
+language pack is installed.
+
+## Opt-in: `bundled-translations` feature flag
+
+Each plugin (`fair-events`, `fair-payment`, `fair-audience`, `fair-platform`,
+`fair-timetable`) exposes a `bundled-translations` flag through its `Features`
+registry. When the flag is **on**:
+
+- `load_plugin_textdomain( '{slug}', false, '{slug}/languages' )` is invoked on
+  `init`, so the bundled `.mo` files in `languages/` are loaded.
+- `wp_set_script_translations()` is passed the bundled `build/languages/` path,
+  so JS strings resolve from there too.
+
+This is useful while a locale is below the 90% publish threshold on
+translate.wordpress.org, or when iterating on strings that have not yet been
+uploaded.
+
+**Resolution order** (first match wins; mirrors the existing Fair Events
+features pattern):
+
+1. Per-feature constant `FAIR_{PLUGIN}_FEATURE_BUNDLED_TRANSLATIONS`
+2. Master switch `FAIR_{PLUGIN}_INTERNAL`
+3. `fair_{plugin}_feature_enabled` filter
+4. Stored option `fair_{plugin}_features` (Settings → Features tab)
+5. Hardcoded default (`false`)
+
+**Helper.** Each plugin's `Features` class exposes
+`Features::script_translations_path()` returning either the bundled path or
+`null`. Call sites pass the helper directly:
 
 ```php
-load_plugin_textdomain( 'fair-audience', false, 'fair-audience/languages' );
+wp_set_script_translations(
+    'fair-events-manage-event',
+    'fair-events',
+    \FairEvents\Core\Features::script_translations_path()
+);
 ```
 
-**For this project:**
-
-- All plugins call `load_plugin_textdomain()` in their `Plugin::init()` method
-- PHP `.mo` files are in the plugin's `languages/` directory
-- JavaScript translations use `wp_set_script_translations()` pointing to `build/languages/`
-
-**Reference**: [WordPress Plugin Internationalization Handbook](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#loading-text-domain)
+**Reference**: [I18n improvements in WordPress 6.7](https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/)

--- a/fair-audience/src/Admin/AdminHooks.php
+++ b/fair-audience/src/Admin/AdminHooks.php
@@ -688,6 +688,13 @@ class AdminHooks {
 		// Settings page.
 		if ( 'fair-audience_page_fair-audience-settings' === $hook ) {
 			$this->enqueue_page_script( 'settings', $plugin_dir );
+			wp_localize_script(
+				'fair-audience-settings',
+				'fairAudienceSettingsData',
+				array(
+					'features' => \FairAudience\Core\Features::all(),
+				)
+			);
 		}
 	}
 
@@ -714,7 +721,7 @@ class AdminHooks {
 			wp_set_script_translations(
 				"fair-audience-{$page_name}",
 				'fair-audience',
-				$plugin_dir . 'build/languages'
+				\FairAudience\Core\Features::script_translations_path()
 			);
 
 			wp_enqueue_style( 'wp-components' );

--- a/fair-audience/src/Admin/settings/FeaturesTab.js
+++ b/fair-audience/src/Admin/settings/FeaturesTab.js
@@ -1,0 +1,162 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import {
+	Button,
+	ToggleControl,
+	Card,
+	CardHeader,
+	CardBody,
+	Notice,
+} from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Features Tab Component
+ *
+ * Per-bundle toggles backed by the `fair_audience_features` option.
+ *
+ * @param {Object}   props          Props
+ * @param {Function} props.onNotice Handler for displaying notices
+ * @return {JSX.Element} The Features settings tab
+ */
+export default function FeaturesTab({ onNotice }) {
+	const registry = window.fairAudienceSettingsData?.features || {};
+	const [values, setValues] = useState({});
+	const [isLoading, setIsLoading] = useState(true);
+	const [isSaving, setIsSaving] = useState(false);
+
+	useEffect(() => {
+		apiFetch({ path: '/wp/v2/settings' })
+			.then((settings) => {
+				const stored = settings.fair_audience_features || {};
+				const next = {};
+				Object.entries(registry).forEach(([key, meta]) => {
+					if (meta.always_on || meta.forced) {
+						next[key] = meta.enabled;
+					} else {
+						next[key] =
+							typeof stored[key] === 'boolean'
+								? stored[key]
+								: meta.enabled;
+					}
+				});
+				setValues(next);
+				setIsLoading(false);
+			})
+			.catch(() => {
+				onNotice({
+					status: 'error',
+					message: __('Failed to load features.', 'fair-audience'),
+				});
+				setIsLoading(false);
+			});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [onNotice]);
+
+	const handleSave = () => {
+		const payload = {};
+		Object.entries(registry).forEach(([key, meta]) => {
+			if (meta.always_on || meta.forced) {
+				return;
+			}
+			payload[key] = !!values[key];
+		});
+
+		setIsSaving(true);
+		apiFetch({
+			path: '/wp/v2/settings',
+			method: 'POST',
+			data: { fair_audience_features: payload },
+		})
+			.then(() => {
+				onNotice({
+					status: 'success',
+					message: __('Features saved.', 'fair-audience'),
+				});
+				setIsSaving(false);
+			})
+			.catch(() => {
+				onNotice({
+					status: 'error',
+					message: __('Failed to save features.', 'fair-audience'),
+				});
+				setIsSaving(false);
+			});
+	};
+
+	if (isLoading) {
+		return (
+			<Card style={{ marginTop: '16px' }}>
+				<CardBody>
+					<p>{__('Loading features...', 'fair-audience')}</p>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	const entries = Object.entries(registry);
+
+	return (
+		<Card style={{ marginTop: '16px' }}>
+			<CardHeader>
+				<h2>{__('Feature Bundles', 'fair-audience')}</h2>
+			</CardHeader>
+			<CardBody>
+				<p className="description">
+					{__(
+						'Toggle optional feature bundles. Bundles fixed in wp-config (FAIR_AUDIENCE_INTERNAL or FAIR_AUDIENCE_FEATURE_*) are read-only here.',
+						'fair-audience'
+					)}
+				</p>
+
+				{entries.map(([key, meta]) => {
+					const help = meta.forced
+						? __(
+								'Forced by a wp-config constant — change it there.',
+								'fair-audience'
+						  )
+						: meta.description;
+
+					return (
+						<div key={key} style={{ marginBottom: '1rem' }}>
+							<ToggleControl
+								label={meta.label}
+								checked={!!values[key]}
+								onChange={(value) =>
+									setValues({ ...values, [key]: value })
+								}
+								disabled={
+									isSaving || meta.always_on || meta.forced
+								}
+								help={help}
+							/>
+						</div>
+					);
+				})}
+
+				{entries.some(([, meta]) => meta.forced) && (
+					<Notice status="info" isDismissible={false}>
+						{__(
+							'One or more bundles are forced by wp-config and cannot be toggled here.',
+							'fair-audience'
+						)}
+					</Notice>
+				)}
+
+				<Button
+					variant="primary"
+					onClick={handleSave}
+					isBusy={isSaving}
+					disabled={isSaving}
+				>
+					{isSaving
+						? __('Saving...', 'fair-audience')
+						: __('Save Features', 'fair-audience')}
+				</Button>
+			</CardBody>
+		</Card>
+	);
+}

--- a/fair-audience/src/Admin/settings/SettingsApp.js
+++ b/fair-audience/src/Admin/settings/SettingsApp.js
@@ -10,6 +10,7 @@ import { Notice, TabPanel } from '@wordpress/components';
  */
 import InstagramTab from './InstagramTab.js';
 import MailingTab from './MailingTab.js';
+import FeaturesTab from './FeaturesTab.js';
 import { saveSettings } from './settings-api.js';
 
 /**
@@ -138,6 +139,10 @@ export default function SettingsApp() {
 						name: 'mailing',
 						title: __('Mailing', 'fair-audience'),
 					},
+					{
+						name: 'features',
+						title: __('Features', 'fair-audience'),
+					},
 				]}
 			>
 				{(tab) => (
@@ -150,6 +155,9 @@ export default function SettingsApp() {
 						)}
 						{tab.name === 'mailing' && (
 							<MailingTab onNotice={setNotice} />
+						)}
+						{tab.name === 'features' && (
+							<FeaturesTab onNotice={setNotice} />
 						)}
 					</div>
 				)}

--- a/fair-audience/src/Core/Features.php
+++ b/fair-audience/src/Core/Features.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Feature flag registry for Fair Audience.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Core;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Feature flag registry.
+ *
+ * Resolution order for is_enabled() (first match wins):
+ *
+ *   1. Per-feature constant `FAIR_AUDIENCE_FEATURE_<UPPER>` (true/false).
+ *   2. Master switch `FAIR_AUDIENCE_INTERNAL` (true → every bundle on).
+ *   3. `fair_audience_feature_enabled` filter (programmatic / tests).
+ *   4. Stored option `fair_audience_features` ([ key => bool ]) from Settings UI.
+ *   5. Hardcoded default in the registry below.
+ */
+class Features {
+
+	public const OPTION = 'fair_audience_features';
+
+	public const MASTER_CONSTANT = 'FAIR_AUDIENCE_INTERNAL';
+
+	/**
+	 * Canonical bundle registry. Labels/descriptions stay untranslated here so
+	 * `is_enabled()` is safe to call before `init`.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on?:bool}>
+	 */
+	public static function registry() {
+		return array(
+			'core'                 => array(
+				'label'       => 'Core',
+				'description' => 'Participants, polls, signups, blocks. Always on.',
+				'default'     => true,
+				'always_on'   => true,
+			),
+			'bundled-translations' => array(
+				'label'       => 'Bundled translations',
+				'description' => 'Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings.',
+				'default'     => false,
+			),
+		);
+	}
+
+	/**
+	 * Resolve whether a feature bundle is enabled.
+	 *
+	 * @param string $key Bundle key.
+	 * @return bool
+	 */
+	public static function is_enabled( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $registry[ $key ]['always_on'] ) ) {
+			return true;
+		}
+
+		$constant = self::feature_constant_name( $key );
+		if ( defined( $constant ) ) {
+			return (bool) constant( $constant );
+		}
+
+		if ( defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT ) ) {
+			$enabled = true;
+		} else {
+			$stored  = get_option( self::OPTION, array() );
+			$enabled = is_array( $stored ) && array_key_exists( $key, $stored )
+				? (bool) $stored[ $key ]
+				: (bool) $registry[ $key ]['default'];
+		}
+
+		return (bool) apply_filters( 'fair_audience_feature_enabled', $enabled, $key );
+	}
+
+	/**
+	 * Whether the resolved value is forced by a constant.
+	 *
+	 * @param string $key Bundle key.
+	 * @return bool
+	 */
+	public static function is_forced( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $registry[ $key ]['always_on'] ) ) {
+			return true;
+		}
+
+		if ( defined( self::feature_constant_name( $key ) ) ) {
+			return true;
+		}
+
+		return defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT );
+	}
+
+	/**
+	 * Full snapshot for the Settings UI.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on:bool,enabled:bool,forced:bool}>
+	 */
+	public static function all() {
+		$translated = array(
+			'core'                 => array(
+				'label'       => __( 'Core', 'fair-audience' ),
+				'description' => __( 'Participants, polls, signups, blocks. Always on.', 'fair-audience' ),
+			),
+			'bundled-translations' => array(
+				'label'       => __( 'Bundled translations', 'fair-audience' ),
+				'description' => __( 'Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings.', 'fair-audience' ),
+			),
+		);
+
+		$out = array();
+		foreach ( self::registry() as $key => $entry ) {
+			$out[ $key ] = array(
+				'label'       => $translated[ $key ]['label'] ?? $entry['label'],
+				'description' => $translated[ $key ]['description'] ?? $entry['description'],
+				'default'     => (bool) $entry['default'],
+				'always_on'   => ! empty( $entry['always_on'] ),
+				'enabled'     => self::is_enabled( $key ),
+				'forced'      => self::is_forced( $key ),
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Sanitize an option payload to the known key set, dropping forced keys.
+	 *
+	 * @param mixed $value Raw option value.
+	 * @return array<string,bool>
+	 */
+	public static function sanitize_option( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$existing = get_option( self::OPTION, array() );
+		if ( ! is_array( $existing ) ) {
+			$existing = array();
+		}
+
+		$out = array();
+		foreach ( self::registry() as $key => $entry ) {
+			if ( ! empty( $entry['always_on'] ) ) {
+				continue;
+			}
+
+			if ( self::is_forced( $key ) ) {
+				if ( array_key_exists( $key, $existing ) ) {
+					$out[ $key ] = (bool) $existing[ $key ];
+				}
+				continue;
+			}
+
+			if ( array_key_exists( $key, $value ) ) {
+				$out[ $key ] = (bool) $value[ $key ];
+			} elseif ( array_key_exists( $key, $existing ) ) {
+				$out[ $key ] = (bool) $existing[ $key ];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Path passed to wp_set_script_translations() for the bundled-translations
+	 * opt-in. Returns null when the flag is off.
+	 *
+	 * @return string|null
+	 */
+	public static function script_translations_path() {
+		return self::is_enabled( 'bundled-translations' )
+			? FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			: null;
+	}
+
+	/**
+	 * Per-feature constant name.
+	 *
+	 * @param string $key Bundle key.
+	 * @return string
+	 */
+	private static function feature_constant_name( $key ) {
+		return 'FAIR_AUDIENCE_FEATURE_' . strtoupper( str_replace( '-', '_', $key ) );
+	}
+}

--- a/fair-audience/src/Core/Plugin.php
+++ b/fair-audience/src/Core/Plugin.php
@@ -44,10 +44,14 @@ class Plugin {
 	 * Initialize the plugin.
 	 */
 	public function init() {
+		// Default: rely on WordPress.org language packs. The `bundled-translations`
+		// feature flag opts into loading the .mo files we ship in `languages/`.
 		add_action(
 			'init',
 			function () {
-				load_plugin_textdomain( 'fair-audience', false, 'fair-audience/languages' );
+				if ( Features::is_enabled( 'bundled-translations' ) ) {
+					load_plugin_textdomain( 'fair-audience', false, 'fair-audience/languages' );
+				}
 			}
 		);
 

--- a/fair-audience/src/Hooks/BlockHooks.php
+++ b/fair-audience/src/Hooks/BlockHooks.php
@@ -48,147 +48,147 @@ class BlockHooks {
 		wp_set_script_translations(
 			'fair-audience-mailing-signup-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for mailing-signup blocks (frontend scripts).
 		wp_set_script_translations(
 			'fair-audience-mailing-signup-view-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for event-signup blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-event-signup-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for event-signup blocks (frontend scripts).
 		wp_set_script_translations(
 			'fair-audience-event-signup-view-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for signups-list blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-signups-list-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for audience-signup blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-audience-signup-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for audience-signup blocks (frontend scripts).
 		wp_set_script_translations(
 			'fair-audience-audience-signup-view-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for event-interest blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-event-interest-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for event-interest blocks (frontend scripts).
 		wp_set_script_translations(
 			'fair-audience-event-interest-view-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form blocks (frontend scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-view-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form-short-text blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-short-text-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form-long-text blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-long-text-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form-phone blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-phone-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form-select-one blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-select-one-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form-multiselect blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-multiselect-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form-radio blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-radio-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form-option blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-option-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form-file-upload blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-file-upload-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form-conditional blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-conditional-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 
 		// Set script translations for fair-form-mailing-signup blocks (editor scripts).
 		wp_set_script_translations(
 			'fair-audience-fair-form-mailing-signup-editor-script',
 			'fair-audience',
-			FAIR_AUDIENCE_PLUGIN_DIR . 'build/languages'
+			\FairAudience\Core\Features::script_translations_path()
 		);
 	}
 }

--- a/fair-audience/src/Settings/Settings.php
+++ b/fair-audience/src/Settings/Settings.php
@@ -137,5 +137,24 @@ class Settings {
 				'default'           => array(),
 			)
 		);
+
+		// Feature flag bundle toggles — UI state only, never overrides a
+		// wp-config constant (see Features::sanitize_option()).
+		register_setting(
+			'fair_audience_settings',
+			\FairAudience\Core\Features::OPTION,
+			array(
+				'type'              => 'object',
+				'description'       => __( 'Per-bundle feature toggles', 'fair-audience' ),
+				'sanitize_callback' => array( \FairAudience\Core\Features::class, 'sanitize_option' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'additionalProperties' => array( 'type' => 'boolean' ),
+					),
+				),
+				'default'           => array(),
+			)
+		);
 	}
 }

--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -313,7 +313,7 @@ class AdminPages {
 			wp_set_script_translations(
 				'fair-events-calendar',
 				'fair-events',
-				FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+				\FairEvents\Core\Features::script_translations_path()
 			);
 
 			return;
@@ -342,7 +342,7 @@ class AdminPages {
 			wp_set_script_translations(
 				'fair-events-all-events',
 				'fair-events',
-				FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+				\FairEvents\Core\Features::script_translations_path()
 			);
 
 			wp_enqueue_style( 'wp-components' );
@@ -373,7 +373,7 @@ class AdminPages {
 			wp_set_script_translations(
 				'fair-events-sources',
 				'fair-events',
-				FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+				\FairEvents\Core\Features::script_translations_path()
 			);
 
 			wp_enqueue_style( 'wp-components' );
@@ -395,7 +395,7 @@ class AdminPages {
 			wp_set_script_translations(
 				'fair-events-migration',
 				'fair-events',
-				FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+				\FairEvents\Core\Features::script_translations_path()
 			);
 
 			wp_enqueue_style( 'wp-components' );
@@ -417,7 +417,7 @@ class AdminPages {
 			wp_set_script_translations(
 				'fair-events-migration-summary',
 				'fair-events',
-				FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+				\FairEvents\Core\Features::script_translations_path()
 			);
 
 			wp_enqueue_style( 'wp-components' );
@@ -463,7 +463,7 @@ class AdminPages {
 			wp_set_script_translations(
 				'fair-events-source-view',
 				'fair-events',
-				FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+				\FairEvents\Core\Features::script_translations_path()
 			);
 
 			return;
@@ -505,7 +505,7 @@ class AdminPages {
 			wp_set_script_translations(
 				'fair-events-manage-invitations',
 				'fair-events',
-				FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+				\FairEvents\Core\Features::script_translations_path()
 			);
 
 			wp_enqueue_style( 'wp-components' );
@@ -576,7 +576,7 @@ class AdminPages {
 			wp_set_script_translations(
 				'fair-events-manage-event',
 				'fair-events',
-				FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+				\FairEvents\Core\Features::script_translations_path()
 			);
 
 			wp_enqueue_style( 'wp-components' );
@@ -598,7 +598,7 @@ class AdminPages {
 			wp_set_script_translations(
 				'fair-events-venues',
 				'fair-events',
-				FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+				\FairEvents\Core\Features::script_translations_path()
 			);
 
 			wp_enqueue_style( 'wp-components' );
@@ -637,7 +637,7 @@ class AdminPages {
 			wp_set_script_translations(
 				'fair-events-settings',
 				'fair-events',
-				FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+				\FairEvents\Core\Features::script_translations_path()
 			);
 
 			wp_enqueue_style( 'wp-components' );

--- a/fair-events/src/Core/Features.php
+++ b/fair-events/src/Core/Features.php
@@ -57,43 +57,61 @@ class Features {
 	 */
 	public static function registry() {
 		return array(
-			'core'        => array(
+			'core'                 => array(
 				'label'       => 'Core',
 				'description' => 'Events, calendar, all-events, settings, core blocks. Always on.',
 				'default'     => true,
 				'always_on'   => true,
 			),
-			'venues'      => array(
+			'venues'               => array(
 				'label'       => 'Venues',
 				'description' => 'Venues admin page and REST controller.',
 				'default'     => false,
 			),
-			'sources'     => array(
+			'sources'              => array(
 				'label'       => 'Event sources & feeds',
 				'description' => 'External event sources, Facebook import, iCal/JSON feeds, event proposals, weekly schedule.',
 				'default'     => false,
 			),
-			'galleries'   => array(
+			'galleries'            => array(
 				'label'       => 'Galleries',
 				'description' => 'Per-event photo galleries, photo likes/downloads, image exports, media library hooks.',
 				'default'     => false,
 			),
-			'ticketing'   => array(
+			'ticketing'            => array(
 				'label'       => 'Ticketing',
 				'description' => 'Tickets, group pricing/permission rules, invitations. Requires fair-audience.',
 				'default'     => false,
 			),
-			'event-tools' => array(
+			'event-tools'          => array(
 				'label'       => 'Event tools',
 				'description' => 'Event duplication, merge, and admin-bar Copy button.',
 				'default'     => false,
 			),
-			'migration'   => array(
+			'migration'            => array(
 				'label'       => 'Migration',
 				'description' => 'One-time post → event migration tooling.',
 				'default'     => false,
 			),
+			'bundled-translations' => array(
+				'label'       => 'Bundled translations',
+				'description' => 'Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings.',
+				'default'     => false,
+			),
 		);
+	}
+
+	/**
+	 * Path passed to wp_set_script_translations() for the bundled-translations
+	 * opt-in. When the flag is off, returns null so core resolves JSON from the
+	 * WP.org language-pack location.
+	 *
+	 * @return string|null
+	 */
+	public static function script_translations_path() {
+		return self::is_enabled( 'bundled-translations' )
+			? FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+			: null;
 	}
 
 	/**
@@ -173,33 +191,37 @@ class Features {
 		// Literal strings are required for makepot extraction; the registry's
 		// raw values are kept in sync with these and serve as fallback.
 		$translated = array(
-			'core'        => array(
+			'core'                 => array(
 				'label'       => __( 'Core', 'fair-events' ),
 				'description' => __( 'Events, calendar, all-events, settings, core blocks. Always on.', 'fair-events' ),
 			),
-			'venues'      => array(
+			'venues'               => array(
 				'label'       => __( 'Venues', 'fair-events' ),
 				'description' => __( 'Venues admin page and REST controller.', 'fair-events' ),
 			),
-			'sources'     => array(
+			'sources'              => array(
 				'label'       => __( 'Event sources & feeds', 'fair-events' ),
 				'description' => __( 'External event sources, Facebook import, iCal/JSON feeds, event proposals, weekly schedule.', 'fair-events' ),
 			),
-			'galleries'   => array(
+			'galleries'            => array(
 				'label'       => __( 'Galleries', 'fair-events' ),
 				'description' => __( 'Per-event photo galleries, photo likes/downloads, image exports, media library hooks.', 'fair-events' ),
 			),
-			'ticketing'   => array(
+			'ticketing'            => array(
 				'label'       => __( 'Ticketing', 'fair-events' ),
 				'description' => __( 'Tickets, group pricing/permission rules, invitations. Requires fair-audience.', 'fair-events' ),
 			),
-			'event-tools' => array(
+			'event-tools'          => array(
 				'label'       => __( 'Event tools', 'fair-events' ),
 				'description' => __( 'Event duplication, merge, and admin-bar Copy button.', 'fair-events' ),
 			),
-			'migration'   => array(
+			'migration'            => array(
 				'label'       => __( 'Migration', 'fair-events' ),
 				'description' => __( 'One-time post → event migration tooling.', 'fair-events' ),
+			),
+			'bundled-translations' => array(
+				'label'       => __( 'Bundled translations', 'fair-events' ),
+				'description' => __( 'Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings.', 'fair-events' ),
 			),
 		);
 

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -38,10 +38,15 @@ class Plugin {
 	 * @return void
 	 */
 	public function init() {
+		// Default: rely on WordPress.org language packs. The `bundled-translations`
+		// feature flag opts into loading the .mo files we ship in `languages/`,
+		// which is useful while a locale is below the WP.org publish threshold.
 		add_action(
 			'init',
 			function () {
-				load_plugin_textdomain( 'fair-events', false, 'fair-events/languages' );
+				if ( Features::is_enabled( 'bundled-translations' ) ) {
+					load_plugin_textdomain( 'fair-events', false, 'fair-events/languages' );
+				}
 			}
 		);
 

--- a/fair-events/src/Frontend/EventGalleryPage.php
+++ b/fair-events/src/Frontend/EventGalleryPage.php
@@ -248,7 +248,7 @@ class EventGalleryPage {
 		wp_set_script_translations(
 			'fair-events-gallery',
 			'fair-events',
-			FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+			\FairEvents\Core\Features::script_translations_path()
 		);
 	}
 

--- a/fair-events/src/Hooks/BlockHooks.php
+++ b/fair-events/src/Hooks/BlockHooks.php
@@ -56,49 +56,49 @@ class BlockHooks {
 		wp_set_script_translations(
 			'fair-events-events-list-editor-script',
 			'fair-events',
-			$plugin_dir . 'build/languages'
+			\FairEvents\Core\Features::script_translations_path()
 		);
 
 		// Event dates block editor script
 		wp_set_script_translations(
 			'fair-events-event-dates-editor-script',
 			'fair-events',
-			$plugin_dir . 'build/languages'
+			\FairEvents\Core\Features::script_translations_path()
 		);
 
 		// Events calendar block editor script
 		wp_set_script_translations(
 			'fair-events-events-calendar-editor-script',
 			'fair-events',
-			$plugin_dir . 'build/languages'
+			\FairEvents\Core\Features::script_translations_path()
 		);
 
 		// Weekly schedule block editor script
 		wp_set_script_translations(
 			'fair-events-weekly-schedule-editor-script',
 			'fair-events',
-			$plugin_dir . 'build/languages'
+			\FairEvents\Core\Features::script_translations_path()
 		);
 
 		// Event proposal block editor script
 		wp_set_script_translations(
 			'fair-events-event-proposal-editor-script',
 			'fair-events',
-			$plugin_dir . 'build/languages'
+			\FairEvents\Core\Features::script_translations_path()
 		);
 
 		// Event proposal block view script (frontend)
 		wp_set_script_translations(
 			'fair-events-event-proposal-view-script',
 			'fair-events',
-			$plugin_dir . 'build/languages'
+			\FairEvents\Core\Features::script_translations_path()
 		);
 
 		// Event info block editor script
 		wp_set_script_translations(
 			'fair-events-event-info-editor-script',
 			'fair-events',
-			$plugin_dir . 'build/languages'
+			\FairEvents\Core\Features::script_translations_path()
 		);
 	}
 }

--- a/fair-events/src/Hooks/CalendarButtonHooks.php
+++ b/fair-events/src/Hooks/CalendarButtonHooks.php
@@ -194,7 +194,7 @@ class CalendarButtonHooks {
 		wp_set_script_translations(
 			'fair-events-calendar-button-editor',
 			'fair-events',
-			FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+			\FairEvents\Core\Features::script_translations_path()
 		);
 	}
 
@@ -264,7 +264,7 @@ class CalendarButtonHooks {
 		wp_set_script_translations(
 			'fair-events-calendar-button-frontend',
 			'fair-events',
-			FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+			\FairEvents\Core\Features::script_translations_path()
 		);
 	}
 }

--- a/fair-events/src/PostTypes/Event.php
+++ b/fair-events/src/PostTypes/Event.php
@@ -201,7 +201,7 @@ class Event {
 		wp_set_script_translations(
 			'fair-events-event-meta-box',
 			'fair-events',
-			FAIR_EVENTS_PLUGIN_DIR . 'build/languages'
+			\FairEvents\Core\Features::script_translations_path()
 		);
 	}
 

--- a/fair-payment/src/Admin/AdminPages.php
+++ b/fair-payment/src/Admin/AdminPages.php
@@ -149,6 +149,13 @@ class AdminPages {
 		// Settings page.
 		if ( false !== strpos( $hook, 'fair-payment-settings' ) ) {
 			$this->enqueue_admin_page_script( 'settings' );
+			wp_localize_script(
+				'fair-payment-settings',
+				'fairPaymentSettingsData',
+				array(
+					'features' => \FairPayment\Core\Features::all(),
+				)
+			);
 			return;
 		}
 

--- a/fair-payment/src/Admin/settings/FeaturesTab.js
+++ b/fair-payment/src/Admin/settings/FeaturesTab.js
@@ -9,6 +9,7 @@ import {
 	ToggleControl,
 	Button,
 	Spinner,
+	Notice,
 } from '@wordpress/components';
 
 /**
@@ -20,30 +21,59 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Features Tab Component
  *
- * Displays feature toggles for the plugin.
+ * Displays feature toggles for the plugin. Budgeting stays in its existing
+ * standalone option; the rest of the toggles come from the
+ * `fair_payment_features` registry (currently just `bundled-translations`).
  *
  * @param {Object}   props          Props
  * @param {Function} props.onNotice Handler for displaying notices
  * @return {JSX.Element} The features tab
  */
 export default function FeaturesTab({ onNotice }) {
+	const registry = window.fairPaymentSettingsData?.features || {};
 	const [budgetingEnabled, setBudgetingEnabled] = useState(false);
+	const [featureValues, setFeatureValues] = useState({});
 	const [loading, setLoading] = useState(true);
 	const [isSaving, setIsSaving] = useState(false);
 
 	useEffect(() => {
 		apiFetch({ path: '/wp/v2/settings' }).then((settings) => {
 			setBudgetingEnabled(settings.fair_payment_enable_budgets || false);
+
+			const stored = settings.fair_payment_features || {};
+			const next = {};
+			Object.entries(registry).forEach(([key, meta]) => {
+				if (meta.always_on || meta.forced) {
+					next[key] = meta.enabled;
+				} else {
+					next[key] =
+						typeof stored[key] === 'boolean'
+							? stored[key]
+							: meta.enabled;
+				}
+			});
+			setFeatureValues(next);
 			setLoading(false);
 		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const handleSave = async () => {
+		const payload = {
+			fair_payment_enable_budgets: budgetingEnabled,
+		};
+		const featuresPayload = {};
+		Object.entries(registry).forEach(([key, meta]) => {
+			if (meta.always_on || meta.forced) {
+				return;
+			}
+			featuresPayload[key] = !!featureValues[key];
+		});
+		payload.fair_payment_features = featuresPayload;
+
 		setIsSaving(true);
 		try {
-			await saveSettings({
-				fair_payment_enable_budgets: budgetingEnabled,
-			});
+			await saveSettings(payload);
 			onNotice({
 				status: 'success',
 				message: __(
@@ -67,6 +97,10 @@ export default function FeaturesTab({ onNotice }) {
 		return <Spinner />;
 	}
 
+	const registryEntries = Object.entries(registry).filter(
+		([, meta]) => !meta.always_on
+	);
+
 	return (
 		<Card>
 			<CardBody>
@@ -80,6 +114,43 @@ export default function FeaturesTab({ onNotice }) {
 					checked={budgetingEnabled}
 					onChange={setBudgetingEnabled}
 				/>
+
+				{registryEntries.map(([key, meta]) => {
+					const help = meta.forced
+						? __(
+								'Forced by a wp-config constant — change it there.',
+								'fair-payment'
+						  )
+						: meta.description;
+
+					return (
+						<div key={key} style={{ marginTop: '1rem' }}>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={meta.label}
+								checked={!!featureValues[key]}
+								onChange={(value) =>
+									setFeatureValues({
+										...featureValues,
+										[key]: value,
+									})
+								}
+								disabled={isSaving || meta.forced}
+								help={help}
+							/>
+						</div>
+					);
+				})}
+
+				{registryEntries.some(([, meta]) => meta.forced) && (
+					<Notice status="info" isDismissible={false}>
+						{__(
+							'One or more bundles are forced by wp-config and cannot be toggled here.',
+							'fair-payment'
+						)}
+					</Notice>
+				)}
+
 				<div style={{ marginTop: '16px' }}>
 					<Button
 						variant="primary"

--- a/fair-payment/src/Core/Features.php
+++ b/fair-payment/src/Core/Features.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Feature flag registry for Fair Payment.
+ *
+ * Mirrors the resolution order used by Fair Events so the maintainer can flip
+ * bundles with a single constant in wp-config, while the Settings UI handles
+ * per-feature toggles for everyone else.
+ *
+ * @package FairPayment
+ */
+
+namespace FairPayment\Core;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Feature flag registry.
+ *
+ * Resolution order for is_enabled() (first match wins):
+ *
+ *   1. Per-feature constant `FAIR_PAYMENT_FEATURE_<UPPER>` (true/false).
+ *   2. Master switch `FAIR_PAYMENT_INTERNAL` (true → every bundle on).
+ *   3. `fair_payment_feature_enabled` filter (programmatic / tests).
+ *   4. Stored option `fair_payment_features` ([ key => bool ]) from Settings UI.
+ *   5. Hardcoded default in the registry below.
+ */
+class Features {
+
+	public const OPTION = 'fair_payment_features';
+
+	public const MASTER_CONSTANT = 'FAIR_PAYMENT_INTERNAL';
+
+	/**
+	 * Canonical bundle registry. Labels/descriptions stay untranslated here so
+	 * `is_enabled()` is safe to call before `init`. {@see self::all()} applies
+	 * translation when the Settings UI consumes the registry.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on?:bool}>
+	 */
+	public static function registry() {
+		return array(
+			'core'                 => array(
+				'label'       => 'Core',
+				'description' => 'Transactions, settings, payment blocks. Always on.',
+				'default'     => true,
+				'always_on'   => true,
+			),
+			'bundled-translations' => array(
+				'label'       => 'Bundled translations',
+				'description' => 'Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings.',
+				'default'     => false,
+			),
+		);
+	}
+
+	/**
+	 * Resolve whether a feature bundle is enabled. Unknown keys resolve to
+	 * false (fail-closed).
+	 *
+	 * @param string $key Bundle key from registry().
+	 * @return bool
+	 */
+	public static function is_enabled( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $registry[ $key ]['always_on'] ) ) {
+			return true;
+		}
+
+		$constant = self::feature_constant_name( $key );
+		if ( defined( $constant ) ) {
+			return (bool) constant( $constant );
+		}
+
+		if ( defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT ) ) {
+			$enabled = true;
+		} else {
+			$stored  = get_option( self::OPTION, array() );
+			$enabled = is_array( $stored ) && array_key_exists( $key, $stored )
+				? (bool) $stored[ $key ]
+				: (bool) $registry[ $key ]['default'];
+		}
+
+		return (bool) apply_filters( 'fair_payment_feature_enabled', $enabled, $key );
+	}
+
+	/**
+	 * Whether the resolved value is forced by a constant — used by the
+	 * Settings UI to render the toggle disabled.
+	 *
+	 * @param string $key Bundle key.
+	 * @return bool
+	 */
+	public static function is_forced( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $registry[ $key ]['always_on'] ) ) {
+			return true;
+		}
+
+		if ( defined( self::feature_constant_name( $key ) ) ) {
+			return true;
+		}
+
+		return defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT );
+	}
+
+	/**
+	 * Full snapshot for the Settings UI: registry entries + resolved state.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on:bool,enabled:bool,forced:bool}>
+	 */
+	public static function all() {
+		$translated = array(
+			'core'                 => array(
+				'label'       => __( 'Core', 'fair-payment' ),
+				'description' => __( 'Transactions, settings, payment blocks. Always on.', 'fair-payment' ),
+			),
+			'bundled-translations' => array(
+				'label'       => __( 'Bundled translations', 'fair-payment' ),
+				'description' => __( 'Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings.', 'fair-payment' ),
+			),
+		);
+
+		$out = array();
+		foreach ( self::registry() as $key => $entry ) {
+			$out[ $key ] = array(
+				'label'       => $translated[ $key ]['label'] ?? $entry['label'],
+				'description' => $translated[ $key ]['description'] ?? $entry['description'],
+				'default'     => (bool) $entry['default'],
+				'always_on'   => ! empty( $entry['always_on'] ),
+				'enabled'     => self::is_enabled( $key ),
+				'forced'      => self::is_forced( $key ),
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Sanitize an option payload to the known key set, dropping forced keys.
+	 *
+	 * @param mixed $value Raw option value.
+	 * @return array<string,bool>
+	 */
+	public static function sanitize_option( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$existing = get_option( self::OPTION, array() );
+		if ( ! is_array( $existing ) ) {
+			$existing = array();
+		}
+
+		$out = array();
+		foreach ( self::registry() as $key => $entry ) {
+			if ( ! empty( $entry['always_on'] ) ) {
+				continue;
+			}
+
+			if ( self::is_forced( $key ) ) {
+				if ( array_key_exists( $key, $existing ) ) {
+					$out[ $key ] = (bool) $existing[ $key ];
+				}
+				continue;
+			}
+
+			if ( array_key_exists( $key, $value ) ) {
+				$out[ $key ] = (bool) $value[ $key ];
+			} elseif ( array_key_exists( $key, $existing ) ) {
+				$out[ $key ] = (bool) $existing[ $key ];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Path passed to wp_set_script_translations() for the bundled-translations
+	 * opt-in. Returns null when the flag is off so core resolves JSON from the
+	 * WP.org language-pack location.
+	 *
+	 * @return string|null
+	 */
+	public static function script_translations_path() {
+		return self::is_enabled( 'bundled-translations' )
+			? FAIR_PAYMENT_PLUGIN_DIR . 'build/languages'
+			: null;
+	}
+
+	/**
+	 * Per-feature constant name (e.g. `bundled-translations` → `FAIR_PAYMENT_FEATURE_BUNDLED_TRANSLATIONS`).
+	 *
+	 * @param string $key Bundle key.
+	 * @return string
+	 */
+	private static function feature_constant_name( $key ) {
+		return 'FAIR_PAYMENT_FEATURE_' . strtoupper( str_replace( '-', '_', $key ) );
+	}
+}

--- a/fair-payment/src/Core/Plugin.php
+++ b/fair-payment/src/Core/Plugin.php
@@ -38,10 +38,14 @@ class Plugin {
 	 * @return void
 	 */
 	public function init() {
+		// Default: rely on WordPress.org language packs. The `bundled-translations`
+		// feature flag opts into loading the .mo files we ship in `languages/`.
 		add_action(
 			'init',
 			function () {
-				load_plugin_textdomain( 'fair-payment', false, 'fair-payment/languages' );
+				if ( Features::is_enabled( 'bundled-translations' ) ) {
+					load_plugin_textdomain( 'fair-payment', false, 'fair-payment/languages' );
+				}
 			}
 		);
 

--- a/fair-payment/src/Settings/Settings.php
+++ b/fair-payment/src/Settings/Settings.php
@@ -279,6 +279,25 @@ class Settings {
 			)
 		);
 
+		// Feature flag bundle toggles — UI state only, never overrides a
+		// wp-config constant (see Features::sanitize_option()).
+		register_setting(
+			'fair_payment_settings',
+			\FairPayment\Core\Features::OPTION,
+			array(
+				'type'              => 'object',
+				'description'       => __( 'Per-bundle feature toggles', 'fair-payment' ),
+				'sanitize_callback' => array( \FairPayment\Core\Features::class, 'sanitize_option' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'additionalProperties' => array( 'type' => 'boolean' ),
+					),
+				),
+				'default'           => array(),
+			)
+		);
+
 		// Telegram: include PII placeholders.
 		register_setting(
 			'fair_payment_settings',

--- a/fair-platform/src/Admin/AdminHooks.php
+++ b/fair-platform/src/Admin/AdminHooks.php
@@ -9,6 +9,7 @@ namespace FairPlatform\Admin;
 
 use FairPlatform\Admin\ConnectionsPage;
 use FairPlatform\Admin\InstagramConnectionsPage;
+use FairPlatform\Core\Features;
 
 defined( 'WPINC' ) || die;
 
@@ -59,6 +60,77 @@ class AdminHooks {
 			'fair-platform-instagram-connections',
 			array( $this, 'render_instagram_connections_page' )
 		);
+
+		add_submenu_page(
+			'fair-platform-settings',
+			__( 'Features', 'fair-platform' ),
+			__( 'Features', 'fair-platform' ),
+			'manage_options',
+			'fair-platform-features',
+			array( $this, 'render_features_page' )
+		);
+	}
+
+	/**
+	 * Render features page (bundled-translations toggle).
+	 *
+	 * @return void
+	 */
+	public function render_features_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'fair-platform' ) );
+		}
+
+		if ( isset( $_POST['fair_platform_features_nonce'] ) &&
+			wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['fair_platform_features_nonce'] ) ), 'fair_platform_features' ) ) {
+			$submitted = isset( $_POST['fair_platform_features'] ) && is_array( $_POST['fair_platform_features'] )
+				? wp_unslash( $_POST['fair_platform_features'] )
+				: array();
+			update_option( Features::OPTION, Features::sanitize_option( $submitted ) );
+			add_settings_error( 'fair_platform_features', 'saved', __( 'Features saved.', 'fair-platform' ), 'success' );
+		}
+
+		$features = Features::all();
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Fair Platform - Features', 'fair-platform' ); ?></h1>
+			<?php settings_errors( 'fair_platform_features' ); ?>
+			<form method="post">
+				<?php wp_nonce_field( 'fair_platform_features', 'fair_platform_features_nonce' ); ?>
+				<table class="form-table" role="presentation">
+					<tbody>
+						<?php foreach ( $features as $key => $meta ) : ?>
+							<?php
+							if ( $meta['always_on'] ) {
+								continue; }
+							?>
+							<tr>
+								<th scope="row"><?php echo esc_html( $meta['label'] ); ?></th>
+								<td>
+									<label>
+										<input
+											type="checkbox"
+											name="fair_platform_features[<?php echo esc_attr( $key ); ?>]"
+											value="1"
+											<?php checked( $meta['enabled'] ); ?>
+											<?php disabled( $meta['forced'] ); ?>
+										/>
+										<?php echo esc_html( $meta['description'] ); ?>
+									</label>
+									<?php if ( $meta['forced'] ) : ?>
+										<p class="description">
+											<?php esc_html_e( 'Forced by a wp-config constant — change it there.', 'fair-platform' ); ?>
+										</p>
+									<?php endif; ?>
+								</td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+				<?php submit_button( __( 'Save Features', 'fair-platform' ) ); ?>
+			</form>
+		</div>
+		<?php
 	}
 
 	/**

--- a/fair-platform/src/Core/Features.php
+++ b/fair-platform/src/Core/Features.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Feature flag registry for Fair Platform.
+ *
+ * @package FairPlatform
+ */
+
+namespace FairPlatform\Core;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Feature flag registry.
+ *
+ * Resolution order for is_enabled() (first match wins):
+ *
+ *   1. Per-feature constant `FAIR_PLATFORM_FEATURE_<UPPER>` (true/false).
+ *   2. Master switch `FAIR_PLATFORM_INTERNAL` (true → every bundle on).
+ *   3. `fair_platform_feature_enabled` filter (programmatic / tests).
+ *   4. Stored option `fair_platform_features` ([ key => bool ]) from Settings UI.
+ *   5. Hardcoded default in the registry below.
+ */
+class Features {
+
+	public const OPTION = 'fair_platform_features';
+
+	public const MASTER_CONSTANT = 'FAIR_PLATFORM_INTERNAL';
+
+	/**
+	 * Canonical bundle registry. Labels/descriptions stay untranslated here so
+	 * `is_enabled()` is safe to call before `init`.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on?:bool}>
+	 */
+	public static function registry() {
+		return array(
+			'core'                 => array(
+				'label'       => 'Core',
+				'description' => 'OAuth proxy endpoints and connection logging. Always on.',
+				'default'     => true,
+				'always_on'   => true,
+			),
+			'bundled-translations' => array(
+				'label'       => 'Bundled translations',
+				'description' => 'Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings.',
+				'default'     => false,
+			),
+		);
+	}
+
+	/**
+	 * Resolve whether a feature bundle is enabled.
+	 *
+	 * @param string $key Bundle key.
+	 * @return bool
+	 */
+	public static function is_enabled( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $registry[ $key ]['always_on'] ) ) {
+			return true;
+		}
+
+		$constant = self::feature_constant_name( $key );
+		if ( defined( $constant ) ) {
+			return (bool) constant( $constant );
+		}
+
+		if ( defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT ) ) {
+			$enabled = true;
+		} else {
+			$stored  = get_option( self::OPTION, array() );
+			$enabled = is_array( $stored ) && array_key_exists( $key, $stored )
+				? (bool) $stored[ $key ]
+				: (bool) $registry[ $key ]['default'];
+		}
+
+		return (bool) apply_filters( 'fair_platform_feature_enabled', $enabled, $key );
+	}
+
+	/**
+	 * Whether the resolved value is forced by a constant.
+	 *
+	 * @param string $key Bundle key.
+	 * @return bool
+	 */
+	public static function is_forced( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $registry[ $key ]['always_on'] ) ) {
+			return true;
+		}
+
+		if ( defined( self::feature_constant_name( $key ) ) ) {
+			return true;
+		}
+
+		return defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT );
+	}
+
+	/**
+	 * Full snapshot for the Settings UI.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on:bool,enabled:bool,forced:bool}>
+	 */
+	public static function all() {
+		$translated = array(
+			'core'                 => array(
+				'label'       => __( 'Core', 'fair-platform' ),
+				'description' => __( 'OAuth proxy endpoints and connection logging. Always on.', 'fair-platform' ),
+			),
+			'bundled-translations' => array(
+				'label'       => __( 'Bundled translations', 'fair-platform' ),
+				'description' => __( 'Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings.', 'fair-platform' ),
+			),
+		);
+
+		$out = array();
+		foreach ( self::registry() as $key => $entry ) {
+			$out[ $key ] = array(
+				'label'       => $translated[ $key ]['label'] ?? $entry['label'],
+				'description' => $translated[ $key ]['description'] ?? $entry['description'],
+				'default'     => (bool) $entry['default'],
+				'always_on'   => ! empty( $entry['always_on'] ),
+				'enabled'     => self::is_enabled( $key ),
+				'forced'      => self::is_forced( $key ),
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Sanitize an option payload to the known key set, dropping forced keys.
+	 *
+	 * @param mixed $value Raw option value.
+	 * @return array<string,bool>
+	 */
+	public static function sanitize_option( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$existing = get_option( self::OPTION, array() );
+		if ( ! is_array( $existing ) ) {
+			$existing = array();
+		}
+
+		$out = array();
+		foreach ( self::registry() as $key => $entry ) {
+			if ( ! empty( $entry['always_on'] ) ) {
+				continue;
+			}
+
+			if ( self::is_forced( $key ) ) {
+				if ( array_key_exists( $key, $existing ) ) {
+					$out[ $key ] = (bool) $existing[ $key ];
+				}
+				continue;
+			}
+
+			if ( array_key_exists( $key, $value ) ) {
+				$out[ $key ] = (bool) $value[ $key ];
+			} elseif ( array_key_exists( $key, $existing ) ) {
+				$out[ $key ] = (bool) $existing[ $key ];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Per-feature constant name.
+	 *
+	 * @param string $key Bundle key.
+	 * @return string
+	 */
+	private static function feature_constant_name( $key ) {
+		return 'FAIR_PLATFORM_FEATURE_' . strtoupper( str_replace( '-', '_', $key ) );
+	}
+}

--- a/fair-platform/src/Core/Plugin.php
+++ b/fair-platform/src/Core/Plugin.php
@@ -76,10 +76,30 @@ class Plugin {
 	 * @return void
 	 */
 	private function init_hooks() {
+		// Default: rely on WordPress.org language packs. The `bundled-translations`
+		// feature flag opts into loading the .mo files we ship in `languages/`.
 		add_action(
 			'init',
 			function () {
-				load_plugin_textdomain( 'fair-platform', false, 'fair-platform/languages' );
+				if ( Features::is_enabled( 'bundled-translations' ) ) {
+					load_plugin_textdomain( 'fair-platform', false, 'fair-platform/languages' );
+				}
+			}
+		);
+
+		// Register feature flag option (used by Features admin page).
+		add_action(
+			'admin_init',
+			function () {
+				register_setting(
+					'fair_platform_settings',
+					Features::OPTION,
+					array(
+						'type'              => 'object',
+						'sanitize_callback' => array( Features::class, 'sanitize_option' ),
+						'default'           => array(),
+					)
+				);
 			}
 		);
 

--- a/fair-timetable/src/Core/Features.php
+++ b/fair-timetable/src/Core/Features.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Feature flag registry for Fair Timetable.
+ *
+ * @package FairTimetable
+ */
+
+namespace FairTimetable\Core;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Feature flag registry.
+ *
+ * Resolution order for is_enabled() (first match wins):
+ *
+ *   1. Per-feature constant `FAIR_TIMETABLE_FEATURE_<UPPER>` (true/false).
+ *   2. Master switch `FAIR_TIMETABLE_INTERNAL` (true → every bundle on).
+ *   3. `fair_timetable_feature_enabled` filter (programmatic / tests).
+ *   4. Stored option `fair_timetable_features` ([ key => bool ]) from Settings UI.
+ *   5. Hardcoded default in the registry below.
+ */
+class Features {
+
+	public const OPTION = 'fair_timetable_features';
+
+	public const MASTER_CONSTANT = 'FAIR_TIMETABLE_INTERNAL';
+
+	/**
+	 * Canonical bundle registry. Labels/descriptions stay untranslated here so
+	 * `is_enabled()` is safe to call before `init`.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on?:bool}>
+	 */
+	public static function registry() {
+		return array(
+			'core'                 => array(
+				'label'       => 'Core',
+				'description' => 'Timetable blocks. Always on.',
+				'default'     => true,
+				'always_on'   => true,
+			),
+			'bundled-translations' => array(
+				'label'       => 'Bundled translations',
+				'description' => 'Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings.',
+				'default'     => false,
+			),
+		);
+	}
+
+	/**
+	 * Resolve whether a feature bundle is enabled.
+	 *
+	 * @param string $key Bundle key.
+	 * @return bool
+	 */
+	public static function is_enabled( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $registry[ $key ]['always_on'] ) ) {
+			return true;
+		}
+
+		$constant = self::feature_constant_name( $key );
+		if ( defined( $constant ) ) {
+			return (bool) constant( $constant );
+		}
+
+		if ( defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT ) ) {
+			$enabled = true;
+		} else {
+			$stored  = get_option( self::OPTION, array() );
+			$enabled = is_array( $stored ) && array_key_exists( $key, $stored )
+				? (bool) $stored[ $key ]
+				: (bool) $registry[ $key ]['default'];
+		}
+
+		return (bool) apply_filters( 'fair_timetable_feature_enabled', $enabled, $key );
+	}
+
+	/**
+	 * Whether the resolved value is forced by a constant.
+	 *
+	 * @param string $key Bundle key.
+	 * @return bool
+	 */
+	public static function is_forced( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $registry[ $key ]['always_on'] ) ) {
+			return true;
+		}
+
+		if ( defined( self::feature_constant_name( $key ) ) ) {
+			return true;
+		}
+
+		return defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT );
+	}
+
+	/**
+	 * Full snapshot for the Settings UI.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on:bool,enabled:bool,forced:bool}>
+	 */
+	public static function all() {
+		$translated = array(
+			'core'                 => array(
+				'label'       => __( 'Core', 'fair-timetable' ),
+				'description' => __( 'Timetable blocks. Always on.', 'fair-timetable' ),
+			),
+			'bundled-translations' => array(
+				'label'       => __( 'Bundled translations', 'fair-timetable' ),
+				'description' => __( 'Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings.', 'fair-timetable' ),
+			),
+		);
+
+		$out = array();
+		foreach ( self::registry() as $key => $entry ) {
+			$out[ $key ] = array(
+				'label'       => $translated[ $key ]['label'] ?? $entry['label'],
+				'description' => $translated[ $key ]['description'] ?? $entry['description'],
+				'default'     => (bool) $entry['default'],
+				'always_on'   => ! empty( $entry['always_on'] ),
+				'enabled'     => self::is_enabled( $key ),
+				'forced'      => self::is_forced( $key ),
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Sanitize an option payload to the known key set, dropping forced keys.
+	 *
+	 * @param mixed $value Raw option value.
+	 * @return array<string,bool>
+	 */
+	public static function sanitize_option( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$existing = get_option( self::OPTION, array() );
+		if ( ! is_array( $existing ) ) {
+			$existing = array();
+		}
+
+		$out = array();
+		foreach ( self::registry() as $key => $entry ) {
+			if ( ! empty( $entry['always_on'] ) ) {
+				continue;
+			}
+
+			if ( self::is_forced( $key ) ) {
+				if ( array_key_exists( $key, $existing ) ) {
+					$out[ $key ] = (bool) $existing[ $key ];
+				}
+				continue;
+			}
+
+			if ( array_key_exists( $key, $value ) ) {
+				$out[ $key ] = (bool) $value[ $key ];
+			} elseif ( array_key_exists( $key, $existing ) ) {
+				$out[ $key ] = (bool) $existing[ $key ];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Path passed to wp_set_script_translations() for the bundled-translations
+	 * opt-in. Returns null when the flag is off.
+	 *
+	 * @return string|null
+	 */
+	public static function script_translations_path() {
+		return self::is_enabled( 'bundled-translations' )
+			? plugin_dir_path( dirname( __DIR__ ) ) . 'build/languages'
+			: null;
+	}
+
+	/**
+	 * Per-feature constant name.
+	 *
+	 * @param string $key Bundle key.
+	 * @return string
+	 */
+	private static function feature_constant_name( $key ) {
+		return 'FAIR_TIMETABLE_FEATURE_' . strtoupper( str_replace( '-', '_', $key ) );
+	}
+}

--- a/fair-timetable/src/Core/Plugin.php
+++ b/fair-timetable/src/Core/Plugin.php
@@ -38,14 +38,115 @@ class Plugin {
 	 * @return void
 	 */
 	public function init() {
+		// Default: rely on WordPress.org language packs. The `bundled-translations`
+		// feature flag opts into loading the .mo files we ship in `languages/`.
 		add_action(
 			'init',
 			function () {
-				load_plugin_textdomain( 'fair-timetable', false, 'fair-timetable/languages' );
+				if ( Features::is_enabled( 'bundled-translations' ) ) {
+					load_plugin_textdomain( 'fair-timetable', false, 'fair-timetable/languages' );
+				}
 			}
 		);
 
+		add_action(
+			'admin_init',
+			function () {
+				register_setting(
+					'fair_timetable_settings',
+					Features::OPTION,
+					array(
+						'type'              => 'object',
+						'sanitize_callback' => array( Features::class, 'sanitize_option' ),
+						'default'           => array(),
+					)
+				);
+			}
+		);
+
+		if ( is_admin() ) {
+			add_action( 'admin_menu', array( $this, 'register_settings_page' ) );
+		}
+
 		$this->load_hooks();
+	}
+
+	/**
+	 * Register the Fair Timetable settings page.
+	 *
+	 * @return void
+	 */
+	public function register_settings_page() {
+		add_options_page(
+			__( 'Fair Timetable', 'fair-timetable' ),
+			__( 'Fair Timetable', 'fair-timetable' ),
+			'manage_options',
+			'fair-timetable-settings',
+			array( $this, 'render_settings_page' )
+		);
+	}
+
+	/**
+	 * Render the Fair Timetable settings page (Features-only).
+	 *
+	 * @return void
+	 */
+	public function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'fair-timetable' ) );
+		}
+
+		if ( isset( $_POST['fair_timetable_features_nonce'] ) &&
+			wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['fair_timetable_features_nonce'] ) ), 'fair_timetable_features' ) ) {
+			$submitted = isset( $_POST['fair_timetable_features'] ) && is_array( $_POST['fair_timetable_features'] )
+				? wp_unslash( $_POST['fair_timetable_features'] )
+				: array();
+			update_option( Features::OPTION, Features::sanitize_option( $submitted ) );
+			add_settings_error( 'fair_timetable_features', 'saved', __( 'Features saved.', 'fair-timetable' ), 'success' );
+		}
+
+		$features = Features::all();
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Fair Timetable - Features', 'fair-timetable' ); ?></h1>
+			<?php settings_errors( 'fair_timetable_features' ); ?>
+			<form method="post">
+				<?php wp_nonce_field( 'fair_timetable_features', 'fair_timetable_features_nonce' ); ?>
+				<table class="form-table" role="presentation">
+					<tbody>
+						<?php foreach ( $features as $key => $meta ) : ?>
+							<?php
+							if ( $meta['always_on'] ) {
+								continue;
+							}
+							?>
+							<tr>
+								<th scope="row"><?php echo esc_html( $meta['label'] ); ?></th>
+								<td>
+									<label>
+										<input
+											type="checkbox"
+											name="fair_timetable_features[<?php echo esc_attr( $key ); ?>]"
+											value="1"
+											<?php checked( $meta['enabled'] ); ?>
+											<?php disabled( $meta['forced'] ); ?>
+										/>
+										<?php echo esc_html( $meta['description'] ); ?>
+									</label>
+									<?php if ( $meta['forced'] ) : ?>
+										<p class="description">
+											<?php esc_html_e( 'Forced by a wp-config constant — change it there.', 'fair-timetable' ); ?>
+										</p>
+									<?php endif; ?>
+								</td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+				<?php submit_button( __( 'Save Features', 'fair-timetable' ) ); ?>
+			</form>
+		</div>
+		<?php
 	}
 
 	/**

--- a/fair-timetable/src/Hooks/BlockHooks.php
+++ b/fair-timetable/src/Hooks/BlockHooks.php
@@ -42,8 +42,9 @@ class BlockHooks {
 	public function set_script_translations() {
 		// WordPress auto-generates script handles based on block name and file.
 		// Format: {namespace}-{block-name}-{editor|view}-script.
-		$plugin_dir = plugin_dir_path( __DIR__ . '/../../fair-timetable.php' );
-		$languages  = $plugin_dir . 'build/languages';
+		// Path is null unless `bundled-translations` is on, so by default core
+		// resolves JSON from the WP.org language-pack location.
+		$languages = \FairTimetable\Core\Features::script_translations_path();
 
 		$blocks = array( 'timetable', 'time-slot', 'time-column-body', 'time-column' );
 


### PR DESCRIPTION
Closes #750.

## Summary

WordPress.org plugin review flagged unconditional `load_plugin_textdomain()`
calls as unnecessary for plugins hosted on WordPress.org (core auto-loads
language packs under the plugin slug since WP 4.6, just-in-time since 6.7).

- **Default behaviour** for all five plugins: no `load_plugin_textdomain()`
  call; `wp_set_script_translations()` receives `null` as the third arg, so
  core resolves JSON from `wp-content/languages/plugins/`.
- **Opt-in `bundled-translations` feature flag** (default `false`): when on,
  `load_plugin_textdomain()` is called on `init` with `'{slug}/languages'`, and
  `wp_set_script_translations()` receives the bundled `build/languages/` path.
- Flag is resolved through the same chain as the existing Fair Events
  features: per-feature constant → master internal constant → filter →
  stored option → hardcoded default.

## Per-plugin changes

- **fair-events** — extended the existing `Core\Features` registry with
  `bundled-translations`; introduced `Features::script_translations_path()`;
  gated all `wp_set_script_translations` call sites and the textdomain init
  hook.
- **fair-payment**, **fair-audience** — new `Core\Features.php`; gated
  textdomain; added bundled-translations toggle to the existing React
  Settings UI (fair-payment integrated into the existing FeaturesTab,
  fair-audience adds a new Features tab).
- **fair-platform** — new `Core\Features.php`; gated textdomain; new
  Features submenu page (PHP form, matching the existing settings page
  style).
- **fair-timetable** — new `Core\Features.php`; gated textdomain + the two
  BlockHooks `wp_set_script_translations` calls; new minimal **Settings →
  Fair Timetable** options page hosting the Features form.

## Docs

- `I18N_SETUP.md` — rewrote the textdomain section to describe the new
  default and the opt-in flag resolution order.
- `CLAUDE.md` — updated the i18n bullet.
- `ADDING_NEW_PLUGIN.md` — replaced the unconditional textdomain step with
  the bundled-translations registry pattern.

## Test plan

- [ ] On a dev WP install with the flag **off** (default), switch site to
      `es_ES` and install the language pack from Settings → General. Confirm a
      sample string from each plugin renders translated.
- [ ] Flip `bundled-translations` on for one plugin via Settings → Features.
      Confirm a string that exists only in the bundled `.po` (and not on
      translate.wordpress.org) renders translated.
- [ ] Confirm `_load_textdomain_just_in_time` notices do not appear in
      `debug.log` in either mode.
- [ ] Verify the Features toggle renders read-only when the corresponding
      `FAIR_{PLUGIN}_FEATURE_BUNDLED_TRANSLATIONS` constant is defined.