### PR TITLE
feat(fair-events): include participant email in delete confirmation

### DIFF
--- a/fair-events/src/Admin/manage-event/EventAudience.js
+++ b/fair-events/src/Admin/manage-event/EventAudience.js
@@ -535,14 +535,19 @@ export default function EventAudience({
 	};
 
 	const handleDeleteParticipant = (participant) => {
+		const baseName =
+			participant.participant_name ||
+			__('this participant', 'fair-events');
+		const nameWithEmail = participant.participant_email
+			? `${baseName} (${participant.participant_email})`
+			: baseName;
 		const confirmMessage = sprintf(
-			/* translators: %s: participant name */
+			/* translators: %s: participant name or "name (email)" */
 			__(
 				'Delete %s’s registration for this event date? This cannot be undone.',
 				'fair-events'
 			),
-			participant.participant_name ||
-				__('this participant', 'fair-events')
+			nameWithEmail
 		);
 		if (!window.confirm(confirmMessage)) {
 			return;


### PR DESCRIPTION
## Summary

The delete confirmation popup for removing a participant from an event date now shows the participant's name **and** email address, so the admin can verify they are removing the right person.

- Before: *"Delete Jane Doe's registration for this event date? This cannot be undone."*
- After: *"Delete Jane Doe (jane@example.com)'s registration for this event date? This cannot be undone."*

Falls back to name-only when no email is on record.

## Test plan

- [ ] Open an event date's Audience tab (`/wp-admin/admin.php?page=fair-events-manage-event&tab=audience`)
- [ ] Click **Delete** next to a participant who has an email — confirm the popup shows `Name (email@example.com)`
- [ ] Click **Delete** next to a participant with no email — confirm the popup shows name only
- [ ] Confirm deletion proceeds normally after clicking OK