### PR TITLE
fix: gate Finance tab on fair-finance and fix API paths

### DIFF
--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -310,9 +310,9 @@ class AdminPages {
 				}
 			}
 
-			// Add payment entries URL if fair-payments-connector plugin is active.
-			if ( class_exists( 'FairPaymentsConnector\Core\Plugin' ) ) {
-				$localized_data['paymentEntriesUrl'] = admin_url( 'admin.php?page=fair-payments-connector-entries' );
+			// Add finance entries URL if fair-finance plugin is active.
+			if ( class_exists( 'FairFinance\Core\Plugin' ) ) {
+				$localized_data['paymentEntriesUrl'] = admin_url( 'admin.php?page=fair-finance-entries' );
 			}
 
 			wp_localize_script(

--- a/fair-events/src/Admin/manage-event/EventFinance.js
+++ b/fair-events/src/Admin/manage-event/EventFinance.js
@@ -80,10 +80,10 @@ export default function EventFinance({ eventDateId, entriesUrl }) {
 				expiredData,
 			] = await Promise.all([
 				apiFetch({
-					path: `/fair-payments-connector/v1/financial-entries/totals?event_date_id=${eventDateId}`,
+					path: `/fair-finance/v1/financial-entries/totals?event_date_id=${eventDateId}`,
 				}),
 				apiFetch({
-					path: `/fair-payments-connector/v1/financial-entries?event_date_id=${eventDateId}&per_page=10`,
+					path: `/fair-finance/v1/financial-entries?event_date_id=${eventDateId}&per_page=10`,
 				}),
 				apiFetch({
 					path: `/fair-payments-connector/v1/transactions?event_date_id=${eventDateId}&status=paid&mode=live&per_page=100`,


### PR DESCRIPTION
## Summary

- Gate the Finance tab in Manage Event on `fair-finance` being active (`FairFinance\Core\Plugin`) instead of `fair-payments-connector`
- Fix the two `apiFetch` paths in `EventFinance.js` that were calling `fair-payments-connector/v1/financial-entries/*` — those routes don't exist there; they live under `fair-finance/v1`
- Update the entries link URL passed to `EventFinance` to point to the correct `fair-finance-entries` admin page

## Test plan

- [ ] With fair-finance inactive: Finance tab should not appear on the Manage Event page
- [ ] With fair-finance active: Finance tab appears and loads financial data without the "No route was found" error
- [ ] "View All Entries" button links to the fair-finance entries page

🤖 Generated with [Claude Code](https://claude.com/claude-code)