### PR TITLE
ci: fix Docker image tags in E2E cache steps (#705)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -116,11 +116,11 @@ jobs:
 
             - name: Pull Docker images
               if: steps.docker-cache.outputs.cache-hit != 'true'
-              run: docker pull wordpress:latest && docker pull mariadb:lts && docker pull wordpress:cli
+              run: docker pull wordpress:php8.3 && docker pull wordpress:cli-php8.3 && docker pull mariadb:lts
 
             - name: Save Docker images to cache
               if: steps.docker-cache.outputs.cache-hit != 'true'
-              run: docker save wordpress:latest mariadb:lts wordpress:cli -o /tmp/docker-images.tar
+              run: docker save wordpress:php8.3 wordpress:cli-php8.3 mariadb:lts -o /tmp/docker-images.tar
 
             - name: Boot isolated WordPress env
               run: npm run test:e2e:setup


### PR DESCRIPTION
## Summary

- Fix the Docker image tag names in the cache steps introduced by #761
- `wordpress:latest` and `wordpress:cli` were cached, but wp-env actually pulls `wordpress:php8.3` and `wordpress:cli-php8.3` (driven by `phpVersion: "8.3"` in `.wp-env.json`)
- With the wrong tags cached, every run still had to pull the correct images from Docker Hub, defeating the cache

## Investigation

Also explored caching `~/wp-env` to speed up the "Boot isolated WordPress env" step. This was not viable: the wp-env directory stores docker-compose state that references Docker volumes from a previous runner. On a fresh runner those volumes don't exist, so wp-env skipped database initialization and WordPress failed with "Error establishing a database connection." The wp-env cache approach was dropped.

## Result

| Step | Before fix | After fix |
|---|---|---|
| Boot isolated WordPress env | 143s (cache miss every run) | **108s** (Docker images hit) |
| Job total | 372s | **304s** |

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)