### PR TITLE
ci(fair-finance): add phpcs lint step and bump changeset to minor

### DIFF
--- a/.changeset/fair-finance-scaffold.md
+++ b/.changeset/fair-finance-scaffold.md
@@ -1,5 +1,5 @@
 ---
-"fair-finance": patch
+"fair-finance": minor
 ---
 
 Scaffold fair-finance plugin (empty shell).

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -126,6 +126,9 @@ jobs:
             - name: Install dev PHP dependencies in all plugins
               run: npm run composer:install
 
+            - name: Install root PHP dependencies
+              run: composer install --no-interaction
+
             - name: Lint PHP with phpcs
               run: vendor/bin/phpcs
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -126,6 +126,9 @@ jobs:
             - name: Install dev PHP dependencies in all plugins
               run: npm run composer:install
 
+            - name: Lint PHP with phpcs
+              run: vendor/bin/phpcs
+
             - name: Run unit tests
               run: |
                   npm test


### PR DESCRIPTION
## Summary

- Adds `vendor/bin/phpcs` as an explicit CI step so the root `phpcs.xml` (which covers all plugin `src/` directories including `fair-finance/src/`) is enforced on every PR
- Bumps the `fair-finance` changeset from `patch` to `minor`, appropriate for a new plugin's first release

Closes #782

## Test plan

- [ ] CI passes on this branch
- [ ] Confirm phpcs step appears and passes in the CI run
- [ ] Verify changeset shows `minor` bump for fair-finance