### PR TITLE
Limit printed participant roster to collaborators and registered

### DIFF
--- a/fair-events/src/Admin/manage-event/EventAudience.js
+++ b/fair-events/src/Admin/manage-event/EventAudience.js
@@ -710,7 +710,14 @@ export default function EventAudience({
 			ticketOptions.map((o) => [o.name, o.short_name || o.name || ''])
 		);
 
-		const rows = filteredParticipants
+		// The printed list is the on-site roster: only collaborators and
+		// signed-up (registered) participants. "Interested" and transient
+		// states (e.g. pending_payment) are intentionally excluded.
+		const printParticipants = filteredParticipants.filter(
+			(p) => p.label === 'collaborator' || p.label === 'signed_up'
+		);
+
+		const rows = printParticipants
 			.map((p, index) => {
 				const name = escape(p.participant_name || '');
 				const role = escape(LABEL_DISPLAY[p.label] || p.label || '');
@@ -796,7 +803,7 @@ export default function EventAudience({
 		<h1>${escape(headerTitle)}</h1>
 		<div class="meta">${escape(__('Participant list', 'fair-events'))} — ${escape(
 			dateLabel
-		)} (${filteredParticipants.length})</div>
+		)} (${printParticipants.length})</div>
 	</header>
 	<table>
 		<thead>


### PR DESCRIPTION
## Summary

- The **Print list** action on the manage-event Audience tab printed every visible participant, including "Interested" people and transient `pending_payment` holds.
- The printed roster is the on-site check-in sheet, so it should only contain collaborators and signed-up (registered) participants.
- Scopes the print output (rows + header count) to the `collaborator` and `signed_up` roles. The on-screen Participants table and copy-list buttons are unchanged.

## Notes

- The **Print list** button's disabled guard still keys off the full filtered list, so on an event where everyone is "Interested" the button stays enabled but prints an empty table. Left as-is for now; easy to tighten if desired.

## Test plan

- [ ] Open `admin.php?page=fair-events-manage-event&event_date_id=<id>&tab=audience` on an event date that has collaborators, signed-up, and interested participants.
- [ ] Click **Print list** and confirm only collaborators and registered participants appear, with the header count matching.
- [ ] Confirm the on-screen table and copy-list buttons still include all roles.