### PR TITLE
ci: run E2E on push to main to warm Docker image cache for PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,18 @@ permissions:
     contents: read
 
 on:
+    push:
+        branches: [main]
+        paths:
+            - 'fair-payments-connector/**'
+            - 'fair-events/**'
+            - 'fair-audience/**'
+            - 'fair-platform/**'
+            - 'fair-events-shared/**'
+            - 'e2e/**'
+            - 'playwright.config.js'
+            - '.wp-env.json'
+            - '.github/workflows/e2e.yml'
     pull_request:
         branches: [main]
         paths:


### PR DESCRIPTION
## Summary

- Adds a `push` trigger on `main` (same path filters as `pull_request`) to `e2e.yml`
- Every merge to main now runs E2E and (re)populates the Docker image cache on the `main` branch
- PR branches inherit the `main` cache on their first run, so the cache-miss penalty (pull + save, ~33 s) only occurs after a `.wp-env.json` change, not on every new branch

## Why

GitHub Actions caches are branch-scoped. Without a push-to-main run, only `main` merges populate a cache accessible to all PRs. Previously every PR branch started cold.

## Test plan

- [ ] Merge a PR that touches the path filters — confirm an E2E run fires on `main` after merge
- [ ] Open a subsequent PR — confirm "Load cached Docker images" succeeds on the first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)