### PR TITLE
chore(deps): update @wordpress/env to v11.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -912,7 +912,7 @@
 			"devDependencies": {
 				"@changesets/cli": "^2.29.6",
 				"@playwright/test": "^1.60.0",
-				"@wordpress/env": "^10.39.0",
+				"@wordpress/env": "^11.8.1",
 				"baseline-browser-mapping": "^2.9.19",
 				"dotenv": "^17.2.3"
 			}
@@ -16331,26 +16331,25 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "10.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.39.0.tgz",
-			"integrity": "sha512-Hgl2RQAAzXFMqkpegGWT1/KkX88OVikRroPidWkij1WtU8p+AZniTcncWmlWqbdLdfGbPqQS5ZkqDZCzrQjgnA==",
+			"version": "11.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.8.1.tgz",
+			"integrity": "sha512-wboYnQNPfMfcgYgiNDbrGGZj8RkdeZtaz2UvmAVUrhOgAvHFpZXsKuXuLdCCSv7JdcHGG5xLWMYhvRLTGOcQ1g==",
 			"devOptional": true,
 			"license": "GPL-2.0-or-later",
 			"peer": true,
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
-				"@wp-playground/cli": "^3.0.0",
-				"chalk": "^4.0.0",
+				"@wp-playground/cli": "^3.0.48",
+				"adm-zip": "^0.5.9",
+				"chalk": "^4.1.1",
 				"copy-dir": "^1.3.0",
 				"cross-spawn": "^7.0.6",
 				"docker-compose": "^0.24.3",
-				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
 				"js-yaml": "^3.13.1",
 				"ora": "^4.0.2",
 				"rimraf": "^5.0.10",
-				"simple-git": "^3.5.0",
-				"terminal-link": "^2.0.0",
+				"simple-git": "^3.24.0",
 				"yargs": "^17.3.0"
 			},
 			"bin": {
@@ -16359,32 +16358,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/env/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"devOptional": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/@wordpress/env/node_modules/extract-zip": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
-			"devOptional": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"concat-stream": "^1.6.2",
-				"debug": "^2.6.9",
-				"mkdirp": "^0.5.4",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
 			}
 		},
 		"node_modules/@wordpress/env/node_modules/glob": {
@@ -16408,13 +16381,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
-		},
-		"node_modules/@wordpress/env/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"devOptional": true,
-			"license": "MIT"
 		},
 		"node_modules/@wordpress/env/node_modules/rimraf": {
 			"version": "5.0.10",
@@ -20651,62 +20617,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"license": "MIT"
-		},
-		"node_modules/concat-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"devOptional": true,
-			"engines": [
-				"node >= 0.8"
-			],
-			"license": "MIT",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
-			}
-		},
-		"node_modules/concat-stream/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"devOptional": true,
-			"license": "MIT"
-		},
-		"node_modules/concat-stream/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"devOptional": true,
-			"license": "MIT",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/concat-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"devOptional": true,
-			"license": "MIT"
-		},
-		"node_modules/concat-stream/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"devOptional": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
 		},
 		"node_modules/configstore": {
 			"version": "7.1.0",
@@ -30038,19 +29948,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"devOptional": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			}
-		},
 		"node_modules/module-details-from-path": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -36570,37 +36467,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/terminal-link": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-			"devOptional": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-escapes": "^4.2.1",
-				"supports-hyperlinks": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/terminal-link/node_modules/supports-hyperlinks": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-			"devOptional": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/terser": {
 			"version": "5.46.0",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
@@ -37186,13 +37052,6 @@
 			"version": "2.12.0",
 			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
 			"integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
-			"license": "MIT"
-		},
-		"node_modules/typedarray": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -976,7 +976,7 @@
 	"devDependencies": {
 		"@changesets/cli": "^2.29.6",
 		"@playwright/test": "^1.60.0",
-		"@wordpress/env": "^10.39.0",
+		"@wordpress/env": "^11.8.1",
 		"baseline-browser-mapping": "^2.9.19",
 		"dotenv": "^17.2.3"
 	}


### PR DESCRIPTION
## Summary

- Bumps `@wordpress/env` from `^10.39.0` to `^11.8.1` in root `devDependencies`.

## Notes

This is a major version bump (10 → 11). No config changes were required — the `.wp-env.json` schema is compatible.

## Test plan

- [ ] `docker compose up` starts the WordPress environment without errors
- [ ] `wp-env start` (if used directly) runs cleanly
- [ ] E2E tests pass: `npm run test:e2e`