### PR TITLE
fix(fair-finance): correct budget movements link to fair-finance-entries

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -7,7 +7,8 @@
 		"./fair-events-experimental",
 		"./fair-audience",
 		"./fair-form",
-		"./fair-platform"
+		"./fair-platform",
+		"./fair-finance"
 	],
 	"mappings": {
 		"wp-content/mu-plugins": "./e2e/mu-plugins"

--- a/e2e/mu-plugins/scripts/cleanup-budget.php
+++ b/e2e/mu-plugins/scripts/cleanup-budget.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Tear down E2E-seeded budget data for the budget-entries-link test.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/cleanup-budget.php <budgetId>
+ *
+ * Prints a single `E2E_BUDGET_CLEANUP:{json}` line with the result.
+ *
+ * @package FairEventsE2E
+ */
+
+use FairFinance\Models\Budget;
+
+$budget_id = isset( $args[0] ) ? (int) $args[0] : 0;
+
+if ( ! $budget_id ) {
+	WP_CLI::error( 'Usage: cleanup-budget.php <budgetId>' );
+}
+
+$deleted = Budget::delete( $budget_id );
+
+echo 'E2E_BUDGET_CLEANUP:' . wp_json_encode(
+	array(
+		'deleted' => $deleted,
+	)
+) . "\n";

--- a/e2e/mu-plugins/scripts/seed-budget.php
+++ b/e2e/mu-plugins/scripts/seed-budget.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Seed data for the budget-entries-link e2e test.
+ *
+ * Creates a named budget using FairFinance\Models\Budget and returns its ID.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-budget.php
+ *
+ * Prints a single `E2E_BUDGET_SEED:{json}` line the spec parses.
+ *
+ * @package FairEventsE2E
+ */
+
+use FairFinance\Models\Budget;
+
+$budget_id = Budget::create( 'E2E Test Budget', 'Created by e2e test' );
+
+if ( ! $budget_id ) {
+	WP_CLI::error( 'Failed to create budget.' );
+}
+
+echo 'E2E_BUDGET_SEED:' . wp_json_encode(
+	array(
+		'budgetId' => (int) $budget_id,
+	)
+) . "\n";

--- a/e2e/user-flows/budget-entries-link.spec.js
+++ b/e2e/user-flows/budget-entries-link.spec.js
@@ -1,0 +1,127 @@
+/**
+ * E2E tests for the budget → entries navigation link.
+ *
+ * Regression test for the fix that changed the "View" button href from
+ * `fair-payments-connector-entries` to `fair-finance-entries`.
+ *
+ * Covers:
+ *  1. "View" buttons are visible on the budgets admin page (both a named
+ *     budget row and the always-present "Unbudgeted" row).
+ *  2. Each button links to the `fair-finance-entries` page (not the old
+ *     `fair-payments-connector-entries` page).
+ *  3. Following a "View" button lands on the Financial Entries page and
+ *     shows the expected heading.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminAuth = Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString(
+	'base64'
+);
+
+test.describe('Budget "View" buttons link to fair-finance-entries', () => {
+	let api;
+	let budgetId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const res = await api.post('/wp-json/fair-finance/v1/budgets', {
+			headers: { Authorization: `Basic ${adminAuth}` },
+			data: { name: 'E2E Test Budget', description: 'Created by e2e test' },
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		budgetId = body.id;
+		expect(budgetId).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (budgetId) {
+			await api.delete(`/wp-json/fair-finance/v1/budgets/${budgetId}`, {
+				headers: { Authorization: `Basic ${adminAuth}` },
+			});
+		}
+		await api.dispose();
+	});
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/wp-login.php');
+		await page.fill('#user_login', ADMIN_USER);
+		await page.fill('#user_pass', ADMIN_PASSWORD);
+		await page.click('#wp-submit');
+		await expect(page).toHaveURL(/\/wp-admin\/?/);
+	});
+
+	test('View button for a named budget links to fair-finance-entries', async ({
+		page,
+	}) => {
+		await page.goto('/wp-admin/admin.php?page=fair-finance-budgets');
+
+		// Wait for React app to render the budget table.
+		const budgetRow = page.locator('tr', {
+			has: page.getByText('E2E Test Budget'),
+		});
+		await expect(budgetRow).toBeVisible();
+
+		const viewButton = budgetRow.getByRole('link', {
+			name: 'View',
+			exact: true,
+		});
+		await expect(viewButton).toBeVisible();
+
+		const href = await viewButton.getAttribute('href');
+		expect(href).toContain('page=fair-finance-entries');
+		expect(href).not.toContain('fair-payments-connector-entries');
+		expect(href).toContain(`budget_id=${budgetId}`);
+	});
+
+	test('View button for the Unbudgeted row links to fair-finance-entries', async ({
+		page,
+	}) => {
+		await page.goto('/wp-admin/admin.php?page=fair-finance-budgets');
+
+		// The Unbudgeted row is always rendered at the bottom of the table.
+		const unbudgetedRow = page.locator('tr', {
+			has: page.getByText('Unbudgeted'),
+		});
+		await expect(unbudgetedRow).toBeVisible();
+
+		const viewButton = unbudgetedRow.getByRole('link', {
+			name: 'View',
+			exact: true,
+		});
+		await expect(viewButton).toBeVisible();
+
+		const href = await viewButton.getAttribute('href');
+		expect(href).toContain('page=fair-finance-entries');
+		expect(href).not.toContain('fair-payments-connector-entries');
+		expect(href).toContain('budget_id=none');
+	});
+
+	test('clicking the Unbudgeted View button opens the Financial Entries page', async ({
+		page,
+	}) => {
+		await page.goto('/wp-admin/admin.php?page=fair-finance-budgets');
+
+		const unbudgetedRow = page.locator('tr', {
+			has: page.getByText('Unbudgeted'),
+		});
+		await expect(unbudgetedRow).toBeVisible();
+
+		await unbudgetedRow
+			.getByRole('link', { name: 'View', exact: true })
+			.click();
+
+		await expect(page).toHaveURL(/page=fair-finance-entries/);
+
+		// The Financial Entries React app should render its heading.
+		await expect(
+			page.getByRole('heading', { name: 'Financial Entries' })
+		).toBeVisible();
+	});
+});

--- a/e2e/user-flows/budget-entries-link.spec.js
+++ b/e2e/user-flows/budget-entries-link.spec.js
@@ -13,48 +13,25 @@
  *     shows the expected heading.
  */
 
-import { test, expect, request } from '@playwright/test';
-
-const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
-const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
-const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
-
-const adminAuth = Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString(
-	'base64'
-);
+import { test, expect } from '@playwright/test';
+import { runScript, loginAsAdmin } from '../support/wp-cli.js';
 
 test.describe('Budget "View" buttons link to fair-finance-entries', () => {
-	let api;
 	let budgetId;
 
-	test.beforeAll(async () => {
-		api = await request.newContext({ baseURL: BASE_URL });
-
-		const res = await api.post('/wp-json/fair-finance/v1/budgets', {
-			headers: { Authorization: `Basic ${adminAuth}` },
-			data: { name: 'E2E Test Budget', description: 'Created by e2e test' },
-		});
-		expect(res.ok()).toBeTruthy();
-		const body = await res.json();
-		budgetId = body.id;
-		expect(budgetId).toBeTruthy();
+	test.beforeAll(() => {
+		const seed = runScript('seed-budget.php', 'E2E_BUDGET_SEED');
+		budgetId = seed.budgetId;
 	});
 
-	test.afterAll(async () => {
+	test.afterAll(() => {
 		if (budgetId) {
-			await api.delete(`/wp-json/fair-finance/v1/budgets/${budgetId}`, {
-				headers: { Authorization: `Basic ${adminAuth}` },
-			});
+			runScript('cleanup-budget.php', 'E2E_BUDGET_CLEANUP', `${budgetId}`);
 		}
-		await api.dispose();
 	});
 
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/wp-login.php');
-		await page.fill('#user_login', ADMIN_USER);
-		await page.fill('#user_pass', ADMIN_PASSWORD);
-		await page.click('#wp-submit');
-		await expect(page).toHaveURL(/\/wp-admin\/?/);
+		await loginAsAdmin(page);
 	});
 
 	test('View button for a named budget links to fair-finance-entries', async ({

--- a/e2e/user-flows/budget-entries-link.spec.js
+++ b/e2e/user-flows/budget-entries-link.spec.js
@@ -26,7 +26,11 @@ test.describe('Budget "View" buttons link to fair-finance-entries', () => {
 
 	test.afterAll(() => {
 		if (budgetId) {
-			runScript('cleanup-budget.php', 'E2E_BUDGET_CLEANUP', `${budgetId}`);
+			runScript(
+				'cleanup-budget.php',
+				'E2E_BUDGET_CLEANUP',
+				`${budgetId}`
+			);
 		}
 	});
 

--- a/fair-finance/src/Admin/budgets/BudgetsApp.js
+++ b/fair-finance/src/Admin/budgets/BudgetsApp.js
@@ -415,7 +415,7 @@ const BudgetsApp = () => {
 															<Button
 																variant="secondary"
 																size="small"
-																href={`admin.php?page=fair-payments-connector-entries&budget_id=${budget.id}`}
+																href={`admin.php?page=fair-finance-entries&budget_id=${budget.id}`}
 															>
 																{__(
 																	'View',
@@ -514,7 +514,7 @@ const BudgetsApp = () => {
 												<Button
 													variant="secondary"
 													size="small"
-													href="admin.php?page=fair-payments-connector-entries&budget_id=none"
+													href="admin.php?page=fair-finance-entries&budget_id=none"
 												>
 													{__(
 														'View',


### PR DESCRIPTION
## Summary
- The "View" buttons on the budgets page (`fair-finance-budgets`) were linking to `fair-payments-connector-entries` instead of `fair-finance-entries`
- Fixed both the per-budget link and the "no budget" entries link in `BudgetsApp.js`

## Test plan
- [ ] Go to `/wp-admin/admin.php?page=fair-finance-budgets`
- [ ] Click "View" on any budget row — confirm it navigates to `?page=fair-finance-entries&budget_id=<id>`
- [ ] Check the "no budget" row link also points to `?page=fair-finance-entries&budget_id=none`