### PR TITLE
fix(fair-audience): update GroupPermissionRule namespace in signups-list render

### DIFF
--- a/.changeset/fix-signups-list-group-permission-namespace.md
+++ b/.changeset/fix-signups-list-group-permission-namespace.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": patch
+---
+
+Fix signups-list block always showing count-only view for token-bearing participants with group view_signups permission (stale GroupPermissionRule namespace after move to fair-events-experimental).

--- a/e2e/mu-plugins/scripts/cleanup-signups-list.php
+++ b/e2e/mu-plugins/scripts/cleanup-signups-list.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Tear down E2E-seeded data for the signups-list test (issue #888).
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/cleanup-signups-list.php \
+ *     <eventId> <eventDateId> <groupId> <memberParticipantId> <otherParticipantId>
+ *
+ * Prints a single `E2E_SIGNUPS_CLEANUP:{json}` line with row counts.
+ *
+ * @package FairEventsE2E
+ */
+
+global $wpdb;
+
+$event_id              = isset( $args[0] ) ? (int) $args[0] : 0;
+$event_date_id         = isset( $args[1] ) ? (int) $args[1] : 0;
+$group_id              = isset( $args[2] ) ? (int) $args[2] : 0;
+$member_participant_id = isset( $args[3] ) ? (int) $args[3] : 0;
+$other_participant_id  = isset( $args[4] ) ? (int) $args[4] : 0;
+
+if ( ! $event_id || ! $event_date_id || ! $group_id || ! $member_participant_id || ! $other_participant_id ) {
+	WP_CLI::error( 'Usage: cleanup-signups-list.php <eventId> <eventDateId> <groupId> <memberParticipantId> <otherParticipantId>' );
+}
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off teardown script.
+
+$deleted = array();
+
+$perm_rules_table   = $wpdb->prefix . 'fair_events_group_permission_rules';
+$event_parts_table  = $wpdb->prefix . 'fair_audience_event_participants';
+$participants_table = $wpdb->prefix . 'fair_audience_participants';
+$group_parts_table  = $wpdb->prefix . 'fair_audience_group_participants';
+$groups_table       = $wpdb->prefix . 'fair_audience_groups';
+$dates_table        = $wpdb->prefix . 'fair_event_dates';
+
+$deleted['permission_rules']   = (int) $wpdb->delete( $perm_rules_table, array( 'event_date_id' => $event_date_id ), array( '%d' ) );
+$deleted['event_participants'] = (int) $wpdb->delete( $event_parts_table, array( 'event_date_id' => $event_date_id ), array( '%d' ) );
+$deleted['group_participants'] = (int) $wpdb->delete( $group_parts_table, array( 'group_id' => $group_id ), array( '%d' ) );
+$deleted['groups']             = (int) $wpdb->delete( $groups_table, array( 'id' => $group_id ), array( '%d' ) );
+
+$participant_ids = array( $member_participant_id, $other_participant_id );
+$placeholders    = implode( ', ', array_fill( 0, 2, '%d' ) );
+// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- safe %d placeholders.
+$deleted['participants'] = (int) $wpdb->query(
+	$wpdb->prepare(
+		"DELETE FROM %i WHERE id IN ({$placeholders})",
+		array_merge( array( $participants_table ), $participant_ids )
+	)
+);
+// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+$deleted['event_dates'] = (int) $wpdb->delete( $dates_table, array( 'event_id' => $event_id ), array( '%d' ) );
+$deleted['post']        = wp_delete_post( $event_id, true ) ? 1 : 0;
+
+// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+echo 'E2E_SIGNUPS_CLEANUP:' . wp_json_encode( $deleted ) . "\n";

--- a/e2e/mu-plugins/scripts/seed-signups-list.php
+++ b/e2e/mu-plugins/scripts/seed-signups-list.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Seed data for the signups-list e2e test (issue #888).
+ *
+ * Creates a published fair_event with the signups-list block, an event date,
+ * several signed-up participants, a group, a GroupPermissionRule granting
+ * view_signups, and returns a participant_token for a group member and for a
+ * non-member so both positive and negative assertions can run.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-signups-list.php
+ *
+ * Prints a single `E2E_SIGNUPS_SEED:{json}` line the spec parses.
+ *
+ * @package FairEventsE2E
+ */
+
+use FairEvents\Models\EventDates;
+use FairEventsExperimental\Models\GroupPermissionRule;
+use FairAudience\Models\Group;
+use FairAudience\Models\Participant;
+use FairAudience\Database\EventParticipantRepository;
+use FairAudience\Database\GroupParticipantRepository;
+use FairAudience\Services\ParticipantToken;
+
+$event_id = wp_insert_post(
+	array(
+		'post_type'    => 'fair_event',
+		'post_status'  => 'publish',
+		'post_title'   => 'E2E Signups List ' . gmdate( 'YmdHis' ),
+		'post_content' => '<!-- wp:fair-audience/signups-list /-->',
+	),
+	true
+);
+
+if ( is_wp_error( $event_id ) ) {
+	WP_CLI::error( 'Failed to create event: ' . $event_id->get_error_message() );
+}
+
+$event_date_id = EventDates::save_occurrence(
+	$event_id,
+	gmdate( 'Y-m-d H:i:s', strtotime( '+7 days' ) ),
+	gmdate( 'Y-m-d H:i:s', strtotime( '+7 days +2 hours' ) ),
+	false,
+	'single'
+);
+
+if ( ! $event_date_id ) {
+	WP_CLI::error( 'Failed to create event date.' );
+}
+
+$event_participant_repo = new EventParticipantRepository();
+$group_participant_repo = new GroupParticipantRepository();
+
+// Seed two participants that are signed up on this event date.
+$member_participant = new Participant(
+	array(
+		'name'    => 'Alice',
+		'surname' => 'Member',
+		'email'   => 'alice.member.' . gmdate( 'YmdHis' ) . '@example.com',
+	)
+);
+if ( ! $member_participant->save() ) {
+	WP_CLI::error( 'Failed to create member participant.' );
+}
+
+$other_participant = new Participant(
+	array(
+		'name'    => 'Bob',
+		'surname' => 'Other',
+		'email'   => 'bob.other.' . gmdate( 'YmdHis' ) . '@example.com',
+	)
+);
+if ( ! $other_participant->save() ) {
+	WP_CLI::error( 'Failed to create other participant.' );
+}
+
+// Register both as signed_up on the event date.
+foreach ( array( $member_participant->id, $other_participant->id ) as $pid ) {
+	$event_participant_repo->add_participant_to_event( $event_id, $pid, 'signed_up', $event_date_id );
+}
+
+// Create a group, add only the member participant.
+$group = new Group( array( 'name' => 'E2E View Group ' . gmdate( 'YmdHis' ) ) );
+if ( ! $group->save() ) {
+	WP_CLI::error( 'Failed to create group.' );
+}
+
+$group_participant_repo->add_participant_to_group( $group->id, $member_participant->id );
+
+// Grant view_signups for this event date.
+$rule_id = GroupPermissionRule::create( $event_date_id, $group->id, 'view_signups' );
+if ( ! $rule_id ) {
+	WP_CLI::error( 'Failed to create group permission rule.' );
+}
+
+$member_token = ParticipantToken::generate( $member_participant->id, $event_date_id );
+$other_token  = ParticipantToken::generate( $other_participant->id, $event_date_id );
+
+echo 'E2E_SIGNUPS_SEED:' . wp_json_encode(
+	array(
+		'pageUrl'             => get_permalink( $event_id ),
+		'eventId'             => (int) $event_id,
+		'eventDateId'         => (int) $event_date_id,
+		'groupId'             => (int) $group->id,
+		'ruleId'              => (int) $rule_id,
+		'memberParticipantId' => (int) $member_participant->id,
+		'otherParticipantId'  => (int) $other_participant->id,
+		'memberToken'         => $member_token,
+		'otherToken'          => $other_token,
+	)
+) . "\n";

--- a/e2e/user-flows/signups-list-permission.spec.js
+++ b/e2e/user-flows/signups-list-permission.spec.js
@@ -1,0 +1,96 @@
+/**
+ * E2E: signups-list block renders the full participant list for a token-bearing
+ * viewer whose participant belongs to a group granted view_signups (#888).
+ *
+ * Positive case: group member visits with their participant_token → sees the
+ * .audience-signups__list, not the count-only fallback.
+ * Negative case: non-member token → count-only .audience-signups__count.
+ *
+ * Covers the class of regression where class_exists() silently returns false
+ * (stale namespace) and the permission gate always fails — a PHP unit test
+ * mocking the model would not catch that.
+ */
+
+import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+
+/**
+ * Run a WP-CLI command against the wp-env `tests` instance and return stdout.
+ *
+ * @param {string} args WP-CLI arguments (everything after `wp`).
+ * @return {string} Command stdout.
+ */
+function wpCli(args) {
+	return execSync(`npx wp-env run tests-cli wp ${args}`, {
+		cwd: process.cwd(),
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+}
+
+/**
+ * Run a seed/state eval-file script and parse its `MARKER:{json}` output.
+ *
+ * @param {string} file      Script filename under mu-plugins/scripts/.
+ * @param {string} marker    Output marker (e.g. 'E2E_SIGNUPS_SEED').
+ * @param {string} extraArgs Positional args passed to the script.
+ * @return {object} Parsed JSON payload.
+ */
+function runScript(file, marker, extraArgs = '') {
+	const out = wpCli(
+		`eval-file wp-content/mu-plugins/scripts/${file} ${extraArgs}`.trim()
+	);
+	const match = out.match(new RegExp(`${marker}:(\\{.*\\})`));
+	if (!match) {
+		throw new Error(`Expected ${marker} in WP-CLI output, got:\n${out}`);
+	}
+	return JSON.parse(match[1]);
+}
+
+let seed;
+
+test.beforeAll(() => {
+	seed = runScript('seed-signups-list.php', 'E2E_SIGNUPS_SEED');
+});
+
+test.afterAll(() => {
+	runScript(
+		'cleanup-signups-list.php',
+		'E2E_SIGNUPS_CLEANUP',
+		`${seed.eventId} ${seed.eventDateId} ${seed.groupId} ${seed.memberParticipantId} ${seed.otherParticipantId}`
+	);
+});
+
+test.describe('signups-list group permission', () => {
+	test('group member with participant_token sees full participant list', async ({
+		browser,
+	}) => {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+
+		await page.goto(
+			`${seed.pageUrl}?participant_token=${seed.memberToken}`
+		);
+
+		await expect(page.locator('.audience-signups__list')).toBeVisible();
+		await expect(
+			page.locator('.audience-signups__count')
+		).not.toBeVisible();
+
+		await context.close();
+	});
+
+	test('non-member participant_token shows count-only fallback', async ({
+		browser,
+	}) => {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+
+		await page.goto(`${seed.pageUrl}?participant_token=${seed.otherToken}`);
+
+		await expect(page.locator('.audience-signups__count')).toBeVisible();
+		await expect(page.locator('.audience-signups__list')).not.toBeVisible();
+
+		await context.close();
+	});
+});

--- a/fair-audience/src/blocks/signups-list/render.php
+++ b/fair-audience/src/blocks/signups-list/render.php
@@ -27,7 +27,7 @@ if ( ! function_exists( 'fair_audience_check_signup_permission' ) ) {
 	function fair_audience_check_signup_permission( $event_id, $participant_repo ) {
 		// Need fair-events for event_date lookup and group permission rules.
 		if ( ! class_exists( \FairEvents\Models\EventDates::class ) ||
-		! class_exists( \FairEvents\Models\GroupPermissionRule::class ) ) {
+		! class_exists( \FairEventsExperimental\Models\GroupPermissionRule::class ) ) {
 			return false;
 		}
 
@@ -40,7 +40,7 @@ if ( ! function_exists( 'fair_audience_check_signup_permission' ) ) {
 		$event_date_id = (int) $event_date->id;
 
 		// Get permission rules for this event date.
-		$permission_rules = \FairEvents\Models\GroupPermissionRule::get_all_by_event_date_id( $event_date_id );
+		$permission_rules = \FairEventsExperimental\Models\GroupPermissionRule::get_all_by_event_date_id( $event_date_id );
 		if ( empty( $permission_rules ) ) {
 			return false;
 		}


### PR DESCRIPTION
## Summary

- `render.php` referenced `\FairEvents\Models\GroupPermissionRule` after the class was moved to `\FairEventsExperimental\Models` in commit `290a56ae`. `class_exists()` on the stale string returned `false`, so `fair_audience_check_signup_permission()` always returned `false` early — token-bearing participants with `view_signups` permission always saw the count-only view instead of the full list.
- Both namespace references (lines 30 and 43) updated to `\FairEventsExperimental\Models\GroupPermissionRule`.
- `fair-audience` rebuilt so `build/blocks/signups-list/render.php` reflects the fix.
- New e2e test (`e2e/user-flows/signups-list-permission.spec.js`) with seed/cleanup scripts exercises the real cross-plugin permission path end-to-end, so this class of silent regression will fail loudly in CI.

Closes #888

## Test plan

- [ ] `npm run build` in `fair-audience` — green
- [ ] Manual: visit a public event page with `?participant_token=<token>` for a group member with `view_signups` — full `.audience-signups__list` renders
- [ ] Manual: same page with a token for a non-member — `.audience-signups__count` fallback renders
- [ ] `npm run test:e2e` — `signups-list-permission.spec.js` passes (positive + negative cases)