### PR TITLE
Move mailings tab to fair-events-experimental feature flag

### DIFF
--- a/fair-events-experimental/src/Core/Features.php
+++ b/fair-events-experimental/src/Core/Features.php
@@ -2,8 +2,8 @@
 /**
  * Feature flag registry for Fair Events Experimental.
  *
- * Manages the six advanced bundles moved out of fair-events:
- * galleries, sources, ticketing, event-tools, migration, venues.
+ * Manages the advanced bundles moved out of fair-events:
+ * galleries, sources, ticketing, event-tools, migration, venues, mailings.
  * All default to true — installing this plugin signals intent to use the full
  * internal feature set.
  *
@@ -79,6 +79,11 @@ class Features {
 			'audience-statistics' => array(
 				'label'       => 'Audience statistics',
 				'description' => 'Per-event statistics charts (activity breakdown, sales lead time). Requires fair-audience.',
+				'default'     => true,
+			),
+			'mailings'    => array(
+				'label'       => 'Mailings',
+				'description' => 'Scheduled email mailings for event attendees. Requires fair-audience.',
 				'default'     => true,
 			),
 		);
@@ -171,6 +176,10 @@ class Features {
 			'audience-statistics' => array(
 				'label'       => __( 'Audience statistics', 'fair-events-experimental' ),
 				'description' => __( 'Per-event statistics charts (activity breakdown, sales lead time). Requires fair-audience.', 'fair-events-experimental' ),
+			),
+			'mailings'    => array(
+				'label'       => __( 'Mailings', 'fair-events-experimental' ),
+				'description' => __( 'Scheduled email mailings for event attendees. Requires fair-audience.', 'fair-events-experimental' ),
 			),
 		);
 

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -61,6 +61,7 @@ export default function ManageEventApp() {
 	const galleriesEnabled = !!enabledFeatures.galleries;
 	const ticketingEnabled = !!enabledFeatures.ticketing;
 	const venuesEnabled = !!enabledFeatures.venues;
+	const mailingsEnabled = !!enabledFeatures.mailings;
 
 	const [eventDate, setEventDate] = useState(null);
 	const [loading, setLoading] = useState(true);
@@ -574,10 +575,14 @@ export default function ManageEventApp() {
 							name: 'audience',
 							title: __('Audience', 'fair-events'),
 						},
-						{
-							name: 'mailings',
-							title: __('Mailings', 'fair-events'),
-						},
+						...(mailingsEnabled
+							? [
+									{
+										name: 'mailings',
+										title: __('Mailings', 'fair-events'),
+									},
+							  ]
+							: []),
 				  ]
 				: []),
 			...(statisticsUrl
@@ -607,6 +612,7 @@ export default function ManageEventApp() {
 			paymentEntriesUrl,
 			isGeneratedOccurrence,
 			galleriesEnabled,
+			mailingsEnabled,
 			ticketingEnabled,
 		]
 	);


### PR DESCRIPTION
## Summary

- Adds a `mailings` bundle to `fair-events-experimental/src/Core/Features.php`, following the same pattern as `galleries`, `ticketing`, and `venues`
- Gates the Mailings tab in `ManageEventApp` behind `mailingsEnabled` (from `enabledFeatures`) in addition to the existing `audienceUrl` guard
- Defaults to `true` so existing installs with fair-events-experimental active see no change in behaviour

## Test plan

- [ ] With fair-events-experimental active and `mailings` feature enabled (default), confirm the Mailings tab appears at `wp-admin/admin.php?page=fair-events-manage-event&event_date_id=<id>&tab=mailings` when fair-audience is also active
- [ ] Disable the `mailings` feature in Experimental Settings and confirm the tab disappears
- [ ] Confirm `audience` and `statistics` tabs still appear when `mailings` is disabled
- [ ] Confirm no JS console errors in either state