### PR TITLE
chore: add changesets for recent fair-finance, fair-payments-connector, and fair-events-experimental work

### DIFF
--- a/.changeset/fair-events-experimental-scaffold.md
+++ b/.changeset/fair-events-experimental-scaffold.md
@@ -1,0 +1,5 @@
+---
+"fair-events-experimental": major
+---
+
+Introduce fair-events-experimental plugin as an internal bundle for experimental feature flags and functionality.

--- a/.changeset/fair-finance-tags-csv.md
+++ b/.changeset/fair-finance-tags-csv.md
@@ -1,0 +1,5 @@
+---
+"fair-finance": minor
+---
+
+Add tag field to financial entries with income/expense-by-tag chart, and CSV export of financial entries scoped to a budget.

--- a/.changeset/fair-payments-connector-fee-dashboard.md
+++ b/.changeset/fair-payments-connector-fee-dashboard.md
@@ -1,0 +1,5 @@
+---
+"fair-payments-connector": minor
+---
+
+Add Fee Dashboard admin page with monthly-summary REST endpoint, MonthlyFeeCapService, fee cap fields in dashboard summary, and lower platform fee to 1% with updated monthly caps.


### PR DESCRIPTION
## Summary

- Adds changeset for `fair-finance` (minor): tag field on financial entries, income/expense-by-tag chart, and CSV export
- Adds changeset for `fair-payments-connector` (minor): Fee Dashboard admin page, MonthlyFeeCapService, fee cap fields, monthly-summary REST endpoint, fee lowered to 1%
- Adds changeset for `fair-events-experimental` (major): new plugin scaffold

## Test plan

- [ ] Verify `npx changeset status` shows the expected version bumps for all three packages