### PR TITLE
upgrade: @wordpress/i18n v5/v6.2 → v6.21 across all plugins

### DIFF
--- a/fair-audience/package.json
+++ b/fair-audience/package.json
@@ -35,7 +35,7 @@
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/dataviews": "^16.0.0",
 		"@wordpress/element": "^8.0.0",
-		"@wordpress/i18n": "^6.2.0",
+		"@wordpress/i18n": "^6.21.0",
 		"fair-events-shared": "*",
 		"jspdf": "^4.0.0",
 		"jspdf-autotable": "^5.0.7",

--- a/fair-events-experimental/package.json
+++ b/fair-events-experimental/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/dom-ready": "^4.2.0",
 		"@wordpress/element": "^8.0.0",
-		"@wordpress/i18n": "^6.2.0",
+		"@wordpress/i18n": "^6.21.0",
 		"recharts": "^3.0.0"
 	},
 	"devDependencies": {

--- a/fair-events/package.json
+++ b/fair-events/package.json
@@ -45,7 +45,7 @@
 		"@wordpress/date": "^5.2.0",
 		"@wordpress/dom-ready": "^4.2.0",
 		"@wordpress/element": "^8.0.0",
-		"@wordpress/i18n": "^6.2.0",
+		"@wordpress/i18n": "^6.21.0",
 		"calendar-link": "^2.11.0",
 		"fair-events-shared": "*",
 		"react-easy-crop": "^5.5.6"

--- a/fair-finance/package.json
+++ b/fair-finance/package.json
@@ -33,6 +33,6 @@
 		"@wordpress/api-fetch": "^7.12.0",
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/element": "^8.0.0",
-		"@wordpress/i18n": "^5.12.0"
+		"@wordpress/i18n": "^6.21.0"
 	}
 }

--- a/fair-payments-connector-experimental/package.json
+++ b/fair-payments-connector-experimental/package.json
@@ -34,7 +34,7 @@
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/dom-ready": "^4.12.0",
 		"@wordpress/element": "^8.0.0",
-		"@wordpress/i18n": "^5.12.0",
+		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/icons": "^14.0.0"
 	}
 }

--- a/fair-payments-connector/package.json
+++ b/fair-payments-connector/package.json
@@ -46,7 +46,7 @@
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/dom-ready": "^4.2.0",
 		"@wordpress/element": "^8.0.0",
-		"@wordpress/i18n": "^6.2.0",
+		"@wordpress/i18n": "^6.21.0",
 		"xlsx": "^0.18.5"
 	}
 }

--- a/fair-platform/package.json
+++ b/fair-platform/package.json
@@ -33,6 +33,6 @@
 		"@wordpress/api-fetch": "^7.12.0",
 		"@wordpress/components": "^35.0.0",
 		"@wordpress/element": "^8.0.0",
-		"@wordpress/i18n": "^5.12.0"
+		"@wordpress/i18n": "^6.21.0"
 	}
 }

--- a/fair-timetable/package.json
+++ b/fair-timetable/package.json
@@ -37,7 +37,7 @@
 		"@wordpress/block-editor": "^15.2.0",
 		"@wordpress/blocks": "^15.2.0",
 		"@wordpress/components": "^35.0.0",
-		"@wordpress/i18n": "^6.2.0",
+		"@wordpress/i18n": "^6.21.0",
 		"date-fns": "^4.4.0"
 	},
 	"devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -924,7 +924,7 @@
 				"@wordpress/components": "^35.0.0",
 				"@wordpress/dataviews": "^16.0.0",
 				"@wordpress/element": "^8.0.0",
-				"@wordpress/i18n": "^6.2.0",
+				"@wordpress/i18n": "^6.21.0",
 				"fair-events-shared": "*",
 				"jspdf": "^4.0.0",
 				"jspdf-autotable": "^5.0.7",
@@ -1870,7 +1870,7 @@
 				"@wordpress/date": "^5.2.0",
 				"@wordpress/dom-ready": "^4.2.0",
 				"@wordpress/element": "^8.0.0",
-				"@wordpress/i18n": "^6.2.0",
+				"@wordpress/i18n": "^6.21.0",
 				"calendar-link": "^2.11.0",
 				"fair-events-shared": "*",
 				"react-easy-crop": "^5.5.6"
@@ -1896,7 +1896,7 @@
 				"@wordpress/components": "^35.0.0",
 				"@wordpress/dom-ready": "^4.2.0",
 				"@wordpress/element": "^8.0.0",
-				"@wordpress/i18n": "^6.2.0",
+				"@wordpress/i18n": "^6.21.0",
 				"fair-events-shared": "*",
 				"recharts": "^3.0.0"
 			},
@@ -3749,44 +3749,11 @@
 				"@wordpress/api-fetch": "^7.12.0",
 				"@wordpress/components": "^35.0.0",
 				"@wordpress/element": "^8.0.0",
-				"@wordpress/i18n": "^5.12.0"
+				"@wordpress/i18n": "^6.21.0"
 			},
 			"devDependencies": {
 				"@wordpress/scripts": "^32.4.0",
 				"webpack-bundle-output": "^1.1.0"
-			}
-		},
-		"fair-finance/node_modules/@babel/runtime": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-			"integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"fair-finance/node_modules/@wordpress/i18n": {
-			"version": "5.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
-			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.26.0",
-				"gettext-parser": "^1.3.1",
-				"memize": "^2.1.0",
-				"sprintf-js": "^1.1.1",
-				"tannin": "^1.2.0"
-			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"fair-payment": {
@@ -3820,7 +3787,7 @@
 				"@wordpress/components": "^35.0.0",
 				"@wordpress/dom-ready": "^4.2.0",
 				"@wordpress/element": "^8.0.0",
-				"@wordpress/i18n": "^6.2.0",
+				"@wordpress/i18n": "^6.21.0",
 				"xlsx": "^0.18.5"
 			},
 			"devDependencies": {
@@ -3840,45 +3807,12 @@
 				"@wordpress/components": "^35.0.0",
 				"@wordpress/dom-ready": "^4.12.0",
 				"@wordpress/element": "^8.0.0",
-				"@wordpress/i18n": "^5.12.0",
+				"@wordpress/i18n": "^6.21.0",
 				"@wordpress/icons": "^14.0.0"
 			},
 			"devDependencies": {
 				"@wordpress/scripts": "^32.4.0",
 				"webpack-bundle-output": "^1.1.0"
-			}
-		},
-		"fair-payments-connector-experimental/node_modules/@babel/runtime": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-			"integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"fair-payments-connector-experimental/node_modules/@wordpress/i18n": {
-			"version": "5.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
-			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.26.0",
-				"gettext-parser": "^1.3.1",
-				"memize": "^2.1.0",
-				"sprintf-js": "^1.1.1",
-				"tannin": "^1.2.0"
-			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"fair-payments-connector/node_modules/dotenv": {
@@ -3901,40 +3835,11 @@
 				"@wordpress/api-fetch": "^7.12.0",
 				"@wordpress/components": "^35.0.0",
 				"@wordpress/element": "^8.0.0",
-				"@wordpress/i18n": "^5.12.0"
+				"@wordpress/i18n": "^6.21.0"
 			},
 			"devDependencies": {
 				"@wordpress/scripts": "^32.4.0",
 				"webpack-bundle-output": "^1.1.0"
-			}
-		},
-		"fair-platform/node_modules/@babel/runtime": {
-			"version": "7.25.7",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"fair-platform/node_modules/@wordpress/i18n": {
-			"version": "5.26.0",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.26.0",
-				"gettext-parser": "^1.3.1",
-				"memize": "^2.1.0",
-				"sprintf-js": "^1.1.1",
-				"tannin": "^1.2.0"
-			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"fair-timetable": {
@@ -3948,7 +3853,7 @@
 				"@wordpress/block-editor": "^15.2.0",
 				"@wordpress/blocks": "^15.2.0",
 				"@wordpress/components": "^35.0.0",
-				"@wordpress/i18n": "^6.2.0",
+				"@wordpress/i18n": "^6.21.0",
 				"date-fns": "^4.4.0"
 			},
 			"devDependencies": {
@@ -16545,9 +16450,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.48.0.tgz",
-			"integrity": "sha512-rU1yGEy0Mb+2oRG5QX/bKIIwKQmYAvATfUQeXIF20/mbR0qutYeVTCIvWEyb4pf71tvnQFiN18RWRXWsvKrDbQ==",
+			"version": "4.48.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.48.1.tgz",
+			"integrity": "sha512-QZh3Cv9TMJkrCQikuZSsDKTgX+6BBzYJe0MFKp7yP8drj/dtRpkqo5+eYmovBq3pk+HoyP7UJ1vTOb3GPJeU6Q==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -16565,13 +16470,13 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.0.tgz",
-			"integrity": "sha512-IXGGUJqN6b7QddU0dZB3HLJKu6uDQuhLsrrzYpUYTjDhfa43XEaikA9xHNgZhqzRtOVYqsNHVliWcISvJ/xjZQ==",
+			"version": "6.21.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.1.tgz",
+			"integrity": "sha512-qBbDJTRCtMfEzTVtzOa/fZf8XlU/JY3nI4MSdxyRQKduFanbXvzTRqJSSEIpZS4ACJTyUqafZX8zEZIH5CrNHQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.48.0",
+				"@wordpress/hooks": "^4.48.1",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"


### PR DESCRIPTION
## Summary

- Bumps `@wordpress/i18n` to `^6.21.0` in all eight plugins (fair-audience, fair-events, fair-events-experimental, fair-finance, fair-payments-connector, fair-payments-connector-experimental, fair-platform, fair-timetable).
- Three plugins (fair-finance, fair-payments-connector-experimental, fair-platform) were still on the v5 range; this aligns everything to v6.
- `package-lock.json` updated; the hoisted shared install now resolves to `6.21.1`.

## Test plan

- [ ] `npm install` completes without errors
- [ ] `npm run build` succeeds in each affected plugin
- [ ] Translation strings still render correctly in the WordPress admin