### PR TITLE
test(fair-payments-connector): value-asserting tests, composite index, timezone note — closes #773

### DIFF
--- a/fair-payments-connector/src/API/__tests__/DashboardController.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/DashboardController.api.spec.js
@@ -49,4 +49,66 @@ test.describe('DashboardController — monthly-summary', () => {
 		const res = await api.get(ENDPOINT);
 		expect(res.status()).toBe(401);
 	});
+
+	test('fee_cap reflects at least the base connector price (4 EUR)', async () => {
+		const res = await api.get(ENDPOINT, {
+			headers: {
+				Authorization:
+					'Basic ' +
+					Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString(
+						'base64'
+					),
+			},
+		});
+		const body = await res.json();
+		// fair-payments-connector base price is 4 EUR; site currency defaults to EUR.
+		// With fair-events also active the cap is 12 EUR (4 + 8).
+		expect(body.fee_cap).toBeGreaterThanOrEqual(4);
+	});
+
+	test('cap_remaining equals max(0, fee_cap - total_fees)', async () => {
+		const res = await api.get(ENDPOINT, {
+			headers: {
+				Authorization:
+					'Basic ' +
+					Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString(
+						'base64'
+					),
+			},
+		});
+		const body = await res.json();
+		const expected = Math.max(0, body.fee_cap - body.total_fees);
+		// Allow 0.01 rounding tolerance from decimal arithmetic.
+		expect(Math.abs(body.cap_remaining - expected)).toBeLessThanOrEqual(
+			0.01
+		);
+	});
+
+	test('cap_remaining is never negative', async () => {
+		const res = await api.get(ENDPOINT, {
+			headers: {
+				Authorization:
+					'Basic ' +
+					Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString(
+						'base64'
+					),
+			},
+		});
+		const body = await res.json();
+		expect(body.cap_remaining).toBeGreaterThanOrEqual(0);
+	});
+
+	test('total_fees is non-negative', async () => {
+		const res = await api.get(ENDPOINT, {
+			headers: {
+				Authorization:
+					'Basic ' +
+					Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString(
+						'base64'
+					),
+			},
+		});
+		const body = await res.json();
+		expect(body.total_fees).toBeGreaterThanOrEqual(0);
+	});
 });

--- a/fair-payments-connector/src/Database/Schema.php
+++ b/fair-payments-connector/src/Database/Schema.php
@@ -164,9 +164,10 @@ class Schema {
 		self::migrate_to_v19();
 		self::migrate_to_v20();
 		self::migrate_to_v21();
+		self::migrate_to_v22();
 
 		// Store database version for future migrations.
-		update_option( 'fair_payment_db_version', '21.0' );
+		update_option( 'fair_payment_db_version', '22.0' );
 	}
 
 	/**
@@ -1120,6 +1121,42 @@ class Schema {
 						array( '%d' )
 					);
 				}
+			}
+		}
+	}
+
+	/**
+	 * Migrate database from v21.0 to v22.0
+	 *
+	 * Adds a composite index on (status, testmode, created_at) to the payments table
+	 * so the MonthlyFeeCapService::get_month_total() aggregation query is fully covered
+	 * by an index rather than falling back to the single-column status key.
+	 *
+	 * @return void
+	 */
+	public static function migrate_to_v22() {
+		global $wpdb;
+
+		$current_version = get_option( 'fair_payment_db_version', '1.0' );
+
+		if ( version_compare( $current_version, '22.0', '<' ) ) {
+			$table_name = self::get_payments_table_name();
+
+			$index_exists = $wpdb->get_results(
+				$wpdb->prepare(
+					'SHOW INDEX FROM %i WHERE Key_name = %s',
+					$table_name,
+					'fee_cap_month'
+				)
+			);
+
+			if ( empty( $index_exists ) ) {
+				$wpdb->query(
+					$wpdb->prepare(
+						'ALTER TABLE %i ADD KEY fee_cap_month (status, testmode, created_at)',
+						$table_name
+					)
+				);
 			}
 		}
 	}

--- a/fair-payments-connector/src/Services/MonthlyFeeCapService.php
+++ b/fair-payments-connector/src/Services/MonthlyFeeCapService.php
@@ -66,6 +66,7 @@ class MonthlyFeeCapService {
 		$table    = Schema::get_payments_table_name();
 		$testmode = 'test' === get_option( 'fair_payment_mode', 'test' ) ? 1 : 0;
 
+		// gmdate() returns UTC; assumes the DB session timezone is also UTC (WordPress default).
 		$month_start = gmdate( 'Y-m-01 00:00:00' );
 		$month_end   = gmdate( 'Y-m-t 23:59:59' );
 


### PR DESCRIPTION
## Summary

- Adds four value-asserting API tests to `DashboardController.api.spec.js` covering the acceptance criteria from #773: `fee_cap >= 4 EUR` (base connector price), the `cap_remaining = max(0, fee_cap - total_fees)` invariant, floor-at-0 (`cap_remaining >= 0`), and `total_fees >= 0`
- Adds migration v22: composite index `fee_cap_month(status, testmode, created_at)` on the payments table so `MonthlyFeeCapService::get_month_total()` is fully index-covered instead of falling back to the single-column `status` key
- Adds an inline comment in `get_month_total()` noting the UTC assumption for `gmdate()` vs MySQL `CURRENT_TIMESTAMP`

## Test plan

- [ ] Run `npm run test:api` in `fair-payments-connector` against the Docker stack — all five dashboard tests should pass
- [ ] Confirm the new index appears after `create_tables()` / plugin deactivation+reactivation: `SHOW INDEX FROM wp_fair_payment_transactions WHERE Key_name = 'fee_cap_month'`