### PR TITLE
feat(fair-payments-connector): add dashboard monthly-summary REST endpoint

### DIFF
--- a/fair-payments-connector/jest.config.js
+++ b/fair-payments-connector/jest.config.js
@@ -2,7 +2,13 @@ module.exports = {
 	preset: '@wordpress/jest-preset-default',
 	testEnvironment: 'jsdom',
 	testMatch: ['**/__tests__/**/*.js', '**/?(*.)+(spec|test).js'],
-	testPathIgnorePatterns: ['/node_modules/', '/vendor/', '/build/', '/e2e/'],
+	testPathIgnorePatterns: [
+		'/node_modules/',
+		'/vendor/',
+		'/build/',
+		'/e2e/',
+		'\\.api\\.spec\\.js$',
+	],
 	transform: {
 		'^.+\\.[jt]sx?$': [
 			'babel-jest',

--- a/fair-payments-connector/package.json
+++ b/fair-payments-connector/package.json
@@ -16,6 +16,7 @@
 		"format": "wp-scripts format",
 		"test": "npm-run-all test:js",
 		"test:js": "jest",
+		"test:api": "playwright test",
 		"test:php": "vendor/bin/phpunit",
 		"makepot": "wp i18n make-pot . languages/fair-payments-connector.pot --exclude=node_modules,vendor,tests,build,svn",
 		"makejson": "wp i18n make-json languages ./build/languages --domain=fair-payments-connector --pretty-print --no-purge --use-map=build/map.json",
@@ -31,9 +32,11 @@
 	"author": "Fair Event Plugins",
 	"license": "GPL-2.0-or-later",
 	"devDependencies": {
+		"@playwright/test": "^1.40.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^14.3.1",
 		"@wordpress/scripts": "^32.4.0",
+		"dotenv": "^16.3.1",
 		"webpack-bundle-output": "^1.1.0"
 	},
 	"dependencies": {

--- a/fair-payments-connector/playwright.config.js
+++ b/fair-payments-connector/playwright.config.js
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export default defineConfig({
+	testDir: './',
+	testMatch: ['e2e/**/*.spec.js', 'src/API/__tests__/**/*.api.spec.js'],
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: 1,
+	reporter: 'html',
+	use: {
+		baseURL: process.env.WP_BASE_URL || 'http://localhost:8080',
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+	webServer: {
+		command: 'docker compose up',
+		url: 'http://localhost:8080',
+		reuseExistingServer: !process.env.CI,
+		timeout: 120 * 1000,
+	},
+});

--- a/fair-payments-connector/src/API/DashboardController.php
+++ b/fair-payments-connector/src/API/DashboardController.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * REST API Controller for the admin dashboard
+ *
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery -- aggregation queries on a custom table; caching not applicable for real-time summaries.
+ *
+ * @package FairPaymentsConnector
+ */
+
+namespace FairPaymentsConnector\API;
+
+defined( 'WPINC' ) || die;
+
+use FairPaymentsConnector\Database\Schema;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Provides read-only summary stats for the admin dashboard.
+ */
+class DashboardController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-payments-connector/v1';
+
+	/**
+	 * Register the dashboard routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/dashboard/monthly-summary',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_monthly_summary' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Require manage_options capability.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool
+	 */
+	public function get_item_permissions_check( $request ) {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Return current-month payment totals.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_monthly_summary( $request ) {
+		global $wpdb;
+
+		$table    = Schema::get_payments_table_name();
+		$testmode = 'test' === get_option( 'fair_payment_mode', 'test' ) ? 1 : 0;
+		$month    = gmdate( 'Y-m' );
+
+		$month_start = gmdate( 'Y-m-01 00:00:00' );
+		$month_end   = gmdate( 'Y-m-t 23:59:59' );
+
+		$total_volume = (float) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT SUM(amount) FROM %i WHERE status = %s AND testmode = %d AND created_at BETWEEN %s AND %s',
+				$table,
+				'paid',
+				$testmode,
+				$month_start,
+				$month_end
+			)
+		);
+
+		$total_fees = (float) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT SUM(application_fee) FROM %i WHERE status IN (%s, %s) AND testmode = %d AND created_at BETWEEN %s AND %s',
+				$table,
+				'paid',
+				'pending_payment',
+				$testmode,
+				$month_start,
+				$month_end
+			)
+		);
+
+		return new WP_REST_Response(
+			array(
+				'month'        => $month,
+				'total_volume' => $total_volume,
+				'total_fees'   => $total_fees,
+				'testmode'     => (bool) $testmode,
+			),
+			200
+		);
+	}
+}

--- a/fair-payments-connector/src/API/RestHooks.php
+++ b/fair-payments-connector/src/API/RestHooks.php
@@ -56,5 +56,8 @@ class RestHooks {
 
 		$connected_sites_controller = new \FairPaymentsConnector\API\ConnectedSitesController();
 		$connected_sites_controller->register_routes();
+
+		$dashboard_controller = new \FairPaymentsConnector\API\DashboardController();
+		$dashboard_controller->register_routes();
 	}
 }

--- a/fair-payments-connector/src/API/__tests__/DashboardController.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/DashboardController.api.spec.js
@@ -1,0 +1,48 @@
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const ENDPOINT =
+	'/wp-json/fair-payments-connector/v1/dashboard/monthly-summary';
+
+test.describe('DashboardController — monthly-summary', () => {
+	let api;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test('GET returns 200 with required fields for admin', async () => {
+		const res = await api.get(ENDPOINT, {
+			headers: {
+				Authorization:
+					'Basic ' +
+					Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString(
+						'base64'
+					),
+			},
+		});
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(body).toHaveProperty('month');
+		expect(body).toHaveProperty('total_volume');
+		expect(body).toHaveProperty('total_fees');
+		expect(body).toHaveProperty('testmode');
+		expect(typeof body.month).toBe('string');
+		expect(/^\d{4}-\d{2}$/.test(body.month)).toBe(true);
+		expect(typeof body.total_volume).toBe('number');
+		expect(typeof body.total_fees).toBe('number');
+		expect(typeof body.testmode).toBe('boolean');
+	});
+
+	test('GET without auth returns 401', async () => {
+		const res = await api.get(ENDPOINT);
+		expect(res.status()).toBe(401);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `GET /wp-json/fair-payments-connector/v1/dashboard/monthly-summary` returning `month`, `total_volume`, `total_fees`, and `testmode` for the current calendar month
- Requires `manage_options` — unauthenticated requests get 401, non-admin 403
- Adds Playwright test infrastructure (`playwright.config.js`, `@playwright/test` dev dep) and an API spec covering the 200 success case and 401 unauthenticated case

`fee_cap` and `cap_remaining` are intentionally omitted; they will be added once `MonthlyFeeCapService` is implemented in #773.

Closes #775

## Test plan

- [ ] `vendor/bin/phpcs fair-payments-connector/src/API/DashboardController.php` — no errors
- [ ] With Docker running: `GET /wp-json/fair-payments-connector/v1/dashboard/monthly-summary` without auth → 401
- [ ] Same endpoint with admin Basic auth → 200, body contains `month` (YYYY-MM), `total_volume`, `total_fees`, `testmode`
- [ ] `cd fair-payments-connector && npx playwright test` — both spec cases pass