### PR TITLE
refactor(e2e): migrate specs to shared wp-cli helpers

### DIFF
--- a/e2e/fair-events-admin-menu.spec.js
+++ b/e2e/fair-events-admin-menu.spec.js
@@ -15,19 +15,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { execSync } from 'node:child_process';
-
-const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
-const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
-
-/** Run a WP-CLI command against the wp-env `tests` instance. */
-function wpCli(args) {
-	return execSync(`npx wp-env run tests-cli wp ${args}`, {
-		cwd: process.cwd(),
-		encoding: 'utf8',
-		stdio: ['ignore', 'pipe', 'pipe'],
-	});
-}
+import { wpCli, loginAsAdmin } from './support/wp-cli.js';
 
 /**
  * Turn every feature bundle on. These bundles now live in fair-events-experimental.
@@ -81,14 +69,6 @@ const PAGES = [
 	},
 ];
 
-async function login(page) {
-	await page.goto('/wp-login.php');
-	await page.fill('#user_login', ADMIN_USER);
-	await page.fill('#user_pass', ADMIN_PASSWORD);
-	await page.click('#wp-submit');
-	await expect(page).toHaveURL(/\/wp-admin\/?/);
-}
-
 /**
  * Assert a page's React root is present AND something mounted into it. An empty
  * root with no children is the exact failure mode of a broken enqueue (the page
@@ -128,7 +108,7 @@ test.describe('Fair Events admin menu — CPT registered (regression)', () => {
 	test('one top-level Fair Events menu, Calendar first and Settings present', async ({
 		page,
 	}) => {
-		await login(page);
+		await loginAsAdmin(page);
 		await page.goto('/wp-admin/admin.php?page=fair-events-calendar');
 
 		const topLevel = page.locator('#toplevel_page_fair-events-calendar');
@@ -151,7 +131,7 @@ test.describe('Fair Events admin menu — CPT registered (regression)', () => {
 	test('CPT-only menu items are present when the Events post type is on', async ({
 		page,
 	}) => {
-		await login(page);
+		await loginAsAdmin(page);
 		await page.goto('/wp-admin/admin.php?page=fair-events-calendar');
 
 		await expect(
@@ -165,7 +145,7 @@ test.describe('Fair Events admin menu — CPT registered (regression)', () => {
 	});
 
 	test('every page mounts its React root', async ({ page }) => {
-		await login(page);
+		await loginAsAdmin(page);
 		for (const { slug, root } of PAGES) {
 			await expectRootMounts(page, slug, root);
 		}
@@ -187,7 +167,7 @@ test.describe('Fair Events admin menu — Events post type off', () => {
 	test('top-level menu and every non-CPT page still mount', async ({
 		page,
 	}) => {
-		await login(page);
+		await loginAsAdmin(page);
 
 		await expect(
 			page.locator('#toplevel_page_fair-events-calendar'),
@@ -205,7 +185,7 @@ test.describe('Fair Events admin menu — Events post type off', () => {
 	test('CPT-only menu items are hidden when the Events post type is off', async ({
 		page,
 	}) => {
-		await login(page);
+		await loginAsAdmin(page);
 		await page.goto('/wp-admin/admin.php?page=fair-events-calendar');
 
 		await expect(

--- a/e2e/fair-events-feature-flags.spec.js
+++ b/e2e/fair-events-feature-flags.spec.js
@@ -22,19 +22,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { execSync } from 'node:child_process';
-
-const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
-const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
-
-/** Run a WP-CLI command against the wp-env `tests` instance. */
-function wpCli(args) {
-	return execSync(`npx wp-env run tests-cli wp ${args}`, {
-		cwd: process.cwd(),
-		encoding: 'utf8',
-		stdio: ['ignore', 'pipe', 'pipe'],
-	});
-}
+import { wpCli, loginAsAdmin } from './support/wp-cli.js';
 
 /** Set the `fair_events_experimental_features` option to a `{bundle: bool}` map. */
 function setExperimentalFeatures(map) {
@@ -111,14 +99,6 @@ const BUNDLE_PROBE_ROUTES = {
 	migration: '/fair-events/v1/migration/post-types',
 };
 
-async function login(page) {
-	await page.goto('/wp-login.php');
-	await page.fill('#user_login', ADMIN_USER);
-	await page.fill('#user_pass', ADMIN_PASSWORD);
-	await page.click('#wp-submit');
-	await expect(page).toHaveURL(/\/wp-admin\/?/);
-}
-
 async function expectRootMounts(page, slug, root) {
 	await page.goto(`/wp-admin/admin.php?page=${slug}`);
 	await expect(
@@ -172,7 +152,7 @@ test.describe('Fair Events — simplified public build (no bundles set)', () => 
 	test('only core admin pages mount; bundle pages are gone', async ({
 		page,
 	}) => {
-		await login(page);
+		await loginAsAdmin(page);
 
 		// Core pages stay available regardless of feature state.
 		await expectRootMounts(
@@ -208,7 +188,7 @@ test.describe('Fair Events — simplified public build (no bundles set)', () => 
 	});
 
 	test('Settings page exposes the Features tab', async ({ page }) => {
-		await login(page);
+		await loginAsAdmin(page);
 		await page.goto('/wp-admin/admin.php?page=fair-events-settings');
 		await expect(
 			page.getByRole('tab', { name: 'Features' }),
@@ -229,7 +209,7 @@ test.describe('Fair Events — full internal build (all bundles on)', () => {
 	});
 
 	test('every bundle page mounts its React root', async ({ page }) => {
-		await login(page);
+		await loginAsAdmin(page);
 		for (const pages of Object.values(BUNDLE_PAGES)) {
 			for (const { slug, root } of pages) {
 				await expectRootMounts(page, slug, root);
@@ -247,7 +227,7 @@ test.describe('Fair Events — full internal build (all bundles on)', () => {
 	});
 
 	test('Settings page still exposes the Features tab', async ({ page }) => {
-		await login(page);
+		await loginAsAdmin(page);
 		await page.goto('/wp-admin/admin.php?page=fair-events-settings');
 		await expect(page.getByRole('tab', { name: 'Features' })).toBeVisible();
 	});

--- a/e2e/plugin-check.spec.js
+++ b/e2e/plugin-check.spec.js
@@ -21,8 +21,8 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { execSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
+import { wpCli } from './support/wp-cli.js';
 
 /** Plugin directory slugs (mirrors `.wp-env.json` `plugins`). */
 const PLUGINS = [
@@ -40,31 +40,6 @@ const PLUGINS = [
  * since that is what the plugin actually ships.
  */
 const CHECK_FLAGS = '--include-experimental --severity=0 --format=json';
-
-/**
- * Run a WP-CLI command against the wp-env `tests` instance and return stdout.
- *
- * @param {string}  args                 WP-CLI arguments (everything after `wp`).
- * @param {object}  [options]
- * @param {boolean} [options.allowFailure] Return stdout instead of throwing on
- *                                          a non-zero exit (Plugin Check exits
- *                                          non-zero when it finds errors).
- * @return {string} Command stdout.
- */
-function wpCli(args, { allowFailure = false } = {}) {
-	try {
-		return execSync(`npx wp-env run tests-cli wp ${args}`, {
-			cwd: process.cwd(),
-			encoding: 'utf8',
-			stdio: ['ignore', 'pipe', 'pipe'],
-		});
-	} catch (err) {
-		if (allowFailure) {
-			return `${err.stdout || ''}`;
-		}
-		throw err;
-	}
-}
 
 /** Ensure the Plugin Check plugin is installed and active (idempotent). */
 function ensurePluginCheck() {

--- a/e2e/support/wp-cli.js
+++ b/e2e/support/wp-cli.js
@@ -15,15 +15,25 @@ export const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
 /**
  * Run a WP-CLI command against the wp-env `tests` instance and return stdout.
  *
- * @param {string} args WP-CLI arguments (everything after `wp`).
+ * @param {string}  args                   WP-CLI arguments (everything after `wp`).
+ * @param {object}  [options]
+ * @param {boolean} [options.allowFailure]  Return stdout instead of throwing on
+ *                                          a non-zero exit code.
  * @return {string} Command stdout.
  */
-export function wpCli(args) {
-	return execSync(`npx wp-env run tests-cli wp ${args}`, {
-		cwd: process.cwd(),
-		encoding: 'utf8',
-		stdio: ['ignore', 'pipe', 'pipe'],
-	});
+export function wpCli(args, { allowFailure = false } = {}) {
+	try {
+		return execSync(`npx wp-env run tests-cli wp ${args}`, {
+			cwd: process.cwd(),
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+	} catch (err) {
+		if (allowFailure) {
+			return `${err.stdout || ''}`;
+		}
+		throw err;
+	}
 }
 
 /**

--- a/e2e/user-flows/conditional-signup-fields.spec.js
+++ b/e2e/user-flows/conditional-signup-fields.spec.js
@@ -13,40 +13,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { execSync } from 'node:child_process';
-
-/**
- * Run a WP-CLI command against the wp-env `tests` instance and return stdout.
- *
- * @param {string} args WP-CLI arguments (everything after `wp`).
- * @return {string} Command stdout.
- */
-function wpCli(args) {
-	return execSync(`npx wp-env run tests-cli wp ${args}`, {
-		cwd: process.cwd(),
-		encoding: 'utf8',
-		stdio: ['ignore', 'pipe', 'pipe'],
-	});
-}
-
-/**
- * Run a seed/state eval-file script and parse its `MARKER:{json}` output.
- *
- * @param {string} file      Script filename under mu-plugins/scripts/.
- * @param {string} marker    Output marker (e.g. 'E2E_SEED').
- * @param {string} extraArgs Positional args passed to the script.
- * @return {object} Parsed JSON payload.
- */
-function runScript(file, marker, extraArgs = '') {
-	const out = wpCli(
-		`eval-file wp-content/mu-plugins/scripts/${file} ${extraArgs}`.trim()
-	);
-	const match = out.match(new RegExp(`${marker}:(\\{.*\\})`));
-	if (!match) {
-		throw new Error(`Expected ${marker} in WP-CLI output, got:\n${out}`);
-	}
-	return JSON.parse(match[1]);
-}
+import { runScript } from '../support/wp-cli.js';
 
 let event;
 

--- a/e2e/user-flows/signups-list-permission.spec.js
+++ b/e2e/user-flows/signups-list-permission.spec.js
@@ -12,40 +12,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { execSync } from 'node:child_process';
-
-/**
- * Run a WP-CLI command against the wp-env `tests` instance and return stdout.
- *
- * @param {string} args WP-CLI arguments (everything after `wp`).
- * @return {string} Command stdout.
- */
-function wpCli(args) {
-	return execSync(`npx wp-env run tests-cli wp ${args}`, {
-		cwd: process.cwd(),
-		encoding: 'utf8',
-		stdio: ['ignore', 'pipe', 'pipe'],
-	});
-}
-
-/**
- * Run a seed/state eval-file script and parse its `MARKER:{json}` output.
- *
- * @param {string} file      Script filename under mu-plugins/scripts/.
- * @param {string} marker    Output marker (e.g. 'E2E_SIGNUPS_SEED').
- * @param {string} extraArgs Positional args passed to the script.
- * @return {object} Parsed JSON payload.
- */
-function runScript(file, marker, extraArgs = '') {
-	const out = wpCli(
-		`eval-file wp-content/mu-plugins/scripts/${file} ${extraArgs}`.trim()
-	);
-	const match = out.match(new RegExp(`${marker}:(\\{.*\\})`));
-	if (!match) {
-		throw new Error(`Expected ${marker} in WP-CLI output, got:\n${out}`);
-	}
-	return JSON.parse(match[1]);
-}
+import { runScript } from '../support/wp-cli.js';
 
 let seed;
 


### PR DESCRIPTION
Closes #892

## Summary

- Replace copy-pasted `wpCli` / `runScript` / `login` definitions in five E2E specs with imports from `e2e/support/wp-cli.js`
- Extend the shared `wpCli` with an `allowFailure` option (needed by `plugin-check.spec.js` which must tolerate non-zero exit when Plugin Check finds errors)
- Replace local `login()` helpers in `fair-events-admin-menu.spec.js` and `fair-events-feature-flags.spec.js` with the shared `loginAsAdmin()`

## Test plan

- [ ] `npm run test:e2e` passes — pure refactor, no behaviour changes
- [ ] No E2E spec defines its own `wpCli` or `runScript`
- [ ] No spec imports `execSync` directly except `e2e/support/wp-cli.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)