### PR TITLE
feat(fair-payments-connector): add Fee Dashboard admin page

### DIFF
--- a/fair-payments-connector/src/API/DashboardController.php
+++ b/fair-payments-connector/src/API/DashboardController.php
@@ -88,12 +88,13 @@ class DashboardController extends WP_REST_Controller {
 
 		return new WP_REST_Response(
 			array(
-				'month'         => $month,
-				'total_volume'  => $total_volume,
-				'total_fees'    => MonthlyFeeCapService::get_month_total(),
-				'fee_cap'       => MonthlyFeeCapService::get_cap(),
-				'cap_remaining' => MonthlyFeeCapService::get_remaining(),
-				'testmode'      => (bool) $testmode,
+				'month'          => $month,
+				'total_volume'   => $total_volume,
+				'total_fees'     => MonthlyFeeCapService::get_month_total(),
+				'fee_cap'        => MonthlyFeeCapService::get_cap(),
+				'cap_remaining'  => MonthlyFeeCapService::get_remaining(),
+				'testmode'       => (bool) $testmode,
+				'plan_breakdown' => MonthlyFeeCapService::plugin_price_map(),
 			),
 			200
 		);

--- a/fair-payments-connector/src/Admin/AdminPages.php
+++ b/fair-payments-connector/src/Admin/AdminPages.php
@@ -92,6 +92,16 @@ class AdminPages {
 			'fair-payments-connector-connected-sites',
 			array( $this, 'render_connected_sites_page' )
 		);
+
+		// Fee Dashboard submenu.
+		add_submenu_page(
+			'fair-payments-connector-transactions',
+			__( 'Fee Dashboard', 'fair-payments-connector' ),
+			__( 'Fee Dashboard', 'fair-payments-connector' ),
+			'manage_options',
+			'fair-payments-connector-fee-dashboard',
+			array( $this, 'render_fee_dashboard_page' )
+		);
 	}
 
 	/**
@@ -138,6 +148,12 @@ class AdminPages {
 		// Connected Sites page.
 		if ( false !== strpos( $hook, 'fair-payments-connector-connected-sites' ) ) {
 			$this->enqueue_admin_page_script( 'connected-sites' );
+			return;
+		}
+
+		// Fee Dashboard page.
+		if ( false !== strpos( $hook, 'fair-payments-connector-fee-dashboard' ) ) {
+			$this->enqueue_admin_page_script( 'fee-dashboard' );
 			return;
 		}
 
@@ -308,6 +324,17 @@ class AdminPages {
 	public function render_connected_sites_page() {
 		?>
 		<div id="fair-payments-connector-connected-sites-root"></div>
+		<?php
+	}
+
+	/**
+	 * Render fee dashboard page
+	 *
+	 * @return void
+	 */
+	public function render_fee_dashboard_page() {
+		?>
+		<div id="fair-payments-connector-fee-dashboard-root"></div>
 		<?php
 	}
 }

--- a/fair-payments-connector/src/Admin/fee-dashboard/FeeDashboardApp.js
+++ b/fair-payments-connector/src/Admin/fee-dashboard/FeeDashboardApp.js
@@ -1,0 +1,204 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	Spinner,
+	Notice,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+const formatEur = (amount) =>
+	new Intl.NumberFormat('de-DE', {
+		style: 'currency',
+		currency: 'EUR',
+	}).format(amount ?? 0);
+
+const ProgressBar = ({ value, max }) => {
+	const pct = max > 0 ? Math.min((value / max) * 100, 100) : 0;
+	const color = pct >= 100 ? '#d63638' : pct >= 80 ? '#946800' : '#007017';
+
+	return (
+		<div>
+			<div
+				style={{
+					background: '#ddd',
+					borderRadius: '4px',
+					overflow: 'hidden',
+					height: '12px',
+				}}
+			>
+				<div
+					style={{
+						width: `${pct}%`,
+						background: color,
+						height: '100%',
+						transition: 'width 0.3s',
+					}}
+				/>
+			</div>
+			<p style={{ margin: '4px 0 0', color }}>
+				{formatEur(value)} / {formatEur(max)} ({Math.round(pct)}%)
+			</p>
+		</div>
+	);
+};
+
+const StatCard = ({ label, children }) => (
+	<Card>
+		<CardHeader>
+			<h3 style={{ margin: 0 }}>{label}</h3>
+		</CardHeader>
+		<CardBody>{children}</CardBody>
+	</Card>
+);
+
+const FeeDashboardApp = () => {
+	const [summary, setSummary] = useState(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(null);
+
+	useEffect(() => {
+		apiFetch({
+			path: '/fair-payments-connector/v1/dashboard/monthly-summary',
+		})
+			.then((data) => setSummary(data))
+			.catch((err) =>
+				setError(
+					err.message ||
+						__(
+							'Failed to load dashboard data.',
+							'fair-payments-connector'
+						)
+				)
+			)
+			.finally(() => setLoading(false));
+	}, []);
+
+	const monthLabel = summary?.month
+		? new Date(summary.month + '-01').toLocaleString('default', {
+				month: 'long',
+				year: 'numeric',
+		  })
+		: '';
+
+	const planEntries = summary?.plan_breakdown
+		? Object.entries(summary.plan_breakdown)
+		: [];
+	const [basePlan, ...addOns] = planEntries;
+
+	return (
+		<div className="wrap fair-payments-connector-fee-dashboard-page">
+			<VStack spacing={4}>
+				<HStack justify="space-between" align="center">
+					<h1 style={{ margin: 0 }}>
+						{__('Fee Dashboard', 'fair-payments-connector')}
+					</h1>
+					{monthLabel && (
+						<span style={{ color: '#666' }}>{monthLabel}</span>
+					)}
+				</HStack>
+
+				{summary?.testmode && (
+					<Notice status="warning" isDismissible={false}>
+						{__(
+							'Test mode — these figures reflect test transactions only.',
+							'fair-payments-connector'
+						)}
+					</Notice>
+				)}
+
+				{error && (
+					<Notice
+						status="error"
+						isDismissible
+						onRemove={() => setError(null)}
+					>
+						{error}
+					</Notice>
+				)}
+
+				{loading && (
+					<div>
+						<Spinner />
+					</div>
+				)}
+
+				{!loading && summary && (
+					<VStack spacing={4}>
+						<StatCard
+							label={__(
+								'Total payment volume this month',
+								'fair-payments-connector'
+							)}
+						>
+							<p style={{ fontSize: '1.5em', margin: 0 }}>
+								{formatEur(summary.total_volume)}
+							</p>
+						</StatCard>
+
+						<StatCard
+							label={__(
+								'Integration fees this month',
+								'fair-payments-connector'
+							)}
+						>
+							<p style={{ fontSize: '1.5em', margin: 0 }}>
+								{formatEur(summary.total_fees)}
+							</p>
+						</StatCard>
+
+						<StatCard
+							label={__(
+								'Monthly fee cap',
+								'fair-payments-connector'
+							)}
+						>
+							<VStack spacing={2}>
+								<ProgressBar
+									value={summary.total_fees}
+									max={summary.fee_cap}
+								/>
+								<p style={{ margin: 0, color: '#666' }}>
+									{formatEur(summary.cap_remaining)}{' '}
+									{__('remaining', 'fair-payments-connector')}
+								</p>
+							</VStack>
+						</StatCard>
+
+						{planEntries.length > 0 && (
+							<StatCard
+								label={__(
+									'Active plan',
+									'fair-payments-connector'
+								)}
+							>
+								<VStack spacing={1}>
+									{basePlan && (
+										<p style={{ margin: 0 }}>
+											<strong>{basePlan[0]}</strong> (
+											{formatEur(basePlan[1])})
+										</p>
+									)}
+									{addOns.map(([slug, price]) => (
+										<p key={slug} style={{ margin: 0 }}>
+											+ {slug} (+{formatEur(price)})
+										</p>
+									))}
+								</VStack>
+							</StatCard>
+						)}
+					</VStack>
+				)}
+			</VStack>
+		</div>
+	);
+};
+
+export default FeeDashboardApp;

--- a/fair-payments-connector/src/Admin/fee-dashboard/index.js
+++ b/fair-payments-connector/src/Admin/fee-dashboard/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import FeeDashboardApp from './FeeDashboardApp.js';
+
+domReady(() => {
+	const root = document.getElementById(
+		'fair-payments-connector-fee-dashboard-root'
+	);
+	if (root) {
+		createRoot(root).render(<FeeDashboardApp />);
+	}
+});

--- a/fair-payments-connector/src/Services/MonthlyFeeCapService.php
+++ b/fair-payments-connector/src/Services/MonthlyFeeCapService.php
@@ -27,7 +27,7 @@ class MonthlyFeeCapService {
 	 *
 	 * @return array<string,float>
 	 */
-	private static function plugin_price_map(): array {
+	public static function plugin_price_map(): array {
 		$prices = array(
 			'fair-payments-connector' => 5.0,
 		);

--- a/fair-payments-connector/webpack.config.cjs
+++ b/fair-payments-connector/webpack.config.cjs
@@ -33,6 +33,10 @@ module.exports = {
       process.cwd(),
       "src/Admin/connected-sites/index.js",
     ),
+    "admin/fee-dashboard/index": path.resolve(
+      process.cwd(),
+      "src/Admin/fee-dashboard/index.js",
+    ),
     "payment-callback": path.resolve(
       process.cwd(),
       "src/payment-callback.js",


### PR DESCRIPTION
## Summary

- Adds **Fee Dashboard** submenu page under Fair Payments Connector showing monthly payment volume, integration fees, fee cap progress bar, and active plan tier
- Extends `GET /fair-payments-connector/v1/dashboard/monthly-summary` with a `plan_breakdown` field (plugin slug → EUR price) by making `MonthlyFeeCapService::plugin_price_map()` public
- Progress bar turns amber at ≥ 80% and red at 100%; test-mode warning banner shown when `testmode: true`

## Test plan

- [ ] **Fee Dashboard** submenu appears under Fair Payments Connector in wp-admin
- [ ] Page loads without JS console errors
- [ ] All three stat cards render with correct values from the API
- [ ] Progress bar reflects `total_fees / fee_cap` with correct colour thresholds
- [ ] Active plan tier lists `fair-payments-connector` (and `fair-events` if active)
- [ ] Test-mode banner is visible (default mode is `test`)

Closes #776