### PR TITLE
feat(events-week): include page URL in copy-summary header

### DIFF
--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -389,7 +389,9 @@ $next_url = add_query_arg( 'week_view', sprintf( '%04d-W%02d', $next['year'], $n
 $summary_text = '';
 if ( $show_copy_summary ) {
 	$page_title    = get_the_title( get_queried_object_id() );
-	$summary_lines = array( $page_title . ', ' . $nav_title . ':' );
+	$page_url      = get_permalink( get_queried_object_id() );
+	$page_label    = $page_url ? $page_title . ' (' . $page_url . ')' : $page_title;
+	$summary_lines = array( $page_label . ', ' . $nav_title . ':' );
 
 	foreach ( $days as $day ) {
 		foreach ( $day['events'] as $ev ) {

--- a/fair-events/src/blocks/events-week/style.scss
+++ b/fair-events/src/blocks/events-week/style.scss
@@ -61,6 +61,7 @@
 		display: flex;
 		flex-direction: column;
 		min-height: 120px;
+		min-width: 0; // Allow grid cell to shrink below content size
 
 		&:last-child {
 			border-right: none;
@@ -129,6 +130,7 @@
 		flex-direction: column;
 		gap: 2px;
 		flex: 1;
+		min-width: 0; // Allow shrinking below content size
 	}
 
 	// Event chip — shared base
@@ -137,6 +139,7 @@
 		font-size: 0.75rem;
 		line-height: 1.35;
 		text-decoration: none;
+		min-width: 0; // Allow shrinking below content size
 
 		.week-event-time {
 			font-weight: 700;


### PR DESCRIPTION
## Summary

- The copied summary header now reads "Page Title (https://…), date range:" instead of just "Page Title, date range:"
- Falls back to title-only if `get_permalink` returns falsy

## Test plan

- [ ] On a page with the events-week block and Copy Summary enabled, click "Copy summary"
- [ ] Verify the first line includes the page URL in parentheses
- [ ] Verify the rest of the summary (individual events) is unchanged