### PR TITLE
Upgrade @fortawesome v6 → v7 in fair-events

### DIFF
--- a/fair-events/package.json
+++ b/fair-events/package.json
@@ -33,9 +33,9 @@
 		"playwright:up": "playwright test --headed --ui"
 	},
 	"dependencies": {
-		"@fortawesome/fontawesome-svg-core": "^6.0.0",
-		"@fortawesome/free-brands-svg-icons": "^6.0.0",
-		"@fortawesome/free-solid-svg-icons": "^6.0.0",
+		"@fortawesome/fontawesome-svg-core": "^7.0.0",
+		"@fortawesome/free-brands-svg-icons": "^7.0.0",
+		"@fortawesome/free-solid-svg-icons": "^7.0.0",
 		"@wordpress/api-fetch": "^7.2.0",
 		"@wordpress/block-editor": "^15.2.0",
 		"@wordpress/blocks": "^15.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2029,9 +2029,9 @@
 			"version": "1.4.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@fortawesome/fontawesome-svg-core": "^6.0.0",
-				"@fortawesome/free-brands-svg-icons": "^6.0.0",
-				"@fortawesome/free-solid-svg-icons": "^6.0.0",
+				"@fortawesome/fontawesome-svg-core": "^7.0.0",
+				"@fortawesome/free-brands-svg-icons": "^7.0.0",
+				"@fortawesome/free-solid-svg-icons": "^7.0.0",
 				"@wordpress/api-fetch": "^7.2.0",
 				"@wordpress/block-editor": "^15.2.0",
 				"@wordpress/blocks": "^15.2.0",
@@ -3353,43 +3353,6 @@
 			"license": "MIT",
 			"bin": {
 				"uuid": "dist-node/bin/uuid"
-			}
-		},
-		"fair-events/node_modules/@fortawesome/fontawesome-common-types": {
-			"version": "6.7.2",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"fair-events/node_modules/@fortawesome/fontawesome-svg-core": {
-			"version": "6.7.2",
-			"license": "MIT",
-			"dependencies": {
-				"@fortawesome/fontawesome-common-types": "6.7.2"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"fair-events/node_modules/@fortawesome/free-brands-svg-icons": {
-			"version": "6.7.2",
-			"license": "(CC-BY-4.0 AND MIT)",
-			"dependencies": {
-				"@fortawesome/fontawesome-common-types": "6.7.2"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"fair-events/node_modules/@fortawesome/free-solid-svg-icons": {
-			"version": "6.7.2",
-			"license": "(CC-BY-4.0 AND MIT)",
-			"dependencies": {
-				"@fortawesome/fontawesome-common-types": "6.7.2"
-			},
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"fair-events/node_modules/@jest/core": {
@@ -9465,6 +9428,18 @@
 			"integrity": "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==",
 			"license": "MIT",
 			"peer": true,
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "7.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/free-brands-svg-icons": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.2.0.tgz",
+			"integrity": "sha512-VNG8xqOip1JuJcC3zsVsKRQ60oXG9+oYNDCosjoU/H9pgYmLTEwWw8pE0jhPz/JWdHeUuK6+NQ3qsM4gIbdbYQ==",
+			"license": "(CC-BY-4.0 AND MIT)",
 			"dependencies": {
 				"@fortawesome/fontawesome-common-types": "7.2.0"
 			},


### PR DESCRIPTION
## Summary

- Bumps `@fortawesome/fontawesome-svg-core`, `@fortawesome/free-brands-svg-icons`, and `@fortawesome/free-solid-svg-icons` from `^6.0.0` to `^7.0.0` in `fair-events/package.json`
- No changes needed in `calendar-handler.js` — the `icon()` API and all icon identifiers (`faGoogle`, `faMicrosoft`, `faYahoo`, `faDownload`) remain compatible in v7
- `npm run build` passes cleanly (only pre-existing bundle size warnings)

Closes #811

## Test plan

- [ ] Calendar button block renders in the frontend with correct Google / Outlook / Yahoo / ICS icons
- [ ] No console errors when the calendar link modal opens