### PR TITLE
feat(fair-events): add recurrence_scope to ticket types

### DIFF
--- a/fair-events/src/API/TicketsController.php
+++ b/fair-events/src/API/TicketsController.php
@@ -357,8 +357,11 @@ class TicketsController extends WP_REST_Controller {
 			$disable_at         = isset( $item['disable_at'] ) && '' !== $item['disable_at'] && null !== $item['disable_at']
 				? sanitize_text_field( $item['disable_at'] )
 				: null;
+			$recurrence_scope   = in_array( $item['recurrence_scope'] ?? '', TicketType::RECURRENCE_SCOPES, true )
+				? $item['recurrence_scope']
+				: 'single_instance';
 
-			$new_id = TicketType::create( $event_date_id, $name, $capacity, $index, $seats_per_ticket, $invitation_only, $minimum_activities, $disable_at );
+			$new_id = TicketType::create( $event_date_id, $name, $capacity, $index, $seats_per_ticket, $invitation_only, $minimum_activities, $disable_at, $recurrence_scope );
 			if ( $new_id ) {
 				$type_ids_by_index[ $index ] = (int) $new_id;
 
@@ -523,6 +526,9 @@ class TicketsController extends WP_REST_Controller {
 			$disable_at         = isset( $item['disable_at'] ) && '' !== $item['disable_at'] && null !== $item['disable_at']
 				? sanitize_text_field( $item['disable_at'] )
 				: null;
+			$recurrence_scope   = in_array( $item['recurrence_scope'] ?? '', TicketType::RECURRENCE_SCOPES, true )
+				? $item['recurrence_scope']
+				: 'single_instance';
 			$sort_order         = $index;
 			$group_ids          = isset( $item['group_ids'] ) && is_array( $item['group_ids'] ) ? array_map( 'absint', $item['group_ids'] ) : array();
 
@@ -537,6 +543,7 @@ class TicketsController extends WP_REST_Controller {
 						'invitation_only'    => $invitation_only,
 						'minimum_activities' => $minimum_activities,
 						'disable_at'         => $disable_at,
+						'recurrence_scope'   => $recurrence_scope,
 						'sort_order'         => $sort_order,
 					)
 				);
@@ -544,7 +551,7 @@ class TicketsController extends WP_REST_Controller {
 					\FairEventsExperimental\Models\TicketTypeGroupRestriction::sync_for_ticket_type( (int) $item['id'], $group_ids );
 				}
 			} else {
-				$new_id           = TicketType::create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket, $invitation_only, $minimum_activities, $disable_at );
+				$new_id           = TicketType::create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket, $invitation_only, $minimum_activities, $disable_at, $recurrence_scope );
 				$id_map[ $index ] = (int) $new_id;
 				if ( $new_id && ! empty( $group_ids ) && class_exists( \FairEventsExperimental\Models\TicketTypeGroupRestriction::class ) ) {
 					\FairEventsExperimental\Models\TicketTypeGroupRestriction::sync_for_ticket_type( (int) $new_id, $group_ids );

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -16,6 +16,7 @@ import {
 	FormTokenField,
 	Panel,
 	PanelBody,
+	SelectControl,
 	Spinner,
 	Notice,
 	TextControl,
@@ -32,6 +33,7 @@ export default function EventTickets({
 	onDataRef,
 	startDatetime,
 	endDatetime: endDatetimeProp,
+	isRecurring,
 }) {
 	const [capacity, setCapacity] = useState('');
 	const [signupPrice, setSignupPrice] = useState('');
@@ -383,6 +385,7 @@ export default function EventTickets({
 				invitation_only: t.invitation_only || false,
 				minimum_activities: t.minimum_activities || 0,
 				disable_at: t.disable_at || null,
+				recurrence_scope: t.recurrence_scope || 'single_instance',
 				group_ids: t.group_ids || [],
 			})),
 			sale_periods: getEffectiveSalePeriods().map((p) => ({
@@ -517,6 +520,7 @@ export default function EventTickets({
 				invitation_only: false,
 				minimum_activities: 0,
 				disable_at: null,
+				recurrence_scope: 'single_instance',
 				group_ids: [],
 				sort_order: ticketTypes.length,
 			},
@@ -1455,6 +1459,14 @@ export default function EventTickets({
 															)}
 														</th>
 													)}
+													{isRecurring && (
+														<th>
+															{__(
+																'Scope',
+																'fair-events'
+															)}
+														</th>
+													)}
 													{salePeriods.map(
 														(period, pIndex) => {
 															const isContinuous =
@@ -1751,6 +1763,42 @@ export default function EventTickets({
 																					: null
 																			)
 																		}
+																	/>
+																</td>
+															)}
+															{isRecurring && (
+																<td>
+																	<SelectControl
+																		value={
+																			type.recurrence_scope ||
+																			'single_instance'
+																		}
+																		options={[
+																			{
+																				value: 'single_instance',
+																				label: __(
+																					'This instance',
+																					'fair-events'
+																				),
+																			},
+																			{
+																				value: 'whole_series',
+																				label: __(
+																					'Whole series',
+																					'fair-events'
+																				),
+																			},
+																		]}
+																		onChange={(
+																			v
+																		) =>
+																			updateTicketType(
+																				tIndex,
+																				'recurrence_scope',
+																				v
+																			)
+																		}
+																		__nextHasNoMarginBottom
 																	/>
 																</td>
 															)}

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -1226,6 +1226,7 @@ export default function ManageEventApp() {
 								onSaveRef={ticketSaveRef}
 								startDatetime={eventDate.start_datetime}
 								endDatetime={eventDate.end_datetime}
+								isRecurring={recurrenceEnabled}
 							/>
 						);
 					}

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -229,6 +229,11 @@ class Installer {
 			self::migrate_to_3_13_0();
 		}
 
+		// Run migration if upgrading from pre-3.14.0 (add recurrence_scope to ticket_types).
+		if ( version_compare( $current_version, '3.14.0', '<' ) ) {
+			self::migrate_to_3_14_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -1423,6 +1428,36 @@ class Installer {
 			$wpdb->query(
 				$wpdb->prepare(
 					'ALTER TABLE %i ADD COLUMN disable_at DATETIME DEFAULT NULL AFTER minimum_activities',
+					$table_name
+				)
+			);
+		}
+	}
+
+	/**
+	 * Migrate to version 3.14.0 - Add recurrence_scope column to ticket_types table.
+	 *
+	 * Defaults all existing rows to 'single_instance' so behaviour is unchanged.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_14_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_events_ticket_types';
+
+		$column_exists = $wpdb->get_results(
+			$wpdb->prepare(
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'recurrence_scope' )
+			)
+		);
+
+		if ( empty( $column_exists ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					"ALTER TABLE %i ADD COLUMN recurrence_scope ENUM('single_instance','whole_series') NOT NULL DEFAULT 'single_instance' AFTER disable_at",
 					$table_name
 				)
 			);

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.13.0';
+	const DB_VERSION = '3.14.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -255,6 +255,7 @@ class Schema {
 			invitation_only TINYINT(1) NOT NULL DEFAULT 0,
 			minimum_activities INT UNSIGNED NOT NULL DEFAULT 0,
 			disable_at DATETIME DEFAULT NULL,
+			recurrence_scope ENUM('single_instance','whole_series') NOT NULL DEFAULT 'single_instance',
 			sort_order INT UNSIGNED NOT NULL DEFAULT 0,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/fair-events/src/Models/TicketType.php
+++ b/fair-events/src/Models/TicketType.php
@@ -76,6 +76,13 @@ class TicketType {
 	public $disable_at;
 
 	/**
+	 * Whether this ticket type covers a single occurrence or the whole recurring series
+	 *
+	 * @var string 'single_instance'|'whole_series'
+	 */
+	public $recurrence_scope = 'single_instance';
+
+	/**
 	 * Sort order
 	 *
 	 * @var int
@@ -164,22 +171,32 @@ class TicketType {
 	}
 
 	/**
+	 * Valid values for the recurrence_scope column.
+	 */
+	const RECURRENCE_SCOPES = array( 'single_instance', 'whole_series' );
+
+	/**
 	 * Create a new ticket type
 	 *
-	 * @param int         $event_date_id   Event date ID.
-	 * @param string      $name            Name.
-	 * @param int|null    $capacity        Capacity (null = no limit).
-	 * @param int         $sort_order      Sort order.
-	 * @param int         $seats_per_ticket Seats consumed per ticket (default 1).
-	 * @param bool        $invitation_only Whether this ticket requires an invitation token.
+	 * @param int         $event_date_id      Event date ID.
+	 * @param string      $name               Name.
+	 * @param int|null    $capacity           Capacity (null = no limit).
+	 * @param int         $sort_order         Sort order.
+	 * @param int         $seats_per_ticket   Seats consumed per ticket (default 1).
+	 * @param bool        $invitation_only    Whether this ticket requires an invitation token.
 	 * @param int         $minimum_activities Minimum activities this type requires (0 = inherit global).
-	 * @param string|null $disable_at Date/time after which this ticket type is unavailable (null = no end date).
+	 * @param string|null $disable_at         Date/time after which this ticket type is unavailable (null = no end date).
+	 * @param string      $recurrence_scope   'single_instance' or 'whole_series'.
 	 * @return int|false The ticket type ID on success, false on failure.
 	 */
-	public static function create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket = 1, $invitation_only = false, $minimum_activities = 0, $disable_at = null ) {
+	public static function create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket = 1, $invitation_only = false, $minimum_activities = 0, $disable_at = null, $recurrence_scope = 'single_instance' ) {
 		global $wpdb;
 
 		$table_name = self::get_table_name();
+
+		if ( ! in_array( $recurrence_scope, self::RECURRENCE_SCOPES, true ) ) {
+			$recurrence_scope = 'single_instance';
+		}
 
 		$result = $wpdb->insert(
 			$table_name,
@@ -191,9 +208,10 @@ class TicketType {
 				'invitation_only'    => $invitation_only ? 1 : 0,
 				'minimum_activities' => max( 0, (int) $minimum_activities ),
 				'disable_at'         => $disable_at,
+				'recurrence_scope'   => $recurrence_scope,
 				'sort_order'         => $sort_order,
 			),
-			array( '%d', '%s', '%d', '%d', '%d', '%d', '%s', '%d' )
+			array( '%d', '%s', '%d', '%d', '%d', '%d', '%s', '%s', '%d' )
 		);
 
 		if ( $result ) {
@@ -246,6 +264,14 @@ class TicketType {
 		if ( array_key_exists( 'disable_at', $data ) ) {
 			$update_data['disable_at'] = $data['disable_at'];
 			$update_format[]           = '%s';
+		}
+
+		if ( isset( $data['recurrence_scope'] ) ) {
+			$scope                           = in_array( $data['recurrence_scope'], self::RECURRENCE_SCOPES, true )
+				? $data['recurrence_scope']
+				: 'single_instance';
+			$update_data['recurrence_scope'] = $scope;
+			$update_format[]                 = '%s';
 		}
 
 		if ( isset( $data['sort_order'] ) ) {
@@ -324,11 +350,22 @@ class TicketType {
 		$item->invitation_only    = isset( $row->invitation_only ) && (int) $row->invitation_only === 1;
 		$item->minimum_activities = isset( $row->minimum_activities ) ? (int) $row->minimum_activities : 0;
 		$item->disable_at         = $row->disable_at ?? null;
+		$raw_scope                = $row->recurrence_scope ?? 'single_instance';
+		$item->recurrence_scope   = in_array( $raw_scope, self::RECURRENCE_SCOPES, true ) ? $raw_scope : 'single_instance';
 		$item->sort_order         = (int) $row->sort_order;
 		$item->created_at         = $row->created_at;
 		$item->updated_at         = $row->updated_at;
 
 		return $item;
+	}
+
+	/**
+	 * Whether this ticket type covers the whole recurring series.
+	 *
+	 * @return bool
+	 */
+	public function is_whole_series() {
+		return 'whole_series' === $this->recurrence_scope;
 	}
 
 	/**
@@ -346,6 +383,7 @@ class TicketType {
 			'invitation_only'    => $this->invitation_only,
 			'minimum_activities' => $this->minimum_activities,
 			'disable_at'         => $this->disable_at,
+			'recurrence_scope'   => $this->recurrence_scope,
 			'sort_order'         => $this->sort_order,
 			'created_at'         => $this->created_at,
 			'updated_at'         => $this->updated_at,


### PR DESCRIPTION
## Summary

Adds a `recurrence_scope` field (`single_instance` | `whole_series`) to ticket types, scoping each type either to the specific occurrence it belongs to or to the entire recurring series. Existing rows default to `single_instance` — no behaviour change.

Refs #663

## Changes

- **Schema** — DB_VERSION bumped to 3.14.0; `recurrence_scope ENUM('single_instance','whole_series') NOT NULL DEFAULT 'single_instance'` added after `disable_at` in `fair_events_ticket_types`.
- **Migration** — `Installer::migrate_to_3_14_0()` uses a `SHOW COLUMNS` guard before `ALTER TABLE`, wired into both `install()` and `maybe_upgrade()` chains.
- **Model** (`TicketType`) — `$recurrence_scope` property, `RECURRENCE_SCOPES` constant, `is_whole_series()` helper; allow-list validated in `create()`, `update()`, `hydrate()`; exposed via `to_array()`.
- **REST** (`TicketsController`) — `sync_ticket_types()` and `import_items()` read and sanitize `recurrence_scope`; `build_response()` picks it up automatically through `to_array()`.
- **Admin UI** (`EventTickets.js`) — new `isRecurring` prop (fed from `recurrenceEnabled` in `ManageEventApp`); when true, a **Scope** column appears in the ticket-types table with a `SelectControl` ("This instance" / "Whole series"); field seeded to `single_instance` in `addTicketType()` and included in the export payload.

## Notes

- Signup semantics (§5 of the plan), capacity resolver (§6), and tests (§7) are not yet implemented — this PR covers the data layer and admin UI only.
- The `SelectControl` import was added to the `@wordpress/components` destructure in `EventTickets.js`.

## Test plan

- [ ] Fresh install: `fair_events_db_version` advances to `3.14.0`; `SHOW COLUMNS FROM fair_events_ticket_types LIKE 'recurrence_scope'` returns the new column.
- [ ] Upgrade path: existing rows retain `single_instance`; column is not added twice (guard works).
- [ ] Non-recurring event: Scope column is absent from the ticket-types table.
- [ ] Recurring event: Scope column appears; selecting "Whole series" saves and round-trips correctly (GET → PUT → GET).
- [ ] Export/import: `recurrence_scope` is present in the export JSON and re-applied on import.