### PR TITLE
ci: benchmark hot Docker image cache (#761)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,5 @@
 name: E2E
+# benchmark: hot Docker cache measurement for #761
 
 permissions:
     contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
 name: E2E
-# benchmark: hot Docker cache measurement for #761
+# benchmark run 2: hot Docker cache measurement for #761
 
 permissions:
     contents: read


### PR DESCRIPTION
Dummy PR to trigger E2E on a warm Docker image cache. Results will be reported in #761.

Will be closed after measurements are taken.