### PR TITLE
feat: add fair-events-experimental plugin for internal feature bundles

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,6 +40,7 @@ jobs:
                       ./fair-audience/vendor
                       ./fair-timetable/vendor
                       ./fair-finance/vendor
+                      ./fair-events-experimental/vendor
                       ./vendor
                   key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
                   restore-keys: |
@@ -62,6 +63,7 @@ jobs:
                       ./fair-audience/node_modules
                       ./fair-timetable/node_modules
                       ./fair-finance/node_modules
+                      ./fair-events-experimental/node_modules
                       ./fair-events-shared/node_modules
                   key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
 

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -96,7 +96,7 @@ jobs:
                   fi
 
                   if [ "$PLUGINS_TO_DEPLOY" = "all" ]; then
-                    PLUGINS="fair-events fair-payments-connector fair-audience fair-timetable fair-finance"
+                    PLUGINS="fair-events fair-payments-connector fair-audience fair-timetable fair-finance fair-events-experimental"
                   else
                     # Convert comma-separated list to space-separated
                     PLUGINS=$(echo "$PLUGINS_TO_DEPLOY" | tr ',' ' ')

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,7 @@ on:
         paths:
             - 'fair-payments-connector/**'
             - 'fair-events/**'
+            - 'fair-events-experimental/**'
             - 'fair-audience/**'
             - 'fair-platform/**'
             - 'fair-events-shared/**'
@@ -21,6 +22,7 @@ on:
         paths:
             - 'fair-payments-connector/**'
             - 'fair-events/**'
+            - 'fair-events-experimental/**'
             - 'fair-audience/**'
             - 'fair-platform/**'
             - 'fair-events-shared/**'
@@ -49,6 +51,7 @@ jobs:
                   path: |
                       ./fair-payments-connector/vendor
                       ./fair-events/vendor
+                      ./fair-events-experimental/vendor
                       ./fair-platform/vendor
                       ./fair-audience/vendor
                       ./vendor
@@ -68,6 +71,7 @@ jobs:
                   path: |
                       ./node_modules
                       ./fair-events/node_modules
+                      ./fair-events-experimental/node_modules
                       ./fair-payments-connector/node_modules
                       ./fair-platform/node_modules
                       ./fair-audience/node_modules

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,6 +4,7 @@
 	"plugins": [
 		"./fair-payments-connector",
 		"./fair-events",
+		"./fair-events-experimental",
 		"./fair-audience",
 		"./fair-platform"
 	],

--- a/compose.yml
+++ b/compose.yml
@@ -17,6 +17,7 @@ services:
             - ./fair-audience:/var/www/html/wp-content/plugins/fair-audience
             - ./fair-timetable:/var/www/html/wp-content/plugins/fair-timetable
             - ./fair-finance:/var/www/html/wp-content/plugins/fair-finance
+            - ./fair-events-experimental:/var/www/html/wp-content/plugins/fair-events-experimental
             - ./uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
 
     db:
@@ -53,6 +54,7 @@ services:
             - ./fair-audience:/var/www/html/wp-content/plugins/fair-audience
             - ./fair-timetable:/var/www/html/wp-content/plugins/fair-timetable
             - ./fair-finance:/var/www/html/wp-content/plugins/fair-finance
+            - ./fair-events-experimental:/var/www/html/wp-content/plugins/fair-events-experimental
 
         environment:
             WORDPRESS_DB_HOST: db

--- a/e2e/fair-events-admin-menu.spec.js
+++ b/e2e/fair-events-admin-menu.spec.js
@@ -30,11 +30,11 @@ function wpCli(args) {
 }
 
 /**
- * Turn every #654 feature bundle on. This suite covers the #656 menu/CPT
- * decoupling, which assumes the full page inventory exists — bundle gating
- * lives in `fair-events-feature-flags.spec.js`.
+ * Turn every feature bundle on. These bundles now live in fair-events-experimental.
+ * This suite covers the #656 menu/CPT decoupling — bundle gating lives in
+ * `fair-events-feature-flags.spec.js`.
  */
-const ALL_BUNDLES_ON = {
+const ALL_EXPERIMENTAL_BUNDLES_ON = {
 	venues: true,
 	sources: true,
 	galleries: true,
@@ -43,11 +43,16 @@ const ALL_BUNDLES_ON = {
 	migration: true,
 };
 function enableAllBundles() {
-	const json = JSON.stringify(ALL_BUNDLES_ON).replace(/'/g, "'\\''");
-	wpCli(`option update fair_events_features '${json}' --format=json`);
+	const json = JSON.stringify(ALL_EXPERIMENTAL_BUNDLES_ON).replace(
+		/'/g,
+		"'\\''"
+	);
+	wpCli(
+		`option update fair_events_experimental_features '${json}' --format=json`
+	);
 }
 function clearBundles() {
-	wpCli('option delete fair_events_features');
+	wpCli('option delete fair_events_experimental_features');
 }
 
 /** Every Fair Events admin page and its React root element id. */
@@ -120,7 +125,7 @@ test.describe('Fair Events admin menu — CPT registered (regression)', () => {
 		clearBundles();
 	});
 
-	test('one top-level Fair Events menu, Calendar first and Settings last', async ({
+	test('one top-level Fair Events menu, Calendar first and Settings present', async ({
 		page,
 	}) => {
 		await login(page);
@@ -140,7 +145,7 @@ test.describe('Fair Events admin menu — CPT registered (regression)', () => {
 			.filter(Boolean);
 
 		expect(labels[0]).toBe('Calendar');
-		expect(labels[labels.length - 1]).toBe('Settings');
+		expect(labels).toContain('Settings');
 	});
 
 	test('CPT-only menu items are present when the Events post type is on', async ({

--- a/e2e/fair-events-feature-flags.spec.js
+++ b/e2e/fair-events-feature-flags.spec.js
@@ -36,18 +36,20 @@ function wpCli(args) {
 	});
 }
 
-/** Set the `fair_events_features` option to a `{bundle: bool}` map. */
-function setFeatures(map) {
+/** Set the `fair_events_experimental_features` option to a `{bundle: bool}` map. */
+function setExperimentalFeatures(map) {
 	const json = JSON.stringify(map).replace(/'/g, "'\\''");
-	wpCli(`option update fair_events_features '${json}' --format=json`);
+	wpCli(
+		`option update fair_events_experimental_features '${json}' --format=json`
+	);
 }
 
-/** Clear the option entirely — minimal-public defaults. */
-function clearFeatures() {
-	wpCli('option delete fair_events_features');
+/** Clear the experimental features option — restores all-on defaults. */
+function clearExperimentalFeatures() {
+	wpCli('option delete fair_events_experimental_features');
 }
 
-/** Bundle keys mirror FairEvents\\Core\\Features::registry(). */
+/** Bundle keys mirror FairEventsExperimental\\Core\\Features::registry(). */
 const ALL_BUNDLES_ON = {
 	venues: true,
 	sources: true,
@@ -55,6 +57,15 @@ const ALL_BUNDLES_ON = {
 	ticketing: true,
 	'event-tools': true,
 	migration: true,
+};
+
+const ALL_BUNDLES_OFF = {
+	venues: false,
+	sources: false,
+	galleries: false,
+	ticketing: false,
+	'event-tools': false,
+	migration: false,
 };
 
 /**
@@ -151,7 +162,11 @@ async function routeIsRegistered(request, path) {
 
 test.describe('Fair Events — simplified public build (no bundles set)', () => {
 	test.beforeAll(() => {
-		clearFeatures();
+		setExperimentalFeatures(ALL_BUNDLES_OFF);
+	});
+
+	test.afterAll(() => {
+		clearExperimentalFeatures();
 	});
 
 	test('only core admin pages mount; bundle pages are gone', async ({
@@ -204,13 +219,13 @@ test.describe('Fair Events — simplified public build (no bundles set)', () => 
 
 test.describe('Fair Events — full internal build (all bundles on)', () => {
 	test.beforeAll(() => {
-		setFeatures(ALL_BUNDLES_ON);
+		setExperimentalFeatures(ALL_BUNDLES_ON);
 	});
 
 	test.afterAll(() => {
 		// Leave the suite in the minimal-public default so other suites
 		// inherit a clean baseline.
-		clearFeatures();
+		clearExperimentalFeatures();
 	});
 
 	test('every bundle page mounts its React root', async ({ page }) => {

--- a/fair-events-experimental/composer.json
+++ b/fair-events-experimental/composer.json
@@ -1,0 +1,25 @@
+{
+	"name": "fair-event-plugins/fair-events-experimental",
+	"description": "Experimental feature bundles extension for Fair Events",
+	"type": "wordpress-plugin",
+	"license": "GPL-3.0-or-later",
+	"authors": [
+		{
+			"name": "Marcin Wosinek",
+			"email": "marcin.wosinek@gmail.com"
+		}
+	],
+	"require": {
+		"php": ">=8.0 <9.0"
+	},
+	"config": {
+		"platform": {
+			"php": "8.3"
+		}
+	},
+	"autoload": {
+		"psr-4": {
+			"FairEventsExperimental\\": "src/"
+		}
+	}
+}

--- a/fair-events-experimental/composer.lock
+++ b/fair-events-experimental/composer.lock
@@ -1,0 +1,23 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "2b9116f957cee496195a600c727f1491",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.0 <9.0"
+    },
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.3"
+    },
+    "plugin-api-version": "2.9.0"
+}

--- a/fair-events-experimental/fair-events-experimental.php
+++ b/fair-events-experimental/fair-events-experimental.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Plugin Name: Fair Events Experimental
+ * Plugin URI: https://github.com/marcin-wosinek/fair-event-plugins
+ * Description: Activates advanced feature bundles for Fair Events (galleries, sources, ticketing, event-tools, migration, venues). Requires fair-events.
+ * Version: 0.1.0
+ * Requires at least: 6.7
+ * Requires PHP: 8.0
+ * Requires Plugins: fair-events
+ * Author: Marcin Wosinek
+ * Author URI: https://github.com/marcin-wosinek
+ * License: GPLv3 or later
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ * Text Domain: fair-events-experimental
+ * Domain Path: /languages
+ *
+ * @package FairEventsExperimental
+ */
+
+namespace FairEventsExperimental;
+
+defined( 'ABSPATH' ) || die;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+// Defer bootstrap to plugins_loaded so fair-events (loaded alphabetically after
+// fair-events-experimental) has already been included and FAIR_EVENTS_VERSION is defined.
+add_action(
+	'plugins_loaded',
+	function () {
+		// Runtime guard: deactivate gracefully when fair-events is not active.
+		if ( ! defined( 'FAIR_EVENTS_VERSION' ) ) {
+			add_action(
+				'admin_notices',
+				function () {
+					echo '<div class="notice notice-error"><p>'
+						. esc_html__( 'Fair Events Experimental requires the Fair Events plugin to be active.', 'fair-events-experimental' )
+						. '</p></div>';
+				}
+			);
+			// Deactivate self if called during activation.
+			if ( isset( $_GET['activate'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				add_action(
+					'admin_init',
+					function () {
+						deactivate_plugins( plugin_basename( __FILE__ ) );
+					}
+				);
+			}
+			return;
+		}
+
+		define( 'FAIR_EVENTS_EXPERIMENTAL_VERSION', '0.1.0' );
+		define( 'FAIR_EVENTS_EXPERIMENTAL_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+		define( 'FAIR_EVENTS_EXPERIMENTAL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+		\FairEventsExperimental\Core\Plugin::instance()->init();
+	},
+	5
+);

--- a/fair-events-experimental/package.json
+++ b/fair-events-experimental/package.json
@@ -1,0 +1,41 @@
+{
+	"name": "fair-events-experimental",
+	"version": "0.1.0",
+	"description": "Fair Events Experimental WordPress plugin",
+	"license": "GPL-3.0-or-later",
+	"author": "Marcin Wosinek",
+	"type": "module",
+	"main": "build/index.js",
+	"scripts": {
+		"build": "wp-scripts build --config webpack.config.cjs; npm run makejson || true",
+		"clean": "rm -rf build",
+		"prebuild": "npm run clean",
+		"start": "wp-scripts start",
+		"format": "wp-scripts format",
+		"composer:install": "composer install",
+		"composer:install:prod": "composer install --no-dev",
+		"composer:update": "composer update",
+		"composer:validate": "composer validate --strict",
+		"makepot": "wp i18n make-pot . languages/fair-events-experimental.pot --exclude=node_modules,vendor,tests,build,svn",
+		"makejson": "wp i18n make-json languages ./build/languages --domain=fair-events-experimental --pretty-print --no-purge --use-map=build/map.json",
+		"makemo": "wp i18n make-mo languages/",
+		"updatepo": "wp i18n update-po languages/fair-events-experimental.pot languages/",
+		"test": "npm-run-all test:js",
+		"test:js": "jest --passWithNoTests"
+	},
+	"dependencies": {
+		"@wordpress/api-fetch": "^7.2.0",
+		"@wordpress/components": "^30.2.0",
+		"@wordpress/element": "^6.2.0",
+		"@wordpress/i18n": "^6.2.0"
+	},
+	"devDependencies": {
+		"@babel/core": "^7.28.3",
+		"@babel/preset-env": "^7.28.3",
+		"@wordpress/scripts": "^32.4.0",
+		"babel-jest": "^30.0.5",
+		"jest": "^30.0.0",
+		"npm-run-all": "^4.1.5",
+		"webpack-bundle-output": "^1.1.0"
+	}
+}

--- a/fair-events-experimental/readme.txt
+++ b/fair-events-experimental/readme.txt
@@ -1,0 +1,29 @@
+=== Fair Events Experimental ===
+Contributors: marcinwosinek
+Tags: events, experimental
+Requires at least: 6.7
+Tested up to: 6.7
+Stable tag: 0.1.0
+Requires PHP: 8.0
+License: GPLv3 or later
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
+
+Activates advanced feature bundles for Fair Events: galleries, sources, ticketing, event-tools, migration, venues.
+
+== Description ==
+
+This plugin is a companion to Fair Events. It activates six advanced feature bundles that are excluded from the public Fair Events build:
+
+* **Galleries** — Per-event photo galleries, photo likes/downloads, image exports.
+* **Event sources & feeds** — External event sources, iCal/JSON feeds, event proposals.
+* **Ticketing** — Tickets, group pricing/permission rules, invitations.
+* **Event tools** — Event duplication, merge, and admin-bar Copy button.
+* **Migration** — One-time post → event migration tooling.
+* **Venues** — Venues admin page.
+
+Requires Fair Events to be active.
+
+== Changelog ==
+
+= 0.1.0 =
+* Initial release — moves internal feature bundles out of fair-events.

--- a/fair-events-experimental/src/Admin/AdminPages.php
+++ b/fair-events-experimental/src/Admin/AdminPages.php
@@ -1,0 +1,454 @@
+<?php
+/**
+ * Admin Pages for Fair Events Experimental
+ *
+ * Registers the experimental feature admin pages (migration, sources, venues,
+ * invitations, copy, settings) as submenus under the fair-events-calendar menu.
+ * Page rendering and JS assets are delegated to the fair-events plugin; only
+ * the settings page uses assets from this plugin's own build directory.
+ *
+ * @package FairEventsExperimental
+ */
+
+namespace FairEventsExperimental\Admin;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Admin Pages class for registering experimental admin menu pages
+ */
+class AdminPages {
+	/**
+	 * Map of page slug => admin page hook name.
+	 *
+	 * @var array<string,string>
+	 */
+	private $page_hooks = array();
+
+	/**
+	 * Parent menu slug (owned by fair-events).
+	 *
+	 * @return string
+	 */
+	private function get_menu_parent_slug() {
+		return 'fair-events-calendar';
+	}
+
+	/**
+	 * Initialize admin pages
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action( 'admin_menu', array( $this, 'register_admin_pages' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+	}
+
+	/**
+	 * Register admin menu pages
+	 *
+	 * @return void
+	 */
+	public function register_admin_pages() {
+		$parent = $this->get_menu_parent_slug();
+
+		// Settings page for experimental feature toggles.
+		$this->page_hooks['fair-events-experimental-settings'] = add_submenu_page(
+			$parent,
+			__( 'Experimental Settings', 'fair-events-experimental' ),
+			__( 'Experimental', 'fair-events-experimental' ),
+			'manage_options',
+			'fair-events-experimental-settings',
+			array( $this, 'render_settings_page' )
+		);
+
+		// Migration pages — `migration` bundle.
+		if ( \FairEventsExperimental\Core\Features::is_enabled( 'migration' ) && post_type_exists( 'fair_event' ) ) {
+			$this->page_hooks['fair-events-migration'] = add_submenu_page(
+				$parent,
+				__( 'Migrate Posts to Events', 'fair-events-experimental' ),
+				__( 'Migrate Posts', 'fair-events-experimental' ),
+				'manage_options',
+				'fair-events-migration',
+				array( $this, 'render_migration_page' )
+			);
+
+			$this->page_hooks['fair-events-migration-summary'] = add_submenu_page(
+				$parent,
+				__( 'Migration Summary', 'fair-events-experimental' ),
+				__( 'Migration Summary', 'fair-events-experimental' ),
+				'manage_options',
+				'fair-events-migration-summary',
+				array( $this, 'render_migration_summary_page' )
+			);
+		}
+
+		// Event Sources page — `sources` bundle.
+		if ( \FairEventsExperimental\Core\Features::is_enabled( 'sources' ) ) {
+			$this->page_hooks['fair-events-sources'] = add_submenu_page(
+				$parent,
+				__( 'Event Sources', 'fair-events-experimental' ),
+				__( 'Event Sources', 'fair-events-experimental' ),
+				'manage_options',
+				'fair-events-sources',
+				array( $this, 'render_sources_page' )
+			);
+
+			$this->page_hooks['fair-events-source-view'] = add_submenu_page(
+				'',
+				__( 'View Source', 'fair-events-experimental' ),
+				__( 'View Source', 'fair-events-experimental' ),
+				'manage_options',
+				'fair-events-source-view',
+				array( $this, 'render_source_view_page' )
+			);
+
+			$this->set_hidden_page_title( $this->page_hooks['fair-events-source-view'], __( 'View Source', 'fair-events-experimental' ) );
+		}
+
+		// Venues page — `venues` bundle.
+		if ( \FairEventsExperimental\Core\Features::is_enabled( 'venues' ) ) {
+			$this->page_hooks['fair-events-venues'] = add_submenu_page(
+				$parent,
+				__( 'Venues', 'fair-events-experimental' ),
+				__( 'Venues', 'fair-events-experimental' ),
+				'manage_options',
+				'fair-events-venues',
+				array( $this, 'render_venues_page' )
+			);
+		}
+
+		// Manage Invitations page — `ticketing` bundle (hidden).
+		if ( \FairEventsExperimental\Core\Features::is_enabled( 'ticketing' ) ) {
+			$this->page_hooks['fair-events-manage-invitations'] = add_submenu_page(
+				'',
+				__( 'Manage Invitations', 'fair-events-experimental' ),
+				__( 'Manage Invitations', 'fair-events-experimental' ),
+				'manage_options',
+				'fair-events-manage-invitations',
+				array( $this, 'render_manage_invitations_page' )
+			);
+
+			$this->set_hidden_page_title( $this->page_hooks['fair-events-manage-invitations'], __( 'Manage Invitations', 'fair-events-experimental' ) );
+		}
+
+		// Copy Event page — `event-tools` bundle (hidden).
+		if ( \FairEventsExperimental\Core\Features::is_enabled( 'event-tools' ) ) {
+			$this->page_hooks['fair-events-copy'] = add_submenu_page(
+				'',
+				__( 'Copy Event', 'fair-events-experimental' ),
+				__( 'Copy Event', 'fair-events-experimental' ),
+				'edit_posts',
+				'fair-events-copy',
+				array( $this, 'render_copy_event_page' )
+			);
+
+			$this->set_hidden_page_title( $this->page_hooks['fair-events-copy'], __( 'Copy Event', 'fair-events-experimental' ) );
+
+			add_action( 'load-' . $this->page_hooks['fair-events-copy'], array( $this, 'handle_copy_event_submission' ) );
+
+			add_action( 'admin_bar_menu', array( $this, 'add_copy_button_to_admin_bar' ), 100 );
+		}
+	}
+
+	/**
+	 * Set the page title for a hidden admin page.
+	 *
+	 * @param string $hookname  The page hook name returned by add_submenu_page().
+	 * @param string $page_title The title to set.
+	 * @return void
+	 */
+	private function set_hidden_page_title( $hookname, $page_title ) {
+		add_action(
+			'load-' . $hookname,
+			static function () use ( $page_title ) {
+				global $title;
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$title = $page_title;
+			}
+		);
+	}
+
+	/**
+	 * Enqueue admin scripts
+	 *
+	 * @param string $hook Current admin page hook.
+	 * @return void
+	 */
+	public function enqueue_admin_scripts( $hook ) {
+		$slug = array_search( $hook, $this->page_hooks, true );
+		if ( false === $slug ) {
+			return;
+		}
+
+		// Settings page uses this plugin's own build.
+		if ( 'fair-events-experimental-settings' === $slug ) {
+			$asset_file = include FAIR_EVENTS_EXPERIMENTAL_PLUGIN_DIR . 'build/admin/settings/index.asset.php';
+
+			wp_enqueue_script(
+				'fair-events-experimental-settings',
+				FAIR_EVENTS_EXPERIMENTAL_PLUGIN_URL . 'build/admin/settings/index.js',
+				$asset_file['dependencies'],
+				$asset_file['version'],
+				true
+			);
+
+			wp_localize_script(
+				'fair-events-experimental-settings',
+				'fairEventsExperimentalSettingsData',
+				array(
+					'features' => \FairEventsExperimental\Core\Features::all(),
+				)
+			);
+
+			wp_set_script_translations( 'fair-events-experimental-settings', 'fair-events-experimental' );
+			wp_enqueue_style( 'wp-components' );
+			return;
+		}
+
+		// All other pages load JS from the fair-events build directory.
+		$fe_url = FAIR_EVENTS_PLUGIN_URL;
+		$fe_dir = FAIR_EVENTS_PLUGIN_DIR;
+
+		switch ( $slug ) {
+			case 'fair-events-migration':
+				$asset_file = include $fe_dir . 'build/admin/migration/index.asset.php';
+				wp_enqueue_script( 'fair-events-migration', $fe_url . 'build/admin/migration/index.js', $asset_file['dependencies'], $asset_file['version'], true );
+				wp_set_script_translations( 'fair-events-migration', 'fair-events', \FairEvents\Core\Features::script_translations_path() );
+				wp_enqueue_style( 'wp-components' );
+				break;
+
+			case 'fair-events-migration-summary':
+				$asset_file = include $fe_dir . 'build/admin/migration-summary/index.asset.php';
+				wp_enqueue_script( 'fair-events-migration-summary', $fe_url . 'build/admin/migration-summary/index.js', $asset_file['dependencies'], $asset_file['version'], true );
+				wp_set_script_translations( 'fair-events-migration-summary', 'fair-events', \FairEvents\Core\Features::script_translations_path() );
+				wp_enqueue_style( 'wp-components' );
+				break;
+
+			case 'fair-events-sources':
+				$asset_file = include $fe_dir . 'build/admin/sources/index.asset.php';
+				wp_enqueue_script( 'fair-events-sources', $fe_url . 'build/admin/sources/index.js', $asset_file['dependencies'], $asset_file['version'], true );
+				wp_localize_script(
+					'fair-events-sources',
+					'fairEventsSourcesData',
+					array(
+						'icalUrlTemplate' => rest_url( 'fair-events/v1/sources/{slug}/ical' ),
+						'jsonUrlTemplate' => rest_url( 'fair-events/v1/sources/{slug}/json' ),
+					)
+				);
+				wp_set_script_translations( 'fair-events-sources', 'fair-events', \FairEvents\Core\Features::script_translations_path() );
+				wp_enqueue_style( 'wp-components' );
+				break;
+
+			case 'fair-events-source-view':
+				$asset_file     = include $fe_dir . 'build/admin/source-view/index.asset.php';
+				$calendar_asset = include $fe_dir . 'build/admin/calendar/index.asset.php';
+				wp_enqueue_script( 'fair-events-source-view', $fe_url . 'build/admin/source-view/index.js', $asset_file['dependencies'], $asset_file['version'], true );
+				wp_enqueue_style( 'fair-events-calendar', $fe_url . 'build/admin/calendar/style-index.css', array( 'wp-components' ), $calendar_asset['version'] );
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$source_id = isset( $_GET['source_id'] ) ? absint( $_GET['source_id'] ) : 0;
+				wp_localize_script(
+					'fair-events-source-view',
+					'fairEventsSourceViewData',
+					array(
+						'sourceId'        => $source_id,
+						'startOfWeek'     => (int) get_option( 'start_of_week', 1 ),
+						'sourcesListUrl'  => admin_url( 'admin.php?page=fair-events-sources' ),
+						'icalUrlTemplate' => rest_url( 'fair-events/v1/sources/{slug}/ical' ),
+						'jsonUrlTemplate' => rest_url( 'fair-events/v1/sources/{slug}/json' ),
+					)
+				);
+				wp_set_script_translations( 'fair-events-source-view', 'fair-events', \FairEvents\Core\Features::script_translations_path() );
+				break;
+
+			case 'fair-events-venues':
+				$asset_file = include $fe_dir . 'build/admin/venues/index.asset.php';
+				wp_enqueue_script( 'fair-events-venues', $fe_url . 'build/admin/venues/index.js', $asset_file['dependencies'], $asset_file['version'], true );
+				wp_set_script_translations( 'fair-events-venues', 'fair-events', \FairEvents\Core\Features::script_translations_path() );
+				wp_enqueue_style( 'wp-components' );
+				break;
+
+			case 'fair-events-manage-invitations':
+				$asset_file = include $fe_dir . 'build/admin/manage-invitations/index.asset.php';
+				wp_enqueue_script( 'fair-events-manage-invitations', $fe_url . 'build/admin/manage-invitations/index.js', $asset_file['dependencies'], $asset_file['version'], true );
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$event_date_id   = isset( $_GET['event_date_id'] ) ? absint( $_GET['event_date_id'] ) : 0;
+				$signup_page_url = '';
+				if ( $event_date_id ) {
+					$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+					if ( $event_date && $event_date->event_id ) {
+						$signup_page_url = get_permalink( $event_date->event_id );
+					}
+				}
+				wp_localize_script(
+					'fair-events-manage-invitations',
+					'fairEventsManageInvitationsData',
+					array(
+						'eventDateId'    => $event_date_id,
+						'manageEventUrl' => admin_url( 'admin.php?page=fair-events-manage-event' ),
+						'signupPageUrl'  => $signup_page_url,
+					)
+				);
+				wp_set_script_translations( 'fair-events-manage-invitations', 'fair-events', \FairEvents\Core\Features::script_translations_path() );
+				wp_enqueue_style( 'wp-components' );
+				break;
+		}
+	}
+
+	/**
+	 * Render experimental settings page
+	 *
+	 * @return void
+	 */
+	public function render_settings_page() {
+		?>
+		<div id="fair-events-experimental-settings-root"></div>
+		<?php
+	}
+
+	/**
+	 * Render migration page
+	 *
+	 * @return void
+	 */
+	public function render_migration_page() {
+		?>
+		<div id="fair-events-migration-root"></div>
+		<?php
+	}
+
+	/**
+	 * Render migration summary page
+	 *
+	 * @return void
+	 */
+	public function render_migration_summary_page() {
+		?>
+		<div id="fair-events-migration-summary-root"></div>
+		<?php
+	}
+
+	/**
+	 * Render event sources page
+	 *
+	 * @return void
+	 */
+	public function render_sources_page() {
+		?>
+		<div id="fair-events-sources-root"></div>
+		<?php
+	}
+
+	/**
+	 * Render source view page
+	 *
+	 * @return void
+	 */
+	public function render_source_view_page() {
+		?>
+		<div id="fair-events-source-view-root"></div>
+		<?php
+	}
+
+	/**
+	 * Render venues page
+	 *
+	 * @return void
+	 */
+	public function render_venues_page() {
+		?>
+		<div id="fair-events-venues-root"></div>
+		<?php
+	}
+
+	/**
+	 * Render manage invitations page
+	 *
+	 * @return void
+	 */
+	public function render_manage_invitations_page() {
+		$manage_invitations_page = new \FairEvents\Admin\ManageInvitationsPage();
+		$manage_invitations_page->render();
+	}
+
+	/**
+	 * Handle copy event form submission
+	 *
+	 * @return void
+	 */
+	public function handle_copy_event_submission() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( ! isset( $_POST['copy_event_submit'] ) ) {
+			return;
+		}
+
+		$copy_page = new \FairEvents\Admin\CopyEventPage();
+		$copy_page->handle_submission();
+	}
+
+	/**
+	 * Render copy event page
+	 *
+	 * @return void
+	 */
+	public function render_copy_event_page() {
+		$copy_page = new \FairEvents\Admin\CopyEventPage();
+		$copy_page->render();
+	}
+
+	/**
+	 * Add Copy button to admin bar on event edit pages
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar The admin bar object.
+	 * @return void
+	 */
+	public function add_copy_button_to_admin_bar( $wp_admin_bar ) {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		if ( ! post_type_exists( 'fair_event' ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+		if ( ! $screen || 'fair_event' !== $screen->post_type || 'post' !== $screen->base ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
+		if ( ! $post_id ) {
+			return;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post || 'fair_event' !== $post->post_type ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+
+		$copy_url = add_query_arg(
+			array(
+				'page'     => 'fair-events-copy',
+				'event_id' => $post_id,
+				'_wpnonce' => wp_create_nonce( 'copy_fair_event_' . $post_id ),
+			),
+			admin_url( 'admin.php' )
+		);
+
+		$wp_admin_bar->add_node(
+			array(
+				'id'    => 'copy-event',
+				'title' => __( 'Copy', 'fair-events-experimental' ),
+				'href'  => $copy_url,
+				'meta'  => array(
+					'title' => __( 'Copy this event', 'fair-events-experimental' ),
+				),
+			)
+		);
+	}
+}

--- a/fair-events-experimental/src/Admin/settings/FeaturesTab.js
+++ b/fair-events-experimental/src/Admin/settings/FeaturesTab.js
@@ -1,0 +1,175 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import {
+	Button,
+	ToggleControl,
+	Card,
+	CardHeader,
+	CardBody,
+	Notice,
+} from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Features Tab Component for Fair Events Experimental.
+ *
+ * Per-bundle toggles backed by the `fair_events_experimental_features` option.
+ *
+ * @param {Object}   props          Props
+ * @param {Function} props.onNotice Handler for displaying notices
+ * @return {JSX.Element} The Features settings tab
+ */
+export default function FeaturesTab({ onNotice }) {
+	const registry = window.fairEventsExperimentalSettingsData?.features || {};
+	const [values, setValues] = useState({});
+	const [isLoading, setIsLoading] = useState(true);
+	const [isSaving, setIsSaving] = useState(false);
+
+	useEffect(() => {
+		apiFetch({ path: '/wp/v2/settings' })
+			.then((settings) => {
+				const stored = settings.fair_events_experimental_features || {};
+				const next = {};
+				Object.entries(registry).forEach(([key, meta]) => {
+					if (meta.always_on || meta.forced) {
+						next[key] = meta.enabled;
+					} else {
+						next[key] =
+							typeof stored[key] === 'boolean'
+								? stored[key]
+								: meta.enabled;
+					}
+				});
+				setValues(next);
+				setIsLoading(false);
+			})
+			.catch(() => {
+				onNotice({
+					status: 'error',
+					message: __(
+						'Failed to load features.',
+						'fair-events-experimental'
+					),
+				});
+				setIsLoading(false);
+			});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [onNotice]);
+
+	const handleToggle = (key, value) => {
+		setValues({ ...values, [key]: value });
+	};
+
+	const handleSave = () => {
+		const payload = {};
+		Object.entries(registry).forEach(([key, meta]) => {
+			if (meta.always_on || meta.forced) {
+				return;
+			}
+			payload[key] = !!values[key];
+		});
+
+		setIsSaving(true);
+		apiFetch({
+			path: '/wp/v2/settings',
+			method: 'POST',
+			data: { fair_events_experimental_features: payload },
+		})
+			.then(() => {
+				onNotice({
+					status: 'success',
+					message: __(
+						'Features saved. Reload the page to see admin-menu changes.',
+						'fair-events-experimental'
+					),
+				});
+				setIsSaving(false);
+			})
+			.catch(() => {
+				onNotice({
+					status: 'error',
+					message: __(
+						'Failed to save features.',
+						'fair-events-experimental'
+					),
+				});
+				setIsSaving(false);
+			});
+	};
+
+	if (isLoading) {
+		return (
+			<Card style={{ marginTop: '16px' }}>
+				<CardBody>
+					<p>
+						{__('Loading features...', 'fair-events-experimental')}
+					</p>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	const entries = Object.entries(registry);
+
+	return (
+		<Card style={{ marginTop: '16px' }}>
+			<CardHeader>
+				<h2>{__('Feature Bundles', 'fair-events-experimental')}</h2>
+			</CardHeader>
+			<CardBody>
+				<p className="description">
+					{__(
+						'Toggle optional experimental feature bundles. Bundles fixed in wp-config (FAIR_EVENTS_EXPERIMENTAL_INTERNAL or FAIR_EVENTS_EXPERIMENTAL_FEATURE_*) are read-only here.',
+						'fair-events-experimental'
+					)}
+				</p>
+
+				{entries.map(([key, meta]) => {
+					const help = meta.forced
+						? __(
+								'Forced by a wp-config constant — change it there.',
+								'fair-events-experimental'
+						  )
+						: meta.description;
+
+					return (
+						<div key={key} style={{ marginBottom: '1rem' }}>
+							<ToggleControl
+								label={meta.label}
+								checked={!!values[key]}
+								onChange={(value) => handleToggle(key, value)}
+								disabled={
+									isSaving || meta.always_on || meta.forced
+								}
+								help={help}
+							/>
+						</div>
+					);
+				})}
+
+				{entries.some(([, meta]) => meta.forced) && (
+					<Notice status="info" isDismissible={false}>
+						{__(
+							'One or more bundles are forced by wp-config and cannot be toggled here.',
+							'fair-events-experimental'
+						)}
+					</Notice>
+				)}
+
+				<Button
+					variant="primary"
+					onClick={handleSave}
+					isBusy={isSaving}
+					disabled={isSaving}
+				>
+					{isSaving
+						? __('Saving...', 'fair-events-experimental')
+						: __('Save Features', 'fair-events-experimental')}
+				</Button>
+			</CardBody>
+		</Card>
+	);
+}

--- a/fair-events-experimental/src/Admin/settings/SettingsApp.js
+++ b/fair-events-experimental/src/Admin/settings/SettingsApp.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import FeaturesTab from './FeaturesTab.js';
+
+/**
+ * Settings App Component for Fair Events Experimental.
+ *
+ * Renders just the features tab — there are no general settings for this plugin.
+ *
+ * @return {JSX.Element} The Settings app component
+ */
+export default function SettingsApp() {
+	const [notice, setNotice] = useState(null);
+
+	return (
+		<div className="wrap fair-events-experimental-settings">
+			<h1>
+				{__(
+					'Fair Events Experimental Settings',
+					'fair-events-experimental'
+				)}
+			</h1>
+
+			{notice && (
+				<Notice
+					status={notice.status}
+					isDismissible={true}
+					onRemove={() => setNotice(null)}
+				>
+					{notice.message}
+				</Notice>
+			)}
+
+			<FeaturesTab onNotice={setNotice} />
+		</div>
+	);
+}

--- a/fair-events-experimental/src/Admin/settings/index.js
+++ b/fair-events-experimental/src/Admin/settings/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { render } from '@wordpress/element';
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * Internal dependencies
+ */
+import SettingsApp from './SettingsApp.js';
+
+domReady(() => {
+	const root = document.getElementById(
+		'fair-events-experimental-settings-root'
+	);
+	if (root) {
+		render(<SettingsApp />, root);
+	}
+});

--- a/fair-events-experimental/src/Core/Features.php
+++ b/fair-events-experimental/src/Core/Features.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Feature flag registry for Fair Events Experimental.
+ *
+ * Manages the six advanced bundles moved out of fair-events:
+ * galleries, sources, ticketing, event-tools, migration, venues.
+ * All default to true — installing this plugin signals intent to use the full
+ * internal feature set.
+ *
+ * Resolution order (first match wins):
+ *   1. Per-feature constant `FAIR_EVENTS_EXPERIMENTAL_FEATURE_<UPPER>`
+ *   2. Master switch `FAIR_EVENTS_EXPERIMENTAL_INTERNAL` (true → all bundles on)
+ *   3. `fair_events_experimental_feature_enabled` filter
+ *   4. Stored option `fair_events_experimental_features`
+ *   5. Hardcoded default (true for all bundles)
+ *
+ * @package FairEventsExperimental
+ */
+
+namespace FairEventsExperimental\Core;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Feature flag registry for experimental bundles.
+ */
+class Features {
+
+	/**
+	 * Option key holding user-toggled feature state.
+	 */
+	public const OPTION = 'fair_events_experimental_features';
+
+	/**
+	 * Master switch constant.
+	 */
+	public const MASTER_CONSTANT = 'FAIR_EVENTS_EXPERIMENTAL_INTERNAL';
+
+	/**
+	 * Canonical bundle registry.
+	 *
+	 * Labels are intentionally untranslated here; translation is applied in
+	 * {@see self::all()} which only runs in admin REST contexts.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on?:bool}>
+	 */
+	public static function registry() {
+		return array(
+			'galleries'   => array(
+				'label'       => 'Galleries',
+				'description' => 'Per-event photo galleries, photo likes/downloads, image exports, media library hooks.',
+				'default'     => true,
+			),
+			'sources'     => array(
+				'label'       => 'Event sources & feeds',
+				'description' => 'External event sources, Facebook import, iCal/JSON feeds, event proposals, weekly schedule.',
+				'default'     => true,
+			),
+			'ticketing'   => array(
+				'label'       => 'Ticketing',
+				'description' => 'Tickets, group pricing/permission rules, invitations. Requires fair-audience.',
+				'default'     => true,
+			),
+			'event-tools' => array(
+				'label'       => 'Event tools',
+				'description' => 'Event duplication, merge, and admin-bar Copy button.',
+				'default'     => true,
+			),
+			'migration'   => array(
+				'label'       => 'Migration',
+				'description' => 'One-time post → event migration tooling.',
+				'default'     => true,
+			),
+			'venues'      => array(
+				'label'       => 'Venues',
+				'description' => 'Venues admin page and REST controller.',
+				'default'     => true,
+			),
+		);
+	}
+
+	/**
+	 * Resolve whether a feature bundle is enabled.
+	 *
+	 * @param string $key Bundle key from registry().
+	 * @return bool
+	 */
+	public static function is_enabled( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		// 1. Per-feature constant always wins.
+		$constant = self::feature_constant_name( $key );
+		if ( defined( $constant ) ) {
+			return (bool) constant( $constant );
+		}
+
+		// 2. Master switch flips every bundle on.
+		if ( defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT ) ) {
+			$enabled = true;
+		} else {
+			// 4. Stored option, then 5. hardcoded default.
+			$stored  = get_option( self::OPTION, array() );
+			$enabled = is_array( $stored ) && array_key_exists( $key, $stored )
+				? (bool) $stored[ $key ]
+				: (bool) $registry[ $key ]['default'];
+		}
+
+		// 3. Filter runs after constants.
+		return (bool) apply_filters( 'fair_events_experimental_feature_enabled', $enabled, $key );
+	}
+
+	/**
+	 * Whether the resolved value is forced by a constant.
+	 *
+	 * @param string $key Bundle key.
+	 * @return bool
+	 */
+	public static function is_forced( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( defined( self::feature_constant_name( $key ) ) ) {
+			return true;
+		}
+
+		return defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT );
+	}
+
+	/**
+	 * Full snapshot for the Settings UI.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on:bool,enabled:bool,forced:bool}>
+	 */
+	public static function all() {
+		$out        = array();
+		$translated = array(
+			'galleries'   => array(
+				'label'       => __( 'Galleries', 'fair-events-experimental' ),
+				'description' => __( 'Per-event photo galleries, photo likes/downloads, image exports, media library hooks.', 'fair-events-experimental' ),
+			),
+			'sources'     => array(
+				'label'       => __( 'Event sources & feeds', 'fair-events-experimental' ),
+				'description' => __( 'External event sources, Facebook import, iCal/JSON feeds, event proposals, weekly schedule.', 'fair-events-experimental' ),
+			),
+			'ticketing'   => array(
+				'label'       => __( 'Ticketing', 'fair-events-experimental' ),
+				'description' => __( 'Tickets, group pricing/permission rules, invitations. Requires fair-audience.', 'fair-events-experimental' ),
+			),
+			'event-tools' => array(
+				'label'       => __( 'Event tools', 'fair-events-experimental' ),
+				'description' => __( 'Event duplication, merge, and admin-bar Copy button.', 'fair-events-experimental' ),
+			),
+			'migration'   => array(
+				'label'       => __( 'Migration', 'fair-events-experimental' ),
+				'description' => __( 'One-time post → event migration tooling.', 'fair-events-experimental' ),
+			),
+			'venues'      => array(
+				'label'       => __( 'Venues', 'fair-events-experimental' ),
+				'description' => __( 'Venues admin page and REST controller.', 'fair-events-experimental' ),
+			),
+		);
+
+		foreach ( self::registry() as $key => $entry ) {
+			$out[ $key ] = array(
+				'label'       => $translated[ $key ]['label'] ?? $entry['label'],
+				'description' => $translated[ $key ]['description'] ?? $entry['description'],
+				'default'     => (bool) $entry['default'],
+				'always_on'   => ! empty( $entry['always_on'] ),
+				'enabled'     => self::is_enabled( $key ),
+				'forced'      => self::is_forced( $key ),
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Sanitize an option payload for the known key set, dropping forced keys.
+	 *
+	 * @param mixed $value Raw option value.
+	 * @return array<string,bool>
+	 */
+	public static function sanitize_option( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$existing = get_option( self::OPTION, array() );
+		if ( ! is_array( $existing ) ) {
+			$existing = array();
+		}
+
+		$registry = self::registry();
+		$out      = array();
+		foreach ( $registry as $key => $entry ) {
+			if ( ! empty( $entry['always_on'] ) ) {
+				continue;
+			}
+
+			if ( self::is_forced( $key ) ) {
+				if ( array_key_exists( $key, $existing ) ) {
+					$out[ $key ] = (bool) $existing[ $key ];
+				}
+				continue;
+			}
+
+			if ( array_key_exists( $key, $value ) ) {
+				$out[ $key ] = (bool) $value[ $key ];
+			} elseif ( array_key_exists( $key, $existing ) ) {
+				$out[ $key ] = (bool) $existing[ $key ];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Per-feature constant name (e.g. `galleries` → `FAIR_EVENTS_EXPERIMENTAL_FEATURE_GALLERIES`).
+	 *
+	 * @param string $key Bundle key.
+	 * @return string
+	 */
+	private static function feature_constant_name( $key ) {
+		return 'FAIR_EVENTS_EXPERIMENTAL_FEATURE_' . strtoupper( str_replace( '-', '_', $key ) );
+	}
+}

--- a/fair-events-experimental/src/Core/Plugin.php
+++ b/fair-events-experimental/src/Core/Plugin.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Plugin core class for Fair Events Experimental
+ *
+ * @package FairEventsExperimental
+ */
+
+namespace FairEventsExperimental\Core;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Main plugin class implementing singleton pattern
+ */
+class Plugin {
+	/**
+	 * Single instance of the plugin
+	 *
+	 * @var Plugin|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get singleton instance of the plugin
+	 *
+	 * @return Plugin Plugin instance
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Initialize the plugin
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->load_admin();
+		$this->load_settings();
+		$this->load_rest_api();
+		$this->load_frontend();
+
+		// Merge experimental feature states into the manage-event enabledFeatures map
+		// so the React UI can show galleries/ticketing/venues tabs when active.
+		add_filter(
+			'fair_events_enabled_features_map',
+			function ( $map ) {
+				foreach ( array_keys( Features::registry() ) as $key ) {
+					$map[ $key ] = Features::is_enabled( $key );
+				}
+				return $map;
+			}
+		);
+	}
+
+	/**
+	 * Load and initialize admin pages
+	 *
+	 * @return void
+	 */
+	private function load_admin() {
+		if ( is_admin() ) {
+			$admin = new \FairEventsExperimental\Admin\AdminPages();
+			$admin->init();
+
+			if ( Features::is_enabled( 'galleries' ) ) {
+				\FairEvents\Admin\MediaLibraryHooks::init();
+				\FairEvents\Admin\MediaBatchActions::init();
+			}
+		}
+	}
+
+	/**
+	 * Load and initialize settings
+	 *
+	 * @return void
+	 */
+	private function load_settings() {
+		$settings = new \FairEventsExperimental\Settings\Settings();
+		$settings->init();
+	}
+
+	/**
+	 * Load and initialize REST API endpoints
+	 *
+	 * @return void
+	 */
+	private function load_rest_api() {
+		if ( Features::is_enabled( 'sources' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\EventSourceController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\EventProposalController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\WeeklyEventsController();
+					$controller->register_routes();
+				}
+			);
+		}
+
+		if ( Features::is_enabled( 'galleries' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\EventGalleryEndpoint();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\PhotoLikesController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\PhotoDownloadController();
+					$controller->register_routes();
+				}
+			);
+		}
+
+		if ( Features::is_enabled( 'migration' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\MigrationController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\MigrationSummaryController();
+					$controller->register_routes();
+				}
+			);
+		}
+
+		if ( Features::is_enabled( 'ticketing' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\GroupPricingRulesController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\GroupPermissionRulesController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\TicketsController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\InvitationTokensController();
+					$controller->register_routes();
+				}
+			);
+		}
+
+		if ( Features::is_enabled( 'event-tools' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\EventDuplicationController();
+					$controller->register_routes();
+				}
+			);
+
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEvents\API\EventMergeController();
+					$controller->register_routes();
+				}
+			);
+		}
+	}
+
+	/**
+	 * Load frontend pages
+	 *
+	 * @return void
+	 */
+	private function load_frontend() {
+		if ( Features::is_enabled( 'galleries' ) ) {
+			\FairEvents\Frontend\EventGalleryPage::init();
+		}
+	}
+
+	/**
+	 * Private constructor to prevent instantiation
+	 */
+	private function __construct() {
+		// Prevent instantiation.
+	}
+
+	/**
+	 * Prevent cloning
+	 *
+	 * @return void
+	 */
+	private function __clone() {
+		// Prevent cloning.
+	}
+
+	/**
+	 * Prevent unserialization
+	 *
+	 * @return void
+	 */
+	public function __wakeup() {
+		// Prevent unserialization.
+	}
+}

--- a/fair-events-experimental/src/Settings/Settings.php
+++ b/fair-events-experimental/src/Settings/Settings.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Settings for Fair Events Experimental
+ *
+ * @package FairEventsExperimental
+ */
+
+namespace FairEventsExperimental\Settings;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Settings class for registering plugin settings
+ */
+class Settings {
+	/**
+	 * Initialize settings
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action( 'init', array( $this, 'register_settings' ) );
+	}
+
+	/**
+	 * Register plugin settings
+	 *
+	 * @return void
+	 */
+	public function register_settings() {
+		register_setting(
+			'fair_events_experimental_settings',
+			\FairEventsExperimental\Core\Features::OPTION,
+			array(
+				'type'              => 'object',
+				'description'       => __( 'Per-bundle feature toggles for experimental features', 'fair-events-experimental' ),
+				'sanitize_callback' => array( \FairEventsExperimental\Core\Features::class, 'sanitize_option' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'additionalProperties' => array( 'type' => 'boolean' ),
+					),
+				),
+				'default'           => array(),
+			)
+		);
+	}
+}

--- a/fair-events-experimental/webpack.config.cjs
+++ b/fair-events-experimental/webpack.config.cjs
@@ -1,0 +1,20 @@
+const defaultConfig = require("@wordpress/scripts/config/webpack.config");
+const path = require("path");
+const BundleOutputPlugin = require("webpack-bundle-output");
+
+module.exports = {
+  ...defaultConfig,
+  entry: {
+    "admin/settings/index": path.resolve(
+      process.cwd(),
+      "src/Admin/settings/index.js",
+    ),
+  },
+  plugins: [
+    ...defaultConfig.plugins,
+    new BundleOutputPlugin({
+      cwd: process.cwd(),
+      output: "map.json",
+    }),
+  ],
+};

--- a/fair-events/fair-events.php
+++ b/fair-events/fair-events.php
@@ -37,6 +37,7 @@ namespace FairEvents {
 	defined( 'WPINC' ) || die;
 
 	// Define plugin constants.
+	define( 'FAIR_EVENTS_VERSION', '1.3.4' );
 	define( 'FAIR_EVENTS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 	define( 'FAIR_EVENTS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -68,7 +68,6 @@ class AdminPages {
 		add_action( 'admin_menu', array( $this, 'reorder_admin_menu' ), 999 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 		add_action( 'pre_get_posts', array( $this, 'filter_upcoming_events' ) );
-		add_action( 'admin_bar_menu', array( $this, 'add_copy_button_to_admin_bar' ), 100 );
 		add_filter( 'views_edit-fair_event', array( $this, 'add_upcoming_view_link' ) );
 	}
 
@@ -129,66 +128,6 @@ class AdminPages {
 			array( $this, 'render_settings_page' )
 		);
 
-		// Migration pages only make sense when the CPT exists (migration
-		// targets it) AND the `migration` feature bundle is enabled.
-		if ( \FairEvents\Core\Features::is_enabled( 'migration' ) && post_type_exists( 'fair_event' ) ) {
-			// Migration page
-			$this->page_hooks['fair-events-migration'] = add_submenu_page(
-				$parent,
-				__( 'Migrate Posts to Events', 'fair-events' ),
-				__( 'Migrate Posts', 'fair-events' ),
-				'manage_options',
-				'fair-events-migration',
-				array( $this, 'render_migration_page' )
-			);
-
-			// Migration Summary page
-			$this->page_hooks['fair-events-migration-summary'] = add_submenu_page(
-				$parent,
-				__( 'Migration Summary', 'fair-events' ),
-				__( 'Migration Summary', 'fair-events' ),
-				'manage_options',
-				'fair-events-migration-summary',
-				array( $this, 'render_migration_summary_page' )
-			);
-		}
-
-		// Event Sources page — `sources` bundle.
-		if ( \FairEvents\Core\Features::is_enabled( 'sources' ) ) {
-			$this->page_hooks['fair-events-sources'] = add_submenu_page(
-				$parent,
-				__( 'Event Sources', 'fair-events' ),
-				__( 'Event Sources', 'fair-events' ),
-				'manage_options',
-				'fair-events-sources',
-				array( $this, 'render_sources_page' )
-			);
-
-			// Source View page (hidden from menu, accessed via sources list).
-			$this->page_hooks['fair-events-source-view'] = add_submenu_page(
-				'',
-				__( 'View Source', 'fair-events' ),
-				__( 'View Source', 'fair-events' ),
-				'manage_options',
-				'fair-events-source-view',
-				array( $this, 'render_source_view_page' )
-			);
-
-			$this->set_hidden_page_title( $this->page_hooks['fair-events-source-view'], __( 'View Source', 'fair-events' ) );
-		}
-
-		// Venues page — `venues` bundle.
-		if ( \FairEvents\Core\Features::is_enabled( 'venues' ) ) {
-			$this->page_hooks['fair-events-venues'] = add_submenu_page(
-				$parent,
-				__( 'Venues', 'fair-events' ),
-				__( 'Venues', 'fair-events' ),
-				'manage_options',
-				'fair-events-venues',
-				array( $this, 'render_venues_page' )
-			);
-		}
-
 		// Manage Event page (hidden from menu, accessed via calendar)
 		$this->page_hooks['fair-events-manage-event'] = add_submenu_page(
 			'', // Hidden from menu (empty string instead of null for PHP 8.1+ compatibility)
@@ -198,39 +137,6 @@ class AdminPages {
 			'fair-events-manage-event',
 			array( $this, 'render_manage_event_page' )
 		);
-
-		// Manage Invitations page — `ticketing` bundle (hidden, linked from
-		// the tickets tab).
-		if ( \FairEvents\Core\Features::is_enabled( 'ticketing' ) ) {
-			$this->page_hooks['fair-events-manage-invitations'] = add_submenu_page(
-				'',
-				__( 'Manage Invitations', 'fair-events' ),
-				__( 'Manage Invitations', 'fair-events' ),
-				'manage_options',
-				'fair-events-manage-invitations',
-				array( $this, 'render_manage_invitations_page' )
-			);
-
-			$this->set_hidden_page_title( $this->page_hooks['fair-events-manage-invitations'], __( 'Manage Invitations', 'fair-events' ) );
-		}
-
-		// Copy Event page — `event-tools` bundle (hidden, linked from row
-		// action / admin bar).
-		if ( \FairEvents\Core\Features::is_enabled( 'event-tools' ) ) {
-			$this->page_hooks['fair-events-copy'] = add_submenu_page(
-				'',
-				__( 'Copy Event', 'fair-events' ),
-				__( 'Copy Event', 'fair-events' ),
-				'edit_posts',
-				'fair-events-copy',
-				array( $this, 'render_copy_event_page' )
-			);
-
-			$this->set_hidden_page_title( $this->page_hooks['fair-events-copy'], __( 'Copy Event', 'fair-events' ) );
-
-			// Handle copy event form submission before page render.
-			add_action( 'load-' . $this->page_hooks['fair-events-copy'], array( $this, 'handle_copy_event_submission' ) );
-		}
 
 		// Manage Event hidden-page title (always on; the page itself is core).
 		$this->set_hidden_page_title( $this->page_hooks['fair-events-manage-event'], __( 'Manage Event', 'fair-events' ) );
@@ -349,169 +255,6 @@ class AdminPages {
 			return;
 		}
 
-		// Event Sources page
-		if ( 'fair-events-sources' === $slug ) {
-			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/sources/index.asset.php';
-
-			wp_enqueue_script(
-				'fair-events-sources',
-				FAIR_EVENTS_PLUGIN_URL . 'build/admin/sources/index.js',
-				$asset_file['dependencies'],
-				$asset_file['version'],
-				true
-			);
-
-			wp_localize_script(
-				'fair-events-sources',
-				'fairEventsSourcesData',
-				array(
-					'icalUrlTemplate' => rest_url( 'fair-events/v1/sources/{slug}/ical' ),
-					'jsonUrlTemplate' => rest_url( 'fair-events/v1/sources/{slug}/json' ),
-				)
-			);
-
-			wp_set_script_translations(
-				'fair-events-sources',
-				'fair-events',
-				\FairEvents\Core\Features::script_translations_path()
-			);
-
-			wp_enqueue_style( 'wp-components' );
-			return;
-		}
-
-		// Migration page
-		if ( 'fair-events-migration' === $slug ) {
-			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/migration/index.asset.php';
-
-			wp_enqueue_script(
-				'fair-events-migration',
-				FAIR_EVENTS_PLUGIN_URL . 'build/admin/migration/index.js',
-				$asset_file['dependencies'],
-				$asset_file['version'],
-				true
-			);
-
-			wp_set_script_translations(
-				'fair-events-migration',
-				'fair-events',
-				\FairEvents\Core\Features::script_translations_path()
-			);
-
-			wp_enqueue_style( 'wp-components' );
-			return;
-		}
-
-		// Migration Summary page
-		if ( 'fair-events-migration-summary' === $slug ) {
-			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/migration-summary/index.asset.php';
-
-			wp_enqueue_script(
-				'fair-events-migration-summary',
-				FAIR_EVENTS_PLUGIN_URL . 'build/admin/migration-summary/index.js',
-				$asset_file['dependencies'],
-				$asset_file['version'],
-				true
-			);
-
-			wp_set_script_translations(
-				'fair-events-migration-summary',
-				'fair-events',
-				\FairEvents\Core\Features::script_translations_path()
-			);
-
-			wp_enqueue_style( 'wp-components' );
-			return;
-		}
-
-		// Source View page
-		if ( 'fair-events-source-view' === $slug ) {
-			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/source-view/index.asset.php';
-
-			wp_enqueue_script(
-				'fair-events-source-view',
-				FAIR_EVENTS_PLUGIN_URL . 'build/admin/source-view/index.js',
-				$asset_file['dependencies'],
-				$asset_file['version'],
-				true
-			);
-
-			// Reuse the calendar stylesheet (shared CSS for calendar grid components).
-			$calendar_asset = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/calendar/index.asset.php';
-			wp_enqueue_style(
-				'fair-events-calendar',
-				FAIR_EVENTS_PLUGIN_URL . 'build/admin/calendar/style-index.css',
-				array( 'wp-components' ),
-				$calendar_asset['version']
-			);
-
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$source_id = isset( $_GET['source_id'] ) ? absint( $_GET['source_id'] ) : 0;
-
-			wp_localize_script(
-				'fair-events-source-view',
-				'fairEventsSourceViewData',
-				array(
-					'sourceId'        => $source_id,
-					'startOfWeek'     => (int) get_option( 'start_of_week', 1 ),
-					'sourcesListUrl'  => admin_url( 'admin.php?page=fair-events-sources' ),
-					'icalUrlTemplate' => rest_url( 'fair-events/v1/sources/{slug}/ical' ),
-					'jsonUrlTemplate' => rest_url( 'fair-events/v1/sources/{slug}/json' ),
-				)
-			);
-
-			wp_set_script_translations(
-				'fair-events-source-view',
-				'fair-events',
-				\FairEvents\Core\Features::script_translations_path()
-			);
-
-			return;
-		}
-
-		// Manage Invitations page
-		if ( 'fair-events-manage-invitations' === $slug ) {
-			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/manage-invitations/index.asset.php';
-
-			wp_enqueue_script(
-				'fair-events-manage-invitations',
-				FAIR_EVENTS_PLUGIN_URL . 'build/admin/manage-invitations/index.js',
-				$asset_file['dependencies'],
-				$asset_file['version'],
-				true
-			);
-
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$event_date_id = isset( $_GET['event_date_id'] ) ? absint( $_GET['event_date_id'] ) : 0;
-
-			$signup_page_url = '';
-			if ( $event_date_id ) {
-				$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
-				if ( $event_date && $event_date->event_id ) {
-					$signup_page_url = get_permalink( $event_date->event_id );
-				}
-			}
-
-			wp_localize_script(
-				'fair-events-manage-invitations',
-				'fairEventsManageInvitationsData',
-				array(
-					'eventDateId'    => $event_date_id,
-					'manageEventUrl' => admin_url( 'admin.php?page=fair-events-manage-event' ),
-					'signupPageUrl'  => $signup_page_url,
-				)
-			);
-
-			wp_set_script_translations(
-				'fair-events-manage-invitations',
-				'fair-events',
-				\FairEvents\Core\Features::script_translations_path()
-			);
-
-			wp_enqueue_style( 'wp-components' );
-			return;
-		}
-
 		// Manage Event page
 		if ( 'fair-events-manage-event' === $slug ) {
 			wp_enqueue_media();
@@ -549,7 +292,9 @@ class AdminPages {
 				// Resolved feature map — React reads this to hide tabs whose
 				// bundle is off (mirroring the existing audienceUrl /
 				// paymentEntriesUrl conditionals).
-				'enabledFeatures'  => \FairEvents\Core\Features::public_map(),
+				// Extensions (e.g. fair-events-experimental) can merge their
+				// feature states into this map via the filter.
+				'enabledFeatures'  => apply_filters( 'fair_events_enabled_features_map', \FairEvents\Core\Features::public_map() ),
 			);
 
 			// Audience-dependent URLs require both the sibling plugin AND the
@@ -575,28 +320,6 @@ class AdminPages {
 
 			wp_set_script_translations(
 				'fair-events-manage-event',
-				'fair-events',
-				\FairEvents\Core\Features::script_translations_path()
-			);
-
-			wp_enqueue_style( 'wp-components' );
-			return;
-		}
-
-		// Venues page
-		if ( 'fair-events-venues' === $slug ) {
-			$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/venues/index.asset.php';
-
-			wp_enqueue_script(
-				'fair-events-venues',
-				FAIR_EVENTS_PLUGIN_URL . 'build/admin/venues/index.js',
-				$asset_file['dependencies'],
-				$asset_file['version'],
-				true
-			);
-
-			wp_set_script_translations(
-				'fair-events-venues',
 				'fair-events',
 				\FairEvents\Core\Features::script_translations_path()
 			);
@@ -935,74 +658,5 @@ class AdminPages {
 		remove_filter( 'posts_clauses', array( $this, 'upcoming_events_clauses' ), 10 );
 
 		return $clauses;
-	}
-
-	/**
-	 * Add Copy button to admin bar on event edit pages
-	 *
-	 * @param \WP_Admin_Bar $wp_admin_bar The admin bar object.
-	 * @return void
-	 */
-	public function add_copy_button_to_admin_bar( $wp_admin_bar ) {
-		// Only show on event edit pages in admin
-		if ( ! is_admin() ) {
-			return;
-		}
-
-		// The Copy flow lives in the `event-tools` bundle — without it
-		// enabled the target admin page is not registered.
-		if ( ! \FairEvents\Core\Features::is_enabled( 'event-tools' ) ) {
-			return;
-		}
-
-		// Copy targets the fair_event CPT; nothing to copy when it's not registered.
-		if ( ! post_type_exists( 'fair_event' ) ) {
-			return;
-		}
-
-		$screen = get_current_screen();
-		if ( ! $screen || 'fair_event' !== $screen->post_type || 'post' !== $screen->base ) {
-			return;
-		}
-
-		// Get current post ID
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
-		if ( ! $post_id ) {
-			return;
-		}
-
-		// Verify it's a fair_event post
-		$post = get_post( $post_id );
-		if ( ! $post || 'fair_event' !== $post->post_type ) {
-			return;
-		}
-
-		// Check user permissions
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			return;
-		}
-
-		// Build copy URL with nonce
-		$copy_url = add_query_arg(
-			array(
-				'page'     => 'fair-events-copy',
-				'event_id' => $post_id,
-				'_wpnonce' => wp_create_nonce( 'copy_fair_event_' . $post_id ),
-			),
-			admin_url( 'admin.php' )
-		);
-
-		// Add the Copy button
-		$wp_admin_bar->add_node(
-			array(
-				'id'    => 'copy-event',
-				'title' => __( 'Copy', 'fair-events' ),
-				'href'  => $copy_url,
-				'meta'  => array(
-					'title' => __( 'Copy this event', 'fair-events' ),
-				),
-			)
-		);
 	}
 }

--- a/fair-events/src/Core/Features.php
+++ b/fair-events/src/Core/Features.php
@@ -63,36 +63,6 @@ class Features {
 				'default'     => true,
 				'always_on'   => true,
 			),
-			'venues'               => array(
-				'label'       => 'Venues',
-				'description' => 'Venues admin page and REST controller.',
-				'default'     => false,
-			),
-			'sources'              => array(
-				'label'       => 'Event sources & feeds',
-				'description' => 'External event sources, Facebook import, iCal/JSON feeds, event proposals, weekly schedule.',
-				'default'     => false,
-			),
-			'galleries'            => array(
-				'label'       => 'Galleries',
-				'description' => 'Per-event photo galleries, photo likes/downloads, image exports, media library hooks.',
-				'default'     => false,
-			),
-			'ticketing'            => array(
-				'label'       => 'Ticketing',
-				'description' => 'Tickets, group pricing/permission rules, invitations. Requires fair-audience.',
-				'default'     => false,
-			),
-			'event-tools'          => array(
-				'label'       => 'Event tools',
-				'description' => 'Event duplication, merge, and admin-bar Copy button.',
-				'default'     => false,
-			),
-			'migration'            => array(
-				'label'       => 'Migration',
-				'description' => 'One-time post → event migration tooling.',
-				'default'     => false,
-			),
 			'bundled-translations' => array(
 				'label'       => 'Bundled translations',
 				'description' => 'Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings.',
@@ -194,30 +164,6 @@ class Features {
 			'core'                 => array(
 				'label'       => __( 'Core', 'fair-events' ),
 				'description' => __( 'Events, calendar, all-events, settings, core blocks. Always on.', 'fair-events' ),
-			),
-			'venues'               => array(
-				'label'       => __( 'Venues', 'fair-events' ),
-				'description' => __( 'Venues admin page and REST controller.', 'fair-events' ),
-			),
-			'sources'              => array(
-				'label'       => __( 'Event sources & feeds', 'fair-events' ),
-				'description' => __( 'External event sources, Facebook import, iCal/JSON feeds, event proposals, weekly schedule.', 'fair-events' ),
-			),
-			'galleries'            => array(
-				'label'       => __( 'Galleries', 'fair-events' ),
-				'description' => __( 'Per-event photo galleries, photo likes/downloads, image exports, media library hooks.', 'fair-events' ),
-			),
-			'ticketing'            => array(
-				'label'       => __( 'Ticketing', 'fair-events' ),
-				'description' => __( 'Tickets, group pricing/permission rules, invitations. Requires fair-audience.', 'fair-events' ),
-			),
-			'event-tools'          => array(
-				'label'       => __( 'Event tools', 'fair-events' ),
-				'description' => __( 'Event duplication, merge, and admin-bar Copy button.', 'fair-events' ),
-			),
-			'migration'            => array(
-				'label'       => __( 'Migration', 'fair-events' ),
-				'description' => __( 'One-time post → event migration tooling.', 'fair-events' ),
 			),
 			'bundled-translations' => array(
 				'label'       => __( 'Bundled translations', 'fair-events' ),

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -96,13 +96,6 @@ class Plugin {
 		if ( is_admin() ) {
 			$admin = new \FairEvents\Admin\AdminPages();
 			$admin->init();
-
-			// Media library integrations only fire when galleries are on —
-			// they tag attachments with event metadata and bulk-attach photos.
-			if ( Features::is_enabled( 'galleries' ) ) {
-				\FairEvents\Admin\MediaLibraryHooks::init();
-				\FairEvents\Admin\MediaBatchActions::init();
-			}
 		}
 	}
 
@@ -147,82 +140,9 @@ class Plugin {
 			}
 		);
 
-		// `sources` bundle — external sources, feeds, proposals, weekly schedule.
-		if ( Features::is_enabled( 'sources' ) ) {
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\EventSourceController();
-					$controller->register_routes();
-				}
-			);
-
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\EventProposalController();
-					$controller->register_routes();
-				}
-			);
-
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\WeeklyEventsController();
-					$controller->register_routes();
-				}
-			);
-		}
-
-		// `galleries` bundle — per-event photo galleries.
-		if ( Features::is_enabled( 'galleries' ) ) {
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\EventGalleryEndpoint();
-					$controller->register_routes();
-				}
-			);
-
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\PhotoLikesController();
-					$controller->register_routes();
-				}
-			);
-
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\PhotoDownloadController();
-					$controller->register_routes();
-				}
-			);
-		}
-
-		// `migration` bundle — one-time post → event migration tooling.
-		if ( Features::is_enabled( 'migration' ) ) {
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\MigrationController();
-					$controller->register_routes();
-				}
-			);
-
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\MigrationSummaryController();
-					$controller->register_routes();
-				}
-			);
-		}
-
 		// Venues controller — registered unconditionally so the core
-		// calendar/manage-event venue dropdowns keep working. Only the
-		// dedicated Venues admin page is hidden by the `venues` bundle.
+		// calendar/manage-event venue dropdowns keep working. The dedicated
+		// Venues admin page is provided by fair-events-experimental.
 		add_action(
 			'rest_api_init',
 			function () {
@@ -230,62 +150,6 @@ class Plugin {
 				$controller->register_routes();
 			}
 		);
-
-		// `ticketing` bundle — composes with the existing fair-audience
-		// dependency check inside each controller (e.g.
-		// GroupPricingRulesController guards on FAIR_AUDIENCE_PLUGIN_DIR).
-		if ( Features::is_enabled( 'ticketing' ) ) {
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\GroupPricingRulesController();
-					$controller->register_routes();
-				}
-			);
-
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\GroupPermissionRulesController();
-					$controller->register_routes();
-				}
-			);
-
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\TicketsController();
-					$controller->register_routes();
-				}
-			);
-
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\InvitationTokensController();
-					$controller->register_routes();
-				}
-			);
-		}
-
-		// `event-tools` bundle — duplication / merge.
-		if ( Features::is_enabled( 'event-tools' ) ) {
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\EventDuplicationController();
-					$controller->register_routes();
-				}
-			);
-
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\EventMergeController();
-					$controller->register_routes();
-				}
-			);
-		}
 
 		// Add event relationship to attachment REST responses.
 		add_action(
@@ -326,9 +190,7 @@ class Plugin {
 	 * @return void
 	 */
 	private function load_frontend() {
-		if ( Features::is_enabled( 'galleries' ) ) {
-			\FairEvents\Frontend\EventGalleryPage::init();
-		}
+		// Gallery frontend is loaded by fair-events-experimental when active.
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
 				"fair-platform",
 				"fair-audience",
 				"fair-timetable",
-				"fair-finance"
+				"fair-finance",
+				"fair-events-experimental"
 			],
 			"dependencies": {
 				"@wordpress/scripts": "^32.4.0",
@@ -2011,6 +2012,1187 @@
 				"dotenv": "^16.3.1",
 				"jest": "^30.0.0",
 				"webpack-bundle-output": "^1.1.0"
+			}
+		},
+		"fair-events-experimental": {
+			"version": "0.1.0",
+			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"@wordpress/api-fetch": "^7.2.0",
+				"@wordpress/components": "^30.2.0",
+				"@wordpress/element": "^6.2.0",
+				"@wordpress/i18n": "^6.2.0"
+			},
+			"devDependencies": {
+				"@babel/core": "^7.28.3",
+				"@babel/preset-env": "^7.28.3",
+				"@wordpress/scripts": "^32.4.0",
+				"babel-jest": "^30.0.5",
+				"jest": "^30.0.0",
+				"npm-run-all": "^4.1.5",
+				"webpack-bundle-output": "^1.1.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/console": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+			"integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/core": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+			"integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.4.1",
+				"@jest/pattern": "30.4.0",
+				"@jest/reporters": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"exit-x": "^0.2.2",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.11",
+				"jest-changed-files": "30.4.1",
+				"jest-config": "30.4.2",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-resolve-dependencies": "30.4.2",
+				"jest-runner": "30.4.2",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/diff-sequences": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+			"integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/environment": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+			"integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-mock": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/expect": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expect": "30.4.1",
+				"jest-snapshot": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/expect-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+			"integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/fake-timers": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+			"integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@sinonjs/fake-timers": "^15.4.0",
+				"@types/node": "*",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/globals": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+			"integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/types": "30.4.1",
+				"jest-mock": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/reporters": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+			"integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"collect-v8-coverage": "^1.0.2",
+				"exit-x": "^0.2.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^6.0.0",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^5.0.0",
+				"istanbul-reports": "^3.1.3",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
+				"slash": "^3.0.0",
+				"string-length": "^4.0.2",
+				"v8-to-istanbul": "^9.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/schemas": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/snapshot-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+			"integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"natural-compare": "^1.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/test-result": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+			"integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"collect-v8-coverage": "^1.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/test-sequencer": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+			"integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/test-result": "30.4.1",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/transform": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+			"integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@jest/types": "30.4.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"babel-plugin-istanbul": "^7.0.1",
+				"chalk": "^4.1.2",
+				"convert-source-map": "^2.0.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"pirates": "^4.0.7",
+				"slash": "^3.0.0",
+				"write-file-atomic": "^5.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@jest/types": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@sinonjs/fake-timers": {
+			"version": "15.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"fair-events-experimental/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"fair-events-experimental/node_modules/babel-jest": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+			"integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/transform": "30.4.1",
+				"@types/babel__core": "^7.20.5",
+				"babel-plugin-istanbul": "^7.0.1",
+				"babel-preset-jest": "30.4.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0 || ^8.0.0-0"
+			}
+		},
+		"fair-events-experimental/node_modules/babel-plugin-istanbul": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+			"integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"workspaces": [
+				"test/babel-8"
+			],
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-instrument": "^6.0.2",
+				"test-exclude": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"fair-events-experimental/node_modules/babel-plugin-jest-hoist": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+			"integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/babel__core": "^7.20.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/babel-preset-jest": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+			"integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-plugin-jest-hoist": "30.4.0",
+				"babel-preset-current-node-syntax": "^1.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+			}
+		},
+		"fair-events-experimental/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"fair-events-experimental/node_modules/cjs-module-lexer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-events-experimental/node_modules/expect": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/expect-utils": "30.4.1",
+				"@jest/get-type": "30.1.0",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"fair-events-experimental/node_modules/istanbul-lib-instrument": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@babel/core": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-coverage": "^3.2.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"fair-events-experimental/node_modules/istanbul-lib-source-maps": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"fair-events-experimental/node_modules/jest": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+			"integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/core": "30.4.2",
+				"@jest/types": "30.4.1",
+				"import-local": "^3.2.0",
+				"jest-cli": "30.4.2"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"fair-events-experimental/node_modules/jest-changed-files": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+			"integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^5.1.1",
+				"jest-util": "30.4.1",
+				"p-limit": "^3.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-circus": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+			"integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"co": "^4.6.0",
+				"dedent": "^1.6.0",
+				"is-generator-fn": "^2.1.0",
+				"jest-each": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"p-limit": "^3.1.0",
+				"pretty-format": "30.4.1",
+				"pure-rand": "^7.0.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-cli": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+			"integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/core": "30.4.2",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"exit-x": "^0.2.2",
+				"import-local": "^3.2.0",
+				"jest-config": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"fair-events-experimental/node_modules/jest-config": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+			"integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@jest/get-type": "30.1.0",
+				"@jest/pattern": "30.4.0",
+				"@jest/test-sequencer": "30.4.1",
+				"@jest/types": "30.4.1",
+				"babel-jest": "30.4.1",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"deepmerge": "^4.3.1",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-circus": "30.4.2",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-runner": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"parse-json": "^5.2.0",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@types/node": "*",
+				"esbuild-register": ">=3.4.0",
+				"ts-node": ">=9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"esbuild-register": {
+					"optional": true
+				},
+				"ts-node": {
+					"optional": true
+				}
+			}
+		},
+		"fair-events-experimental/node_modules/jest-diff": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+			"integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/diff-sequences": "30.4.0",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-docblock": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+			"integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"detect-newline": "^3.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-each": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+			"integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-environment-node": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+			"integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-haste-map": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+			"integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"anymatch": "^3.1.3",
+				"fb-watchman": "^2.0.2",
+				"graceful-fs": "^4.2.11",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
+				"picomatch": "^4.0.3",
+				"walker": "^1.0.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "^2.3.3"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-leak-detector": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+			"integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-matcher-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+			"integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.4.1",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-message-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+			"integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.4.1",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-util": "30.4.1",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-mock": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+			"integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-regex-util": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-resolve": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+			"integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-pnp-resolver": "^1.2.3",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"slash": "^3.0.0",
+				"unrs-resolver": "^1.7.11"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-resolve-dependencies": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+			"integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jest-regex-util": "30.4.0",
+				"jest-snapshot": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-runner": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+			"integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.4.1",
+				"@jest/environment": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-haste-map": "30.4.1",
+				"jest-leak-detector": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-resolve": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"jest-worker": "30.4.1",
+				"p-limit": "^3.1.0",
+				"source-map-support": "0.5.13"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-runtime": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+			"integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/globals": "30.4.1",
+				"@jest/source-map": "30.0.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"cjs-module-lexer": "^2.1.0",
+				"collect-v8-coverage": "^1.0.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-snapshot": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+			"integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@babel/generator": "^7.27.5",
+				"@babel/plugin-syntax-jsx": "^7.27.1",
+				"@babel/plugin-syntax-typescript": "^7.27.1",
+				"@babel/types": "^7.27.3",
+				"@jest/expect-utils": "30.4.1",
+				"@jest/get-type": "30.1.0",
+				"@jest/snapshot-utils": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"babel-preset-current-node-syntax": "^1.2.0",
+				"chalk": "^4.1.2",
+				"expect": "30.4.1",
+				"graceful-fs": "^4.2.11",
+				"jest-diff": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1",
+				"semver": "^7.7.2",
+				"synckit": "^0.11.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+			"integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-validate": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+			"integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.4.1",
+				"camelcase": "^6.3.0",
+				"chalk": "^4.1.2",
+				"leven": "^3.1.0",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-watcher": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+			"integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"jest-util": "30.4.1",
+				"string-length": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/jest-worker": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+			"integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@ungap/structured-clone": "^1.3.0",
+				"jest-util": "30.4.1",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.1.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"fair-events-experimental/node_modules/pretty-format": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+			"integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.4.1",
+				"ansi-styles": "^5.2.0",
+				"react-is-18": "npm:react-is@^18.3.1",
+				"react-is-19": "npm:react-is@^19.2.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/pure-rand": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+			"integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT"
+		},
+		"fair-events-experimental/node_modules/semver": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"fair-events-experimental/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"fair-events-experimental/node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"fair-events-experimental/node_modules/source-map-support": {
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"fair-events-experimental/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"fair-events-experimental/node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"fair-events-shared": {
@@ -7462,7 +8644,6 @@
 			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
 			"integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@emotion/memoize": "^0.9.0"
 			}
@@ -23435,6 +24616,10 @@
 		},
 		"node_modules/fair-events": {
 			"resolved": "fair-events",
+			"link": true
+		},
+		"node_modules/fair-events-experimental": {
+			"resolved": "fair-events-experimental",
 			"link": true
 		},
 		"node_modules/fair-events-shared": {

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
 		"composer:update": "npm run composer:update --workspaces --if-present",
 		"composer:update:shared": "npm run composer:update:shared --workspaces --if-present",
 		"composer:validate": "npm run composer:validate --workspaces --if-present",
-		"start": "npm run start --workspace=fair-payments-connector & npm run start --workspace=fair-events & npm run start --workspace=fair-audience & npm run start --workspace=fair-timetable & npm run start --workspace=fair-finance & wait",
+		"start": "npm run start --workspace=fair-payments-connector & npm run start --workspace=fair-events & npm run start --workspace=fair-audience & npm run start --workspace=fair-timetable & npm run start --workspace=fair-finance & npm run start --workspace=fair-events-experimental & wait",
 		"format": "npm-run-all format:*",
 		"format:js": "wp-scripts format",
-		"format:php": "vendor/bin/phpcbf --standard=WordPress --extensions=php fair-payments-connector/src/ fair-events/src/ fair-events/__tests__/ fair-platform/src/ fair-audience/src/ fair-audience/__tests__/ fair-timetable/src/ fair-timetable/__tests__/ fair-finance/src/ fair-finance/__tests__/",
+		"format:php": "vendor/bin/phpcbf --standard=WordPress --extensions=php fair-payments-connector/src/ fair-events/src/ fair-events/__tests__/ fair-platform/src/ fair-audience/src/ fair-audience/__tests__/ fair-timetable/src/ fair-timetable/__tests__/ fair-finance/src/ fair-finance/__tests__/ fair-events-experimental/src/",
 		"prepare": "husky",
 		"changeset": "changeset",
 		"changeset:add": "changeset add",
@@ -62,6 +62,7 @@
 		"dist-archive:fair-audience": "wp dist-archive fair-audience dist --create-target-dir",
 		"dist-archive:fair-timetable": "wp dist-archive fair-timetable dist --create-target-dir",
 		"dist-archive:fair-finance": "wp dist-archive fair-finance dist --create-target-dir",
+		"dist-archive:fair-events-experimental": "wp dist-archive fair-events-experimental dist --create-target-dir",
 		"translation:update": "node scripts/translation/update-translations.js",
 		"translation:untranslated": "node scripts/translation/get-untranslated.js",
 		"translation:coverage": "node scripts/translation/coverage-report.js",
@@ -976,7 +977,8 @@
 		"fair-platform",
 		"fair-audience",
 		"fair-timetable",
-		"fair-finance"
+		"fair-finance",
+		"fair-events-experimental"
 	],
 	"devDependencies": {
 		"@changesets/cli": "^2.29.6",

--- a/scripts/deploy-local.js
+++ b/scripts/deploy-local.js
@@ -38,6 +38,7 @@ const ALL_PLUGINS = [
 	'fair-audience',
 	'fair-timetable',
 	'fair-finance',
+	'fair-events-experimental',
 ];
 const MAX_ATTEMPTS = 2;
 

--- a/scripts/sync-wp-versions.js
+++ b/scripts/sync-wp-versions.js
@@ -30,6 +30,7 @@ const plugins = [
 		packagePath: 'fair-events/package.json',
 		phpFiles: ['fair-events/fair-events.php'],
 		readmeFiles: ['fair-events/readme.txt'],
+		versionConstant: 'FAIR_EVENTS_VERSION',
 	},
 	{
 		name: 'fair-platform',
@@ -57,6 +58,13 @@ const plugins = [
 		phpFiles: ['fair-finance/fair-finance.php'],
 		readmeFiles: ['fair-finance/readme.txt'],
 		versionConstant: 'FAIR_FINANCE_VERSION',
+	},
+	{
+		name: 'fair-events-experimental',
+		packagePath: 'fair-events-experimental/package.json',
+		phpFiles: ['fair-events-experimental/fair-events-experimental.php'],
+		readmeFiles: ['fair-events-experimental/readme.txt'],
+		versionConstant: 'FAIR_EVENTS_EXPERIMENTAL_VERSION',
 	},
 ];
 


### PR DESCRIPTION
## Summary

- Adds new `fair-events-experimental` plugin that activates the six advanced feature bundles previously gated in `fair-events`: galleries, sources, ticketing, event-tools, migration, venues.
- Trims `fair-events` Features registry to `core` + `bundled-translations` only — the public plugin now ships a lean, stable surface.
- Activating both plugins with `FAIR_EVENTS_EXPERIMENTAL_INTERNAL=true` restores the full current feature set.
- All six bundles default to `true` in the experimental plugin (opt-in install signals intent for the full set).

Closes #789

## Notes

- PHP classes stay in `fair-events`; experimental plugin calls into `FairEvents\API\*` controllers directly — zero risk to existing installs.
- `VenueController` remains unconditionally registered in fair-events so the core venue dropdown keeps working; only the Venues admin page moved.
- A new `fair_events_enabled_features_map` filter lets the experimental plugin merge its feature states into the manage-event React page's `enabledFeatures` data, so galleries/ticketing/venues tabs stay visible when the experimental plugin is active.
- Admin pages for migrated features (migration, sources, venues, invitations, copy) re-use JS assets from `fair-events/build/`; only the Experimental Settings page uses its own build.

## Test plan

- [ ] Activate only `fair-events` on a clean WP install → no migration, sources, venues, galleries, ticketing, or event-tools pages in the admin menu.
- [ ] Activate `fair-events-experimental` too → migrated admin pages appear; manage-event tabs for galleries/ticketing/venues are visible.
- [ ] Set `FAIR_EVENTS_EXPERIMENTAL_INTERNAL=true` in `wp-config.php` → all experimental bundles forced on; toggles on Experimental Settings page show as read-only.
- [ ] Toggle a bundle off on the Experimental Settings page → corresponding admin page disappears after reload.
- [ ] `vendor/bin/phpcs fair-events-experimental/src/` passes clean.
- [ ] `npm run build --workspace=fair-events-experimental` succeeds.
- [ ] `npm run test:api` and `npm run test:e2e` in `fair-events` pass with both plugins active.