### PR TITLE
upgrade: mollie/mollie-api-php v2 → v3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,29 +8,29 @@
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.1.2",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
                 "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
@@ -100,31 +100,31 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-07-17T20:45:56+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca"
+                "reference": "b598aa890815b8df16363271b659d73280129101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/fa4b8d051e278072928e32d817456a7fdb57b6ca",
-                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
+                "reference": "b598aa890815b8df16363271b659d73280129101",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
+                "phpcsstandards/phpcsutils": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
                 "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
@@ -182,32 +182,32 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-06-14T07:40:39+00:00"
+            "time": "2025-11-12T23:06:57+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.1.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd"
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
-                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
                 "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
             "type": "phpcodesniffer-standard",
@@ -275,20 +275,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-08-10T01:04:45+00:00"
+            "time": "2025-12-08T14:27:58+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.2",
+            "version": "3.13.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
-                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
                 "shasum": ""
             },
             "require": {
@@ -305,11 +305,6 @@
                 "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -359,20 +354,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-06-17T22:17:01+00:00"
+            "time": "2025-11-04T16:30:35+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.2.0",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
-                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
                 "shasum": ""
             },
             "require": {
@@ -380,17 +375,17 @@
                 "ext-libxml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
-                "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.4.0",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.0",
                 "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.0"
+                "squizlabs/php_codesniffer": "^3.13.4"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "suggest": {
                 "ext-iconv": "For improved results",
@@ -425,7 +420,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-07-24T20:08:31+00:00"
+            "time": "2025-11-25T12:08:04+00:00"
         }
     ],
     "packages-dev": [],
@@ -436,5 +431,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/e2e/mu-plugins/lib/mollie-http-double.php
+++ b/e2e/mu-plugins/lib/mollie-http-double.php
@@ -2,12 +2,13 @@
 /**
  * Fake Mollie HTTP transport for E2E tests.
  *
- * The Mollie PHP SDK's adapter picker does `new CurlMollieHttpAdapter()` when no
- * HTTP client is injected. By declaring that exact class here — before the
- * vendored `final class` is autoloaded — every Mollie API call is served by this
- * double instead of hitting the network. The rest of the SDK (URL building,
- * response decoding, resource hydration) and ALL of the fair-payments-connector /
- * fair-audience code runs unchanged.
+ * The Mollie PHP SDK v3's adapter picker instantiates CurlMollieHttpAdapter
+ * from the Mollie\Api\Http\Adapter namespace when no HTTP client is injected.
+ * By declaring that exact class here — before the vendored `final class` is
+ * autoloaded — every Mollie API call is served by this double instead of
+ * hitting the network. The rest of the SDK (URL building, response decoding,
+ * resource hydration) and ALL of the fair-payments-connector / fair-audience
+ * code runs unchanged.
  *
  * Canned behaviour, enough to drive the ticket-purchase flow:
  *   - POST /v2/payments        -> a payment in status "open" whose checkout link
@@ -23,7 +24,12 @@
  * @package FairEventsE2E
  */
 
-namespace Mollie\Api\HttpAdapter;
+namespace Mollie\Api\Http\Adapter;
+
+use Mollie\Api\Contracts\HttpAdapterContract;
+use Mollie\Api\Http\PendingRequest;
+use Mollie\Api\Http\Response;
+use Mollie\Api\Traits\HasDefaultFactories;
 
 // If the real adapter somehow loaded first, don't redeclare.
 if ( class_exists( __NAMESPACE__ . '\\CurlMollieHttpAdapter', false ) ) {
@@ -31,59 +37,39 @@ if ( class_exists( __NAMESPACE__ . '\\CurlMollieHttpAdapter', false ) ) {
 }
 
 /**
- * Drop-in stand-in for the SDK's cURL adapter. Intentionally does not implement
- * MollieHttpAdapterInterface (the interface may not be autoloadable this early);
- * the SDK only calls send()/versionString() and enforces no type.
+ * Drop-in stand-in for the SDK's cURL adapter (Mollie v3).
+ *
+ * Implements HttpAdapterContract so the adapter picker accepts it as a valid
+ * replacement. HasDefaultFactories provides the factories() method the SDK
+ * needs to build PSR-7 requests and responses.
  */
-class CurlMollieHttpAdapter {
+class CurlMollieHttpAdapter implements HttpAdapterContract {
+	use HasDefaultFactories;
 
 	/**
-	 * Serve a canned response for a Mollie API request.
+	 * Serve a canned PSR-7 response for a Mollie API request.
 	 *
-	 * @param string       $http_method HTTP verb.
-	 * @param string       $url         Full request URL.
-	 * @param string|array $headers     Request headers (ignored).
-	 * @param string       $http_body   JSON request body.
-	 * @return \stdClass|null Decoded response body, or null for no content.
+	 * @param PendingRequest $pending_request Incoming SDK request.
+	 * @return Response
 	 */
-	public function send( $http_method, $url, $headers, $http_body ) {
-		$path    = (string) \wp_parse_url( $url, PHP_URL_PATH );
-		$payload = ! empty( $http_body ) ? \json_decode( $http_body, true ) : array();
-		$payload = \is_array( $payload ) ? $payload : array();
+	public function sendRequest( PendingRequest $pending_request ): Response {
+		$psr_request = $pending_request->createPsrRequest();
+		$method      = \strtoupper( $pending_request->method() );
+		$path        = (string) \wp_parse_url( $pending_request->url(), PHP_URL_PATH );
+		$raw_body    = (string) $psr_request->getBody();
+		$payload     = ! empty( $raw_body ) ? \json_decode( $raw_body, true ) : array();
+		$payload     = \is_array( $payload ) ? $payload : array();
 
-		// Create payment: POST /v2/payments
-		if ( 'POST' === \strtoupper( $http_method ) && \preg_match( '#/payments/?$#', $path ) ) {
-			return $this->payment_response( $payload, 'open' );
-		}
+		$data = $this->canned_response( $method, $path, $payload );
+		$json = \wp_json_encode( $data );
 
-		// Get single payment: GET /v2/payments/{id}
-		if ( \preg_match( '#/payments/([^/]+)$#', $path, $m ) ) {
-			return $this->payment_response( $payload, 'paid', $m[1] );
-		}
+		$fc          = $pending_request->getFactoryCollection();
+		$psr_response = $fc->responseFactory
+			->createResponse( 200 )
+			->withHeader( 'Content-Type', 'application/json' )
+			->withBody( $fc->streamFactory->createStream( $json ) );
 
-		// Payment methods allowlist lookup: GET /v2/methods
-		if ( \preg_match( '#/methods#', $path ) ) {
-			return $this->objectify(
-				array(
-					'count'     => 0,
-					'_embedded' => array( 'methods' => array() ),
-					'_links'    => new \stdClass(),
-				)
-			);
-		}
-
-		// Balance / balance-transactions lookup used by fee capture.
-		if ( \preg_match( '#/balances|/balance-transactions#', $path ) ) {
-			return $this->objectify(
-				array(
-					'count'     => 0,
-					'_embedded' => array( 'balance_transactions' => array() ),
-					'_links'    => array( 'next' => null ),
-				)
-			);
-		}
-
-		return new \stdClass();
+		return new Response( $psr_response, $psr_request, $pending_request );
 	}
 
 	/**
@@ -91,22 +77,62 @@ class CurlMollieHttpAdapter {
 	 *
 	 * @return string
 	 */
-	public function versionString() {
-		return 'FairEventsE2EMock/1.0';
+	public function version(): string {
+		return 'FairEventsE2EMock/2.0';
 	}
 
 	/**
-	 * Build a Mollie payment response object.
+	 * Route a request to its canned response data.
+	 *
+	 * @param string $method  HTTP verb.
+	 * @param string $path    URL path component.
+	 * @param array  $payload Decoded request body.
+	 * @return array|\stdClass
+	 */
+	private function canned_response( string $method, string $path, array $payload ) {
+		// Create payment: POST /v2/payments
+		if ( 'POST' === $method && \preg_match( '#/payments/?$#', $path ) ) {
+			return $this->payment_response( $payload, 'open' );
+		}
+
+		// Get single payment: GET /v2/payments/{id}
+		if ( \preg_match( '#/payments/([^/]+)$#', $path, $m ) ) {
+			return $this->payment_response( array(), 'paid', $m[1] );
+		}
+
+		// Payment methods allowlist lookup: GET /v2/methods
+		if ( \preg_match( '#/methods#', $path ) ) {
+			return array(
+				'count'     => 0,
+				'_embedded' => array( 'methods' => array() ),
+				'_links'    => new \stdClass(),
+			);
+		}
+
+		// Balance / balance-transactions lookup used by fee capture.
+		if ( \preg_match( '#/balances|/balance-transactions#', $path ) ) {
+			return array(
+				'count'     => 0,
+				'_embedded' => array( 'balance_transactions' => array() ),
+				'_links'    => array( 'next' => null ),
+			);
+		}
+
+		return new \stdClass();
+	}
+
+	/**
+	 * Build a Mollie payment response array.
 	 *
 	 * @param array       $payload Decoded request body (create only).
 	 * @param string      $status  Payment status to report.
 	 * @param string|null $id      Existing payment id (get) or null to mint one.
-	 * @return \stdClass
+	 * @return array
 	 */
-	private function payment_response( $payload, $status, $id = null ) {
-		$id           = $id ? $id : 'tr_' . \strtoupper( \substr( \md5( \uniqid( '', true ) ), 0, 10 ) );
-		$redirect_url = isset( $payload['redirectUrl'] ) ? $payload['redirectUrl'] : \home_url( '/' );
-		$amount       = isset( $payload['amount'] ) && \is_array( $payload['amount'] )
+	private function payment_response( array $payload, string $status, ?string $id = null ): array {
+		$id           = $id ?? 'tr_' . \strtoupper( \substr( \md5( \uniqid( '', true ) ), 0, 10 ) );
+		$redirect_url = $payload['redirectUrl'] ?? \home_url( '/' );
+		$amount       = ( isset( $payload['amount'] ) && \is_array( $payload['amount'] ) )
 			? $payload['amount']
 			: array(
 				'currency' => 'EUR',
@@ -119,8 +145,8 @@ class CurlMollieHttpAdapter {
 			'mode'        => 'test',
 			'status'      => $status,
 			'amount'      => $amount,
-			'description' => isset( $payload['description'] ) ? $payload['description'] : 'E2E payment',
-			'metadata'    => isset( $payload['metadata'] ) ? $payload['metadata'] : new \stdClass(),
+			'description' => $payload['description'] ?? 'E2E payment',
+			'metadata'    => $payload['metadata'] ?? new \stdClass(),
 			'createdAt'   => \gmdate( 'c' ),
 			'_links'      => array(
 				'checkout' => array(
@@ -134,17 +160,6 @@ class CurlMollieHttpAdapter {
 			$data['paidAt'] = \gmdate( 'c' );
 		}
 
-		return $this->objectify( $data );
-	}
-
-	/**
-	 * Convert a nested array into the nested stdClass the SDK expects from a
-	 * decoded JSON body.
-	 *
-	 * @param array $data Response data.
-	 * @return \stdClass
-	 */
-	private function objectify( $data ) {
-		return \json_decode( \json_encode( $data ) );
+		return $data;
 	}
 }

--- a/e2e/mu-plugins/lib/mollie-http-double.php
+++ b/e2e/mu-plugins/lib/mollie-http-double.php
@@ -26,6 +26,23 @@
 
 namespace Mollie\Api\Http\Adapter;
 
+// During the initial wp-env setup pass WordPress may load before
+// fair-payments-connector is activated (and its Composer autoloader registered).
+// Explicitly require the autoloader so the Mollie SDK traits are resolvable.
+// If neither path works, bail silently — no Mollie API calls happen during
+// initial setup anyway, so the double isn't needed at that point.
+$_fpc_autoload = defined( 'WP_PLUGIN_DIR' )
+	? WP_PLUGIN_DIR . '/fair-payments-connector/vendor/autoload.php'
+	: null;
+if ( $_fpc_autoload && file_exists( $_fpc_autoload ) ) {
+	require_once $_fpc_autoload;
+}
+unset( $_fpc_autoload );
+
+if ( ! trait_exists( 'Mollie\\Api\\Traits\\HasDefaultFactories', true ) ) {
+	return;
+}
+
 use Mollie\Api\Contracts\HttpAdapterContract;
 use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\Http\Response;
@@ -63,7 +80,7 @@ class CurlMollieHttpAdapter implements HttpAdapterContract {
 		$data = $this->canned_response( $method, $path, $payload );
 		$json = \wp_json_encode( $data );
 
-		$fc          = $pending_request->getFactoryCollection();
+		$fc           = $pending_request->getFactoryCollection();
 		$psr_response = $fc->responseFactory
 			->createResponse( 200 )
 			->withHeader( 'Content-Type', 'application/json' )

--- a/fair-payments-connector/composer.json
+++ b/fair-payments-connector/composer.json
@@ -19,7 +19,7 @@
 	],
 	"require": {
 		"php": ">=7.4",
-		"mollie/mollie-api-php": "^2.0",
+		"mollie/mollie-api-php": "^3.0",
 		"fair-events/shared": "^0.1"
 	},
 	"require-dev": {

--- a/fair-payments-connector/composer.lock
+++ b/fair-payments-connector/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "937d7c0a966a2b2c8a5588b5877ead03",
+    "content-hash": "15abb3eb1730cb215cd1c12939944ac3",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -106,31 +106,35 @@
         },
         {
             "name": "mollie/mollie-api-php",
-            "version": "v2.79.1",
+            "version": "v3.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mollie/mollie-api-php.git",
-                "reference": "4c1cf5f603178dd15bdf60b5e3999f91bb59f5b0"
+                "reference": "c35f5b1549a032a3cb52014828485bb6c40396cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mollie/mollie-api-php/zipball/4c1cf5f603178dd15bdf60b5e3999f91bb59f5b0",
-                "reference": "4c1cf5f603178dd15bdf60b5e3999f91bb59f5b0",
+                "url": "https://api.github.com/repos/mollie/mollie-api-php/zipball/c35f5b1549a032a3cb52014828485bb6c40396cb",
+                "reference": "c35f5b1549a032a3cb52014828485bb6c40396cb",
                 "shasum": ""
             },
             "require": {
-                "composer/ca-bundle": "^1.2",
+                "composer/ca-bundle": "^1.4",
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-openssl": "*",
-                "php": "^7.2|^8.0"
+                "nyholm/psr7": "^1.8",
+                "php": "^7.4|^8.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^1.1|^2.0"
             },
             "require-dev": {
-                "eloquent/liberator": "^2.0||^3.0",
-                "friendsofphp/php-cs-fixer": "^3.0",
-                "guzzlehttp/guzzle": "^6.3 || ^7.0",
-                "phpstan/phpstan": "^1.12",
-                "phpunit/phpunit": "^8.5 || ^9.5"
+                "brianium/paratest": "^6.11",
+                "guzzlehttp/guzzle": "^7.6",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/var-dumper": "^5.4|^6.4|^7.2"
             },
             "suggest": {
                 "mollie/oauth2-mollie-php": "Use OAuth to authenticate with the Mollie API. This is needed for some endpoints. Visit https://docs.mollie.com/ for more information."
@@ -192,9 +196,247 @@
             ],
             "support": {
                 "issues": "https://github.com/mollie/mollie-api-php/issues",
-                "source": "https://github.com/mollie/mollie-api-php/tree/v2.79.1"
+                "source": "https://github.com/mollie/mollie-api-php/tree/v3.13.1"
             },
-            "time": "2025-05-06T10:55:09+00:00"
+            "time": "2026-06-08T09:26:28+00:00"
+        },
+        {
+            "name": "nyholm/psr7",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nyholm/psr7.git",
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "php-http/message-factory-implementation": "1.0",
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "http-interop/http-factory-tests": "^0.9",
+                "php-http/message-factory": "^1.0",
+                "php-http/psr7-integration-tests": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
+                "symfony/error-handler": "^4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "A fast PHP7 implementation of PSR-7",
+            "homepage": "https://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/Nyholm/psr7/issues",
+                "source": "https://github.com/Nyholm/psr7/tree/1.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-09T07:06:30+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
         }
     ],
     "packages-dev": [

--- a/fair-payments-connector/src/Payment/MolliePaymentHandler.php
+++ b/fair-payments-connector/src/Payment/MolliePaymentHandler.php
@@ -377,7 +377,7 @@ class MolliePaymentHandler {
 				$parameters['testmode']  = $testmode ? 'true' : 'false';
 			}
 
-			$methods = $this->mollie->methods->allActive( $parameters );
+			$methods = $this->mollie->methods->allEnabled( $parameters );
 		} catch ( ApiException $e ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/fair-platform/composer.json
+++ b/fair-platform/composer.json
@@ -5,7 +5,7 @@
 	"license": "proprietary",
 	"require": {
 		"php": "^8.0",
-		"mollie/mollie-api-php": "^2.0"
+		"mollie/mollie-api-php": "^3.0"
 	},
 	"authors": [
 		{


### PR DESCRIPTION
## Summary

- Bumps `mollie/mollie-api-php` constraint from `^2.0` to `^3.0` in `fair-payments-connector` and `fair-platform`
- Runs `composer update` to install v3.13.1 (adds three new PSR dependencies: `nyholm/psr7`, `psr/http-client`, `psr/http-factory`)
- Renames the one removed API call: `methods->allActive()` → `methods->allEnabled()` in `MolliePaymentHandler.php:380`

All other SDK calls (`payments->create`, `payments->get`, `profiles->get`, `balanceTransactions->iteratorForPrimary`, `setApiKey`, `setAccessToken`, `ApiException`) remain compatible with the legacy array approach unchanged.

`fair-platform` uses only `class_exists('\Mollie\Api\MollieApiClient')` as a health check and makes direct HTTP calls to Mollie REST endpoints — no SDK method calls, so no code changes were needed there.

Closes #807

## Test plan

- [ ] `vendor/bin/phpcs` in `fair-payments-connector` passes (verified locally — no output)
- [ ] `npm run test:e2e` in `fair-payments-connector` — payment creation, webhook, and OAuth flows pass
- [ ] Manual smoke test: create a test payment end-to-end in the local Docker environment