### PR TITLE
Echo client OAuth state back through Mollie proxy

### DIFF
--- a/fair-platform/src/Core/Plugin.php
+++ b/fair-platform/src/Core/Plugin.php
@@ -263,10 +263,11 @@ class Plugin {
 	 */
 	private function handle_authorize() {
 		// Get and validate parameters.
-		$site_id    = sanitize_text_field( $_GET['site_id'] ?? '' );
-		$return_url = esc_url_raw( $_GET['return_url'] ?? '' );
-		$site_name  = sanitize_text_field( $_GET['site_name'] ?? '' );
-		$site_url   = esc_url_raw( $_GET['site_url'] ?? '' );
+		$site_id      = sanitize_text_field( $_GET['site_id'] ?? '' );
+		$return_url   = esc_url_raw( $_GET['return_url'] ?? '' );
+		$site_name    = sanitize_text_field( $_GET['site_name'] ?? '' );
+		$site_url     = esc_url_raw( $_GET['site_url'] ?? '' );
+		$client_state = sanitize_text_field( $_GET['state'] ?? '' );
 
 		if ( empty( $site_id ) || empty( $return_url ) ) {
 			wp_die( 'Missing required parameters: site_id and return_url' );
@@ -286,11 +287,12 @@ class Plugin {
 		set_transient(
 			"mollie_oauth_{$state}",
 			array(
-				'site_id'    => $site_id,
-				'return_url' => $return_url,
-				'site_name'  => $site_name,
-				'site_url'   => $site_url,
-				'timestamp'  => time(),
+				'site_id'      => $site_id,
+				'return_url'   => $return_url,
+				'site_name'    => $site_name,
+				'site_url'     => $site_url,
+				'client_state' => $client_state,
+				'timestamp'    => time(),
 			),
 			600
 		);
@@ -905,6 +907,7 @@ class Plugin {
 				'mollie_organization_id' => $session_data['organization_id'] ?? '',
 				'mollie_profile_id'      => $profile_id,
 				'mollie_test_mode'       => $session_data['testmode'] ?? 0,
+				'state'                  => $site_data['client_state'] ?? '',
 			),
 			$site_data['return_url']
 		);


### PR DESCRIPTION
## Summary

Fixes the Mollie OAuth connect flow failing with **"OAuth callback is missing the state parameter. Please try connecting again."**

The `fair-payments-connector` plugin uses a plugin↔proxy CSRF round trip: it generates a `state` token, stores it in a transient, sends it to the proxy at `/oauth/authorize`, and expects the proxy to **echo it back** on return so it can validate server-side. The Mollie proxy (`fair-platform/src/Core/Plugin.php`) was dropping this `state` entirely — it only generated its own state for the proxy↔Mollie leg, so the final redirect returned the `mollie_*` tokens without `state`, and the plugin rejected the callback.

This change makes the proxy capture the client's `state` in `handle_authorize()`, carry it through the `mollie_oauth_{state}` transient and the profile-selection session, and append it to the redirect back to the connecting site.

The proxy's own Mollie-leg state is untouched — that's a separate concern and was already working.

## Notes

- Only the success path forwards `state`; the error path (`error=access_denied` etc.) doesn't need it, since the plugin handles errors without requiring state.
- The connecting plugin's state transient is valid for 5 minutes — re-test the flow fresh after deploying.

## Test plan

- [ ] Deploy `fair-platform` to the proxy host (fair-event-plugins.com).
- [ ] From a connecting site, run the Mollie connect flow end to end.
- [ ] Confirm the return URL now includes `&state=...` alongside the `mollie_*` params.
- [ ] Confirm the plugin saves credentials without the "missing the state parameter" error.