### PR TITLE
refactor: move Venue model and VenueController to fair-events-experimental

### DIFF
--- a/fair-events-experimental/src/API/VenueController.php
+++ b/fair-events-experimental/src/API/VenueController.php
@@ -2,14 +2,14 @@
 /**
  * REST API Controller for Venues
  *
- * @package FairEvents
+ * @package FairEventsExperimental
  */
 
-namespace FairEvents\API;
+namespace FairEventsExperimental\API;
 
 defined( 'WPINC' ) || die;
 
-use FairEvents\Models\Venue;
+use FairEventsExperimental\Models\Venue;
 use WP_REST_Controller;
 use WP_REST_Server;
 use WP_REST_Request;
@@ -34,8 +34,8 @@ class VenueController extends WP_REST_Controller {
 	 * @return void
 	 */
 	public function register_routes() {
-		// GET /fair-events/v1/venues - Get all venues
-		// POST /fair-events/v1/venues - Create venue
+		// GET /fair-events/v1/venues — Get all venues.
+		// POST /fair-events/v1/venues — Create venue.
 		register_rest_route(
 			$this->namespace,
 			'/venues',
@@ -54,9 +54,9 @@ class VenueController extends WP_REST_Controller {
 			)
 		);
 
-		// GET /fair-events/v1/venues/{id} - Get single venue
-		// PUT /fair-events/v1/venues/{id} - Update venue
-		// DELETE /fair-events/v1/venues/{id} - Delete venue
+		// GET /fair-events/v1/venues/{id} — Get single venue.
+		// PUT /fair-events/v1/venues/{id} — Update venue.
+		// DELETE /fair-events/v1/venues/{id} — Delete venue.
 		register_rest_route(
 			$this->namespace,
 			'/venues/(?P<id>\d+)',
@@ -67,7 +67,7 @@ class VenueController extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 					'args'                => array(
 						'id' => array(
-							'description' => __( 'Unique identifier for the venue.', 'fair-events' ),
+							'description' => __( 'Unique identifier for the venue.', 'fair-events-experimental' ),
 							'type'        => 'integer',
 						),
 					),
@@ -84,7 +84,7 @@ class VenueController extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
 					'args'                => array(
 						'id' => array(
-							'description' => __( 'Unique identifier for the venue.', 'fair-events' ),
+							'description' => __( 'Unique identifier for the venue.', 'fair-events-experimental' ),
 							'type'        => 'integer',
 						),
 					),
@@ -101,49 +101,49 @@ class VenueController extends WP_REST_Controller {
 	private function get_create_update_args() {
 		return array(
 			'name'               => array(
-				'description'       => __( 'Venue name.', 'fair-events' ),
+				'description'       => __( 'Venue name.', 'fair-events-experimental' ),
 				'type'              => 'string',
 				'required'          => true,
 				'sanitize_callback' => 'sanitize_text_field',
 			),
 			'address'            => array(
-				'description'       => __( 'Venue address.', 'fair-events' ),
+				'description'       => __( 'Venue address.', 'fair-events-experimental' ),
 				'type'              => 'string',
 				'required'          => false,
 				'sanitize_callback' => 'sanitize_textarea_field',
 			),
 			'google_maps_link'   => array(
-				'description'       => __( 'Google Maps URL.', 'fair-events' ),
+				'description'       => __( 'Google Maps URL.', 'fair-events-experimental' ),
 				'type'              => 'string',
 				'required'          => false,
 				'sanitize_callback' => 'esc_url_raw',
 			),
 			'latitude'           => array(
-				'description'       => __( 'Latitude coordinate.', 'fair-events' ),
+				'description'       => __( 'Latitude coordinate.', 'fair-events-experimental' ),
 				'type'              => 'string',
 				'required'          => false,
 				'sanitize_callback' => 'sanitize_text_field',
 			),
 			'longitude'          => array(
-				'description'       => __( 'Longitude coordinate.', 'fair-events' ),
+				'description'       => __( 'Longitude coordinate.', 'fair-events-experimental' ),
 				'type'              => 'string',
 				'required'          => false,
 				'sanitize_callback' => 'sanitize_text_field',
 			),
 			'facebook_page_link' => array(
-				'description'       => __( 'Facebook page URL.', 'fair-events' ),
+				'description'       => __( 'Facebook page URL.', 'fair-events-experimental' ),
 				'type'              => 'string',
 				'required'          => false,
 				'sanitize_callback' => 'esc_url_raw',
 			),
 			'instagram_handle'   => array(
-				'description'       => __( 'Instagram handle (without @).', 'fair-events' ),
+				'description'       => __( 'Instagram handle (without @).', 'fair-events-experimental' ),
 				'type'              => 'string',
 				'required'          => false,
 				'sanitize_callback' => 'sanitize_text_field',
 			),
 			'website_url'        => array(
-				'description'       => __( 'Website URL.', 'fair-events' ),
+				'description'       => __( 'Website URL.', 'fair-events-experimental' ),
 				'type'              => 'string',
 				'required'          => false,
 				'sanitize_callback' => 'esc_url_raw',
@@ -183,7 +183,7 @@ class VenueController extends WP_REST_Controller {
 		if ( ! $venue ) {
 			return new WP_Error(
 				'rest_venue_not_found',
-				__( 'Venue not found.', 'fair-events' ),
+				__( 'Venue not found.', 'fair-events-experimental' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -210,7 +210,7 @@ class VenueController extends WP_REST_Controller {
 		if ( empty( $name ) ) {
 			return new WP_Error(
 				'rest_invalid_name',
-				__( 'Venue name is required.', 'fair-events' ),
+				__( 'Venue name is required.', 'fair-events-experimental' ),
 				array( 'status' => 400 )
 			);
 		}
@@ -220,7 +220,7 @@ class VenueController extends WP_REST_Controller {
 		if ( ! $venue_id ) {
 			return new WP_Error(
 				'rest_venue_creation_failed',
-				__( 'Failed to create venue.', 'fair-events' ),
+				__( 'Failed to create venue.', 'fair-events-experimental' ),
 				array( 'status' => 500 )
 			);
 		}
@@ -252,7 +252,7 @@ class VenueController extends WP_REST_Controller {
 		if ( ! $existing ) {
 			return new WP_Error(
 				'rest_venue_not_found',
-				__( 'Venue not found.', 'fair-events' ),
+				__( 'Venue not found.', 'fair-events-experimental' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -260,7 +260,7 @@ class VenueController extends WP_REST_Controller {
 		if ( empty( $name ) ) {
 			return new WP_Error(
 				'rest_invalid_name',
-				__( 'Venue name is required.', 'fair-events' ),
+				__( 'Venue name is required.', 'fair-events-experimental' ),
 				array( 'status' => 400 )
 			);
 		}
@@ -270,7 +270,7 @@ class VenueController extends WP_REST_Controller {
 		if ( ! $success ) {
 			return new WP_Error(
 				'rest_venue_update_failed',
-				__( 'Failed to update venue.', 'fair-events' ),
+				__( 'Failed to update venue.', 'fair-events-experimental' ),
 				array( 'status' => 500 )
 			);
 		}
@@ -294,7 +294,7 @@ class VenueController extends WP_REST_Controller {
 		if ( ! $existing ) {
 			return new WP_Error(
 				'rest_venue_not_found',
-				__( 'Venue not found.', 'fair-events' ),
+				__( 'Venue not found.', 'fair-events-experimental' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -304,7 +304,7 @@ class VenueController extends WP_REST_Controller {
 		if ( ! $success ) {
 			return new WP_Error(
 				'rest_venue_delete_failed',
-				__( 'Failed to delete venue.', 'fair-events' ),
+				__( 'Failed to delete venue.', 'fair-events-experimental' ),
 				array( 'status' => 500 )
 			);
 		}

--- a/fair-events-experimental/src/Core/Plugin.php
+++ b/fair-events-experimental/src/Core/Plugin.php
@@ -226,6 +226,16 @@ class Plugin {
 			);
 		}
 
+		if ( Features::is_enabled( 'venues' ) ) {
+			add_action(
+				'rest_api_init',
+				function () {
+					$controller = new \FairEventsExperimental\API\VenueController();
+					$controller->register_routes();
+				}
+			);
+		}
+
 		if ( Features::is_enabled( 'event-tools' ) ) {
 			add_action(
 				'rest_api_init',

--- a/fair-events-experimental/src/Models/Venue.php
+++ b/fair-events-experimental/src/Models/Venue.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Venue model for Fair Events
+ * Venue model for Fair Events Experimental
  *
- * @package FairEvents
+ * @package FairEventsExperimental
  */
 
-namespace FairEvents\Models;
+namespace FairEventsExperimental\Models;
 
 defined( 'WPINC' ) || die;
 
@@ -250,7 +250,7 @@ class Venue {
 			array( '%d' )
 		);
 
-		return $result !== false;
+		return false !== $result;
 	}
 
 	/**
@@ -281,7 +281,7 @@ class Venue {
 			array( '%d' )
 		);
 
-		return $result !== false;
+		return false !== $result;
 	}
 
 	/**

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -139,17 +139,6 @@ class Plugin {
 				$controller->register_routes();
 			}
 		);
-
-		// Venues controller — registered unconditionally so the core
-		// calendar/manage-event venue dropdowns keep working. The dedicated
-		// Venues admin page is provided by fair-events-experimental.
-		add_action(
-			'rest_api_init',
-			function () {
-				$controller = new \FairEvents\API\VenueController();
-				$controller->register_routes();
-			}
-		);
 	}
 
 	/**

--- a/fair-events/src/Hooks/CalendarButtonHooks.php
+++ b/fair-events/src/Hooks/CalendarButtonHooks.php
@@ -14,7 +14,6 @@ namespace FairEvents\Hooks;
 
 use FairEvents\Helpers\SelectedOccurrence;
 use FairEvents\Models\EventDates;
-use FairEvents\Models\Venue;
 use FairEvents\Settings\Settings;
 
 defined( 'WPINC' ) || die;
@@ -104,8 +103,9 @@ class CalendarButtonHooks {
 		// Get location from venue if available, otherwise fall back to the
 		// event date's inline address (used when Venues is disabled).
 		$location = '';
-		if ( ! empty( $event_dates->venue_id ) ) {
-			$venue = Venue::get_by_id( $event_dates->venue_id );
+		if ( ! empty( $event_dates->venue_id )
+			&& class_exists( \FairEventsExperimental\Models\Venue::class ) ) {
+			$venue = \FairEventsExperimental\Models\Venue::get_by_id( $event_dates->venue_id );
 			if ( $venue ) {
 				$location = $venue->name;
 				if ( ! empty( $venue->address ) ) {

--- a/fair-events/src/Hooks/OpenGraphHooks.php
+++ b/fair-events/src/Hooks/OpenGraphHooks.php
@@ -12,7 +12,6 @@
 namespace FairEvents\Hooks;
 
 use FairEvents\Models\EventDates;
-use FairEvents\Models\Venue;
 use FairEvents\Settings\Settings;
 
 defined( 'WPINC' ) || die;
@@ -194,8 +193,9 @@ class OpenGraphHooks {
 	 * @return array|null Location data array or null.
 	 */
 	private function get_jsonld_location( $event_date, $post_id ) {
-		if ( ! empty( $event_date->venue_id ) ) {
-			$venue = Venue::get_by_id( $event_date->venue_id );
+		if ( ! empty( $event_date->venue_id )
+			&& class_exists( \FairEventsExperimental\Models\Venue::class ) ) {
+			$venue = \FairEventsExperimental\Models\Venue::get_by_id( $event_date->venue_id );
 			if ( $venue ) {
 				$location = array(
 					'@type' => 'Place',
@@ -288,8 +288,9 @@ class OpenGraphHooks {
 	 * @return string|null Location string or null.
 	 */
 	private function get_location( $event_date, $post_id ) {
-		if ( ! empty( $event_date->venue_id ) ) {
-			$venue = Venue::get_by_id( $event_date->venue_id );
+		if ( ! empty( $event_date->venue_id )
+			&& class_exists( \FairEventsExperimental\Models\Venue::class ) ) {
+			$venue = \FairEventsExperimental\Models\Venue::get_by_id( $event_date->venue_id );
 			if ( $venue ) {
 				$location = $venue->name;
 				if ( ! empty( $venue->address ) ) {


### PR DESCRIPTION
## Summary

- Moves `Venue.php` model and `VenueController.php` from `fair-events` to `fair-events-experimental` with updated namespaces (`FairEventsExperimental\Models\Venue`, `FairEventsExperimental\API\VenueController`)
- Registers the controller in experimental's `load_rest_api()` under the existing `venues` feature flag
- Removes the unconditional VenueController registration from `fair-events/src/Core/Plugin.php`
- Adds `class_exists(\FairEventsExperimental\Models\Venue::class)` guards in `OpenGraphHooks` and `CalendarButtonHooks` so venue lookups are safely skipped when the experimental plugin is inactive
- REST namespace (`fair-events/v1`) is unchanged — `VenuesApp.js` requires no changes

## Test plan

- [ ] With both plugins active: venue dropdown in Manage Event and Calendar still loads; Venues admin page CRUD works
- [ ] With only `fair-events` active: no PHP fatal errors on the frontend (hooks guard prevents class-not-found crash)
- [ ] `vendor/bin/phpcs fair-events/src fair-events-experimental/src` passes with no errors
- [ ] `npm test` passes in `fair-events` and `fair-events-experimental`

Refs #789