### PR TITLE
fair-events: add optional per-ticket-type end date

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -584,6 +584,12 @@ class EventSignupController extends WP_REST_Controller {
 			return $capacity_error;
 		}
 
+		// Reject expired ticket types server-side.
+		$disable_at_error = $this->validate_ticket_type_disable_at( $ticket_type_id );
+		if ( is_wp_error( $disable_at_error ) ) {
+			return $disable_at_error;
+		}
+
 		// Check if already signed up.
 		if ( $event_date_id ) {
 			$existing = $this->event_participant_repository->get_by_event_date_and_participant(
@@ -975,6 +981,33 @@ class EventSignupController extends WP_REST_Controller {
 			return new WP_Error(
 				'ticket_type_sold_out',
 				__( 'This ticket type is sold out. Please pick another option.', 'fair-audience' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Reject purchases of ticket types whose end date has passed.
+	 *
+	 * @param int|null $ticket_type_id Ticket type ID.
+	 * @return WP_Error|null WP_Error if expired, null if valid.
+	 */
+	private function validate_ticket_type_disable_at( $ticket_type_id ) {
+		if ( ! $ticket_type_id || ! class_exists( \FairEvents\Models\TicketType::class ) ) {
+			return null;
+		}
+
+		$ticket_type = \FairEvents\Models\TicketType::get_by_id( $ticket_type_id );
+		if ( ! $ticket_type || ! $ticket_type->disable_at ) {
+			return null;
+		}
+
+		if ( strtotime( $ticket_type->disable_at ) <= time() ) {
+			return new WP_Error(
+				'ticket_type_disabled',
+				__( 'This ticket type is no longer available. Please pick another option.', 'fair-audience' ),
 				array( 'status' => 409 )
 			);
 		}
@@ -2247,6 +2280,12 @@ class EventSignupController extends WP_REST_Controller {
 		$capacity_error = $this->validate_ticket_type_capacity( $ticket_type_id );
 		if ( is_wp_error( $capacity_error ) ) {
 			return $capacity_error;
+		}
+
+		// Reject expired ticket types server-side.
+		$disable_at_error = $this->validate_ticket_type_disable_at( $ticket_type_id );
+		if ( is_wp_error( $disable_at_error ) ) {
+			return $disable_at_error;
 		}
 
 		// Paid path takes over when a positive price resolves for this participant.

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -375,6 +375,11 @@ if ( $pricing_event_date_id && class_exists( \FairEvents\Models\TicketType::clas
 			continue;
 		}
 
+		// Hide ticket types whose end date has passed.
+		if ( $tt->disable_at && strtotime( $tt->disable_at ) <= time() ) {
+			continue;
+		}
+
 		// Skip ticket types restricted to groups the participant doesn't belong to
 		// (but skip this check for invitation-only types unlocked by a valid token).
 		$allowed_groups = $tt_group_restrictions[ $tt->id ] ?? array();

--- a/fair-events/src/API/TicketsController.php
+++ b/fair-events/src/API/TicketsController.php
@@ -350,8 +350,11 @@ class TicketsController extends WP_REST_Controller {
 			$seats_per_ticket   = isset( $item['seats_per_ticket'] ) ? max( 1, absint( $item['seats_per_ticket'] ) ) : 1;
 			$invitation_only    = ! empty( $item['invitation_only'] );
 			$minimum_activities = isset( $item['minimum_activities'] ) ? absint( $item['minimum_activities'] ) : 0;
+			$disable_at         = isset( $item['disable_at'] ) && '' !== $item['disable_at'] && null !== $item['disable_at']
+				? sanitize_text_field( $item['disable_at'] )
+				: null;
 
-			$new_id = TicketType::create( $event_date_id, $name, $capacity, $index, $seats_per_ticket, $invitation_only, $minimum_activities );
+			$new_id = TicketType::create( $event_date_id, $name, $capacity, $index, $seats_per_ticket, $invitation_only, $minimum_activities, $disable_at );
 			if ( $new_id ) {
 				$type_ids_by_index[ $index ] = (int) $new_id;
 
@@ -505,6 +508,9 @@ class TicketsController extends WP_REST_Controller {
 			$seats_per_ticket   = isset( $item['seats_per_ticket'] ) ? max( 1, absint( $item['seats_per_ticket'] ) ) : 1;
 			$invitation_only    = ! empty( $item['invitation_only'] );
 			$minimum_activities = isset( $item['minimum_activities'] ) ? absint( $item['minimum_activities'] ) : 0;
+			$disable_at         = isset( $item['disable_at'] ) && '' !== $item['disable_at'] && null !== $item['disable_at']
+				? sanitize_text_field( $item['disable_at'] )
+				: null;
 			$sort_order         = $index;
 			$group_ids          = isset( $item['group_ids'] ) && is_array( $item['group_ids'] ) ? array_map( 'absint', $item['group_ids'] ) : array();
 
@@ -518,12 +524,13 @@ class TicketsController extends WP_REST_Controller {
 						'seats_per_ticket'   => $seats_per_ticket,
 						'invitation_only'    => $invitation_only,
 						'minimum_activities' => $minimum_activities,
+						'disable_at'         => $disable_at,
 						'sort_order'         => $sort_order,
 					)
 				);
 				TicketTypeGroupRestriction::sync_for_ticket_type( (int) $item['id'], $group_ids );
 			} else {
-				$new_id           = TicketType::create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket, $invitation_only, $minimum_activities );
+				$new_id           = TicketType::create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket, $invitation_only, $minimum_activities, $disable_at );
 				$id_map[ $index ] = (int) $new_id;
 				if ( $new_id && ! empty( $group_ids ) ) {
 					TicketTypeGroupRestriction::sync_for_ticket_type( (int) $new_id, $group_ids );

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -47,6 +47,7 @@ export default function EventTickets({
 		minimum_activities: 0,
 		show_ticket_type_minimum_activities: false,
 		activity_period_pricing: false,
+		show_ticket_type_end_date: false,
 	});
 	const [options, setOptions] = useState([]);
 	const [loading, setLoading] = useState(!initialData);
@@ -357,6 +358,7 @@ export default function EventTickets({
 				seats_per_ticket: t.seats_per_ticket || 1,
 				invitation_only: t.invitation_only || false,
 				minimum_activities: t.minimum_activities || 0,
+				disable_at: t.disable_at || null,
 				group_ids: t.group_ids || [],
 			})),
 			sale_periods: getEffectiveSalePeriods().map((p) => ({
@@ -490,6 +492,7 @@ export default function EventTickets({
 				seats_per_ticket: 1,
 				invitation_only: false,
 				minimum_activities: 0,
+				disable_at: null,
 				group_ids: [],
 				sort_order: ticketTypes.length,
 			},
@@ -1339,6 +1342,14 @@ export default function EventTickets({
 																)}
 															</th>
 														)}
+													{settings.show_ticket_type_end_date && (
+														<th>
+															{__(
+																'End date',
+																'fair-events'
+															)}
+														</th>
+													)}
 													{salePeriods.map(
 														(period, pIndex) => {
 															const isContinuous =
@@ -1614,6 +1625,35 @@ export default function EventTickets({
 																		/>
 																	</td>
 																)}
+															{settings.show_ticket_type_end_date && (
+																<td>
+																	<TextControl
+																		type="datetime-local"
+																		value={
+																			type.disable_at
+																				? type.disable_at.replace(
+																					' ',
+																					'T'
+																				)
+																				: ''
+																		}
+																		onChange={(
+																			v
+																		) =>
+																			updateTicketType(
+																				tIndex,
+																				'disable_at',
+																				v
+																					? v.replace(
+																						'T',
+																						' '
+																					)
+																					: null
+																			)
+																		}
+																	/>
+																</td>
+															)}
 															{salePeriods.map(
 																(
 																	period,
@@ -1778,6 +1818,10 @@ export default function EventTickets({
 																: 0) +
 															(settings.show_ticket_type_minimum_activities &&
 															options.length > 0
+																? 1
+																: 0)
+															+
+															(settings.show_ticket_type_end_date
 																? 1
 																: 0)
 														}
@@ -2327,6 +2371,23 @@ export default function EventTickets({
 										...prev,
 										show_ticket_type_minimum_activities:
 											value,
+									}))
+								}
+							/>
+							<CheckboxControl
+								label={__(
+									'Per-ticket-type end date',
+									'fair-events'
+								)}
+								help={__(
+									'Show a date/time input on each ticket type to stop selling it after a fixed date, regardless of remaining capacity.',
+									'fair-events'
+								)}
+								checked={settings.show_ticket_type_end_date}
+								onChange={(value) =>
+									setSettings((prev) => ({
+										...prev,
+										show_ticket_type_end_date: value,
 									}))
 								}
 							/>

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -224,6 +224,11 @@ class Installer {
 			self::migrate_to_3_12_0();
 		}
 
+		// Run migration if upgrading from pre-3.13.0 (add disable_at column to ticket_types).
+		if ( version_compare( $current_version, '3.13.0', '<' ) ) {
+			self::migrate_to_3_13_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -1390,6 +1395,34 @@ class Installer {
 			$wpdb->query(
 				$wpdb->prepare(
 					'ALTER TABLE %i DROP COLUMN theme_image_id',
+					$table_name
+				)
+			);
+		}
+	}
+
+	/**
+	 * Migrate to version 3.13.0 - Add disable_at column to ticket_types table.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_13_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_events_ticket_types';
+
+		$column_exists = $wpdb->get_results(
+			$wpdb->prepare(
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'disable_at' )
+			)
+		);
+
+		if ( empty( $column_exists ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD COLUMN disable_at DATETIME DEFAULT NULL AFTER minimum_activities',
 					$table_name
 				)
 			);

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.12.0';
+	const DB_VERSION = '3.13.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -254,6 +254,7 @@ class Schema {
 			seats_per_ticket INT UNSIGNED NOT NULL DEFAULT 1,
 			invitation_only TINYINT(1) NOT NULL DEFAULT 0,
 			minimum_activities INT UNSIGNED NOT NULL DEFAULT 0,
+			disable_at DATETIME DEFAULT NULL,
 			sort_order INT UNSIGNED NOT NULL DEFAULT 0,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/fair-events/src/Models/EventDateSetting.php
+++ b/fair-events/src/Models/EventDateSetting.php
@@ -75,6 +75,7 @@ class EventDateSetting {
 		'minimum_activities'                  => '0',
 		'show_ticket_type_minimum_activities' => '0',
 		'activity_period_pricing'             => '0',
+		'show_ticket_type_end_date'           => '0',
 	);
 
 	/**

--- a/fair-events/src/Models/TicketType.php
+++ b/fair-events/src/Models/TicketType.php
@@ -69,6 +69,13 @@ class TicketType {
 	public $minimum_activities = 0;
 
 	/**
+	 * Date/time after which this ticket type is no longer available (null = no end date)
+	 *
+	 * @var string|null
+	 */
+	public $disable_at;
+
+	/**
 	 * Sort order
 	 *
 	 * @var int
@@ -159,16 +166,17 @@ class TicketType {
 	/**
 	 * Create a new ticket type
 	 *
-	 * @param int      $event_date_id   Event date ID.
-	 * @param string   $name            Name.
-	 * @param int|null $capacity        Capacity (null = no limit).
-	 * @param int      $sort_order      Sort order.
-	 * @param int      $seats_per_ticket Seats consumed per ticket (default 1).
-	 * @param bool     $invitation_only Whether this ticket requires an invitation token.
-	 * @param int      $minimum_activities Minimum activities this type requires (0 = inherit global).
+	 * @param int         $event_date_id   Event date ID.
+	 * @param string      $name            Name.
+	 * @param int|null    $capacity        Capacity (null = no limit).
+	 * @param int         $sort_order      Sort order.
+	 * @param int         $seats_per_ticket Seats consumed per ticket (default 1).
+	 * @param bool        $invitation_only Whether this ticket requires an invitation token.
+	 * @param int         $minimum_activities Minimum activities this type requires (0 = inherit global).
+	 * @param string|null $disable_at Date/time after which this ticket type is unavailable (null = no end date).
 	 * @return int|false The ticket type ID on success, false on failure.
 	 */
-	public static function create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket = 1, $invitation_only = false, $minimum_activities = 0 ) {
+	public static function create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket = 1, $invitation_only = false, $minimum_activities = 0, $disable_at = null ) {
 		global $wpdb;
 
 		$table_name = self::get_table_name();
@@ -182,9 +190,10 @@ class TicketType {
 				'seats_per_ticket'   => max( 1, (int) $seats_per_ticket ),
 				'invitation_only'    => $invitation_only ? 1 : 0,
 				'minimum_activities' => max( 0, (int) $minimum_activities ),
+				'disable_at'         => $disable_at,
 				'sort_order'         => $sort_order,
 			),
-			array( '%d', '%s', '%d', '%d', '%d', '%d', '%d' )
+			array( '%d', '%s', '%d', '%d', '%d', '%d', '%s', '%d' )
 		);
 
 		if ( $result ) {
@@ -232,6 +241,11 @@ class TicketType {
 		if ( array_key_exists( 'minimum_activities', $data ) ) {
 			$update_data['minimum_activities'] = max( 0, (int) $data['minimum_activities'] );
 			$update_format[]                   = '%d';
+		}
+
+		if ( array_key_exists( 'disable_at', $data ) ) {
+			$update_data['disable_at'] = $data['disable_at'];
+			$update_format[]           = '%s';
 		}
 
 		if ( isset( $data['sort_order'] ) ) {
@@ -309,6 +323,7 @@ class TicketType {
 		$item->seats_per_ticket   = isset( $row->seats_per_ticket ) ? max( 1, (int) $row->seats_per_ticket ) : 1;
 		$item->invitation_only    = isset( $row->invitation_only ) && (int) $row->invitation_only === 1;
 		$item->minimum_activities = isset( $row->minimum_activities ) ? (int) $row->minimum_activities : 0;
+		$item->disable_at         = $row->disable_at ?? null;
 		$item->sort_order         = (int) $row->sort_order;
 		$item->created_at         = $row->created_at;
 		$item->updated_at         = $row->updated_at;
@@ -330,6 +345,7 @@ class TicketType {
 			'seats_per_ticket'   => $this->seats_per_ticket,
 			'invitation_only'    => $this->invitation_only,
 			'minimum_activities' => $this->minimum_activities,
+			'disable_at'         => $this->disable_at,
 			'sort_order'         => $this->sort_order,
 			'created_at'         => $this->created_at,
 			'updated_at'         => $this->updated_at,


### PR DESCRIPTION
## Summary

- Adds an optional `disable_at` datetime field per ticket type so organizers can close a tier at a fixed date, independent of remaining capacity
- Mirrors the existing `invitation_only` / `show_ticket_type_capacity` patterns throughout the stack (DB, model, API, admin UI, frontend block, signup validation)
- Controlled per event via a new **Per-ticket-type end date** toggle in the event settings panel (off by default)

## Changes

- **DB:** `disable_at DATETIME DEFAULT NULL` column on `fair_events_ticket_types`; version bumped `3.12.0 → 3.13.0` with safe `ALTER TABLE` migration
- **`TicketType` model:** property, `hydrate`, `to_array`, `create`, `update`
- **`EventDateSetting`:** `show_ticket_type_end_date` toggle (default `'0'`)
- **`TicketsController`:** sanitize and persist `disable_at` on import and sync
- **`EventTickets.js`:** per-event toggle in settings panel + `datetime-local` input per ticket type row
- **`event-signup/render.php`:** skip expired types before building the display list
- **`EventSignupController`:** `validate_ticket_type_disable_at` guard in both `create_signup` and `register_and_signup` (returns 409 when expired)

## Test plan

- [ ] Enable **Per-ticket-type end date** toggle in event settings
- [ ] Set a past `disable_at` on one ticket type → it should not appear in the frontend signup block
- [ ] Set a future `disable_at` → ticket type appears normally
- [ ] POST a signup directly to the API with an expired ticket type ID → expect 409 `ticket_type_disabled`
- [ ] Save and reload the event admin page; `disable_at` value should round-trip correctly

Closes #708