### PR TITLE
fix(fair-payments-connector): show transaction dates in site timezone

### DIFF
--- a/fair-payments-connector/src/API/PaymentLogController.php
+++ b/fair-payments-connector/src/API/PaymentLogController.php
@@ -159,7 +159,7 @@ class PaymentLogController extends WP_REST_Controller {
 			'user_id'        => null === $entry->user_id ? null : (int) $entry->user_id,
 			'ip_address'     => $entry->ip_address,
 			'request_id'     => $entry->request_id,
-			'created_at'     => $entry->created_at,
+			'created_at'     => $entry->created_at ? get_date_from_gmt( $entry->created_at ) : '',
 		);
 	}
 }

--- a/fair-payments-connector/src/API/TransactionsController.php
+++ b/fair-payments-connector/src/API/TransactionsController.php
@@ -240,7 +240,7 @@ class TransactionsController extends WP_REST_Controller {
 				'participant_id'    => $participant_id,
 				'participant'       => $participant,
 				'entry_ids'         => $entry_ids_by_txn[ (int) $transaction->id ] ?? array(),
-				'created_at'        => $transaction->created_at ?? '',
+				'created_at'        => $transaction->created_at ? get_date_from_gmt( $transaction->created_at ) : '',
 			);
 		}
 
@@ -501,9 +501,9 @@ class TransactionsController extends WP_REST_Controller {
 			'webhook_url'          => $transaction->webhook_url ?? '',
 			'checkout_url'         => $transaction->checkout_url ?? '',
 			'metadata'             => $metadata,
-			'created_at'           => $transaction->created_at ?? '',
-			'payment_initiated_at' => $transaction->payment_initiated_at ?? '',
-			'updated_at'           => $transaction->updated_at ?? '',
+			'created_at'           => $transaction->created_at ? get_date_from_gmt( $transaction->created_at ) : '',
+			'payment_initiated_at' => $transaction->payment_initiated_at ? get_date_from_gmt( $transaction->payment_initiated_at ) : '',
+			'updated_at'           => $transaction->updated_at ? get_date_from_gmt( $transaction->updated_at ) : '',
 			'line_items'           => $line_item_data,
 		);
 


### PR DESCRIPTION
## Summary

Transaction timestamps in the admin UI (transactions list, transaction detail, and payment log) were displaying in UTC instead of the configured WordPress site timezone. A transaction created at 18:03 Madrid time (CEST, UTC+2) was showing as 16:03.

The fix applies `get_date_from_gmt()` to all timestamp fields before serialising them in the REST response. This function reads `timezone_string` / `gmt_offset` from WordPress settings, so the result automatically matches whatever timezone the site admin has configured. No React changes are needed — the components already render whatever string the API returns.

Closes #801

## Changes

- `TransactionsController::prepare_transaction_response()` — `created_at`, `payment_initiated_at`, `updated_at` now converted from UTC to site timezone
- `TransactionsController` collection response — `created_at` in the transactions list also converted
- `PaymentLogController` — `created_at` on log entries converted

## Test plan

- [ ] Open the transactions list (`/wp-admin/admin.php?page=fair-payments-connector-transactions`) and confirm timestamps match the site timezone
- [ ] Open a transaction detail page and confirm Created / Payment Initiated / Updated rows show site-timezone times
- [ ] Open the payment log tab on a transaction and confirm log entry timestamps are in site timezone
- [ ] Verify on acroyoga-club.es (CEST, UTC+2): a transaction created at 18:03 local time shows `2026-06-10 18:03:06`