### PR TITLE
feat(fair-audience): highlight participant name in signup block greeting

### DIFF
--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -1190,23 +1190,26 @@ const CSS_PREFIX = 'fair-audience-signup';
 						return;
 					}
 
-					// Get participant name from greeting or fallback
-					const greetingEl = block.querySelector(
-						'.fair-audience-signup-greeting'
+					// Get participant name from the highlighted name element
+					const nameEl = block.querySelector(
+						'.fair-audience-signup-greeting-name'
 					);
-					const participantName = greetingEl
-						? greetingEl.textContent.match(
-								/(?:Hi|Hola|Salut|Ciao)\s+(.+?)!/
-						  )?.[1] || ''
+					const participantName = nameEl
+						? nameEl.textContent.trim()
 						: '';
 
 					// Replace with signup form
 					if (container) {
-						const greetingText = participantName
+						const nameHtml = participantName
+							? '<strong class="fair-audience-signup-greeting-name">' +
+							  participantName +
+							  '</strong>'
+							: '';
+						const greetingHtml = nameHtml
 							? __(
 									'Hi %s! You can sign up for this event.',
 									'fair-audience'
-							  ).replace('%s', participantName)
+							  ).replace('%s', nameHtml)
 							: __(
 									'You can sign up for this event.',
 									'fair-audience'
@@ -1220,7 +1223,7 @@ const CSS_PREFIX = 'fair-audience-signup';
 						container.className = wrapClass;
 						container.innerHTML =
 							'<p class="fair-audience-signup-greeting">' +
-							greetingText +
+							greetingHtml +
 							'</p>' +
 							'<div class="wp-block-button">' +
 							'<button type="button" class="wp-block-button__link wp-element-button fair-audience-signup-button" data-action="signup">' +

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -1071,31 +1071,32 @@ if ( ! $is_valid_post_type ) :
 		// Unified authenticated form: when a recurrence picker is present the
 		// signup and cancel buttons live in the same container so the JS can
 		// toggle which one is visible as the user selects a different date.
-		$form_class = 'with_token' === $state
+		$form_class            = 'with_token' === $state
 			? 'fair-audience-signup-token-form'
 			: 'fair-audience-signup-linked-form';
+		$participant_name_html = '<strong class="fair-audience-signup-greeting-name">' . esc_html( $participant->name ) . '</strong>';
 		if ( $is_signed_up ) {
-			$greeting = sprintf(
+			$greeting_html = sprintf(
 				/* translators: %s: participant name */
 				__( 'Hi %s! Here is your registration for this event.', 'fair-audience' ),
-				$participant->name
+				$participant_name_html
 			);
 		} elseif ( 'with_token' === $state ) {
-			$greeting = sprintf(
+			$greeting_html = sprintf(
 				/* translators: %s: participant name */
 				__( 'Hi %s! Click the button below to sign up for this event.', 'fair-audience' ),
-				$participant->name
+				$participant_name_html
 			);
 		} else {
-			$greeting = sprintf(
+			$greeting_html = sprintf(
 				/* translators: %s: participant name */
 				__( 'Hi %s! You can sign up for this event.', 'fair-audience' ),
-				$participant->name
+				$participant_name_html
 			);
 		}
 		?>
 		<div class="<?php echo esc_attr( $form_class ); ?>">
-			<p class="fair-audience-signup-greeting"><?php echo esc_html( $greeting ); ?></p>
+			<p class="fair-audience-signup-greeting"><?php echo wp_kses( $greeting_html, array( 'strong' => array( 'class' => array() ) ) ); ?></p>
 			<?php $render_occurrence_picker(); ?>
 			<div class="fair-audience-signup-action-signup"<?php echo $is_signed_up ? ' style="display: none;"' : ''; ?>>
 				<?php $render_ticket_types(); ?>

--- a/fair-audience/src/blocks/event-signup/style.css
+++ b/fair-audience/src/blocks/event-signup/style.css
@@ -101,6 +101,11 @@
 	margin-bottom: 20px;
 }
 
+.fair-audience-signup-greeting-name {
+	font-weight: 700;
+	color: #0073aa;
+}
+
 /* Status messages */
 .fair-audience-signup-status {
 	padding: 15px 20px;


### PR DESCRIPTION
## Summary

- Wraps the recognized participant's name in a `<strong class="fair-audience-signup-greeting-name">` element in the server-rendered greeting
- Styles the name bold and blue (`#0073aa`) via a new CSS rule so it stands out from the surrounding text
- Updates the client-side unsignup flow to reconstruct the same highlighted markup when rebuilding the greeting after cancellation

## Motivation

Users arriving with a `participant_token` weren't aware the system had already identified them — the greeting ("Hi Marcin! Click the button below…") blended in with the rest of the text. Highlighting the name makes the personalization immediately visible.

## Test plan

- [ ] Visit an event signup page with a valid `participant_token` — confirm the participant's name appears bold and blue in the greeting
- [ ] Cancel signup, then re-signup inline — confirm the name stays highlighted after the JS rebuilds the greeting

🤖 Generated with [Claude Code](https://claude.com/claude-code)