### PR TITLE
feat: move Budget and FinancialEntry models to fair-finance

### DIFF
--- a/fair-finance/src/Core/Plugin.php
+++ b/fair-finance/src/Core/Plugin.php
@@ -7,6 +7,8 @@
 
 namespace FairFinance\Core;
 
+use FairFinance\Database\Schema;
+
 defined( 'ABSPATH' ) || die;
 
 /**
@@ -53,6 +55,7 @@ class Plugin {
 	 * @return void
 	 */
 	public static function activate() {
+		Schema::create_tables();
 	}
 
 	/**

--- a/fair-finance/src/Database/Schema.php
+++ b/fair-finance/src/Database/Schema.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Database schema for Fair Finance
+ *
+ * @package FairFinance
+ *
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery -- schema creation legitimately uses dbDelta directly.
+ */
+
+namespace FairFinance\Database;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Schema class for managing database tables
+ */
+class Schema {
+	/**
+	 * Get the table name for budgets
+	 *
+	 * @return string Full table name with prefix.
+	 */
+	public static function get_budgets_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . 'fair_payment_budgets';
+	}
+
+	/**
+	 * Get the table name for financial entries
+	 *
+	 * @return string Full table name with prefix.
+	 */
+	public static function get_financial_entries_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . 'fair_payment_financial_entries';
+	}
+
+	/**
+	 * Create database tables
+	 *
+	 * @return void
+	 */
+	public static function create_tables() {
+		self::create_budgets_table();
+		self::create_financial_entries_table();
+	}
+
+	/**
+	 * Create budgets table
+	 *
+	 * @return void
+	 */
+	public static function create_budgets_table() {
+		global $wpdb;
+
+		$table_name      = self::get_budgets_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE $table_name (
+			id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+			name varchar(255) NOT NULL,
+			description text DEFAULT NULL,
+			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY  (id)
+		) $charset_collate;";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Create financial entries table
+	 *
+	 * @return void
+	 */
+	public static function create_financial_entries_table() {
+		global $wpdb;
+
+		$table_name      = self::get_financial_entries_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE $table_name (
+			id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+			amount decimal(10,2) NOT NULL,
+			entry_type varchar(20) NOT NULL,
+			entry_date date NOT NULL,
+			description text DEFAULT NULL,
+			budget_id bigint(20) UNSIGNED DEFAULT NULL,
+			transaction_id bigint(20) UNSIGNED DEFAULT NULL,
+			external_reference varchar(255) DEFAULT NULL,
+			import_source varchar(255) DEFAULT NULL,
+			parent_entry_id bigint(20) UNSIGNED DEFAULT NULL,
+			event_url varchar(500) DEFAULT NULL,
+			event_date_id bigint(20) UNSIGNED DEFAULT NULL,
+			participant_id bigint(20) UNSIGNED DEFAULT NULL,
+			imported_at datetime DEFAULT NULL,
+			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY  (id),
+			UNIQUE KEY external_reference (external_reference),
+			KEY entry_type (entry_type),
+			KEY entry_date (entry_date),
+			KEY budget_id (budget_id),
+			KEY transaction_id (transaction_id),
+			KEY parent_entry_id (parent_entry_id),
+			KEY event_date_id (event_date_id),
+			KEY participant_id (participant_id)
+		) $charset_collate;";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+}

--- a/fair-finance/src/Models/Budget.php
+++ b/fair-finance/src/Models/Budget.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Budget model for Fair Payments Connector
+ * Budget model for Fair Finance
  *
- * @package FairPaymentsConnector
+ * @package FairFinance
  */
 
-namespace FairPaymentsConnector\Models;
+namespace FairFinance\Models;
 
-use FairPaymentsConnector\Database\Schema;
+use FairFinance\Database\Schema;
 
 defined( 'WPINC' ) || die;
 

--- a/fair-finance/src/Models/FinancialEntry.php
+++ b/fair-finance/src/Models/FinancialEntry.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Financial Entry model for Fair Payments Connector
+ * Financial Entry model for Fair Finance
  *
- * @package FairPaymentsConnector
+ * @package FairFinance
  *
  * phpcs:disable WordPress.DB.DirectDatabaseQuery -- model layer reads/writes a custom table directly; caching is left to callers.
  */
 
-namespace FairPaymentsConnector\Models;
+namespace FairFinance\Models;
 
-use FairPaymentsConnector\Database\Schema;
+use FairFinance\Database\Schema;
 
 defined( 'WPINC' ) || die;
 
@@ -301,8 +301,8 @@ class FinancialEntry {
 			$where_values[]  = $filters['entry_type'];
 		}
 
-		if ( ! empty( $filters['unmatched'] ) ) {
-			$junction_table  = Schema::get_entry_transactions_table_name();
+		if ( ! empty( $filters['unmatched'] ) && class_exists( '\\FairPaymentsConnector\\Database\\Schema' ) ) {
+			$junction_table  = \FairPaymentsConnector\Database\Schema::get_entry_transactions_table_name();
 			$where_clauses[] = $wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- $table_name comes from Schema::get_*_table_name() and is not user input.
 				'NOT EXISTS (SELECT 1 FROM %i WHERE entry_id = ' . $table_name . '.id)',
@@ -419,8 +419,8 @@ class FinancialEntry {
 			$where_values[]  = (int) $filters['event_date_id'];
 		}
 
-		if ( ! empty( $filters['unmatched'] ) ) {
-			$junction_table  = Schema::get_entry_transactions_table_name();
+		if ( ! empty( $filters['unmatched'] ) && class_exists( '\\FairPaymentsConnector\\Database\\Schema' ) ) {
+			$junction_table  = \FairPaymentsConnector\Database\Schema::get_entry_transactions_table_name();
 			$where_clauses[] = $wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- $table_name comes from Schema::get_*_table_name() and is not user input.
 				'NOT EXISTS (SELECT 1 FROM %i WHERE entry_id = ' . $table_name . '.id)',
@@ -653,8 +653,10 @@ class FinancialEntry {
 
 		$table_name = self::get_table_name();
 
-		// Write to junction table (source of truth).
-		EntryTransaction::link( $id, $transaction_id );
+		// Write to junction table (source of truth) when connector is active.
+		if ( class_exists( '\\FairPaymentsConnector\\Models\\EntryTransaction' ) ) {
+			\FairPaymentsConnector\Models\EntryTransaction::link( $id, $transaction_id );
+		}
 
 		// Also update legacy column for backward compatibility.
 		$result = $wpdb->update(
@@ -676,8 +678,10 @@ class FinancialEntry {
 	 * @return bool True on success, false on failure.
 	 */
 	public static function match_transactions( $id, $transaction_ids ) {
-		foreach ( $transaction_ids as $transaction_id ) {
-			EntryTransaction::link( $id, (int) $transaction_id );
+		if ( class_exists( '\\FairPaymentsConnector\\Models\\EntryTransaction' ) ) {
+			foreach ( $transaction_ids as $transaction_id ) {
+				\FairPaymentsConnector\Models\EntryTransaction::link( $id, (int) $transaction_id );
+			}
 		}
 
 		// Update legacy column with the first transaction ID.
@@ -708,8 +712,10 @@ class FinancialEntry {
 
 		$table_name = self::get_table_name();
 
-		// Clear junction table.
-		EntryTransaction::unlink_all_for_entry( $id );
+		// Clear junction table when connector is active.
+		if ( class_exists( '\\FairPaymentsConnector\\Models\\EntryTransaction' ) ) {
+			\FairPaymentsConnector\Models\EntryTransaction::unlink_all_for_entry( $id );
+		}
 
 		// Clear legacy column.
 		$result = $wpdb->update(
@@ -731,14 +737,18 @@ class FinancialEntry {
 	 * @return bool True on success, false on failure.
 	 */
 	public static function unmatch_single_transaction( $id, $transaction_id ) {
-		EntryTransaction::unlink( $id, $transaction_id );
-
-		// Update legacy column: set to first remaining linked transaction or null.
-		$remaining = EntryTransaction::get_transaction_ids_for_entry( $id );
-
 		global $wpdb;
+
 		$table_name = self::get_table_name();
 
+		$remaining = array();
+
+		if ( class_exists( '\\FairPaymentsConnector\\Models\\EntryTransaction' ) ) {
+			\FairPaymentsConnector\Models\EntryTransaction::unlink( $id, $transaction_id );
+			$remaining = \FairPaymentsConnector\Models\EntryTransaction::get_transaction_ids_for_entry( $id );
+		}
+
+		// Update legacy column: set to first remaining linked transaction or null.
 		$wpdb->update(
 			$table_name,
 			array( 'transaction_id' => ! empty( $remaining ) ? $remaining[0] : null ),
@@ -1342,9 +1352,9 @@ class FinancialEntry {
 		$entry->created_at         = $row->created_at;
 		$entry->updated_at         = $row->updated_at;
 
-		// Load transaction IDs from junction table.
-		if ( $entry->id ) {
-			$entry->transaction_ids = EntryTransaction::get_transaction_ids_for_entry( $entry->id );
+		// Load transaction IDs from junction table when connector is active.
+		if ( $entry->id && class_exists( '\\FairPaymentsConnector\\Models\\EntryTransaction' ) ) {
+			$entry->transaction_ids = \FairPaymentsConnector\Models\EntryTransaction::get_transaction_ids_for_entry( $entry->id );
 		}
 
 		return $entry;

--- a/fair-payments-connector/src/Database/Schema.php
+++ b/fair-payments-connector/src/Database/Schema.php
@@ -36,26 +36,6 @@ class Schema {
 	}
 
 	/**
-	 * Get the table name for budgets
-	 *
-	 * @return string Full table name with prefix.
-	 */
-	public static function get_budgets_table_name() {
-		global $wpdb;
-		return $wpdb->prefix . 'fair_payment_budgets';
-	}
-
-	/**
-	 * Get the table name for financial entries
-	 *
-	 * @return string Full table name with prefix.
-	 */
-	public static function get_financial_entries_table_name() {
-		global $wpdb;
-		return $wpdb->prefix . 'fair_payment_financial_entries';
-	}
-
-	/**
 	 * Get the table name for entry-transaction junction table
 	 *
 	 * @return string Full table name with prefix.
@@ -73,6 +53,26 @@ class Schema {
 	public static function get_log_table_name() {
 		global $wpdb;
 		return $wpdb->prefix . 'fair_payment_log';
+	}
+
+	/**
+	 * Get the table name for financial entries (owned by fair-finance plugin)
+	 *
+	 * @return string Full table name with prefix.
+	 */
+	public static function get_financial_entries_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . 'fair_payment_financial_entries';
+	}
+
+	/**
+	 * Get the table name for budgets (owned by fair-finance plugin)
+	 *
+	 * @return string Full table name with prefix.
+	 */
+	public static function get_budgets_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . 'fair_payment_budgets';
 	}
 
 	/**
@@ -134,12 +134,6 @@ class Schema {
 		// Create line items table.
 		self::create_line_items_table();
 
-		// Create budgets table.
-		self::create_budgets_table();
-
-		// Create financial entries table.
-		self::create_financial_entries_table();
-
 		// Create entry-transaction junction table.
 		self::create_entry_transactions_table();
 
@@ -198,73 +192,6 @@ class Schema {
 			PRIMARY KEY  (id),
 			KEY transaction_id (transaction_id),
 			KEY sort_order (sort_order)
-		) $charset_collate;";
-
-		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-		dbDelta( $sql );
-	}
-
-	/**
-	 * Create budgets table
-	 *
-	 * @return void
-	 */
-	public static function create_budgets_table() {
-		global $wpdb;
-
-		$table_name      = self::get_budgets_table_name();
-		$charset_collate = $wpdb->get_charset_collate();
-
-		$sql = "CREATE TABLE $table_name (
-			id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-			name varchar(255) NOT NULL,
-			description text DEFAULT NULL,
-			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-			PRIMARY KEY  (id)
-		) $charset_collate;";
-
-		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-		dbDelta( $sql );
-	}
-
-	/**
-	 * Create financial entries table
-	 *
-	 * @return void
-	 */
-	public static function create_financial_entries_table() {
-		global $wpdb;
-
-		$table_name      = self::get_financial_entries_table_name();
-		$charset_collate = $wpdb->get_charset_collate();
-
-		$sql = "CREATE TABLE $table_name (
-			id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-			amount decimal(10,2) NOT NULL,
-			entry_type varchar(20) NOT NULL,
-			entry_date date NOT NULL,
-			description text DEFAULT NULL,
-			budget_id bigint(20) UNSIGNED DEFAULT NULL,
-			transaction_id bigint(20) UNSIGNED DEFAULT NULL,
-			external_reference varchar(255) DEFAULT NULL,
-			import_source varchar(255) DEFAULT NULL,
-			parent_entry_id bigint(20) UNSIGNED DEFAULT NULL,
-			event_url varchar(500) DEFAULT NULL,
-			event_date_id bigint(20) UNSIGNED DEFAULT NULL,
-			participant_id bigint(20) UNSIGNED DEFAULT NULL,
-			imported_at datetime DEFAULT NULL,
-			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-			PRIMARY KEY  (id),
-			UNIQUE KEY external_reference (external_reference),
-			KEY entry_type (entry_type),
-			KEY entry_date (entry_date),
-			KEY budget_id (budget_id),
-			KEY transaction_id (transaction_id),
-			KEY parent_entry_id (parent_entry_id),
-			KEY event_date_id (event_date_id),
-			KEY participant_id (participant_id)
 		) $charset_collate;";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
@@ -538,6 +465,73 @@ class Schema {
 	}
 
 	/**
+	 * Create budgets table inline (used when fair-finance plugin is not yet loaded)
+	 *
+	 * @return void
+	 */
+	private static function create_budgets_table_inline() {
+		global $wpdb;
+
+		$table_name      = self::get_budgets_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE $table_name (
+			id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+			name varchar(255) NOT NULL,
+			description text DEFAULT NULL,
+			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY  (id)
+		) $charset_collate;";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Create financial entries table inline (used when fair-finance plugin is not yet loaded)
+	 *
+	 * @return void
+	 */
+	private static function create_financial_entries_table_inline() {
+		global $wpdb;
+
+		$table_name      = self::get_financial_entries_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE $table_name (
+			id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+			amount decimal(10,2) NOT NULL,
+			entry_type varchar(20) NOT NULL,
+			entry_date date NOT NULL,
+			description text DEFAULT NULL,
+			budget_id bigint(20) UNSIGNED DEFAULT NULL,
+			transaction_id bigint(20) UNSIGNED DEFAULT NULL,
+			external_reference varchar(255) DEFAULT NULL,
+			import_source varchar(255) DEFAULT NULL,
+			parent_entry_id bigint(20) UNSIGNED DEFAULT NULL,
+			event_url varchar(500) DEFAULT NULL,
+			event_date_id bigint(20) UNSIGNED DEFAULT NULL,
+			participant_id bigint(20) UNSIGNED DEFAULT NULL,
+			imported_at datetime DEFAULT NULL,
+			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY  (id),
+			UNIQUE KEY external_reference (external_reference),
+			KEY entry_type (entry_type),
+			KEY entry_date (entry_date),
+			KEY budget_id (budget_id),
+			KEY transaction_id (transaction_id),
+			KEY parent_entry_id (parent_entry_id),
+			KEY event_date_id (event_date_id),
+			KEY participant_id (participant_id)
+		) $charset_collate;";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
 	 * Migrate database from v5.0 to v6.0
 	 *
 	 * Adds budgets and financial_entries tables for cost & income tracking.
@@ -548,10 +542,15 @@ class Schema {
 		$current_version = get_option( 'fair_payment_db_version', '1.0' );
 
 		if ( version_compare( $current_version, '6.0', '<' ) ) {
-			// Tables are created via dbDelta in create_tables() method.
-			// This migration just ensures they exist for existing installations.
-			self::create_budgets_table();
-			self::create_financial_entries_table();
+			// Delegate to FairFinance if it's already loaded; otherwise create tables inline
+			// so this migration works regardless of plugin activation order.
+			if ( class_exists( '\FairFinance\Database\Schema' ) ) {
+				\FairFinance\Database\Schema::create_budgets_table();
+				\FairFinance\Database\Schema::create_financial_entries_table();
+			} else {
+				self::create_budgets_table_inline();
+				self::create_financial_entries_table_inline();
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds `fair-finance/src/Database/Schema.php` with `get_budgets_table_name()`, `get_financial_entries_table_name()`, `create_budgets_table()`, `create_financial_entries_table()`, and `create_tables()`
- Moves `Budget` and `FinancialEntry` models to `fair-finance/src/Models/` under the `FairFinance\Models` namespace
- Wires `Schema::create_tables()` into `fair-finance/src/Core/Plugin.php::activate()` so tables are created on activation
- All calls to `EntryTransaction` (staying in `fair-payments-connector`) are gated behind `class_exists()` guards so `fair-finance` works standalone
- Removes `get_budgets_table_name()`, `get_financial_entries_table_name()`, `create_budgets_table()`, `create_financial_entries_table()` from `fair-payments-connector/src/Database/Schema.php`; migration methods updated to call `\FairFinance\Database\Schema::` equivalents
- Deletes `fair-payments-connector/src/Models/Budget.php` and `fair-payments-connector/src/Models/FinancialEntry.php`
- Table names unchanged (`wp_fair_payment_budgets`, `wp_fair_payment_financial_entries`) — no data migration needed

## Test plan

- [ ] Activate `fair-finance` on a clean install — `wp_fair_payment_budgets` and `wp_fair_payment_financial_entries` tables are created
- [ ] Existing data in those tables is untouched on upgrade (table names unchanged)
- [ ] `fair-finance` active alone (connector absent): `transaction_ids` returns `[]`, matching/unmatching methods no-op gracefully, `unmatched` filter skipped
- [ ] Both plugins active: transaction matching/unmatching works as before
- [ ] `vendor/bin/phpcs` passes on all modified files

Closes #778