### PR TITLE
Cache Playwright browsers between e2e runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,8 +74,21 @@ jobs:
                   sudo mv wp-cli.phar /usr/local/bin/wp
                   wp --info
 
+            - name: Cache Playwright browsers
+              id: playwright-cache
+              uses: actions/cache@v5
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+                  restore-keys: ${{ runner.os }}-playwright-
+
             - name: Install Playwright browser
-              run: npx playwright install --with-deps chromium
+              run: |
+                  if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+                      npx playwright install-deps chromium
+                  else
+                      npx playwright install --with-deps chromium
+                  fi
 
             - name: Boot isolated WordPress env
               run: npm run test:e2e:setup


### PR DESCRIPTION
## Summary

Adds a `Cache Playwright browsers` step before `Install Playwright browser` in the e2e workflow. Chromium (~175 MB) is currently re-downloaded on every cold runner (~30s per run); with this cache it is reused between runs when the Playwright version in `package-lock.json` hasn't changed. On cache hit the install step runs only `install-deps` (the apt packages needed at runtime) instead of the full `--with-deps` download.

Closes #704

## Notes

- Cache key: `${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}` — invalidates automatically on Playwright version bumps.
- On cache hit: `npx playwright install-deps chromium` (apt only, ~a few seconds).
- On cache miss: `npx playwright install --with-deps chromium` (full download, same as before).

## Test plan

- [ ] Merge and let one run prime the cache
- [ ] On the next qualifying PR, confirm `Cache Playwright browsers` shows a cache hit and `Install Playwright browser` completes in ≤ 5s
- [ ] Confirm improvement vs the [baseline measurements](https://github.com/marcin-wosinek/fair-event-plugins/issues/704#issuecomment-4650762242) (~32s average)
- [ ] Bump Playwright version in `package-lock.json` on a test branch and verify cache miss path still installs and tests pass