### PR TITLE
refactor(fair-finance): remove budgetingEnabled flag

### DIFF
--- a/fair-finance/src/Admin/entries/EntriesApp.js
+++ b/fair-finance/src/Admin/entries/EntriesApp.js
@@ -28,7 +28,6 @@ import TransferModal from './components/TransferModal.js';
 import TagChart from './components/TagChart.js';
 import { buildEntriesCsv, downloadCsv } from './exportEntriesCsv.js';
 
-const budgetingEnabled = window.fairPaymentSettings?.budgetingEnabled === '1';
 const eventsEnabled = window.fairPaymentSettings?.eventsEnabled === '1';
 
 const getEventUrlLabel = (url) => {
@@ -89,14 +88,12 @@ const EntriesApp = () => {
 	const [expandedEntries, setExpandedEntries] = useState({});
 
 	useEffect(() => {
-		if (budgetingEnabled) {
-			loadBudgets();
+		loadBudgets();
 
-			const params = new URLSearchParams(window.location.search);
-			const budgetId = params.get('budget_id');
-			if (budgetId) {
-				setFilters((prev) => ({ ...prev, budget_id: budgetId }));
-			}
+		const params = new URLSearchParams(window.location.search);
+		const budgetId = params.get('budget_id');
+		if (budgetId) {
+			setFilters((prev) => ({ ...prev, budget_id: budgetId }));
 		}
 		if (eventsEnabled) {
 			loadEventUrls();
@@ -714,17 +711,12 @@ const EntriesApp = () => {
 								>
 									{__('Add Entry', 'fair-payments-connector')}
 								</Button>
-								{budgetingEnabled && (
-									<Button
-										variant="secondary"
-										onClick={handleTransfer}
-									>
-										{__(
-											'Transfer',
-											'fair-payments-connector'
-										)}
-									</Button>
-								)}
+								<Button
+									variant="secondary"
+									onClick={handleTransfer}
+								>
+									{__('Transfer', 'fair-payments-connector')}
+								</Button>
 								<Button
 									variant="secondary"
 									onClick={handleImport}
@@ -773,22 +765,17 @@ const EntriesApp = () => {
 									}
 									type="date"
 								/>
-								{budgetingEnabled && (
-									<SelectControl
-										label={__(
-											'Budget',
-											'fair-payments-connector'
-										)}
-										value={filters.budget_id}
-										options={budgetOptions}
-										onChange={(value) =>
-											handleFilterChange(
-												'budget_id',
-												value
-											)
-										}
-									/>
-								)}
+								<SelectControl
+									label={__(
+										'Budget',
+										'fair-payments-connector'
+									)}
+									value={filters.budget_id}
+									options={budgetOptions}
+									onChange={(value) =>
+										handleFilterChange('budget_id', value)
+									}
+								/>
 								{eventsEnabled &&
 									eventDateOptions.length > 0 && (
 										<SelectControl
@@ -1013,14 +1000,12 @@ const EntriesApp = () => {
 															'fair-payments-connector'
 														)}
 													</th>
-													{budgetingEnabled && (
-														<SortableHeader column="budget_id">
-															{__(
-																'Budget',
-																'fair-payments-connector'
-															)}
-														</SortableHeader>
-													)}
+													<SortableHeader column="budget_id">
+														{__(
+															'Budget',
+															'fair-payments-connector'
+														)}
+													</SortableHeader>
 													{eventsEnabled && (
 														<SortableHeader column="event_date_id">
 															{__(
@@ -1174,8 +1159,7 @@ const EntriesApp = () => {
 																		</div>
 																	)}
 																</td>
-																{budgetingEnabled && (
-																	<td>
+																																	<td>
 																		{isTransfer ? (
 																			(() => {
 																				const costChild =
@@ -1246,7 +1230,7 @@ const EntriesApp = () => {
 																			)
 																		)}
 																	</td>
-																)}
+																
 																{eventsEnabled && (
 																	<td>
 																		{entry.event_url ? (
@@ -1609,13 +1593,12 @@ const EntriesApp = () => {
 																					</em>
 																				)}
 																			</td>
-																			{budgetingEnabled && (
-																				<td>
+																																							<td>
 																					{getBudgetName(
 																						child.budget_id
 																					)}
 																				</td>
-																			)}
+																			
 																			{eventsEnabled && (
 																				<td>
 																					{child.event_url ? (
@@ -1688,13 +1671,12 @@ const EntriesApp = () => {
 																					</em>
 																				)}
 																			</td>
-																			{budgetingEnabled && (
-																				<td>
+																																							<td>
 																					{getBudgetName(
 																						child.budget_id
 																					)}
 																				</td>
-																			)}
+																			
 																			{eventsEnabled && (
 																				<td>
 																					{child.event_url ? (
@@ -1800,7 +1782,6 @@ const EntriesApp = () => {
 				<EntryForm
 					entry={editingEntry}
 					budgets={budgets}
-					budgetingEnabled={budgetingEnabled}
 					eventsEnabled={eventsEnabled}
 					tags={tags}
 					onSave={handleFormSave}
@@ -1830,7 +1811,6 @@ const EntriesApp = () => {
 				<SplitModal
 					entry={splittingEntry}
 					budgets={budgets}
-					budgetingEnabled={budgetingEnabled}
 					eventsEnabled={eventsEnabled}
 					onSplit={handleSplitComplete}
 					onCancel={handleSplitCancel}

--- a/fair-finance/src/Admin/entries/EntriesApp.js
+++ b/fair-finance/src/Admin/entries/EntriesApp.js
@@ -1159,78 +1159,78 @@ const EntriesApp = () => {
 																		</div>
 																	)}
 																</td>
-																																	<td>
-																		{isTransfer ? (
-																			(() => {
-																				const costChild =
-																					entry.children?.find(
-																						(
-																							c
-																						) =>
-																							c.entry_type ===
-																							'cost'
-																					);
-																				const incomeChild =
-																					entry.children?.find(
-																						(
-																							c
-																						) =>
-																							c.entry_type ===
-																							'income'
-																					);
-																				return (
-																					<span
-																						style={{
-																							fontSize:
-																								'12px',
-																							lineHeight:
-																								'1.4',
-																						}}
-																					>
-																						{getBudgetName(
-																							costChild?.budget_id
-																						)}
-																						<br />
-																						→
-																						<br />
-																						{getBudgetName(
-																							incomeChild?.budget_id
-																						)}
-																					</span>
+																<td>
+																	{isTransfer ? (
+																		(() => {
+																			const costChild =
+																				entry.children?.find(
+																					(
+																						c
+																					) =>
+																						c.entry_type ===
+																						'cost'
 																				);
-																			})()
-																		) : isSplit ? (
-																			<Button
-																				variant="link"
-																				size="small"
-																				onClick={() =>
-																					toggleExpanded(
-																						entry.id
-																					)
-																				}
-																				style={{
-																					color: '#2271b1',
-																					fontWeight:
-																						'bold',
-																				}}
-																			>
-																				{isExpanded
-																					? __(
-																							'Split \u25BE',
-																							'fair-payments-connector'
-																					  )
-																					: __(
-																							'Split \u25B8',
-																							'fair-payments-connector'
-																					  )}
-																			</Button>
-																		) : (
-																			getBudgetName(
-																				entry.budget_id
-																			)
-																		)}
-																	</td>
-																
+																			const incomeChild =
+																				entry.children?.find(
+																					(
+																						c
+																					) =>
+																						c.entry_type ===
+																						'income'
+																				);
+																			return (
+																				<span
+																					style={{
+																						fontSize:
+																							'12px',
+																						lineHeight:
+																							'1.4',
+																					}}
+																				>
+																					{getBudgetName(
+																						costChild?.budget_id
+																					)}
+																					<br />
+																					→
+																					<br />
+																					{getBudgetName(
+																						incomeChild?.budget_id
+																					)}
+																				</span>
+																			);
+																		})()
+																	) : isSplit ? (
+																		<Button
+																			variant="link"
+																			size="small"
+																			onClick={() =>
+																				toggleExpanded(
+																					entry.id
+																				)
+																			}
+																			style={{
+																				color: '#2271b1',
+																				fontWeight:
+																					'bold',
+																			}}
+																		>
+																			{isExpanded
+																				? __(
+																						'Split \u25BE',
+																						'fair-payments-connector'
+																				  )
+																				: __(
+																						'Split \u25B8',
+																						'fair-payments-connector'
+																				  )}
+																		</Button>
+																	) : (
+																		getBudgetName(
+																			entry.budget_id
+																		)
+																	)}
+																</td>
+
 																{eventsEnabled && (
 																	<td>
 																		{entry.event_url ? (
@@ -1593,12 +1593,12 @@ const EntriesApp = () => {
 																					</em>
 																				)}
 																			</td>
-																																							<td>
-																					{getBudgetName(
-																						child.budget_id
-																					)}
-																				</td>
-																			
+																			<td>
+																				{getBudgetName(
+																					child.budget_id
+																				)}
+																			</td>
+
 																			{eventsEnabled && (
 																				<td>
 																					{child.event_url ? (
@@ -1671,12 +1671,12 @@ const EntriesApp = () => {
 																					</em>
 																				)}
 																			</td>
-																																							<td>
-																					{getBudgetName(
-																						child.budget_id
-																					)}
-																				</td>
-																			
+																			<td>
+																				{getBudgetName(
+																					child.budget_id
+																				)}
+																			</td>
+
 																			{eventsEnabled && (
 																				<td>
 																					{child.event_url ? (

--- a/fair-finance/src/Admin/entries/components/EntryForm.js
+++ b/fair-finance/src/Admin/entries/components/EntryForm.js
@@ -183,17 +183,14 @@ const EntryForm = ({
 						)}
 					/>
 
-											<SelectControl
-							label={__(
-								'Budget Category',
-								'fair-payments-connector'
-							)}
-							value={formData.budget_id}
-							options={budgetOptions}
-							onChange={(value) =>
-								setFormData({ ...formData, budget_id: value })
-							}
-						/>
+					<SelectControl
+						label={__('Budget Category', 'fair-payments-connector')}
+						value={formData.budget_id}
+						options={budgetOptions}
+						onChange={(value) =>
+							setFormData({ ...formData, budget_id: value })
+						}
+					/>
 
 					{eventsEnabled && (
 						<EventUrlField

--- a/fair-finance/src/Admin/entries/components/EntryForm.js
+++ b/fair-finance/src/Admin/entries/components/EntryForm.js
@@ -23,7 +23,6 @@ import TagField from './TagField.js';
 const EntryForm = ({
 	entry,
 	budgets,
-	budgetingEnabled,
 	eventsEnabled,
 	tags,
 	onSave,
@@ -184,8 +183,7 @@ const EntryForm = ({
 						)}
 					/>
 
-					{budgetingEnabled && (
-						<SelectControl
+											<SelectControl
 							label={__(
 								'Budget Category',
 								'fair-payments-connector'
@@ -196,7 +194,6 @@ const EntryForm = ({
 								setFormData({ ...formData, budget_id: value })
 							}
 						/>
-					)}
 
 					{eventsEnabled && (
 						<EventUrlField

--- a/fair-finance/src/Admin/entries/components/SplitModal.js
+++ b/fair-finance/src/Admin/entries/components/SplitModal.js
@@ -168,7 +168,6 @@ const SplitEventUrlField = ({ value, eventDateId, onChange }) => {
 const SplitModal = ({
 	entry,
 	budgets,
-	budgetingEnabled,
 	eventsEnabled,
 	onSplit,
 	onCancel,
@@ -363,8 +362,7 @@ const SplitModal = ({
 							}}
 						>
 							<HStack spacing={2} alignment="top" wrap>
-								{budgetingEnabled && (
-									<div
+																	<div
 										style={{
 											flex: 1,
 											minWidth: '150px',
@@ -386,7 +384,6 @@ const SplitModal = ({
 											}
 										/>
 									</div>
-								)}
 								<div style={{ width: '120px' }}>
 									<TextControl
 										label={__(

--- a/fair-finance/src/Admin/entries/components/SplitModal.js
+++ b/fair-finance/src/Admin/entries/components/SplitModal.js
@@ -362,28 +362,28 @@ const SplitModal = ({
 							}}
 						>
 							<HStack spacing={2} alignment="top" wrap>
-																	<div
-										style={{
-											flex: 1,
-											minWidth: '150px',
-										}}
-									>
-										<SelectControl
-											label={__(
-												'Budget',
-												'fair-payments-connector'
-											)}
-											value={allocation.budget_id}
-											options={budgetOptions}
-											onChange={(value) =>
-												updateAllocation(
-													index,
-													'budget_id',
-													value
-												)
-											}
-										/>
-									</div>
+								<div
+									style={{
+										flex: 1,
+										minWidth: '150px',
+									}}
+								>
+									<SelectControl
+										label={__(
+											'Budget',
+											'fair-payments-connector'
+										)}
+										value={allocation.budget_id}
+										options={budgetOptions}
+										onChange={(value) =>
+											updateAllocation(
+												index,
+												'budget_id',
+												value
+											)
+										}
+									/>
+								</div>
 								<div style={{ width: '120px' }}>
 									<TextControl
 										label={__(


### PR DESCRIPTION
## Summary

- `fair-finance` is the budget plugin — there is no use case where budgeting would be disabled
- Removes the dead `budgetingEnabled` constant (was never set in `wp_localize_script`, so it was always `false`, hiding the Transfer button and budget UI)
- All budget-related UI (Transfer button, Budget filter, Budget column, budget fields in EntryForm/SplitModal) now renders unconditionally

## Test plan

- [ ] Visit `/wp-admin/admin.php?page=fair-finance-entries` and confirm the **Transfer** button appears in the header
- [ ] Confirm the **Budget** filter dropdown is visible in the filter row
- [ ] Confirm the **Budget** column appears in the entries table
- [ ] Open the Add Entry form and confirm the **Budget Category** field is present
- [ ] Open the Split modal and confirm the **Budget** field is present per allocation