### PR TITLE
feat(fair-payments-connector): show "not set up" notice when Mollie is unconfigured

### DIFF
--- a/fair-payments-connector/src/Admin/AdminPages.php
+++ b/fair-payments-connector/src/Admin/AdminPages.php
@@ -164,14 +164,21 @@ class AdminPages {
 		}
 
 		$settings_url = add_query_arg( 'page', 'fair-payments-connector-settings', admin_url( 'admin.php' ) );
+
+		if ( $this->is_configured() ) {
+			/* translators: %s: link to settings page */
+			$message = __( 'Fair Payment is in <strong>Test mode</strong> — no real payments are being processed. <a href="%s">Switch to Live mode</a>.', 'fair-payments-connector' );
+		} else {
+			/* translators: %s: link to settings page */
+			$message = __( 'Fair Payment is <strong>not set up</strong> — no payments can be processed yet. <a href="%s">Set up Mollie</a>.', 'fair-payments-connector' );
+		}
 		?>
 		<div class="notice notice-warning">
 			<p>
 				<?php
 				printf(
 					wp_kses(
-						/* translators: %s: link to settings page */
-						__( 'Fair Payment is in <strong>Test mode</strong> — no real payments are being processed. <a href="%s">Switch to Live mode</a>.', 'fair-payments-connector' ),
+						$message,
 						array(
 							'strong' => array(),
 							'a'      => array( 'href' => array() ),
@@ -186,6 +193,19 @@ class AdminPages {
 	}
 
 	/**
+	 * Whether Mollie is configured (OAuth connection or stored API keys).
+	 *
+	 * @return bool
+	 */
+	private function is_configured() {
+		$connected = get_option( 'fair_payment_mollie_connected', false );
+		$test_key  = get_option( 'fair_payment_test_api_key', '' );
+		$live_key  = get_option( 'fair_payment_live_api_key', '' );
+
+		return (bool) ( $connected || $test_key || $live_key );
+	}
+
+	/**
 	 * Add action links on the plugins list page.
 	 *
 	 * Shows a "Set up" link when Mollie is not yet configured (no OAuth connection
@@ -195,12 +215,7 @@ class AdminPages {
 	 * @return string[] Modified action links.
 	 */
 	public function add_plugin_action_links( $links ) {
-		$connected     = get_option( 'fair_payment_mollie_connected', false );
-		$test_key      = get_option( 'fair_payment_test_api_key', '' );
-		$live_key      = get_option( 'fair_payment_live_api_key', '' );
-		$is_configured = $connected || $test_key || $live_key;
-
-		if ( ! $is_configured ) {
+		if ( ! $this->is_configured() ) {
 			$settings_url = add_query_arg( 'page', 'fair-payments-connector-settings', admin_url( 'admin.php' ) );
 			$setup_link   = '<a href="' . esc_url( $settings_url ) . '">' . esc_html__( 'Set up', 'fair-payments-connector' ) . '</a>';
 			array_unshift( $links, $setup_link );


### PR DESCRIPTION
## Summary

The admin test-mode notice always told admins to "Switch to Live mode" — even on a fresh install where no Mollie credentials exist yet. This branches the notice on whether Mollie is actually configured:

- **Configured** (OAuth connection or stored API key): unchanged — *"Fair Payment is in **Test mode** — no real payments are being processed. Switch to Live mode."*
- **Not configured**: *"Fair Payment is **not set up** — no payments can be processed yet. Set up Mollie."*

The shared configured-check is extracted into a private `is_configured()` helper, reused by the existing plugin-action-links logic (removing duplicated `get_option` calls).

## Notes

The notice only renders while `fair_payment_mode` is `test` (the default), so a fresh unconfigured install shows the "not set up" message correctly.

## Test plan

- [ ] Fresh install (no OAuth, no API keys) → notice reads "not set up — Set up Mollie"
- [ ] Mollie configured, test mode → notice reads "Test mode — Switch to Live mode"
- [ ] phpcs passes