### PR TITLE
feat(fair-payments-connector): add "Need help?" link to settings page

### DIFF
--- a/fair-payments-connector/src/Admin/settings/SettingsApp.js
+++ b/fair-payments-connector/src/Admin/settings/SettingsApp.js
@@ -220,6 +220,16 @@ export default function SettingsApp() {
 					</div>
 				)}
 			</TabPanel>
+
+			<p style={{ marginTop: '2rem' }}>
+				<a
+					href="https://fair-event-plugins.com/contact/"
+					target="_blank"
+					rel="noreferrer"
+				>
+					{__('Need help?', 'fair-payments-connector')}
+				</a>
+			</p>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- Adds a \"Need help?\" link at the bottom of the Fair Payments Connector settings page
- Link opens https://fair-event-plugins.com/contact/ in a new tab

## Test plan

- [ ] Navigate to WP Admin → Fair Payments Connector → Settings
- [ ] Verify \"Need help?\" link appears below the tab panel
- [ ] Verify clicking the link opens https://fair-event-plugins.com/contact/ in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)