### PR TITLE
Add fair-event-icon.svg

### DIFF
--- a/images/fair-event-icon.svg
+++ b/images/fair-event-icon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+  <g transform="translate(60,60)">
+    <circle cx="0" cy="0" r="44" fill="none" stroke="#7BBF95" stroke-width="2" stroke-dasharray="3.5 4"/>
+    <g transform="rotate(0)">   <circle cx="0" cy="-54" r="6" fill="#F5EDD8"/><rect x="-5" y="-47" width="10" height="11" rx="5" fill="#F5EDD8"/></g>
+    <g transform="rotate(45)">  <circle cx="0" cy="-54" r="6" fill="#F5EDD8"/><rect x="-5" y="-47" width="10" height="11" rx="5" fill="#F5EDD8"/></g>
+    <g transform="rotate(90)">  <circle cx="0" cy="-54" r="6" fill="#7BBF95"/><rect x="-5" y="-47" width="10" height="11" rx="5" fill="#7BBF95"/></g>
+    <g transform="rotate(135)"> <circle cx="0" cy="-54" r="6" fill="#F5EDD8"/><rect x="-5" y="-47" width="10" height="11" rx="5" fill="#F5EDD8"/></g>
+    <g transform="rotate(180)"> <circle cx="0" cy="-54" r="6" fill="#7BBF95"/><rect x="-5" y="-47" width="10" height="11" rx="5" fill="#7BBF95"/></g>
+    <g transform="rotate(225)"> <circle cx="0" cy="-54" r="6" fill="#F5EDD8"/><rect x="-5" y="-47" width="10" height="11" rx="5" fill="#F5EDD8"/></g>
+    <g transform="rotate(270)"> <circle cx="0" cy="-54" r="6" fill="#7BBF95"/><rect x="-5" y="-47" width="10" height="11" rx="5" fill="#7BBF95"/></g>
+    <g transform="rotate(315)"> <circle cx="0" cy="-54" r="6" fill="#F5EDD8"/><rect x="-5" y="-47" width="10" height="11" rx="5" fill="#F5EDD8"/></g>
+    <circle cx="0" cy="0" r="10" fill="#E8AC4A"/>
+    <circle cx="0" cy="0" r="4"  fill="#1E2D27"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Adds the Fair Event logo (`fair-event-icon.svg`) to the `images/` directory alongside the existing `Calendar_Button_Icon.jpg`.

## Test plan

- [ ] Verify the SVG renders correctly when opened in a browser.