### PR TITLE
Add site-wide currency setting to fair-payments-connector

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -855,7 +855,7 @@ class EventSignupController extends WP_REST_Controller {
 		$transaction_id = \FairPaymentsConnector\API\TransactionAPI::create_transaction(
 			$line_items,
 			array(
-				'currency'      => 'EUR',
+				'currency'      => get_option( 'fair_payment_currency', 'EUR' ),
 				'description'   => $description,
 				'post_id'       => $event_id,
 				'event_date_id' => $event_date_id,
@@ -905,7 +905,7 @@ class EventSignupController extends WP_REST_Controller {
 				'checkout_url'   => $payment['checkout_url'],
 				'transaction_id' => $transaction_id,
 				'amount'         => $total_amount,
-				'currency'       => 'EUR',
+				'currency'       => get_option( 'fair_payment_currency', 'EUR' ),
 			)
 		);
 	}
@@ -1503,7 +1503,7 @@ class EventSignupController extends WP_REST_Controller {
 		$transaction_id = \FairPaymentsConnector\API\TransactionAPI::create_transaction(
 			$line_items,
 			array(
-				'currency'      => 'EUR',
+				'currency'      => get_option( 'fair_payment_currency', 'EUR' ),
 				'description'   => $line_item_description,
 				'post_id'       => $event_id,
 				'event_date_id' => $event_date_id,
@@ -1557,7 +1557,7 @@ class EventSignupController extends WP_REST_Controller {
 				'checkout_url'   => $payment['checkout_url'],
 				'transaction_id' => $transaction_id,
 				'amount'         => $total_amount,
-				'currency'       => 'EUR',
+				'currency'       => get_option( 'fair_payment_currency', 'EUR' ),
 			)
 		);
 	}

--- a/fair-audience/src/API/FeesController.php
+++ b/fair-audience/src/API/FeesController.php
@@ -331,7 +331,7 @@ class FeesController extends WP_REST_Controller {
 				'description' => $request->get_param( 'description' ) ?? '',
 				'group_id'    => $group_id,
 				'amount'      => $amount,
-				'currency'    => $request->get_param( 'currency' ) ?? 'EUR',
+				'currency'    => $request->get_param( 'currency' ) ?? get_option( 'fair_payment_currency', 'EUR' ),
 				'budget_id'   => $budget_id,
 				'due_date'    => $request->get_param( 'due_date' ) ?? '',
 				'status'      => $request->get_param( 'status' ) ?? 'active',

--- a/fair-audience/src/Admin/AdminHooks.php
+++ b/fair-audience/src/Admin/AdminHooks.php
@@ -621,6 +621,13 @@ class AdminHooks {
 		// Fee Detail page.
 		if ( 'admin_page_fair-audience-fee-detail' === $hook ) {
 			$this->enqueue_page_script( 'fee-detail', $plugin_dir );
+			wp_localize_script(
+				'fair-audience-fee-detail',
+				'fairPaymentsConnector',
+				array(
+					'currency' => get_option( 'fair_payment_currency', 'EUR' ),
+				)
+			);
 		}
 
 		// Submission Detail page.

--- a/fair-audience/src/Admin/fee-detail/FeeDetail.js
+++ b/fair-audience/src/Admin/fee-detail/FeeDetail.js
@@ -1039,7 +1039,11 @@ export default function FeeDetail() {
 													{parseFloat(
 														entry.amount
 													).toFixed(2)}{' '}
-													{entry.currency || 'EUR'}
+													{entry.currency ||
+														window
+															.fairPaymentsConnector
+															?.currency ||
+														'EUR'}
 												</>
 											)}
 										</div>

--- a/fair-audience/src/Models/Fee.php
+++ b/fair-audience/src/Models/Fee.php
@@ -120,7 +120,7 @@ class Fee {
 		$this->description = isset( $data['description'] ) ? sanitize_textarea_field( $data['description'] ) : '';
 		$this->group_id    = isset( $data['group_id'] ) ? (int) $data['group_id'] : 0;
 		$this->amount      = isset( $data['amount'] ) ? $data['amount'] : '0.00';
-		$this->currency    = isset( $data['currency'] ) ? sanitize_text_field( $data['currency'] ) : 'EUR';
+		$this->currency    = isset( $data['currency'] ) ? sanitize_text_field( $data['currency'] ) : get_option( 'fair_payment_currency', 'EUR' );
 		$this->budget_id   = isset( $data['budget_id'] ) ? ( ! empty( $data['budget_id'] ) ? (int) $data['budget_id'] : null ) : null;
 		$this->due_date    = isset( $data['due_date'] ) ? sanitize_text_field( $data['due_date'] ) : '';
 		$this->status      = isset( $data['status'] ) ? sanitize_text_field( $data['status'] ) : 'draft';

--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -326,6 +326,14 @@ class AdminPages {
 				$localized_data
 			);
 
+			wp_localize_script(
+				'fair-events-manage-event',
+				'fairPaymentsConnector',
+				array(
+					'currency' => get_option( 'fair_payment_currency', 'EUR' ),
+				)
+			);
+
 			wp_set_script_translations(
 				'fair-events-manage-event',
 				'fair-events',

--- a/fair-events/src/Admin/manage-event/EventFinance.js
+++ b/fair-events/src/Admin/manage-event/EventFinance.js
@@ -21,10 +21,12 @@ import {
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
+const siteCurrency = window.fairPaymentsConnector?.currency || 'EUR';
+
 const formatAmount = (amount) => {
 	return new Intl.NumberFormat('en-US', {
 		style: 'currency',
-		currency: 'EUR',
+		currency: siteCurrency,
 	}).format(amount);
 };
 

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -707,10 +707,12 @@ export default function EventTickets({
 		return prices[key] || { price: '', capacity: '', enabled: true };
 	};
 
+	const siteCurrency = window.fairPaymentsConnector?.currency || 'EUR';
+
 	const formatCurrency = (value) => {
 		return new Intl.NumberFormat('en-US', {
 			style: 'currency',
-			currency: 'EUR',
+			currency: siteCurrency,
 		}).format(value);
 	};
 
@@ -1253,9 +1255,13 @@ export default function EventTickets({
 							{!hasAdvancedTickets ? (
 								<VStack spacing={3}>
 									<TextControl
-										label={__(
-											'Signup price (EUR)',
-											'fair-events'
+										/* translators: %s: currency code, e.g. EUR */
+										label={sprintf(
+											__(
+												'Signup price (%s)',
+												'fair-events'
+											),
+											siteCurrency
 										)}
 										help={__(
 											'Leave empty for free signup. Group discounts (Groups tab) apply to this base price.',
@@ -1897,16 +1903,25 @@ export default function EventTickets({
 													{__('Name', 'fair-events')}
 												</th>
 												<th>
-													{__(
-														'Price (EUR)',
-														'fair-events'
+													{/* translators: %s: currency code */}
+													{sprintf(
+														__(
+															'Price (%s)',
+															'fair-events'
+														),
+														siteCurrency
 													)}
 												</th>
 												{settings.activity_collaborator_discount && (
 													<th>
-														{__(
-															'Discounted price (EUR)',
-															'fair-events'
+														{/* translators: %s: currency code */}
+														{sprintf(
+															__(
+																'Discounted price (%s)',
+																'fair-events'
+															),
+															siteCurrency
+														)}
 														)}
 													</th>
 												)}

--- a/fair-events/src/Admin/manage-event/GroupRules.js
+++ b/fair-events/src/Admin/manage-event/GroupRules.js
@@ -37,13 +37,15 @@ const discountTypeOptions = [
 	},
 ];
 
+const siteCurrency = window.fairPaymentsConnector?.currency || 'EUR';
+
 const formatDiscount = (type, value) => {
 	if (type === 'percentage') {
 		return `${value}%`;
 	}
 	return new Intl.NumberFormat('en-US', {
 		style: 'currency',
-		currency: 'EUR',
+		currency: siteCurrency,
 	}).format(value);
 };
 

--- a/fair-payments-connector/src/API/PaymentEndpoint.php
+++ b/fair-payments-connector/src/API/PaymentEndpoint.php
@@ -73,7 +73,7 @@ class PaymentEndpoint extends WP_REST_Controller {
 						'currency'    => array(
 							'required'          => false,
 							'type'              => 'string',
-							'default'           => 'EUR',
+							'default'           => get_option( 'fair_payment_currency', 'EUR' ),
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'description' => array(

--- a/fair-payments-connector/src/Admin/AdminPages.php
+++ b/fair-payments-connector/src/Admin/AdminPages.php
@@ -124,6 +124,13 @@ class AdminPages {
 		// Fee Dashboard page.
 		if ( false !== strpos( $hook, 'fair-payments-connector-fee-dashboard' ) ) {
 			$this->enqueue_admin_page_script( 'fee-dashboard' );
+			wp_localize_script(
+				'fair-payments-connector-fee-dashboard',
+				'fairPaymentsConnector',
+				array(
+					'currency' => get_option( 'fair_payment_currency', 'EUR' ),
+				)
+			);
 			return;
 		}
 

--- a/fair-payments-connector/src/Admin/fee-dashboard/FeeDashboardApp.js
+++ b/fair-payments-connector/src/Admin/fee-dashboard/FeeDashboardApp.js
@@ -14,10 +14,12 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 
+const siteCurrency = window.fairPaymentsConnector?.currency || 'EUR';
+
 const formatEur = (amount) =>
 	new Intl.NumberFormat('de-DE', {
 		style: 'currency',
-		currency: 'EUR',
+		currency: siteCurrency,
 	}).format(amount ?? 0);
 
 const ProgressBar = ({ value, max }) => {

--- a/fair-payments-connector/src/Admin/settings/CurrencyTab.js
+++ b/fair-payments-connector/src/Admin/settings/CurrencyTab.js
@@ -1,0 +1,130 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import {
+	Card,
+	CardBody,
+	SelectControl,
+	Button,
+	Spinner,
+} from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { saveSettings } from './settings-api.js';
+
+const SUPPORTED_CURRENCIES = [
+	{ label: 'EUR — Euro', value: 'EUR' },
+	{ label: 'USD — US Dollar', value: 'USD' },
+	{ label: 'GBP — British Pound', value: 'GBP' },
+	{ label: 'CHF — Swiss Franc', value: 'CHF' },
+	{ label: 'DKK — Danish Krone', value: 'DKK' },
+	{ label: 'NOK — Norwegian Krone', value: 'NOK' },
+	{ label: 'SEK — Swedish Krona', value: 'SEK' },
+	{ label: 'PLN — Polish Złoty', value: 'PLN' },
+	{ label: 'CZK — Czech Koruna', value: 'CZK' },
+	{ label: 'HUF — Hungarian Forint', value: 'HUF' },
+];
+
+/**
+ * Currency Tab Component
+ *
+ * Lets the admin set the site-wide default currency for all new transactions.
+ *
+ * @param {Object}   props          Props
+ * @param {Function} props.onNotice Handler for displaying notices
+ * @return {JSX.Element} The currency tab
+ */
+export default function CurrencyTab({ onNotice }) {
+	const [currency, setCurrency] = useState('EUR');
+	const [loading, setLoading] = useState(true);
+	const [isSaving, setIsSaving] = useState(false);
+
+	useEffect(() => {
+		apiFetch({ path: '/wp/v2/settings' })
+			.then((settings) => {
+				setCurrency(settings.fair_payment_currency || 'EUR');
+				setLoading(false);
+			})
+			.catch((err) => {
+				onNotice({
+					status: 'error',
+					message:
+						err.message ||
+						__(
+							'Failed to load currency settings.',
+							'fair-payments-connector'
+						),
+				});
+				setLoading(false);
+			});
+	}, []);
+
+	const handleSave = async () => {
+		setIsSaving(true);
+		try {
+			await saveSettings({ fair_payment_currency: currency });
+			onNotice({
+				status: 'success',
+				message: __(
+					'Currency settings saved.',
+					'fair-payments-connector'
+				),
+			});
+		} catch (err) {
+			onNotice({
+				status: 'error',
+				message:
+					err.message ||
+					__(
+						'Failed to save currency settings.',
+						'fair-payments-connector'
+					),
+			});
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	if (loading) {
+		return <Spinner />;
+	}
+
+	return (
+		<Card>
+			<CardBody>
+				<h2>{__('Default Currency', 'fair-payments-connector')}</h2>
+				<p style={{ color: '#666', marginBottom: '1rem' }}>
+					{__(
+						'Set the default currency for all new transactions. Existing transaction records are not affected.',
+						'fair-payments-connector'
+					)}
+				</p>
+
+				<div style={{ maxWidth: '320px' }}>
+					<SelectControl
+						label={__('Site currency', 'fair-payments-connector')}
+						value={currency}
+						options={SUPPORTED_CURRENCIES}
+						onChange={setCurrency}
+					/>
+				</div>
+
+				<div style={{ marginTop: '16px' }}>
+					<Button
+						variant="primary"
+						onClick={handleSave}
+						isBusy={isSaving}
+						disabled={isSaving}
+					>
+						{__('Save', 'fair-payments-connector')}
+					</Button>
+				</div>
+			</CardBody>
+		</Card>
+	);
+}

--- a/fair-payments-connector/src/Admin/settings/SettingsApp.js
+++ b/fair-payments-connector/src/Admin/settings/SettingsApp.js
@@ -9,6 +9,7 @@ import { Notice, TabPanel } from '@wordpress/components';
  * Internal dependencies
  */
 import ConnectionTab from './ConnectionTab';
+import CurrencyTab from './CurrencyTab.js';
 import FeaturesTab from './FeaturesTab.js';
 import PaymentMethodsTab from './PaymentMethodsTab.js';
 import { saveOAuthCallback } from './settings-api';
@@ -192,6 +193,10 @@ export default function SettingsApp() {
 						name: 'payment-methods',
 						title: __('Payment Methods', 'fair-payments-connector'),
 					},
+					{
+						name: 'currency',
+						title: __('Currency', 'fair-payments-connector'),
+					},
 				]}
 				onSelect={handleTabSelect}
 			>
@@ -208,6 +213,9 @@ export default function SettingsApp() {
 						)}
 						{tab.name === 'payment-methods' && (
 							<PaymentMethodsTab onNotice={setNotice} />
+						)}
+						{tab.name === 'currency' && (
+							<CurrencyTab onNotice={setNotice} />
 						)}
 					</div>
 				)}

--- a/fair-payments-connector/src/Core/Plugin.php
+++ b/fair-payments-connector/src/Core/Plugin.php
@@ -50,6 +50,7 @@ class Plugin {
 		);
 
 		add_action( 'init', array( $this, 'register_blocks' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'localize_block_editor_data' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_callback_script' ) );
 
 		// Initialize REST API hooks.
@@ -61,6 +62,22 @@ class Plugin {
 		$this->load_admin();
 		$this->load_settings();
 		$this->load_migration_notice();
+	}
+
+	/**
+	 * Expose site-wide payment settings to the block editor via a JS global.
+	 *
+	 * Allows block editor scripts to read the configured currency without an
+	 * extra REST round-trip (e.g. to seed the simple-payment block default).
+	 *
+	 * @return void
+	 */
+	public function localize_block_editor_data() {
+		wp_add_inline_script(
+			'fair-payment-simple-payment-editor-script',
+			'window.fairPaymentsConnector = window.fairPaymentsConnector || {}; window.fairPaymentsConnector.currency = ' . wp_json_encode( get_option( 'fair_payment_currency', 'EUR' ) ) . ';',
+			'before'
+		);
 	}
 
 	/**

--- a/fair-payments-connector/src/Database/Schema.php
+++ b/fair-payments-connector/src/Database/Schema.php
@@ -163,9 +163,10 @@ class Schema {
 		self::migrate_to_v18();
 		self::migrate_to_v19();
 		self::migrate_to_v20();
+		self::migrate_to_v21();
 
 		// Store database version for future migrations.
-		update_option( 'fair_payment_db_version', '20.0' );
+		update_option( 'fair_payment_db_version', '21.0' );
 	}
 
 	/**
@@ -1121,6 +1122,23 @@ class Schema {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Migrate database from v20.0 to v21.0
+	 *
+	 * Bookkeeping migration for the introduction of the fair_payment_currency
+	 * site setting. No schema change is needed — the currency column already
+	 * exists on the transactions table and existing rows correctly store 'EUR',
+	 * the only value that was ever written. This migration simply records the
+	 * version bump so future migrations can gate on it.
+	 *
+	 * @return void
+	 */
+	public static function migrate_to_v21() {
+		// No schema changes required — the currency column exists since the initial
+		// schema and existing rows correctly store 'EUR'. The fair_payment_currency
+		// site option now drives the default for all new transactions.
 	}
 
 	/**

--- a/fair-payments-connector/src/Models/Transaction.php
+++ b/fair-payments-connector/src/Models/Transaction.php
@@ -36,7 +36,7 @@ class Transaction {
 			'user_id'           => get_current_user_id(),
 			'participant_id'    => null,
 			'amount'            => 0,
-			'currency'          => 'EUR',
+			'currency'          => get_option( 'fair_payment_currency', 'EUR' ),
 			'status'            => 'draft',
 			'testmode'          => $testmode,
 			'description'       => '',
@@ -121,7 +121,7 @@ class Transaction {
 
 		$row = array(
 			'amount'          => isset( $data['amount'] ) ? (float) $data['amount'] : 0,
-			'currency'        => ! empty( $data['currency'] ) ? (string) $data['currency'] : 'EUR',
+			'currency'        => ! empty( $data['currency'] ) ? (string) $data['currency'] : get_option( 'fair_payment_currency', 'EUR' ),
 			'mollie_fee'      => isset( $data['mollie_fee'] ) && null !== $data['mollie_fee'] ? (float) $data['mollie_fee'] : null,
 			'application_fee' => isset( $data['application_fee'] ) && null !== $data['application_fee'] ? (float) $data['application_fee'] : null,
 			'status'          => ! empty( $data['status'] ) ? (string) $data['status'] : 'paid',

--- a/fair-payments-connector/src/Payment/MolliePaymentHandler.php
+++ b/fair-payments-connector/src/Payment/MolliePaymentHandler.php
@@ -219,7 +219,7 @@ class MolliePaymentHandler {
 	public function create_payment( $args ) {
 		$defaults = array(
 			'amount'          => '10.00',
-			'currency'        => 'EUR',
+			'currency'        => get_option( 'fair_payment_currency', 'EUR' ),
 			'application_fee' => null,
 			'description'     => __( 'Payment', 'fair-payments-connector' ),
 			'redirect_url'    => home_url(),

--- a/fair-payments-connector/src/Settings/Settings.php
+++ b/fair-payments-connector/src/Settings/Settings.php
@@ -219,6 +219,19 @@ class Settings {
 			)
 		);
 
+		// Default currency for all transactions.
+		register_setting(
+			'fair_payment_settings',
+			'fair_payment_currency',
+			array(
+				'type'              => 'string',
+				'description'       => __( 'Default currency for all transactions', 'fair-payments-connector' ),
+				'sanitize_callback' => array( $this, 'sanitize_currency' ),
+				'show_in_rest'      => true,
+				'default'           => 'EUR',
+			)
+		);
+
 		// Feature flag bundle toggles — UI state only, never overrides a
 		// wp-config constant (see Features::sanitize_option()).
 		register_setting(
@@ -257,5 +270,18 @@ class Settings {
 	 */
 	public function sanitize_mode( $value ) {
 		return in_array( $value, array( 'test', 'live' ), true ) ? $value : 'test';
+	}
+
+	/**
+	 * Sanitize currency setting
+	 *
+	 * Allowlist of ISO 4217 codes supported by Mollie.
+	 *
+	 * @param string $value Currency code.
+	 * @return string Validated currency code, or 'EUR' as fallback.
+	 */
+	public function sanitize_currency( $value ) {
+		$allowed = array( 'EUR', 'USD', 'GBP', 'CHF', 'DKK', 'NOK', 'SEK', 'PLN', 'CZK', 'HUF' );
+		return in_array( strtoupper( (string) $value ), $allowed, true ) ? strtoupper( (string) $value ) : 'EUR';
 	}
 }

--- a/fair-payments-connector/src/blocks/simple-payment/index.js
+++ b/fair-payments-connector/src/blocks/simple-payment/index.js
@@ -32,6 +32,11 @@ registerBlockType(metadata.name, {
 			if (!blockId) {
 				setAttributes({ blockId: crypto.randomUUID() });
 			}
+			if (!currency) {
+				setAttributes({
+					currency: window.fairPaymentsConnector?.currency || 'EUR',
+				});
+			}
 		}, []);
 
 		return (

--- a/fair-payments-connector/src/blocks/simple-payment/render.php
+++ b/fair-payments-connector/src/blocks/simple-payment/render.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 
 $block_id        = isset( $attributes['blockId'] ) ? $attributes['blockId'] : '';
 $amount          = isset( $attributes['amount'] ) ? $attributes['amount'] : '10';
-$currency        = isset( $attributes['currency'] ) ? $attributes['currency'] : 'EUR';
+$currency        = ! empty( $attributes['currency'] ) ? $attributes['currency'] : get_option( 'fair_payment_currency', 'EUR' );
 $description     = isset( $attributes['description'] ) ? $attributes['description'] : '';
 $current_post_id = get_the_ID();
 


### PR DESCRIPTION
## Summary

- Adds a `fair_payment_currency` WordPress option that controls the default currency for all new transactions. Previously the currency was hard-coded to `EUR` throughout the plugin.
- New **Currency** tab in the Settings admin page lets admins pick from 10 Mollie-supported ISO 4217 codes (EUR, USD, GBP, CHF, DKK, NOK, SEK, PLN, CZK, HUF).
- `window.fairPaymentsConnector.currency` is exposed via `wp_localize_script` so admin pages and the block editor can read the configured currency without an extra REST round-trip.
- Existing transaction rows are not touched — each row already stores its own `currency` value, so historical display is correct regardless of future setting changes.

Closes #842

## Test plan

- [ ] Settings → Currency tab loads, shows the current value (EUR on fresh install), allows selecting another currency, and saves successfully.
- [ ] After saving a non-EUR currency, create a payment via the simple-payment block — the new transaction's `currency` column reflects the configured currency.
- [ ] Fee Dashboard formats amounts using the configured currency symbol.
- [ ] Inserting a new simple-payment block in the editor pre-fills the Currency field with the site setting.
- [ ] Changing the currency setting does **not** alter existing transaction rows.
- [ ] PHP: `vendor/bin/phpcs` passes on all modified files.
- [ ] JS: `npm run build` in `fair-payments-connector` compiles without errors.