### PR TITLE
ci: cache Docker images in E2E workflow to prevent Hub timeout failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,6 +77,26 @@ jobs:
             - name: Install Playwright browser
               run: npx playwright install --with-deps chromium
 
+            - name: Cache Docker images
+              id: docker-cache
+              uses: actions/cache@v5
+              with:
+                  path: /tmp/docker-images.tar
+                  key: ${{ runner.os }}-docker-${{ hashFiles('.wp-env.json') }}
+                  restore-keys: ${{ runner.os }}-docker-
+
+            - name: Load cached Docker images
+              if: steps.docker-cache.outputs.cache-hit == 'true'
+              run: docker load -i /tmp/docker-images.tar
+
+            - name: Pull Docker images
+              if: steps.docker-cache.outputs.cache-hit != 'true'
+              run: docker pull wordpress:latest && docker pull mariadb:lts && docker pull wordpress:cli
+
+            - name: Save Docker images to cache
+              if: steps.docker-cache.outputs.cache-hit != 'true'
+              run: docker save wordpress:latest mariadb:lts wordpress:cli -o /tmp/docker-images.tar
+
             - name: Boot isolated WordPress env
               run: npm run test:e2e:setup
 


### PR DESCRIPTION
## Summary

- Adds `docker save` / `docker load` cache steps (keyed on `.wp-env.json`) before "Boot isolated WordPress env"
- Pulls `wordpress:latest`, `mariadb:lts`, and `wordpress:cli` on cache miss and saves them to `/tmp/docker-images.tar`
- On cache hit, loads the tar locally so `wp-env start` finds images already present and skips the Docker Hub pull entirely

## Test plan

- [ ] Verify first run (cache miss) pulls all three images and saves the tar — no regression in "Boot isolated WordPress env" duration (~124 s baseline)
- [ ] Verify second run (cache hit) loads from tar and "Boot isolated WordPress env" is faster than the ~124 s baseline
- [ ] Confirm `du -sh /tmp/docker-images.tar` on a cache-miss run is in the 600–800 MB range (within 10 GB repo cache budget)
- [ ] Confirm no Docker Hub timeout failures on subsequent cache-hit runs

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)