### PR TITLE
fix(events-week): use block colors for all events, including external

### DIFF
--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -452,8 +452,8 @@ if ( $show_copy_summary ) {
 						$classes[] = 'is-draft';
 					}
 
-					$ev_bg   = $ev['color'] ?? $bg_color_value;
-					$ev_text = $ev['color'] ? '#ffffff' : $text_color_value;
+					$ev_bg   = $bg_color_value;
+					$ev_text = $text_color_value;
 					$style   = sprintf(
 						'--event-bg-color: %s; --event-text-color: %s;',
 						esc_attr( $ev_bg ),

--- a/fair-events/src/blocks/events-week/style.scss
+++ b/fair-events/src/blocks/events-week/style.scss
@@ -140,6 +140,7 @@
 		line-height: 1.35;
 		text-decoration: none;
 		min-width: 0; // Allow shrinking below content size
+		overflow: hidden; // Prevent chip from overflowing the column
 
 		.week-event-time {
 			font-weight: 700;


### PR DESCRIPTION
iCal/external events were using their source color instead of the block's
configured background and text colors, causing a visual mismatch with the
events-calendar block which applies the block color uniformly to all events.
