### PR TITLE
feat: add CSV export of financial entries (budget-scoped)

### DIFF
--- a/fair-finance/src/Admin/entries/EntriesApp.js
+++ b/fair-finance/src/Admin/entries/EntriesApp.js
@@ -25,6 +25,10 @@ import MatchModal from './components/MatchModal.js';
 import ImportModal from './components/ImportModal.js';
 import SplitModal from './components/SplitModal.js';
 import TransferModal from './components/TransferModal.js';
+import {
+	buildEntriesCsv,
+	downloadCsv,
+} from './exportEntriesCsv.js';
 
 const budgetingEnabled = window.fairPaymentSettings?.budgetingEnabled === '1';
 const eventsEnabled = window.fairPaymentSettings?.eventsEnabled === '1';
@@ -69,6 +73,7 @@ const EntriesApp = () => {
 		order: 'desc',
 	});
 	const [loading, setLoading] = useState(true);
+	const [exportLoading, setExportLoading] = useState(false);
 	const [error, setError] = useState(null);
 	const [success, setSuccess] = useState(null);
 
@@ -236,6 +241,54 @@ const EntriesApp = () => {
 			setTotals(data);
 		} catch (err) {
 			console.error('Failed to load totals:', err);
+		}
+	};
+
+	const exportCsv = async () => {
+		setExportLoading(true);
+		try {
+			const params = new URLSearchParams();
+			if (filters.date_from)
+				params.append('date_from', filters.date_from);
+			if (filters.date_to) params.append('date_to', filters.date_to);
+			if (filters.budget_id)
+				params.append('budget_id', filters.budget_id);
+			if (filters.event_url)
+				params.append('event_url', filters.event_url);
+			if (filters.event_date_id)
+				params.append('event_date_id', filters.event_date_id);
+			if (filters.entry_type)
+				params.append('entry_type', filters.entry_type);
+			if (filters.unmatched) params.append('unmatched', 'true');
+			params.append('orderby', sort.orderby);
+			params.append('order', sort.order);
+			params.append('per_page', 100);
+
+			let allEntries = [];
+			let page = 1;
+			let totalPages = 1;
+			do {
+				params.set('page', page);
+				const data = await apiFetch({
+					path: `/fair-finance/v1/financial-entries?${params.toString()}`,
+				});
+				allEntries = allEntries.concat(data.entries);
+				totalPages = data.pages;
+				page++;
+			} while (page <= totalPages);
+
+			const scope = filters.budget_id
+				? `budget-${filters.budget_id}`
+				: 'all';
+			const filename = `fair-finance-entries-${scope}.csv`;
+			downloadCsv(buildEntriesCsv(allEntries, budgets), filename);
+		} catch (err) {
+			setError(
+				err.message ||
+					__('Failed to export entries.', 'fair-payments-connector')
+			);
+		} finally {
+			setExportLoading(false);
 		}
 	};
 
@@ -639,6 +692,20 @@ const EntriesApp = () => {
 									onClick={handleImport}
 								>
 									{__('Import', 'fair-payments-connector')}
+								</Button>
+								<Button
+									variant="secondary"
+									onClick={exportCsv}
+									disabled={
+										exportLoading ||
+										entries.length === 0
+									}
+									isBusy={exportLoading}
+								>
+									{__(
+										'Export CSV',
+										'fair-payments-connector'
+									)}
 								</Button>
 							</div>
 						</HStack>

--- a/fair-finance/src/Admin/entries/__tests__/exportEntriesCsv.test.js
+++ b/fair-finance/src/Admin/entries/__tests__/exportEntriesCsv.test.js
@@ -1,0 +1,126 @@
+/**
+ * Internal dependencies
+ */
+import { escapeCsvField, buildEntriesCsv } from '../exportEntriesCsv.js';
+
+describe( 'escapeCsvField', () => {
+	it( 'returns a plain string unchanged', () => {
+		expect( escapeCsvField( 'hello' ) ).toBe( 'hello' );
+	} );
+
+	it( 'quotes a field containing a comma', () => {
+		expect( escapeCsvField( 'a,b' ) ).toBe( '"a,b"' );
+	} );
+
+	it( 'quotes a field containing a double-quote and doubles it', () => {
+		expect( escapeCsvField( 'say "hi"' ) ).toBe( '"say ""hi"""' );
+	} );
+
+	it( 'quotes a field containing a newline', () => {
+		expect( escapeCsvField( 'line1\nline2' ) ).toBe( '"line1\nline2"' );
+	} );
+
+	it( 'prefixes = with a single quote to prevent formula injection', () => {
+		expect( escapeCsvField( '=SUM(A1)' ) ).toBe( "'=SUM(A1)" );
+	} );
+
+	it( 'prefixes + with a single quote', () => {
+		expect( escapeCsvField( '+100' ) ).toBe( "'+100" );
+	} );
+
+	it( 'prefixes - with a single quote', () => {
+		expect( escapeCsvField( '-100' ) ).toBe( "'-100" );
+	} );
+
+	it( 'prefixes @ with a single quote', () => {
+		expect( escapeCsvField( '@user' ) ).toBe( "'@user" );
+	} );
+
+	it( 'returns empty string for null', () => {
+		expect( escapeCsvField( null ) ).toBe( '' );
+	} );
+
+	it( 'returns empty string for undefined', () => {
+		expect( escapeCsvField( undefined ) ).toBe( '' );
+	} );
+
+	it( 'coerces numbers to string', () => {
+		expect( escapeCsvField( 42.5 ) ).toBe( '42.5' );
+	} );
+} );
+
+describe( 'buildEntriesCsv', () => {
+	const budgets = [
+		{ id: 1, name: 'Marketing' },
+		{ id: 2, name: 'Operations' },
+	];
+
+	const entry = {
+		entry_date: '2025-01-15',
+		entry_type: 'cost',
+		amount: 99.5,
+		description: 'Venue hire',
+		budget_id: 1,
+		event_date_id: null,
+		imported_at: '2025-01-16 10:00:00',
+	};
+
+	it( 'starts with a UTF-8 BOM', () => {
+		const csv = buildEntriesCsv( [ entry ], budgets );
+		expect( csv.charCodeAt( 0 ) ).toBe( 0xfeff );
+	} );
+
+	it( 'includes a header row', () => {
+		const csv = buildEntriesCsv( [ entry ], budgets );
+		const firstLine = csv.replace( /^﻿/, '' ).split( '\n' )[ 0 ];
+		expect( firstLine ).toContain( 'Date' );
+		expect( firstLine ).toContain( 'Amount' );
+		expect( firstLine ).toContain( 'Budget' );
+	} );
+
+	it( 'resolves budget name from the budgets array', () => {
+		const csv = buildEntriesCsv( [ entry ], budgets );
+		expect( csv ).toContain( 'Marketing' );
+	} );
+
+	it( 'leaves budget empty when budget_id is not in the budgets array', () => {
+		const entryUnknownBudget = { ...entry, budget_id: 999 };
+		const csv = buildEntriesCsv( [ entryUnknownBudget ], budgets );
+		const dataLine = csv.replace( /^﻿/, '' ).split( '\n' )[ 1 ];
+		// Budget column (index 4) should be empty — check that no budget name appears
+		expect( dataLine ).not.toContain( 'Marketing' );
+		expect( dataLine ).not.toContain( 'Operations' );
+	} );
+
+	it( 'leaves budget empty when budget_id is null', () => {
+		const entryNoBudget = { ...entry, budget_id: null };
+		const csv = buildEntriesCsv( [ entryNoBudget ], budgets );
+		expect( csv ).not.toContain( 'Marketing' );
+	} );
+
+	it( 'outputs amount as a raw decimal', () => {
+		const csv = buildEntriesCsv( [ entry ], budgets );
+		expect( csv ).toContain( '99.5' );
+	} );
+
+	it( 'quotes a description that contains a comma', () => {
+		const entryWithComma = {
+			...entry,
+			description: 'Food, drinks',
+		};
+		const csv = buildEntriesCsv( [ entryWithComma ], budgets );
+		expect( csv ).toContain( '"Food, drinks"' );
+	} );
+
+	it( 'produces one header row + one data row for a single entry', () => {
+		const csv = buildEntriesCsv( [ entry ], budgets );
+		const lines = csv.replace( /^﻿/, '' ).split( '\n' );
+		expect( lines ).toHaveLength( 2 );
+	} );
+
+	it( 'handles an empty entries array (header only)', () => {
+		const csv = buildEntriesCsv( [], budgets );
+		const lines = csv.replace( /^﻿/, '' ).split( '\n' );
+		expect( lines ).toHaveLength( 1 );
+	} );
+} );

--- a/fair-finance/src/Admin/entries/exportEntriesCsv.js
+++ b/fair-finance/src/Admin/entries/exportEntriesCsv.js
@@ -1,0 +1,81 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Escapes a single CSV field value.
+ *
+ * Quotes fields containing commas, double-quotes, or newlines.
+ * Prefixes fields starting with = + - @ to prevent spreadsheet formula injection.
+ */
+export const escapeCsvField = ( field ) => {
+	const str = String( field ?? '' );
+
+	// CSV injection: prefix formula-starting chars with a single quote.
+	const safe =
+		str.length > 0 && '=+-@'.includes( str[ 0 ] ) ? "'" + str : str;
+
+	if ( safe.includes( ',' ) || safe.includes( '"' ) || safe.includes( '\n' ) ) {
+		return '"' + safe.replace( /"/g, '""' ) + '"';
+	}
+	return safe;
+};
+
+/**
+ * Builds a CSV string (with UTF-8 BOM) from an array of financial entries.
+ *
+ * @param {Array}  entries Entries returned by /fair-finance/v1/financial-entries.
+ * @param {Array}  budgets Budgets array (id, name) for resolving budget names.
+ */
+export const buildEntriesCsv = ( entries, budgets ) => {
+	const budgetMap = Object.fromEntries(
+		( budgets || [] ).map( ( b ) => [ String( b.id ), b.name ] )
+	);
+
+	const headers = [
+		__( 'Date', 'fair-payments-connector' ),
+		__( 'Type', 'fair-payments-connector' ),
+		__( 'Amount', 'fair-payments-connector' ),
+		__( 'Description', 'fair-payments-connector' ),
+		__( 'Budget', 'fair-payments-connector' ),
+		__( 'Event Date', 'fair-payments-connector' ),
+		__( 'Imported', 'fair-payments-connector' ),
+	];
+
+	const rows = entries.map( ( entry ) => [
+		entry.entry_date ?? '',
+		entry.entry_type ?? '',
+		entry.amount ?? '',
+		entry.description ?? '',
+		entry.budget_id ? ( budgetMap[ String( entry.budget_id ) ] ?? '' ) : '',
+		entry.event_date_id ?? '',
+		entry.imported_at ?? '',
+	] );
+
+	const csvContent = [
+		headers.map( escapeCsvField ).join( ',' ),
+		...rows.map( ( row ) => row.map( escapeCsvField ).join( ',' ) ),
+	].join( '\n' );
+
+	// BOM for UTF-8 Excel compatibility.
+	return '﻿' + csvContent;
+};
+
+/**
+ * Triggers a browser download of the given CSV string.
+ *
+ * @param {string} csvContent Full CSV text (including BOM if needed).
+ * @param {string} filename   Suggested download filename.
+ */
+export const downloadCsv = ( csvContent, filename ) => {
+	const blob = new Blob( [ csvContent ], {
+		type: 'text/csv;charset=utf-8;',
+	} );
+	const url = URL.createObjectURL( blob );
+	const link = document.createElement( 'a' );
+	link.href = url;
+	link.download = filename;
+	link.click();
+	URL.revokeObjectURL( url );
+};


### PR DESCRIPTION
Closes #725

## Summary

- Adds an **Export CSV** button to the Financial Entries page toolbar
- On click, fetches all entries matching the active filters (budget, date range, search, type) across pages (`per_page=100`), not just the current view
- Builds and downloads a UTF-8 CSV file (with BOM for Excel compatibility)
- Filename reflects the active scope: `fair-finance-entries-budget-2.csv` or `fair-finance-entries-all.csv`
- CSV fields are escaped for formula injection (`= + - @` prefixed with `'`)

## Implementation

- New utility module `exportEntriesCsv.js` with `escapeCsvField`, `buildEntriesCsv`, `downloadCsv` — mirrors the pattern in `fair-audience`'s `QuestionnaireResponses.js`
- 20 unit tests in `__tests__/exportEntriesCsv.test.js` covering field escaping, BOM, budget name resolution, empty entries, and special-character handling
- `EntriesApp.js`: `exportLoading` state + `exportCsv()` async handler + Export CSV button (disabled while loading or when no entries are shown)

## Test plan

- [ ] `npm test` in `fair-finance` passes (28 tests)
- [ ] Open `admin.php?page=fair-finance-entries` — Export CSV button visible
- [ ] Filter by a budget (`&budget_id=2`), click Export CSV → file downloads as `fair-finance-entries-budget-2.csv`
- [ ] CSV opens in a spreadsheet with all matching entries (not just the current page)
- [ ] Descriptions containing commas appear as a single quoted field
- [ ] UTF-8 BOM present (no garbled characters in Excel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)