### PR TITLE
feat(fair-payments-connector): add MonthlyFeeCapService and fee cap fields to dashboard summary

### DIFF
--- a/fair-payments-connector/src/API/DashboardController.php
+++ b/fair-payments-connector/src/API/DashboardController.php
@@ -12,6 +12,7 @@ namespace FairPaymentsConnector\API;
 defined( 'WPINC' ) || die;
 
 use FairPaymentsConnector\Database\Schema;
+use FairPaymentsConnector\Services\MonthlyFeeCapService;
 use WP_REST_Controller;
 use WP_REST_Server;
 use WP_REST_Request;
@@ -85,24 +86,14 @@ class DashboardController extends WP_REST_Controller {
 			)
 		);
 
-		$total_fees = (float) $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT SUM(application_fee) FROM %i WHERE status IN (%s, %s) AND testmode = %d AND created_at BETWEEN %s AND %s',
-				$table,
-				'paid',
-				'pending_payment',
-				$testmode,
-				$month_start,
-				$month_end
-			)
-		);
-
 		return new WP_REST_Response(
 			array(
-				'month'        => $month,
-				'total_volume' => $total_volume,
-				'total_fees'   => $total_fees,
-				'testmode'     => (bool) $testmode,
+				'month'         => $month,
+				'total_volume'  => $total_volume,
+				'total_fees'    => MonthlyFeeCapService::get_month_total(),
+				'fee_cap'       => MonthlyFeeCapService::get_cap(),
+				'cap_remaining' => MonthlyFeeCapService::get_remaining(),
+				'testmode'      => (bool) $testmode,
 			),
 			200
 		);

--- a/fair-payments-connector/src/API/__tests__/DashboardController.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/DashboardController.api.spec.js
@@ -33,11 +33,15 @@ test.describe('DashboardController — monthly-summary', () => {
 		expect(body).toHaveProperty('month');
 		expect(body).toHaveProperty('total_volume');
 		expect(body).toHaveProperty('total_fees');
+		expect(body).toHaveProperty('fee_cap');
+		expect(body).toHaveProperty('cap_remaining');
 		expect(body).toHaveProperty('testmode');
 		expect(typeof body.month).toBe('string');
 		expect(/^\d{4}-\d{2}$/.test(body.month)).toBe(true);
 		expect(typeof body.total_volume).toBe('number');
 		expect(typeof body.total_fees).toBe('number');
+		expect(typeof body.fee_cap).toBe('number');
+		expect(typeof body.cap_remaining).toBe('number');
 		expect(typeof body.testmode).toBe('boolean');
 	});
 

--- a/fair-payments-connector/src/Services/MonthlyFeeCapService.php
+++ b/fair-payments-connector/src/Services/MonthlyFeeCapService.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Monthly fee cap service for Fair Payments Connector.
+ *
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery -- aggregation query on a custom table; caching not applicable for real-time summaries.
+ *
+ * @package FairPaymentsConnector
+ */
+
+namespace FairPaymentsConnector\Services;
+
+defined( 'WPINC' ) || die;
+
+use FairPaymentsConnector\Database\Schema;
+
+/**
+ * Computes the configured monthly fee cap and the current month's accumulated fees.
+ */
+class MonthlyFeeCapService {
+
+	/**
+	 * Return the active-plugin price map filtered through `fair_payment_active_plugin_prices`.
+	 *
+	 * Keys are plugin slugs; values are their EUR contribution to the monthly cap.
+	 * fair-payments-connector is always included. fair-events is added when its
+	 * bootstrap constant is defined (i.e. the plugin is active).
+	 *
+	 * @return array<string,float>
+	 */
+	private static function plugin_price_map(): array {
+		$prices = array(
+			'fair-payments-connector' => 5.0,
+		);
+
+		if ( defined( 'FAIR_EVENTS_VERSION' ) ) {
+			$prices['fair-events'] = 10.0;
+		}
+
+		return (array) apply_filters( 'fair_payment_active_plugin_prices', $prices );
+	}
+
+	/**
+	 * Return the configured monthly cap in EUR.
+	 *
+	 * Sums the per-plugin prices for every currently active Fair Event plugin.
+	 *
+	 * @return float
+	 */
+	public static function get_cap(): float {
+		return (float) array_sum( self::plugin_price_map() );
+	}
+
+	/**
+	 * Return the sum of application_fee for paid/pending_payment transactions
+	 * in the current calendar month, filtered to the current testmode.
+	 *
+	 * @return float
+	 */
+	public static function get_month_total(): float {
+		global $wpdb;
+
+		$table    = Schema::get_payments_table_name();
+		$testmode = 'test' === get_option( 'fair_payment_mode', 'test' ) ? 1 : 0;
+
+		$month_start = gmdate( 'Y-m-01 00:00:00' );
+		$month_end   = gmdate( 'Y-m-t 23:59:59' );
+
+		return (float) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT SUM(application_fee) FROM %i WHERE status IN (%s, %s) AND testmode = %d AND created_at BETWEEN %s AND %s',
+				$table,
+				'paid',
+				'pending_payment',
+				$testmode,
+				$month_start,
+				$month_end
+			)
+		);
+	}
+
+	/**
+	 * Return the remaining cap for the current month (floored at 0).
+	 *
+	 * @return float
+	 */
+	public static function get_remaining(): float {
+		return max( 0.0, self::get_cap() - self::get_month_total() );
+	}
+}


### PR DESCRIPTION
## Summary

- Implements #773
- Adds `MonthlyFeeCapService` (`src/Services/`) with three public static methods: `get_cap()`, `get_month_total()`, and `get_remaining()`
- Fee cap is computed from a per-plugin price map (`fair-payments-connector`: 5 EUR, `fair-events`: +10 EUR when active); the map is filterable via `fair_payment_active_plugin_prices` for testing
- `DashboardController::get_monthly_summary()` now delegates `total_fees` to the service and exposes two new response fields: `fee_cap` and `cap_remaining`
- API spec updated to assert both new fields are present and numeric

## Test plan

- [ ] Run `vendor/bin/phpcs fair-payments-connector/src/Services/MonthlyFeeCapService.php` — no errors
- [ ] Run `cd fair-payments-connector && npm run test:js` — passes
- [ ] Run `cd fair-payments-connector && npm run test:api` (requires Docker) — `DashboardController.api.spec.js` passes with new `fee_cap` / `cap_remaining` assertions
- [ ] Call `GET /wp-json/fair-payments-connector/v1/dashboard/monthly-summary` as admin and confirm response includes `fee_cap` and `cap_remaining`