### PR TITLE
Guard webhook handler against terminal-state replays

### DIFF
--- a/fair-payments-connector/src/API/WebhookEndpoint.php
+++ b/fair-payments-connector/src/API/WebhookEndpoint.php
@@ -112,6 +112,35 @@ class WebhookEndpoint extends WP_REST_Controller {
 				);
 			}
 
+			// Skip terminal-state transactions — re-processing would re-fire hooks and
+			// re-run the balance fee scan. `authorized` is excluded: it can still move
+			// to `paid` so a follow-up webhook must be handled normally.
+			$terminal_states = array( 'paid', 'failed', 'canceled', 'expired' );
+			if ( in_array( $transaction->status, $terminal_states, true ) ) {
+				$logger->log(
+					'webhook_skipped',
+					array(
+						'level'          => 'info',
+						'transaction_id' => (int) $transaction->id,
+						'message'        => sprintf(
+							'Webhook skipped — transaction already in terminal state "%s"',
+							$transaction->status
+						),
+						'context'        => array(
+							'mollie_payment_id' => $mollie_payment_id,
+							'status'            => $transaction->status,
+						),
+					)
+				);
+				return new WP_REST_Response(
+					array(
+						'success' => true,
+						'status'  => $transaction->status,
+					),
+					200
+				);
+			}
+
 			// Retrieve payment status from Mollie using correct testmode.
 			$handler = new MolliePaymentHandler();
 			$options = array(

--- a/fair-payments-connector/src/API/__tests__/WebhookEndpoint.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/WebhookEndpoint.api.spec.js
@@ -1,0 +1,32 @@
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ENDPOINT = '/wp-json/fair-payments-connector/v1/webhook';
+
+test.describe('WebhookEndpoint — POST /webhook', () => {
+	let api;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test('returns 400 when id param is missing', async () => {
+		const res = await api.post(ENDPOINT, { data: {} });
+		expect(res.status()).toBe(400);
+		const body = await res.json();
+		expect(body.code).toBe('missing_payment_id');
+	});
+
+	test('returns 404 for an unknown mollie payment id', async () => {
+		const res = await api.post(ENDPOINT, {
+			data: { id: 'tr_nonexistent_test_id' },
+		});
+		expect(res.status()).toBe(404);
+		const body = await res.json();
+		expect(body.code).toBe('transaction_not_found');
+	});
+});


### PR DESCRIPTION
## Summary

Repeated Mollie webhook deliveries (or deliberate replays with a known `mollie_payment_id`) re-fired `fair_payment_paid` / `fair_payment_failed` and re-ran the balance-transaction fee scan on every call because the handler never checked whether the status was already final in the DB.

Adds an early-return guard in `WebhookEndpoint::handle_webhook()`: if the stored transaction status is already one of `paid`, `failed`, `canceled`, or `expired`, return 200 immediately — no Mollie API call, no DB update, no action hooks.

`authorized` is intentionally excluded: it is an intermediate state (Klarna, vouchers) that can still transition to `paid`, so a second webhook for that status must be processed normally.

Also adds `WebhookEndpoint.api.spec.js` covering the 400 (missing id) and 404 (unknown id) error paths.

Closes #844

## Notes

Full replay integration testing (verifying hooks don't double-fire) requires Mollie test doubles from `e2e/mu-plugins/` — that is out of scope for this PR and noted in the issue.

## Test plan

- [ ] `npm run test:api` in `fair-payments-connector` — new spec passes (requires Docker env on :8080)
- [ ] Manual: POST `/wp-json/fair-payments-connector/v1/webhook` without `id` → 400 `missing_payment_id`
- [ ] Manual: POST with unknown id → 404 `transaction_not_found`
- [ ] Manual: POST with a `paid` transaction's Mollie ID → 200 `{success: true, status: "paid"}` without triggering hooks a second time (check payment log table — no `webhook_status_updated` row added on replay)