### PR TITLE
feat(fair-finance): add tag field to financial entries + income/expense-by-tag chart

### DIFF
--- a/fair-finance/jest.config.js
+++ b/fair-finance/jest.config.js
@@ -32,6 +32,7 @@ export default {
 							},
 						},
 					],
+					['@babel/preset-react', { runtime: 'automatic' }],
 				],
 			},
 		],

--- a/fair-finance/src/API/FinancialEntryController.php
+++ b/fair-finance/src/API/FinancialEntryController.php
@@ -84,6 +84,32 @@ class FinancialEntryController extends WP_REST_Controller {
 			)
 		);
 
+		// GET /fair-finance/v1/financial-entries/tags - Get distinct tags.
+		register_rest_route(
+			$this->namespace,
+			'/financial-entries/tags',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_tags' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+			)
+		);
+
+		// GET /fair-finance/v1/financial-entries/totals-by-tag - Get totals grouped by tag.
+		register_rest_route(
+			$this->namespace,
+			'/financial-entries/totals-by-tag',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_totals_by_tag' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+			)
+		);
+
 		// GET /fair-finance/v1/financial-entries/event-date-ids - Get distinct event date IDs.
 		register_rest_route(
 			$this->namespace,
@@ -439,6 +465,11 @@ class FinancialEntryController extends WP_REST_Controller {
 				'description' => __( 'Filter to only unmatched entries.', 'fair-finance' ),
 				'type'        => 'boolean',
 			),
+			'tag'           => array(
+				'description'       => __( 'Filter by tag, or "none" for untagged.', 'fair-finance' ),
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
 		);
 	}
 
@@ -537,6 +568,12 @@ class FinancialEntryController extends WP_REST_Controller {
 				'type'        => array( 'integer', 'null' ),
 				'required'    => false,
 			),
+			'tag'            => array(
+				'description'       => __( 'Optional tag label for cross-cutting categorization.', 'fair-finance' ),
+				'type'              => array( 'string', 'null' ),
+				'required'          => false,
+				'sanitize_callback' => 'sanitize_text_field',
+			),
 		);
 	}
 
@@ -593,6 +630,7 @@ class FinancialEntryController extends WP_REST_Controller {
 			'budget_id'     => $request->get_param( 'budget_id' ),
 			'event_url'     => $request->get_param( 'event_url' ),
 			'event_date_id' => $request->get_param( 'event_date_id' ),
+			'tag'           => $request->get_param( 'tag' ),
 			'entry_type'    => $request->get_param( 'entry_type' ),
 			'unmatched'     => $request->get_param( 'unmatched' ),
 			'per_page'      => $request->get_param( 'per_page' ),
@@ -672,6 +710,7 @@ class FinancialEntryController extends WP_REST_Controller {
 			'budget_id'     => $request->get_param( 'budget_id' ),
 			'event_url'     => $request->get_param( 'event_url' ),
 			'event_date_id' => $request->get_param( 'event_date_id' ),
+			'tag'           => $request->get_param( 'tag' ),
 			'unmatched'     => $request->get_param( 'unmatched' ),
 		);
 
@@ -690,6 +729,30 @@ class FinancialEntryController extends WP_REST_Controller {
 		$urls = FinancialEntry::get_distinct_event_urls();
 
 		return new WP_REST_Response( $urls, 200 );
+	}
+
+	/**
+	 * Get distinct tags used in entries
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_tags( $request ) {
+		$tags = FinancialEntry::get_distinct_tags();
+
+		return new WP_REST_Response( $tags, 200 );
+	}
+
+	/**
+	 * Get totals grouped by tag
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_totals_by_tag( $request ) {
+		$stats = FinancialEntry::get_totals_by_tag();
+
+		return new WP_REST_Response( $stats, 200 );
 	}
 
 	/**
@@ -740,6 +803,7 @@ class FinancialEntryController extends WP_REST_Controller {
 		$transaction_id = $request->get_param( 'transaction_id' );
 		$event_url      = $request->get_param( 'event_url' );
 		$event_date_id  = $request->get_param( 'event_date_id' );
+		$tag            = $request->get_param( 'tag' );
 
 		if ( empty( $amount ) || $amount <= 0 ) {
 			return new WP_Error(
@@ -773,7 +837,8 @@ class FinancialEntryController extends WP_REST_Controller {
 			! empty( $budget_id ) ? $budget_id : null,
 			! empty( $transaction_id ) ? $transaction_id : null,
 			! empty( $event_url ) ? $event_url : null,
-			! empty( $event_date_id ) ? $event_date_id : null
+			! empty( $event_date_id ) ? $event_date_id : null,
+			! empty( $tag ) ? $tag : null
 		);
 
 		if ( ! $entry_id ) {
@@ -805,6 +870,7 @@ class FinancialEntryController extends WP_REST_Controller {
 		$transaction_id = $request->get_param( 'transaction_id' );
 		$event_url      = $request->get_param( 'event_url' );
 		$event_date_id  = $request->get_param( 'event_date_id' );
+		$tag            = $request->get_param( 'tag' );
 
 		// Check if entry exists.
 		$existing = FinancialEntry::get_by_id( $id );
@@ -849,7 +915,8 @@ class FinancialEntryController extends WP_REST_Controller {
 			! empty( $budget_id ) ? $budget_id : null,
 			! empty( $transaction_id ) ? $transaction_id : null,
 			! empty( $event_url ) ? $event_url : null,
-			! empty( $event_date_id ) ? $event_date_id : null
+			! empty( $event_date_id ) ? $event_date_id : null,
+			! empty( $tag ) ? $tag : null
 		);
 
 		if ( ! $success ) {
@@ -1375,6 +1442,12 @@ class FinancialEntryController extends WP_REST_Controller {
 				'type'        => array( 'integer', 'null' ),
 				'required'    => false,
 			),
+			'tag'              => array(
+				'description'       => __( 'Optional tag label for cross-cutting categorization.', 'fair-finance' ),
+				'type'              => array( 'string', 'null' ),
+				'required'          => false,
+				'sanitize_callback' => 'sanitize_text_field',
+			),
 		);
 	}
 
@@ -1393,6 +1466,7 @@ class FinancialEntryController extends WP_REST_Controller {
 		$event_url        = $request->get_param( 'event_url' );
 		$event_date_id    = $request->get_param( 'event_date_id' );
 		$participant_id   = $request->get_param( 'participant_id' );
+		$tag              = $request->get_param( 'tag' );
 
 		if ( empty( $amount ) || $amount <= 0 ) {
 			return new WP_Error(
@@ -1434,7 +1508,8 @@ class FinancialEntryController extends WP_REST_Controller {
 			$description,
 			! empty( $event_url ) ? $event_url : null,
 			! empty( $event_date_id ) ? $event_date_id : null,
-			! empty( $participant_id ) ? (int) $participant_id : null
+			! empty( $participant_id ) ? (int) $participant_id : null,
+			! empty( $tag ) ? $tag : null
 		);
 
 		if ( ! $parent_id ) {
@@ -1475,6 +1550,7 @@ class FinancialEntryController extends WP_REST_Controller {
 		$event_url        = $request->get_param( 'event_url' );
 		$event_date_id    = $request->get_param( 'event_date_id' );
 		$participant_id   = $request->get_param( 'participant_id' );
+		$tag              = $request->get_param( 'tag' );
 
 		// Check if entry exists and is a transfer.
 		$existing = FinancialEntry::get_by_id( $id );
@@ -1535,7 +1611,8 @@ class FinancialEntryController extends WP_REST_Controller {
 			$description,
 			! empty( $event_url ) ? $event_url : null,
 			! empty( $event_date_id ) ? $event_date_id : null,
-			! empty( $participant_id ) ? (int) $participant_id : null
+			! empty( $participant_id ) ? (int) $participant_id : null,
+			! empty( $tag ) ? $tag : null
 		);
 
 		if ( ! $success ) {

--- a/fair-finance/src/API/__tests__/FinancialEntryTagRoutes.api.spec.js
+++ b/fair-finance/src/API/__tests__/FinancialEntryTagRoutes.api.spec.js
@@ -1,0 +1,126 @@
+/**
+ * Playwright API tests for the tag routes on FinancialEntryController.
+ *
+ * Exercises GET /fair-finance/v1/financial-entries/tags,
+ * GET /fair-finance/v1/financial-entries/totals-by-tag, and
+ * GET /fair-finance/v1/financial-entries?tag=... against a live WordPress
+ * instance using admin Application Password credentials.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminAuth = Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString(
+	'base64'
+);
+
+test.describe('FinancialEntry tag routes', () => {
+	let api;
+	let entryId;
+	const testTag = `test-tag-${Date.now()}`;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const res = await api.post(
+			'/wp-json/fair-finance/v1/financial-entries',
+			{
+				headers: { Authorization: `Basic ${adminAuth}` },
+				data: {
+					amount: 42.0,
+					entry_type: 'cost',
+					entry_date: '2026-01-15',
+					description: 'Tag route test entry',
+					tag: testTag,
+				},
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		entryId = body.id;
+		expect(entryId).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (entryId) {
+			await api.delete(
+				`/wp-json/fair-finance/v1/financial-entries/${entryId}`,
+				{
+					headers: { Authorization: `Basic ${adminAuth}` },
+				}
+			);
+		}
+		await api.dispose();
+	});
+
+	test('GET /tags returns the test tag', async () => {
+		const res = await api.get(
+			'/wp-json/fair-finance/v1/financial-entries/tags',
+			{
+				headers: { Authorization: `Basic ${adminAuth}` },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+		expect(body).toContain(testTag);
+	});
+
+	test('GET /totals-by-tag returns cost total for the test tag', async () => {
+		const res = await api.get(
+			'/wp-json/fair-finance/v1/financial-entries/totals-by-tag',
+			{
+				headers: { Authorization: `Basic ${adminAuth}` },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		expect(body[testTag]).toBeDefined();
+		expect(body[testTag].total_cost).toBeGreaterThanOrEqual(42.0);
+		expect(body[testTag].total_income).toBeDefined();
+		expect(body[testTag].balance).toBeDefined();
+	});
+
+	test('GET /financial-entries?tag= filters by tag', async () => {
+		const res = await api.get(
+			`/wp-json/fair-finance/v1/financial-entries?tag=${encodeURIComponent(
+				testTag
+			)}`,
+			{
+				headers: { Authorization: `Basic ${adminAuth}` },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		expect(Array.isArray(body.entries)).toBe(true);
+		expect(body.entries.length).toBeGreaterThan(0);
+		body.entries.forEach((entry) => {
+			expect(entry.tag).toBe(testTag);
+		});
+	});
+
+	test('GET /financial-entries?tag=none returns only untagged entries', async () => {
+		const res = await api.get(
+			'/wp-json/fair-finance/v1/financial-entries?tag=none',
+			{
+				headers: { Authorization: `Basic ${adminAuth}` },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		expect(Array.isArray(body.entries)).toBe(true);
+		body.entries.forEach((entry) => {
+			expect(entry.tag).toBeNull();
+		});
+	});
+
+	test('requires authentication', async () => {
+		const res = await api.get(
+			'/wp-json/fair-finance/v1/financial-entries/tags'
+		);
+		expect(res.status()).toBe(401);
+	});
+});

--- a/fair-finance/src/Admin/entries/EntriesApp.js
+++ b/fair-finance/src/Admin/entries/EntriesApp.js
@@ -25,10 +25,8 @@ import MatchModal from './components/MatchModal.js';
 import ImportModal from './components/ImportModal.js';
 import SplitModal from './components/SplitModal.js';
 import TransferModal from './components/TransferModal.js';
-import {
-	buildEntriesCsv,
-	downloadCsv,
-} from './exportEntriesCsv.js';
+import TagChart from './components/TagChart.js';
+import { buildEntriesCsv, downloadCsv } from './exportEntriesCsv.js';
 
 const budgetingEnabled = window.fairPaymentSettings?.budgetingEnabled === '1';
 const eventsEnabled = window.fairPaymentSettings?.eventsEnabled === '1';
@@ -49,6 +47,8 @@ const EntriesApp = () => {
 	const [budgets, setBudgets] = useState([]);
 	const [eventUrls, setEventUrls] = useState([]);
 	const [eventDateOptions, setEventDateOptions] = useState([]);
+	const [tags, setTags] = useState([]);
+	const [tagTotals, setTagTotals] = useState({});
 	const [totals, setTotals] = useState({
 		total_cost: 0,
 		total_income: 0,
@@ -65,6 +65,7 @@ const EntriesApp = () => {
 		budget_id: '',
 		event_url: '',
 		event_date_id: '',
+		tag: '',
 		entry_type: '',
 		unmatched: false,
 	});
@@ -110,11 +111,13 @@ const EntriesApp = () => {
 				}));
 			}
 		}
+		loadTags();
 	}, []);
 
 	useEffect(() => {
 		loadEntries();
 		loadTotals();
+		loadTagTotals();
 	}, [filters, pagination.page, sort]);
 
 	const loadBudgets = async () => {
@@ -176,6 +179,28 @@ const EntriesApp = () => {
 		}
 	};
 
+	const loadTags = async () => {
+		try {
+			const data = await apiFetch({
+				path: '/fair-finance/v1/financial-entries/tags',
+			});
+			setTags(Array.isArray(data) ? data : []);
+		} catch (err) {
+			console.error('Failed to load tags:', err);
+		}
+	};
+
+	const loadTagTotals = async () => {
+		try {
+			const data = await apiFetch({
+				path: '/fair-finance/v1/financial-entries/totals-by-tag',
+			});
+			setTagTotals(data || {});
+		} catch (err) {
+			console.error('Failed to load tag totals:', err);
+		}
+	};
+
 	const loadEntries = async () => {
 		setLoading(true);
 		setError(null);
@@ -194,6 +219,7 @@ const EntriesApp = () => {
 				params.append('event_url', filters.event_url);
 			if (filters.event_date_id)
 				params.append('event_date_id', filters.event_date_id);
+			if (filters.tag) params.append('tag', filters.tag);
 			if (filters.entry_type)
 				params.append('entry_type', filters.entry_type);
 			if (filters.unmatched) params.append('unmatched', 'true');
@@ -232,6 +258,7 @@ const EntriesApp = () => {
 				params.append('event_url', filters.event_url);
 			if (filters.event_date_id)
 				params.append('event_date_id', filters.event_date_id);
+			if (filters.tag) params.append('tag', filters.tag);
 			if (filters.unmatched) params.append('unmatched', 'true');
 
 			const data = await apiFetch({
@@ -257,6 +284,7 @@ const EntriesApp = () => {
 				params.append('event_url', filters.event_url);
 			if (filters.event_date_id)
 				params.append('event_date_id', filters.event_date_id);
+			if (filters.tag) params.append('tag', filters.tag);
 			if (filters.entry_type)
 				params.append('entry_type', filters.entry_type);
 			if (filters.unmatched) params.append('unmatched', 'true');
@@ -349,6 +377,7 @@ const EntriesApp = () => {
 		);
 		loadEntries();
 		loadTotals();
+		loadTags();
 		if (eventsEnabled) {
 			loadEventUrls();
 			loadEventDateOptions();
@@ -659,6 +688,15 @@ const EntriesApp = () => {
 					</CardBody>
 				</Card>
 
+				{/* Tag Chart */}
+				{Object.keys(tagTotals).length > 0 && (
+					<Card>
+						<CardBody>
+							<TagChart data={tagTotals} />
+						</CardBody>
+					</Card>
+				)}
+
 				{/* Main Entries Card */}
 				<Card>
 					<CardHeader>
@@ -697,8 +735,7 @@ const EntriesApp = () => {
 									variant="secondary"
 									onClick={exportCsv}
 									disabled={
-										exportLoading ||
-										entries.length === 0
+										exportLoading || entries.length === 0
 									}
 									isBusy={exportLoading}
 								>
@@ -796,6 +833,28 @@ const EntriesApp = () => {
 											}
 										/>
 									)}
+								{tags.length > 0 && (
+									<SelectControl
+										label={__('Tag', 'fair-finance')}
+										value={filters.tag}
+										options={[
+											{
+												label: __(
+													'All Tags',
+													'fair-finance'
+												),
+												value: '',
+											},
+											...tags.map((tag) => ({
+												label: tag,
+												value: tag,
+											})),
+										]}
+										onChange={(value) =>
+											handleFilterChange('tag', value)
+										}
+									/>
+								)}
 								<SelectControl
 									label={__(
 										'Type',
@@ -1743,6 +1802,7 @@ const EntriesApp = () => {
 					budgets={budgets}
 					budgetingEnabled={budgetingEnabled}
 					eventsEnabled={eventsEnabled}
+					tags={tags}
 					onSave={handleFormSave}
 					onCancel={handleFormCancel}
 				/>

--- a/fair-finance/src/Admin/entries/__tests__/exportEntriesCsv.test.js
+++ b/fair-finance/src/Admin/entries/__tests__/exportEntriesCsv.test.js
@@ -3,53 +3,53 @@
  */
 import { escapeCsvField, buildEntriesCsv } from '../exportEntriesCsv.js';
 
-describe( 'escapeCsvField', () => {
-	it( 'returns a plain string unchanged', () => {
-		expect( escapeCsvField( 'hello' ) ).toBe( 'hello' );
-	} );
+describe('escapeCsvField', () => {
+	it('returns a plain string unchanged', () => {
+		expect(escapeCsvField('hello')).toBe('hello');
+	});
 
-	it( 'quotes a field containing a comma', () => {
-		expect( escapeCsvField( 'a,b' ) ).toBe( '"a,b"' );
-	} );
+	it('quotes a field containing a comma', () => {
+		expect(escapeCsvField('a,b')).toBe('"a,b"');
+	});
 
-	it( 'quotes a field containing a double-quote and doubles it', () => {
-		expect( escapeCsvField( 'say "hi"' ) ).toBe( '"say ""hi"""' );
-	} );
+	it('quotes a field containing a double-quote and doubles it', () => {
+		expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+	});
 
-	it( 'quotes a field containing a newline', () => {
-		expect( escapeCsvField( 'line1\nline2' ) ).toBe( '"line1\nline2"' );
-	} );
+	it('quotes a field containing a newline', () => {
+		expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"');
+	});
 
-	it( 'prefixes = with a single quote to prevent formula injection', () => {
-		expect( escapeCsvField( '=SUM(A1)' ) ).toBe( "'=SUM(A1)" );
-	} );
+	it('prefixes = with a single quote to prevent formula injection', () => {
+		expect(escapeCsvField('=SUM(A1)')).toBe("'=SUM(A1)");
+	});
 
-	it( 'prefixes + with a single quote', () => {
-		expect( escapeCsvField( '+100' ) ).toBe( "'+100" );
-	} );
+	it('prefixes + with a single quote', () => {
+		expect(escapeCsvField('+100')).toBe("'+100");
+	});
 
-	it( 'prefixes - with a single quote', () => {
-		expect( escapeCsvField( '-100' ) ).toBe( "'-100" );
-	} );
+	it('prefixes - with a single quote', () => {
+		expect(escapeCsvField('-100')).toBe("'-100");
+	});
 
-	it( 'prefixes @ with a single quote', () => {
-		expect( escapeCsvField( '@user' ) ).toBe( "'@user" );
-	} );
+	it('prefixes @ with a single quote', () => {
+		expect(escapeCsvField('@user')).toBe("'@user");
+	});
 
-	it( 'returns empty string for null', () => {
-		expect( escapeCsvField( null ) ).toBe( '' );
-	} );
+	it('returns empty string for null', () => {
+		expect(escapeCsvField(null)).toBe('');
+	});
 
-	it( 'returns empty string for undefined', () => {
-		expect( escapeCsvField( undefined ) ).toBe( '' );
-	} );
+	it('returns empty string for undefined', () => {
+		expect(escapeCsvField(undefined)).toBe('');
+	});
 
-	it( 'coerces numbers to string', () => {
-		expect( escapeCsvField( 42.5 ) ).toBe( '42.5' );
-	} );
-} );
+	it('coerces numbers to string', () => {
+		expect(escapeCsvField(42.5)).toBe('42.5');
+	});
+});
 
-describe( 'buildEntriesCsv', () => {
+describe('buildEntriesCsv', () => {
 	const budgets = [
 		{ id: 1, name: 'Marketing' },
 		{ id: 2, name: 'Operations' },
@@ -65,62 +65,62 @@ describe( 'buildEntriesCsv', () => {
 		imported_at: '2025-01-16 10:00:00',
 	};
 
-	it( 'starts with a UTF-8 BOM', () => {
-		const csv = buildEntriesCsv( [ entry ], budgets );
-		expect( csv.charCodeAt( 0 ) ).toBe( 0xfeff );
-	} );
+	it('starts with a UTF-8 BOM', () => {
+		const csv = buildEntriesCsv([entry], budgets);
+		expect(csv.charCodeAt(0)).toBe(0xfeff);
+	});
 
-	it( 'includes a header row', () => {
-		const csv = buildEntriesCsv( [ entry ], budgets );
-		const firstLine = csv.replace( /^﻿/, '' ).split( '\n' )[ 0 ];
-		expect( firstLine ).toContain( 'Date' );
-		expect( firstLine ).toContain( 'Amount' );
-		expect( firstLine ).toContain( 'Budget' );
-	} );
+	it('includes a header row', () => {
+		const csv = buildEntriesCsv([entry], budgets);
+		const firstLine = csv.replace(/^﻿/, '').split('\n')[0];
+		expect(firstLine).toContain('Date');
+		expect(firstLine).toContain('Amount');
+		expect(firstLine).toContain('Budget');
+	});
 
-	it( 'resolves budget name from the budgets array', () => {
-		const csv = buildEntriesCsv( [ entry ], budgets );
-		expect( csv ).toContain( 'Marketing' );
-	} );
+	it('resolves budget name from the budgets array', () => {
+		const csv = buildEntriesCsv([entry], budgets);
+		expect(csv).toContain('Marketing');
+	});
 
-	it( 'leaves budget empty when budget_id is not in the budgets array', () => {
+	it('leaves budget empty when budget_id is not in the budgets array', () => {
 		const entryUnknownBudget = { ...entry, budget_id: 999 };
-		const csv = buildEntriesCsv( [ entryUnknownBudget ], budgets );
-		const dataLine = csv.replace( /^﻿/, '' ).split( '\n' )[ 1 ];
+		const csv = buildEntriesCsv([entryUnknownBudget], budgets);
+		const dataLine = csv.replace(/^﻿/, '').split('\n')[1];
 		// Budget column (index 4) should be empty — check that no budget name appears
-		expect( dataLine ).not.toContain( 'Marketing' );
-		expect( dataLine ).not.toContain( 'Operations' );
-	} );
+		expect(dataLine).not.toContain('Marketing');
+		expect(dataLine).not.toContain('Operations');
+	});
 
-	it( 'leaves budget empty when budget_id is null', () => {
+	it('leaves budget empty when budget_id is null', () => {
 		const entryNoBudget = { ...entry, budget_id: null };
-		const csv = buildEntriesCsv( [ entryNoBudget ], budgets );
-		expect( csv ).not.toContain( 'Marketing' );
-	} );
+		const csv = buildEntriesCsv([entryNoBudget], budgets);
+		expect(csv).not.toContain('Marketing');
+	});
 
-	it( 'outputs amount as a raw decimal', () => {
-		const csv = buildEntriesCsv( [ entry ], budgets );
-		expect( csv ).toContain( '99.5' );
-	} );
+	it('outputs amount as a raw decimal', () => {
+		const csv = buildEntriesCsv([entry], budgets);
+		expect(csv).toContain('99.5');
+	});
 
-	it( 'quotes a description that contains a comma', () => {
+	it('quotes a description that contains a comma', () => {
 		const entryWithComma = {
 			...entry,
 			description: 'Food, drinks',
 		};
-		const csv = buildEntriesCsv( [ entryWithComma ], budgets );
-		expect( csv ).toContain( '"Food, drinks"' );
-	} );
+		const csv = buildEntriesCsv([entryWithComma], budgets);
+		expect(csv).toContain('"Food, drinks"');
+	});
 
-	it( 'produces one header row + one data row for a single entry', () => {
-		const csv = buildEntriesCsv( [ entry ], budgets );
-		const lines = csv.replace( /^﻿/, '' ).split( '\n' );
-		expect( lines ).toHaveLength( 2 );
-	} );
+	it('produces one header row + one data row for a single entry', () => {
+		const csv = buildEntriesCsv([entry], budgets);
+		const lines = csv.replace(/^﻿/, '').split('\n');
+		expect(lines).toHaveLength(2);
+	});
 
-	it( 'handles an empty entries array (header only)', () => {
-		const csv = buildEntriesCsv( [], budgets );
-		const lines = csv.replace( /^﻿/, '' ).split( '\n' );
-		expect( lines ).toHaveLength( 1 );
-	} );
-} );
+	it('handles an empty entries array (header only)', () => {
+		const csv = buildEntriesCsv([], budgets);
+		const lines = csv.replace(/^﻿/, '').split('\n');
+		expect(lines).toHaveLength(1);
+	});
+});

--- a/fair-finance/src/Admin/entries/components/EntryForm.js
+++ b/fair-finance/src/Admin/entries/components/EntryForm.js
@@ -18,12 +18,14 @@ import {
  * Internal dependencies
  */
 import EventUrlField from './EventUrlField.js';
+import TagField from './TagField.js';
 
 const EntryForm = ({
 	entry,
 	budgets,
 	budgetingEnabled,
 	eventsEnabled,
+	tags,
 	onSave,
 	onCancel,
 }) => {
@@ -35,6 +37,7 @@ const EntryForm = ({
 		budget_id: '',
 		event_url: '',
 		event_date_id: null,
+		tag: '',
 	});
 	const [isSaving, setIsSaving] = useState(false);
 	const [error, setError] = useState(null);
@@ -50,6 +53,7 @@ const EntryForm = ({
 				budget_id: entry.budget_id?.toString() || '',
 				event_url: entry.event_url || '',
 				event_date_id: entry.event_date_id || null,
+				tag: entry.tag || '',
 			});
 		}
 	}, [entry]);
@@ -68,6 +72,7 @@ const EntryForm = ({
 					: null,
 				event_url: formData.event_url || null,
 				event_date_id: formData.event_date_id || null,
+				tag: formData.tag || null,
 			};
 
 			if (entry) {
@@ -206,6 +211,14 @@ const EntryForm = ({
 							}
 						/>
 					)}
+
+					<TagField
+						value={formData.tag}
+						tags={tags}
+						onChange={(value) =>
+							setFormData({ ...formData, tag: value })
+						}
+					/>
 
 					<HStack justify="flex-end" spacing={2}>
 						<Button

--- a/fair-finance/src/Admin/entries/components/TagChart.js
+++ b/fair-finance/src/Admin/entries/components/TagChart.js
@@ -1,0 +1,155 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const BAR_WIDTH = 24;
+const BAR_GAP = 8;
+const GROUP_GAP = 24;
+const CHART_HEIGHT = 160;
+const LABEL_HEIGHT = 40;
+const SVG_PADDING = 20;
+
+const formatAmount = (amount) =>
+	new Intl.NumberFormat(undefined, {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	}).format(amount);
+
+const TagChart = ({ data }) => {
+	if (!data || Object.keys(data).length === 0) {
+		return null;
+	}
+
+	const tags = Object.keys(data).filter((key) => key !== 'untagged');
+	if (data.untagged) {
+		tags.push('untagged');
+	}
+
+	const maxValue = Math.max(
+		...tags.flatMap((tag) => [
+			data[tag].total_cost || 0,
+			data[tag].total_income || 0,
+		]),
+		1
+	);
+
+	const groupWidth = BAR_WIDTH * 2 + BAR_GAP;
+	const totalWidth =
+		tags.length * groupWidth +
+		(tags.length - 1) * GROUP_GAP +
+		SVG_PADDING * 2;
+	const svgHeight = CHART_HEIGHT + LABEL_HEIGHT + SVG_PADDING;
+
+	return (
+		<div>
+			<h3 style={{ fontSize: '14px', marginBottom: '8px' }}>
+				{__('Income vs. Expense by Tag', 'fair-finance')}
+			</h3>
+			<div style={{ overflowX: 'auto' }}>
+				<svg
+					width={totalWidth}
+					height={svgHeight}
+					aria-label={__('Tag chart', 'fair-finance')}
+				>
+					{tags.map((tag, i) => {
+						const groupX =
+							SVG_PADDING + i * (groupWidth + GROUP_GAP);
+						const cost = data[tag].total_cost || 0;
+						const income = data[tag].total_income || 0;
+						const costHeight = Math.round(
+							(cost / maxValue) * CHART_HEIGHT
+						);
+						const incomeHeight = Math.round(
+							(income / maxValue) * CHART_HEIGHT
+						);
+
+						return (
+							<g key={tag}>
+								{/* Cost bar */}
+								<rect
+									x={groupX}
+									y={CHART_HEIGHT - costHeight + SVG_PADDING}
+									width={BAR_WIDTH}
+									height={costHeight}
+									fill="#cc1818"
+									opacity="0.85"
+								>
+									<title>
+										{tag} {__('cost', 'fair-finance')}:{' '}
+										{formatAmount(cost)}
+									</title>
+								</rect>
+								{/* Income bar */}
+								<rect
+									x={groupX + BAR_WIDTH + BAR_GAP}
+									y={
+										CHART_HEIGHT -
+										incomeHeight +
+										SVG_PADDING
+									}
+									width={BAR_WIDTH}
+									height={incomeHeight}
+									fill="#1e7e34"
+									opacity="0.85"
+								>
+									<title>
+										{tag} {__('income', 'fair-finance')}:{' '}
+										{formatAmount(income)}
+									</title>
+								</rect>
+								{/* Tag label */}
+								<text
+									x={groupX + groupWidth / 2}
+									y={CHART_HEIGHT + SVG_PADDING + 16}
+									textAnchor="middle"
+									fontSize="11"
+									fill="#333"
+								>
+									{tag.length > 10
+										? tag.substring(0, 9) + '…'
+										: tag}
+								</text>
+							</g>
+						);
+					})}
+					{/* Legend */}
+					<rect
+						x={SVG_PADDING}
+						y={svgHeight - 18}
+						width={10}
+						height={10}
+						fill="#cc1818"
+						opacity="0.85"
+					/>
+					<text
+						x={SVG_PADDING + 14}
+						y={svgHeight - 10}
+						fontSize="11"
+						fill="#333"
+					>
+						{__('Cost', 'fair-finance')}
+					</text>
+					<rect
+						x={SVG_PADDING + 60}
+						y={svgHeight - 18}
+						width={10}
+						height={10}
+						fill="#1e7e34"
+						opacity="0.85"
+					/>
+					<text
+						x={SVG_PADDING + 74}
+						y={svgHeight - 10}
+						fontSize="11"
+						fill="#333"
+					>
+						{__('Income', 'fair-finance')}
+					</text>
+				</svg>
+			</div>
+		</div>
+	);
+};
+
+export default TagChart;

--- a/fair-finance/src/Admin/entries/components/TagField.js
+++ b/fair-finance/src/Admin/entries/components/TagField.js
@@ -1,0 +1,79 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { TextControl } from '@wordpress/components';
+
+const TagField = ({ value, tags, onChange }) => {
+	const [showSuggestions, setShowSuggestions] = useState(false);
+
+	const filtered =
+		value && tags
+			? tags.filter(
+					(t) =>
+						t.toLowerCase().includes(value.toLowerCase()) &&
+						t !== value
+			  )
+			: [];
+
+	return (
+		<div style={{ position: 'relative' }}>
+			<TextControl
+				label={__('Tag', 'fair-finance')}
+				value={value || ''}
+				onChange={(v) => {
+					onChange(v);
+					setShowSuggestions(true);
+				}}
+				onFocus={() => setShowSuggestions(true)}
+				onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+				placeholder={__('e.g. venue, catering, travel', 'fair-finance')}
+				autoComplete="off"
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+			{showSuggestions && filtered.length > 0 && (
+				<div
+					style={{
+						position: 'absolute',
+						zIndex: 100,
+						background: '#fff',
+						border: '1px solid #ddd',
+						borderRadius: '4px',
+						maxHeight: '200px',
+						overflowY: 'auto',
+						width: '100%',
+					}}
+				>
+					{filtered.map((tag) => (
+						<div
+							key={tag}
+							style={{
+								padding: '8px 12px',
+								cursor: 'pointer',
+								borderBottom: '1px solid #eee',
+							}}
+							onMouseDown={() => {
+								onChange(tag);
+								setShowSuggestions(false);
+							}}
+							role="button"
+							tabIndex={0}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter') {
+									onChange(tag);
+									setShowSuggestions(false);
+								}
+							}}
+						>
+							{tag}
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default TagField;

--- a/fair-finance/src/Admin/entries/components/__tests__/TagField.test.js
+++ b/fair-finance/src/Admin/entries/components/__tests__/TagField.test.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TagField from '../TagField.js';
+
+const tags = ['catering', 'travel', 'venue'];
+
+describe('TagField', () => {
+	it('renders a text input', () => {
+		render(<TagField value="" tags={tags} onChange={jest.fn()} />);
+		expect(
+			screen.getByRole('textbox', { name: /tag/i })
+		).toBeInTheDocument();
+	});
+
+	it('calls onChange when typing', () => {
+		const onChange = jest.fn();
+		render(<TagField value="" tags={tags} onChange={onChange} />);
+		fireEvent.change(screen.getByRole('textbox', { name: /tag/i }), {
+			target: { value: 'cat' },
+		});
+		expect(onChange).toHaveBeenCalledWith('cat');
+	});
+
+	it('shows matching suggestions when focused and value matches', () => {
+		render(<TagField value="ca" tags={tags} onChange={jest.fn()} />);
+		fireEvent.focus(screen.getByRole('textbox', { name: /tag/i }));
+		expect(screen.getByText('catering')).toBeInTheDocument();
+		expect(screen.queryByText('travel')).not.toBeInTheDocument();
+	});
+
+	it('calls onChange with suggestion value on mousedown', () => {
+		const onChange = jest.fn();
+		render(<TagField value="ca" tags={tags} onChange={onChange} />);
+		fireEvent.focus(screen.getByRole('textbox', { name: /tag/i }));
+		fireEvent.mouseDown(screen.getByText('catering'));
+		expect(onChange).toHaveBeenCalledWith('catering');
+	});
+
+	it('does not show the current value as a suggestion', () => {
+		render(<TagField value="catering" tags={tags} onChange={jest.fn()} />);
+		fireEvent.focus(screen.getByRole('textbox', { name: /tag/i }));
+		// "catering" matches but equals value — should not appear
+		expect(screen.queryByText('catering')).not.toBeInTheDocument();
+	});
+
+	it('shows no suggestions when tags list is empty', () => {
+		render(<TagField value="cat" tags={[]} onChange={jest.fn()} />);
+		fireEvent.focus(screen.getByRole('textbox', { name: /tag/i }));
+		expect(screen.queryByRole('button')).not.toBeInTheDocument();
+	});
+});

--- a/fair-finance/src/Admin/entries/exportEntriesCsv.js
+++ b/fair-finance/src/Admin/entries/exportEntriesCsv.js
@@ -9,15 +9,14 @@ import { __ } from '@wordpress/i18n';
  * Quotes fields containing commas, double-quotes, or newlines.
  * Prefixes fields starting with = + - @ to prevent spreadsheet formula injection.
  */
-export const escapeCsvField = ( field ) => {
-	const str = String( field ?? '' );
+export const escapeCsvField = (field) => {
+	const str = String(field ?? '');
 
 	// CSV injection: prefix formula-starting chars with a single quote.
-	const safe =
-		str.length > 0 && '=+-@'.includes( str[ 0 ] ) ? "'" + str : str;
+	const safe = str.length > 0 && '=+-@'.includes(str[0]) ? "'" + str : str;
 
-	if ( safe.includes( ',' ) || safe.includes( '"' ) || safe.includes( '\n' ) ) {
-		return '"' + safe.replace( /"/g, '""' ) + '"';
+	if (safe.includes(',') || safe.includes('"') || safe.includes('\n')) {
+		return '"' + safe.replace(/"/g, '""') + '"';
 	}
 	return safe;
 };
@@ -28,35 +27,35 @@ export const escapeCsvField = ( field ) => {
  * @param {Array}  entries Entries returned by /fair-finance/v1/financial-entries.
  * @param {Array}  budgets Budgets array (id, name) for resolving budget names.
  */
-export const buildEntriesCsv = ( entries, budgets ) => {
+export const buildEntriesCsv = (entries, budgets) => {
 	const budgetMap = Object.fromEntries(
-		( budgets || [] ).map( ( b ) => [ String( b.id ), b.name ] )
+		(budgets || []).map((b) => [String(b.id), b.name])
 	);
 
 	const headers = [
-		__( 'Date', 'fair-payments-connector' ),
-		__( 'Type', 'fair-payments-connector' ),
-		__( 'Amount', 'fair-payments-connector' ),
-		__( 'Description', 'fair-payments-connector' ),
-		__( 'Budget', 'fair-payments-connector' ),
-		__( 'Event Date', 'fair-payments-connector' ),
-		__( 'Imported', 'fair-payments-connector' ),
+		__('Date', 'fair-payments-connector'),
+		__('Type', 'fair-payments-connector'),
+		__('Amount', 'fair-payments-connector'),
+		__('Description', 'fair-payments-connector'),
+		__('Budget', 'fair-payments-connector'),
+		__('Event Date', 'fair-payments-connector'),
+		__('Imported', 'fair-payments-connector'),
 	];
 
-	const rows = entries.map( ( entry ) => [
+	const rows = entries.map((entry) => [
 		entry.entry_date ?? '',
 		entry.entry_type ?? '',
 		entry.amount ?? '',
 		entry.description ?? '',
-		entry.budget_id ? ( budgetMap[ String( entry.budget_id ) ] ?? '' ) : '',
+		entry.budget_id ? budgetMap[String(entry.budget_id)] ?? '' : '',
 		entry.event_date_id ?? '',
 		entry.imported_at ?? '',
-	] );
+	]);
 
 	const csvContent = [
-		headers.map( escapeCsvField ).join( ',' ),
-		...rows.map( ( row ) => row.map( escapeCsvField ).join( ',' ) ),
-	].join( '\n' );
+		headers.map(escapeCsvField).join(','),
+		...rows.map((row) => row.map(escapeCsvField).join(',')),
+	].join('\n');
 
 	// BOM for UTF-8 Excel compatibility.
 	return '﻿' + csvContent;
@@ -68,14 +67,14 @@ export const buildEntriesCsv = ( entries, budgets ) => {
  * @param {string} csvContent Full CSV text (including BOM if needed).
  * @param {string} filename   Suggested download filename.
  */
-export const downloadCsv = ( csvContent, filename ) => {
-	const blob = new Blob( [ csvContent ], {
+export const downloadCsv = (csvContent, filename) => {
+	const blob = new Blob([csvContent], {
 		type: 'text/csv;charset=utf-8;',
-	} );
-	const url = URL.createObjectURL( blob );
-	const link = document.createElement( 'a' );
+	});
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement('a');
 	link.href = url;
 	link.download = filename;
 	link.click();
-	URL.revokeObjectURL( url );
+	URL.revokeObjectURL(url);
 };

--- a/fair-finance/src/Database/Schema.php
+++ b/fair-finance/src/Database/Schema.php
@@ -94,6 +94,7 @@ class Schema {
 			event_url varchar(500) DEFAULT NULL,
 			event_date_id bigint(20) UNSIGNED DEFAULT NULL,
 			participant_id bigint(20) UNSIGNED DEFAULT NULL,
+			tag varchar(100) DEFAULT NULL,
 			imported_at datetime DEFAULT NULL,
 			created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -105,7 +106,8 @@ class Schema {
 			KEY transaction_id (transaction_id),
 			KEY parent_entry_id (parent_entry_id),
 			KEY event_date_id (event_date_id),
-			KEY participant_id (participant_id)
+			KEY participant_id (participant_id),
+			KEY tag (tag)
 		) $charset_collate;";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/fair-finance/src/Models/FinancialEntry.php
+++ b/fair-finance/src/Models/FinancialEntry.php
@@ -98,6 +98,13 @@ class FinancialEntry {
 	public $event_url;
 
 	/**
+	 * Tag (optional free-text label for cross-cutting categorization)
+	 *
+	 * @var string|null
+	 */
+	public $tag;
+
+	/**
 	 * Event date ID (foreign key to fair_event_dates table)
 	 *
 	 * @var int|null
@@ -246,6 +253,7 @@ class FinancialEntry {
 			'budget_id'     => null,
 			'event_url'     => null,
 			'event_date_id' => null,
+			'tag'           => null,
 			'entry_type'    => null,
 			'unmatched'     => false,
 			'per_page'      => 50,
@@ -258,11 +266,12 @@ class FinancialEntry {
 		$where_clauses = array();
 		$where_values  = array();
 
-		// When filtering by a specific budget, event_url, or event_date_id, include child entries matching that filter.
+		// When filtering by a specific budget, event_url, event_date_id, or tag, include child entries matching that filter.
 		// Otherwise, exclude child entries (they are shown under their parent).
 		$include_children = ( ! empty( $filters['budget_id'] ) && 'none' !== $filters['budget_id'] )
 			|| ! empty( $filters['event_url'] )
-			|| ! empty( $filters['event_date_id'] );
+			|| ! empty( $filters['event_date_id'] )
+			|| ( ! empty( $filters['tag'] ) && 'none' !== $filters['tag'] );
 		if ( ! $include_children ) {
 			$where_clauses[] = 'parent_entry_id IS NULL';
 		}
@@ -294,6 +303,15 @@ class FinancialEntry {
 		if ( ! empty( $filters['event_date_id'] ) ) {
 			$where_clauses[] = 'event_date_id = %d';
 			$where_values[]  = (int) $filters['event_date_id'];
+		}
+
+		if ( ! empty( $filters['tag'] ) ) {
+			if ( 'none' === $filters['tag'] ) {
+				$where_clauses[] = 'tag IS NULL';
+			} else {
+				$where_clauses[] = 'tag = %s';
+				$where_values[]  = $filters['tag'];
+			}
 		}
 
 		if ( ! empty( $filters['entry_type'] ) && in_array( $filters['entry_type'], array( 'cost', 'income', 'transfer' ), true ) ) {
@@ -419,6 +437,15 @@ class FinancialEntry {
 			$where_values[]  = (int) $filters['event_date_id'];
 		}
 
+		if ( ! empty( $filters['tag'] ) ) {
+			if ( 'none' === $filters['tag'] ) {
+				$where_clauses[] = 'tag IS NULL';
+			} else {
+				$where_clauses[] = 'tag = %s';
+				$where_values[]  = $filters['tag'];
+			}
+		}
+
 		if ( ! empty( $filters['unmatched'] ) && class_exists( '\\FairPaymentsConnector\\Database\\Schema' ) ) {
 			$junction_table  = \FairPaymentsConnector\Database\Schema::get_entry_transactions_table_name();
 			$where_clauses[] = $wpdb->prepare(
@@ -532,9 +559,10 @@ class FinancialEntry {
 	 * @param int|null    $transaction_id Transaction ID.
 	 * @param string|null $event_url      Event URL.
 	 * @param int|null    $event_date_id  Event date ID.
+	 * @param string|null $tag            Optional tag label.
 	 * @return int|false The entry ID on success, false on failure.
 	 */
-	public static function create( $amount, $entry_type, $entry_date, $description = null, $budget_id = null, $transaction_id = null, $event_url = null, $event_date_id = null ) {
+	public static function create( $amount, $entry_type, $entry_date, $description = null, $budget_id = null, $transaction_id = null, $event_url = null, $event_date_id = null, $tag = null ) {
 		global $wpdb;
 
 		$table_name = self::get_table_name();
@@ -553,9 +581,10 @@ class FinancialEntry {
 			'transaction_id' => $transaction_id ? (int) $transaction_id : null,
 			'event_url'      => $event_url ? $event_url : null,
 			'event_date_id'  => $event_date_id ? (int) $event_date_id : null,
+			'tag'            => $tag ? sanitize_text_field( $tag ) : null,
 		);
 
-		$format = array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d' );
+		$format = array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d', '%s' );
 
 		$result = $wpdb->insert( $table_name, $data, $format );
 
@@ -578,9 +607,10 @@ class FinancialEntry {
 	 * @param int|null    $transaction_id Transaction ID.
 	 * @param string|null $event_url      Event URL.
 	 * @param int|null    $event_date_id  Event date ID.
+	 * @param string|null $tag            Optional tag label.
 	 * @return bool True on success, false on failure.
 	 */
-	public static function update( $id, $amount, $entry_type, $entry_date, $description = null, $budget_id = null, $transaction_id = null, $event_url = null, $event_date_id = null ) {
+	public static function update( $id, $amount, $entry_type, $entry_date, $description = null, $budget_id = null, $transaction_id = null, $event_url = null, $event_date_id = null, $tag = null ) {
 		global $wpdb;
 
 		$table_name = self::get_table_name();
@@ -599,9 +629,10 @@ class FinancialEntry {
 			'transaction_id' => $transaction_id ? (int) $transaction_id : null,
 			'event_url'      => $event_url ? $event_url : null,
 			'event_date_id'  => $event_date_id ? (int) $event_date_id : null,
+			'tag'            => $tag ? sanitize_text_field( $tag ) : null,
 		);
 
-		$format = array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d' );
+		$format = array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d', '%s' );
 
 		$result = $wpdb->update(
 			$table_name,
@@ -916,16 +947,17 @@ class FinancialEntry {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->query( 'START TRANSACTION' );
 
-		// Clear budget, event_url, and event_date_id on parent — they are now on the children.
+		// Clear budget, event_url, event_date_id, and tag on parent — they are now on the children.
 		$wpdb->update(
 			$table_name,
 			array(
 				'budget_id'     => null,
 				'event_url'     => null,
 				'event_date_id' => null,
+				'tag'           => null,
 			),
 			array( 'id' => $id ),
-			array( '%d', '%s', '%d' ),
+			array( '%d', '%s', '%d', '%s' ),
 			array( '%d' )
 		);
 
@@ -942,9 +974,10 @@ class FinancialEntry {
 				'parent_entry_id' => $id,
 				'event_url'       => ! empty( $allocation['event_url'] ) ? $allocation['event_url'] : null,
 				'event_date_id'   => ! empty( $allocation['event_date_id'] ) ? (int) $allocation['event_date_id'] : null,
+				'tag'             => ! empty( $allocation['tag'] ) ? sanitize_text_field( $allocation['tag'] ) : $entry->tag,
 			);
 
-			$format = array( '%f', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%d' );
+			$format = array( '%f', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%d', '%s' );
 
 			$result = $wpdb->insert( $table_name, $data, $format );
 
@@ -990,16 +1023,17 @@ class FinancialEntry {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->query( 'START TRANSACTION' );
 
-		// Ensure parent has no budget, event_url, or event_date_id — they are on the children.
+		// Ensure parent has no budget, event_url, event_date_id, or tag — they are on the children.
 		$wpdb->update(
 			$table_name,
 			array(
 				'budget_id'     => null,
 				'event_url'     => null,
 				'event_date_id' => null,
+				'tag'           => null,
 			),
 			array( 'id' => $id ),
-			array( '%d', '%s', '%d' ),
+			array( '%d', '%s', '%d', '%s' ),
 			array( '%d' )
 		);
 
@@ -1030,9 +1064,10 @@ class FinancialEntry {
 				'parent_entry_id' => $id,
 				'event_url'       => ! empty( $allocation['event_url'] ) ? $allocation['event_url'] : null,
 				'event_date_id'   => ! empty( $allocation['event_date_id'] ) ? (int) $allocation['event_date_id'] : null,
+				'tag'             => ! empty( $allocation['tag'] ) ? sanitize_text_field( $allocation['tag'] ) : $entry->tag,
 			);
 
-			$format = array( '%f', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%d' );
+			$format = array( '%f', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%d', '%s' );
 
 			$result = $wpdb->insert( $table_name, $data, $format );
 
@@ -1065,12 +1100,15 @@ class FinancialEntry {
 	 * @param string|null $event_url         Event URL.
 	 * @param int|null    $event_date_id     Event date ID.
 	 * @param int|null    $participant_id    Participant ID.
+	 * @param string|null $tag               Optional tag label.
 	 * @return int|false The parent entry ID on success, false on failure.
 	 */
-	public static function create_transfer( $amount, $entry_date, $source_budget_id, $target_budget_id, $description = null, $event_url = null, $event_date_id = null, $participant_id = null ) {
+	public static function create_transfer( $amount, $entry_date, $source_budget_id, $target_budget_id, $description = null, $event_url = null, $event_date_id = null, $participant_id = null, $tag = null ) {
 		global $wpdb;
 
 		$table_name = self::get_table_name();
+
+		$tag = $tag ? sanitize_text_field( $tag ) : null;
 
 		// Start transaction.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -1083,9 +1121,10 @@ class FinancialEntry {
 			'entry_date'     => $entry_date,
 			'description'    => $description,
 			'participant_id' => $participant_id ? (int) $participant_id : null,
+			'tag'            => $tag,
 		);
 
-		$result = $wpdb->insert( $table_name, $parent_data, array( '%f', '%s', '%s', '%s', '%d' ) );
+		$result = $wpdb->insert( $table_name, $parent_data, array( '%f', '%s', '%s', '%s', '%d', '%s' ) );
 
 		if ( ! $result ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -1105,9 +1144,10 @@ class FinancialEntry {
 			'parent_entry_id' => $parent_id,
 			'event_url'       => $event_url ? $event_url : null,
 			'event_date_id'   => $event_date_id ? (int) $event_date_id : null,
+			'tag'             => $tag,
 		);
 
-		$result = $wpdb->insert( $table_name, $cost_data, array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d' ) );
+		$result = $wpdb->insert( $table_name, $cost_data, array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d', '%s' ) );
 
 		if ( ! $result ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -1125,9 +1165,10 @@ class FinancialEntry {
 			'parent_entry_id' => $parent_id,
 			'event_url'       => $event_url ? $event_url : null,
 			'event_date_id'   => $event_date_id ? (int) $event_date_id : null,
+			'tag'             => $tag,
 		);
 
-		$result = $wpdb->insert( $table_name, $income_data, array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d' ) );
+		$result = $wpdb->insert( $table_name, $income_data, array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d', '%s' ) );
 
 		if ( ! $result ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -1155,12 +1196,15 @@ class FinancialEntry {
 	 * @param string|null $event_url         Event URL.
 	 * @param int|null    $event_date_id     Event date ID.
 	 * @param int|null    $participant_id    Participant ID.
+	 * @param string|null $tag               Optional tag label.
 	 * @return bool True on success, false on failure.
 	 */
-	public static function update_transfer( $id, $amount, $entry_date, $source_budget_id, $target_budget_id, $description = null, $event_url = null, $event_date_id = null, $participant_id = null ) {
+	public static function update_transfer( $id, $amount, $entry_date, $source_budget_id, $target_budget_id, $description = null, $event_url = null, $event_date_id = null, $participant_id = null, $tag = null ) {
 		global $wpdb;
 
 		$table_name = self::get_table_name();
+
+		$tag = $tag ? sanitize_text_field( $tag ) : null;
 
 		// Validate the entry exists and is a transfer.
 		$entry = self::get_by_id( $id );
@@ -1185,9 +1229,10 @@ class FinancialEntry {
 				'entry_date'     => $entry_date,
 				'description'    => $description,
 				'participant_id' => $participant_id ? (int) $participant_id : null,
+				'tag'            => $tag,
 			),
 			array( 'id' => $id ),
-			array( '%f', '%s', '%s', '%d' ),
+			array( '%f', '%s', '%s', '%d', '%s' ),
 			array( '%d' )
 		);
 
@@ -1220,9 +1265,10 @@ class FinancialEntry {
 			'parent_entry_id' => $id,
 			'event_url'       => $event_url ? $event_url : null,
 			'event_date_id'   => $event_date_id ? (int) $event_date_id : null,
+			'tag'             => $tag,
 		);
 
-		$result = $wpdb->insert( $table_name, $cost_data, array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d' ) );
+		$result = $wpdb->insert( $table_name, $cost_data, array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d', '%s' ) );
 
 		if ( ! $result ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -1240,9 +1286,10 @@ class FinancialEntry {
 			'parent_entry_id' => $id,
 			'event_url'       => $event_url ? $event_url : null,
 			'event_date_id'   => $event_date_id ? (int) $event_date_id : null,
+			'tag'             => $tag,
 		);
 
-		$result = $wpdb->insert( $table_name, $income_data, array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d' ) );
+		$result = $wpdb->insert( $table_name, $income_data, array( '%f', '%s', '%s', '%s', '%d', '%d', '%s', '%d', '%s' ) );
 
 		if ( ! $result ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -1328,6 +1375,77 @@ class FinancialEntry {
 	}
 
 	/**
+	 * Get distinct tags from all entries
+	 *
+	 * @return string[] Array of unique tags.
+	 */
+	public static function get_distinct_tags() {
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		$results = $wpdb->get_col(
+			$wpdb->prepare(
+				'SELECT DISTINCT tag FROM %i WHERE tag IS NOT NULL ORDER BY tag ASC',
+				$table_name
+			)
+		);
+
+		return $results ? $results : array();
+	}
+
+	/**
+	 * Get totals grouped by tag
+	 *
+	 * @return array Array with tag as key and totals as value.
+	 */
+	public static function get_totals_by_tag() {
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		// Exclude parent entries that have children (to avoid double-counting splits).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT tag, entry_type, SUM(amount) as total, COUNT(*) as count FROM %i WHERE id NOT IN (SELECT DISTINCT parent_entry_id FROM %i WHERE parent_entry_id IS NOT NULL) GROUP BY tag, entry_type',
+				$table_name,
+				$table_name
+			)
+		);
+
+		$stats = array();
+
+		foreach ( $results as $row ) {
+			$tag_key = null === $row->tag ? 'untagged' : $row->tag;
+
+			if ( ! isset( $stats[ $tag_key ] ) ) {
+				$stats[ $tag_key ] = array(
+					'total_cost'   => 0.0,
+					'total_income' => 0.0,
+					'cost_count'   => 0,
+					'income_count' => 0,
+				);
+			}
+
+			if ( 'cost' === $row->entry_type ) {
+				$stats[ $tag_key ]['total_cost'] = (float) $row->total;
+				$stats[ $tag_key ]['cost_count'] = (int) $row->count;
+			} elseif ( 'income' === $row->entry_type ) {
+				$stats[ $tag_key ]['total_income'] = (float) $row->total;
+				$stats[ $tag_key ]['income_count'] = (int) $row->count;
+			}
+		}
+
+		foreach ( $stats as $key => $data ) {
+			$stats[ $key ]['balance']     = $data['total_income'] - $data['total_cost'];
+			$stats[ $key ]['total_count'] = $data['cost_count'] + $data['income_count'];
+		}
+
+		return $stats;
+	}
+
+	/**
 	 * Hydrate an entry object from a database row
 	 *
 	 * @param object $row Database row.
@@ -1347,6 +1465,7 @@ class FinancialEntry {
 		$entry->event_url          = isset( $row->event_url ) ? $row->event_url : null;
 		$entry->event_date_id      = isset( $row->event_date_id ) && $row->event_date_id ? (int) $row->event_date_id : null;
 		$entry->participant_id     = isset( $row->participant_id ) && $row->participant_id ? (int) $row->participant_id : null;
+		$entry->tag                = isset( $row->tag ) ? $row->tag : null;
 		$entry->import_source      = isset( $row->import_source ) ? $row->import_source : null;
 		$entry->imported_at        = isset( $row->imported_at ) ? $row->imported_at : null;
 		$entry->created_at         = $row->created_at;
@@ -1380,6 +1499,7 @@ class FinancialEntry {
 			'event_url'          => $this->event_url,
 			'event_date_id'      => $this->event_date_id,
 			'participant_id'     => $this->participant_id,
+			'tag'                => $this->tag,
 			'import_source'      => $this->import_source,
 			'imported_at'        => $this->imported_at,
 			'created_at'         => $this->created_at,


### PR DESCRIPTION
Closes #726.

## Summary

- **DB**: adds `tag varchar(100) DEFAULT NULL` column + `KEY tag (tag)` index to `fair_payment_financial_entries` via `dbDelta` — no separate migration function; applied automatically on next plugin activation
- **Model** (`FinancialEntry.php`): `$tag` property threaded through `create()`, `update()`, `get_filtered()`, `get_totals()`, `split_entry()`, `update_split()`, `create_transfer()`, `update_transfer()`; new `get_distinct_tags()` and `get_totals_by_tag()` static methods
- **Controller** (`FinancialEntryController.php`): new `GET .../tags` and `GET .../totals-by-tag` routes (both behind `get_items_permissions_check`); `tag` added to filter params, create/update args, and transfer args
- **Frontend**: new `TagField.js` autocomplete component; new `TagChart.js` plain-SVG grouped bar chart (cost vs income per tag); tag field added to `EntryForm`; tag filter `SelectControl` and chart added to `EntriesApp`
- **Tests**: Playwright API spec (`FinancialEntryTagRoutes.api.spec.js`) covering the two new routes + filter + auth; 6-test RTL suite for `TagField`; `jest.config.js` updated with `@babel/preset-react` to support JSX in tests

No feature flag — tag field is always-on as per the updated issue comment.

## Test plan

- [ ] Activate the plugin and verify `SHOW COLUMNS FROM fair_payment_financial_entries LIKE 'tag'` returns the column
- [ ] Create an entry with a tag; confirm it round-trips through edit and re-appears after save
- [ ] `GET /wp-json/fair-finance/v1/financial-entries/tags` returns the tag
- [ ] `GET /wp-json/fair-finance/v1/financial-entries/totals-by-tag` returns per-tag cost/income/balance
- [ ] Tag filter in the entries list shows only matching entries
- [ ] Tag chart renders for entries that have tags set
- [ ] `npm run test:js` passes in `fair-finance/`
- [ ] `vendor/bin/phpcs fair-finance/src/` reports no errors