### PR TITLE
fix(fair-payments-connector): protect public payment endpoint with block nonce and server-side amount floor

### DIFF
--- a/fair-payments-connector/src/API/PaymentEndpoint.php
+++ b/fair-payments-connector/src/API/PaymentEndpoint.php
@@ -45,6 +45,19 @@ class PaymentEndpoint extends WP_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
+			'/nonce',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_nonce' ),
+					// Public — generates a nonce for anonymous payment forms; reads no data.
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base,
 			array(
 				array(
@@ -73,6 +86,16 @@ class PaymentEndpoint extends WP_REST_Controller {
 							'required'          => false,
 							'type'              => 'integer',
 							'sanitize_callback' => 'absint',
+						),
+						'block_id'    => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'nonce'       => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
 				),
@@ -108,6 +131,37 @@ class PaymentEndpoint extends WP_REST_Controller {
 	}
 
 	/**
+	 * Return a fresh nonce for the payment form.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_nonce() {
+		return new WP_REST_Response( array( 'nonce' => wp_create_nonce( 'fpc_payment_form' ) ) );
+	}
+
+	/**
+	 * Find a block in a parsed block tree by its blockId attribute.
+	 *
+	 * @param array  $blocks   Parsed blocks array.
+	 * @param string $block_id UUID to search for.
+	 * @return array|null Matching block or null.
+	 */
+	private function find_block_by_id( array $blocks, string $block_id ): ?array {
+		foreach ( $blocks as $block ) {
+			if ( isset( $block['attrs']['blockId'] ) && $block['attrs']['blockId'] === $block_id ) {
+				return $block;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$found = $this->find_block_by_id( $block['innerBlocks'], $block_id );
+				if ( null !== $found ) {
+					return $found;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Create a new payment
 	 *
 	 * @param WP_REST_Request $request Request object.
@@ -119,12 +173,57 @@ class PaymentEndpoint extends WP_REST_Controller {
 		// - Anonymous users: Require email.
 		// See: REST_API_BACKEND.md for implementation guidance.
 
+		// Manual nonce check — apiFetch nonce auto-verification only applies to authenticated
+		// requests; public endpoints must verify manually. See REST_API_BACKEND.md.
+		if ( ! wp_verify_nonce( $request->get_param( 'nonce' ), 'fpc_payment_form' ) ) {
+			return new WP_Error(
+				'invalid_nonce',
+				__( 'Invalid request.', 'fair-payments-connector' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		$logger = new PaymentLogRepository();
 
-		$amount      = $request->get_param( 'amount' );
 		$currency    = $request->get_param( 'currency' );
 		$description = $request->get_param( 'description' );
 		$post_id     = $request->get_param( 'post_id' );
+		$block_id    = $request->get_param( 'block_id' );
+
+		// Derive authoritative amount from saved block content.
+		$post = $post_id ? get_post( $post_id ) : null;
+		if ( ! $post ) {
+			return new WP_Error(
+				'invalid_block',
+				__( 'Block not found.', 'fair-payments-connector' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$blocks        = parse_blocks( $post->post_content );
+		$matched_block = $this->find_block_by_id( $blocks, $block_id );
+
+		if ( ! $matched_block ) {
+			return new WP_Error(
+				'invalid_block',
+				__( 'Block not found.', 'fair-payments-connector' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$expected_amount  = floatval( $matched_block['attrs']['amount'] ?? 0 );
+		$submitted_amount = floatval( $request->get_param( 'amount' ) );
+
+		if ( $submitted_amount < $expected_amount ) {
+			return new WP_Error(
+				'amount_too_low',
+				__( 'Amount does not match block configuration.', 'fair-payments-connector' ),
+				array( 'status' => 422 )
+			);
+		}
+
+		// Use the server-derived amount, not the client value.
+		$amount = (string) $expected_amount;
 
 		$logger->log(
 			'payment_creation_started',

--- a/fair-payments-connector/src/API/__tests__/PaymentEndpoint.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/PaymentEndpoint.api.spec.js
@@ -1,0 +1,90 @@
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const NONCE_ENDPOINT = '/wp-json/fair-payments-connector/v1/nonce';
+const PAYMENTS_ENDPOINT = '/wp-json/fair-payments-connector/v1/payments';
+
+test.describe('PaymentEndpoint — GET /nonce', () => {
+	let api;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test('returns a nonce string', async () => {
+		const res = await api.get(NONCE_ENDPOINT);
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(typeof body.nonce).toBe('string');
+		expect(body.nonce.length).toBeGreaterThan(0);
+	});
+});
+
+test.describe('PaymentEndpoint — POST /payments security checks', () => {
+	let api;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test('returns 400 when nonce param is missing', async () => {
+		const res = await api.post(PAYMENTS_ENDPOINT, {
+			data: {
+				amount: '10',
+				currency: 'EUR',
+				block_id: 'some-block-id',
+			},
+		});
+		expect(res.status()).toBe(400);
+	});
+
+	test('returns 403 for an invalid nonce', async () => {
+		const res = await api.post(PAYMENTS_ENDPOINT, {
+			data: {
+				amount: '10',
+				currency: 'EUR',
+				block_id: 'some-block-id',
+				nonce: 'invalid_nonce_value',
+			},
+		});
+		expect(res.status()).toBe(403);
+		const body = await res.json();
+		expect(body.code).toBe('invalid_nonce');
+	});
+
+	test('returns 400 when block_id param is missing', async () => {
+		const res = await api.post(PAYMENTS_ENDPOINT, {
+			data: {
+				amount: '10',
+				currency: 'EUR',
+				nonce: 'some_nonce',
+			},
+		});
+		expect(res.status()).toBe(400);
+	});
+
+	test('returns 403 for a valid nonce but missing post_id', async () => {
+		const nonceRes = await api.get(NONCE_ENDPOINT);
+		const { nonce } = await nonceRes.json();
+
+		const res = await api.post(PAYMENTS_ENDPOINT, {
+			data: {
+				amount: '10',
+				currency: 'EUR',
+				block_id: 'non-existent-block-id',
+				nonce,
+			},
+		});
+		expect(res.status()).toBe(403);
+		const body = await res.json();
+		expect(body.code).toBe('invalid_block');
+	});
+});

--- a/fair-payments-connector/src/blocks/simple-payment/block.json
+++ b/fair-payments-connector/src/blocks/simple-payment/block.json
@@ -12,6 +12,10 @@
 	"render": "file:./render.php",
 	"viewScript": "file:./view.js",
 	"attributes": {
+		"blockId": {
+			"type": "string",
+			"default": ""
+		},
 		"amount": {
 			"type": "string",
 			"default": "10"

--- a/fair-payments-connector/src/blocks/simple-payment/index.js
+++ b/fair-payments-connector/src/blocks/simple-payment/index.js
@@ -5,6 +5,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
 import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Block metadata
@@ -25,7 +26,13 @@ registerBlockType(metadata.name, {
 	 */
 	edit: ({ attributes, setAttributes }) => {
 		const blockProps = useBlockProps();
-		const { amount, currency, description } = attributes;
+		const { blockId, amount, currency, description } = attributes;
+
+		useEffect(() => {
+			if (!blockId) {
+				setAttributes({ blockId: crypto.randomUUID() });
+			}
+		}, []);
 
 		return (
 			<div {...blockProps}>

--- a/fair-payments-connector/src/blocks/simple-payment/render.php
+++ b/fair-payments-connector/src/blocks/simple-payment/render.php
@@ -11,6 +11,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
+$block_id        = isset( $attributes['blockId'] ) ? $attributes['blockId'] : '';
 $amount          = isset( $attributes['amount'] ) ? $attributes['amount'] : '10';
 $currency        = isset( $attributes['currency'] ) ? $attributes['currency'] : 'EUR';
 $description     = isset( $attributes['description'] ) ? $attributes['description'] : '';
@@ -66,6 +67,7 @@ $block_id = 'fair-payments-connector-' . wp_unique_id();
 					data-currency="<?php echo esc_attr( $currency ); ?>"
 					data-description="<?php echo esc_attr( $description ); ?>"
 					data-post-id="<?php echo esc_attr( $current_post_id ); ?>"
+					data-block-id="<?php echo esc_attr( $block_id ); ?>"
 				>
 					<?php esc_html_e( 'Pay Now', 'fair-payments-connector' ); ?>
 				</button>

--- a/fair-payments-connector/src/blocks/simple-payment/view.js
+++ b/fair-payments-connector/src/blocks/simple-payment/view.js
@@ -27,7 +27,15 @@ import apiFetch from '@wordpress/api-fetch';
 		);
 
 		buttons.forEach(function (button) {
-			button.addEventListener('click', handlePaymentClick);
+			// Fetch a fresh nonce per button instance on page load so cached pages
+			// don't embed a stale nonce in static HTML.
+			const noncePromise = apiFetch({
+				path: '/fair-payments-connector/v1/nonce',
+			}).then((res) => res.nonce);
+
+			button.addEventListener('click', (event) =>
+				handlePaymentClick(event, noncePromise)
+			);
 		});
 	}
 
@@ -55,7 +63,7 @@ import apiFetch from '@wordpress/api-fetch';
 		window.history.replaceState({}, '', url.toString());
 	}
 
-	async function handlePaymentClick(event) {
+	async function handlePaymentClick(event, noncePromise) {
 		const button = event.target;
 		const paymentBlock = button.closest('.fair-payments-connector-block');
 		const loadingEl = paymentBlock.querySelector(
@@ -70,6 +78,7 @@ import apiFetch from '@wordpress/api-fetch';
 		const currency = button.getAttribute('data-currency');
 		const description = button.getAttribute('data-description');
 		const postId = button.getAttribute('data-post-id');
+		const blockId = button.getAttribute('data-block-id');
 
 		// Hide error, show loading
 		if (errorEl) {
@@ -81,6 +90,8 @@ import apiFetch from '@wordpress/api-fetch';
 		button.disabled = true;
 
 		try {
+			const nonce = await noncePromise;
+
 			// Create payment via REST API using WordPress apiFetch
 			const data = await apiFetch({
 				path: '/fair-payments-connector/v1/payments',
@@ -90,6 +101,8 @@ import apiFetch from '@wordpress/api-fetch';
 					currency: currency,
 					description: description,
 					post_id: postId,
+					block_id: blockId,
+					nonce: nonce,
 				},
 			});
 


### PR DESCRIPTION
Closes #846.

## Summary

- **`GET /nonce` endpoint** — new public endpoint that returns a fresh `wp_create_nonce('fpc_payment_form')` value; fetched on page load so cached pages never embed a stale nonce in static HTML
- **`blockId` attribute** — added to `block.json`; auto-generated as a UUID on first editor insert (`useEffect` in `index.js`) and persisted in post content
- **`render.php`** — emits `data-block-id` on the Pay Now button
- **`view.js`** — fetches the nonce eagerly per button on page load; passes `block_id` and `nonce` in the POST body
- **`PaymentEndpoint.php`** — verifies the nonce before any other logic (403 on failure); resolves the authoritative amount from `parse_blocks()` by matching `blockId` (403 if post or block not found); rejects requests where the submitted amount is below the block-configured floor (422); creates the Mollie transaction using the server-derived amount, not the client value

## Test plan

- [ ] `POST` without a nonce param returns 400
- [ ] `POST` with an invalid nonce returns 403 (`invalid_nonce`)
- [ ] `POST` with a valid nonce but no matching block returns 403 (`invalid_block`)
- [ ] `POST` with a below-minimum amount returns 422 (`amount_too_low`)
- [ ] Legitimate submission (fresh nonce + correct `post_id` + `block_id`) succeeds and transaction amount equals block-configured value
- [ ] API spec tests in `PaymentEndpoint.api.spec.js` pass against a live WP environment