### PR TITLE
fix(events-week): add clipboard fallback so copy button works in all browsers

### DIFF
--- a/fair-events/src/blocks/events-week/frontend.js
+++ b/fair-events/src/blocks/events-week/frontend.js
@@ -7,6 +7,23 @@
 (function () {
 	'use strict';
 
+	function fallbackCopy(text, onSuccess) {
+		const textarea = document.createElement('textarea');
+		textarea.value = text;
+		textarea.style.position = 'fixed';
+		textarea.style.opacity = '0';
+		document.body.appendChild(textarea);
+		textarea.focus();
+		textarea.select();
+		try {
+			if (document.execCommand('copy')) {
+				onSuccess();
+			}
+		} finally {
+			document.body.removeChild(textarea);
+		}
+	}
+
 	function initCopySummaryButtons() {
 		const buttons = document.querySelectorAll(
 			'.fair-events-copy-summary-btn'
@@ -19,13 +36,24 @@
 					return;
 				}
 
-				navigator.clipboard.writeText(summary).then(() => {
+				const showCopied = () => {
 					const original = button.textContent;
 					button.textContent = button.dataset.copiedLabel || '✓';
 					setTimeout(() => {
 						button.textContent = original;
 					}, 2000);
-				});
+				};
+
+				if (navigator.clipboard) {
+					navigator.clipboard
+						.writeText(summary)
+						.then(showCopied)
+						.catch(() => {
+							fallbackCopy(summary, showCopied);
+						});
+				} else {
+					fallbackCopy(summary, showCopied);
+				}
 			});
 		});
 	}


### PR DESCRIPTION
## Summary

- `navigator.clipboard` can be `undefined` in non-secure contexts and can have its promise rejected even on HTTPS (e.g. missing `Permissions-Policy` header or browser permission denial)
- The original code had no `.catch()`, so rejections were silently swallowed and nothing happened
- Added a `fallbackCopy()` helper that uses a temporary `<textarea>` + `document.execCommand('copy')` as a fallback

## Test plan

- [ ] Enable the "Copy summary" button on the events-week block
- [ ] Click the button — text should be copied and the button label should briefly change to ✓
- [ ] Verify it works on the live site at https://acro-agenda.es/