### PR TITLE
fair-payments-connector: show admin notice when in test mode

### DIFF
--- a/fair-payments-connector/src/Admin/AdminPages.php
+++ b/fair-payments-connector/src/Admin/AdminPages.php
@@ -21,6 +21,7 @@ class AdminPages {
 	public function init() {
 		add_action( 'admin_menu', array( $this, 'register_admin_pages' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+		add_action( 'admin_notices', array( $this, 'render_test_mode_notice' ) );
 	}
 
 	/**
@@ -141,6 +142,7 @@ class AdminPages {
 				'fairPaymentTransactions',
 				array(
 					'organizationId' => get_option( 'fair_payment_organization_id', '' ),
+					'testMode'       => 'test' === get_option( 'fair_payment_mode', 'test' ),
 				)
 			);
 			return;
@@ -154,6 +156,7 @@ class AdminPages {
 				'fairPaymentSettingsData',
 				array(
 					'features' => \FairPaymentsConnector\Core\Features::all(),
+					'testMode' => 'test' === get_option( 'fair_payment_mode', 'test' ),
 				)
 			);
 			return;
@@ -209,6 +212,42 @@ class AdminPages {
 			);
 			return;
 		}
+	}
+
+	/**
+	 * Render a non-dismissible warning notice on all admin pages when in test mode.
+	 *
+	 * @return void
+	 */
+	public function render_test_mode_notice() {
+		if ( 'test' !== get_option( 'fair_payment_mode', 'test' ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$settings_url = add_query_arg( 'page', 'fair-payments-connector-settings', admin_url( 'admin.php' ) );
+		?>
+		<div class="notice notice-warning">
+			<p>
+				<?php
+				printf(
+					/* translators: %s: link to settings page */
+					wp_kses(
+						__( 'Fair Payment is in <strong>Test mode</strong> — no real payments are being processed. <a href="%s">Switch to Live mode</a>.', 'fair-payments-connector' ),
+						array(
+							'strong' => array(),
+							'a'      => array( 'href' => array() ),
+						)
+					),
+					esc_url( $settings_url )
+				);
+				?>
+			</p>
+		</div>
+		<?php
 	}
 
 	/**

--- a/fair-payments-connector/src/Settings/Settings.php
+++ b/fair-payments-connector/src/Settings/Settings.php
@@ -313,6 +313,15 @@ class Settings {
 	}
 
 	/**
+	 * Label shown in test mode contexts (admin notice, Telegram template).
+	 *
+	 * @return string
+	 */
+	public static function test_label() {
+		return __( '[TEST] ', 'fair-payments-connector' );
+	}
+
+	/**
 	 * Default Telegram message template.
 	 *
 	 * @return string


### PR DESCRIPTION
## Summary

- Adds a non-dismissible `notice notice-warning` banner on every wp-admin page when `fair_payment_mode === 'test'`, with a link to the Settings page to switch to live mode
- Gates the notice on `current_user_can( 'manage_options' )` so it only shows to admins who can act on it
- Adds `Settings::test_label()` static helper to centralise the test label string (reusable by the Telegram `{test_label}` placeholder)
- Passes `testMode` bool to the transactions and settings JS bundles via `wp_localize_script`, wiring up for React header badge work

## Test plan

- [ ] Set `fair_payment_mode` to `test` — warning banner appears on every wp-admin page
- [ ] Set `fair_payment_mode` to `live` — no banner
- [ ] Log in as a user without `manage_options` — no banner even in test mode
- [ ] Click the "Switch to Live mode" link in the banner — navigates to Settings page
- [ ] Check `window.fairPaymentTransactions.testMode === true` on Transactions page in test mode
- [ ] Check `window.fairPaymentSettingsData.testMode === true` on Settings page in test mode

Closes #707