### PR TITLE
feat: opt-in "Powered by Fair Event Plugins" branding (#864)

### DIFF
--- a/.changeset/powered-by-branding.md
+++ b/.changeset/powered-by-branding.md
@@ -1,0 +1,6 @@
+---
+"fair-events": minor
+"fair-audience": minor
+---
+
+Add an opt-in "Powered by Fair Event Plugins" attribution. A single toggle in the fair-events General settings (off by default) renders a subtle, translatable line under the fair-audience signup blocks and at the bottom of participant emails.

--- a/fair-audience/src/Services/Branding.php
+++ b/fair-audience/src/Services/Branding.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * "Powered by Fair Event Plugins" branding markup.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Centralizes the opt-in attribution line so the copy and link live in one
+ * place, shared by the public signup blocks and the participant emails.
+ *
+ * The toggle is owned by fair-events (`fair_events_powered_by_branding`) but
+ * rendered here. We guard purely on the option value via get_option(), which
+ * returns the default when fair-events is inactive, so this keeps working even
+ * if the plugins are activated independently.
+ */
+class Branding {
+
+	/**
+	 * Destination for the attribution link. A lightweight ref param lets the
+	 * landing site attribute organic traffic from these surfaces.
+	 *
+	 * @var string
+	 */
+	const URL = 'https://fair-event-plugins.com/?ref=poweredby';
+
+	/**
+	 * Whether the "Powered by" attribution is enabled.
+	 *
+	 * @return bool True when an admin has opted in.
+	 */
+	public static function is_enabled() {
+		return (bool) get_option( 'fair_events_powered_by_branding', false );
+	}
+
+	/**
+	 * Subtle attribution line for the public signup blocks.
+	 *
+	 * @return string HTML, or '' when the branding is disabled.
+	 */
+	public static function block_html() {
+		if ( ! self::is_enabled() ) {
+			return '';
+		}
+
+		return '<p class="fair-audience-powered-by">'
+			. sprintf(
+				/* translators: %s: "Fair Event Plugins" linked to the project site */
+				esc_html__( 'Powered by %s', 'fair-audience' ),
+				'<a href="' . esc_url( self::URL ) . '" target="_blank" rel="noopener nofollow">Fair Event Plugins</a>'
+			)
+			. '</p>';
+	}
+
+	/**
+	 * Inline-styled attribution footer for HTML emails.
+	 *
+	 * Email clients strip <style> blocks, so the styling is inlined and kept
+	 * small and muted to stay unobtrusive.
+	 *
+	 * @return string HTML, or '' when the branding is disabled.
+	 */
+	public static function email_footer_html() {
+		if ( ! self::is_enabled() ) {
+			return '';
+		}
+
+		return '<p style="margin: 16px 0 0 0; text-align: center; font-size: 12px; color: #999999;">'
+			. sprintf(
+				/* translators: %s: "Fair Event Plugins" linked to the project site */
+				esc_html__( 'Powered by %s', 'fair-audience' ),
+				'<a href="' . esc_url( self::URL ) . '" target="_blank" rel="noopener nofollow" style="color: #999999;">Fair Event Plugins</a>'
+			)
+			. '</p>';
+	}
+}

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -269,7 +269,7 @@ class EmailService {
 		);
 
 		// Send email.
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		// Reset content type to avoid conflicts.
 		remove_filter(
@@ -513,7 +513,7 @@ class EmailService {
 		);
 
 		// Send email.
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		// Reset content type to avoid conflicts.
 		remove_filter(
@@ -726,7 +726,7 @@ class EmailService {
 		);
 
 		// Send email.
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		// Reset content type to avoid conflicts.
 		remove_filter(
@@ -849,7 +849,7 @@ class EmailService {
 		);
 
 		// Send email.
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		// Reset content type to avoid conflicts.
 		remove_filter(
@@ -981,7 +981,7 @@ class EmailService {
 		);
 
 		// Send email.
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		// Reset content type to avoid conflicts.
 		remove_filter(
@@ -1140,10 +1140,34 @@ class EmailService {
 		};
 
 		add_filter( 'wp_mail_content_type', $content_type );
-		$result = wp_mail( $to, $subject, $message );
+		$result = wp_mail( $to, $subject, $this->append_branding_footer( $message ) );
 		remove_filter( 'wp_mail_content_type', $content_type );
 
 		return $result;
+	}
+
+	/**
+	 * Append the opt-in "Powered by Fair Event Plugins" footer to an HTML body.
+	 *
+	 * Inserts the inline-styled line just before </body> so it sits at the very
+	 * bottom of every participant email. A no-op (returns the message unchanged)
+	 * when the branding setting is off, so disabling it removes the markup
+	 * entirely rather than merely hiding it.
+	 *
+	 * @param string $message Full HTML email body.
+	 * @return string Message with the footer injected, or unchanged when off.
+	 */
+	private function append_branding_footer( $message ) {
+		$footer = \FairAudience\Services\Branding::email_footer_html();
+		if ( '' === $footer ) {
+			return $message;
+		}
+
+		if ( false === strpos( $message, '</body>' ) ) {
+			return $message . $footer;
+		}
+
+		return str_replace( '</body>', $footer . '</body>', $message );
 	}
 
 	/**
@@ -1265,7 +1289,7 @@ class EmailService {
 		);
 
 		// Send email.
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		// Reset content type to avoid conflicts.
 		remove_filter(
@@ -1549,7 +1573,7 @@ class EmailService {
 		);
 
 		// Send email.
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		// Reset content type to avoid conflicts.
 		remove_filter(
@@ -1717,7 +1741,7 @@ class EmailService {
 		);
 
 		// Send email.
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		// Reset content type to avoid conflicts.
 		remove_filter(
@@ -1920,7 +1944,7 @@ class EmailService {
 			}
 		);
 
-		$result = wp_mail( $to_email, $subject, $message );
+		$result = wp_mail( $to_email, $subject, $this->append_branding_footer( $message ) );
 
 		remove_filter(
 			'wp_mail_content_type',
@@ -2116,7 +2140,7 @@ class EmailService {
 			}
 		);
 
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		remove_filter(
 			'wp_mail_content_type',
@@ -2282,7 +2306,7 @@ class EmailService {
 			}
 		);
 
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		remove_filter(
 			'wp_mail_content_type',
@@ -2418,7 +2442,7 @@ class EmailService {
 			}
 		);
 
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		remove_filter(
 			'wp_mail_content_type',
@@ -2554,7 +2578,7 @@ class EmailService {
 			}
 		);
 
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		remove_filter(
 			'wp_mail_content_type',
@@ -2722,7 +2746,7 @@ class EmailService {
 		);
 
 		// Send email.
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 
 		// Reset content type to avoid conflicts.
 		remove_filter(
@@ -2983,7 +3007,7 @@ class EmailService {
 			return 'text/html';
 		};
 		add_filter( 'wp_mail_content_type', $content_type_filter );
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 		remove_filter( 'wp_mail_content_type', $content_type_filter );
 
 		return (bool) $result;
@@ -3078,7 +3102,7 @@ class EmailService {
 			return 'text/html';
 		};
 		add_filter( 'wp_mail_content_type', $content_type_filter );
-		$result = wp_mail( $participant->email, $subject, $message );
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
 		remove_filter( 'wp_mail_content_type', $content_type_filter );
 
 		return (bool) $result;

--- a/fair-audience/src/blocks/audience-signup/render.php
+++ b/fair-audience/src/blocks/audience-signup/render.php
@@ -404,4 +404,5 @@ $wrapper_attributes = get_block_wrapper_attributes( $wrapper_data );
 
 		<div class="fair-audience-audience-message" style="display: none;"></div>
 	</form>
+	<?php echo wp_kses_post( \FairAudience\Services\Branding::block_html() ); ?>
 </div>

--- a/fair-audience/src/blocks/audience-signup/style.css
+++ b/fair-audience/src/blocks/audience-signup/style.css
@@ -108,7 +108,6 @@
 	margin-top: 24px;
 }
 
-
 /* Disabled button state */
 .fair-audience-audience-submit-button:disabled {
 	opacity: 0.6;
@@ -158,4 +157,16 @@
 .fair-audience-not-you:hover,
 .fair-audience-not-you:focus {
 	color: #005a87;
+}
+
+/* "Powered by Fair Event Plugins" attribution (opt-in, issue #864). */
+.fair-audience-powered-by {
+	margin: 16px 0 0;
+	text-align: center;
+	font-size: 0.75em;
+	color: #999;
+}
+
+.fair-audience-powered-by a {
+	color: inherit;
 }

--- a/fair-audience/src/blocks/event-interest/render.php
+++ b/fair-audience/src/blocks/event-interest/render.php
@@ -170,5 +170,6 @@ $wrapper_attributes = get_block_wrapper_attributes( $wrapper_data );
 
 		<div class="fair-audience-signup-message fair-audience-event-interest-message" style="display: none;"></div>
 	</form>
+	<?php echo wp_kses_post( \FairAudience\Services\Branding::block_html() ); ?>
 </div>
 <?php endif; ?>

--- a/fair-audience/src/blocks/event-interest/style.css
+++ b/fair-audience/src/blocks/event-interest/style.css
@@ -19,8 +19,8 @@
 	color: #d63638;
 }
 
-.fair-audience-event-interest .fair-audience-signup-form input[type='text'],
-.fair-audience-event-interest .fair-audience-signup-form input[type='email'] {
+.fair-audience-event-interest .fair-audience-signup-form input[type="text"],
+.fair-audience-event-interest .fair-audience-signup-form input[type="email"] {
 	width: 100%;
 	padding: 14px 16px;
 	border: 1px solid #ccc;
@@ -33,10 +33,10 @@
 
 .fair-audience-event-interest
 	.fair-audience-signup-form
-	input[type='text']:focus,
+	input[type="text"]:focus,
 .fair-audience-event-interest
 	.fair-audience-signup-form
-	input[type='email']:focus {
+	input[type="email"]:focus {
 	outline: none;
 	border-color: #0073aa;
 	box-shadow: 0 0 0 1px #0073aa;
@@ -90,4 +90,16 @@
 	border: 1px solid #f5c6cb;
 	border-radius: 4px;
 	text-align: center;
+}
+
+/* "Powered by Fair Event Plugins" attribution (opt-in, issue #864). */
+.fair-audience-powered-by {
+	margin: 16px 0 0;
+	text-align: center;
+	font-size: 0.75em;
+	color: #999;
+}
+
+.fair-audience-powered-by a {
+	color: inherit;
 }

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -1266,5 +1266,6 @@ if ( ! $is_valid_post_type ) :
 			<?php endif; ?>
 		</div>
 	<?php endif; ?>
+	<?php echo wp_kses_post( \FairAudience\Services\Branding::block_html() ); ?>
 </div>
 <?php endif; ?>

--- a/fair-audience/src/blocks/event-signup/style.css
+++ b/fair-audience/src/blocks/event-signup/style.css
@@ -527,3 +527,15 @@
 .fair-audience-thank-you-dismiss {
 	margin-top: 8px;
 }
+
+/* "Powered by Fair Event Plugins" attribution (opt-in, issue #864). */
+.fair-audience-powered-by {
+	margin: 16px 0 0;
+	text-align: center;
+	font-size: 0.75em;
+	color: #999;
+}
+
+.fair-audience-powered-by a {
+	color: inherit;
+}

--- a/fair-audience/src/blocks/fair-form/render.php
+++ b/fair-audience/src/blocks/fair-form/render.php
@@ -92,4 +92,5 @@ $wrapper_attributes = get_block_wrapper_attributes(
 
 		<div class="fair-form-message" style="display: none;"></div>
 	</form>
+	<?php echo wp_kses_post( \FairAudience\Services\Branding::block_html() ); ?>
 </div>

--- a/fair-audience/src/blocks/fair-form/style.css
+++ b/fair-audience/src/blocks/fair-form/style.css
@@ -73,3 +73,15 @@
 	border: 1px solid #d63638;
 	color: #d63638;
 }
+
+/* "Powered by Fair Event Plugins" attribution (opt-in, issue #864). */
+.fair-audience-powered-by {
+	margin: 16px 0 0;
+	text-align: center;
+	font-size: 0.75em;
+	color: #999;
+}
+
+.fair-audience-powered-by a {
+	color: inherit;
+}

--- a/fair-audience/src/blocks/mailing-signup/render.php
+++ b/fair-audience/src/blocks/mailing-signup/render.php
@@ -165,4 +165,5 @@ $wrapper_attributes = get_block_wrapper_attributes(
 
 		<div class="fair-audience-mailing-message" style="display: none;"></div>
 	</form>
+	<?php echo wp_kses_post( \FairAudience\Services\Branding::block_html() ); ?>
 </div>

--- a/fair-audience/src/blocks/mailing-signup/style.css
+++ b/fair-audience/src/blocks/mailing-signup/style.css
@@ -65,7 +65,6 @@
 	margin-top: 24px;
 }
 
-
 /* Disabled button state */
 .fair-audience-mailing-submit-button:disabled {
 	opacity: 0.6;
@@ -115,4 +114,16 @@
 .fair-audience-not-you:hover,
 .fair-audience-not-you:focus {
 	color: #005a87;
+}
+
+/* "Powered by Fair Event Plugins" attribution (opt-in, issue #864). */
+.fair-audience-powered-by {
+	margin: 16px 0 0;
+	text-align: center;
+	font-size: 0.75em;
+	color: #999;
+}
+
+.fair-audience-powered-by a {
+	color: inherit;
 }

--- a/fair-events/src/Admin/settings/GeneralTab.js
+++ b/fair-events/src/Admin/settings/GeneralTab.js
@@ -36,6 +36,7 @@ export default function GeneralTab({ onNotice }) {
 	const [enabledPostTypes, setEnabledPostTypes] = useState([]);
 	const [registerPostType, setRegisterPostType] = useState(true);
 	const [availablePostTypes, setAvailablePostTypes] = useState([]);
+	const [poweredByBranding, setPoweredByBranding] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
 	const [isSaving, setIsSaving] = useState(false);
 
@@ -46,6 +47,7 @@ export default function GeneralTab({ onNotice }) {
 				setSlug(settings.slug);
 				setEnabledPostTypes(settings.enabledPostTypes);
 				setRegisterPostType(settings.registerPostType);
+				setPoweredByBranding(settings.poweredByBranding);
 
 				// Filter to get content post types that make sense for events.
 				// Exclude system types that shouldn't have event data.
@@ -111,6 +113,7 @@ export default function GeneralTab({ onNotice }) {
 			fair_events_slug: slug,
 			fair_events_register_post_type: registerPostType,
 			fair_events_enabled_post_types: otherPostTypes,
+			fair_events_powered_by_branding: poweredByBranding,
 		})
 			.then(() => {
 				return loadGeneralSettings();
@@ -119,6 +122,7 @@ export default function GeneralTab({ onNotice }) {
 				setSlug(settings.slug);
 				setEnabledPostTypes(settings.enabledPostTypes);
 				setRegisterPostType(settings.registerPostType);
+				setPoweredByBranding(settings.poweredByBranding);
 				onNotice({
 					status: 'success',
 					message: __('Settings saved successfully.', 'fair-events'),
@@ -264,6 +268,27 @@ export default function GeneralTab({ onNotice }) {
 								'fair-events'
 							)}
 						</p>
+					</CardBody>
+				</Card>
+
+				<Card>
+					<CardHeader>
+						<h2>{__('Branding', 'fair-events')}</h2>
+					</CardHeader>
+					<CardBody>
+						<ToggleControl
+							label={__(
+								"Show 'Powered by Fair Event Plugins'",
+								'fair-events'
+							)}
+							checked={poweredByBranding}
+							onChange={(value) => setPoweredByBranding(value)}
+							help={__(
+								'Adds a subtle attribution line under public signup forms and at the bottom of participant emails. Off by default.',
+								'fair-events'
+							)}
+							disabled={isSaving}
+						/>
 					</CardBody>
 				</Card>
 

--- a/fair-events/src/Admin/settings/__tests__/GeneralTab.test.jsx
+++ b/fair-events/src/Admin/settings/__tests__/GeneralTab.test.jsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import GeneralTab from '../GeneralTab.js';
+import { loadGeneralSettings, saveSettings } from '../settings-api.js';
+
+jest.mock('@wordpress/api-fetch');
+jest.mock('../settings-api.js');
+
+const baseSettings = {
+	slug: 'fair-events',
+	enabledPostTypes: [],
+	registerPostType: true,
+	poweredByBranding: false,
+};
+
+beforeEach(() => {
+	window.fairEventsSettingsData = {
+		eventsApiUrl: 'https://example.com/wp-json/fair-events/v1/events',
+	};
+	loadGeneralSettings.mockResolvedValue({ ...baseSettings });
+	saveSettings.mockResolvedValue({});
+	// Component fetches /wp/v2/types alongside the settings on mount.
+	apiFetch.mockResolvedValue({});
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+const branding = () =>
+	screen.getByRole('checkbox', {
+		name: /Powered by Fair Event Plugins/i,
+	});
+
+test('renders the branding toggle, off by default', async () => {
+	render(<GeneralTab onNotice={jest.fn()} />);
+
+	await waitFor(() => expect(branding()).toBeInTheDocument());
+	expect(branding()).not.toBeChecked();
+
+	// @wordpress/components TextControl emits a size deprecation notice on
+	// render; acknowledge it so jest-console doesn't fail the suite.
+	expect(console).toHaveWarned();
+});
+
+test('toggling the branding setting and saving sends the new value', async () => {
+	render(<GeneralTab onNotice={jest.fn()} />);
+
+	await waitFor(() => expect(branding()).toBeInTheDocument());
+
+	fireEvent.click(branding());
+	expect(branding()).toBeChecked();
+
+	fireEvent.click(screen.getByRole('button', { name: /Save Settings/i }));
+
+	await waitFor(() => expect(saveSettings).toHaveBeenCalledTimes(1));
+	expect(saveSettings).toHaveBeenCalledWith(
+		expect.objectContaining({ fair_events_powered_by_branding: true })
+	);
+});

--- a/fair-events/src/Admin/settings/settings-api.js
+++ b/fair-events/src/Admin/settings/settings-api.js
@@ -14,6 +14,8 @@ export function loadGeneralSettings() {
 			slug: settings.fair_events_slug || 'fair-events',
 			enabledPostTypes: settings.fair_events_enabled_post_types || [],
 			registerPostType: settings.fair_events_register_post_type ?? true,
+			poweredByBranding:
+				settings.fair_events_powered_by_branding ?? false,
 		};
 	});
 }

--- a/fair-events/src/Settings/Settings.php
+++ b/fair-events/src/Settings/Settings.php
@@ -102,6 +102,22 @@ class Settings {
 				'default'           => true,
 			)
 		);
+
+		// Opt-in "Powered by Fair Event Plugins" attribution. Read cross-plugin
+		// by fair-audience (signup blocks + participant emails); lives here so it
+		// sits with the rest of the public-facing event configuration. Off by
+		// default so existing installs are unchanged until an admin opts in.
+		register_setting(
+			'fair_events_settings',
+			'fair_events_powered_by_branding',
+			array(
+				'type'              => 'boolean',
+				'description'       => __( 'Show a "Powered by Fair Event Plugins" line on signup forms and participant emails', 'fair-events' ),
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'show_in_rest'      => true,
+				'default'           => false,
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds an opt-in **"Powered by Fair Event Plugins"** attribution, controlled by a single toggle. When enabled it appears as a subtle footer on the public registration blocks and at the bottom of participant emails. **Off by default**, so existing installs are unchanged until an admin opts in.

Closes #864.

## Changes

**fair-events (the setting)**
- Register `fair_events_powered_by_branding` (boolean, `rest_sanitize_boolean`, `show_in_rest`, default `false`) — read/written through the core `/wp/v2/settings` endpoint.
- New "Branding" card with a `ToggleControl` on the General settings tab; wired through `settings-api.js` and `GeneralTab` save/load.

**fair-audience (the rendering)**
- New `FairAudience\Services\Branding` service centralizes the markup: `is_enabled()`, `block_html()`, `email_footer_html()`. Guards on the option value via `get_option()`, so it works even if fair-events is inactive.
- Inject `Branding::block_html()` into the five signup block render templates: event-signup, audience-signup, mailing-signup, event-interest, fair-form. Added a `.fair-audience-powered-by` style rule per block.
- Inject `Branding::email_footer_html()` into **every** participant email via a single `append_branding_footer()` helper applied at all 17 send points (15 direct `wp_mail` calls + the `$to_email` form notification + `dispatch_html_mail`).

## Decisions
- **Default off** (opt-in), per the issue recommendation.
- Link uses `?ref=poweredby` for lightweight attribution analytics.
- Email footer is a separate, lighter line (inline-styled, since clients strip `<style>`).

## Security
- Output escaped (`esc_url()`, `esc_html__()`/`sprintf`); no user input involved.
- Setting sanitized with `rest_sanitize_boolean`; writes go through core settings REST (capability-checked) — no custom endpoint.
- `target="_blank"` link uses `rel="noopener nofollow"`.
- When **off**, no markup is emitted at all (not merely hidden).

## Testing
- Jest + RTL test for the GeneralTab toggle (loads off by default; toggling + saving sends `fair_events_powered_by_branding: true`).
- `npm run build` run in both plugins; phpcs introduces no new violations.
- Translatable strings on the `fair-audience` / `fair-events` textdomains.

A changeset is included (`fair-events` minor, `fair-audience` minor).