### PR TITLE
chore: upgrade @wordpress/components v31 → v35

### DIFF
--- a/fair-audience/jest.config.js
+++ b/fair-audience/jest.config.js
@@ -8,6 +8,9 @@ export default {
 		'/e2e/',
 		'\\.api\\.spec\\.js$',
 	],
+	transformIgnorePatterns: [
+		'/node_modules/(?!(uuid|@wordpress/components)/)',
+	],
 	collectCoverageFrom: [
 		'src/**/*.js',
 		'!src/**/index.js',

--- a/fair-audience/package.json
+++ b/fair-audience/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "^7.2.0",
-		"@wordpress/components": "^30.2.0",
+		"@wordpress/components": "^35.0.0",
 		"@wordpress/dataviews": "^16.0.0",
 		"@wordpress/element": "^6.2.0",
 		"@wordpress/i18n": "^6.2.0",

--- a/fair-events-experimental/package.json
+++ b/fair-events-experimental/package.json
@@ -25,7 +25,7 @@
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "^7.2.0",
-		"@wordpress/components": "^30.2.0",
+		"@wordpress/components": "^35.0.0",
 		"@wordpress/element": "^6.2.0",
 		"@wordpress/i18n": "^6.2.0"
 	},

--- a/fair-events-shared/jest.config.cjs
+++ b/fair-events-shared/jest.config.cjs
@@ -1,6 +1,9 @@
 module.exports = {
   testEnvironment: "jsdom",
   testMatch: ["<rootDir>/__tests__/**/*.test.js"],
+  transformIgnorePatterns: [
+    "/node_modules/(?!(uuid|@wordpress/components)/)",
+  ],
   transform: {
     "^.+\\.js$": "babel-jest",
   },

--- a/fair-events-shared/package.json
+++ b/fair-events-shared/package.json
@@ -16,7 +16,7 @@
 	"author": "",
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
-		"@wordpress/components": "^31.0.0",
+		"@wordpress/components": "^35.0.0",
 		"@wordpress/scripts": "^32.4.0",
 		"date-fns": "^2.30.0"
 	}

--- a/fair-events/jest.config.cjs
+++ b/fair-events/jest.config.cjs
@@ -3,6 +3,9 @@ module.exports = {
 	testEnvironment: 'jsdom',
 	testMatch: ['**/?(*.)+(test).[jt]s?(x)'],
 	testPathIgnorePatterns: ['/node_modules/', '/vendor/', '/build/', '/e2e/'],
+	transformIgnorePatterns: [
+		'/node_modules/(?!(uuid|@wordpress/components)/)',
+	],
 	transform: {
 		'^.+\\.[jt]sx?$': [
 			'babel-jest',

--- a/fair-events/package.json
+++ b/fair-events/package.json
@@ -39,7 +39,7 @@
 		"@wordpress/api-fetch": "^7.2.0",
 		"@wordpress/block-editor": "^15.2.0",
 		"@wordpress/blocks": "^15.2.0",
-		"@wordpress/components": "^31.0.0",
+		"@wordpress/components": "^35.0.0",
 		"@wordpress/data": "^10.2.0",
 		"@wordpress/dataviews": "^16.0.0",
 		"@wordpress/date": "^5.2.0",

--- a/fair-finance/jest.config.js
+++ b/fair-finance/jest.config.js
@@ -8,6 +8,9 @@ export default {
 		'/e2e/',
 		'\\.api\\.spec\\.js$',
 	],
+	transformIgnorePatterns: [
+		'/node_modules/(?!(uuid|@wordpress/components)/)',
+	],
 	collectCoverageFrom: [
 		'src/**/*.js',
 		'!src/**/index.js',

--- a/fair-finance/package.json
+++ b/fair-finance/package.json
@@ -31,7 +31,7 @@
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "^7.12.0",
-		"@wordpress/components": "^31.0.0",
+		"@wordpress/components": "^35.0.0",
 		"@wordpress/element": "^6.12.0",
 		"@wordpress/i18n": "^5.12.0"
 	}

--- a/fair-payments-connector/jest.config.js
+++ b/fair-payments-connector/jest.config.js
@@ -9,6 +9,9 @@ module.exports = {
 		'/e2e/',
 		'\\.api\\.spec\\.js$',
 	],
+	transformIgnorePatterns: [
+		'/node_modules/(?!(uuid|@wordpress/components)/)',
+	],
 	transform: {
 		'^.+\\.[jt]sx?$': [
 			'babel-jest',

--- a/fair-payments-connector/package.json
+++ b/fair-payments-connector/package.json
@@ -43,7 +43,7 @@
 		"@wordpress/api-fetch": "^7.2.0",
 		"@wordpress/block-editor": "^15.2.0",
 		"@wordpress/blocks": "^15.2.0",
-		"@wordpress/components": "^31.0.0",
+		"@wordpress/components": "^35.0.0",
 		"@wordpress/dom-ready": "^4.2.0",
 		"@wordpress/element": "^6.2.0",
 		"@wordpress/i18n": "^6.2.0",

--- a/fair-platform/package.json
+++ b/fair-platform/package.json
@@ -31,7 +31,7 @@
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "^7.12.0",
-		"@wordpress/components": "^31.0.0",
+		"@wordpress/components": "^35.0.0",
 		"@wordpress/element": "^6.12.0",
 		"@wordpress/i18n": "^5.12.0"
 	}

--- a/fair-timetable/jest.config.cjs
+++ b/fair-timetable/jest.config.cjs
@@ -1,6 +1,9 @@
 module.exports = {
   testEnvironment: "node",
   testMatch: ["<rootDir>/__tests__/**/*.test.js"],
+  transformIgnorePatterns: [
+    "/node_modules/(?!(uuid|@wordpress/components)/)",
+  ],
   transform: {
     "^.+\\.js$": "babel-jest",
   },

--- a/fair-timetable/package.json
+++ b/fair-timetable/package.json
@@ -36,7 +36,7 @@
 		"@fortawesome/react-fontawesome": "^0.2.3",
 		"@wordpress/block-editor": "^15.2.0",
 		"@wordpress/blocks": "^15.2.0",
-		"@wordpress/components": "^31.0.0",
+		"@wordpress/components": "^35.0.0",
 		"@wordpress/i18n": "^6.2.0",
 		"date-fns": "^4.1.0"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -920,7 +920,7 @@
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
-				"@wordpress/components": "^30.2.0",
+				"@wordpress/components": "^35.0.0",
 				"@wordpress/dataviews": "^16.0.0",
 				"@wordpress/element": "^6.2.0",
 				"@wordpress/i18n": "^6.2.0",
@@ -1031,6 +1031,189 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"fair-audience/node_modules/@wordpress/base-styles": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-audience/node_modules/@wordpress/components": {
+			"version": "35.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/native": "^11.11.0",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.48.0",
+				"@wordpress/base-styles": "^9.1.0",
+				"@wordpress/compose": "^8.1.0",
+				"@wordpress/date": "^5.48.0",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/hooks": "^4.48.0",
+				"@wordpress/html-entities": "^4.48.0",
+				"@wordpress/i18n": "^6.21.0",
+				"@wordpress/icons": "^13.3.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/primitives": "^4.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/rich-text": "^7.48.0",
+				"@wordpress/style-runtime": "^0.4.0",
+				"@wordpress/ui": "^0.15.0",
+				"@wordpress/warning": "^3.48.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"fair-audience/node_modules/@wordpress/components/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-audience/node_modules/@wordpress/compose": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
+			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/priority-queue": "^3.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/undo-manager": "^1.48.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-audience/node_modules/@wordpress/compose/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-audience/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-audience/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"fair-audience/node_modules/ansi-styles": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1134,6 +1317,16 @@
 			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"fair-audience/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
 		},
 		"fair-audience/node_modules/dotenv": {
 			"version": "16.6.1",
@@ -1734,6 +1927,12 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"fair-audience/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"license": "MIT"
+		},
 		"fair-audience/node_modules/picomatch": {
 			"version": "4.0.3",
 			"dev": true,
@@ -1839,6 +2038,19 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"fair-audience/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
 		"fair-audience/node_modules/write-file-atomic": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -1863,7 +2075,7 @@
 				"@wordpress/api-fetch": "^7.2.0",
 				"@wordpress/block-editor": "^15.2.0",
 				"@wordpress/blocks": "^15.2.0",
-				"@wordpress/components": "^31.0.0",
+				"@wordpress/components": "^35.0.0",
 				"@wordpress/data": "^10.2.0",
 				"@wordpress/dataviews": "^16.0.0",
 				"@wordpress/date": "^5.2.0",
@@ -1893,7 +2105,7 @@
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
-				"@wordpress/components": "^30.2.0",
+				"@wordpress/components": "^35.0.0",
 				"@wordpress/element": "^6.2.0",
 				"@wordpress/i18n": "^6.2.0"
 			},
@@ -1995,6 +2207,189 @@
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@wordpress/base-styles": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-events-experimental/node_modules/@wordpress/components": {
+			"version": "35.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/native": "^11.11.0",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.48.0",
+				"@wordpress/base-styles": "^9.1.0",
+				"@wordpress/compose": "^8.1.0",
+				"@wordpress/date": "^5.48.0",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/hooks": "^4.48.0",
+				"@wordpress/html-entities": "^4.48.0",
+				"@wordpress/i18n": "^6.21.0",
+				"@wordpress/icons": "^13.3.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/primitives": "^4.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/rich-text": "^7.48.0",
+				"@wordpress/style-runtime": "^0.4.0",
+				"@wordpress/ui": "^0.15.0",
+				"@wordpress/warning": "^3.48.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@wordpress/components/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-events-experimental/node_modules/@wordpress/compose": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
+			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/priority-queue": "^3.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/undo-manager": "^1.48.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@wordpress/compose/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-events-experimental/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"fair-events-experimental/node_modules/ansi-styles": {
@@ -2104,6 +2499,16 @@
 			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"fair-events-experimental/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
 		},
 		"fair-events-experimental/node_modules/expect": {
 			"version": "30.4.1",
@@ -2695,6 +3100,12 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"fair-events-experimental/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"license": "MIT"
+		},
 		"fair-events-experimental/node_modules/picomatch": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -2804,6 +3215,19 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"fair-events-experimental/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
 		"fair-events-experimental/node_modules/write-file-atomic": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -2822,49 +3246,66 @@
 			"version": "0.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/components": "^31.0.0",
+				"@wordpress/components": "^35.0.0",
 				"@wordpress/scripts": "^32.4.0",
 				"date-fns": "^2.30.0"
 			}
 		},
+		"fair-events-shared/node_modules/@wordpress/base-styles": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"fair-events-shared/node_modules/@wordpress/components": {
-			"version": "31.0.0",
+			"version": "35.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
+				"@ariakit/react": "^0.4.22",
 				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/native": "^11.11.0",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
 				"@floating-ui/react-dom": "2.0.8",
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.37.0",
-				"@wordpress/base-styles": "^6.13.0",
-				"@wordpress/compose": "^7.37.0",
-				"@wordpress/date": "^5.37.0",
-				"@wordpress/deprecated": "^4.37.0",
-				"@wordpress/dom": "^4.37.0",
-				"@wordpress/element": "^6.37.0",
-				"@wordpress/escape-html": "^3.37.0",
-				"@wordpress/hooks": "^4.37.0",
-				"@wordpress/html-entities": "^4.37.0",
-				"@wordpress/i18n": "^6.10.0",
-				"@wordpress/icons": "^11.4.0",
-				"@wordpress/is-shallow-equal": "^5.37.0",
-				"@wordpress/keycodes": "^4.37.0",
-				"@wordpress/primitives": "^4.37.0",
-				"@wordpress/private-apis": "^1.37.0",
-				"@wordpress/rich-text": "^7.37.0",
-				"@wordpress/warning": "^3.37.0",
+				"@wordpress/a11y": "^4.48.0",
+				"@wordpress/base-styles": "^9.1.0",
+				"@wordpress/compose": "^8.1.0",
+				"@wordpress/date": "^5.48.0",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/hooks": "^4.48.0",
+				"@wordpress/html-entities": "^4.48.0",
+				"@wordpress/i18n": "^6.21.0",
+				"@wordpress/icons": "^13.3.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/primitives": "^4.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/rich-text": "^7.48.0",
+				"@wordpress/style-runtime": "^0.4.0",
+				"@wordpress/ui": "^0.15.0",
+				"@wordpress/warning": "^3.48.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
-				"date-fns": "^3.6.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.15.0",
@@ -2874,10 +3315,10 @@
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
+				"react-colorful": "^5.6.1",
 				"react-day-picker": "^9.7.0",
 				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2889,11 +3330,78 @@
 			}
 		},
 		"fair-events-shared/node_modules/@wordpress/components/node_modules/date-fns": {
-			"version": "3.6.0",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
+		"fair-events-shared/node_modules/@wordpress/compose": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
+			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/priority-queue": "^3.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/undo-manager": "^1.48.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-events-shared/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"fair-events-shared/node_modules/date-fns": {
@@ -2915,14 +3423,16 @@
 			"license": "MIT"
 		},
 		"fair-events-shared/node_modules/uuid": {
-			"version": "9.0.1",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-events/node_modules/@fortawesome/fontawesome-common-types": {
@@ -3052,44 +3562,61 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"fair-events/node_modules/@wordpress/base-styles": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"fair-events/node_modules/@wordpress/components": {
-			"version": "31.0.0",
+			"version": "35.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
+				"@ariakit/react": "^0.4.22",
 				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/native": "^11.11.0",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
 				"@floating-ui/react-dom": "2.0.8",
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.37.0",
-				"@wordpress/base-styles": "^6.13.0",
-				"@wordpress/compose": "^7.37.0",
-				"@wordpress/date": "^5.37.0",
-				"@wordpress/deprecated": "^4.37.0",
-				"@wordpress/dom": "^4.37.0",
-				"@wordpress/element": "^6.37.0",
-				"@wordpress/escape-html": "^3.37.0",
-				"@wordpress/hooks": "^4.37.0",
-				"@wordpress/html-entities": "^4.37.0",
-				"@wordpress/i18n": "^6.10.0",
-				"@wordpress/icons": "^11.4.0",
-				"@wordpress/is-shallow-equal": "^5.37.0",
-				"@wordpress/keycodes": "^4.37.0",
-				"@wordpress/primitives": "^4.37.0",
-				"@wordpress/private-apis": "^1.37.0",
-				"@wordpress/rich-text": "^7.37.0",
-				"@wordpress/warning": "^3.37.0",
+				"@wordpress/a11y": "^4.48.0",
+				"@wordpress/base-styles": "^9.1.0",
+				"@wordpress/compose": "^8.1.0",
+				"@wordpress/date": "^5.48.0",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/hooks": "^4.48.0",
+				"@wordpress/html-entities": "^4.48.0",
+				"@wordpress/i18n": "^6.21.0",
+				"@wordpress/icons": "^13.3.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/primitives": "^4.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/rich-text": "^7.48.0",
+				"@wordpress/style-runtime": "^0.4.0",
+				"@wordpress/ui": "^0.15.0",
+				"@wordpress/warning": "^3.48.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
-				"date-fns": "^3.6.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.15.0",
@@ -3099,10 +3626,10 @@
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
+				"react-colorful": "^5.6.1",
 				"react-day-picker": "^9.7.0",
 				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -3111,6 +3638,111 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"fair-events/node_modules/@wordpress/components/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-events/node_modules/@wordpress/compose": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
+			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/priority-queue": "^3.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/undo-manager": "^1.48.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-events/node_modules/@wordpress/compose/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-events/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-events/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"fair-events/node_modules/ansi-styles": {
@@ -3216,6 +3848,16 @@
 			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"fair-events/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
 		},
 		"fair-events/node_modules/dotenv": {
 			"version": "16.6.1",
@@ -3926,14 +4568,16 @@
 			}
 		},
 		"fair-events/node_modules/uuid": {
-			"version": "9.0.1",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-events/node_modules/write-file-atomic": {
@@ -3955,7 +4599,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.12.0",
-				"@wordpress/components": "^31.0.0",
+				"@wordpress/components": "^35.0.0",
 				"@wordpress/element": "^6.12.0",
 				"@wordpress/i18n": "^5.12.0"
 			},
@@ -3976,46 +4620,61 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"fair-finance/node_modules/@wordpress/base-styles": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"fair-finance/node_modules/@wordpress/components": {
-			"version": "31.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-31.0.0.tgz",
-			"integrity": "sha512-2Oz4r+4KCDTV5fMC2l9bDYfRAsLQLs29fLB4PelckW+X3KhhFM6gz5vx5N7hO3WLY19Fn6qKZgtgJjOKWG7+1w==",
+			"version": "35.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
+				"@ariakit/react": "^0.4.22",
 				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/native": "^11.11.0",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
 				"@floating-ui/react-dom": "2.0.8",
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.37.0",
-				"@wordpress/base-styles": "^6.13.0",
-				"@wordpress/compose": "^7.37.0",
-				"@wordpress/date": "^5.37.0",
-				"@wordpress/deprecated": "^4.37.0",
-				"@wordpress/dom": "^4.37.0",
-				"@wordpress/element": "^6.37.0",
-				"@wordpress/escape-html": "^3.37.0",
-				"@wordpress/hooks": "^4.37.0",
-				"@wordpress/html-entities": "^4.37.0",
-				"@wordpress/i18n": "^6.10.0",
-				"@wordpress/icons": "^11.4.0",
-				"@wordpress/is-shallow-equal": "^5.37.0",
-				"@wordpress/keycodes": "^4.37.0",
-				"@wordpress/primitives": "^4.37.0",
-				"@wordpress/private-apis": "^1.37.0",
-				"@wordpress/rich-text": "^7.37.0",
-				"@wordpress/warning": "^3.37.0",
+				"@wordpress/a11y": "^4.48.0",
+				"@wordpress/base-styles": "^9.1.0",
+				"@wordpress/compose": "^8.1.0",
+				"@wordpress/date": "^5.48.0",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/hooks": "^4.48.0",
+				"@wordpress/html-entities": "^4.48.0",
+				"@wordpress/i18n": "^6.21.0",
+				"@wordpress/icons": "^13.3.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/primitives": "^4.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/rich-text": "^7.48.0",
+				"@wordpress/style-runtime": "^0.4.0",
+				"@wordpress/ui": "^0.15.0",
+				"@wordpress/warning": "^3.48.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
-				"date-fns": "^3.6.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.15.0",
@@ -4025,10 +4684,10 @@
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
+				"react-colorful": "^5.6.1",
 				"react-day-picker": "^9.7.0",
 				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -4037,6 +4696,26 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"fair-finance/node_modules/@wordpress/components/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"fair-finance/node_modules/@wordpress/components/node_modules/@wordpress/i18n": {
@@ -4053,6 +4732,53 @@
 			},
 			"bin": {
 				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-finance/node_modules/@wordpress/compose": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
+			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/priority-queue": "^3.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/undo-manager": "^1.48.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-finance/node_modules/@wordpress/compose/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -4080,6 +4806,54 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"fair-finance/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-finance/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-finance/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
 		"fair-finance/node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -4087,17 +4861,16 @@
 			"license": "MIT"
 		},
 		"fair-finance/node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-payment": {
@@ -4128,7 +4901,7 @@
 				"@wordpress/api-fetch": "^7.2.0",
 				"@wordpress/block-editor": "^15.2.0",
 				"@wordpress/blocks": "^15.2.0",
-				"@wordpress/components": "^31.0.0",
+				"@wordpress/components": "^35.0.0",
 				"@wordpress/dom-ready": "^4.2.0",
 				"@wordpress/element": "^6.2.0",
 				"@wordpress/i18n": "^6.2.0",
@@ -4143,46 +4916,61 @@
 				"webpack-bundle-output": "^1.1.0"
 			}
 		},
+		"fair-payments-connector/node_modules/@wordpress/base-styles": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"fair-payments-connector/node_modules/@wordpress/components": {
-			"version": "31.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-31.0.0.tgz",
-			"integrity": "sha512-2Oz4r+4KCDTV5fMC2l9bDYfRAsLQLs29fLB4PelckW+X3KhhFM6gz5vx5N7hO3WLY19Fn6qKZgtgJjOKWG7+1w==",
+			"version": "35.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
+				"@ariakit/react": "^0.4.22",
 				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/native": "^11.11.0",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
 				"@floating-ui/react-dom": "2.0.8",
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.37.0",
-				"@wordpress/base-styles": "^6.13.0",
-				"@wordpress/compose": "^7.37.0",
-				"@wordpress/date": "^5.37.0",
-				"@wordpress/deprecated": "^4.37.0",
-				"@wordpress/dom": "^4.37.0",
-				"@wordpress/element": "^6.37.0",
-				"@wordpress/escape-html": "^3.37.0",
-				"@wordpress/hooks": "^4.37.0",
-				"@wordpress/html-entities": "^4.37.0",
-				"@wordpress/i18n": "^6.10.0",
-				"@wordpress/icons": "^11.4.0",
-				"@wordpress/is-shallow-equal": "^5.37.0",
-				"@wordpress/keycodes": "^4.37.0",
-				"@wordpress/primitives": "^4.37.0",
-				"@wordpress/private-apis": "^1.37.0",
-				"@wordpress/rich-text": "^7.37.0",
-				"@wordpress/warning": "^3.37.0",
+				"@wordpress/a11y": "^4.48.0",
+				"@wordpress/base-styles": "^9.1.0",
+				"@wordpress/compose": "^8.1.0",
+				"@wordpress/date": "^5.48.0",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/hooks": "^4.48.0",
+				"@wordpress/html-entities": "^4.48.0",
+				"@wordpress/i18n": "^6.21.0",
+				"@wordpress/icons": "^13.3.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/primitives": "^4.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/rich-text": "^7.48.0",
+				"@wordpress/style-runtime": "^0.4.0",
+				"@wordpress/ui": "^0.15.0",
+				"@wordpress/warning": "^3.48.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
-				"date-fns": "^3.6.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.15.0",
@@ -4192,10 +4980,10 @@
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
+				"react-colorful": "^5.6.1",
 				"react-day-picker": "^9.7.0",
 				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -4204,6 +4992,121 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@wordpress/components/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-payments-connector/node_modules/@wordpress/compose": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
+			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/priority-queue": "^3.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/undo-manager": "^1.48.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@wordpress/compose/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-payments-connector/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-payments-connector/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"fair-payments-connector/node_modules/dotenv": {
@@ -4226,17 +5129,16 @@
 			"license": "MIT"
 		},
 		"fair-payments-connector/node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-platform": {
@@ -4244,7 +5146,7 @@
 			"license": "proprietary",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.12.0",
-				"@wordpress/components": "^31.0.0",
+				"@wordpress/components": "^35.0.0",
 				"@wordpress/element": "^6.12.0",
 				"@wordpress/i18n": "^5.12.0"
 			},
@@ -4263,44 +5165,61 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"fair-platform/node_modules/@wordpress/base-styles": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"fair-platform/node_modules/@wordpress/components": {
-			"version": "31.0.0",
+			"version": "35.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
+				"@ariakit/react": "^0.4.22",
 				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/native": "^11.11.0",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
 				"@floating-ui/react-dom": "2.0.8",
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.37.0",
-				"@wordpress/base-styles": "^6.13.0",
-				"@wordpress/compose": "^7.37.0",
-				"@wordpress/date": "^5.37.0",
-				"@wordpress/deprecated": "^4.37.0",
-				"@wordpress/dom": "^4.37.0",
-				"@wordpress/element": "^6.37.0",
-				"@wordpress/escape-html": "^3.37.0",
-				"@wordpress/hooks": "^4.37.0",
-				"@wordpress/html-entities": "^4.37.0",
-				"@wordpress/i18n": "^6.10.0",
-				"@wordpress/icons": "^11.4.0",
-				"@wordpress/is-shallow-equal": "^5.37.0",
-				"@wordpress/keycodes": "^4.37.0",
-				"@wordpress/primitives": "^4.37.0",
-				"@wordpress/private-apis": "^1.37.0",
-				"@wordpress/rich-text": "^7.37.0",
-				"@wordpress/warning": "^3.37.0",
+				"@wordpress/a11y": "^4.48.0",
+				"@wordpress/base-styles": "^9.1.0",
+				"@wordpress/compose": "^8.1.0",
+				"@wordpress/date": "^5.48.0",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/hooks": "^4.48.0",
+				"@wordpress/html-entities": "^4.48.0",
+				"@wordpress/i18n": "^6.21.0",
+				"@wordpress/icons": "^13.3.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/primitives": "^4.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/rich-text": "^7.48.0",
+				"@wordpress/style-runtime": "^0.4.0",
+				"@wordpress/ui": "^0.15.0",
+				"@wordpress/warning": "^3.48.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
-				"date-fns": "^3.6.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.15.0",
@@ -4310,10 +5229,10 @@
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
+				"react-colorful": "^5.6.1",
 				"react-day-picker": "^9.7.0",
 				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -4322,6 +5241,26 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"fair-platform/node_modules/@wordpress/components/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"fair-platform/node_modules/@wordpress/components/node_modules/@wordpress/i18n": {
@@ -4338,6 +5277,53 @@
 			},
 			"bin": {
 				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-platform/node_modules/@wordpress/compose": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
+			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/priority-queue": "^3.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/undo-manager": "^1.48.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-platform/node_modules/@wordpress/compose/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -4363,19 +5349,69 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"fair-platform/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-platform/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-platform/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
 		"fair-platform/node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"license": "MIT"
 		},
 		"fair-platform/node_modules/uuid": {
-			"version": "9.0.1",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-timetable": {
@@ -4388,7 +5424,7 @@
 				"@fortawesome/react-fontawesome": "^0.2.3",
 				"@wordpress/block-editor": "^15.2.0",
 				"@wordpress/blocks": "^15.2.0",
-				"@wordpress/components": "^31.0.0",
+				"@wordpress/components": "^35.0.0",
 				"@wordpress/i18n": "^6.2.0",
 				"date-fns": "^4.1.0"
 			},
@@ -4493,46 +5529,61 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"fair-timetable/node_modules/@wordpress/base-styles": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"fair-timetable/node_modules/@wordpress/components": {
-			"version": "31.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-31.0.0.tgz",
-			"integrity": "sha512-2Oz4r+4KCDTV5fMC2l9bDYfRAsLQLs29fLB4PelckW+X3KhhFM6gz5vx5N7hO3WLY19Fn6qKZgtgJjOKWG7+1w==",
+			"version": "35.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
+				"@ariakit/react": "^0.4.22",
 				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/native": "^11.11.0",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
 				"@floating-ui/react-dom": "2.0.8",
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.37.0",
-				"@wordpress/base-styles": "^6.13.0",
-				"@wordpress/compose": "^7.37.0",
-				"@wordpress/date": "^5.37.0",
-				"@wordpress/deprecated": "^4.37.0",
-				"@wordpress/dom": "^4.37.0",
-				"@wordpress/element": "^6.37.0",
-				"@wordpress/escape-html": "^3.37.0",
-				"@wordpress/hooks": "^4.37.0",
-				"@wordpress/html-entities": "^4.37.0",
-				"@wordpress/i18n": "^6.10.0",
-				"@wordpress/icons": "^11.4.0",
-				"@wordpress/is-shallow-equal": "^5.37.0",
-				"@wordpress/keycodes": "^4.37.0",
-				"@wordpress/primitives": "^4.37.0",
-				"@wordpress/private-apis": "^1.37.0",
-				"@wordpress/rich-text": "^7.37.0",
-				"@wordpress/warning": "^3.37.0",
+				"@wordpress/a11y": "^4.48.0",
+				"@wordpress/base-styles": "^9.1.0",
+				"@wordpress/compose": "^8.1.0",
+				"@wordpress/date": "^5.48.0",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/hooks": "^4.48.0",
+				"@wordpress/html-entities": "^4.48.0",
+				"@wordpress/i18n": "^6.21.0",
+				"@wordpress/icons": "^13.3.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/primitives": "^4.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/rich-text": "^7.48.0",
+				"@wordpress/style-runtime": "^0.4.0",
+				"@wordpress/ui": "^0.15.0",
+				"@wordpress/warning": "^3.48.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
-				"date-fns": "^3.6.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.15.0",
@@ -4542,10 +5593,10 @@
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
+				"react-colorful": "^5.6.1",
 				"react-day-picker": "^9.7.0",
 				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -4556,14 +5607,69 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"fair-timetable/node_modules/@wordpress/components/node_modules/date-fns": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
+		"fair-timetable/node_modules/@wordpress/compose": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
+			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/priority-queue": "^3.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/undo-manager": "^1.48.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"fair-timetable/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"fair-timetable/node_modules/ansi-styles": {
@@ -5403,17 +6509,16 @@
 			}
 		},
 		"fair-timetable/node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-timetable/node_modules/write-file-atomic": {
@@ -15984,16 +17089,6 @@
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
-		"node_modules/@wordpress/base-styles": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
-			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/blob": {
 			"version": "4.48.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.48.0.tgz",
@@ -16536,88 +17631,6 @@
 			"license": "MIT",
 			"bin": {
 				"uuid": "dist-node/bin/uuid"
-			}
-		},
-		"node_modules/@wordpress/components": {
-			"version": "30.9.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
-			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.15",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.36.0",
-				"@wordpress/base-styles": "^6.12.0",
-				"@wordpress/compose": "^7.36.0",
-				"@wordpress/date": "^5.36.0",
-				"@wordpress/deprecated": "^4.36.0",
-				"@wordpress/dom": "^4.36.0",
-				"@wordpress/element": "^6.36.0",
-				"@wordpress/escape-html": "^3.36.0",
-				"@wordpress/hooks": "^4.36.0",
-				"@wordpress/html-entities": "^4.36.0",
-				"@wordpress/i18n": "^6.9.0",
-				"@wordpress/icons": "^11.3.0",
-				"@wordpress/is-shallow-equal": "^5.36.0",
-				"@wordpress/keycodes": "^4.36.0",
-				"@wordpress/primitives": "^4.36.0",
-				"@wordpress/private-apis": "^1.36.0",
-				"@wordpress/rich-text": "^7.36.0",
-				"@wordpress/warning": "^3.36.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"date-fns": "^3.6.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/components/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/components/node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@wordpress/compose": {
@@ -17216,23 +18229,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/icons": {
-			"version": "11.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
-			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^6.39.0",
-				"@wordpress/primitives": "^4.39.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/image-cropper": {


### PR DESCRIPTION
Closes #813

## Summary

- Bumps `@wordpress/components` from `^30.2.0` / `^31.0.0` to `^35.0.0` across all workspace packages
- Resolves to `35.0.0` in `package-lock.json`
- Packages updated: `fair-events`, `fair-payments-connector`, `fair-events-shared`, `fair-finance`, `fair-timetable`, `fair-platform`, `fair-audience`, `fair-events-experimental`

## Test plan

- [ ] Run `npm run build` in each plugin and confirm no build errors
- [ ] Verify admin pages render correctly in Docker WordPress environment
- [ ] Spot-check `@wordpress/components` import usage for any deprecated APIs removed in v32–v35