### PR TITLE
feat: add fair-payments-connector-experimental plugin

### DIFF
--- a/.changeset/add-fair-payments-connector-experimental.md
+++ b/.changeset/add-fair-payments-connector-experimental.md
@@ -1,0 +1,5 @@
+---
+"fair-payments-connector-experimental": minor
+---
+
+Initial release: moves API Tokens, Connected Sites, and Telegram notification dispatch out of fair-payments-connector into a new experimental plugin

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,6 +41,7 @@ jobs:
                       ./fair-timetable/vendor
                       ./fair-finance/vendor
                       ./fair-events-experimental/vendor
+                      ./fair-payments-connector-experimental/vendor
                       ./vendor
                   key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
                   restore-keys: |
@@ -64,6 +65,7 @@ jobs:
                       ./fair-timetable/node_modules
                       ./fair-finance/node_modules
                       ./fair-events-experimental/node_modules
+                      ./fair-payments-connector-experimental/node_modules
                       ./fair-events-shared/node_modules
                   key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
 

--- a/compose.yml
+++ b/compose.yml
@@ -18,6 +18,7 @@ services:
             - ./fair-timetable:/var/www/html/wp-content/plugins/fair-timetable
             - ./fair-finance:/var/www/html/wp-content/plugins/fair-finance
             - ./fair-events-experimental:/var/www/html/wp-content/plugins/fair-events-experimental
+            - ./fair-payments-connector-experimental:/var/www/html/wp-content/plugins/fair-payments-connector-experimental
             - ./uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
 
     db:
@@ -55,6 +56,7 @@ services:
             - ./fair-timetable:/var/www/html/wp-content/plugins/fair-timetable
             - ./fair-finance:/var/www/html/wp-content/plugins/fair-finance
             - ./fair-events-experimental:/var/www/html/wp-content/plugins/fair-events-experimental
+            - ./fair-payments-connector-experimental:/var/www/html/wp-content/plugins/fair-payments-connector-experimental
 
         environment:
             WORDPRESS_DB_HOST: db

--- a/e2e/mu-plugins/fair-e2e-support.php
+++ b/e2e/mu-plugins/fair-e2e-support.php
@@ -26,12 +26,19 @@ defined( 'ABSPATH' ) || exit;
 /*
  * 1. Intercept the Mollie HTTP transport.
  *
- * Declared at mu-plugin load time — before fair-payments-connector's Composer autoloader
- * gets a chance to load the vendored CurlMollieHttpAdapter — so the SDK's
- * adapter picker instantiates our double instead. The real MollieApiClient
- * (URL building, response parsing, resource hydration) is untouched.
+ * Hooks into plugins_loaded (priority 1) — after fair-payments-connector has
+ * registered its Composer autoloader (so SDK traits/interfaces are resolvable)
+ * but before any REST request triggers new MollieApiClient() (which is the
+ * earliest the adapter picker could instantiate the vendored class). Declaring
+ * our double at that point is enough to shadow the final class.
  */
-require_once __DIR__ . '/lib/mollie-http-double.php';
+\add_action(
+	'plugins_loaded',
+	static function () {
+		require_once __DIR__ . '/lib/mollie-http-double.php';
+	},
+	1
+);
 
 /*
  * 2. Force fair-payments-connector into test mode with a syntactically valid dummy key.

--- a/fair-payments-connector-experimental/.distignore
+++ b/fair-payments-connector-experimental/.distignore
@@ -1,0 +1,23 @@
+# Development files
+.git/
+.gitignore
+.github/
+node_modules/
+tests/
+__tests__/
+e2e/
+svn/
+.distignore
+.editorconfig
+.eslintrc.js
+.prettierrc.js
+composer.lock
+package.json
+package-lock.json
+phpcs.xml
+webpack.config.cjs
+*.md
+!CHANGELOG.md
+
+# Build artifacts that should be included
+!/vendor/

--- a/fair-payments-connector-experimental/.gitignore
+++ b/fair-payments-connector-experimental/.gitignore
@@ -1,0 +1,29 @@
+# Dependencies
+/vendor/
+/node_modules/
+composer.lock
+package-lock.json
+
+# Build
+/build/
+
+# WordPress
+.htaccess
+
+# IDE
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+.env.local
+
+# Logs
+*.log
+npm-debug.log*

--- a/fair-payments-connector-experimental/CHANGELOG.md
+++ b/fair-payments-connector-experimental/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 0.1.0
+
+### Added
+- Initial release: API Tokens, Connected Sites, and Telegram Notifications moved from fair-payments-connector

--- a/fair-payments-connector-experimental/__tests__/example.test.js
+++ b/fair-payments-connector-experimental/__tests__/example.test.js
@@ -1,0 +1,5 @@
+describe('Fair Payments Connector Experimental Plugin', () => {
+	it('should exist', () => {
+		expect(true).toBe(true);
+	});
+});

--- a/fair-payments-connector-experimental/composer.json
+++ b/fair-payments-connector-experimental/composer.json
@@ -1,0 +1,32 @@
+{
+	"name": "fair-event-plugins/fair-payments-connector-experimental",
+	"description": "Experimental features for Fair Payments Connector",
+	"type": "wordpress-plugin",
+	"license": "proprietary",
+	"authors": [
+		{
+			"name": "Marcin Wosinek",
+			"email": "marcin.wosinek@gmail.com"
+		}
+	],
+	"require": {
+		"php": "^8.0"
+	},
+	"require-dev": {
+		"squizlabs/php_codesniffer": "^3.7",
+		"wp-coding-standards/wpcs": "^3.0"
+	},
+	"autoload": {
+		"psr-4": {
+			"FairPaymentsConnectorExperimental\\": "src/"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"platform": {
+			"php": "8.2"
+		}
+	}
+}

--- a/fair-payments-connector-experimental/fair-payments-connector-experimental.php
+++ b/fair-payments-connector-experimental/fair-payments-connector-experimental.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Plugin Name: Fair Payments Connector Experimental
+ * Plugin URI: https://github.com/marcin-wosinek/fair-event-plugins
+ * Description: Experimental features for Fair Payments Connector: API tokens, connected sites, and Telegram notifications.
+ * Version: 0.1.0
+ * Author: Marcin Wosinek
+ * Author URI: https://github.com/marcin-wosinek
+ * License: Private
+ * Text Domain: fair-payments-connector-experimental
+ * Domain Path: /languages
+ * Requires at least: 6.7
+ * Requires PHP: 8.0
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental;
+
+defined( 'ABSPATH' ) || die;
+
+// Plugin constants.
+define( 'FAIR_PAYMENTS_CONNECTOR_EXPERIMENTAL_VERSION', '0.1.0' );
+define( 'FAIR_PAYMENTS_CONNECTOR_EXPERIMENTAL_FILE', __FILE__ );
+define( 'FAIR_PAYMENTS_CONNECTOR_EXPERIMENTAL_DIR', plugin_dir_path( __FILE__ ) );
+define( 'FAIR_PAYMENTS_CONNECTOR_EXPERIMENTAL_URL', plugin_dir_url( __FILE__ ) );
+
+// Composer autoloader.
+require_once __DIR__ . '/vendor/autoload.php';
+
+// Initialize plugin.
+use FairPaymentsConnectorExperimental\Core\Plugin;
+add_action( 'plugins_loaded', array( Plugin::class, 'instance' ) );

--- a/fair-payments-connector-experimental/jest.config.js
+++ b/fair-payments-connector-experimental/jest.config.js
@@ -1,0 +1,45 @@
+export default {
+	preset: '@wordpress/jest-preset-default',
+	testEnvironment: 'jsdom',
+	testMatch: ['**/__tests__/**/*.js', '**/?(*.)+(spec|test).js'],
+	testPathIgnorePatterns: [
+		'/node_modules/',
+		'/vendor/',
+		'/e2e/',
+		'\\.api\\.spec\\.js$',
+	],
+	transformIgnorePatterns: [
+		'/node_modules/(?!(uuid|@wordpress/components)/)',
+	],
+	collectCoverageFrom: [
+		'src/**/*.js',
+		'!src/**/index.js',
+		'!**/node_modules/**',
+		'!**/build/**',
+		'!**/vendor/**',
+		'!**/e2e/**',
+	],
+	coverageDirectory: 'coverage',
+	coverageReporters: ['text', 'lcov', 'html'],
+	setupFilesAfterEnv: [],
+	transform: {
+		'^.+\\.[jt]sx?$': [
+			'babel-jest',
+			{
+				presets: [
+					[
+						'@babel/preset-env',
+						{
+							targets: {
+								node: 'current',
+							},
+						},
+					],
+				],
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^@/(.*)$': '<rootDir>/src/$1',
+	},
+};

--- a/fair-payments-connector-experimental/package.json
+++ b/fair-payments-connector-experimental/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "fair-payments-connector-experimental",
+	"version": "0.1.0",
+	"description": "Experimental features for Fair Payments Connector",
+	"license": "proprietary",
+	"author": "Marcin Wosinek",
+	"type": "module",
+	"main": "build/index.js",
+	"scripts": {
+		"build": "wp-scripts build --config webpack.config.cjs",
+		"clean": "rm -rf build",
+		"start": "wp-scripts start --config webpack.config.cjs",
+		"format": "wp-scripts format",
+		"composer:install": "composer install",
+		"composer:install:prod": "composer install --no-dev",
+		"composer:update": "composer update",
+		"composer:validate": "composer validate --strict",
+		"makepot": "wp i18n make-pot . languages/fair-payments-connector-experimental.pot --exclude=node_modules,vendor,tests,build,svn",
+		"makejson": "wp i18n make-json languages ./build/languages --domain=fair-payments-connector-experimental --pretty-print --no-purge --use-map=build/map.json",
+		"makemo": "wp i18n make-mo languages/",
+		"updatepo": "wp i18n update-po languages/fair-payments-connector-experimental.pot languages/",
+		"test": "wp-scripts test-unit-js --config jest.config.js",
+		"test:js": "wp-scripts test-unit-js --config jest.config.js",
+		"test:php": "vendor/bin/phpunit",
+		"svn:checkout": "svn co https://plugins.svn.wordpress.org/fair-payments-connector-experimental svn",
+		"svn:copy": "cp -r readme.txt fair-payments-connector-experimental.php composer* languages CHANGELOG.md svn/trunk"
+	},
+	"devDependencies": {
+		"@wordpress/scripts": "^32.4.0",
+		"webpack-bundle-output": "^1.1.0"
+	},
+	"dependencies": {
+		"@wordpress/api-fetch": "^7.12.0",
+		"@wordpress/components": "^35.0.0",
+		"@wordpress/dom-ready": "^4.12.0",
+		"@wordpress/element": "^8.0.0",
+		"@wordpress/i18n": "^5.12.0"
+	}
+}

--- a/fair-payments-connector-experimental/playwright.config.js
+++ b/fair-payments-connector-experimental/playwright.config.js
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export default defineConfig({
+	testDir: './',
+	testMatch: ['e2e/**/*.spec.js', 'src/API/__tests__/**/*.api.spec.js'],
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: 1,
+	reporter: 'html',
+	use: {
+		baseURL: process.env.WP_BASE_URL || 'http://localhost:8080',
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+	webServer: {
+		command: 'docker compose up',
+		url: 'http://localhost:8080',
+		reuseExistingServer: !process.env.CI,
+		timeout: 120 * 1000,
+	},
+});

--- a/fair-payments-connector-experimental/readme.txt
+++ b/fair-payments-connector-experimental/readme.txt
@@ -1,0 +1,26 @@
+=== Fair Payments Connector Experimental ===
+Contributors: marcinwosinek
+Tags: payments, mollie, telegram
+Requires at least: 6.7
+Tested up to: 7.0
+Requires PHP: 8.0
+Stable tag: 0.1.0
+License: Private
+License URI: https://fair-event-plugins.com
+
+Experimental features for Fair Payments Connector: API tokens, connected sites, and Telegram notifications.
+
+== Description ==
+
+This plugin houses features that are under active development and not yet ready for general availability. Requires Fair Payments Connector to be active.
+
+**Features:**
+
+* API Tokens — issue scoped bearer tokens so other sites can read transaction data
+* Connected Sites — pull transaction data from other sites over the data sharing API
+* Telegram Notifications — send payment notifications to Telegram chats
+
+== Changelog ==
+
+= 0.1.0 =
+* Initial release — moved from fair-payments-connector

--- a/fair-payments-connector-experimental/src/API/ApiTokenAuth.php
+++ b/fair-payments-connector-experimental/src/API/ApiTokenAuth.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Bearer token authentication for the data sharing API.
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\API;
+
+use FairPaymentsConnectorExperimental\Models\ApiToken;
+use WP_Error;
+use WP_REST_Request;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Authenticates public external REST endpoints via scoped bearer tokens.
+ */
+class ApiTokenAuth {
+	/**
+	 * Authenticate a request and verify it carries the required scope.
+	 *
+	 * @param WP_REST_Request $request        Incoming request.
+	 * @param string|null     $required_scope Scope the endpoint requires, or null
+	 *                                        to require only a valid active token.
+	 * @return true|WP_Error True when authorized, WP_Error otherwise.
+	 */
+	public static function authenticate( WP_REST_Request $request, $required_scope = null ) {
+		$header = $request->get_header( 'authorization' );
+
+		$token = self::parse_bearer_token( $header );
+
+		if ( '' === $token ) {
+			return self::unauthorized();
+		}
+
+		$row = ApiToken::find_by_token( $token );
+
+		if ( ! $row || ! ApiToken::is_active( $row ) ) {
+			return self::unauthorized();
+		}
+
+		if ( null !== $required_scope && ! ApiToken::has_scope( $row, $required_scope ) ) {
+			return new WP_Error(
+				'rest_insufficient_scope',
+				__( 'This token does not have the required scope.', 'fair-payments-connector-experimental' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		ApiToken::touch_last_used( (int) $row->id );
+		$request->set_param( '_fair_api_token', $row );
+
+		return true;
+	}
+
+	/**
+	 * Build a permission_callback that requires a given scope.
+	 *
+	 * @param string $scope Required scope.
+	 * @return callable permission_callback for register_rest_route().
+	 */
+	public static function require_scope( $scope ) {
+		return function ( WP_REST_Request $request ) use ( $scope ) {
+			return self::authenticate( $request, $scope );
+		};
+	}
+
+	/**
+	 * Build a permission_callback that requires only a valid active token.
+	 *
+	 * @return callable permission_callback for register_rest_route().
+	 */
+	public static function require_token() {
+		return function ( WP_REST_Request $request ) {
+			return self::authenticate( $request );
+		};
+	}
+
+	/**
+	 * Extract the token from an Authorization header value.
+	 *
+	 * @param string|null $header Header value.
+	 * @return string Token, or empty string when not a valid Bearer header.
+	 */
+	private static function parse_bearer_token( $header ) {
+		if ( ! is_string( $header ) || '' === $header ) {
+			return '';
+		}
+
+		if ( ! preg_match( '/^Bearer\s+(.+)$/i', trim( $header ), $matches ) ) {
+			return '';
+		}
+
+		return trim( $matches[1] );
+	}
+
+	/**
+	 * Standard 401 error for missing/invalid tokens.
+	 *
+	 * @return WP_Error
+	 */
+	private static function unauthorized() {
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'Invalid or missing API token.', 'fair-payments-connector-experimental' ),
+			array( 'status' => 401 )
+		);
+	}
+}

--- a/fair-payments-connector-experimental/src/API/ApiTokensController.php
+++ b/fair-payments-connector-experimental/src/API/ApiTokensController.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Admin REST API controller for API tokens.
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\API;
+
+defined( 'WPINC' ) || die;
+
+use FairPaymentsConnectorExperimental\Models\ApiToken;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+/**
+ * Handles admin endpoints for listing, creating and revoking API tokens.
+ */
+class ApiTokensController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-payments-connector/v1';
+
+	/**
+	 * Register the admin API token routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/admin/api-tokens',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'label'  => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'scopes' => array(
+							'type'     => 'array',
+							'required' => true,
+							'items'    => array(
+								'type' => 'string',
+								'enum' => ApiToken::ALLOWED_SCOPES,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/admin/api-tokens/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'type'              => 'integer',
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Admin capability check for all routes.
+	 *
+	 * @return bool
+	 */
+	public function permissions_check() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * List all API tokens.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$tokens = ApiToken::get_all();
+
+		$data = array_map(
+			array( ApiToken::class, 'to_array' ),
+			$tokens
+		);
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Create a new API token.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$label  = $request->get_param( 'label' );
+		$scopes = (array) $request->get_param( 'scopes' );
+
+		if ( empty( $label ) ) {
+			return new WP_Error(
+				'rest_invalid_label',
+				__( 'A label is required.', 'fair-payments-connector-experimental' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$valid_scopes = array_values( array_intersect( $scopes, ApiToken::ALLOWED_SCOPES ) );
+
+		if ( empty( $valid_scopes ) ) {
+			return new WP_Error(
+				'rest_invalid_scopes',
+				__( 'At least one valid scope is required.', 'fair-payments-connector-experimental' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$result = ApiToken::create( $label, $valid_scopes );
+
+		if ( ! $result ) {
+			return new WP_Error(
+				'rest_api_token_creation_failed',
+				__( 'Failed to create API token.', 'fair-payments-connector-experimental' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$row      = ApiToken::get_by_id( $result['id'] );
+		$response = ApiToken::to_array( $row );
+
+		// One-time plaintext token; never retrievable again.
+		$response['token'] = $result['token'];
+
+		return new WP_REST_Response( $response, 201 );
+	}
+
+	/**
+	 * Revoke an API token.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$id = (int) $request->get_param( 'id' );
+
+		$existing = ApiToken::get_by_id( $id );
+		if ( ! $existing ) {
+			return new WP_Error(
+				'rest_api_token_not_found',
+				__( 'API token not found.', 'fair-payments-connector-experimental' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		ApiToken::revoke( $id );
+
+		$row = ApiToken::get_by_id( $id );
+
+		return new WP_REST_Response( ApiToken::to_array( $row ), 200 );
+	}
+}

--- a/fair-payments-connector-experimental/src/API/ConnectedSitesController.php
+++ b/fair-payments-connector-experimental/src/API/ConnectedSitesController.php
@@ -1,0 +1,417 @@
+<?php
+/**
+ * Admin REST API controller for connected sites.
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\API;
+
+defined( 'WPINC' ) || die;
+
+use FairPaymentsConnectorExperimental\Models\ConnectedSite;
+use FairPaymentsConnector\Models\Transaction;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+/**
+ * Handles admin endpoints for managing connected sites.
+ */
+class ConnectedSitesController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-payments-connector/v1';
+
+	/**
+	 * Register the admin connected-sites routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		$args = array(
+			'label'    => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'base_url' => array(
+				'type'              => 'string',
+				'sanitize_callback' => 'esc_url_raw',
+			),
+			'token'    => array(
+				'type' => 'string',
+			),
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/admin/connected-sites',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $args,
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/admin/connected-sites/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $args,
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/admin/connected-sites/(?P<id>\d+)/test',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'test_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/admin/connected-sites/(?P<id>\d+)/import-transactions',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'import_transactions' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Admin capability check for all routes.
+	 *
+	 * @return bool
+	 */
+	public function permissions_check() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * List all connected sites.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$data = array_map(
+			array( ConnectedSite::class, 'to_array' ),
+			ConnectedSite::get_all()
+		);
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Create a new connected site.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$label    = (string) $request->get_param( 'label' );
+		$base_url = (string) $request->get_param( 'base_url' );
+		$token    = (string) $request->get_param( 'token' );
+
+		if ( '' === trim( $label ) || '' === trim( $base_url ) || '' === trim( $token ) ) {
+			return new WP_Error(
+				'rest_invalid_connected_site',
+				__( 'Label, base URL and token are all required.', 'fair-payments-connector-experimental' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$record = ConnectedSite::create(
+			array(
+				'label'    => $label,
+				'base_url' => $base_url,
+				'token'    => $token,
+			)
+		);
+
+		return new WP_REST_Response( ConnectedSite::to_array( $record ), 201 );
+	}
+
+	/**
+	 * Update a connected site.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$id = (int) $request->get_param( 'id' );
+
+		if ( ! ConnectedSite::get_by_id( $id ) ) {
+			return $this->not_found();
+		}
+
+		$data = array();
+		if ( null !== $request->get_param( 'label' ) ) {
+			$data['label'] = (string) $request->get_param( 'label' );
+		}
+		if ( null !== $request->get_param( 'base_url' ) ) {
+			$data['base_url'] = (string) $request->get_param( 'base_url' );
+		}
+		if ( null !== $request->get_param( 'token' ) ) {
+			$data['token'] = (string) $request->get_param( 'token' );
+		}
+
+		$record = ConnectedSite::update( $id, $data );
+
+		return new WP_REST_Response( ConnectedSite::to_array( $record ), 200 );
+	}
+
+	/**
+	 * Delete a connected site.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$id = (int) $request->get_param( 'id' );
+
+		if ( ! ConnectedSite::get_by_id( $id ) ) {
+			return $this->not_found();
+		}
+
+		ConnectedSite::delete( $id );
+
+		return new WP_REST_Response( array( 'deleted' => true ), 200 );
+	}
+
+	/**
+	 * Test a connected site's token against its remote /external/me endpoint.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function test_item( $request ) {
+		$id     = (int) $request->get_param( 'id' );
+		$record = ConnectedSite::get_by_id( $id );
+
+		if ( ! $record ) {
+			return $this->not_found();
+		}
+
+		$url = trailingslashit( $record['base_url'] ) . 'wp-json/fair-payments-connector/v1/external/me';
+
+		$response = wp_safe_remote_get(
+			$url,
+			array(
+				'timeout' => 10,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $record['token'],
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			ConnectedSite::mark_failed( $id );
+
+			return new WP_Error(
+				'rest_connected_site_unreachable',
+				__( 'Could not reach the remote site.', 'fair-payments-connector-experimental' ),
+				array( 'status' => 502 )
+			);
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( 200 !== $code || ! is_array( $body ) ) {
+			ConnectedSite::mark_failed( $id );
+
+			$message = 401 === $code || 403 === $code
+				? __( 'The remote site rejected the token.', 'fair-payments-connector-experimental' )
+				: __( 'The remote site returned an unexpected response.', 'fair-payments-connector-experimental' );
+
+			return new WP_Error(
+				'rest_connected_site_test_failed',
+				$message,
+				array( 'status' => 400 )
+			);
+		}
+
+		$scopes = isset( $body['scopes'] ) && is_array( $body['scopes'] ) ? $body['scopes'] : array();
+		ConnectedSite::record_test_result( $id, $scopes );
+
+		return new WP_REST_Response(
+			array(
+				'ok'     => true,
+				'label'  => isset( $body['label'] ) ? sanitize_text_field( $body['label'] ) : '',
+				'scopes' => array_values( array_map( 'sanitize_text_field', $scopes ) ),
+			),
+			200
+		);
+	}
+
+	/**
+	 * Pull transactions from a connected site and import them locally.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function import_transactions( $request ) {
+		$id     = (int) $request->get_param( 'id' );
+		$record = ConnectedSite::get_by_id( $id );
+
+		if ( ! $record ) {
+			return $this->not_found();
+		}
+
+		$source_domain = (string) wp_parse_url( $record['base_url'], PHP_URL_HOST );
+		$base          = trailingslashit( $record['base_url'] ) . 'wp-json/fair-payments-connector/v1/external/transactions';
+		$per_page      = 200;
+		$page          = 1;
+		$created       = 0;
+		$updated       = 0;
+		$skipped       = 0;
+
+		do {
+			$url = add_query_arg(
+				array(
+					'page'     => $page,
+					'per_page' => $per_page,
+				),
+				$base
+			);
+
+			$response = wp_safe_remote_get(
+				$url,
+				array(
+					'timeout' => 30,
+					'headers' => array(
+						'Authorization' => 'Bearer ' . $record['token'],
+					),
+				)
+			);
+
+			if ( is_wp_error( $response ) ) {
+				ConnectedSite::mark_failed( $id );
+
+				return new WP_Error(
+					'rest_connected_site_unreachable',
+					__( 'Could not reach the remote site.', 'fair-payments-connector-experimental' ),
+					array( 'status' => 502 )
+				);
+			}
+
+			$code = (int) wp_remote_retrieve_response_code( $response );
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			if ( 200 !== $code || ! is_array( $body ) || ! isset( $body['transactions'] ) ) {
+				ConnectedSite::mark_failed( $id );
+
+				$message = 401 === $code || 403 === $code
+					? __( 'The remote site rejected the token, or it lacks the transactions:read scope.', 'fair-payments-connector-experimental' )
+					: __( 'The remote site returned an unexpected response.', 'fair-payments-connector-experimental' );
+
+				return new WP_Error(
+					'rest_connected_site_import_failed',
+					$message,
+					array( 'status' => 400 )
+				);
+			}
+
+			$transactions = is_array( $body['transactions'] ) ? $body['transactions'] : array();
+
+			foreach ( $transactions as $transaction ) {
+				if ( ! is_array( $transaction ) ) {
+					++$skipped;
+					continue;
+				}
+
+				$result = Transaction::import(
+					array(
+						'mollie_payment_id' => $transaction['mollie_payment_id'] ?? '',
+						'amount'            => $transaction['amount'] ?? 0,
+						'currency'          => $transaction['currency'] ?? 'EUR',
+						'application_fee'   => $transaction['application_fee'] ?? null,
+						'status'            => $transaction['status'] ?? 'paid',
+						'testmode'          => ! empty( $transaction['testmode'] ),
+						'description'       => $transaction['description'] ?? '',
+						'created_at'        => $transaction['created_at'] ?? '',
+						'event_date_id'     => $transaction['event_date_id'] ?? null,
+						'detail_url'        => $transaction['event_url'] ?? '',
+						'source_domain'     => $source_domain,
+					)
+				);
+
+				if ( 'created' === $result ) {
+					++$created;
+				} elseif ( 'updated' === $result ) {
+					++$updated;
+				} else {
+					++$skipped;
+				}
+			}
+
+			$total    = isset( $body['total'] ) ? (int) $body['total'] : 0;
+			$fetched  = $page * $per_page;
+			$has_more = count( $transactions ) === $per_page && $fetched < $total;
+			++$page;
+		} while ( $has_more );
+
+		return new WP_REST_Response(
+			array(
+				'created' => $created,
+				'updated' => $updated,
+				'skipped' => $skipped,
+				'message' => sprintf(
+					/* translators: 1: created count, 2: updated count, 3: skipped count, 4: connected site label */
+					__( 'Imported %1$d new, updated %2$d, skipped %3$d transaction(s) from %4$s.', 'fair-payments-connector-experimental' ),
+					$created,
+					$updated,
+					$skipped,
+					$record['label']
+				),
+			),
+			200
+		);
+	}
+
+	/**
+	 * Standard 404 error.
+	 *
+	 * @return WP_Error
+	 */
+	private function not_found() {
+		return new WP_Error(
+			'rest_connected_site_not_found',
+			__( 'Connected site not found.', 'fair-payments-connector-experimental' ),
+			array( 'status' => 404 )
+		);
+	}
+}

--- a/fair-payments-connector-experimental/src/API/ExternalMeController.php
+++ b/fair-payments-connector-experimental/src/API/ExternalMeController.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Public external REST API controller for token introspection.
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\API;
+
+defined( 'WPINC' ) || die;
+
+use FairPaymentsConnectorExperimental\Models\ApiToken;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Handles the public GET /external/me endpoint.
+ */
+class ExternalMeController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-payments-connector/v1';
+
+	/**
+	 * Register the route for token introspection.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/external/me',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => ApiTokenAuth::require_token(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Return the authenticated token's label and scopes.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$row = $request->get_param( '_fair_api_token' );
+
+		return new WP_REST_Response( ApiToken::to_array( $row ), 200 );
+	}
+}

--- a/fair-payments-connector-experimental/src/API/ExternalTransactionsController.php
+++ b/fair-payments-connector-experimental/src/API/ExternalTransactionsController.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Public external REST API controller for transactions.
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\API;
+
+defined( 'WPINC' ) || die;
+
+use FairPaymentsConnector\Models\Transaction;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Handles the public GET /external/transactions endpoint.
+ */
+class ExternalTransactionsController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-payments-connector/v1';
+
+	/**
+	 * Maximum number of items per page.
+	 *
+	 * @var int
+	 */
+	const MAX_PER_PAGE = 200;
+
+	/**
+	 * Register the routes for external transactions.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/external/transactions',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => ApiTokenAuth::require_scope( 'transactions:read' ),
+					'args'                => $this->get_collection_params(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Collection parameters for the external transactions endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		return array(
+			'page'     => array(
+				'type'              => 'integer',
+				'default'           => 1,
+				'minimum'           => 1,
+				'sanitize_callback' => 'absint',
+			),
+			'per_page' => array(
+				'type'              => 'integer',
+				'default'           => 50,
+				'minimum'           => 1,
+				'maximum'           => self::MAX_PER_PAGE,
+				'sanitize_callback' => 'absint',
+			),
+			'status'   => array(
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'from'     => array(
+				'type'              => 'string',
+				'default'           => '',
+				'description'       => __( 'Filter by transaction date (created_at) from this date, e.g. 2026-01-01.', 'fair-payments-connector-experimental' ),
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => array( $this, 'validate_date' ),
+			),
+			'to'       => array(
+				'type'              => 'string',
+				'default'           => '',
+				'description'       => __( 'Filter by transaction date (created_at) up to this date, e.g. 2026-12-31.', 'fair-payments-connector-experimental' ),
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => array( $this, 'validate_date' ),
+			),
+		);
+	}
+
+	/**
+	 * Validate an ISO date / datetime query parameter.
+	 *
+	 * @param string $value Value to validate.
+	 * @return bool True when empty or a parseable date.
+	 */
+	public function validate_date( $value ) {
+		if ( '' === $value || null === $value ) {
+			return true;
+		}
+
+		return false !== strtotime( $value );
+	}
+
+	/**
+	 * Get a collection of transactions.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$per_page = (int) $request->get_param( 'per_page' );
+		$page     = (int) $request->get_param( 'page' );
+
+		if ( $per_page < 1 ) {
+			$per_page = 50;
+		}
+		$per_page = min( $per_page, self::MAX_PER_PAGE );
+		$page     = max( $page, 1 );
+		$offset   = ( $page - 1 ) * $per_page;
+
+		$status = (string) $request->get_param( 'status' );
+		$from   = (string) $request->get_param( 'from' );
+		$to     = (string) $request->get_param( 'to' );
+
+		$query_args = array(
+			'limit'     => $per_page,
+			'offset'    => $offset,
+			'status'    => $status,
+			'date_from' => $from,
+			'date_to'   => $to,
+			'orderby'   => 'created_at',
+			'order'     => 'DESC',
+		);
+
+		$transactions = Transaction::get_all( $query_args );
+		$total        = Transaction::count(
+			array(
+				'status'    => $status,
+				'date_from' => $from,
+				'date_to'   => $to,
+			)
+		);
+
+		$data = array();
+		foreach ( $transactions as $transaction ) {
+			$data[] = $this->prepare_transaction( $transaction );
+		}
+
+		return new WP_REST_Response(
+			array(
+				'transactions' => $data,
+				'total'        => $total,
+				'page'         => $page,
+				'per_page'     => $per_page,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Shape a transaction row for the external response.
+	 *
+	 * @param object $transaction Transaction row.
+	 * @return array
+	 */
+	private function prepare_transaction( $transaction ) {
+		$event_date_id = $transaction->event_date_id ? (int) $transaction->event_date_id : null;
+		$event_url     = '';
+
+		if ( $event_date_id && class_exists( '\\FairEvents\\Models\\EventDates' ) ) {
+			$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+			if ( $event_date && ! empty( $event_date->event_id ) ) {
+				$permalink = get_permalink( (int) $event_date->event_id );
+				if ( $permalink ) {
+					$event_url = $permalink;
+				}
+			}
+		}
+
+		return array(
+			'id'                => (int) $transaction->id,
+			'mollie_payment_id' => $transaction->mollie_payment_id ?? '',
+			'amount'            => (float) ( $transaction->amount ?? 0 ),
+			'currency'          => $transaction->currency ?? 'EUR',
+			'application_fee'   => null !== $transaction->application_fee ? (float) $transaction->application_fee : null,
+			'status'            => $transaction->status ?? 'unknown',
+			'testmode'          => ! empty( $transaction->testmode ),
+			'description'       => $transaction->description ?? '',
+			'event_date_id'     => $event_date_id,
+			'event_url'         => $event_url,
+			'created_at'        => $transaction->created_at ?? '',
+		);
+	}
+}

--- a/fair-payments-connector-experimental/src/API/RestHooks.php
+++ b/fair-payments-connector-experimental/src/API/RestHooks.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * REST API hooks for Fair Payments Connector Experimental
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\API;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Handles WordPress REST API hooks and endpoints
+ */
+class RestHooks {
+	/**
+	 * Constructor - registers WordPress hooks
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register REST API routes
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		$api_tokens_controller = new \FairPaymentsConnectorExperimental\API\ApiTokensController();
+		$api_tokens_controller->register_routes();
+
+		$external_me = new \FairPaymentsConnectorExperimental\API\ExternalMeController();
+		$external_me->register_routes();
+
+		$external_transactions = new \FairPaymentsConnectorExperimental\API\ExternalTransactionsController();
+		$external_transactions->register_routes();
+
+		$connected_sites_controller = new \FairPaymentsConnectorExperimental\API\ConnectedSitesController();
+		$connected_sites_controller->register_routes();
+
+		$telegram_controller = new \FairPaymentsConnectorExperimental\API\TelegramSettingsController();
+		$telegram_controller->register_routes();
+	}
+}

--- a/fair-payments-connector-experimental/src/API/TelegramSettingsController.php
+++ b/fair-payments-connector-experimental/src/API/TelegramSettingsController.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Telegram settings REST controller
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\API;
+
+use FairPaymentsConnectorExperimental\Hooks\NotificationHooks;
+use FairPaymentsConnectorExperimental\Services\TelegramService;
+use FairPaymentsConnector\Settings\Settings;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * REST endpoints for the Telegram notification settings.
+ *
+ * Settings themselves are stored as discrete options and read/written through
+ * the standard `/wp/v2/settings` endpoint. This controller adds the one
+ * operation that doesn't fit there: a "send test message" action that
+ * exercises the bot token + chat IDs against the real Telegram API.
+ *
+ * Routes are registered under fair-payments-connector/v1 so TelegramTab.js
+ * in fair-payments-connector does not need to change.
+ */
+class TelegramSettingsController extends \WP_REST_Controller {
+
+	/**
+	 * Register routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'fair-payments-connector/v1',
+			'/telegram/test',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'send_test_message' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+				'args'                => array(
+					'bot_token'   => array(
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'chat_ids'    => array(
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'template'    => array(
+						'type'     => 'string',
+						'required' => false,
+					),
+					'include_pii' => array(
+						'type'     => 'boolean',
+						'required' => false,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Send a test message to all configured (or supplied) chat IDs.
+	 *
+	 * @param \WP_REST_Request $request Incoming request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function send_test_message( $request ) {
+		$bot_token = $request->get_param( 'bot_token' );
+		if ( null === $bot_token || '' === $bot_token ) {
+			$bot_token = (string) get_option( 'fair_payment_telegram_bot_token', '' );
+		}
+
+		$chat_ids_raw = $request->get_param( 'chat_ids' );
+		if ( null === $chat_ids_raw || '' === $chat_ids_raw ) {
+			$chat_ids_raw = (string) get_option( 'fair_payment_telegram_chat_ids', '' );
+		}
+
+		$template = $request->get_param( 'template' );
+		if ( null === $template || '' === $template ) {
+			$template = (string) get_option( 'fair_payment_telegram_template', Settings::default_template() );
+		}
+
+		$include_pii = $request->get_param( 'include_pii' );
+		if ( null === $include_pii ) {
+			$include_pii = (bool) get_option( 'fair_payment_telegram_include_pii', true );
+		} else {
+			$include_pii = (bool) $include_pii;
+		}
+
+		if ( '' === trim( (string) $bot_token ) ) {
+			return new \WP_Error(
+				'fair_payment_telegram_missing_token',
+				__( 'Bot token is required.', 'fair-payments-connector-experimental' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$chat_ids = NotificationHooks::parse_chat_ids( (string) $chat_ids_raw );
+		if ( empty( $chat_ids ) ) {
+			return new \WP_Error(
+				'fair_payment_telegram_missing_chat_id',
+				__( 'At least one chat ID is required.', 'fair-payments-connector-experimental' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$service = new TelegramService();
+		$text    = $service->render_template( (string) $template, NotificationHooks::sample_context(), (bool) $include_pii );
+
+		$results = array();
+		$any_ok  = false;
+		$errors  = array();
+
+		foreach ( $chat_ids as $chat_id ) {
+			$response = $service->send( (string) $bot_token, $chat_id, $text );
+			if ( is_wp_error( $response ) ) {
+				$results[] = array(
+					'chat_id' => $chat_id,
+					'ok'      => false,
+					'error'   => $response->get_error_message(),
+				);
+				$errors[]  = $chat_id . ': ' . $response->get_error_message();
+			} else {
+				$any_ok    = true;
+				$results[] = array(
+					'chat_id' => $chat_id,
+					'ok'      => true,
+				);
+			}
+		}
+
+		if ( ! $any_ok ) {
+			return new \WP_Error(
+				'fair_payment_telegram_test_failed',
+				__( 'Telegram test message failed for all chat IDs.', 'fair-payments-connector-experimental' ) . ' ' . implode( '; ', $errors ),
+				array(
+					'status'  => 502,
+					'results' => $results,
+				)
+			);
+		}
+
+		return new \WP_REST_Response(
+			array(
+				'success' => true,
+				'message' => __( 'Telegram test message sent.', 'fair-payments-connector-experimental' ),
+				'results' => $results,
+				'text'    => $text,
+			),
+			200
+		);
+	}
+}

--- a/fair-payments-connector-experimental/src/Admin/AdminPages.php
+++ b/fair-payments-connector-experimental/src/Admin/AdminPages.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Admin Pages for Fair Payments Connector Experimental
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\Admin;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Registers admin submenus and enqueues their scripts.
+ */
+class AdminPages {
+	/**
+	 * Initialize admin pages
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action( 'admin_menu', array( $this, 'register_admin_pages' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+	}
+
+	/**
+	 * Register admin menu pages
+	 *
+	 * @return void
+	 */
+	public function register_admin_pages() {
+		// API Tokens submenu under the fair-payments-connector menu.
+		add_submenu_page(
+			'fair-payments-connector-transactions',
+			__( 'API Tokens', 'fair-payments-connector-experimental' ),
+			__( 'API Tokens', 'fair-payments-connector-experimental' ),
+			'manage_options',
+			'fair-payments-connector-api-tokens',
+			array( $this, 'render_api_tokens_page' )
+		);
+
+		// Connected Sites submenu under the fair-payments-connector menu.
+		add_submenu_page(
+			'fair-payments-connector-transactions',
+			__( 'Connected Sites', 'fair-payments-connector-experimental' ),
+			__( 'Connected Sites', 'fair-payments-connector-experimental' ),
+			'manage_options',
+			'fair-payments-connector-connected-sites',
+			array( $this, 'render_connected_sites_page' )
+		);
+	}
+
+	/**
+	 * Enqueue admin scripts
+	 *
+	 * @param string $hook Current admin page hook.
+	 * @return void
+	 */
+	public function enqueue_admin_scripts( $hook ) {
+		if ( false !== strpos( $hook, 'fair-payments-connector-api-tokens' ) ) {
+			$this->enqueue_admin_page_script( 'api-tokens' );
+			return;
+		}
+
+		if ( false !== strpos( $hook, 'fair-payments-connector-connected-sites' ) ) {
+			$this->enqueue_admin_page_script( 'connected-sites' );
+			return;
+		}
+	}
+
+	/**
+	 * Enqueue script for an admin page
+	 *
+	 * @param string $page Page name (api-tokens, connected-sites).
+	 * @return void
+	 */
+	private function enqueue_admin_page_script( $page ) {
+		$asset_file_path = FAIR_PAYMENTS_CONNECTOR_EXPERIMENTAL_DIR . 'build/admin/' . $page . '/index.asset.php';
+
+		if ( ! file_exists( $asset_file_path ) ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'Fair Payments Connector Experimental: Asset file not found at ' . $asset_file_path );
+			}
+			return;
+		}
+
+		$asset_file = include $asset_file_path;
+
+		wp_enqueue_script(
+			'fair-payments-connector-experimental-' . $page,
+			FAIR_PAYMENTS_CONNECTOR_EXPERIMENTAL_URL . 'build/admin/' . $page . '/index.js',
+			$asset_file['dependencies'],
+			$asset_file['version'],
+			true
+		);
+
+		wp_enqueue_style( 'wp-components' );
+
+		$style_file_path = FAIR_PAYMENTS_CONNECTOR_EXPERIMENTAL_DIR . 'build/admin/' . $page . '/style-index.css';
+
+		if ( file_exists( $style_file_path ) ) {
+			wp_enqueue_style(
+				'fair-payments-connector-experimental-' . $page,
+				FAIR_PAYMENTS_CONNECTOR_EXPERIMENTAL_URL . 'build/admin/' . $page . '/style-index.css',
+				array( 'wp-components' ),
+				$asset_file['version']
+			);
+		}
+	}
+
+	/**
+	 * Render API tokens page
+	 *
+	 * @return void
+	 */
+	public function render_api_tokens_page() {
+		?>
+		<div id="fair-payments-connector-api-tokens-root"></div>
+		<?php
+	}
+
+	/**
+	 * Render connected sites page
+	 *
+	 * @return void
+	 */
+	public function render_connected_sites_page() {
+		?>
+		<div id="fair-payments-connector-connected-sites-root"></div>
+		<?php
+	}
+}

--- a/fair-payments-connector-experimental/src/Admin/api-tokens/ApiTokensApp.js
+++ b/fair-payments-connector-experimental/src/Admin/api-tokens/ApiTokensApp.js
@@ -1,0 +1,491 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	Button,
+	Spinner,
+	Notice,
+	Modal,
+	TextControl,
+	CheckboxControl,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+const AVAILABLE_SCOPES = [
+	{
+		value: 'transactions:read',
+		label: __('Read transactions', 'fair-payments-connector-experimental'),
+	},
+	{
+		value: 'locations:read',
+		label: __('Read locations', 'fair-payments-connector-experimental'),
+	},
+];
+
+const ApiTokensApp = () => {
+	const [tokens, setTokens] = useState([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(null);
+	const [success, setSuccess] = useState(null);
+	const [isFormOpen, setIsFormOpen] = useState(false);
+	const [isSaving, setIsSaving] = useState(false);
+	const [label, setLabel] = useState('');
+	const [scopes, setScopes] = useState(['transactions:read']);
+	const [newToken, setNewToken] = useState(null);
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		loadTokens();
+	}, []);
+
+	const loadTokens = async () => {
+		setLoading(true);
+		setError(null);
+
+		try {
+			const data = await apiFetch({
+				path: '/fair-payments-connector/v1/admin/api-tokens',
+			});
+			setTokens(data);
+		} catch (err) {
+			setError(
+				err.message ||
+					__(
+						'Failed to load API tokens.',
+						'fair-payments-connector-experimental'
+					)
+			);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleOpenForm = () => {
+		setLabel('');
+		setScopes(['transactions:read']);
+		setNewToken(null);
+		setCopied(false);
+		setError(null);
+		setIsFormOpen(true);
+	};
+
+	const toggleScope = (scope, checked) => {
+		setScopes((current) =>
+			checked ? [...current, scope] : current.filter((s) => s !== scope)
+		);
+	};
+
+	const handleCreate = async (e) => {
+		e.preventDefault();
+		setIsSaving(true);
+		setError(null);
+
+		try {
+			const response = await apiFetch({
+				path: '/fair-payments-connector/v1/admin/api-tokens',
+				method: 'POST',
+				data: { label, scopes },
+			});
+			setNewToken(response.token);
+			setSuccess(
+				__('API token created.', 'fair-payments-connector-experimental')
+			);
+			loadTokens();
+		} catch (err) {
+			setError(
+				err.message ||
+					__(
+						'Failed to create API token.',
+						'fair-payments-connector-experimental'
+					)
+			);
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const handleRevoke = async (id) => {
+		if (
+			!window.confirm(
+				__(
+					'Revoke this token? Any site using it will immediately lose access.',
+					'fair-payments-connector-experimental'
+				)
+			)
+		) {
+			return;
+		}
+
+		setError(null);
+		setSuccess(null);
+
+		try {
+			await apiFetch({
+				path: `/fair-payments-connector/v1/admin/api-tokens/${id}`,
+				method: 'DELETE',
+			});
+			setSuccess(
+				__('API token revoked.', 'fair-payments-connector-experimental')
+			);
+			loadTokens();
+		} catch (err) {
+			setError(
+				err.message ||
+					__(
+						'Failed to revoke API token.',
+						'fair-payments-connector-experimental'
+					)
+			);
+		}
+	};
+
+	const handleCopy = () => {
+		if (newToken && navigator.clipboard) {
+			navigator.clipboard.writeText(newToken).then(() => {
+				setCopied(true);
+			});
+		}
+	};
+
+	const handleCloseForm = () => {
+		setIsFormOpen(false);
+		setNewToken(null);
+	};
+
+	return (
+		<div className="wrap fair-payments-connector-api-tokens-page">
+			<VStack spacing={4}>
+				<Card>
+					<CardHeader>
+						<HStack justify="space-between">
+							<h1>
+								{__(
+									'API Tokens',
+									'fair-payments-connector-experimental'
+								)}
+							</h1>
+							<Button variant="primary" onClick={handleOpenForm}>
+								{__(
+									'Generate Token',
+									'fair-payments-connector-experimental'
+								)}
+							</Button>
+						</HStack>
+					</CardHeader>
+					<CardBody>
+						<VStack spacing={4}>
+							<p style={{ color: '#666', margin: 0 }}>
+								{__(
+									"Issue scoped tokens so other sites can read this site's data over the data sharing API.",
+									'fair-payments-connector-experimental'
+								)}
+							</p>
+
+							{error && (
+								<Notice
+									status="error"
+									isDismissible
+									onRemove={() => setError(null)}
+								>
+									{error}
+								</Notice>
+							)}
+
+							{success && (
+								<Notice
+									status="success"
+									isDismissible
+									onRemove={() => setSuccess(null)}
+								>
+									{success}
+								</Notice>
+							)}
+
+							{loading && (
+								<div>
+									<Spinner />
+									<p>
+										{__(
+											'Loading tokens…',
+											'fair-payments-connector-experimental'
+										)}
+									</p>
+								</div>
+							)}
+
+							{!loading && tokens.length === 0 && (
+								<p>
+									{__(
+										'No API tokens yet. Generate one to share data with another site.',
+										'fair-payments-connector-experimental'
+									)}
+								</p>
+							)}
+
+							{!loading && tokens.length > 0 && (
+								<table className="wp-list-table widefat fixed striped">
+									<thead>
+										<tr>
+											<th>
+												{__(
+													'Label',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+											<th>
+												{__(
+													'Scopes',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+											<th>
+												{__(
+													'Created',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+											<th>
+												{__(
+													'Last used',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+											<th>
+												{__(
+													'Status',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+											<th style={{ width: '120px' }}>
+												{__(
+													'Actions',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+										</tr>
+									</thead>
+									<tbody>
+										{tokens.map((token) => (
+											<tr key={token.id}>
+												<td>
+													<strong>
+														{token.label}
+													</strong>
+												</td>
+												<td>
+													{token.scopes.join(', ')}
+												</td>
+												<td>{token.created_at}</td>
+												<td>
+													{token.last_used_at || (
+														<em>
+															{__(
+																'Never',
+																'fair-payments-connector-experimental'
+															)}
+														</em>
+													)}
+												</td>
+												<td>
+													<span
+														style={{
+															color:
+																token.status ===
+																'active'
+																	? '#007017'
+																	: '#d63638',
+															fontWeight: 'bold',
+														}}
+													>
+														{token.status ===
+														'active'
+															? __(
+																	'Active',
+																	'fair-payments-connector-experimental'
+															  )
+															: __(
+																	'Revoked',
+																	'fair-payments-connector-experimental'
+															  )}
+													</span>
+												</td>
+												<td>
+													{token.status ===
+														'active' && (
+														<Button
+															variant="tertiary"
+															size="small"
+															isDestructive
+															onClick={() =>
+																handleRevoke(
+																	token.id
+																)
+															}
+														>
+															{__(
+																'Revoke',
+																'fair-payments-connector-experimental'
+															)}
+														</Button>
+													)}
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							)}
+						</VStack>
+					</CardBody>
+				</Card>
+			</VStack>
+
+			{isFormOpen && (
+				<Modal
+					title={
+						newToken
+							? __(
+									'Token created',
+									'fair-payments-connector-experimental'
+							  )
+							: __(
+									'Generate API Token',
+									'fair-payments-connector-experimental'
+							  )
+					}
+					onRequestClose={handleCloseForm}
+					style={{ maxWidth: '500px', width: '100%' }}
+				>
+					{newToken ? (
+						<VStack spacing={4}>
+							<Notice status="warning" isDismissible={false}>
+								{__(
+									'Copy this token now. For security it will not be shown again.',
+									'fair-payments-connector-experimental'
+								)}
+							</Notice>
+							<code
+								style={{
+									display: 'block',
+									padding: '12px',
+									background: '#f0f0f1',
+									wordBreak: 'break-all',
+								}}
+							>
+								{newToken}
+							</code>
+							<HStack justify="flex-end" spacing={2}>
+								<Button
+									variant="secondary"
+									onClick={handleCopy}
+								>
+									{copied
+										? __(
+												'Copied!',
+												'fair-payments-connector-experimental'
+										  )
+										: __(
+												'Copy token',
+												'fair-payments-connector-experimental'
+										  )}
+								</Button>
+								<Button
+									variant="primary"
+									onClick={handleCloseForm}
+								>
+									{__(
+										'Done',
+										'fair-payments-connector-experimental'
+									)}
+								</Button>
+							</HStack>
+						</VStack>
+					) : (
+						<form onSubmit={handleCreate}>
+							<VStack spacing={4}>
+								<TextControl
+									label={__(
+										'Label',
+										'fair-payments-connector-experimental'
+									)}
+									value={label}
+									onChange={setLabel}
+									help={__(
+										'A name to identify who this token is for, e.g. lamutable.es',
+										'fair-payments-connector-experimental'
+									)}
+									required
+								/>
+								<fieldset>
+									<legend
+										style={{
+											fontWeight: 'bold',
+											marginBottom: '8px',
+										}}
+									>
+										{__(
+											'Scopes',
+											'fair-payments-connector-experimental'
+										)}
+									</legend>
+									<VStack spacing={2}>
+										{AVAILABLE_SCOPES.map((scope) => (
+											<CheckboxControl
+												key={scope.value}
+												label={scope.label}
+												checked={scopes.includes(
+													scope.value
+												)}
+												onChange={(checked) =>
+													toggleScope(
+														scope.value,
+														checked
+													)
+												}
+											/>
+										))}
+									</VStack>
+								</fieldset>
+								<HStack justify="flex-end" spacing={2}>
+									<Button
+										variant="tertiary"
+										onClick={handleCloseForm}
+										disabled={isSaving}
+									>
+										{__(
+											'Cancel',
+											'fair-payments-connector-experimental'
+										)}
+									</Button>
+									<Button
+										variant="primary"
+										type="submit"
+										isBusy={isSaving}
+										disabled={
+											isSaving ||
+											!label ||
+											scopes.length === 0
+										}
+									>
+										{__(
+											'Generate',
+											'fair-payments-connector-experimental'
+										)}
+									</Button>
+								</HStack>
+							</VStack>
+						</form>
+					)}
+				</Modal>
+			)}
+		</div>
+	);
+};
+
+export default ApiTokensApp;

--- a/fair-payments-connector-experimental/src/Admin/api-tokens/index.js
+++ b/fair-payments-connector-experimental/src/Admin/api-tokens/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ApiTokensApp from './ApiTokensApp.js';
+
+/**
+ * Initialize the API tokens page
+ */
+domReady(() => {
+	const root = document.getElementById(
+		'fair-payments-connector-api-tokens-root'
+	);
+	if (root) {
+		createRoot(root).render(<ApiTokensApp />);
+	}
+});

--- a/fair-payments-connector-experimental/src/Admin/connected-sites/ConnectedSitesApp.js
+++ b/fair-payments-connector-experimental/src/Admin/connected-sites/ConnectedSitesApp.js
@@ -1,0 +1,545 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	Button,
+	Spinner,
+	Notice,
+	Modal,
+	TextControl,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+const STATUS_LABELS = {
+	connected: {
+		text: __('Connected', 'fair-payments-connector-experimental'),
+		color: '#007017',
+	},
+	error: {
+		text: __('Error', 'fair-payments-connector-experimental'),
+		color: '#d63638',
+	},
+	unverified: {
+		text: __('Unverified', 'fair-payments-connector-experimental'),
+		color: '#946800',
+	},
+};
+
+const ConnectedSitesApp = () => {
+	const [sites, setSites] = useState([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(null);
+	const [success, setSuccess] = useState(null);
+	const [isFormOpen, setIsFormOpen] = useState(false);
+	const [isSaving, setIsSaving] = useState(false);
+	const [editingId, setEditingId] = useState(null);
+	const [testingId, setTestingId] = useState(null);
+	const [label, setLabel] = useState('');
+	const [baseUrl, setBaseUrl] = useState('');
+	const [token, setToken] = useState('');
+
+	useEffect(() => {
+		loadSites();
+	}, []);
+
+	const loadSites = async () => {
+		setLoading(true);
+		setError(null);
+
+		try {
+			const data = await apiFetch({
+				path: '/fair-payments-connector/v1/admin/connected-sites',
+			});
+			setSites(data);
+		} catch (err) {
+			setError(
+				err.message ||
+					__(
+						'Failed to load connected sites.',
+						'fair-payments-connector-experimental'
+					)
+			);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleOpenAdd = () => {
+		setEditingId(null);
+		setLabel('');
+		setBaseUrl('');
+		setToken('');
+		setError(null);
+		setIsFormOpen(true);
+	};
+
+	const handleOpenEdit = (site) => {
+		setEditingId(site.id);
+		setLabel(site.label);
+		setBaseUrl(site.base_url);
+		setToken('');
+		setError(null);
+		setIsFormOpen(true);
+	};
+
+	const handleCloseForm = () => {
+		setIsFormOpen(false);
+		setEditingId(null);
+	};
+
+	const handleSave = async (e) => {
+		e.preventDefault();
+		setIsSaving(true);
+		setError(null);
+
+		try {
+			if (editingId) {
+				const data = { label, base_url: baseUrl };
+				if (token) {
+					data.token = token;
+				}
+				await apiFetch({
+					path: `/fair-payments-connector/v1/admin/connected-sites/${editingId}`,
+					method: 'PUT',
+					data,
+				});
+				setSuccess(
+					__(
+						'Connected site updated.',
+						'fair-payments-connector-experimental'
+					)
+				);
+			} else {
+				await apiFetch({
+					path: '/fair-payments-connector/v1/admin/connected-sites',
+					method: 'POST',
+					data: { label, base_url: baseUrl, token },
+				});
+				setSuccess(
+					__(
+						'Connected site added.',
+						'fair-payments-connector-experimental'
+					)
+				);
+			}
+			handleCloseForm();
+			loadSites();
+		} catch (err) {
+			setError(
+				err.message ||
+					__(
+						'Failed to save connected site.',
+						'fair-payments-connector-experimental'
+					)
+			);
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const handleTest = async (id) => {
+		setTestingId(id);
+		setError(null);
+		setSuccess(null);
+
+		try {
+			const result = await apiFetch({
+				path: `/fair-payments-connector/v1/admin/connected-sites/${id}/test`,
+				method: 'POST',
+			});
+			const scopes =
+				result.scopes && result.scopes.length
+					? result.scopes.join(', ')
+					: __('no scopes', 'fair-payments-connector-experimental');
+			setSuccess(
+				__(
+					'Connection succeeded. Granted scopes: ',
+					'fair-payments-connector-experimental'
+				) + scopes
+			);
+			loadSites();
+		} catch (err) {
+			setError(
+				err.message ||
+					__(
+						'Connection test failed.',
+						'fair-payments-connector-experimental'
+					)
+			);
+			loadSites();
+		} finally {
+			setTestingId(null);
+		}
+	};
+
+	const handleRemove = async (id) => {
+		if (
+			!window.confirm(
+				__(
+					'Remove this connected site? Stored token will be deleted.',
+					'fair-payments-connector-experimental'
+				)
+			)
+		) {
+			return;
+		}
+
+		setError(null);
+		setSuccess(null);
+
+		try {
+			await apiFetch({
+				path: `/fair-payments-connector/v1/admin/connected-sites/${id}`,
+				method: 'DELETE',
+			});
+			setSuccess(
+				__(
+					'Connected site removed.',
+					'fair-payments-connector-experimental'
+				)
+			);
+			loadSites();
+		} catch (err) {
+			setError(
+				err.message ||
+					__(
+						'Failed to remove connected site.',
+						'fair-payments-connector-experimental'
+					)
+			);
+		}
+	};
+
+	const renderStatus = (status) => {
+		const meta = STATUS_LABELS[status] || STATUS_LABELS.unverified;
+		return (
+			<span style={{ color: meta.color, fontWeight: 'bold' }}>
+				{meta.text}
+			</span>
+		);
+	};
+
+	return (
+		<div className="wrap fair-payments-connector-connected-sites-page">
+			<VStack spacing={4}>
+				<Card>
+					<CardHeader>
+						<HStack justify="space-between">
+							<h1>
+								{__(
+									'Connected Sites',
+									'fair-payments-connector-experimental'
+								)}
+							</h1>
+							<Button variant="primary" onClick={handleOpenAdd}>
+								{__(
+									'Add Site',
+									'fair-payments-connector-experimental'
+								)}
+							</Button>
+						</HStack>
+					</CardHeader>
+					<CardBody>
+						<VStack spacing={4}>
+							<p style={{ color: '#666', margin: 0 }}>
+								{__(
+									'Register other sites this site pulls data from. Paste a token generated on the other site’s API Tokens page.',
+									'fair-payments-connector-experimental'
+								)}
+							</p>
+
+							{error && (
+								<Notice
+									status="error"
+									isDismissible
+									onRemove={() => setError(null)}
+								>
+									{error}
+								</Notice>
+							)}
+
+							{success && (
+								<Notice
+									status="success"
+									isDismissible
+									onRemove={() => setSuccess(null)}
+								>
+									{success}
+								</Notice>
+							)}
+
+							{loading && (
+								<div>
+									<Spinner />
+									<p>
+										{__(
+											'Loading sites…',
+											'fair-payments-connector-experimental'
+										)}
+									</p>
+								</div>
+							)}
+
+							{!loading && sites.length === 0 && (
+								<p>
+									{__(
+										'No connected sites yet. Add one to pull data from another site.',
+										'fair-payments-connector-experimental'
+									)}
+								</p>
+							)}
+
+							{!loading && sites.length > 0 && (
+								<table className="wp-list-table widefat fixed striped">
+									<thead>
+										<tr>
+											<th>
+												{__(
+													'Label',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+											<th>
+												{__(
+													'Base URL',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+											<th>
+												{__(
+													'Scopes',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+											<th>
+												{__(
+													'Status',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+											<th>
+												{__(
+													'Last sync',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+											<th style={{ width: '220px' }}>
+												{__(
+													'Actions',
+													'fair-payments-connector-experimental'
+												)}
+											</th>
+										</tr>
+									</thead>
+									<tbody>
+										{sites.map((site) => (
+											<tr key={site.id}>
+												<td>
+													<strong>
+														{site.label}
+													</strong>
+												</td>
+												<td>{site.base_url}</td>
+												<td>
+													{site.scopes.length ? (
+														site.scopes.join(', ')
+													) : (
+														<em>—</em>
+													)}
+												</td>
+												<td>
+													{renderStatus(site.status)}
+												</td>
+												<td>
+													{site.last_sync_at || (
+														<em>
+															{__(
+																'Never',
+																'fair-payments-connector-experimental'
+															)}
+														</em>
+													)}
+												</td>
+												<td>
+													<HStack
+														spacing={1}
+														justify="flex-start"
+													>
+														<Button
+															variant="secondary"
+															size="small"
+															isBusy={
+																testingId ===
+																site.id
+															}
+															disabled={
+																testingId !==
+																null
+															}
+															onClick={() =>
+																handleTest(
+																	site.id
+																)
+															}
+														>
+															{__(
+																'Test',
+																'fair-payments-connector-experimental'
+															)}
+														</Button>
+														<Button
+															variant="tertiary"
+															size="small"
+															onClick={() =>
+																handleOpenEdit(
+																	site
+																)
+															}
+														>
+															{__(
+																'Edit',
+																'fair-payments-connector-experimental'
+															)}
+														</Button>
+														<Button
+															variant="tertiary"
+															size="small"
+															isDestructive
+															onClick={() =>
+																handleRemove(
+																	site.id
+																)
+															}
+														>
+															{__(
+																'Remove',
+																'fair-payments-connector-experimental'
+															)}
+														</Button>
+													</HStack>
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							)}
+						</VStack>
+					</CardBody>
+				</Card>
+			</VStack>
+
+			{isFormOpen && (
+				<Modal
+					title={
+						editingId
+							? __(
+									'Edit Connected Site',
+									'fair-payments-connector-experimental'
+							  )
+							: __(
+									'Add Connected Site',
+									'fair-payments-connector-experimental'
+							  )
+					}
+					onRequestClose={handleCloseForm}
+					style={{ maxWidth: '500px', width: '100%' }}
+				>
+					<form onSubmit={handleSave}>
+						<VStack spacing={4}>
+							<TextControl
+								label={__(
+									'Label',
+									'fair-payments-connector-experimental'
+								)}
+								value={label}
+								onChange={setLabel}
+								help={__(
+									'A name to identify this site, e.g. acroyoga-club.es',
+									'fair-payments-connector-experimental'
+								)}
+								required
+							/>
+							<TextControl
+								label={__(
+									'Base URL',
+									'fair-payments-connector-experimental'
+								)}
+								type="url"
+								value={baseUrl}
+								onChange={setBaseUrl}
+								help={__(
+									'The other site’s address, e.g. https://acroyoga-club.es',
+									'fair-payments-connector-experimental'
+								)}
+								required
+							/>
+							<TextControl
+								label={__(
+									'Token',
+									'fair-payments-connector-experimental'
+								)}
+								type="password"
+								value={token}
+								onChange={setToken}
+								help={
+									editingId
+										? __(
+												'Leave blank to keep the existing token.',
+												'fair-payments-connector-experimental'
+										  )
+										: __(
+												'Paste the token from the other site’s API Tokens page.',
+												'fair-payments-connector-experimental'
+										  )
+								}
+								required={!editingId}
+							/>
+							<HStack justify="flex-end" spacing={2}>
+								<Button
+									variant="tertiary"
+									onClick={handleCloseForm}
+									disabled={isSaving}
+								>
+									{__(
+										'Cancel',
+										'fair-payments-connector-experimental'
+									)}
+								</Button>
+								<Button
+									variant="primary"
+									type="submit"
+									isBusy={isSaving}
+									disabled={
+										isSaving ||
+										!label ||
+										!baseUrl ||
+										(!editingId && !token)
+									}
+								>
+									{editingId
+										? __(
+												'Save',
+												'fair-payments-connector-experimental'
+										  )
+										: __(
+												'Add Site',
+												'fair-payments-connector-experimental'
+										  )}
+								</Button>
+							</HStack>
+						</VStack>
+					</form>
+				</Modal>
+			)}
+		</div>
+	);
+};
+
+export default ConnectedSitesApp;

--- a/fair-payments-connector-experimental/src/Admin/connected-sites/index.js
+++ b/fair-payments-connector-experimental/src/Admin/connected-sites/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ConnectedSitesApp from './ConnectedSitesApp.js';
+
+/**
+ * Initialize the connected sites page
+ */
+domReady(() => {
+	const root = document.getElementById(
+		'fair-payments-connector-connected-sites-root'
+	);
+	if (root) {
+		createRoot(root).render(<ConnectedSitesApp />);
+	}
+});

--- a/fair-payments-connector-experimental/src/Core/Features.php
+++ b/fair-payments-connector-experimental/src/Core/Features.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Feature flags for Fair Payments Connector Experimental
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\Core;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Reads feature flags stored in the plugin option.
+ */
+class Features {
+	const OPTION = 'fair_payments_connector_experimental_features';
+
+	/**
+	 * Whether a named feature flag is enabled.
+	 *
+	 * @param string $feature Feature name.
+	 * @return bool
+	 */
+	public static function is_enabled( $feature ) {
+		$flags = get_option( self::OPTION, array() );
+		return ! empty( $flags[ $feature ] );
+	}
+
+	/**
+	 * Return the bundled translations path when the flag is on, null otherwise.
+	 *
+	 * @return string|null
+	 */
+	public static function script_translations_path() {
+		return self::is_enabled( 'bundled-translations' )
+			? FAIR_PAYMENTS_CONNECTOR_EXPERIMENTAL_DIR . 'build/languages'
+			: null;
+	}
+}

--- a/fair-payments-connector-experimental/src/Core/Plugin.php
+++ b/fair-payments-connector-experimental/src/Core/Plugin.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Plugin core class for Fair Payments Connector Experimental
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\Core;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Main plugin class implementing singleton pattern
+ */
+class Plugin {
+	/**
+	 * Single instance of the plugin
+	 *
+	 * @var Plugin|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get singleton instance of the plugin
+	 *
+	 * @return Plugin Plugin instance
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Initialize the plugin
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action(
+			'init',
+			function () {
+				if ( Features::is_enabled( 'bundled-translations' ) ) {
+					load_plugin_textdomain( 'fair-payments-connector-experimental', false, 'fair-payments-connector-experimental/languages' );
+				}
+			}
+		);
+
+		new \FairPaymentsConnectorExperimental\API\RestHooks();
+
+		$notifications = new \FairPaymentsConnectorExperimental\Hooks\NotificationHooks();
+		$notifications->init();
+
+		if ( is_admin() ) {
+			$admin = new \FairPaymentsConnectorExperimental\Admin\AdminPages();
+			$admin->init();
+		}
+	}
+
+	/**
+	 * Private constructor to prevent instantiation
+	 */
+	private function __construct() {
+		$this->init();
+	}
+
+	private function __clone() {}
+
+	public function __wakeup() {}
+}

--- a/fair-payments-connector-experimental/src/Hooks/NotificationHooks.php
+++ b/fair-payments-connector-experimental/src/Hooks/NotificationHooks.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Notification hooks for Fair Payments Connector Experimental
+ *
+ * Listens to fair_payment_paid and dispatches Telegram notifications asynchronously
+ * via wp_schedule_single_event so the Mollie webhook is never blocked.
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\Hooks;
+
+use FairPaymentsConnectorExperimental\Services\TelegramService;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Wires Telegram notifications to successful-transaction events.
+ */
+class NotificationHooks {
+
+	const CRON_HOOK = 'fair_payment_send_telegram_notification';
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		// Run after fair-audience handle_signup_paid (priority 10) so any
+		// label/flip side effects are complete before we build the message.
+		add_action( 'fair_payment_paid', array( $this, 'on_payment_paid' ), 20, 2 );
+		add_action( self::CRON_HOOK, array( $this, 'dispatch_messages' ), 10, 1 );
+	}
+
+	/**
+	 * Build the notification context and schedule async sending.
+	 *
+	 * @param object $payment     Mollie payment object.
+	 * @param object $transaction Transaction row.
+	 * @return void
+	 */
+	public function on_payment_paid( $payment, $transaction ) {
+		if ( ! get_option( 'fair_payment_telegram_enabled', false ) ) {
+			return;
+		}
+
+		$bot_token = (string) get_option( 'fair_payment_telegram_bot_token', '' );
+		$chat_ids  = $this->parse_chat_ids( (string) get_option( 'fair_payment_telegram_chat_ids', '' ) );
+
+		if ( '' === $bot_token || empty( $chat_ids ) ) {
+			return;
+		}
+
+		$context = $this->build_context( $payment, $transaction );
+
+		$template    = (string) get_option( 'fair_payment_telegram_template', \FairPaymentsConnector\Settings\Settings::default_template() );
+		$include_pii = (bool) get_option( 'fair_payment_telegram_include_pii', true );
+
+		$service = new TelegramService();
+		$text    = $service->render_template( $template, $context, $include_pii );
+
+		$payload = array(
+			'bot_token' => $bot_token,
+			'chat_ids'  => $chat_ids,
+			'text'      => $text,
+		);
+
+		wp_schedule_single_event( time(), self::CRON_HOOK, array( $payload ) );
+	}
+
+	/**
+	 * Cron handler — fans out the message to all configured chats.
+	 *
+	 * @param array $payload Payload with bot_token, chat_ids[], text.
+	 * @return void
+	 */
+	public function dispatch_messages( $payload ) {
+		if ( ! is_array( $payload ) || empty( $payload['chat_ids'] ) || empty( $payload['text'] ) ) {
+			return;
+		}
+
+		$service   = new TelegramService();
+		$bot_token = ! empty( $payload['bot_token'] ) ? $payload['bot_token'] : (string) get_option( 'fair_payment_telegram_bot_token', '' );
+
+		foreach ( (array) $payload['chat_ids'] as $chat_id ) {
+			$service->send( $bot_token, (string) $chat_id, (string) $payload['text'] );
+		}
+	}
+
+	/**
+	 * Parse the comma-separated chat IDs setting into a clean array.
+	 *
+	 * @param string $raw Raw setting value.
+	 * @return string[]
+	 */
+	public static function parse_chat_ids( $raw ) {
+		$parts = preg_split( '/[\s,]+/', (string) $raw );
+		if ( ! is_array( $parts ) ) {
+			return array();
+		}
+		return array_values( array_filter( array_map( 'trim', $parts ), 'strlen' ) );
+	}
+
+	/**
+	 * Assemble the notification context for template rendering.
+	 *
+	 * Other plugins (fair-audience) hook `fair_payment_notification_context` to
+	 * fill in participant/event details. Defaults degrade gracefully when no
+	 * enrichment is available.
+	 *
+	 * @param object $payment     Mollie payment object.
+	 * @param object $transaction Transaction row.
+	 * @return array
+	 */
+	public function build_context( $payment, $transaction ) {
+		$amount   = isset( $transaction->amount ) ? $transaction->amount : null;
+		$currency = isset( $transaction->currency ) ? $transaction->currency : '';
+		$created  = isset( $transaction->created_at ) ? $transaction->created_at : '';
+		$date     = '';
+		if ( $created ) {
+			$ts = strtotime( $created );
+			if ( $ts ) {
+				$date = gmdate( 'Y-m-d', $ts );
+			}
+		}
+
+		$is_test = ! empty( $transaction->testmode );
+
+		$base = array(
+			'transaction'            => $transaction,
+			'payment'                => $payment,
+			'test_label'             => $is_test ? '[TEST] ' : '',
+			'site_domain'            => (string) wp_parse_url( home_url(), PHP_URL_HOST ),
+			'amount'                 => null !== $amount ? number_format( (float) $amount, 2, '.', '' ) : '',
+			'currency'               => $currency,
+			'date'                   => $date,
+			'transaction_id'         => isset( $transaction->id ) ? (string) $transaction->id : '',
+			'event_title'            => '',
+			'event_url'              => '',
+			'participant_name'       => '',
+			'participant_name_short' => '',
+			'participant_url'        => '',
+			'participant_email'      => '',
+			'ticket_label'           => '',
+			'activities'             => '',
+			'discounts'              => '',
+		);
+
+		return apply_filters( 'fair_payment_notification_context', $base, $transaction, $payment );
+	}
+
+	/**
+	 * Provide a sample context for the "Send test message" button.
+	 *
+	 * @return array
+	 */
+	public static function sample_context() {
+		return array(
+			'test_label'             => '[TEST] ',
+			'site_domain'            => (string) wp_parse_url( home_url(), PHP_URL_HOST ),
+			'amount'                 => '10.00',
+			'currency'               => 'EUR',
+			'date'                   => gmdate( 'Y-m-d' ),
+			'transaction_id'         => 'TEST-0001',
+			'event_title'            => 'Sample Event',
+			'event_url'              => admin_url( 'edit.php' ),
+			'participant_name'       => 'Sample Participant',
+			'participant_name_short' => 'Sample P.',
+			'participant_url'        => admin_url( 'admin.php?page=fair-audience-participants' ),
+			'participant_email'      => 'sample@example.com',
+			'ticket_label'           => 'Regular',
+			'activities'             => 'Sample Activity A, Sample Activity B',
+			'discounts'              => 'Early bird -10%',
+		);
+	}
+}

--- a/fair-payments-connector-experimental/src/Models/ApiToken.php
+++ b/fair-payments-connector-experimental/src/Models/ApiToken.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * API Token Model
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\Models;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Model class for data sharing API tokens.
+ *
+ * Tokens are stored only as a SHA-256 hash. The plaintext token is generated
+ * once on creation, returned to the caller so it can be shown to the admin a
+ * single time, and never persisted.
+ */
+class ApiToken {
+	/**
+	 * Allowed scopes for API tokens.
+	 *
+	 * @var string[]
+	 */
+	const ALLOWED_SCOPES = array( 'transactions:read', 'locations:read' );
+
+	/**
+	 * Generate a new cryptographically random plaintext token.
+	 *
+	 * @return string 40-character token.
+	 */
+	public static function generate_token() {
+		return wp_generate_password( 40, false );
+	}
+
+	/**
+	 * Hash a plaintext token for storage / lookup.
+	 *
+	 * @param string $plaintext Plaintext token.
+	 * @return string SHA-256 hex hash.
+	 */
+	public static function hash_token( $plaintext ) {
+		return hash( 'sha256', $plaintext );
+	}
+
+	/**
+	 * Create a new API token.
+	 *
+	 * @param string   $label  Human-readable label (e.g. "lamutable.es").
+	 * @param string[] $scopes List of scopes to grant.
+	 * @return array|false Array with 'id' and one-time plaintext 'token', or false on failure.
+	 */
+	public static function create( $label, array $scopes ) {
+		global $wpdb;
+		$table_name = \FairPaymentsConnector\Database\Schema::get_api_tokens_table_name();
+
+		$valid_scopes = array_values( array_intersect( $scopes, self::ALLOWED_SCOPES ) );
+
+		$plaintext  = self::generate_token();
+		$token_hash = self::hash_token( $plaintext );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$inserted = $wpdb->insert(
+			$table_name,
+			array(
+				'label'      => $label,
+				'token_hash' => $token_hash,
+				'scopes'     => wp_json_encode( $valid_scopes ),
+				'created_at' => current_time( 'mysql', true ),
+			),
+			array( '%s', '%s', '%s', '%s' )
+		);
+
+		if ( ! $inserted ) {
+			return false;
+		}
+
+		return array(
+			'id'    => (int) $wpdb->insert_id,
+			'token' => $plaintext,
+		);
+	}
+
+	/**
+	 * Find an active (non-revoked) token row by its plaintext value.
+	 *
+	 * @param string $plaintext Plaintext token.
+	 * @return object|null Token row or null if not found / revoked.
+	 */
+	public static function find_by_token( $plaintext ) {
+		global $wpdb;
+		$table_name = \FairPaymentsConnector\Database\Schema::get_api_tokens_table_name();
+
+		$token_hash = self::hash_token( $plaintext );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE token_hash = %s AND revoked_at IS NULL',
+				$table_name,
+				$token_hash
+			)
+		);
+	}
+
+	/**
+	 * Get a single token row by ID.
+	 *
+	 * @param int $id Token ID.
+	 * @return object|null Token row or null.
+	 */
+	public static function get_by_id( $id ) {
+		global $wpdb;
+		$table_name = \FairPaymentsConnector\Database\Schema::get_api_tokens_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE id = %d',
+				$table_name,
+				$id
+			)
+		);
+	}
+
+	/**
+	 * Get all token rows, newest first.
+	 *
+	 * @return object[] Array of token rows.
+	 */
+	public static function get_all() {
+		global $wpdb;
+		$table_name = \FairPaymentsConnector\Database\Schema::get_api_tokens_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i ORDER BY created_at DESC',
+				$table_name
+			)
+		);
+	}
+
+	/**
+	 * Revoke a token by ID.
+	 *
+	 * @param int $id Token ID.
+	 * @return bool True on success.
+	 */
+	public static function revoke( $id ) {
+		global $wpdb;
+		$table_name = \FairPaymentsConnector\Database\Schema::get_api_tokens_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (bool) $wpdb->update(
+			$table_name,
+			array( 'revoked_at' => current_time( 'mysql', true ) ),
+			array( 'id' => $id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+	}
+
+	/**
+	 * Update the last_used_at timestamp for a token.
+	 *
+	 * @param int $id Token ID.
+	 * @return void
+	 */
+	public static function touch_last_used( $id ) {
+		global $wpdb;
+		$table_name = \FairPaymentsConnector\Database\Schema::get_api_tokens_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->update(
+			$table_name,
+			array( 'last_used_at' => current_time( 'mysql', true ) ),
+			array( 'id' => $id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+	}
+
+	/**
+	 * Whether a token row is active (not revoked).
+	 *
+	 * @param object $row Token row.
+	 * @return bool
+	 */
+	public static function is_active( $row ) {
+		return $row && null === $row->revoked_at;
+	}
+
+	/**
+	 * Decode the scopes stored on a token row.
+	 *
+	 * @param object $row Token row.
+	 * @return string[] List of scopes.
+	 */
+	public static function get_scopes( $row ) {
+		if ( ! $row || empty( $row->scopes ) ) {
+			return array();
+		}
+
+		$scopes = json_decode( $row->scopes, true );
+
+		return is_array( $scopes ) ? $scopes : array();
+	}
+
+	/**
+	 * Whether a token row grants the given scope.
+	 *
+	 * @param object $row   Token row.
+	 * @param string $scope Scope to check.
+	 * @return bool
+	 */
+	public static function has_scope( $row, $scope ) {
+		return in_array( $scope, self::get_scopes( $row ), true );
+	}
+
+	/**
+	 * Convert a token row to a safe array for API responses.
+	 *
+	 * Never includes the token hash or any plaintext.
+	 *
+	 * @param object $row Token row.
+	 * @return array
+	 */
+	public static function to_array( $row ) {
+		return array(
+			'id'           => (int) $row->id,
+			'label'        => $row->label,
+			'scopes'       => self::get_scopes( $row ),
+			'created_at'   => $row->created_at,
+			'last_used_at' => $row->last_used_at,
+			'status'       => self::is_active( $row ) ? 'active' : 'revoked',
+		);
+	}
+}

--- a/fair-payments-connector-experimental/src/Models/ConnectedSite.php
+++ b/fair-payments-connector-experimental/src/Models/ConnectedSite.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Connected Site Model
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\Models;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Model for secondary sites this site pulls data from (data sharing consumer side).
+ *
+ * Records are stored in a single option as an array keyed by integer id. The
+ * remote bearer token is stored as-is (plaintext), consistent with how the
+ * plugin already stores Mollie access/refresh tokens; it is only ever exposed
+ * through the admin-only REST controller, never in list responses.
+ */
+class ConnectedSite {
+	/**
+	 * Option name holding the array of connected site records.
+	 *
+	 * @var string
+	 */
+	const OPTION = 'fair_payment_connected_sites';
+
+	/**
+	 * Read the raw array of records from the option.
+	 *
+	 * @return array[] Array of associative records.
+	 */
+	private static function read() {
+		$sites = get_option( self::OPTION, array() );
+
+		return is_array( $sites ) ? array_values( $sites ) : array();
+	}
+
+	/**
+	 * Persist the array of records to the option.
+	 *
+	 * @param array[] $sites Records to store.
+	 * @return void
+	 */
+	private static function write( array $sites ) {
+		update_option( self::OPTION, array_values( $sites ) );
+	}
+
+	/**
+	 * Get all connected sites, newest first.
+	 *
+	 * @return array[] Records ordered by id descending.
+	 */
+	public static function get_all() {
+		$sites = self::read();
+
+		usort(
+			$sites,
+			static function ( $a, $b ) {
+				return (int) $b['id'] - (int) $a['id'];
+			}
+		);
+
+		return $sites;
+	}
+
+	/**
+	 * Get a single connected site by id.
+	 *
+	 * @param int $id Site id.
+	 * @return array|null Record or null when not found.
+	 */
+	public static function get_by_id( $id ) {
+		foreach ( self::read() as $site ) {
+			if ( (int) $site['id'] === (int) $id ) {
+				return $site;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Create a new connected site.
+	 *
+	 * @param array $data Input with label, base_url, token.
+	 * @return array The created record.
+	 */
+	public static function create( array $data ) {
+		$sites = self::read();
+
+		$next_id = 1;
+		foreach ( $sites as $site ) {
+			$next_id = max( $next_id, (int) $site['id'] + 1 );
+		}
+
+		$record = array(
+			'id'           => $next_id,
+			'label'        => sanitize_text_field( $data['label'] ?? '' ),
+			'base_url'     => esc_url_raw( $data['base_url'] ?? '' ),
+			'token'        => trim( (string) ( $data['token'] ?? '' ) ),
+			'scopes'       => array(),
+			'status'       => 'unverified',
+			'created_at'   => current_time( 'mysql', true ),
+			'last_sync_at' => null,
+		);
+
+		$sites[] = $record;
+		self::write( $sites );
+
+		return $record;
+	}
+
+	/**
+	 * Update an existing connected site.
+	 *
+	 * Only label, base_url and a non-empty token are merged; an empty token
+	 * leaves the stored token untouched.
+	 *
+	 * @param int   $id   Site id.
+	 * @param array $data Fields to update.
+	 * @return array|null Updated record, or null when not found.
+	 */
+	public static function update( $id, array $data ) {
+		$sites   = self::read();
+		$updated = null;
+
+		foreach ( $sites as $index => $site ) {
+			if ( (int) $site['id'] !== (int) $id ) {
+				continue;
+			}
+
+			if ( isset( $data['label'] ) ) {
+				$site['label'] = sanitize_text_field( $data['label'] );
+			}
+			if ( isset( $data['base_url'] ) ) {
+				$site['base_url'] = esc_url_raw( $data['base_url'] );
+			}
+			if ( ! empty( $data['token'] ) ) {
+				$site['token'] = trim( (string) $data['token'] );
+			}
+
+			$sites[ $index ] = $site;
+			$updated         = $site;
+			break;
+		}
+
+		if ( null !== $updated ) {
+			self::write( $sites );
+		}
+
+		return $updated;
+	}
+
+	/**
+	 * Delete a connected site.
+	 *
+	 * @param int $id Site id.
+	 * @return bool True when a record was removed.
+	 */
+	public static function delete( $id ) {
+		$sites     = self::read();
+		$remaining = array();
+		$found     = false;
+
+		foreach ( $sites as $site ) {
+			if ( (int) $site['id'] === (int) $id ) {
+				$found = true;
+				continue;
+			}
+			$remaining[] = $site;
+		}
+
+		if ( $found ) {
+			self::write( $remaining );
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Record a successful connection test: store discovered scopes and sync time.
+	 *
+	 * @param int      $id     Site id.
+	 * @param string[] $scopes Scopes reported by the remote token.
+	 * @return void
+	 */
+	public static function record_test_result( $id, array $scopes ) {
+		$sites = self::read();
+
+		foreach ( $sites as $index => $site ) {
+			if ( (int) $site['id'] === (int) $id ) {
+				$site['scopes']       = array_values( array_map( 'sanitize_text_field', $scopes ) );
+				$site['status']       = 'connected';
+				$site['last_sync_at'] = current_time( 'mysql', true );
+				$sites[ $index ]      = $site;
+				break;
+			}
+		}
+
+		self::write( $sites );
+	}
+
+	/**
+	 * Mark a connected site as failing its connection test.
+	 *
+	 * @param int $id Site id.
+	 * @return void
+	 */
+	public static function mark_failed( $id ) {
+		$sites = self::read();
+
+		foreach ( $sites as $index => $site ) {
+			if ( (int) $site['id'] === (int) $id ) {
+				$site['status']  = 'error';
+				$sites[ $index ] = $site;
+				break;
+			}
+		}
+
+		self::write( $sites );
+	}
+
+	/**
+	 * Convert a record to a safe array for admin responses.
+	 *
+	 * Never returns the raw token; exposes only whether one is set and a short
+	 * hint (last 4 characters).
+	 *
+	 * @param array $record Connected site record.
+	 * @return array
+	 */
+	public static function to_array( $record ) {
+		$token = (string) ( $record['token'] ?? '' );
+
+		return array(
+			'id'           => (int) $record['id'],
+			'label'        => $record['label'] ?? '',
+			'base_url'     => $record['base_url'] ?? '',
+			'scopes'       => isset( $record['scopes'] ) && is_array( $record['scopes'] ) ? $record['scopes'] : array(),
+			'status'       => $record['status'] ?? 'unverified',
+			'created_at'   => $record['created_at'] ?? '',
+			'last_sync_at' => $record['last_sync_at'] ?? null,
+			'has_token'    => '' !== $token,
+			'token_hint'   => '' !== $token ? substr( $token, -4 ) : '',
+		);
+	}
+}

--- a/fair-payments-connector-experimental/src/Services/TelegramService.php
+++ b/fair-payments-connector-experimental/src/Services/TelegramService.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Telegram notification sender for Fair Payments Connector Experimental
+ *
+ * @package FairPaymentsConnectorExperimental
+ */
+
+namespace FairPaymentsConnectorExperimental\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Sends messages to Telegram chats via the Bot API.
+ *
+ * Failures never throw — the caller (cron handler) should keep going so a single
+ * misconfigured chat ID does not block the rest of the notifications.
+ */
+class TelegramService {
+
+	/**
+	 * Telegram Bot API base URL.
+	 */
+	const API_BASE = 'https://api.telegram.org';
+
+	/**
+	 * Send a message to a single chat.
+	 *
+	 * @param string $bot_token Telegram bot token.
+	 * @param string $chat_id   Telegram chat ID (numeric or @channelname).
+	 * @param string $text      Message text (parse_mode=HTML).
+	 * @return array|\WP_Error Array with Telegram API response data on success, WP_Error on failure.
+	 */
+	public function send( $bot_token, $chat_id, $text ) {
+		$bot_token = trim( (string) $bot_token );
+		$chat_id   = trim( (string) $chat_id );
+
+		if ( '' === $bot_token ) {
+			return new \WP_Error( 'fair_payment_telegram_missing_token', __( 'Telegram bot token is not configured.', 'fair-payments-connector-experimental' ) );
+		}
+		if ( '' === $chat_id ) {
+			return new \WP_Error( 'fair_payment_telegram_missing_chat_id', __( 'Telegram chat ID is empty.', 'fair-payments-connector-experimental' ) );
+		}
+
+		$url = self::API_BASE . '/bot' . rawurlencode( $bot_token ) . '/sendMessage';
+
+		$response = wp_remote_post(
+			$url,
+			array(
+				'timeout' => 10,
+				'headers' => array( 'Content-Type' => 'application/json' ),
+				'body'    => wp_json_encode(
+					array(
+						'chat_id'                  => $chat_id,
+						'text'                     => $text,
+						'parse_mode'               => 'HTML',
+						'disable_web_page_preview' => true,
+					)
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payments Connector Experimental] Telegram send failed: ' . $response->get_error_message() );
+			}
+			return $response;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		if ( $code < 200 || $code >= 300 || empty( $data['ok'] ) ) {
+			$description = is_array( $data ) && ! empty( $data['description'] ) ? $data['description'] : 'HTTP ' . $code;
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( '[Fair Payments Connector Experimental] Telegram send returned non-OK: ' . $description );
+			}
+			return new \WP_Error(
+				'fair_payment_telegram_api_error',
+				$description,
+				array(
+					'status' => $code,
+					'body'   => $data,
+				)
+			);
+		}
+
+		return is_array( $data ) ? $data : array();
+	}
+
+	/**
+	 * Render a template by substituting placeholders.
+	 *
+	 * When $include_pii is false, {participant_email} renders empty and
+	 * {participant_name} falls back to an abbreviated form (first name + surname
+	 * initial, e.g. "Lucianna C.") so the channel still shows who paid without
+	 * exposing the full identity.
+	 *
+	 * @param string $template    Template string.
+	 * @param array  $context     Context with raw values (will be HTML-escaped on insertion).
+	 * @param bool   $include_pii Whether to substitute PII placeholders.
+	 * @return string
+	 */
+	public function render_template( $template, array $context, $include_pii = true ) {
+		$replacements = array();
+		$placeholders = array(
+			'test_label',
+			'site_domain',
+			'event_title',
+			'event_url',
+			'participant_name',
+			'participant_url',
+			'participant_email',
+			'amount',
+			'currency',
+			'ticket_label',
+			'activities',
+			'discounts',
+			'transaction_id',
+			'date',
+		);
+
+		foreach ( $placeholders as $key ) {
+			$value = '';
+
+			if ( 'participant_name' === $key ) {
+				if ( $include_pii ) {
+					$value = esc_html( (string) ( $context['participant_name'] ?? '' ) );
+				} else {
+					$short = ( isset( $context['participant_name_short'] ) && '' !== $context['participant_name_short'] )
+						? (string) $context['participant_name_short']
+						: self::abbreviate_name( (string) ( $context['participant_name'] ?? '' ) );
+					$value = esc_html( $short );
+				}
+			} elseif ( 'participant_email' === $key && ! $include_pii ) {
+				$value = '';
+			} elseif ( isset( $context[ $key ] ) && null !== $context[ $key ] && '' !== $context[ $key ] ) {
+				if ( in_array( $key, array( 'event_url', 'participant_url' ), true ) ) {
+					$value = esc_url( (string) $context[ $key ] );
+				} else {
+					$value = esc_html( (string) $context[ $key ] );
+				}
+			}
+
+			$replacements[ '{' . $key . '}' ] = $value;
+		}
+
+		return strtr( (string) $template, $replacements );
+	}
+
+	/**
+	 * Abbreviate a full name to "First S." (first name + first surname initial).
+	 *
+	 * @param string $full_name Full name.
+	 * @return string Abbreviated name, or the input unchanged when it has one token.
+	 */
+	private static function abbreviate_name( $full_name ) {
+		$full_name = trim( (string) preg_replace( '/\s+/', ' ', (string) $full_name ) );
+		if ( '' === $full_name ) {
+			return '';
+		}
+
+		$parts = explode( ' ', $full_name );
+		if ( count( $parts ) < 2 ) {
+			return $full_name;
+		}
+
+		$first   = $parts[0];
+		$initial = mb_strtoupper( mb_substr( $parts[1], 0, 1 ) );
+
+		return $first . ' ' . $initial . '.';
+	}
+}

--- a/fair-payments-connector-experimental/webpack.config.cjs
+++ b/fair-payments-connector-experimental/webpack.config.cjs
@@ -1,0 +1,24 @@
+const defaultConfig = require("@wordpress/scripts/config/webpack.config");
+const path = require("path");
+const BundleOutputPlugin = require("webpack-bundle-output");
+
+module.exports = {
+  ...defaultConfig,
+  entry: {
+    "admin/api-tokens/index": path.resolve(
+      process.cwd(),
+      "src/Admin/api-tokens/index.js",
+    ),
+    "admin/connected-sites/index": path.resolve(
+      process.cwd(),
+      "src/Admin/connected-sites/index.js",
+    ),
+  },
+  plugins: [
+    ...defaultConfig.plugins,
+    new BundleOutputPlugin({
+      cwd: process.cwd(),
+      output: "map.json",
+    }),
+  ],
+};

--- a/fair-payments-connector/src/API/RestHooks.php
+++ b/fair-payments-connector/src/API/RestHooks.php
@@ -42,21 +42,6 @@ class RestHooks {
 		$payment_log_controller = new \FairPaymentsConnector\API\PaymentLogController();
 		$payment_log_controller->register_routes();
 
-		$telegram_controller = new \FairPaymentsConnector\API\TelegramSettingsController();
-		$telegram_controller->register_routes();
-
-		$api_tokens_controller = new \FairPaymentsConnector\API\ApiTokensController();
-		$api_tokens_controller->register_routes();
-
-		$external_transactions = new \FairPaymentsConnector\API\ExternalTransactionsController();
-		$external_transactions->register_routes();
-
-		$external_me = new \FairPaymentsConnector\API\ExternalMeController();
-		$external_me->register_routes();
-
-		$connected_sites_controller = new \FairPaymentsConnector\API\ConnectedSitesController();
-		$connected_sites_controller->register_routes();
-
 		$dashboard_controller = new \FairPaymentsConnector\API\DashboardController();
 		$dashboard_controller->register_routes();
 	}

--- a/fair-payments-connector/src/Admin/AdminPages.php
+++ b/fair-payments-connector/src/Admin/AdminPages.php
@@ -73,26 +73,6 @@ class AdminPages {
 			array( $this, 'render_settings_page' )
 		);
 
-		// API Tokens submenu.
-		add_submenu_page(
-			'fair-payments-connector-transactions',
-			__( 'API Tokens', 'fair-payments-connector' ),
-			__( 'API Tokens', 'fair-payments-connector' ),
-			'manage_options',
-			'fair-payments-connector-api-tokens',
-			array( $this, 'render_api_tokens_page' )
-		);
-
-		// Connected Sites submenu.
-		add_submenu_page(
-			'fair-payments-connector-transactions',
-			__( 'Connected Sites', 'fair-payments-connector' ),
-			__( 'Connected Sites', 'fair-payments-connector' ),
-			'manage_options',
-			'fair-payments-connector-connected-sites',
-			array( $this, 'render_connected_sites_page' )
-		);
-
 		// Fee Dashboard submenu.
 		add_submenu_page(
 			'fair-payments-connector-transactions',
@@ -136,18 +116,6 @@ class AdminPages {
 					'testMode' => 'test' === get_option( 'fair_payment_mode', 'test' ),
 				)
 			);
-			return;
-		}
-
-		// API Tokens page.
-		if ( false !== strpos( $hook, 'fair-payments-connector-api-tokens' ) ) {
-			$this->enqueue_admin_page_script( 'api-tokens' );
-			return;
-		}
-
-		// Connected Sites page.
-		if ( false !== strpos( $hook, 'fair-payments-connector-connected-sites' ) ) {
-			$this->enqueue_admin_page_script( 'connected-sites' );
 			return;
 		}
 
@@ -232,7 +200,7 @@ class AdminPages {
 	/**
 	 * Enqueue script for an admin page
 	 *
-	 * @param string $page Page name (transactions, transaction, settings, api-tokens, connected-sites).
+	 * @param string $page Page name (transactions, transaction, settings, fee-dashboard).
 	 * @return void
 	 */
 	private function enqueue_admin_page_script( $page ) {
@@ -302,28 +270,6 @@ class AdminPages {
 	public function render_transactions_page() {
 		?>
 		<div id="fair-payments-connector-transactions-root"></div>
-		<?php
-	}
-
-	/**
-	 * Render API tokens page
-	 *
-	 * @return void
-	 */
-	public function render_api_tokens_page() {
-		?>
-		<div id="fair-payments-connector-api-tokens-root"></div>
-		<?php
-	}
-
-	/**
-	 * Render connected sites page
-	 *
-	 * @return void
-	 */
-	public function render_connected_sites_page() {
-		?>
-		<div id="fair-payments-connector-connected-sites-root"></div>
 		<?php
 	}
 

--- a/fair-payments-connector/src/Core/Plugin.php
+++ b/fair-payments-connector/src/Core/Plugin.php
@@ -61,17 +61,6 @@ class Plugin {
 		$this->load_admin();
 		$this->load_settings();
 		$this->load_migration_notice();
-		$this->load_notifications();
-	}
-
-	/**
-	 * Load and initialize notification hooks (Telegram, etc.)
-	 *
-	 * @return void
-	 */
-	private function load_notifications() {
-		$notifications = new \FairPaymentsConnector\Hooks\NotificationHooks();
-		$notifications->init();
 	}
 
 	/**

--- a/fair-payments-connector/webpack.config.cjs
+++ b/fair-payments-connector/webpack.config.cjs
@@ -25,14 +25,6 @@ module.exports = {
       process.cwd(),
       "src/Admin/settings/index.js",
     ),
-    "admin/api-tokens/index": path.resolve(
-      process.cwd(),
-      "src/Admin/api-tokens/index.js",
-    ),
-    "admin/connected-sites/index": path.resolve(
-      process.cwd(),
-      "src/Admin/connected-sites/index.js",
-    ),
     "admin/fee-dashboard/index": path.resolve(
       process.cwd(),
       "src/Admin/fee-dashboard/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
 				"fair-audience",
 				"fair-timetable",
 				"fair-finance",
-				"fair-events-experimental"
+				"fair-events-experimental",
+				"fair-payments-connector-experimental"
 			],
 			"dependencies": {
 				"@wordpress/scripts": "^32.4.0",
@@ -1031,149 +1032,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"fair-audience/node_modules/@wordpress/base-styles": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
-			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-audience/node_modules/@wordpress/icons": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
-			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/primitives": "^4.48.0",
-				"change-case": "4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
 		"fair-audience/node_modules/ansi-styles": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1877,12 +1735,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"fair-audience/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT"
-		},
 		"fair-audience/node_modules/picomatch": {
 			"version": "4.0.3",
 			"dev": true,
@@ -1986,19 +1838,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"fair-audience/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-audience/node_modules/write-file-atomic": {
@@ -2159,149 +1998,6 @@
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"fair-events-experimental/node_modules/@wordpress/base-styles": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
-			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-events-experimental/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"fair-events-experimental/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"fair-events-experimental/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-events-experimental/node_modules/@wordpress/icons": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
-			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/primitives": "^4.48.0",
-				"change-case": "4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"fair-events-experimental/node_modules/ansi-styles": {
@@ -3002,12 +2698,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"fair-events-experimental/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT"
-		},
 		"fair-events-experimental/node_modules/picomatch": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -3117,19 +2807,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"fair-events-experimental/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
 		"fair-events-experimental/node_modules/write-file-atomic": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -3151,176 +2828,6 @@
 				"@wordpress/components": "^35.0.0",
 				"@wordpress/scripts": "^32.4.0",
 				"date-fns": "^4.0.0"
-			}
-		},
-		"fair-events-shared/node_modules/@wordpress/base-styles": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
-			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-events-shared/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"fair-events-shared/node_modules/@wordpress/components/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
-		"fair-events-shared/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"fair-events-shared/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-events-shared/node_modules/@wordpress/icons": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
-			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/primitives": "^4.48.0",
-				"change-case": "4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"fair-events-shared/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"license": "MIT"
-		},
-		"fair-events-shared/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-events/node_modules/@jest/core": {
@@ -3411,149 +2918,6 @@
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"fair-events/node_modules/@wordpress/base-styles": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
-			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-events/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"fair-events/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"fair-events/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-events/node_modules/@wordpress/icons": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
-			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/primitives": "^4.48.0",
-				"change-case": "4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"fair-events/node_modules/ansi-styles": {
@@ -4259,10 +3623,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"fair-events/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"license": "MIT"
-		},
 		"fair-events/node_modules/picomatch": {
 			"version": "4.0.3",
 			"dev": true,
@@ -4368,19 +3728,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"fair-events/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
 		"fair-events/node_modules/write-file-atomic": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -4421,151 +3768,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"fair-finance/node_modules/@wordpress/base-styles": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
-			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-finance/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"fair-finance/node_modules/@wordpress/components/node_modules/@wordpress/i18n": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.0.tgz",
-			"integrity": "sha512-IXGGUJqN6b7QddU0dZB3HLJKu6uDQuhLsrrzYpUYTjDhfa43XEaikA9xHNgZhqzRtOVYqsNHVliWcISvJ/xjZQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.48.0",
-				"gettext-parser": "^1.3.1",
-				"memize": "^2.1.0",
-				"tannin": "^1.2.0"
-			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-finance/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"fair-finance/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"fair-finance/node_modules/@wordpress/i18n": {
 			"version": "5.26.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
@@ -4585,43 +3787,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			}
-		},
-		"fair-finance/node_modules/@wordpress/icons": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
-			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/primitives": "^4.48.0",
-				"change-case": "4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"fair-finance/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT"
-		},
-		"fair-finance/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-payment": {
@@ -4667,147 +3832,52 @@
 				"webpack-bundle-output": "^1.1.0"
 			}
 		},
-		"fair-payments-connector/node_modules/@wordpress/base-styles": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
-			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+		"fair-payments-connector-experimental": {
+			"version": "0.1.0",
+			"license": "proprietary",
+			"dependencies": {
+				"@wordpress/api-fetch": "^7.12.0",
+				"@wordpress/components": "^35.0.0",
+				"@wordpress/dom-ready": "^4.12.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/i18n": "^5.12.0"
+			},
+			"devDependencies": {
+				"@wordpress/scripts": "^32.4.0",
+				"webpack-bundle-output": "^1.1.0"
 			}
 		},
-		"fair-payments-connector/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
+		"fair-payments-connector-experimental/node_modules/@babel/runtime": {
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
+			"integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+			"license": "MIT",
+			"dependencies": {
+				"regenerator-runtime": "^0.14.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@wordpress/i18n": {
+			"version": "5.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
+			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
+				"@babel/runtime": "7.25.7",
+				"@wordpress/hooks": "^4.26.0",
+				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"fair-payments-connector/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"fair-payments-connector/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-payments-connector/node_modules/@wordpress/icons": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
-			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/primitives": "^4.48.0",
-				"change-case": "4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"fair-payments-connector/node_modules/dotenv": {
@@ -4821,25 +3891,6 @@
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
-			}
-		},
-		"fair-payments-connector/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT"
-		},
-		"fair-payments-connector/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-platform": {
@@ -4866,151 +3917,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"fair-platform/node_modules/@wordpress/base-styles": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
-			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-platform/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"fair-platform/node_modules/@wordpress/components/node_modules/@wordpress/i18n": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.0.tgz",
-			"integrity": "sha512-IXGGUJqN6b7QddU0dZB3HLJKu6uDQuhLsrrzYpUYTjDhfa43XEaikA9xHNgZhqzRtOVYqsNHVliWcISvJ/xjZQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.48.0",
-				"gettext-parser": "^1.3.1",
-				"memize": "^2.1.0",
-				"tannin": "^1.2.0"
-			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-platform/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"fair-platform/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"fair-platform/node_modules/@wordpress/i18n": {
 			"version": "5.26.0",
 			"license": "GPL-2.0-or-later",
@@ -5028,41 +3934,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			}
-		},
-		"fair-platform/node_modules/@wordpress/icons": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
-			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/primitives": "^4.48.0",
-				"change-case": "4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"fair-platform/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"license": "MIT"
-		},
-		"fair-platform/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-timetable": {
@@ -5178,149 +4049,6 @@
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"fair-timetable/node_modules/@wordpress/base-styles": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
-			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-timetable/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"fair-timetable/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"fair-timetable/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"fair-timetable/node_modules/@wordpress/icons": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
-			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/primitives": "^4.48.0",
-				"change-case": "4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
 			}
 		},
 		"fair-timetable/node_modules/ansi-styles": {
@@ -6034,12 +4762,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"fair-timetable/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT"
-		},
 		"fair-timetable/node_modules/picomatch": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -6147,19 +4869,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"fair-timetable/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"fair-timetable/node_modules/write-file-atomic": {
@@ -15833,6 +14542,13 @@
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
 			"license": "MIT"
 		},
+		"node_modules/@types/semver": {
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/@types/send": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -16020,6 +14736,55 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+			"integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/type-utils": "6.21.0",
+				"@typescript-eslint/utils": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+			"license": "ISC",
+			"optional": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@typescript-eslint/project-service": {
 			"version": "8.61.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
@@ -16054,6 +14819,24 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
 			"version": "8.61.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
@@ -16068,6 +14851,176 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+			"integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"@typescript-eslint/utils": "6.21.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+			"license": "ISC",
+			"optional": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/semver": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+			"license": "ISC",
+			"optional": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
@@ -16878,74 +15831,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/compose": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
@@ -16973,26 +15858,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/block-editor/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/icons": {
 			"version": "13.3.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
@@ -17009,25 +15874,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/block-editor/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/block-editor/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/@wordpress/block-serialization-default-parser": {
@@ -17079,26 +15925,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/blocks/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/blocks/node_modules/uuid": {
@@ -17162,7 +15988,25 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/commands/node_modules/@wordpress/components": {
+		"node_modules/@wordpress/commands/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/components": {
 			"version": "35.0.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
 			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
@@ -17230,7 +16074,17 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/commands/node_modules/@wordpress/compose": {
+		"node_modules/@wordpress/components/node_modules/@wordpress/base-styles": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/compose": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
 			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
@@ -17257,27 +16111,7 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/commands/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/commands/node_modules/@wordpress/icons": {
+		"node_modules/@wordpress/components/node_modules/@wordpress/icons": {
 			"version": "13.3.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
 			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
@@ -17295,13 +16129,13 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/commands/node_modules/path-to-regexp": {
+		"node_modules/@wordpress/components/node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
 			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
 			"license": "MIT"
 		},
-		"node_modules/@wordpress/commands/node_modules/uuid": {
+		"node_modules/@wordpress/components/node_modules/uuid": {
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
 			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
@@ -17370,26 +16204,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/data/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/dataviews": {
 			"version": "16.0.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-16.0.0.tgz",
@@ -17437,74 +16251,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/compose": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
@@ -17532,26 +16278,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/dataviews/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
 			"version": "13.3.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
@@ -17568,25 +16294,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/dataviews/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/dataviews/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/@wordpress/date": {
@@ -17681,6 +16388,26 @@
 			"peerDependencies": {
 				"@playwright/test": ">=1",
 				"@types/node": "^20.17.10"
+			}
+		},
+		"node_modules/@wordpress/element": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/escape-html": "^3.48.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/env": {
@@ -17878,168 +16605,6 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/image-cropper/node_modules/@wordpress/base-styles": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
-			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/image-cropper/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/image-cropper/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/image-cropper/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/image-cropper/node_modules/@wordpress/icons": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
-			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/primitives": "^4.48.0",
-				"change-case": "4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/image-cropper/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/image-cropper/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
 		"node_modules/@wordpress/interactivity": {
 			"version": "6.48.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.48.0.tgz",
@@ -18117,26 +16682,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/keycodes": {
 			"version": "4.48.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.48.0.tgz",
@@ -18167,168 +16712,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/notices/node_modules/@wordpress/base-styles": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
-			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/notices/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/notices/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/notices/node_modules/@wordpress/icons": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
-			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/primitives": "^4.48.0",
-				"change-case": "4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/notices/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/notices/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
@@ -18409,74 +16792,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.22",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^14.0.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/compose": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
@@ -18504,26 +16819,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/preferences/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/icons": {
 			"version": "13.3.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
@@ -18542,25 +16837,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/preferences/node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/preferences/node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
 		"node_modules/@wordpress/primitives": {
 			"version": "4.48.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.48.0.tgz",
@@ -18576,26 +16852,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
@@ -18691,26 +16947,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/scripts": {
@@ -18964,26 +17200,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin": {
@@ -19643,26 +17859,6 @@
 				"stylelint-scss": "^6.4.0"
 			}
 		},
-		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/theme": {
 			"version": "0.15.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.15.0.tgz",
@@ -19829,26 +18025,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/ui/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
 			"version": "13.3.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
@@ -19958,26 +18134,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/upload-media/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/uuid": {
@@ -25495,6 +23651,10 @@
 		},
 		"node_modules/fair-payments-connector": {
 			"resolved": "fair-payments-connector",
+			"link": true
+		},
+		"node_modules/fair-payments-connector-experimental": {
+			"resolved": "fair-payments-connector-experimental",
 			"link": true
 		},
 		"node_modules/fair-platform": {

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
 		"composer:update": "npm run composer:update --workspaces --if-present",
 		"composer:update:shared": "npm run composer:update:shared --workspaces --if-present",
 		"composer:validate": "npm run composer:validate --workspaces --if-present",
-		"start": "npm run start --workspace=fair-payments-connector & npm run start --workspace=fair-events & npm run start --workspace=fair-audience & npm run start --workspace=fair-timetable & npm run start --workspace=fair-finance & npm run start --workspace=fair-events-experimental & wait",
+		"start": "npm run start --workspace=fair-payments-connector & npm run start --workspace=fair-events & npm run start --workspace=fair-audience & npm run start --workspace=fair-timetable & npm run start --workspace=fair-finance & npm run start --workspace=fair-events-experimental & npm run start --workspace=fair-payments-connector-experimental & wait",
 		"format": "npm-run-all format:*",
 		"format:js": "wp-scripts format",
-		"format:php": "vendor/bin/phpcbf --standard=WordPress --extensions=php fair-payments-connector/src/ fair-events/src/ fair-events/__tests__/ fair-platform/src/ fair-audience/src/ fair-audience/__tests__/ fair-timetable/src/ fair-timetable/__tests__/ fair-finance/src/ fair-finance/__tests__/ fair-events-experimental/src/",
+		"format:php": "vendor/bin/phpcbf --standard=WordPress --extensions=php fair-payments-connector/src/ fair-events/src/ fair-events/__tests__/ fair-platform/src/ fair-audience/src/ fair-audience/__tests__/ fair-timetable/src/ fair-timetable/__tests__/ fair-finance/src/ fair-finance/__tests__/ fair-events-experimental/src/ fair-payments-connector-experimental/src/",
 		"prepare": "husky",
 		"changeset": "changeset",
 		"changeset:add": "changeset add",
@@ -63,6 +63,7 @@
 		"dist-archive:fair-timetable": "wp dist-archive fair-timetable dist --create-target-dir",
 		"dist-archive:fair-finance": "wp dist-archive fair-finance dist --create-target-dir",
 		"dist-archive:fair-events-experimental": "wp dist-archive fair-events-experimental dist --create-target-dir",
+		"dist-archive:fair-payments-connector-experimental": "wp dist-archive fair-payments-connector-experimental dist --create-target-dir",
 		"translation:update": "node scripts/translation/update-translations.js",
 		"translation:untranslated": "node scripts/translation/get-untranslated.js",
 		"translation:coverage": "node scripts/translation/coverage-report.js",
@@ -966,7 +967,8 @@
 		"fair-audience",
 		"fair-timetable",
 		"fair-finance",
-		"fair-events-experimental"
+		"fair-events-experimental",
+		"fair-payments-connector-experimental"
 	],
 	"devDependencies": {
 		"@changesets/cli": "^2.29.6",

--- a/scripts/sync-changelog.js
+++ b/scripts/sync-changelog.js
@@ -38,6 +38,11 @@ const plugins = [
 		changelogPath: 'fair-finance/CHANGELOG.md',
 		readmeFiles: ['fair-finance/readme.txt'],
 	},
+	{
+		name: 'fair-payments-connector-experimental',
+		changelogPath: 'fair-payments-connector-experimental/CHANGELOG.md',
+		readmeFiles: ['fair-payments-connector-experimental/readme.txt'],
+	},
 ];
 
 /**

--- a/scripts/sync-wp-versions.js
+++ b/scripts/sync-wp-versions.js
@@ -66,6 +66,15 @@ const plugins = [
 		readmeFiles: ['fair-events-experimental/readme.txt'],
 		versionConstant: 'FAIR_EVENTS_EXPERIMENTAL_VERSION',
 	},
+	{
+		name: 'fair-payments-connector-experimental',
+		packagePath: 'fair-payments-connector-experimental/package.json',
+		phpFiles: [
+			'fair-payments-connector-experimental/fair-payments-connector-experimental.php',
+		],
+		readmeFiles: ['fair-payments-connector-experimental/readme.txt'],
+		versionConstant: 'FAIR_PAYMENTS_CONNECTOR_EXPERIMENTAL_VERSION',
+	},
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Scaffolds a new `fair-payments-connector-experimental` plugin to house features not ready for public release
- Moves **API Tokens** (admin page + REST controller + `ApiToken` model) from `fair-payments-connector`
- Moves **Connected Sites** (admin page + REST controllers + `ConnectedSite` model + external API endpoints) — keeps cross-reference to `FairPaymentsConnector\Models\Transaction` for import
- Moves **Telegram notification dispatch** (`NotificationHooks`, `TelegramService`, `TelegramSettingsController`) — routes stay under `fair-payments-connector/v1` so `TelegramTab.js` needs no changes

## Test plan

- [ ] Activate both `fair-payments-connector` and `fair-payments-connector-experimental` in WordPress
- [ ] Verify API Tokens and Connected Sites submenus appear under the Fair Payments Connector menu
- [ ] Create an API token and verify it is listed
- [ ] Add a connected site and run the connection test
- [ ] Configure Telegram settings in fair-payments-connector Settings → Telegram tab and send a test message
- [ ] Verify Telegram notification fires on a successful payment (`fair_payment_paid` action)
- [ ] Confirm `npm run build --workspace=fair-payments-connector-experimental` succeeds and `build/map.json` is generated
- [ ] Confirm `npm test --workspace=fair-payments-connector-experimental` passes