### PR TITLE
Fix DKK exchange rate (0.746 → 7.46)

### DIFF
--- a/fair-payments-connector/src/Services/CurrencyRates.php
+++ b/fair-payments-connector/src/Services/CurrencyRates.php
@@ -26,7 +26,7 @@ class CurrencyRates {
 		'USD' => 1.1,
 		'GBP' => 0.85,
 		'CHF' => 0.95,
-		'DKK' => 0.746,
+		'DKK' => 7.46,
 		'NOK' => 12.0,
 		'SEK' => 11.0,
 		'PLN' => 4.25,


### PR DESCRIPTION
## Summary

Corrects the DKK rate in `CurrencyRates::EUR_RATES` from `0.746` to `7.46` — it was off by a factor of 10. 1 EUR ≈ 7.46 DKK.

Closes #842