### PR TITLE
Upgrade @fortawesome/react-fontawesome 0.2.3 → 3.3.1

### DIFF
--- a/fair-timetable/package.json
+++ b/fair-timetable/package.json
@@ -33,7 +33,7 @@
 		"@fortawesome/fontawesome-free": "^7.0.0",
 		"@fortawesome/fontawesome-svg-core": "^7.0.0",
 		"@fortawesome/free-solid-svg-icons": "^7.0.0",
-		"@fortawesome/react-fontawesome": "^0.2.3",
+		"@fortawesome/react-fontawesome": "^3.3.1",
 		"@wordpress/block-editor": "^15.2.0",
 		"@wordpress/blocks": "^15.2.0",
 		"@wordpress/components": "^35.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3944,7 +3944,7 @@
 				"@fortawesome/fontawesome-free": "^7.0.0",
 				"@fortawesome/fontawesome-svg-core": "^7.0.0",
 				"@fortawesome/free-solid-svg-icons": "^7.0.0",
-				"@fortawesome/react-fontawesome": "^0.2.3",
+				"@fortawesome/react-fontawesome": "^3.3.1",
 				"@wordpress/block-editor": "^15.2.0",
 				"@wordpress/blocks": "^15.2.0",
 				"@wordpress/components": "^35.0.0",
@@ -8088,17 +8088,16 @@
 			}
 		},
 		"node_modules/@fortawesome/react-fontawesome": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.6.tgz",
-			"integrity": "sha512-mtBFIi1UsYQo7rYonYFkjgYKGoL8T+fEH6NGUpvuqtY3ytMsAoDaPo5rk25KuMtKDipY4bGYM/CkmCHA1N3FUg==",
-			"deprecated": "v0.2.x is no longer supported. Unless you are still using FontAwesome 5, please update to v3.1.1 or greater.",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
+			"integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
 			"license": "MIT",
-			"dependencies": {
-				"prop-types": "^15.8.1"
+			"engines": {
+				"node": ">=20"
 			},
 			"peerDependencies": {
-				"@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
-				"react": "^16.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+				"@fortawesome/fontawesome-svg-core": "~6 || ~7",
+				"react": "^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@hapi/address": {


### PR DESCRIPTION
## Summary

- Bumps `@fortawesome/react-fontawesome` from `^0.2.3` to `^3.3.1` in `fair-timetable`.

## Notes

This is a major version jump (0.x → 3.x). The package API is stable and
backward-compatible for the usage patterns in this codebase (icon rendering via
`<FontAwesomeIcon>`), but the build should be verified after merge.

## Test plan

- [ ] `npm install` completes without errors
- [ ] `npm run build` in `fair-timetable` produces clean output
- [ ] Timetable blocks render icons correctly in the editor and on the frontend