### PR TITLE
Upgrade recharts v2 → v3 in fair-events-experimental

### DIFF
--- a/fair-events-experimental/package.json
+++ b/fair-events-experimental/package.json
@@ -30,7 +30,7 @@
 		"@wordpress/dom-ready": "^4.2.0",
 		"@wordpress/element": "^8.0.0",
 		"@wordpress/i18n": "^6.2.0",
-		"recharts": "^2.12.0"
+		"recharts": "^3.0.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.28.3",

--- a/fair-events/package.json
+++ b/fair-events/package.json
@@ -48,8 +48,7 @@
 		"@wordpress/i18n": "^6.2.0",
 		"calendar-link": "^2.11.0",
 		"fair-events-shared": "*",
-		"react-easy-crop": "^5.5.6",
-		"recharts": "^2.12.0"
+		"react-easy-crop": "^5.5.6"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.28.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2034,8 +2034,7 @@
 				"@wordpress/i18n": "^6.2.0",
 				"calendar-link": "^2.11.0",
 				"fair-events-shared": "*",
-				"react-easy-crop": "^5.5.6",
-				"recharts": "^2.12.0"
+				"react-easy-crop": "^5.5.6"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.28.3",
@@ -2060,7 +2059,7 @@
 				"@wordpress/element": "^8.0.0",
 				"@wordpress/i18n": "^6.2.0",
 				"fair-events-shared": "*",
-				"recharts": "^2.12.0"
+				"recharts": "^3.0.0"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.28.3",
@@ -14595,6 +14594,42 @@
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
+		"node_modules/@reduxjs/toolkit": {
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+			"integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.0.0",
+				"@standard-schema/utils": "^0.3.0",
+				"immer": "^11.0.0",
+				"redux": "^5.0.1",
+				"redux-thunk": "^3.1.0",
+				"reselect": "^5.1.0"
+			},
+			"peerDependencies": {
+				"react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+				"react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"react-redux": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@reduxjs/toolkit/node_modules/immer": {
+			"version": "11.1.8",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+			"integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
+			}
+		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -14786,6 +14821,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/utils": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+			"integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
 			"license": "MIT"
 		},
 		"node_modules/@stylistic/stylelint-plugin": {
@@ -15903,6 +15944,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/@types/use-sync-external-store": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+			"integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+			"license": "MIT"
 		},
 		"node_modules/@types/webpack": {
 			"version": "4.41.40",
@@ -24021,16 +24068,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/dom-helpers": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.8.7",
-				"csstype": "^3.0.2"
-			}
-		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -24540,6 +24577,16 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/es-toolkit": {
+			"version": "1.47.1",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.1.tgz",
+			"integrity": "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==",
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
@@ -25469,15 +25516,6 @@
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
 			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
 			"license": "Apache-2.0"
-		},
-		"node_modules/fast-equals": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
-			"integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
 		},
 		"node_modules/fast-fifo": {
 			"version": "1.3.2",
@@ -27188,6 +27226,16 @@
 			"resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
 			"integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==",
 			"license": "MIT"
+		},
+		"node_modules/immer": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+			"integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
+			}
 		},
 		"node_modules/immutable": {
 			"version": "5.1.4",
@@ -35122,7 +35170,8 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/react-is-18": {
 			"name": "react-is",
@@ -35266,6 +35315,30 @@
 				}
 			}
 		},
+		"node_modules/react-redux": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+			"integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/use-sync-external-store": "^0.0.6",
+				"use-sync-external-store": "^1.4.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.2.25 || ^19",
+				"react": "^18.0 || ^19",
+				"redux": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"redux": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/react-refresh": {
 			"version": "0.14.2",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -35323,21 +35396,6 @@
 				}
 			}
 		},
-		"node_modules/react-smooth": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
-			"integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
-			"license": "MIT",
-			"dependencies": {
-				"fast-equals": "^5.0.1",
-				"prop-types": "^15.8.1",
-				"react-transition-group": "^4.4.5"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
 		"node_modules/react-style-singleton": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -35358,22 +35416,6 @@
 				"@types/react": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/react-transition-group": {
-			"version": "4.4.5",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-			"integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@babel/runtime": "^7.5.5",
-				"dom-helpers": "^5.0.1",
-				"loose-envify": "^1.4.0",
-				"prop-types": "^15.6.2"
-			},
-			"peerDependencies": {
-				"react": ">=16.6.0",
-				"react-dom": ">=16.6.0"
 			}
 		},
 		"node_modules/read-cache": {
@@ -35556,37 +35598,46 @@
 			}
 		},
 		"node_modules/recharts": {
-			"version": "2.15.4",
-			"resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
-			"integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
-			"deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+			"integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
 			"license": "MIT",
+			"workspaces": [
+				"www"
+			],
 			"dependencies": {
-				"clsx": "^2.0.0",
-				"eventemitter3": "^4.0.1",
-				"lodash": "^4.17.21",
-				"react-is": "^18.3.1",
-				"react-smooth": "^4.0.4",
-				"recharts-scale": "^0.4.4",
-				"tiny-invariant": "^1.3.1",
-				"victory-vendor": "^36.6.8"
+				"@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+				"clsx": "^2.1.1",
+				"decimal.js-light": "^2.5.1",
+				"es-toolkit": "^1.39.3",
+				"eventemitter3": "^5.0.1",
+				"immer": "^10.1.1",
+				"react-redux": "8.x.x || 9.x.x",
+				"reselect": "5.1.1",
+				"tiny-invariant": "^1.3.3",
+				"use-sync-external-store": "^1.2.2",
+				"victory-vendor": "^37.0.2"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
-		"node_modules/recharts-scale": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
-			"integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
-			"license": "MIT",
-			"dependencies": {
-				"decimal.js-light": "^2.4.1"
-			}
+		"node_modules/recharts/node_modules/eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"license": "MIT"
+		},
+		"node_modules/recharts/node_modules/reselect": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+			"integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+			"license": "MIT"
 		},
 		"node_modules/rechoir": {
 			"version": "0.8.0",
@@ -35619,6 +35670,15 @@
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/redux-thunk": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+			"integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"redux": "^5.0.0"
+			}
 		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.10",
@@ -39734,9 +39794,9 @@
 			}
 		},
 		"node_modules/victory-vendor": {
-			"version": "36.9.2",
-			"resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
-			"integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+			"version": "37.3.6",
+			"resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+			"integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
 			"license": "MIT AND ISC",
 			"dependencies": {
 				"@types/d3-array": "^3.0.3",


### PR DESCRIPTION
## Summary

- Upgrades `recharts` from `^2.12.0` to `^3.0.0` in `fair-events-experimental`, where `EventStatistics` now lives.
- Drops the orphaned `recharts` dependency from `fair-events/package.json` — no file in that package imports it since `EventStatistics` was moved.
- No changes to `EventStatistics.js` itself; the components used (`BarChart`, `Bar`, `XAxis`, `YAxis`, `Tooltip`, `CartesianGrid`, `ResponsiveContainer`) work unchanged under v3.

Closes #809

## Test plan

- [x] `npm run test:js` in `fair-events-experimental` — all 10 tests pass
- [x] `npm run test:js` in `fair-events` — all 11 tests pass
- [ ] Visual check: event statistics charts display correctly on the manage-event admin page (audience-statistics feature flag must be on)