### PR TITLE
Add fair-finance to local deploy plugin list

### DIFF
--- a/scripts/deploy-local.js
+++ b/scripts/deploy-local.js
@@ -37,6 +37,7 @@ const ALL_PLUGINS = [
 	'fair-payments-connector',
 	'fair-audience',
 	'fair-timetable',
+	'fair-finance',
 ];
 const MAX_ATTEMPTS = 2;
 


### PR DESCRIPTION
## Summary

- Adds `fair-finance` to `ALL_PLUGINS` in `scripts/deploy-local.js` so it is included when running `npm run deploy:local` with `PLUGINS_TO_DEPLOY=all`.

The CI workflow (`deploy-to-environment.yml`) and `compose.yml` already included `fair-finance`; this was the only remaining gap.

## Test plan

- [ ] Run `npm run deploy:local -- --env=<env> --dry-run` and confirm `fair-finance` appears in the list of plugins to deploy.