### PR TITLE
ci: gate clean-release auto-deploy behind AUTO_DEPLOY_ON_RELEASE env var

### DIFF
--- a/.github/workflows/deploy-from-release.yml
+++ b/.github/workflows/deploy-from-release.yml
@@ -75,6 +75,7 @@ jobs:
         with:
             environment: acroyoga-club.es
             release_tag: ${{ needs.resolve.outputs.release_tag }}
+            is_clean_version: ${{ needs.resolve.outputs.is_clean_version }}
         secrets: inherit
 
     deploy-fair-event-plugins:
@@ -87,6 +88,7 @@ jobs:
         with:
             environment: fair-event-plugins.com
             release_tag: ${{ needs.resolve.outputs.release_tag }}
+            is_clean_version: ${{ needs.resolve.outputs.is_clean_version }}
         secrets: inherit
 
     deploy-lamutable:
@@ -99,6 +101,7 @@ jobs:
         with:
             environment: lamutable.es
             release_tag: ${{ needs.resolve.outputs.release_tag }}
+            is_clean_version: ${{ needs.resolve.outputs.is_clean_version }}
         secrets: inherit
 
     deploy-fusion-dance:
@@ -111,6 +114,7 @@ jobs:
         with:
             environment: fusion-dance.es
             release_tag: ${{ needs.resolve.outputs.release_tag }}
+            is_clean_version: ${{ needs.resolve.outputs.is_clean_version }}
         secrets: inherit
 
     deploy-acro-agenda:
@@ -123,6 +127,7 @@ jobs:
         with:
             environment: acro-agenda.es
             release_tag: ${{ needs.resolve.outputs.release_tag }}
+            is_clean_version: ${{ needs.resolve.outputs.is_clean_version }}
         secrets: inherit
 
     deploy-fusion-circus:
@@ -135,4 +140,5 @@ jobs:
         with:
             environment: fusion-circus.com
             release_tag: ${{ needs.resolve.outputs.release_tag }}
+            is_clean_version: ${{ needs.resolve.outputs.is_clean_version }}
         secrets: inherit

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -11,13 +11,37 @@ on:
                 description: 'GitHub release tag to deploy (e.g., build-1.0.0)'
                 required: true
                 type: string
+            is_clean_version:
+                description: 'Whether the release tag is a clean semver (no pre-release suffix)'
+                required: false
+                type: string
+                default: 'false'
 
 permissions:
     contents: read
 
 jobs:
+    check:
+        name: Auto-deploy gate for ${{ inputs.environment }}
+        runs-on: ubuntu-latest
+        environment: ${{ inputs.environment }}
+        outputs:
+            should_deploy: ${{ steps.gate.outputs.should_deploy }}
+        steps:
+            - name: Check AUTO_DEPLOY_ON_RELEASE
+              id: gate
+              run: |
+                  if [ "${{ inputs.is_clean_version }}" = "true" ] && [ "${{ vars.AUTO_DEPLOY_ON_RELEASE }}" != "true" ]; then
+                    echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+                    echo "Skipping: AUTO_DEPLOY_ON_RELEASE is not set to 'true' for ${{ inputs.environment }}"
+                  else
+                    echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+                  fi
+
     deploy:
         name: Deploy to ${{ inputs.environment }}
+        needs: [check]
+        if: needs.check.outputs.should_deploy == 'true'
         runs-on: ubuntu-latest
         environment: ${{ inputs.environment }}
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -8,32 +8,37 @@ This approach eliminates matrix complexity while maintaining code reusability. I
 
 ## GitHub Environment Configuration
 
-You need to configure two environments in GitHub:
+You need to configure environments in GitHub:
 - **Settings** → **Environments** → **New environment**
 
-### Environment: `acroyoga-club.es`
+### Required variables (all environments)
 
-**Variables:**
-- `PLUGINS_TO_DEPLOY` = `all` (or comma-separated list: `fair-rsvp,fair-events,fair-payments-connector`)
-- `SSH_HOST` - SSH hostname (e.g., `acroyoga-club.es`)
-- `SSH_PORT` - SSH port (e.g., `22`)
-- `SSH_USER` - SSH username
-- `WORDPRESS_PLUGINS_PATH` - Path to WordPress plugins directory (e.g., `/var/www/html/wp-content/plugins`)
+- `PLUGINS_TO_DEPLOY` — `all` or a comma-separated list (e.g. `fair-events,fair-payments-connector`)
+- `SSH_HOST` — SSH hostname
+- `SSH_PORT` — SSH port (e.g. `22`)
+- `SSH_KNOWN_HOSTS` — SSH known hosts entry for the server
+- `SSH_USER` — SSH username
+- `WORDPRESS_PLUGINS_PATH` — absolute path to the WordPress plugins directory
 
-**Secrets:**
-- `SSH_PRIVATE_KEY` - SSH private key for deployment
+### Optional variable: `AUTO_DEPLOY_ON_RELEASE`
 
-### Environment: `fair-event-plugins.com`
+Set `AUTO_DEPLOY_ON_RELEASE=true` on any environment that should receive automatic deploys when a clean `build-X.Y.Z` release is published.
 
-**Variables:**
-- `PLUGINS_TO_DEPLOY` = `fair-platform` (or comma-separated list, or `all`)
-- `SSH_HOST` - SSH hostname
-- `SSH_PORT` - SSH port (e.g., `22`)
-- `SSH_USER` - SSH username
-- `WORDPRESS_PLUGINS_PATH` - Path to WordPress plugins directory (e.g., `/var/www/html/wp-content/plugins`)
+**Currently opted in:** `fair-event-plugins.com`
 
-**Secrets:**
-- `SSH_PRIVATE_KEY` - SSH private key for deployment
+Leave this variable unset (or set it to any value other than `true`) on client sites to require a manual `workflow_dispatch` for every deploy. Manual dispatch always works regardless of this setting.
+
+### Secrets (all environments)
+
+- `SSH_PRIVATE_KEY` — SSH private key for deployment
+
+### Per-environment notes
+
+**`acroyoga-club.es`** — `PLUGINS_TO_DEPLOY=all`. No `AUTO_DEPLOY_ON_RELEASE` — deploys on manual dispatch only.
+
+**`fair-event-plugins.com`** — `PLUGINS_TO_DEPLOY=fair-platform` (or `all`). `AUTO_DEPLOY_ON_RELEASE=true`.
+
+**`lamutable.es`**, **`fusion-dance.es`**, **`acro-agenda.es`**, **`fusion-circus.com`** — set `PLUGINS_TO_DEPLOY` as appropriate. No `AUTO_DEPLOY_ON_RELEASE` — deploys on manual dispatch only.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

- Tagged `build-X.Y.Z` releases previously triggered automatic deploys to all six environments. This changes the behavior so only environments that have opted in will auto-deploy; all others require a manual `workflow_dispatch`.
- Adds a lightweight `check` gate job to `deploy-to-environment.yml` that reads the `AUTO_DEPLOY_ON_RELEASE` GitHub Environment variable. When `is_clean_version=true` and the variable is not `'true'`, `should_deploy=false` and the deploy job is skipped entirely (not just bailed mid-run).
- `deploy-from-release.yml` now passes `is_clean_version` into each reusable workflow call so the gate has the information it needs.
- `DEPLOYMENT.md` updated: documents the new variable, which environments have it set, and the opt-in/out behavior.

## Test plan

- [ ] Verify a clean-version release only deploys to environments with `AUTO_DEPLOY_ON_RELEASE=true` (expected: `fair-event-plugins.com` only).
- [ ] Verify a manual `workflow_dispatch` still targets exactly the selected environment(s), regardless of `AUTO_DEPLOY_ON_RELEASE`.
- [ ] Verify a dirty build (`build-1.2.3-5-gABCDEF`) continues to deploy only via manual dispatch (unchanged behavior).
- [ ] Set `AUTO_DEPLOY_ON_RELEASE=true` on a second environment and confirm it receives the next clean release deploy.

Closes #757