### PR TITLE
chore: upgrade @wordpress/scripts to 32.4.0

### DIFF
--- a/fair-audience/package.json
+++ b/fair-audience/package.json
@@ -45,7 +45,7 @@
 		"@babel/core": "^7.28.3",
 		"@babel/preset-env": "^7.28.3",
 		"@playwright/test": "^1.40.0",
-		"@wordpress/scripts": "^30.20.0",
+		"@wordpress/scripts": "^32.4.0",
 		"babel-jest": "^30.0.5",
 		"dotenv": "^16.3.1",
 		"jest": "^30.0.0",

--- a/fair-events-shared/package.json
+++ b/fair-events-shared/package.json
@@ -17,7 +17,7 @@
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
 		"@wordpress/components": "^31.0.0",
-		"@wordpress/scripts": "^31.2.0",
+		"@wordpress/scripts": "^32.4.0",
 		"date-fns": "^2.30.0"
 	}
 }

--- a/fair-events/package.json
+++ b/fair-events/package.json
@@ -57,7 +57,7 @@
 		"@playwright/test": "^1.40.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^14.3.1",
-		"@wordpress/scripts": "^31.2.0",
+		"@wordpress/scripts": "^32.4.0",
 		"babel-jest": "^30.0.5",
 		"dotenv": "^16.3.1",
 		"jest": "^30.0.0",

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -1632,9 +1632,9 @@ export default function EventTickets({
 																		value={
 																			type.disable_at
 																				? type.disable_at.replace(
-																					' ',
-																					'T'
-																				)
+																						' ',
+																						'T'
+																				  )
 																				: ''
 																		}
 																		onChange={(
@@ -1645,9 +1645,9 @@ export default function EventTickets({
 																				'disable_at',
 																				v
 																					? v.replace(
-																						'T',
-																						' '
-																					)
+																							'T',
+																							' '
+																					  )
 																					: null
 																			)
 																		}
@@ -1819,8 +1819,7 @@ export default function EventTickets({
 															(settings.show_ticket_type_minimum_activities &&
 															options.length > 0
 																? 1
-																: 0)
-															+
+																: 0) +
 															(settings.show_ticket_type_end_date
 																? 1
 																: 0)

--- a/fair-payments-connector/package.json
+++ b/fair-payments-connector/package.json
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^14.3.1",
-		"@wordpress/scripts": "^31.2.0",
+		"@wordpress/scripts": "^32.4.0",
 		"webpack-bundle-output": "^1.1.0"
 	},
 	"dependencies": {

--- a/fair-platform/package.json
+++ b/fair-platform/package.json
@@ -26,7 +26,7 @@
 		"svn:copy": "cp -r readme.txt fair-platform.php composer* languages CHANGELOG.md svn/trunk"
 	},
 	"devDependencies": {
-		"@wordpress/scripts": "^31.2.0",
+		"@wordpress/scripts": "^32.4.0",
 		"webpack-bundle-output": "^1.1.0"
 	},
 	"dependencies": {

--- a/fair-timetable/package.json
+++ b/fair-timetable/package.json
@@ -44,7 +44,7 @@
 		"@babel/core": "^7.28.3",
 		"@babel/preset-env": "^7.28.3",
 		"@playwright/test": "^1.40.0",
-		"@wordpress/scripts": "^31.2.0",
+		"@wordpress/scripts": "^32.4.0",
 		"babel-jest": "^30.0.5",
 		"dotenv": "^16.3.1",
 		"jest": "^30.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"fair-timetable"
 			],
 			"dependencies": {
-				"@wordpress/scripts": "^31.4.0",
+				"@wordpress/scripts": "^32.4.0",
 				"abab": "^2.0.6",
 				"accepts": "^1.3.8",
 				"acorn": "^8.15.0",
@@ -926,7 +926,7 @@
 			}
 		},
 		"fair-audience": {
-			"version": "1.3.3",
+			"version": "1.3.4",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -943,1084 +943,12 @@
 				"@babel/core": "^7.28.3",
 				"@babel/preset-env": "^7.28.3",
 				"@playwright/test": "^1.40.0",
-				"@wordpress/scripts": "^30.20.0",
+				"@wordpress/scripts": "^32.4.0",
 				"babel-jest": "^30.0.5",
 				"dotenv": "^16.3.1",
 				"jest": "^30.0.0",
 				"npm-run-all": "^4.1.5",
 				"webpack-bundle-output": "^1.1.0"
-			}
-		},
-		"fair-audience/node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"dev": true,
-			"license": "MIT"
-		},
-		"fair-audience/node_modules/@wordpress/prettier-config": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.39.0.tgz",
-			"integrity": "sha512-w9NPuyKZ8y7xLNRaXOK6TLw0HdcA9vQBmK65cd16w4WxyPwXwFVGBdwoi2og/RN3UBQLYci25zGp7GtiiVhG+Q==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"prettier": ">=3"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts": {
-			"version": "30.27.0",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/core": "7.25.7",
-				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
-				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.34.0",
-				"@wordpress/browserslist-config": "^6.34.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.34.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.34.0",
-				"@wordpress/eslint-plugin": "^22.20.0",
-				"@wordpress/jest-preset-default": "^12.34.0",
-				"@wordpress/npm-package-json-lint-config": "^5.34.0",
-				"@wordpress/postcss-plugins-preset": "^5.34.0",
-				"@wordpress/prettier-config": "^4.34.0",
-				"@wordpress/stylelint-config": "^23.26.0",
-				"adm-zip": "^0.5.9",
-				"babel-jest": "29.7.0",
-				"babel-loader": "9.2.1",
-				"browserslist": "^4.21.10",
-				"chalk": "^4.0.0",
-				"check-node-version": "^4.1.0",
-				"copy-webpack-plugin": "^10.2.0",
-				"cross-spawn": "^7.0.6",
-				"css-loader": "^6.2.0",
-				"cssnano": "^6.0.1",
-				"cwd": "^0.10.0",
-				"dir-glob": "^3.0.1",
-				"eslint": "^8.3.0",
-				"expect-puppeteer": "^4.4.0",
-				"fast-glob": "^3.2.7",
-				"filenamify": "^4.2.0",
-				"jest": "^29.6.2",
-				"jest-dev-server": "^10.1.4",
-				"jest-environment-jsdom": "^29.6.2",
-				"jest-environment-node": "^29.6.2",
-				"json2php": "^0.0.9",
-				"markdownlint-cli": "^0.31.1",
-				"merge-deep": "^3.0.3",
-				"mini-css-extract-plugin": "^2.9.2",
-				"minimist": "^1.2.0",
-				"npm-package-json-lint": "^6.4.0",
-				"npm-packlist": "^3.0.0",
-				"postcss": "^8.4.5",
-				"postcss-loader": "^6.2.1",
-				"prettier": "npm:wp-prettier@3.0.3",
-				"puppeteer-core": "^23.10.1",
-				"react-refresh": "^0.14.0",
-				"read-pkg-up": "^7.0.1",
-				"resolve-bin": "^0.4.0",
-				"rtlcss": "^4.3.0",
-				"sass": "^1.54.0",
-				"sass-loader": "^16.0.3",
-				"schema-utils": "^4.2.0",
-				"source-map-loader": "^3.0.0",
-				"stylelint": "^16.8.2",
-				"terser-webpack-plugin": "^5.3.10",
-				"url-loader": "^4.1.1",
-				"webpack": "^5.97.0",
-				"webpack-bundle-analyzer": "^4.9.1",
-				"webpack-cli": "^5.1.4",
-				"webpack-dev-server": "^4.15.1"
-			},
-			"bin": {
-				"wp-scripts": "bin/wp-scripts.js"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"@playwright/test": "^1.56.1",
-				"@wordpress/env": "^10.0.0",
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@wordpress/env": {
-					"optional": true
-				}
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@babel/core": {
-			"version": "7.25.7",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.25.7",
-				"@babel/generator": "^7.25.7",
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helpers": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/template": "^7.25.7",
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@jest/console": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@jest/environment": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@jest/expect": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"expect": "^29.7.0",
-				"jest-snapshot": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@jest/expect-utils": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"jest-get-type": "^29.6.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@jest/fake-timers": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@sinonjs/fake-timers": "^10.0.2",
-				"@types/node": "*",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@jest/globals": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"jest-mock": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@jest/schemas": {
-			"version": "29.6.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.27.8"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@jest/source-map": {
-			"version": "29.6.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.9"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@jest/test-result": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"collect-v8-coverage": "^1.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@sinonjs/fake-timers": {
-			"version": "10.3.0",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@sinonjs/commons": "^3.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin": {
-			"version": "22.22.0",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/eslint-parser": "7.25.7",
-				"@typescript-eslint/eslint-plugin": "^6.4.1",
-				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.36.0",
-				"@wordpress/prettier-config": "^4.36.0",
-				"cosmiconfig": "^7.0.0",
-				"eslint-config-prettier": "^8.3.0",
-				"eslint-import-resolver-typescript": "^4.4.4",
-				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^27.4.3",
-				"eslint-plugin-jsdoc": "^46.4.6",
-				"eslint-plugin-jsx-a11y": "^6.5.1",
-				"eslint-plugin-playwright": "^0.15.3",
-				"eslint-plugin-prettier": "^5.0.0",
-				"eslint-plugin-react": "^7.27.0",
-				"eslint-plugin-react-hooks": "^4.3.0",
-				"globals": "^13.12.0",
-				"requireindex": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"@babel/core": ">=7",
-				"eslint": ">=8",
-				"prettier": ">=3",
-				"typescript": ">=5"
-			},
-			"peerDependenciesMeta": {
-				"prettier": {
-					"optional": true
-				},
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/@babel/eslint-parser": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.7.tgz",
-			"integrity": "sha512-B+BO9x86VYsQHimucBAL1fxTJKF4wyKY6ZVzee9QgzdZOUfs3BaR6AQrgoGrRI+7IFS1wUz/VyQ+SoBcSpdPbw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-				"eslint-visitor-keys": "^2.1.0",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.11.0",
-				"eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-config-prettier": {
-			"version": "8.10.2",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
-			"integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"bin": {
-				"eslint-config-prettier": "bin/cli.js"
-			},
-			"peerDependencies": {
-				"eslint": ">=7.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-import-resolver-typescript": {
-			"version": "4.4.4",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"debug": "^4.4.1",
-				"eslint-import-context": "^0.1.8",
-				"get-tsconfig": "^4.10.1",
-				"is-bun-module": "^2.0.0",
-				"stable-hash-x": "^0.2.0",
-				"tinyglobby": "^0.2.14",
-				"unrs-resolver": "^1.7.11"
-			},
-			"engines": {
-				"node": "^16.17.0 || >=18.6.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint-import-resolver-typescript"
-			},
-			"peerDependencies": {
-				"eslint": "*",
-				"eslint-plugin-import": "*",
-				"eslint-plugin-import-x": "*"
-			},
-			"peerDependenciesMeta": {
-				"eslint-plugin-import": {
-					"optional": true
-				},
-				"eslint-plugin-import-x": {
-					"optional": true
-				}
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-prettier": {
-			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"prettier-linter-helpers": "^1.0.1",
-				"synckit": "^0.11.12"
-			},
-			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint-plugin-prettier"
-			},
-			"peerDependencies": {
-				"@types/eslint": ">=8.0.0",
-				"eslint": ">=8.0.0",
-				"eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
-				"prettier": ">=3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/eslint": {
-					"optional": true
-				},
-				"eslint-config-prettier": {
-					"optional": true
-				}
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/babel-jest": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/transform": "^29.7.0",
-				"@types/babel__core": "^7.1.14",
-				"babel-plugin-istanbul": "^6.1.1",
-				"babel-preset-jest": "^29.6.3",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.8.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/babel-plugin-istanbul": {
-			"version": "6.1.1",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@istanbuljs/load-nyc-config": "^1.0.0",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-instrument": "^5.0.4",
-				"test-exclude": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/babel-plugin-jest-hoist": {
-			"version": "29.6.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/template": "^7.3.3",
-				"@babel/types": "^7.3.3",
-				"@types/babel__core": "^7.1.14",
-				"@types/babel__traverse": "^7.0.6"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/babel-preset-jest": {
-			"version": "29.6.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"babel-plugin-jest-hoist": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/ci-info": {
-			"version": "3.9.0",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/cjs-module-lexer": {
-			"version": "1.4.3",
-			"dev": true,
-			"license": "MIT"
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/expect": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/expect-utils": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/glob": {
-			"version": "7.2.3",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/istanbul-lib-instrument": {
-			"version": "5.2.1",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@babel/core": "^7.12.3",
-				"@babel/parser": "^7.14.7",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-coverage": "^3.2.0",
-				"semver": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/core": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"import-local": "^3.0.2",
-				"jest-cli": "^29.7.0"
-			},
-			"bin": {
-				"jest": "bin/jest.js"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-circus": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"co": "^4.6.0",
-				"dedent": "^1.0.0",
-				"is-generator-fn": "^2.0.0",
-				"jest-each": "^29.7.0",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"p-limit": "^3.1.0",
-				"pretty-format": "^29.7.0",
-				"pure-rand": "^6.0.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-cli": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/core": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"create-jest": "^29.7.0",
-				"exit": "^0.1.2",
-				"import-local": "^3.0.2",
-				"jest-config": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"yargs": "^17.3.1"
-			},
-			"bin": {
-				"jest": "bin/jest.js"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-config": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@jest/test-sequencer": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-jest": "^29.7.0",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"deepmerge": "^4.2.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-circus": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"parse-json": "^5.2.0",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-json-comments": "^3.1.1"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"@types/node": "*",
-				"ts-node": ">=9.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"ts-node": {
-					"optional": true
-				}
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-diff": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"diff-sequences": "^29.6.3",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-docblock": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"detect-newline": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-each": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-environment-node": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-haste-map": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/graceful-fs": "^4.1.3",
-				"@types/node": "*",
-				"anymatch": "^3.0.3",
-				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-regex-util": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"walker": "^1.0.8"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "^2.3.2"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-leak-detector": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-matcher-utils": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-mock": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-regex-util": {
-			"version": "29.6.3",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-resolve": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"resolve": "^1.20.0",
-				"resolve.exports": "^2.0.0",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-runner": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/environment": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"emittery": "^0.13.1",
-				"graceful-fs": "^4.2.9",
-				"jest-docblock": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-leak-detector": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-resolve": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"p-limit": "^3.1.0",
-				"source-map-support": "0.5.13"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-runtime": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/globals": "^29.7.0",
-				"@jest/source-map": "^29.6.3",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"cjs-module-lexer": "^1.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-bom": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-snapshot": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@babel/generator": "^7.7.2",
-				"@babel/plugin-syntax-jsx": "^7.7.2",
-				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.7.0",
-				"semver": "^7.5.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-snapshot/node_modules/semver": {
-			"version": "7.7.3",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-util": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-validate": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"camelcase": "^6.2.0",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
-				"leven": "^3.1.0",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-watcher": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"emittery": "^0.13.1",
-				"jest-util": "^29.7.0",
-				"string-length": "^4.0.1"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/jest-worker": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"jest-util": "^29.7.0",
-				"merge-stream": "^2.0.0",
-				"supports-color": "^8.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/minimatch": {
-			"version": "3.1.2",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/picomatch": {
-			"version": "2.3.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/pure-rand": {
-			"version": "6.1.0",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/dubzzz"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fast-check"
-				}
-			],
-			"license": "MIT"
-		},
-		"fair-audience/node_modules/@wordpress/scripts/node_modules/semver": {
-			"version": "6.3.1",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"fair-audience/node_modules/ansi-styles": {
@@ -2125,15 +1053,6 @@
 				"@babel/core": "^7.11.0 || ^8.0.0-beta.1"
 			}
 		},
-		"fair-audience/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"fair-audience/node_modules/ci-info": {
 			"version": "4.3.1",
 			"dev": true,
@@ -2152,21 +1071,6 @@
 			"version": "2.2.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"fair-audience/node_modules/cosmiconfig": {
-			"version": "7.1.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"fair-audience/node_modules/dotenv": {
 			"version": "16.6.1",
@@ -2976,24 +1880,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"fair-audience/node_modules/prettier": {
-			"name": "wp-prettier",
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
-			"integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"bin": {
-				"prettier": "bin/prettier.cjs"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
 		"fair-audience/node_modules/pretty-format": {
 			"version": "30.2.0",
 			"dev": true,
@@ -3092,7 +1978,7 @@
 			}
 		},
 		"fair-events": {
-			"version": "1.3.3",
+			"version": "1.3.4",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@fortawesome/fontawesome-svg-core": "^6.0.0",
@@ -3119,7 +2005,7 @@
 				"@playwright/test": "^1.40.0",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^14.3.1",
-				"@wordpress/scripts": "^31.2.0",
+				"@wordpress/scripts": "^32.4.0",
 				"babel-jest": "^30.0.5",
 				"dotenv": "^16.3.1",
 				"jest": "^30.0.0",
@@ -3131,7 +2017,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/components": "^31.0.0",
-				"@wordpress/scripts": "^31.2.0",
+				"@wordpress/scripts": "^32.4.0",
 				"date-fns": "^2.30.0"
 			}
 		},
@@ -4211,7 +3097,7 @@
 			}
 		},
 		"fair-payments-connector": {
-			"version": "1.3.3",
+			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -4226,7 +3112,7 @@
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^14.3.1",
-				"@wordpress/scripts": "^31.2.0",
+				"@wordpress/scripts": "^32.4.0",
 				"webpack-bundle-output": "^1.1.0"
 			}
 		},
@@ -4314,7 +3200,7 @@
 			}
 		},
 		"fair-platform": {
-			"version": "1.1.2",
+			"version": "1.1.3",
 			"license": "proprietary",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.12.0",
@@ -4323,7 +3209,7 @@
 				"@wordpress/i18n": "^5.12.0"
 			},
 			"devDependencies": {
-				"@wordpress/scripts": "^31.2.0",
+				"@wordpress/scripts": "^32.4.0",
 				"webpack-bundle-output": "^1.1.0"
 			}
 		},
@@ -4451,7 +3337,7 @@
 			}
 		},
 		"fair-timetable": {
-			"version": "0.6.2",
+			"version": "0.6.3",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^7.0.0",
@@ -4468,7 +3354,7 @@
 				"@babel/core": "^7.28.3",
 				"@babel/preset-env": "^7.28.3",
 				"@playwright/test": "^1.40.0",
-				"@wordpress/scripts": "^31.2.0",
+				"@wordpress/scripts": "^32.4.0",
 				"babel-jest": "^30.0.5",
 				"dotenv": "^16.3.1",
 				"jest": "^30.0.0",
@@ -8561,6 +7447,34 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/@eslint-community/eslint-plugin-eslint-comments": {
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
+			"integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0",
+				"ignore": "^7.0.5"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+			}
+		},
+		"node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.9.1",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -8598,6 +7512,100 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@eslint/compat": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
+			"integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"peerDependencies": {
+				"eslint": "^8.40 || 9 || 10"
+			},
+			"peerDependenciesMeta": {
+				"eslint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@eslint/config-array": {
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/object-schema": "^3.0.5",
+				"debug": "^4.3.1",
+				"minimatch": "^10.2.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@eslint/config-helpers": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+			"integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -8670,6 +7678,28 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@eslint/object-schema": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/plugin-kit": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@floating-ui/core": {
@@ -8872,6 +7902,41 @@
 				"@hapi/hoek": "^9.0.0"
 			}
 		},
+		"node_modules/@humanfs/core": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/types": "^0.15.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/node": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/core": "^0.19.2",
+				"@humanfs/types": "^0.15.0",
+				"@humanwhocodes/retry": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/types": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.13.0",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -8928,6 +7993,19 @@
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"deprecated": "Use @eslint/object-schema instead",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/@humanwhocodes/retry": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
 		},
 		"node_modules/@inquirer/ansi": {
 			"version": "1.0.2",
@@ -9767,6 +8845,7 @@
 			"version": "30.2.0",
 			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
 			"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/fake-timers": "30.2.0",
@@ -9779,18 +8858,18 @@
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.2.0.tgz",
-			"integrity": "sha512-kazxw2L9IPuZpQ0mEt9lu9Z98SqR74xcagANmMBU16X0lS23yPc0+S6hGLUz8kVRlomZEs/5S/Zlpqwf5yu6OQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.4.1.tgz",
+			"integrity": "sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==",
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/fake-timers": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/jsdom": "^21.1.7",
 				"@types/node": "*",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -9805,15 +8884,100 @@
 				}
 			}
 		},
-		"node_modules/@jest/environment-jsdom-abstract/node_modules/@types/jsdom": {
-			"version": "21.1.7",
-			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
-			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+			"integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-mock": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+			"integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@sinonjs/fake-timers": "^15.4.0",
+				"@types/node": "*",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
-				"@types/tough-cookie": "*",
-				"parse5": "^7.0.0"
+				"jest-regex-util": "30.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/schemas": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
+			"version": "15.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/ci-info": {
@@ -9831,41 +8995,71 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+			"integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@types/node": "*",
-				"jest-util": "30.2.0"
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.4.1",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-util": "30.4.1",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+			"integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-regex-util": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+			"integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -9874,10 +9068,26 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+			"integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.4.1",
+				"ansi-styles": "^5.2.0",
+				"react-is-18": "npm:react-is@^18.3.1",
+				"react-is-19": "npm:react-is@^19.2.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
 		"node_modules/@jest/environment/node_modules/ci-info": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
 			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -9893,6 +9103,7 @@
 			"version": "30.2.0",
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
 			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/types": "30.2.0",
@@ -9907,6 +9118,7 @@
 			"version": "30.2.0",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
 			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/types": "30.2.0",
@@ -9924,6 +9136,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -10329,6 +9542,7 @@
 			"version": "30.2.0",
 			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
 			"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/types": "30.2.0",
@@ -10346,6 +9560,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -10358,6 +9573,7 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
 			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -10373,6 +9589,7 @@
 			"version": "30.2.0",
 			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
 			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
@@ -10393,6 +9610,7 @@
 			"version": "30.2.0",
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
 			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/types": "30.2.0",
@@ -10407,6 +9625,7 @@
 			"version": "30.2.0",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
 			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/types": "30.2.0",
@@ -10424,6 +9643,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -10436,6 +9656,7 @@
 			"version": "30.2.0",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
 			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/schemas": "30.0.5",
@@ -10538,6 +9759,7 @@
 			"version": "30.0.1",
 			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
 			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
@@ -10551,6 +9773,7 @@
 			"version": "30.0.1",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
 			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -10907,6 +10130,7 @@
 			"version": "30.0.5",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
 			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@sinclair/typebox": "^0.34.0"
@@ -11109,6 +10333,7 @@
 			"version": "30.2.0",
 			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
 			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/pattern": "30.0.1",
@@ -13176,12 +12401,12 @@
 			}
 		},
 		"node_modules/@pkgr/core": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-			"integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+			"integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
 			"license": "MIT",
 			"engines": {
-				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+				"node": "^14.18.0 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/pkgr"
@@ -14024,6 +13249,7 @@
 			"version": "13.0.5",
 			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
 			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.1"
@@ -14707,6 +13933,12 @@
 				"@types/estree": "*"
 			}
 		},
+		"node_modules/@types/esrecurse": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -14827,10 +14059,9 @@
 			}
 		},
 		"node_modules/@types/jsdom": {
-			"version": "20.0.1",
-			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
-			"integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
-			"dev": true,
+			"version": "21.1.7",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
@@ -15221,185 +14452,12 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-			"integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/type-utils": "6.21.0",
-				"@typescript-eslint/utils": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
-				"debug": "^4.3.4",
-				"graphemer": "^1.4.0",
-				"ignore": "^5.2.4",
-				"natural-compare": "^1.4.0",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-				"eslint": "^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
-			"license": "MIT",
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"eslint-visitor-keys": "^3.4.1"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
 			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
 			"license": "BSD-2-Clause",
+			"optional": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "6.21.0",
 				"@typescript-eslint/types": "6.21.0",
@@ -15428,6 +14486,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
 			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"@typescript-eslint/types": "6.21.0",
 				"@typescript-eslint/visitor-keys": "6.21.0"
@@ -15445,6 +14504,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
 			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
 			},
@@ -15458,6 +14518,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
 			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
 			"license": "BSD-2-Clause",
+			"optional": true,
 			"dependencies": {
 				"@typescript-eslint/types": "6.21.0",
 				"@typescript-eslint/visitor-keys": "6.21.0",
@@ -15486,6 +14547,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
 			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"@typescript-eslint/types": "6.21.0",
 				"eslint-visitor-keys": "^3.4.1"
@@ -15503,6 +14565,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
 			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"license": "Apache-2.0",
+			"optional": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -15515,6 +14578,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
 			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -15530,11 +14594,46 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
 			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"license": "ISC",
+			"optional": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/project-service": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+			"integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.61.0",
+				"@typescript-eslint/types": "^8.61.0",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/project-service/node_modules/@typescript-eslint/types": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+			"integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
@@ -15554,11 +14653,28 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+			"integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
 		"node_modules/@typescript-eslint/type-utils": {
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
 			"integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"@typescript-eslint/typescript-estree": "6.21.0",
 				"@typescript-eslint/utils": "6.21.0",
@@ -15586,6 +14702,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
 			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"@typescript-eslint/types": "6.21.0",
 				"@typescript-eslint/visitor-keys": "6.21.0"
@@ -15603,6 +14720,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
 			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
 			},
@@ -15616,6 +14734,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
 			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
 			"license": "BSD-2-Clause",
+			"optional": true,
 			"dependencies": {
 				"@typescript-eslint/types": "6.21.0",
 				"@typescript-eslint/visitor-keys": "6.21.0",
@@ -15644,6 +14763,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
 			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
@@ -15669,6 +14789,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
 			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"@typescript-eslint/types": "6.21.0",
 				"eslint-visitor-keys": "^3.4.1"
@@ -15686,6 +14807,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
 			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"license": "Apache-2.0",
+			"optional": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -15698,6 +14820,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
 			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -15713,6 +14836,7 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
 			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"license": "ISC",
+			"optional": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -16342,9 +15466,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.39.0.tgz",
-			"integrity": "sha512-H5rheT+rrXuPb9+ey5LemC8g4i5uGVndpalboEQHaXVpLII9B283+ZmtQZy1We1RdIyVXD6MB2EtSXt8R4oKuw==",
+			"version": "8.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.48.0.tgz",
+			"integrity": "sha512-arwTuIihbSj/F3S89p1DqmfViCSqfbcCoZEeIcx07kyOR+D+7T+ZRLQ1sX62bZ5NkSC/SsdkBp6GkMCfE8NWqQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
@@ -16353,8 +15477,8 @@
 				"@babel/plugin-transform-runtime": "7.25.7",
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
-				"@wordpress/browserslist-config": "^6.39.0",
-				"@wordpress/warning": "^3.39.0",
+				"@wordpress/browserslist-config": "^6.48.0",
+				"@wordpress/warning": "^3.48.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -16845,9 +15969,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.39.0.tgz",
-			"integrity": "sha512-fHVG274KKjgAyF7ruvKe+H2JXKh3T7wh3jMrLYoIUx39Hr/LfjYbnsVqWaUDyRhx4nLnk0XIpBfGc+38TDuROQ==",
+			"version": "6.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.48.0.tgz",
+			"integrity": "sha512-bPcrwFqlG9i4qLrcrYBj8lOYhB547SYelEZ+HCesfrkUHr5YDM2mnUdqKhj0+E6/T/iSBAht9uK4SEqj/hShqA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -17288,9 +16412,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.39.0.tgz",
-			"integrity": "sha512-5NSKdRd2o+qBkcx6SDaHG1Ow/EkT578SgVsRzzz3BwSRSvUee8+oDYq4SmtNIqRr7Fz5AOONL5jaluMPJBwlbQ==",
+			"version": "6.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.48.0.tgz",
+			"integrity": "sha512-MTIVq7ZQvcVdsBEvPocg4+gy3If8hWsZ0FQtvIrfwLvqqyvlRRkL4xjCVB2S+FHv0VdSj2oj3Sdh0ZKIr5MJ4g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"json2php": "^0.0.7"
@@ -17310,12 +16434,12 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.39.0.tgz",
-			"integrity": "sha512-/vTXUsh2MGOuh8nhzgpBKIKsbgdtgjE2hFiCPw8rP4wwEbKUlxhNdtZdqkaumNtZywfHbRUBWO9xTpAVX17XfA==",
+			"version": "4.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.48.0.tgz",
+			"integrity": "sha512-aTa7oww6hvTjfIvxLsxlcwYj7skAGPnr1V2S0iBVQfiIn5wJPiGjM9hz4QEf6kyR44Vh0IYjW9wSxVuDMGZUdw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/hooks": "^4.39.0"
+				"@wordpress/hooks": "^4.48.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -17346,9 +16470,9 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.39.0.tgz",
-			"integrity": "sha512-ok008Rd8URqNQCzx/9bClC+gk7XxVV+xm5rOJjb6A4EHR8tVlynJEcE4gN0C5qCDIeOdPLbGW8ljNm2DxlelwQ==",
+			"version": "1.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.48.0.tgz",
+			"integrity": "sha512-jLzobHMQha8ZUHkRhl4OJVCkk26jTVqbhN5hFpQruVTETMI3Z1PFJZH1DFAumJKKAIociVMVeH2MDD8XVp72ww==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"change-case": "^4.1.2",
@@ -17367,14 +16491,14 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
-			"integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
+			"version": "6.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
+			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.39.0",
+				"@wordpress/escape-html": "^3.46.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -17488,9 +16612,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.39.0.tgz",
-			"integrity": "sha512-YhAmZYQsOnnfafMwInzy/M1AR77O59u4aaIVSqiQjvCLkY+BQABsU6AizDckCg57mF2SoDnARl6xQY/7FCwEmw==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.48.0.tgz",
+			"integrity": "sha512-phw399RofSqTqIM4DikmkDfgJ7exDYgPfDuxjv3D2YnUTTUsR+U9fA+pA+/rNUiZD1YOmVILQmkJt6oLaVM+nQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -17519,9 +16643,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.39.0.tgz",
-			"integrity": "sha512-FTKdGF5jHHmC8GSO6/ATQqh1IFQeDwapRtlp7t4VaTGwZtX+uzawgq/7QDIhFi3cfg9hNsFF0CSFp/Ul3nEeUA==",
+			"version": "4.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.48.0.tgz",
+			"integrity": "sha512-rU1yGEy0Mb+2oRG5QX/bKIIwKQmYAvATfUQeXIF20/mbR0qutYeVTCIvWEyb4pf71tvnQFiN18RWRXWsvKrDbQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -17706,9 +16830,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.39.0.tgz",
-			"integrity": "sha512-/fgtytFExodPPI3596s/zW8vf+7P56Oqw7AK1wQycfP1biemVQcXHYr4GKpHiahZsuHuYKr/FubmN36zs9SW0Q==",
+			"version": "8.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.48.0.tgz",
+			"integrity": "sha512-/Nza1kPO9/Hm27YcrXHfkXC9cO3u60wGJGwjdV3+1rPX5y6QhdbM4LJYPT6jSU3gKguLEPFrqS177nh4PIR2cA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"jest-matcher-utils": "^29.6.2",
@@ -17723,12 +16847,12 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.39.0.tgz",
-			"integrity": "sha512-rFaz2wY88acg6TFiE4/goo0UBiLMgk0u+WaKd/nYO1Nk7sei0qromabEQO2LPJyAs0SZqbz3fFhcibueFMWFwA==",
+			"version": "12.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.48.0.tgz",
+			"integrity": "sha512-LcYj3+0Ov/x6qNO/ZMxG9TEoXqrbKxptCReyP9s4/VXDaj/7G600oiSFA6vHAQjdU2vZuLAVAvOgcJ8jFaDUMA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.39.0",
+				"@wordpress/jest-console": "^8.48.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -17789,9 +16913,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.39.0.tgz",
-			"integrity": "sha512-svfW7oLwTh6sRp42ATnr18H6wo1qibwercDEz2zsFg/LmWQ4h4agBhsiaDFdDFLgs7KbVwvZUzwgMvytBO9yAw==",
+			"version": "5.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.48.0.tgz",
+			"integrity": "sha512-8F4Yxj+5gBd/UqVmBY5x661XgdYOuk0Bski3pg7oGVGLyvqrOL5SwwDECSVT6XzC9Dd4oCl8rgj3qYtM+7dw4g==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -17802,12 +16926,12 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.39.0.tgz",
-			"integrity": "sha512-r1KaBbrQSnMNOiE58gGU66RxoksRxEIo87BSdEy2tOREUz9Eoa4NExzJmnTmuC786CjadlPsn95Q98x9OWDlNQ==",
+			"version": "5.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.48.0.tgz",
+			"integrity": "sha512-oaeUphnegixPrfZCnJgBQCWnKwYaL70ygVDja2Fm9poml2HUr3tiMLb1QBv2pX5tw+RX7BwUVpG0hrMy6lj/9g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^6.15.0",
+				"@wordpress/base-styles": "^9.1.0",
 				"autoprefixer": "^10.4.20",
 				"postcss-import": "^16.1.1"
 			},
@@ -17817,6 +16941,16 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.0.0"
+			}
+		},
+		"node_modules/@wordpress/postcss-plugins-preset/node_modules/@wordpress/base-styles": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/preferences": {
@@ -17961,9 +17095,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.39.0.tgz",
-			"integrity": "sha512-ssMAzKtjPV/T1IEFWNSVeaecKG3mhRHYHPMy2Ajh7V8RpOCyYBOZ48kZGyOwd25uzQX5k634tmfW27qJ/SMVQA==",
+			"version": "1.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.48.0.tgz",
+			"integrity": "sha512-HHOSXLCAlBggfMozwWtX36wgsSt22g2tZwpka47Rjzr3hNY1BZ6SrrFJumiNxooy5PDKbRgcF092PAF82hdJXg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -18015,24 +17149,24 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "31.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.4.0.tgz",
-			"integrity": "sha512-yy69Ef1YvUdBu980WWPgtuRlqCvQVw28BzqWdXcrxVKTBb11H+nX1ovJPLukmPFM6QXc4ku9y89MWAa1ywMA4w==",
+			"version": "32.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-32.4.0.tgz",
+			"integrity": "sha512-/AjavTutF8DQBFzpfrFZrpjo3pwth4onY9OEdJfJ+HuOdlfJ/RDFVlo6eZ/jDsrx41z1H83sXmitV1P0g6ODEg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.39.0",
-				"@wordpress/browserslist-config": "^6.39.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.39.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.39.0",
-				"@wordpress/eslint-plugin": "^24.1.0",
-				"@wordpress/jest-preset-default": "^12.39.0",
-				"@wordpress/npm-package-json-lint-config": "^5.39.0",
-				"@wordpress/postcss-plugins-preset": "^5.39.0",
-				"@wordpress/prettier-config": "^4.39.0",
-				"@wordpress/stylelint-config": "^23.31.0",
+				"@wordpress/babel-preset-default": "^8.48.0",
+				"@wordpress/browserslist-config": "^6.48.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.48.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.48.0",
+				"@wordpress/eslint-plugin": "^25.4.0",
+				"@wordpress/jest-preset-default": "^12.48.0",
+				"@wordpress/npm-package-json-lint-config": "^5.48.0",
+				"@wordpress/postcss-plugins-preset": "^5.48.0",
+				"@wordpress/prettier-config": "^4.48.0",
+				"@wordpress/stylelint-config": "^23.40.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",
@@ -18045,7 +17179,7 @@
 				"cssnano": "^6.0.1",
 				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
-				"eslint": "^8.57.1",
+				"eslint": "^10.0.0",
 				"expect-puppeteer": "^4.4.0",
 				"fast-glob": "^3.2.7",
 				"filenamify": "^4.2.0",
@@ -18088,8 +17222,8 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.57.0",
-				"@wordpress/env": "^10.0.0",
+				"@playwright/test": "^1.58.2",
+				"@wordpress/env": ">=10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			},
@@ -18130,42 +17264,189 @@
 				"url": "https://opencollective.com/babel"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/@types/jsdom": {
-			"version": "21.1.7",
-			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
-			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+		"node_modules/@wordpress/scripts/node_modules/@es-joy/jsdoccomment": {
+			"version": "0.50.2",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
+			"integrity": "sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/node": "*",
-				"@types/tough-cookie": "*",
-				"parse5": "^7.0.0"
+				"@types/estree": "^1.0.6",
+				"@typescript-eslint/types": "^8.11.0",
+				"comment-parser": "1.4.1",
+				"esquery": "^1.6.0",
+				"jsdoc-type-pratt-parser": "~4.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+			"integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/visitor-keys": "8.61.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@typescript-eslint/types": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+			"integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+			"integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.61.0",
+				"@typescript-eslint/tsconfig-utils": "8.61.0",
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/visitor-keys": "8.61.0",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+			"integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@typescript-eslint/utils": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+			"integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.61.0",
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/typescript-estree": "8.61.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+			"integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.61.0",
+				"eslint-visitor-keys": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin": {
-			"version": "24.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-24.1.0.tgz",
-			"integrity": "sha512-pYFV1XA2uWgryzdTB/IPF8vVO5MsduKIKBEpQFzPhvazZH5Gvc7orVpO5ZGIvkxKbFLNGmYdAUy2Cj0ng+tSdQ==",
+			"version": "25.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-25.4.0.tgz",
+			"integrity": "sha512-f0GQ3oi3Awch5vSSxI0cnubEEkn73Z1rzfj8/pnZMNNCdyMjZRJmMZ3O8W/NL+eW6KabqC17Bb1whXVgO5WxtQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/eslint-parser": "7.25.7",
-				"@typescript-eslint/eslint-plugin": "^6.4.1",
-				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.39.0",
-				"@wordpress/prettier-config": "^4.39.0",
-				"@wordpress/theme": "^0.6.0",
+				"@babel/eslint-parser": "^7.28.6",
+				"@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
+				"@eslint/compat": "^2.0.0",
+				"@wordpress/babel-preset-default": "^8.48.0",
+				"@wordpress/prettier-config": "^4.48.0",
+				"@wordpress/theme": "^0.15.0",
 				"cosmiconfig": "^7.0.0",
-				"eslint-config-prettier": "^8.3.0",
+				"eslint-config-prettier": "^10.0.0",
 				"eslint-import-resolver-typescript": "^4.4.4",
-				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^27.4.3",
-				"eslint-plugin-jsdoc": "^46.4.6",
-				"eslint-plugin-jsx-a11y": "^6.5.1",
-				"eslint-plugin-playwright": "^0.15.3",
+				"eslint-plugin-import": "^2.31.0",
+				"eslint-plugin-jest": "^28.0.0",
+				"eslint-plugin-jsdoc": "^50.0.0",
+				"eslint-plugin-jsx-a11y": "^6.10.0",
+				"eslint-plugin-playwright": "^2.1.0",
 				"eslint-plugin-prettier": "^5.0.0",
-				"eslint-plugin-react": "^7.27.0",
-				"eslint-plugin-react-hooks": "^4.3.0",
-				"globals": "^13.12.0",
-				"requireindex": "^1.2.0"
+				"eslint-plugin-react": "^7.37.0",
+				"eslint-plugin-react-hooks": "7.1.1",
+				"globals": "^16.0.0",
+				"requireindex": "^1.2.0",
+				"typescript-eslint": "^8.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -18173,7 +17454,7 @@
 			},
 			"peerDependencies": {
 				"@babel/core": ">=7",
-				"eslint": ">=8",
+				"eslint": "^9.0.0 || ^10.0.0",
 				"prettier": ">=3",
 				"typescript": ">=5"
 			},
@@ -18187,9 +17468,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/@babel/eslint-parser": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.7.tgz",
-			"integrity": "sha512-B+BO9x86VYsQHimucBAL1fxTJKF4wyKY6ZVzee9QgzdZOUfs3BaR6AQrgoGrRI+7IFS1wUz/VyQ+SoBcSpdPbw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
+			"integrity": "sha512-zxt+UJTOMKvUt3yOg+D58MLuz334pHp93qifMFcjIIO+9hN6t+ufw2gi7vDPMpxvfnHRR+3VVXvIjineCcgyXw==",
 			"license": "MIT",
 			"dependencies": {
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -18204,23 +17485,10 @@
 				"eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-config-prettier": {
-			"version": "8.10.2",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
-			"integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
-			"license": "MIT",
-			"peer": true,
-			"bin": {
-				"eslint-config-prettier": "bin/cli.js"
-			},
-			"peerDependencies": {
-				"eslint": ">=7.0.0"
-			}
-		},
 		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-import-resolver-typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
-			"integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
+			"integrity": "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw==",
 			"license": "ISC",
 			"dependencies": {
 				"debug": "^4.4.1",
@@ -18251,14 +17519,273 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-prettier": {
-			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jest": {
+			"version": "28.14.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.14.0.tgz",
+			"integrity": "sha512-P9s/qXSMTpRTerE2FQ0qJet2gKbcGyFTPAJipoKxmWqR6uuFqIqk8FuEfg5yBieOezVrEfAMZrEwJ6yEp+1MFQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"engines": {
+				"node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
+				"jest": "*"
+			},
+			"peerDependenciesMeta": {
+				"@typescript-eslint/eslint-plugin": {
+					"optional": true
+				},
+				"jest": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jsdoc": {
+			"version": "50.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
+			"integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@es-joy/jsdoccomment": "~0.50.2",
+				"are-docs-informative": "^0.0.2",
+				"comment-parser": "1.4.1",
+				"debug": "^4.4.1",
+				"escape-string-regexp": "^4.0.0",
+				"espree": "^10.3.0",
+				"esquery": "^1.6.0",
+				"parse-imports-exports": "^0.2.4",
+				"semver": "^7.7.2",
+				"spdx-expression-parse": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+			"integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/espree": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/espree/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@wordpress/prettier-config": {
+			"version": "4.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.48.0.tgz",
+			"integrity": "sha512-TOxw/8xfJaUU4sKUQxZIoZOe43pU5J1bneAMDHcK8Qqr0vzAXyhVB6AZG1eRBofRa8DUFI7ipIIDWZWxWYypQg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"prettier": ">=3"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@wordpress/theme": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.15.0.tgz",
+			"integrity": "sha512-qoozJ4YEPb0LvTBnTMj8a7kPlQtT2LeGL7b/vKJkvnB9dIEUOED5c0rpeRZJoK9b77fpUH5GwYzPE3IWiQ6l2w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/style-runtime": "^0.4.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/comment-parser": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+			"integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/cosmiconfig": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/eslint": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
+			"integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@eslint/config-array": "^0.23.5",
+				"@eslint/config-helpers": "^0.6.0",
+				"@eslint/core": "^1.2.1",
+				"@eslint/plugin-kit": "^0.7.2",
+				"@humanfs/node": "^0.16.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@humanwhocodes/retry": "^0.4.2",
+				"@types/estree": "^1.0.6",
+				"ajv": "^6.14.0",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.2",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"espree": "^11.2.0",
+				"esquery": "^1.7.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^8.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"minimatch": "^10.2.4",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/eslint-plugin-playwright": {
+			"version": "2.10.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.4.tgz",
+			"integrity": "sha512-l0V/VxyqfFbtqCTxj5AdRn3Q6S/hIW4nKBnKZVleVbZ24N2My6Usj//ytX3dKKqAoSbvKck9YtSytfdZ5qjLuA==",
+			"license": "MIT",
+			"dependencies": {
+				"globals": "^17.3.0"
+			},
+			"engines": {
+				"node": ">=16.9.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/eslint-plugin-playwright/node_modules/globals": {
+			"version": "17.6.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+			"integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/eslint-plugin-prettier": {
+			"version": "5.5.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+			"integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
 			"license": "MIT",
 			"dependencies": {
 				"prettier-linter-helpers": "^1.0.1",
-				"synckit": "^0.11.12"
+				"synckit": "^0.11.13"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -18281,169 +17808,189 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/@wordpress/prettier-config": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.39.0.tgz",
-			"integrity": "sha512-w9NPuyKZ8y7xLNRaXOK6TLw0HdcA9vQBmK65cd16w4WxyPwXwFVGBdwoi2og/RN3UBQLYci25zGp7GtiiVhG+Q==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"prettier": ">=3"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+		"node_modules/@wordpress/scripts/node_modules/eslint-plugin-react-hooks": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+			"integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
+				"@babel/core": "^7.24.4",
+				"@babel/parser": "^7.24.4",
+				"hermes-parser": "^0.25.1",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-validation-error": "^3.5.0 || ^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/eslint-scope": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/eslint/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/espree": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.16.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^5.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/espree/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/file-entry-cache": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+			"license": "MIT",
+			"dependencies": {
+				"flat-cache": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/cssstyle": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+		"node_modules/@wordpress/scripts/node_modules/flat-cache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/css-color": "^3.2.0",
-				"rrweb-cssom": "^0.8.0"
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.4"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=16"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/data-urls": {
+		"node_modules/@wordpress/scripts/node_modules/globals": {
+			"version": "16.5.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/jsdoc-type-pratt-parser": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+			"integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/p-locate": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"license": "MIT",
 			"dependencies": {
-				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^14.0.0"
+				"p-limit": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/html-encoding-sniffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-encoding": "^3.1.1"
+				"node": ">=10"
 			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/jest-environment-jsdom": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.2.0.tgz",
-			"integrity": "sha512-zbBTiqr2Vl78pKp/laGBREYzbZx9ZtqPjOK4++lL4BNDhxRnahg51HtoDrk9/VjIy9IthNEWdKVd7H5bqBhiWQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/environment-jsdom-abstract": "30.2.0",
-				"@types/jsdom": "^21.1.7",
-				"@types/node": "*",
-				"jsdom": "^26.1.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"canvas": "^3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"canvas": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/jsdom": {
-			"version": "26.1.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-			"license": "MIT",
-			"dependencies": {
-				"cssstyle": "^4.2.1",
-				"data-urls": "^5.0.0",
-				"decimal.js": "^10.5.0",
-				"html-encoding-sniffer": "^4.0.0",
-				"http-proxy-agent": "^7.0.2",
-				"https-proxy-agent": "^7.0.6",
-				"is-potential-custom-element-name": "^1.0.1",
-				"nwsapi": "^2.2.16",
-				"parse5": "^7.2.1",
-				"rrweb-cssom": "^0.8.0",
-				"saxes": "^6.0.0",
-				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^5.1.1",
-				"w3c-xmlserializer": "^5.0.0",
-				"webidl-conversions": "^7.0.0",
-				"whatwg-encoding": "^3.1.1",
-				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^14.1.1",
-				"ws": "^8.18.0",
-				"xml-name-validator": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"canvas": "^3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"canvas": {
-					"optional": true
-				}
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/prettier": {
@@ -18463,84 +18010,16 @@
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/tough-cookie": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"tldts": "^6.1.32"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/tr46": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-			"license": "MIT",
-			"dependencies": {
-				"punycode": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/w3c-xmlserializer": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-			"license": "MIT",
-			"dependencies": {
-				"xml-name-validator": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/whatwg-encoding": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-			"license": "MIT",
-			"dependencies": {
-				"iconv-lite": "0.6.3"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/whatwg-mimetype": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+		"node_modules/@wordpress/scripts/node_modules/ts-api-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/whatwg-url": {
-			"version": "14.2.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-			"license": "MIT",
-			"dependencies": {
-				"tr46": "^5.1.0",
-				"webidl-conversions": "^7.0.0"
+				"node": ">=18.12"
 			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/xml-name-validator": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=18"
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
 			}
 		},
 		"node_modules/@wordpress/shortcode": {
@@ -18569,14 +18048,24 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/style-runtime": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.4.0.tgz",
+			"integrity": "sha512-frzAg1rsn8X0KNgrxxLxszLvWCKY0Nk2e8j8Mjm2pI2URmS8Et7NefuXP3JnHBD4U1L1Ug9yKO/FA65ojQ7CEA==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.31.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.31.0.tgz",
-			"integrity": "sha512-+Vy769qVrjnSqCZCMolh5dHu1np+iZKkICQoccgF/VXXjp+dYLJaDzXqbKqtGU87oirUT7Q1tqWNovbuaBowIA==",
+			"version": "23.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.40.0.tgz",
+			"integrity": "sha512-VzEqHdZauroVzHUvgec8ucGodi0mAgN6eA7qdRUrpfjHCM6caXSarU/Q7PEps4QuooxHCj/4cAx8rtncqvnSwQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/stylelint-plugin": "^3.0.1",
-				"@wordpress/theme": "^0.6.0",
+				"@wordpress/theme": "^0.15.0",
 				"stylelint-config-recommended": "^14.0.1",
 				"stylelint-config-recommended-scss": "^14.1.0"
 			},
@@ -18587,6 +18076,53 @@
 			"peerDependencies": {
 				"stylelint": "^16.8.2",
 				"stylelint-scss": "^6.4.0"
+			}
+		},
+		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/theme": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.15.0.tgz",
+			"integrity": "sha512-qoozJ4YEPb0LvTBnTMj8a7kPlQtT2LeGL7b/vKJkvnB9dIEUOED5c0rpeRZJoK9b77fpUH5GwYzPE3IWiQ6l2w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/style-runtime": "^0.4.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/theme": {
@@ -18716,9 +18252,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.39.0.tgz",
-			"integrity": "sha512-NV2WoU4XxTqZU/3k2D5m5cHIw/uM2dlDgW5u1U5fmFIYLGg43WWMlSHQEu6F4tm7fqFt7k4qwT/FymucqHYp7Q==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.48.0.tgz",
+			"integrity": "sha512-En+A99j8aySNzUH0iXok0H2Xi+Uw2useKqYsvPm33VEMa0a0XIwa2I9srK5STp8RydCm1dK+/41K9e5xeFu23Q==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -19055,9 +18591,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"license": "MIT",
 			"peer": true,
 			"bin": {
@@ -19164,9 +18700,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -23204,6 +22740,22 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint-config-prettier": {
+			"version": "10.1.8",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"eslint-config-prettier": "bin/cli.js"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-config-prettier"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.0.0"
+			}
+		},
 		"node_modules/eslint-import-context": {
 			"version": "0.1.9",
 			"resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
@@ -23356,6 +22908,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
 			"integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/utils": "^5.10.0"
 			},
@@ -24910,9 +24463,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.13.1",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.1.tgz",
-			"integrity": "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==",
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
 			"license": "MIT",
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -25307,6 +24860,21 @@
 			"dependencies": {
 				"capital-case": "^1.0.4",
 				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/hermes-estree": {
+			"version": "0.25.1",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+			"integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+			"license": "MIT"
+		},
+		"node_modules/hermes-parser": {
+			"version": "0.25.1",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+			"integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+			"license": "MIT",
+			"dependencies": {
+				"hermes-estree": "0.25.1"
 			}
 		},
 		"node_modules/highlight-words-core": {
@@ -26088,9 +25656,9 @@
 			}
 		},
 		"node_modules/is-bun-module/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+			"integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -27258,26 +26826,20 @@
 			"license": "MIT"
 		},
 		"node_modules/jest-environment-jsdom": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
-			"integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
-			"dev": true,
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.4.1.tgz",
+			"integrity": "sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==",
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/jsdom": "^20.0.0",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jsdom": "^20.0.0"
+				"@jest/environment": "30.4.1",
+				"@jest/environment-jsdom-abstract": "30.4.1",
+				"jsdom": "^26.1.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"canvas": "^2.5.0"
+				"canvas": "^3.0.0"
 			},
 			"peerDependenciesMeta": {
 				"canvas": {
@@ -27286,85 +26848,202 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-			"dev": true,
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+			"integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
 			"license": "MIT",
 			"dependencies": {
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"jest-mock": "^29.7.0"
+				"jest-mock": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-			"dev": true,
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+			"integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@sinonjs/fake-timers": "^10.0.2",
+				"@jest/types": "30.4.1",
+				"@sinonjs/fake-timers": "^15.4.0",
 				"@types/node": "*",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/@jest/schemas": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-			"dev": true,
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@sinclair/typebox": "^0.27.8"
+				"@sinclair/typebox": "^0.34.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-			"dev": true,
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
 				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-			"dev": true,
+			"version": "15.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@sinonjs/commons": "^3.0.0"
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+			"integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.4.1",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-util": "30.4.1",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/jest-mock": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+			"integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/jest-regex-util": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/jest-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+			"integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/pretty-format": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+			"integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.4.1",
+				"ansi-styles": "^5.2.0",
+				"react-is-18": "npm:react-is@^18.3.1",
+				"react-is-19": "npm:react-is@^19.2.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-node": {
@@ -28470,49 +28149,196 @@
 			}
 		},
 		"node_modules/jsdom": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
-			"integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"abab": "^2.0.6",
-				"acorn": "^8.8.1",
-				"acorn-globals": "^7.0.0",
-				"cssom": "^0.5.0",
-				"cssstyle": "^2.3.0",
-				"data-urls": "^3.0.2",
-				"decimal.js": "^10.4.2",
-				"domexception": "^4.0.0",
-				"escodegen": "^2.0.0",
-				"form-data": "^4.0.0",
-				"html-encoding-sniffer": "^3.0.0",
-				"http-proxy-agent": "^5.0.0",
-				"https-proxy-agent": "^5.0.1",
+				"cssstyle": "^4.2.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
 				"is-potential-custom-element-name": "^1.0.1",
-				"nwsapi": "^2.2.2",
-				"parse5": "^7.1.1",
+				"nwsapi": "^2.2.16",
+				"parse5": "^7.2.1",
+				"rrweb-cssom": "^0.8.0",
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^4.1.2",
-				"w3c-xmlserializer": "^4.0.0",
+				"tough-cookie": "^5.1.1",
+				"w3c-xmlserializer": "^5.0.0",
 				"webidl-conversions": "^7.0.0",
-				"whatwg-encoding": "^2.0.0",
-				"whatwg-mimetype": "^3.0.0",
-				"whatwg-url": "^11.0.0",
-				"ws": "^8.11.0",
-				"xml-name-validator": "^4.0.0"
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.1.1",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"canvas": "^2.5.0"
+				"canvas": "^3.0.0"
 			},
 			"peerDependenciesMeta": {
 				"canvas": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/jsdom/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/jsdom/node_modules/cssstyle": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jsdom/node_modules/data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jsdom/node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jsdom/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/jsdom/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/jsdom/node_modules/tough-cookie": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^6.1.32"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/jsdom/node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jsdom/node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jsdom/node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jsdom/node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jsdom/node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jsdom/node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/jsesc": {
@@ -31332,6 +31158,15 @@
 			"resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
 			"integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
 		},
+		"node_modules/parse-imports-exports": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+			"integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+			"license": "MIT",
+			"dependencies": {
+				"parse-statements": "1.0.11"
+			}
+		},
 		"node_modules/parse-json": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -31358,6 +31193,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/parse-statements": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+			"integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+			"license": "MIT"
 		},
 		"node_modules/parse5": {
 			"version": "7.3.0",
@@ -33114,7 +32955,6 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/react-is-19": {
@@ -33122,7 +32962,6 @@
 			"version": "19.2.6",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
 			"integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/react-refresh": {
@@ -36124,12 +35963,12 @@
 			"license": "MIT"
 		},
 		"node_modules/synckit": {
-			"version": "0.11.12",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+			"version": "0.11.13",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+			"integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
 			"license": "MIT",
 			"dependencies": {
-				"@pkgr/core": "^0.2.9"
+				"@pkgr/core": "^0.3.6"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -36452,13 +36291,13 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.15",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -36485,9 +36324,9 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -36879,6 +36718,284 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/typescript-eslint": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
+			"integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/eslint-plugin": "8.61.0",
+				"@typescript-eslint/parser": "8.61.0",
+				"@typescript-eslint/typescript-estree": "8.61.0",
+				"@typescript-eslint/utils": "8.61.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
+			"integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.12.2",
+				"@typescript-eslint/scope-manager": "8.61.0",
+				"@typescript-eslint/type-utils": "8.61.0",
+				"@typescript-eslint/utils": "8.61.0",
+				"@typescript-eslint/visitor-keys": "8.61.0",
+				"ignore": "^7.0.5",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^8.61.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+			"integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.61.0",
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/typescript-estree": "8.61.0",
+				"@typescript-eslint/visitor-keys": "8.61.0",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+			"integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/visitor-keys": "8.61.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
+			"integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/typescript-estree": "8.61.0",
+				"@typescript-eslint/utils": "8.61.0",
+				"debug": "^4.4.3",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+			"integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+			"integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.61.0",
+				"@typescript-eslint/tsconfig-utils": "8.61.0",
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/visitor-keys": "8.61.0",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+			"integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.61.0",
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/typescript-estree": "8.61.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+			"integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.61.0",
+				"eslint-visitor-keys": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/semver": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+			"integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/ts-api-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
 			}
 		},
 		"node_modules/uc.micro": {
@@ -37662,6 +37779,7 @@
 			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
 			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/bonjour": "^3.5.9",
 				"@types/connect-history-api-fallback": "^1.3.5",
@@ -38323,8 +38441,21 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-validation-error": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+			"integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"translation:ai": "node scripts/translation/ai-translate.js"
 	},
 	"dependencies": {
-		"@wordpress/scripts": "^31.4.0",
+		"@wordpress/scripts": "^32.4.0",
 		"abab": "^2.0.6",
 		"accepts": "^1.3.8",
 		"acorn": "^8.15.0",


### PR DESCRIPTION
## Summary

- Upgrades `@wordpress/scripts` to `^32.4.0` in all 7 `package.json` files (root, `fair-events`, `fair-events-shared`, `fair-payments-connector`, `fair-audience`, `fair-platform`, `fair-timetable`)
- `fair-audience` was furthest behind (30.x); all others were on 31.x
- `package-lock.json` regenerated — all packages now resolve to `32.4.0`

## Test plan

- [ ] `npm run build` passes in each plugin
- [ ] `npm test` passes across the monorepo
- [ ] CI checks pass