### PR TITLE
refactor: use per-plugin scoped tags instead of shared bare semver

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -200,7 +200,7 @@ jobs:
 
             - name: Create GitHub release
               run: |
-                  BUILD_ID="$(git -C repo describe --tags --match='[0-9]*')"
+                  BUILD_ID="$(git -C repo describe --tags --match='fair-events@*' | sed 's/^fair-events@//')"
                   if gh release view "build-${BUILD_ID}" --repo "$GITHUB_REPOSITORY" &>/dev/null; then
                     echo "Release build-${BUILD_ID} already exists, skipping."
                   else

--- a/scripts/stamp-build-version.js
+++ b/scripts/stamp-build-version.js
@@ -3,8 +3,8 @@
 /**
  * Stamp Build Version
  *
- * Replaces the Version: header in WordPress plugin PHP files
- * with the output of `git describe --tags` (e.g., "1.0.0-2-g8f0bec2").
+ * Replaces the Version: header in WordPress plugin PHP files with the output
+ * of `git describe --tags --match="<plugin-name>@*"` (prefix stripped), e.g. "1.0.0-2-g8f0bec2".
  * Run during CI build, after `npm run build`.
  */
 
@@ -16,63 +16,67 @@ import { execSync } from 'child_process';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
 
-const buildVersion = execSync('git describe --tags --match="[0-9]*"', {
-	encoding: 'utf8',
-}).trim();
-
-const pluginFiles = [
-	'fair-events/fair-events.php',
-	'fair-payments-connector/fair-payments-connector.php',
-	'fair-platform/fair-platform.php',
-	'fair-audience/fair-audience.php',
-	'fair-timetable/fair-timetable.php',
-];
-
-const readmeFiles = [
-	'fair-events/readme.txt',
-	'fair-payments-connector/readme.txt',
-	'fair-platform/readme.txt',
-	'fair-audience/readme.txt',
-	'fair-timetable/readme.txt',
-];
-
 const versionRegex = /(\*?\s*Version:\s*)([0-9]+\.[0-9]+\.[0-9]+[^\s*]*)/gi;
 const stableTagRegex = /(Stable tag:\s*)([0-9]+\.[0-9]+\.[0-9]+[^\s]*)/gi;
 
-console.log(`🏷️  Stamping build version: ${buildVersion}\n`);
+const plugins = [
+	{
+		name: 'fair-events',
+		phpFile: 'fair-events/fair-events.php',
+		readmeFile: 'fair-events/readme.txt',
+	},
+	{
+		name: 'fair-payments-connector',
+		phpFile: 'fair-payments-connector/fair-payments-connector.php',
+		readmeFile: 'fair-payments-connector/readme.txt',
+	},
+	{
+		name: 'fair-platform',
+		phpFile: 'fair-platform/fair-platform.php',
+		readmeFile: 'fair-platform/readme.txt',
+	},
+	{
+		name: 'fair-audience',
+		phpFile: 'fair-audience/fair-audience.php',
+		readmeFile: 'fair-audience/readme.txt',
+	},
+	{
+		name: 'fair-timetable',
+		phpFile: 'fair-timetable/fair-timetable.php',
+		readmeFile: 'fair-timetable/readme.txt',
+	},
+];
 
-for (const file of pluginFiles) {
-	const filePath = join(rootDir, file);
+function getBuildVersion(pluginName) {
+	const raw = execSync(`git describe --tags --match="${pluginName}@*"`, {
+		encoding: 'utf8',
+	}).trim();
+	return raw.replace(`${pluginName}@`, '');
+}
+
+function stampFile(filePath, regex, buildVersion) {
 	try {
 		const original = readFileSync(filePath, 'utf8');
-		const updated = original.replace(versionRegex, `$1${buildVersion}`);
-
+		const updated = original.replace(regex, `$1${buildVersion}`);
 		if (original !== updated) {
 			writeFileSync(filePath, updated, 'utf8');
-			console.log(`  ✅ ${file}`);
+			console.log(`  ✅ ${filePath}`);
 		} else {
-			console.log(`  ⏭️  ${file} (no Version header found)`);
+			console.log(`  ⏭️  ${filePath} (no header found)`);
 		}
 	} catch (error) {
-		console.error(`  ❌ ${file}: ${error.message}`);
+		console.error(`  ❌ ${filePath}: ${error.message}`);
 	}
 }
 
-for (const file of readmeFiles) {
-	const filePath = join(rootDir, file);
-	try {
-		const original = readFileSync(filePath, 'utf8');
-		const updated = original.replace(stableTagRegex, `$1${buildVersion}`);
+console.log('🏷️  Stamping build versions...\n');
 
-		if (original !== updated) {
-			writeFileSync(filePath, updated, 'utf8');
-			console.log(`  ✅ ${file}`);
-		} else {
-			console.log(`  ⏭️  ${file} (no Stable tag found)`);
-		}
-	} catch (error) {
-		console.error(`  ❌ ${file}: ${error.message}`);
-	}
+for (const plugin of plugins) {
+	const buildVersion = getBuildVersion(plugin.name);
+	console.log(`📦 ${plugin.name}: ${buildVersion}`);
+	stampFile(join(rootDir, plugin.phpFile), versionRegex, buildVersion);
+	stampFile(join(rootDir, plugin.readmeFile), stableTagRegex, buildVersion);
+	console.log('');
 }
 
-console.log('\n🎉 Stamp complete!');
+console.log('🎉 Stamp complete!');

--- a/scripts/tag-release.js
+++ b/scripts/tag-release.js
@@ -3,9 +3,8 @@
 /**
  * Custom Tag Release Script
  *
- * Creates git tags after changesets version bump:
- * - Single shared tag (e.g., "1.0.0") for the fixed group: fair-events, fair-payments-connector, fair-audience
- * - Individual tag (e.g., "fair-platform@1.1.0") for fair-platform
+ * Creates per-plugin git tags after changesets version bump:
+ * e.g., "fair-events@1.3.4", "fair-audience@1.3.4", "fair-platform@1.1.0"
  */
 
 import { readFileSync } from 'fs';
@@ -18,8 +17,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, '..');
 
-const FIXED_GROUP_PLUGIN = 'fair-events';
-const INDEPENDENT_PLUGINS = ['fair-platform'];
+const ALL_PLUGINS = [
+	'fair-events',
+	'fair-audience',
+	'fair-payments-connector',
+	'fair-platform',
+	'fair-timetable',
+];
 
 function getVersion(pluginName) {
 	const packagePath = join(rootDir, pluginName, 'package.json');
@@ -36,28 +40,18 @@ function tagExists(tag) {
 	}
 }
 
-function createTag(tag, message) {
+function createTag(tag) {
 	if (tagExists(tag)) {
 		console.log(`  ⏭️  Tag ${tag} already exists, skipping`);
 		return;
 	}
-	if (message) {
-		execSync(`git tag -a "${tag}" -m "${message}"`, { stdio: 'inherit' });
-	} else {
-		execSync(`git tag "${tag}"`, { stdio: 'inherit' });
-	}
+	execSync(`git tag "${tag}"`, { stdio: 'inherit' });
 	console.log(`  ✅ Created tag: ${tag}`);
 }
 
 console.log('🏷️  Creating release tags...\n');
 
-const sharedVersion = getVersion(FIXED_GROUP_PLUGIN);
-console.log(
-	`📦 Fixed group (fair-events, fair-payments-connector, fair-audience): ${sharedVersion}`
-);
-createTag(sharedVersion, `Release ${sharedVersion}`);
-
-for (const plugin of INDEPENDENT_PLUGINS) {
+for (const plugin of ALL_PLUGINS) {
 	const version = getVersion(plugin);
 	const tag = `${plugin}@${version}`;
 	console.log(`📦 ${plugin}: ${version}`);


### PR DESCRIPTION
## Summary

Switch release tagging from a single shared bare semver tag (e.g. `1.0.0`) to per-plugin scoped tags (e.g. `fair-events@1.3.4`, `fair-audience@1.3.4`). All five plugins now get their own tag on each release.

- `scripts/tag-release.js` — replaces the fixed-group + independent-plugins split with a single `ALL_PLUGINS` list; all plugins tagged as `<name>@<version>`
- `scripts/stamp-build-version.js` — each plugin resolves its own version via `git describe --tags --match="<plugin>@*"` and strips the prefix before stamping
- `.github/workflows/continuous-integration.yml` — CI uses `fair-events@*` match pattern and strips the prefix for the build ID

This is prerequisite infrastructure for adding `fair-finance` and any future plugin without touching the shared tag logic.

Refs #777

## Test plan

- [ ] `node scripts/tag-release.js` (dry-run against a version bump branch) emits one tag per plugin
- [ ] `node scripts/stamp-build-version.js` stamps the correct per-plugin version into each `.php` and `readme.txt`
- [ ] CI workflow build step produces the same `build-<semver>` release name as before