### PR TITLE
fix: regenerate lock file to include dotenv@16.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -928,7 +928,7 @@
 			}
 		},
 		"fair-audience": {
-			"version": "1.3.4",
+			"version": "1.4.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -1980,7 +1980,7 @@
 			}
 		},
 		"fair-events": {
-			"version": "1.3.4",
+			"version": "1.4.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@fortawesome/fontawesome-svg-core": "^6.0.0",
@@ -2015,7 +2015,7 @@
 			}
 		},
 		"fair-events-experimental": {
-			"version": "0.1.0",
+			"version": "1.0.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -4259,7 +4259,7 @@
 			}
 		},
 		"fair-finance": {
-			"version": "0.1.0",
+			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.12.0",
@@ -4430,7 +4430,7 @@
 			}
 		},
 		"fair-payments-connector": {
-			"version": "1.0.1",
+			"version": "1.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -4443,9 +4443,11 @@
 				"xlsx": "^0.18.5"
 			},
 			"devDependencies": {
+				"@playwright/test": "^1.40.0",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^14.3.1",
 				"@wordpress/scripts": "^32.4.0",
+				"dotenv": "^16.3.1",
 				"webpack-bundle-output": "^1.1.0"
 			}
 		},
@@ -4510,6 +4512,19 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/dotenv": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"fair-payments-connector/node_modules/path-to-regexp": {


### PR DESCRIPTION
## Summary

- Workspace packages (`fair-payments-connector`, `fair-events`, `fair-audience`, `fair-timetable`) depend on `dotenv@^16.3.1`
- The lock file only contained `dotenv@17.2.3` (root dep), so `dotenv@16.6.1` was missing
- This caused `npm ci` to fail in the "Publish fair-events 1.4.0" CI job

## Test plan

- [ ] CI `npm ci` step passes on this branch