### PR TITLE
fix(fair-payments-connector): add OAuth state parameter to prevent CSRF credential replacement

### DIFF
--- a/.changeset/oauth-csrf-state-param.md
+++ b/.changeset/oauth-csrf-state-param.md
@@ -1,0 +1,6 @@
+---
+"fair-payments-connector": minor
+"fair-platform": minor
+---
+
+Add OAuth state parameter to prevent CSRF credential replacement in the Mollie connection flow.

--- a/fair-payments-connector/src/API/OAuthCallbackController.php
+++ b/fair-payments-connector/src/API/OAuthCallbackController.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * OAuth Callback Controller for Fair Payments Connector
+ *
+ * @package FairPaymentsConnector
+ */
+
+namespace FairPaymentsConnector\API;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * REST API controller handling OAuth state generation and credential callback.
+ *
+ * Two-step CSRF protection: the client fetches a short-lived state token before
+ * redirecting to Mollie, then POSTs it back on return so we can verify it
+ * server-side before writing any credentials.
+ */
+class OAuthCallbackController extends \WP_REST_Controller {
+
+	/**
+	 * Register REST API routes
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'fair-payments-connector/v1',
+			'/oauth/state',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'generate_state' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+
+		register_rest_route(
+			'fair-payments-connector/v1',
+			'/oauth/callback',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'handle_callback' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+				'args'                => array(
+					'state'           => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'access_token'    => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'refresh_token'   => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'expires_in'      => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'organization_id' => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+						'default'           => '',
+					),
+					'profile_id'      => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+						'default'           => '',
+					),
+					'test_mode'       => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Generate a one-time OAuth state token and store it in a user-scoped transient.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function generate_state() {
+		$state = wp_generate_password( 32, false );
+		set_transient( $this->state_transient_key(), $state, 5 * MINUTE_IN_SECONDS );
+		return new \WP_REST_Response( array( 'state' => $state ), 200 );
+	}
+
+	/**
+	 * Validate state and persist OAuth credentials.
+	 *
+	 * @param \WP_REST_Request $request Incoming request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function handle_callback( \WP_REST_Request $request ) {
+		$state    = $request->get_param( 'state' );
+		$expected = get_transient( $this->state_transient_key() );
+
+		// Single-use: delete before any branching to prevent replay.
+		delete_transient( $this->state_transient_key() );
+
+		if ( false === $expected || ! hash_equals( $expected, $state ) ) {
+			return new \WP_Error(
+				'invalid_oauth_state',
+				__( 'Invalid or expired OAuth state. Please try connecting again.', 'fair-payments-connector' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		update_option( 'fair_payment_mollie_access_token', $request->get_param( 'access_token' ) );
+		update_option( 'fair_payment_mollie_refresh_token', $request->get_param( 'refresh_token' ) );
+		update_option( 'fair_payment_mollie_token_expires', time() + $request->get_param( 'expires_in' ) );
+		update_option( 'fair_payment_organization_id', $request->get_param( 'organization_id' ) );
+		update_option( 'fair_payment_mollie_profile_id', $request->get_param( 'profile_id' ) );
+		update_option( 'fair_payment_mollie_connected', true );
+		update_option( 'fair_payment_mode', $request->get_param( 'test_mode' ) ? 'test' : 'live' );
+
+		return new \WP_REST_Response( array( 'success' => true ), 200 );
+	}
+
+	/**
+	 * Transient key scoped to the current user.
+	 *
+	 * @return string
+	 */
+	private function state_transient_key() {
+		return 'fpc_oauth_state_' . get_current_user_id();
+	}
+}

--- a/fair-payments-connector/src/API/RestHooks.php
+++ b/fair-payments-connector/src/API/RestHooks.php
@@ -36,6 +36,9 @@ class RestHooks {
 		$connection_controller = new \FairPaymentsConnector\API\ConnectionController();
 		$connection_controller->register_routes();
 
+		$oauth_callback_controller = new \FairPaymentsConnector\API\OAuthCallbackController();
+		$oauth_callback_controller->register_routes();
+
 		$transactions_controller = new \FairPaymentsConnector\API\TransactionsController();
 		$transactions_controller->register_routes();
 

--- a/fair-payments-connector/src/API/__tests__/OAuthCallbackController.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/OAuthCallbackController.api.spec.js
@@ -1,0 +1,126 @@
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const STATE_ENDPOINT = '/wp-json/fair-payments-connector/v1/oauth/state';
+const CALLBACK_ENDPOINT = '/wp-json/fair-payments-connector/v1/oauth/callback';
+
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * Return Basic-auth headers for the WP admin account.
+ */
+function adminAuth() {
+	return {
+		Authorization:
+			'Basic ' +
+			Buffer.from(`${ADMIN_USER}:${ADMIN_PASS}`).toString('base64'),
+	};
+}
+
+const VALID_TOKENS = {
+	access_token: 'access_test_abc123',
+	refresh_token: 'refresh_test_xyz789',
+	expires_in: 3600,
+	organization_id: 'org_test_001',
+	profile_id: 'pfl_test_001',
+	test_mode: true,
+};
+
+test.describe('OAuthCallbackController', () => {
+	let api;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test.describe('POST /oauth/state', () => {
+		test('returns 401 for unauthenticated requests', async () => {
+			const res = await api.post(STATE_ENDPOINT);
+			expect(res.status()).toBe(401);
+		});
+
+		test('returns a state string for an authenticated admin', async () => {
+			const res = await api.post(STATE_ENDPOINT, {
+				headers: adminAuth(),
+			});
+			expect(res.status()).toBe(200);
+			const body = await res.json();
+			expect(typeof body.state).toBe('string');
+			expect(body.state.length).toBeGreaterThan(0);
+		});
+	});
+
+	test.describe('POST /oauth/callback', () => {
+		test('returns 401 for unauthenticated requests', async () => {
+			const res = await api.post(CALLBACK_ENDPOINT, {
+				data: { state: 'x', ...VALID_TOKENS },
+			});
+			expect(res.status()).toBe(401);
+		});
+
+		test('returns 403 when state is missing', async () => {
+			const res = await api.post(CALLBACK_ENDPOINT, {
+				headers: adminAuth(),
+				data: VALID_TOKENS,
+			});
+			expect(res.status()).toBe(400); // missing required param
+		});
+
+		test('returns 403 when state does not match the stored transient', async () => {
+			const res = await api.post(CALLBACK_ENDPOINT, {
+				headers: adminAuth(),
+				data: { state: 'wrong_state', ...VALID_TOKENS },
+			});
+			expect(res.status()).toBe(403);
+			const body = await res.json();
+			expect(body.code).toBe('invalid_oauth_state');
+		});
+
+		test('saves credentials and returns success when state is valid', async () => {
+			// Step 1: get a real state token
+			const stateRes = await api.post(STATE_ENDPOINT, {
+				headers: adminAuth(),
+			});
+			expect(stateRes.status()).toBe(200);
+			const { state } = await stateRes.json();
+
+			// Step 2: complete callback with that state
+			const callbackRes = await api.post(CALLBACK_ENDPOINT, {
+				headers: adminAuth(),
+				data: { state, ...VALID_TOKENS },
+			});
+			expect(callbackRes.status()).toBe(200);
+			const body = await callbackRes.json();
+			expect(body.success).toBe(true);
+		});
+
+		test('rejects a replayed state (single-use)', async () => {
+			// Step 1: generate state
+			const stateRes = await api.post(STATE_ENDPOINT, {
+				headers: adminAuth(),
+			});
+			const { state } = await stateRes.json();
+
+			// Step 2: first use — should succeed
+			const first = await api.post(CALLBACK_ENDPOINT, {
+				headers: adminAuth(),
+				data: { state, ...VALID_TOKENS },
+			});
+			expect(first.status()).toBe(200);
+
+			// Step 3: replay — must be rejected
+			const second = await api.post(CALLBACK_ENDPOINT, {
+				headers: adminAuth(),
+				data: { state, ...VALID_TOKENS },
+			});
+			expect(second.status()).toBe(403);
+			const body = await second.json();
+			expect(body.code).toBe('invalid_oauth_state');
+		});
+	});
+});

--- a/fair-payments-connector/src/Admin/settings/ConnectionTab.js
+++ b/fair-payments-connector/src/Admin/settings/ConnectionTab.js
@@ -19,6 +19,7 @@ import {
 	loadConnectionSettings,
 	saveSettings,
 	testConnection,
+	fetchOAuthState,
 } from './settings-api';
 
 /**
@@ -97,25 +98,38 @@ export default function ConnectionTab({ onNotice, shouldReload }) {
 	}, [shouldReload]);
 
 	/**
-	 * Handle Connect button click
+	 * Handle Connect button click — fetches a CSRF state token first, then redirects.
 	 */
 	const handleConnect = () => {
-		const siteId = btoa(window.location.hostname);
-		const returnUrl =
-			window.location.href.split('?')[0] +
-			'?page=fair-payments-connector-settings';
-		const siteName = document.title;
-		const siteUrl = window.location.origin;
+		fetchOAuthState()
+			.then((state) => {
+				const siteId = btoa(window.location.hostname);
+				const returnUrl =
+					window.location.href.split('?')[0] +
+					'?page=fair-payments-connector-settings';
+				const siteName = document.title;
+				const siteUrl = window.location.origin;
 
-		const authorizeUrl = new URL(
-			'https://fair-event-plugins.com/oauth/authorize'
-		);
-		authorizeUrl.searchParams.set('site_id', siteId);
-		authorizeUrl.searchParams.set('return_url', returnUrl);
-		authorizeUrl.searchParams.set('site_name', siteName);
-		authorizeUrl.searchParams.set('site_url', siteUrl);
+				const authorizeUrl = new URL(
+					'https://fair-event-plugins.com/oauth/authorize'
+				);
+				authorizeUrl.searchParams.set('site_id', siteId);
+				authorizeUrl.searchParams.set('return_url', returnUrl);
+				authorizeUrl.searchParams.set('site_name', siteName);
+				authorizeUrl.searchParams.set('site_url', siteUrl);
+				authorizeUrl.searchParams.set('state', state);
 
-		window.location.href = authorizeUrl.toString();
+				window.location.href = authorizeUrl.toString();
+			})
+			.catch(() => {
+				onNotice({
+					status: 'error',
+					message: __(
+						'Failed to initiate Mollie connection. Please try again.',
+						'fair-payments-connector'
+					),
+				});
+			});
 	};
 
 	/**

--- a/fair-payments-connector/src/Admin/settings/SettingsApp.js
+++ b/fair-payments-connector/src/Admin/settings/SettingsApp.js
@@ -11,7 +11,7 @@ import { Notice, TabPanel } from '@wordpress/components';
 import ConnectionTab from './ConnectionTab';
 import FeaturesTab from './FeaturesTab.js';
 import PaymentMethodsTab from './PaymentMethodsTab.js';
-import { saveSettings } from './settings-api';
+import { saveOAuthCallback } from './settings-api';
 
 /**
  * Settings App Component
@@ -37,25 +37,8 @@ export default function SettingsApp() {
 		const orgId = params.get('mollie_organization_id');
 		const profileId = params.get('mollie_profile_id');
 		const testMode = params.get('mollie_test_mode');
+		const state = params.get('state');
 		const error = params.get('error');
-
-		// Debug: Log received OAuth parameters
-		if (accessToken || refreshToken || error) {
-			console.log(
-				'[Fair Payments Connector OAuth] Callback parameters:',
-				{
-					hasAccessToken: !!accessToken,
-					accessTokenLength: accessToken ? accessToken.length : 0,
-					hasRefreshToken: !!refreshToken,
-					refreshTokenLength: refreshToken ? refreshToken.length : 0,
-					expiresIn,
-					orgId,
-					profileId,
-					testMode,
-					error,
-				}
-			);
-		}
 
 		// Handle OAuth errors
 		if (error === 'access_denied') {
@@ -76,33 +59,40 @@ export default function SettingsApp() {
 			return;
 		}
 
-		// Handle successful OAuth callback
+		if (accessToken && !refreshToken) {
+			setNotice({
+				status: 'warning',
+				message: __(
+					'OAuth callback incomplete: refresh token not received from authorization server.',
+					'fair-payments-connector'
+				),
+			});
+			return;
+		}
+
+		// Handle successful OAuth callback — validate state server-side before saving.
 		if (accessToken && refreshToken) {
-			const settingsData = {
-				fair_payment_mollie_access_token: accessToken,
-				fair_payment_mollie_refresh_token: refreshToken,
-				fair_payment_mollie_token_expires:
-					Math.floor(Date.now() / 1000) + parseInt(expiresIn),
-				fair_payment_organization_id: orgId || '',
-				fair_payment_mollie_profile_id: profileId || '',
-				fair_payment_mollie_connected: true,
-				fair_payment_mode: testMode === '1' ? 'test' : 'live',
-			};
+			if (!state) {
+				setNotice({
+					status: 'error',
+					message: __(
+						'OAuth callback is missing the state parameter. Please try connecting again.',
+						'fair-payments-connector'
+					),
+				});
+				return;
+			}
 
-			// Debug: Log data being sent to API
-			console.log(
-				'[Fair Payments Connector OAuth] Saving settings:',
-				settingsData
-			);
-
-			saveSettings(settingsData)
-				.then((response) => {
-					// Debug: Log successful save
-					console.log(
-						'[Fair Payments Connector OAuth] Settings saved successfully:',
-						response
-					);
-
+			saveOAuthCallback({
+				state,
+				access_token: accessToken,
+				refresh_token: refreshToken,
+				expires_in: parseInt(expiresIn, 10) || 0,
+				organization_id: orgId || '',
+				profile_id: profileId || '',
+				test_mode: testMode === '1',
+			})
+				.then(() => {
 					// Clean URL (remove tokens from address bar)
 					window.history.replaceState(
 						{},
@@ -122,39 +112,16 @@ export default function SettingsApp() {
 						),
 					});
 				})
-				.catch((error) => {
-					// Debug: Log API error
-					console.error(
-						'[Fair Payments Connector OAuth] Save error:',
-						error
-					);
-					console.error(
-						'[Fair Payments Connector OAuth] Error details:',
-						error.message,
-						error.data
-					);
-
+				.catch((err) => {
 					setNotice({
 						status: 'error',
 						message:
 							__(
 								'Failed to save OAuth tokens: ',
 								'fair-payments-connector'
-							) + (error.message || 'Unknown error'),
+							) + (err.message || 'Unknown error'),
 					});
 				});
-		} else if (accessToken && !refreshToken) {
-			// Debug: Access token received but no refresh token
-			console.warn(
-				'[Fair Payments Connector OAuth] Access token received but refresh token is missing!'
-			);
-			setNotice({
-				status: 'warning',
-				message: __(
-					'OAuth callback incomplete: refresh token not received from authorization server.',
-					'fair-payments-connector'
-				),
-			});
 		}
 	}, []);
 

--- a/fair-payments-connector/src/Admin/settings/settings-api.js
+++ b/fair-payments-connector/src/Admin/settings/settings-api.js
@@ -46,6 +46,32 @@ export function saveSettings(data) {
 }
 
 /**
+ * Generate and retrieve a one-time OAuth state token from the server.
+ *
+ * @return {Promise<string>} Promise resolving to the state string
+ */
+export function fetchOAuthState() {
+	return apiFetch({
+		path: '/fair-payments-connector/v1/oauth/state',
+		method: 'POST',
+	}).then((response) => response.state);
+}
+
+/**
+ * Complete OAuth callback: validate state server-side and persist credentials.
+ *
+ * @param {Object} data Callback payload (state + token fields)
+ * @return {Promise<Object>} Promise resolving to the API response
+ */
+export function saveOAuthCallback(data) {
+	return apiFetch({
+		path: '/fair-payments-connector/v1/oauth/callback',
+		method: 'POST',
+		data,
+	});
+}
+
+/**
  * Test Mollie connection and trigger token refresh if needed
  *
  * @return {Promise<Object>} Promise resolving to connection test result


### PR DESCRIPTION
Closes #845.

## Summary

- Added `OAuthCallbackController` with two new endpoints:
  - `POST /fair-payments-connector/v1/oauth/state` — generates a 32-char random state, stores it in a user-scoped transient (5-min TTL), and returns it to the client
  - `POST /fair-payments-connector/v1/oauth/callback` — validates the state against the transient (single-use, deleted before any branching), then writes OAuth credentials; returns 403 on mismatch
- `ConnectionTab.js` now fetches the state server-side before building the Mollie authorization URL and appends `state=…` to it
- `SettingsApp.js` OAuth callback handler now POSTs tokens + state to `/fair-payments-connector/v1/oauth/callback` instead of directly to `/wp/v2/settings`; rejects the callback early if `state` is absent
- `settings-api.js` gets two new helpers: `fetchOAuthState()` and `saveOAuthCallback()`
- API spec tests cover: unauthenticated access (401), wrong/missing state (400/403), valid round-trip (200), and replay rejection

## Test plan

- [ ] Legitimate OAuth flow: click Connect → redirects to Mollie with `state` param → Mollie redirects back → credentials saved, success notice shown
- [ ] Crafted URL attack: manually open `?mollie_access_token=ATTACKER&mollie_refresh_token=X&expires_in=3600&state=wrong` as admin → 403 from callback endpoint, credentials not overwritten
- [ ] No state in URL: manually open callback URL without `state` param → error notice, no save attempted
- [ ] Replay: use a valid state twice → second attempt returns 403
- [ ] API spec: `npm run test:api` passes for `OAuthCallbackController.api.spec.js`