### PR TITLE
Upgrade date-fns v2 → v4 in fair-events-shared, patch bump in fair-timetable

### DIFF
--- a/fair-events-shared/package.json
+++ b/fair-events-shared/package.json
@@ -18,6 +18,6 @@
 	"dependencies": {
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/scripts": "^32.4.0",
-		"date-fns": "^2.30.0"
+		"date-fns": "^4.0.0"
 	}
 }

--- a/fair-timetable/package.json
+++ b/fair-timetable/package.json
@@ -38,7 +38,7 @@
 		"@wordpress/blocks": "^15.2.0",
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/i18n": "^6.2.0",
-		"date-fns": "^4.1.0"
+		"date-fns": "^4.4.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.28.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,16 +1278,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"fair-audience/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
 		"fair-audience/node_modules/dotenv": {
 			"version": "16.6.1",
 			"dev": true,
@@ -2420,16 +2410,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"fair-events-experimental/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
 		"fair-events-experimental/node_modules/expect": {
 			"version": "30.4.1",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
@@ -3168,7 +3148,7 @@
 			"dependencies": {
 				"@wordpress/components": "^35.0.0",
 				"@wordpress/scripts": "^32.4.0",
-				"date-fns": "^2.30.0"
+				"date-fns": "^4.0.0"
 			}
 		},
 		"fair-events-shared/node_modules/@wordpress/base-styles": {
@@ -3322,20 +3302,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"fair-events-shared/node_modules/date-fns": {
-			"version": "2.30.0",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.21.0"
-			},
-			"engines": {
-				"node": ">=0.11"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/date-fns"
 			}
 		},
 		"fair-events-shared/node_modules/path-to-regexp": {
@@ -3728,16 +3694,6 @@
 			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"fair-events/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
 		},
 		"fair-events/node_modules/dotenv": {
 			"version": "16.6.1",
@@ -4684,16 +4640,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"fair-finance/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
 		"fair-finance/node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -4897,16 +4843,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"fair-payments-connector/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"fair-payments-connector/node_modules/dotenv": {
@@ -5147,16 +5083,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"fair-platform/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
 		"fair-platform/node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"license": "MIT"
@@ -5186,7 +5112,7 @@
 				"@wordpress/blocks": "^15.2.0",
 				"@wordpress/components": "^35.0.0",
 				"@wordpress/i18n": "^6.2.0",
-				"date-fns": "^4.1.0"
+				"date-fns": "^4.4.0"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.28.3",
@@ -5539,16 +5465,6 @@
 			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"fair-timetable/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
 		},
 		"fair-timetable/node_modules/dotenv": {
 			"version": "16.6.1",
@@ -17070,16 +16986,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/block-editor/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
 		"node_modules/@wordpress/block-editor/node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -17364,16 +17270,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/commands/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
 		"node_modules/@wordpress/commands/node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -17647,16 +17543,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/dataviews/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/path-to-regexp": {
@@ -18110,16 +17996,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/image-cropper/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
 		"node_modules/@wordpress/image-cropper/node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -18411,16 +18287,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/notices/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
 		"node_modules/@wordpress/notices/node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -18649,16 +18515,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/preferences/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/path-to-regexp": {
@@ -23656,6 +23512,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/date-fns-jalali": {
@@ -35213,16 +35079,6 @@
 			},
 			"peerDependencies": {
 				"react": ">=16.8.0"
-			}
-		},
-		"node_modules/react-day-picker/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/react-devtools-core": {


### PR DESCRIPTION
Closes #810

## Summary
- Bump `date-fns` in `fair-events-shared` from `^2.30.0` to `^4.0.0` (major: v2 → v4)
- Bump `date-fns` in `fair-timetable` from `^4.1.0` to `^4.4.0` (patch)
- No source code changes needed — `parseISO`, `isValid`, `differenceInMinutes`, and `parse` are all unchanged across the v2→v4 range
- Lockfile now deduplicates to a single `date-fns@4.4.0` at the root instead of per-workspace copies

## Test plan
- [x] `npm test` in `fair-events-shared` — 60 tests pass
- [x] `npm run test:js` in `fair-timetable` — 148 tests pass
- [ ] Spot-check timetable block slot times in local Docker to confirm no runtime regressions