### PR TITLE
fix(fair-payments-connector): restrict Mollie API keys to edit context in REST settings

### DIFF
--- a/fair-payments-connector/src/Settings/Settings.php
+++ b/fair-payments-connector/src/Settings/Settings.php
@@ -36,7 +36,12 @@ class Settings {
 				'type'              => 'string',
 				'description'       => __( 'Mollie Test API Key', 'fair-payments-connector' ),
 				'sanitize_callback' => 'sanitize_text_field',
-				'show_in_rest'      => true,
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'    => 'string',
+						'context' => array( 'edit' ),
+					),
+				),
 				'default'           => '',
 			)
 		);
@@ -49,7 +54,12 @@ class Settings {
 				'type'              => 'string',
 				'description'       => __( 'Mollie Live API Key', 'fair-payments-connector' ),
 				'sanitize_callback' => 'sanitize_text_field',
-				'show_in_rest'      => true,
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'    => 'string',
+						'context' => array( 'edit' ),
+					),
+				),
 				'default'           => '',
 			)
 		);


### PR DESCRIPTION
## Summary

Closes #847

Both `fair_payment_test_api_key` and `fair_payment_live_api_key` were registered with `show_in_rest: true` without a context constraint, exposing them in any `GET /wp-json/wp/v2/settings` view-context response. This mirrors the pattern already used for the OAuth tokens in the same file — adding `context: ['edit']` to the schema so the keys are only returned when explicitly requested in edit context (as the settings UI already does via `apiFetch`).

## Notes

No changes to the settings UI are needed — `apiFetch` requests `edit` context automatically, so both keys continue to appear in the admin settings page.

## Test plan

- [ ] `GET /wp-json/wp/v2/settings` (view context) does **not** include `fair_payment_test_api_key` or `fair_payment_live_api_key`
- [ ] `GET /wp-json/wp/v2/settings?context=edit` still returns both keys
- [ ] Settings page displays and saves API keys correctly