### PR TITLE
Upgrade @wordpress/dataviews v4 → v16 (fair-audience, fair-events)

### DIFF
--- a/.changeset/upgrade-dataviews-v16.md
+++ b/.changeset/upgrade-dataviews-v16.md
@@ -1,0 +1,6 @@
+---
+"fair-audience": minor
+"fair-events": minor
+---
+
+Upgrade @wordpress/dataviews from v4 to v16 for admin list views.

--- a/fair-audience/package.json
+++ b/fair-audience/package.json
@@ -33,7 +33,7 @@
 	"dependencies": {
 		"@wordpress/api-fetch": "^7.2.0",
 		"@wordpress/components": "^30.2.0",
-		"@wordpress/dataviews": "^4.0.0",
+		"@wordpress/dataviews": "^16.0.0",
 		"@wordpress/element": "^6.2.0",
 		"@wordpress/i18n": "^6.2.0",
 		"fair-events-shared": "*",

--- a/fair-audience/src/Admin/all-participants/AllParticipants.js
+++ b/fair-audience/src/Admin/all-participants/AllParticipants.js
@@ -466,7 +466,6 @@ export default function AllParticipants() {
 				id: 'delete',
 				label: __('Delete', 'fair-audience'),
 				icon: 'trash',
-				isDestructive: true,
 				callback: handleDelete,
 				supportsBulk: true,
 			},

--- a/fair-audience/src/Admin/event-participants/EventParticipants.js
+++ b/fair-audience/src/Admin/event-participants/EventParticipants.js
@@ -681,7 +681,6 @@ export default function EventParticipants() {
 			{
 				id: 'remove',
 				label: __('Remove', 'fair-audience'),
-				isDestructive: true,
 				callback: handleRemove,
 				supportsBulk: true,
 			},

--- a/fair-audience/src/Admin/fee-detail/FeeDetail.js
+++ b/fair-audience/src/Admin/fee-detail/FeeDetail.js
@@ -571,7 +571,6 @@ export default function FeeDetail() {
 				icon: 'dismiss',
 				callback: ([item]) => handleCancel(item),
 				supportsBulk: false,
-				isDestructive: true,
 				isEligible: (item) => item.status === 'pending',
 			},
 			{

--- a/fair-audience/src/Admin/fees-list/FeesList.js
+++ b/fair-audience/src/Admin/fees-list/FeesList.js
@@ -392,7 +392,6 @@ export default function FeesList() {
 				icon: 'trash',
 				callback: ([item]) => handleDeleteFee(item),
 				supportsBulk: false,
-				isDestructive: true,
 			},
 		],
 		[]

--- a/fair-audience/src/Admin/form-answers/FormAnswers.js
+++ b/fair-audience/src/Admin/form-answers/FormAnswers.js
@@ -223,7 +223,6 @@ export default function FormAnswers() {
 				icon: 'trash',
 				callback: ([item]) => handleDelete(item),
 				supportsBulk: false,
-				isDestructive: true,
 			},
 		],
 		[]

--- a/fair-audience/src/Admin/groups/Groups.js
+++ b/fair-audience/src/Admin/groups/Groups.js
@@ -296,7 +296,6 @@ export default function Groups() {
 				icon: 'trash',
 				callback: ([item]) => handleDeleteGroup(item),
 				supportsBulk: false,
-				isDestructive: true,
 			},
 		],
 		[]

--- a/fair-audience/src/Admin/questionnaire-responses/QuestionnaireResponses.js
+++ b/fair-audience/src/Admin/questionnaire-responses/QuestionnaireResponses.js
@@ -271,7 +271,6 @@ export default function QuestionnaireResponses() {
 				icon: 'trash',
 				callback: ([item]) => handleDelete(item),
 				supportsBulk: false,
-				isDestructive: true,
 			},
 		],
 		[]

--- a/fair-events/package.json
+++ b/fair-events/package.json
@@ -41,7 +41,7 @@
 		"@wordpress/blocks": "^15.2.0",
 		"@wordpress/components": "^31.0.0",
 		"@wordpress/data": "^10.2.0",
-		"@wordpress/dataviews": "^4.0.0",
+		"@wordpress/dataviews": "^16.0.0",
 		"@wordpress/date": "^5.2.0",
 		"@wordpress/dom-ready": "^4.2.0",
 		"@wordpress/element": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,18 +238,6 @@
 				"escape-html": "^1.0.3",
 				"escape-string-regexp": "^4.0.0",
 				"escodegen": "^2.1.0",
-				"eslint": "^8.57.1",
-				"eslint-import-resolver-node": "^0.3.9",
-				"eslint-module-utils": "^2.12.1",
-				"eslint-plugin-import": "^2.32.0",
-				"eslint-plugin-jest": "^27.9.0",
-				"eslint-plugin-jsdoc": "^46.10.1",
-				"eslint-plugin-jsx-a11y": "^6.10.2",
-				"eslint-plugin-playwright": "^0.15.3",
-				"eslint-plugin-react": "^7.37.5",
-				"eslint-plugin-react-hooks": "^4.6.2",
-				"eslint-scope": "^5.1.1",
-				"eslint-visitor-keys": "^2.1.0",
 				"espree": "^9.6.1",
 				"esprima": "^4.0.1",
 				"esquery": "^1.6.0",
@@ -933,7 +921,7 @@
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
 				"@wordpress/components": "^30.2.0",
-				"@wordpress/dataviews": "^4.0.0",
+				"@wordpress/dataviews": "^16.0.0",
 				"@wordpress/element": "^6.2.0",
 				"@wordpress/i18n": "^6.2.0",
 				"fair-events-shared": "*",
@@ -1877,7 +1865,7 @@
 				"@wordpress/blocks": "^15.2.0",
 				"@wordpress/components": "^31.0.0",
 				"@wordpress/data": "^10.2.0",
-				"@wordpress/dataviews": "^4.0.0",
+				"@wordpress/dataviews": "^16.0.0",
 				"@wordpress/date": "^5.2.0",
 				"@wordpress/dom-ready": "^4.2.0",
 				"@wordpress/element": "^6.2.0",
@@ -8243,38 +8231,6 @@
 			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
 			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
 			"license": "MIT"
-		},
-		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
-			"integrity": "sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==",
-			"license": "MIT",
-			"dependencies": {
-				"comment-parser": "1.4.1",
-				"esquery": "^1.5.0",
-				"jsdoc-type-pratt-parser": "~4.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@es-joy/jsdoccomment/node_modules/comment-parser": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
-			"integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/@es-joy/jsdoccomment/node_modules/jsdoc-type-pratt-parser": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
-			"integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			}
 		},
 		"node_modules/@eslint-community/eslint-plugin-eslint-comments": {
 			"version": "4.7.2",
@@ -15077,12 +15033,6 @@
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
 			"license": "MIT"
 		},
-		"node_modules/@types/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-			"license": "MIT"
-		},
 		"node_modules/@types/send": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -15298,23 +15248,6 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
 			"version": "8.61.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
@@ -15329,125 +15262,6 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=4.8.4 <6.1.0"
-			}
-		},
-		"node_modules/@typescript-eslint/types": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@typescript-eslint/utils": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-			"integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.62.0",
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/typescript-estree": "5.62.0",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.3.7"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"eslint-visitor-keys": "^3.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
@@ -16363,43 +16177,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/block-editor/node_modules/@wordpress/dataviews": {
-			"version": "16.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-16.0.0.tgz",
-			"integrity": "sha512-02rbslxalTNasLV8w/zAifCsUU5Pug8GiduWIEKRiNtazvJ8duz8fIcQ2Jgl31ruRItcu3fcG7XUk1OtwsdcZQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.21",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/components": "^35.0.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/data": "^10.48.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"date-fns": "^4.1.0",
-				"deepmerge": "4.3.1",
-				"fast-deep-equal": "^3.1.3",
-				"remove-accents": "^0.5.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/element": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
@@ -16947,102 +16724,32 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-4.22.0.tgz",
-			"integrity": "sha512-6nUE2vWjf4W0JueLhwLFyhhc+vQJWE/blavGdcpI+WfWCOTDlYPPiotIdadIwazUDFiy0Hf9VNNai0/6jAsCIw==",
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-16.0.0.tgz",
+			"integrity": "sha512-02rbslxalTNasLV8w/zAifCsUU5Pug8GiduWIEKRiNtazvJ8duz8fIcQ2Jgl31ruRItcu3fcG7XUk1OtwsdcZQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
-				"@babel/runtime": "7.25.7",
-				"@wordpress/components": "^29.12.0",
-				"@wordpress/compose": "^7.26.0",
-				"@wordpress/data": "^10.26.0",
-				"@wordpress/element": "^6.26.0",
-				"@wordpress/i18n": "^5.26.0",
-				"@wordpress/icons": "^10.26.0",
-				"@wordpress/primitives": "^4.26.0",
-				"@wordpress/private-apis": "^1.26.0",
-				"@wordpress/warning": "^3.26.0",
-				"clsx": "^2.1.1",
-				"remove-accents": "^0.5.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/dataviews/node_modules/@babel/runtime": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-			"integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@wordpress/dataviews/node_modules/@types/gradient-parser": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
-			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ==",
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
-			"version": "29.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-29.12.0.tgz",
-			"integrity": "sha512-jE96pUj84OZya54VusRdEIdTiLjbe2Qst3GbHZcQpA5GiSkPBmGjKWpO6FxR7kRDT4GMnZoVxgtV6xJk4IaNQw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.15",
-				"@babel/runtime": "7.25.7",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "^2.0.8",
-				"@types/gradient-parser": "0.1.3",
-				"@types/highlight-words-core": "1.2.1",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.26.0",
-				"@wordpress/compose": "^7.26.0",
-				"@wordpress/date": "^5.26.0",
-				"@wordpress/deprecated": "^4.26.0",
-				"@wordpress/dom": "^4.26.0",
-				"@wordpress/element": "^6.26.0",
-				"@wordpress/escape-html": "^3.26.0",
-				"@wordpress/hooks": "^4.26.0",
-				"@wordpress/html-entities": "^4.26.0",
-				"@wordpress/i18n": "^5.26.0",
-				"@wordpress/icons": "^10.26.0",
-				"@wordpress/is-shallow-equal": "^5.26.0",
-				"@wordpress/keycodes": "^4.26.0",
-				"@wordpress/primitives": "^4.26.0",
-				"@wordpress/private-apis": "^1.26.0",
-				"@wordpress/rich-text": "^7.26.0",
-				"@wordpress/warning": "^3.26.0",
-				"change-case": "^4.1.2",
+				"@ariakit/react": "^0.4.21",
+				"@wordpress/base-styles": "^9.1.0",
+				"@wordpress/components": "^35.0.0",
+				"@wordpress/compose": "^8.1.0",
+				"@wordpress/data": "^10.48.0",
+				"@wordpress/date": "^5.48.0",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/i18n": "^6.21.0",
+				"@wordpress/icons": "^13.3.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/primitives": "^4.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/ui": "^0.15.0",
+				"@wordpress/warning": "^3.48.0",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
-				"date-fns": "^3.6.0",
-				"deepmerge": "^4.3.0",
+				"date-fns": "^4.1.0",
+				"deepmerge": "4.3.1",
 				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.1.9",
-				"gradient-parser": "1.0.2",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
-				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"remove-accents": "^0.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -17053,21 +16760,125 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/dataviews/node_modules/@wordpress/i18n": {
-			"version": "5.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
-			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+			"version": "35.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.26.0",
-				"gettext-parser": "^1.3.1",
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/native": "^11.11.0",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.48.0",
+				"@wordpress/base-styles": "^9.1.0",
+				"@wordpress/compose": "^8.1.0",
+				"@wordpress/date": "^5.48.0",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/hooks": "^4.48.0",
+				"@wordpress/html-entities": "^4.48.0",
+				"@wordpress/i18n": "^6.21.0",
+				"@wordpress/icons": "^13.3.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/primitives": "^4.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/rich-text": "^7.48.0",
+				"@wordpress/style-runtime": "^0.4.0",
+				"@wordpress/ui": "^0.15.0",
+				"@wordpress/warning": "^3.48.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
-				"sprintf-js": "^1.1.1",
-				"tannin": "^1.2.0"
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
 			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/compose": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
+			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/dom": "^4.48.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/is-shallow-equal": "^5.48.0",
+				"@wordpress/keycodes": "^4.48.0",
+				"@wordpress/priority-queue": "^3.48.0",
+				"@wordpress/private-apis": "^1.48.0",
+				"@wordpress/undo-manager": "^1.48.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -17075,26 +16886,31 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
-			"version": "10.32.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.32.0.tgz",
-			"integrity": "sha512-1WvJdT361X1LnetYBpBWUjAVXZzl+pBdIwHbYRAp8ej47EI/igPmNxmq81nFd40s8fer/9qtipielcqSI6H2rA==",
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.32.0",
-				"@wordpress/primitives": "^4.32.0"
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/dataviews/node_modules/gradient-parser": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.0.2.tgz",
-			"integrity": "sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==",
-			"engines": {
-				"node": ">=0.10.0"
+		"node_modules/@wordpress/dataviews/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/path-to-regexp": {
@@ -17104,16 +16920,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/dataviews/node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/@wordpress/date": {
@@ -24476,76 +24292,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/eslint-plugin-jest": {
-			"version": "27.9.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
-			"integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@typescript-eslint/utils": "^5.10.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
-				"eslint": "^7.0.0 || ^8.0.0",
-				"jest": "*"
-			},
-			"peerDependenciesMeta": {
-				"@typescript-eslint/eslint-plugin": {
-					"optional": true
-				},
-				"jest": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/eslint-plugin-jsdoc": {
-			"version": "46.10.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
-			"integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.41.0",
-				"are-docs-informative": "^0.0.2",
-				"comment-parser": "1.4.1",
-				"debug": "^4.3.4",
-				"escape-string-regexp": "^4.0.0",
-				"esquery": "^1.5.0",
-				"is-builtin-module": "^3.2.1",
-				"semver": "^7.5.4",
-				"spdx-expression-parse": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-jsdoc/node_modules/comment-parser": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
-			"integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/eslint-plugin-jsx-a11y": {
 			"version": "6.10.2",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
@@ -24597,21 +24343,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/eslint-plugin-playwright": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz",
-			"integrity": "sha512-LQMW5y0DLK5Fnpya7JR1oAYL2/7Y9wDiYw6VZqlKqcRGSgjbVKNqxraphk7ra1U3Bb5EK444xMgUlQPbMg2M1g==",
-			"license": "MIT",
-			"peerDependencies": {
-				"eslint": ">=7",
-				"eslint-plugin-jest": ">=25"
-			},
-			"peerDependenciesMeta": {
-				"eslint-plugin-jest": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/eslint-plugin-react": {
 			"version": "7.37.5",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
@@ -24642,18 +24373,6 @@
 			},
 			"peerDependencies": {
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
-			}
-		},
-		"node_modules/eslint-plugin-react-hooks": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-			"integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {


### PR DESCRIPTION
## Summary

Upgrades `@wordpress/dataviews` from `^4.0.0` to `^16.0.0` in both `fair-audience` and `fair-events`. This keeps the admin list views aligned with current WordPress editor conventions. The v16 API is backward-compatible with how these components use DataViews — same `fields`, `view`, `actions`, `paginationInfo`, and `defaultLayouts` shapes — with one cleanup: `isDestructive` was removed from the `Action` type in v10, so those properties are dropped from the seven affected action definitions in `fair-audience`.

Closes #812

## Notes

- String icon props (e.g. `icon: 'trash'`) on actions are left as-is — v16 types them `any` and the item-actions renderer doesn't use them, so they're silently ignored rather than breaking.
- `filterSortAndPaginate` (used in `AllParticipants.js`) is still exported in v16.
- No peer-dependency conflict: v16's `package.json` only lists `react`/`react-dom` as peer deps.

## Test plan

- [x] `npm run test:js` passes in `fair-audience` (10 tests)
- [x] `npm run test:js` passes in `fair-events` (21 tests)
- [x] `npm run build` succeeds in `fair-audience` (180 files)
- [x] `npm run build` succeeds in `fair-events` (80 files)
- [ ] Visual pass of each admin list page in local Docker environment: Events List, Fees List, Collaborators, Form Answers, All Participants, Groups, Event Participants, Fee Detail, Questionnaire Responses, All Events
- [ ] Filters, sorting, pagination, and row actions work correctly on each page