### PR TITLE
Stand up admin infra in fair-form + relocate form answer pages

### DIFF
--- a/.changeset/move-form-admin-pages-to-fair-form.md
+++ b/.changeset/move-form-admin-pages-to-fair-form.md
@@ -1,0 +1,6 @@
+---
+"fair-form": minor
+"fair-audience": minor
+---
+
+Move form answer admin pages (Form Answers, Questionnaire Responses, Submission Detail) from fair-audience into fair-form. The pages now appear under a new Fair Form admin menu. Cross-plugin links to fair-audience (participant detail, by-event back-link, event picker) are preserved as soft dependencies pending Phase 2.

--- a/fair-audience/src/Admin/AdminHooks.php
+++ b/fair-audience/src/Admin/AdminHooks.php
@@ -26,35 +26,27 @@ class AdminHooks {
 	 * @var array<string, array{title: string, callback: string}>
 	 */
 	private const HIDDEN_PAGES = array(
-		'fair-audience-event-participants'      => array(
+		'fair-audience-event-participants' => array(
 			'title'    => 'Event Participants',
 			'callback' => 'render_event_participants_page',
 		),
-		'fair-audience-edit-poll'               => array(
+		'fair-audience-edit-poll'          => array(
 			'title'    => 'Edit Poll',
 			'callback' => 'render_edit_poll_page',
 		),
-		'fair-audience-edit-extra-message'      => array(
+		'fair-audience-edit-extra-message' => array(
 			'title'    => 'Edit Extra Message',
 			'callback' => 'render_edit_extra_message_page',
 		),
-		'fair-audience-fee-detail'              => array(
+		'fair-audience-fee-detail'         => array(
 			'title'    => 'Fee Detail',
 			'callback' => 'render_fee_detail_page',
 		),
-		'fair-audience-questionnaire-responses' => array(
-			'title'    => 'Questionnaire Responses',
-			'callback' => 'render_questionnaire_responses_page',
-		),
-		'fair-audience-submission-detail'       => array(
-			'title'    => 'Submission Detail',
-			'callback' => 'render_submission_detail_page',
-		),
-		'fair-audience-participant-detail'      => array(
+		'fair-audience-participant-detail' => array(
 			'title'    => 'Participant Detail',
 			'callback' => 'render_participant_detail_page',
 		),
-		'fair-audience-group-detail'            => array(
+		'fair-audience-group-detail'       => array(
 			'title'    => 'Group Detail',
 			'callback' => 'render_group_detail_page',
 		),
@@ -217,16 +209,6 @@ class AdminHooks {
 			$this->register_hidden_page( 'fair-audience-fee-detail' );
 		}
 
-		// Submenu page - Form Answers.
-		add_submenu_page(
-			'fair-audience',
-			__( 'Form Answers', 'fair-audience' ),
-			__( 'Form Answers', 'fair-audience' ),
-			'manage_options',
-			'fair-audience-form-answers',
-			array( $this, 'render_form_answers_page' )
-		);
-
 		// Submenu page - By Event.
 		add_submenu_page(
 			'fair-audience',
@@ -239,12 +221,6 @@ class AdminHooks {
 
 		// Hidden submenu page - Event Participants.
 		$this->register_hidden_page( 'fair-audience-event-participants' );
-
-		// Hidden submenu page - Questionnaire Responses.
-		$this->register_hidden_page( 'fair-audience-questionnaire-responses' );
-
-		// Hidden submenu page - Submission Detail.
-		$this->register_hidden_page( 'fair-audience-submission-detail' );
 
 		// Hidden submenu page - Participant Detail.
 		$this->register_hidden_page( 'fair-audience-participant-detail' );
@@ -483,34 +459,10 @@ class AdminHooks {
 	}
 
 	/**
-	 * Render Submission Detail page.
-	 */
-	public function render_submission_detail_page() {
-		$page = new SubmissionDetailPage();
-		$page->render();
-	}
-
-	/**
 	 * Render Participant Detail page.
 	 */
 	public function render_participant_detail_page() {
 		$page = new ParticipantDetailPage();
-		$page->render();
-	}
-
-	/**
-	 * Render Form Answers page.
-	 */
-	public function render_form_answers_page() {
-		$page = new FormAnswersPage();
-		$page->render();
-	}
-
-	/**
-	 * Render Questionnaire Responses page.
-	 */
-	public function render_questionnaire_responses_page() {
-		$page = new QuestionnaireResponsesPage();
 		$page->render();
 	}
 
@@ -630,24 +582,9 @@ class AdminHooks {
 			);
 		}
 
-		// Submission Detail page.
-		if ( 'admin_page_fair-audience-submission-detail' === $hook ) {
-			$this->enqueue_page_script( 'submission-detail', $plugin_dir );
-		}
-
 		// Participant Detail page.
 		if ( 'admin_page_fair-audience-participant-detail' === $hook ) {
 			$this->enqueue_page_script( 'participant-detail', $plugin_dir );
-		}
-
-		// Form Answers page.
-		if ( 'fair-audience_page_fair-audience-form-answers' === $hook ) {
-			$this->enqueue_page_script( 'form-answers', $plugin_dir );
-		}
-
-		// Questionnaire Responses page.
-		if ( 'admin_page_fair-audience-questionnaire-responses' === $hook ) {
-			$this->enqueue_page_script( 'questionnaire-responses', $plugin_dir );
 		}
 
 		// Instagram Posts page.

--- a/fair-audience/webpack.config.cjs
+++ b/fair-audience/webpack.config.cjs
@@ -90,18 +90,6 @@ const customConfig = {
 			process.cwd(),
 			'src/Admin/fee-detail/index.js',
 		),
-		'admin/form-answers/index': path.resolve(
-			process.cwd(),
-			'src/Admin/form-answers/index.js',
-		),
-		'admin/questionnaire-responses/index': path.resolve(
-			process.cwd(),
-			'src/Admin/questionnaire-responses/index.js',
-		),
-		'admin/submission-detail/index': path.resolve(
-			process.cwd(),
-			'src/Admin/submission-detail/index.js',
-		),
 		'admin/participant-detail/index': path.resolve(
 			process.cwd(),
 			'src/Admin/participant-detail/index.js',

--- a/fair-form/src/Admin/AdminHooks.php
+++ b/fair-form/src/Admin/AdminHooks.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Admin Hooks
+ *
+ * @package FairForm
+ */
+
+namespace FairForm\Admin;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Admin hooks for menu and script registration.
+ */
+class AdminHooks {
+
+	/**
+	 * Hidden submenu pages configuration.
+	 *
+	 * WordPress can't find hidden pages (empty parent slug) in the menu structure,
+	 * causing PHP 8.1+ deprecation warnings. This configuration is used to:
+	 * - Register the pages
+	 * - Set proper titles to prevent strip_tags() warnings
+	 * - Set parent_file/submenu_file to prevent null value warnings
+	 *
+	 * @var array<string, array{title: string, callback: string}>
+	 */
+	private const HIDDEN_PAGES = array(
+		'fair-form-questionnaire-responses' => array(
+			'title'    => 'Questionnaire Responses',
+			'callback' => 'render_questionnaire_responses_page',
+		),
+		'fair-form-submission-detail'       => array(
+			'title'    => 'Submission Detail',
+			'callback' => 'render_submission_detail_page',
+		),
+	);
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_admin_menu' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+		add_action( 'current_screen', array( $this, 'set_title_for_hidden_pages' ) );
+		add_filter( 'parent_file', array( $this, 'fix_parent_file_for_hidden_pages' ) );
+		add_filter( 'submenu_file', array( $this, 'fix_submenu_file_for_hidden_pages' ), 10, 2 );
+	}
+
+	/**
+	 * Check if current page is a hidden page.
+	 *
+	 * @return bool True if current page is hidden.
+	 */
+	private function is_hidden_page(): bool {
+		global $plugin_page;
+		return isset( self::HIDDEN_PAGES[ $plugin_page ] );
+	}
+
+	/**
+	 * Fix parent_file for hidden submenu pages to prevent PHP 8.1+ deprecation warnings.
+	 *
+	 * @param string|null $parent_file The parent file.
+	 * @return string The parent file (never null).
+	 */
+	public function fix_parent_file_for_hidden_pages( $parent_file ) {
+		if ( $this->is_hidden_page() ) {
+			return 'fair-form';
+		}
+		return $parent_file ?? '';
+	}
+
+	/**
+	 * Fix submenu_file for hidden submenu pages to prevent PHP 8.1+ deprecation warnings.
+	 *
+	 * @param string|null $submenu_file The submenu file.
+	 * @param string      $parent_file  The parent file.
+	 * @return string The submenu file (never null).
+	 */
+	public function fix_submenu_file_for_hidden_pages( $submenu_file, $parent_file ) {
+		global $plugin_page;
+
+		if ( $this->is_hidden_page() ) {
+			return $plugin_page;
+		}
+		return $submenu_file ?? '';
+	}
+
+	/**
+	 * Set the admin page title for hidden pages to prevent PHP 8.1+ deprecation warnings.
+	 */
+	public function set_title_for_hidden_pages() {
+		global $plugin_page, $title;
+
+		if ( isset( self::HIDDEN_PAGES[ $plugin_page ] ) && empty( $title ) ) {
+			$title = __( self::HIDDEN_PAGES[ $plugin_page ]['title'], 'fair-form' );
+		}
+	}
+
+	/**
+	 * Register a hidden submenu page using the HIDDEN_PAGES configuration.
+	 *
+	 * @param string $menu_slug The menu slug for the hidden page.
+	 */
+	private function register_hidden_page( string $menu_slug ): void {
+		if ( ! isset( self::HIDDEN_PAGES[ $menu_slug ] ) ) {
+			return;
+		}
+
+		$config = self::HIDDEN_PAGES[ $menu_slug ];
+		$title  = __( $config['title'], 'fair-form' );
+
+		add_submenu_page(
+			'', // Hidden from menu.
+			$title,
+			$title,
+			'manage_options',
+			$menu_slug,
+			array( $this, $config['callback'] )
+		);
+	}
+
+	/**
+	 * Register admin menu pages.
+	 */
+	public function register_admin_menu() {
+		// Main menu page.
+		add_menu_page(
+			__( 'Fair Form', 'fair-form' ),
+			__( 'Fair Form', 'fair-form' ),
+			'manage_options',
+			'fair-form',
+			array( $this, 'render_form_answers_page' ),
+			'dashicons-feedback',
+			'20.4'
+		);
+
+		// Visible submenu page - Form Answers (overrides the auto-generated first item).
+		add_submenu_page(
+			'fair-form',
+			__( 'Form Answers', 'fair-form' ),
+			__( 'Form Answers', 'fair-form' ),
+			'manage_options',
+			'fair-form',
+			array( $this, 'render_form_answers_page' )
+		);
+
+		// Hidden submenu page - Questionnaire Responses.
+		$this->register_hidden_page( 'fair-form-questionnaire-responses' );
+
+		// Hidden submenu page - Submission Detail.
+		$this->register_hidden_page( 'fair-form-submission-detail' );
+	}
+
+	/**
+	 * Render Form Answers page.
+	 */
+	public function render_form_answers_page() {
+		$page = new FormAnswersPage();
+		$page->render();
+	}
+
+	/**
+	 * Render Questionnaire Responses page.
+	 */
+	public function render_questionnaire_responses_page() {
+		$page = new QuestionnaireResponsesPage();
+		$page->render();
+	}
+
+	/**
+	 * Render Submission Detail page.
+	 */
+	public function render_submission_detail_page() {
+		$page = new SubmissionDetailPage();
+		$page->render();
+	}
+
+	/**
+	 * Enqueue admin scripts.
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public function enqueue_admin_scripts( $hook ) {
+		$plugin_dir = plugin_dir_path( dirname( __DIR__ ) );
+
+		// Form Answers page (top-level, hook is toplevel_page_fair-form).
+		if ( 'toplevel_page_fair-form' === $hook ) {
+			$this->enqueue_page_script( 'form-answers', $plugin_dir );
+		}
+
+		// Questionnaire Responses page.
+		if ( 'admin_page_fair-form-questionnaire-responses' === $hook ) {
+			$this->enqueue_page_script( 'questionnaire-responses', $plugin_dir );
+		}
+
+		// Submission Detail page.
+		if ( 'admin_page_fair-form-submission-detail' === $hook ) {
+			$this->enqueue_page_script( 'submission-detail', $plugin_dir );
+		}
+	}
+
+	/**
+	 * Enqueue page script.
+	 *
+	 * @param string $page_name  Page name.
+	 * @param string $plugin_dir Plugin directory path.
+	 */
+	private function enqueue_page_script( $page_name, $plugin_dir ) {
+		$asset_file = $plugin_dir . "build/admin/{$page_name}/index.asset.php";
+
+		if ( file_exists( $asset_file ) ) {
+			$asset_data = include $asset_file;
+
+			wp_enqueue_script(
+				"fair-form-{$page_name}",
+				plugin_dir_url( dirname( __DIR__ ) ) . "build/admin/{$page_name}/index.js",
+				$asset_data['dependencies'],
+				$asset_data['version'],
+				true
+			);
+
+			wp_set_script_translations(
+				"fair-form-{$page_name}",
+				'fair-form',
+				\FairForm\Core\Features::script_translations_path()
+			);
+
+			wp_enqueue_style( 'wp-components' );
+		}
+	}
+}

--- a/fair-form/src/Admin/FormAnswersPage.php
+++ b/fair-form/src/Admin/FormAnswersPage.php
@@ -2,10 +2,10 @@
 /**
  * Form Answers Page
  *
- * @package FairAudience
+ * @package FairForm
  */
 
-namespace FairAudience\Admin;
+namespace FairForm\Admin;
 
 defined( 'WPINC' ) || die;
 
@@ -17,6 +17,6 @@ class FormAnswersPage {
 	 * Render page.
 	 */
 	public function render() {
-		echo '<div id="fair-audience-form-answers-root"></div>';
+		echo '<div id="fair-form-form-answers-root"></div>';
 	}
 }

--- a/fair-form/src/Admin/QuestionnaireResponsesPage.php
+++ b/fair-form/src/Admin/QuestionnaireResponsesPage.php
@@ -2,10 +2,10 @@
 /**
  * Questionnaire Responses Page
  *
- * @package FairAudience
+ * @package FairForm
  */
 
-namespace FairAudience\Admin;
+namespace FairForm\Admin;
 
 defined( 'WPINC' ) || die;
 
@@ -17,6 +17,6 @@ class QuestionnaireResponsesPage {
 	 * Render page.
 	 */
 	public function render() {
-		echo '<div id="fair-audience-questionnaire-responses-root"></div>';
+		echo '<div id="fair-form-questionnaire-responses-root"></div>';
 	}
 }

--- a/fair-form/src/Admin/SubmissionDetailPage.php
+++ b/fair-form/src/Admin/SubmissionDetailPage.php
@@ -2,10 +2,10 @@
 /**
  * Submission Detail Page
  *
- * @package FairAudience
+ * @package FairForm
  */
 
-namespace FairAudience\Admin;
+namespace FairForm\Admin;
 
 defined( 'WPINC' ) || die;
 
@@ -17,6 +17,6 @@ class SubmissionDetailPage {
 	 * Render page.
 	 */
 	public function render() {
-		echo '<div id="fair-audience-submission-detail-root"></div>';
+		echo '<div id="fair-form-submission-detail-root"></div>';
 	}
 }

--- a/fair-form/src/Admin/form-answers/FormAnswers.js
+++ b/fair-form/src/Admin/form-answers/FormAnswers.js
@@ -57,6 +57,7 @@ export default function FormAnswers() {
 		if (eventDates.length > 0) {
 			return;
 		}
+		// TODO(phase-2): replace with data-derived event source once available in fair-form.
 		apiFetch({ path: '/fair-audience/v1/custom-mail/events' })
 			.then((data) => {
 				setEventDates(data);
@@ -107,9 +108,9 @@ export default function FormAnswers() {
 			.catch((err) => {
 				// eslint-disable-next-line no-undef
 				alert(
-					__('Error: ', 'fair-audience') +
+					__('Error: ', 'fair-form') +
 						(err.message ||
-							__('Failed to update submission.', 'fair-audience'))
+							__('Failed to update submission.', 'fair-form'))
 				);
 			})
 			.finally(() => {
@@ -121,12 +122,12 @@ export default function FormAnswers() {
 		() => [
 			{
 				id: 'participant_name',
-				label: __('Name', 'fair-audience'),
+				label: __('Name', 'fair-form'),
 				enableSorting: true,
 				enableHiding: false,
 				render: ({ item }) => (
 					<a
-						href={`admin.php?page=fair-audience-submission-detail&submission_id=${item.id}`}
+						href={`admin.php?page=fair-form-submission-detail&submission_id=${item.id}`}
 					>
 						{item.participant_name || '—'}
 					</a>
@@ -135,25 +136,25 @@ export default function FormAnswers() {
 			},
 			{
 				id: 'participant_email',
-				label: __('Email', 'fair-audience'),
+				label: __('Email', 'fair-form'),
 				enableSorting: true,
 				getValue: ({ item }) => item.participant_email || '',
 			},
 			{
 				id: 'title',
-				label: __('Form', 'fair-audience'),
+				label: __('Form', 'fair-form'),
 				enableSorting: true,
 				getValue: ({ item }) => item.title || '',
 			},
 			{
 				id: 'event_name',
-				label: __('Event', 'fair-audience'),
+				label: __('Event', 'fair-form'),
 				enableSorting: true,
 				getValue: ({ item }) => item.event_name || '',
 			},
 			{
 				id: 'created_at',
-				label: __('Date', 'fair-audience'),
+				label: __('Date', 'fair-form'),
 				enableSorting: true,
 				getValue: ({ item }) => item.created_at || '',
 			},
@@ -175,7 +176,7 @@ export default function FormAnswers() {
 			!confirm(
 				__(
 					'Are you sure you want to delete this submission?',
-					'fair-audience'
+					'fair-form'
 				)
 			)
 		) {
@@ -192,9 +193,9 @@ export default function FormAnswers() {
 			.catch((err) => {
 				// eslint-disable-next-line no-undef
 				alert(
-					__('Error: ', 'fair-audience') +
+					__('Error: ', 'fair-form') +
 						(err.message ||
-							__('Failed to delete submission.', 'fair-audience'))
+							__('Failed to delete submission.', 'fair-form'))
 				);
 			});
 	};
@@ -203,23 +204,23 @@ export default function FormAnswers() {
 		() => [
 			{
 				id: 'edit',
-				label: __('Edit', 'fair-audience'),
+				label: __('Edit', 'fair-form'),
 				icon: 'edit',
 				callback: ([item]) => openEdit(item),
 				supportsBulk: false,
 			},
 			{
 				id: 'view',
-				label: __('View', 'fair-audience'),
+				label: __('View', 'fair-form'),
 				icon: 'visibility',
 				callback: ([item]) => {
-					window.location.href = `admin.php?page=fair-audience-submission-detail&submission_id=${item.id}`;
+					window.location.href = `admin.php?page=fair-form-submission-detail&submission_id=${item.id}`;
 				},
 				supportsBulk: false,
 			},
 			{
 				id: 'delete',
-				label: __('Delete', 'fair-audience'),
+				label: __('Delete', 'fair-form'),
 				icon: 'trash',
 				callback: ([item]) => handleDelete(item),
 				supportsBulk: false,
@@ -230,7 +231,7 @@ export default function FormAnswers() {
 
 	const eventDateOptions = useMemo(
 		() => [
-			{ label: __('— None —', 'fair-audience'), value: '' },
+			{ label: __('— None —', 'fair-form'), value: '' },
 			...eventDates.map((ed) => ({
 				label: ed.display_label,
 				value: String(ed.id),
@@ -241,7 +242,7 @@ export default function FormAnswers() {
 
 	return (
 		<div className="wrap">
-			<h1>{__('Form Answers', 'fair-audience')}</h1>
+			<h1>{__('Form Answers', 'fair-form')}</h1>
 
 			<Card>
 				<CardBody>
@@ -261,11 +262,11 @@ export default function FormAnswers() {
 
 			{editingItem && (
 				<Modal
-					title={__('Edit Submission', 'fair-audience')}
+					title={__('Edit Submission', 'fair-form')}
 					onRequestClose={() => setEditingItem(null)}
 				>
 					<SelectControl
-						label={__('Event', 'fair-audience')}
+						label={__('Event', 'fair-form')}
 						value={selectedEventDateId}
 						options={eventDateOptions}
 						onChange={setSelectedEventDateId}
@@ -282,7 +283,7 @@ export default function FormAnswers() {
 							variant="tertiary"
 							onClick={() => setEditingItem(null)}
 						>
-							{__('Cancel', 'fair-audience')}
+							{__('Cancel', 'fair-form')}
 						</Button>
 						<Button
 							variant="primary"
@@ -290,11 +291,7 @@ export default function FormAnswers() {
 							isBusy={isSaving}
 							disabled={isSaving}
 						>
-							{isSaving ? (
-								<Spinner />
-							) : (
-								__('Save', 'fair-audience')
-							)}
+							{isSaving ? <Spinner /> : __('Save', 'fair-form')}
 						</Button>
 					</div>
 				</Modal>

--- a/fair-form/src/Admin/form-answers/index.js
+++ b/fair-form/src/Admin/form-answers/index.js
@@ -1,7 +1,7 @@
 import { createRoot } from '@wordpress/element';
 import FormAnswers from './FormAnswers.js';
 
-const rootElement = document.getElementById('fair-audience-form-answers-root');
+const rootElement = document.getElementById('fair-form-form-answers-root');
 if (rootElement) {
 	createRoot(rootElement).render(<FormAnswers />);
 }

--- a/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
+++ b/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
@@ -105,12 +105,13 @@ export default function QuestionnaireResponses() {
 		const baseFields = [
 			{
 				id: 'participant_name',
-				label: __('Name', 'fair-audience'),
+				label: __('Name', 'fair-form'),
 				enableSorting: true,
 				enableHiding: false,
 				getValue: ({ item }) => item.participant_name || '',
 				render: ({ item }) =>
 					item.participant_id ? (
+						// TODO(phase-3): retarget to fair-form participant detail once it exists.
 						<a
 							href={`admin.php?page=fair-audience-participant-detail&participant_id=${item.participant_id}`}
 						>
@@ -122,19 +123,19 @@ export default function QuestionnaireResponses() {
 			},
 			{
 				id: 'participant_email',
-				label: __('Email', 'fair-audience'),
+				label: __('Email', 'fair-form'),
 				enableSorting: true,
 				getValue: ({ item }) => item.participant_email || '',
 			},
 			{
 				id: 'participant_status',
-				label: __('Status', 'fair-audience'),
+				label: __('Status', 'fair-form'),
 				enableSorting: true,
 				getValue: ({ item }) => item.participant_status || '',
 				render: ({ item }) => {
 					const labels = {
-						pending: __('Pending', 'fair-audience'),
-						confirmed: __('Confirmed', 'fair-audience'),
+						pending: __('Pending', 'fair-form'),
+						confirmed: __('Confirmed', 'fair-form'),
 					};
 					return (
 						labels[item.participant_status] ||
@@ -143,23 +144,23 @@ export default function QuestionnaireResponses() {
 					);
 				},
 				elements: [
-					{ value: 'pending', label: __('Pending', 'fair-audience') },
+					{ value: 'pending', label: __('Pending', 'fair-form') },
 					{
 						value: 'confirmed',
-						label: __('Confirmed', 'fair-audience'),
+						label: __('Confirmed', 'fair-form'),
 					},
 				],
 				filterBy: { operators: ['is'] },
 			},
 			{
 				id: 'participant_mailing',
-				label: __('Mailing', 'fair-audience'),
+				label: __('Mailing', 'fair-form'),
 				enableSorting: true,
 				getValue: ({ item }) => item.participant_mailing || '',
 				render: ({ item }) => {
 					const labels = {
-						minimal: __('Minimal', 'fair-audience'),
-						marketing: __('Marketing', 'fair-audience'),
+						minimal: __('Minimal', 'fair-form'),
+						marketing: __('Marketing', 'fair-form'),
 					};
 					return (
 						labels[item.participant_mailing] ||
@@ -168,17 +169,17 @@ export default function QuestionnaireResponses() {
 					);
 				},
 				elements: [
-					{ value: 'minimal', label: __('Minimal', 'fair-audience') },
+					{ value: 'minimal', label: __('Minimal', 'fair-form') },
 					{
 						value: 'marketing',
-						label: __('Marketing', 'fair-audience'),
+						label: __('Marketing', 'fair-form'),
 					},
 				],
 				filterBy: { operators: ['is'] },
 			},
 			{
 				id: 'participant_categories',
-				label: __('Subscribed Categories', 'fair-audience'),
+				label: __('Subscribed Categories', 'fair-form'),
 				enableSorting: false,
 				getValue: ({ item }) =>
 					(item.participant_categories || [])
@@ -194,7 +195,7 @@ export default function QuestionnaireResponses() {
 			},
 			{
 				id: 'created_at',
-				label: __('Date', 'fair-audience'),
+				label: __('Date', 'fair-form'),
 				enableSorting: true,
 				getValue: ({ item }) => item.created_at || '',
 			},
@@ -239,7 +240,7 @@ export default function QuestionnaireResponses() {
 			!confirm(
 				__(
 					'Are you sure you want to delete this response?',
-					'fair-audience'
+					'fair-form'
 				)
 			)
 		) {
@@ -256,9 +257,9 @@ export default function QuestionnaireResponses() {
 			.catch((err) => {
 				// eslint-disable-next-line no-undef
 				alert(
-					__('Error: ', 'fair-audience') +
+					__('Error: ', 'fair-form') +
 						(err.message ||
-							__('Failed to delete response.', 'fair-audience'))
+							__('Failed to delete response.', 'fair-form'))
 				);
 			});
 	};
@@ -267,7 +268,7 @@ export default function QuestionnaireResponses() {
 		() => [
 			{
 				id: 'delete',
-				label: __('Delete', 'fair-audience'),
+				label: __('Delete', 'fair-form'),
 				icon: 'trash',
 				callback: ([item]) => handleDelete(item),
 				supportsBulk: false,
@@ -362,7 +363,7 @@ export default function QuestionnaireResponses() {
 						// translators: 1: number added, 2: number already in group
 						__(
 							'%1$d participant(s) added, %2$d already in group.',
-							'fair-audience'
+							'fair-form'
 						),
 						added,
 						skipped
@@ -374,10 +375,7 @@ export default function QuestionnaireResponses() {
 					status: 'error',
 					message:
 						err.message ||
-						__(
-							'Failed to add participants to group.',
-							'fair-audience'
-						),
+						__('Failed to add participants to group.', 'fair-form'),
 				});
 			})
 			.finally(() => {
@@ -393,10 +391,10 @@ export default function QuestionnaireResponses() {
 
 	const buildMarkdown = () => {
 		const lines = [];
-		const heading = title || __('Questionnaire Responses', 'fair-audience');
-		const exportedLabel = __('Exported', 'fair-audience');
-		const responsesLabel = __('Responses', 'fair-audience');
-		const adminLinkLabel = __('Admin link', 'fair-audience');
+		const heading = title || __('Questionnaire Responses', 'fair-form');
+		const exportedLabel = __('Exported', 'fair-form');
+		const responsesLabel = __('Responses', 'fair-form');
+		const adminLinkLabel = __('Admin link', 'fair-form');
 
 		const today = new Date().toISOString().split('T')[0];
 
@@ -421,7 +419,7 @@ export default function QuestionnaireResponses() {
 		if (!navigator.clipboard) {
 			setCopyFeedback({
 				status: 'error',
-				message: __('Clipboard not available.', 'fair-audience'),
+				message: __('Clipboard not available.', 'fair-form'),
 			});
 			return;
 		}
@@ -432,14 +430,14 @@ export default function QuestionnaireResponses() {
 					status: 'success',
 					message: __(
 						'Markdown copied to clipboard. Paste into Google Docs.',
-						'fair-audience'
+						'fair-form'
 					),
 				});
 			})
 			.catch(() => {
 				setCopyFeedback({
 					status: 'error',
-					message: __('Failed to copy.', 'fair-audience'),
+					message: __('Failed to copy.', 'fair-form'),
 				});
 			});
 	};
@@ -450,12 +448,12 @@ export default function QuestionnaireResponses() {
 		}
 
 		const headers = [
-			__('Name', 'fair-audience'),
-			__('Email', 'fair-audience'),
-			__('Status', 'fair-audience'),
-			__('Mailing', 'fair-audience'),
-			__('Subscribed Categories', 'fair-audience'),
-			__('Date', 'fair-audience'),
+			__('Name', 'fair-form'),
+			__('Email', 'fair-form'),
+			__('Status', 'fair-form'),
+			__('Mailing', 'fair-form'),
+			__('Subscribed Categories', 'fair-form'),
+			__('Date', 'fair-form'),
 			...questionColumns.map((col) => col.text),
 		];
 
@@ -493,7 +491,7 @@ export default function QuestionnaireResponses() {
 		].join('\n');
 
 		// BOM for UTF-8 Excel compatibility.
-		const bom = '\uFEFF';
+		const bom = '﻿';
 		const blob = new Blob([bom + csvContent], {
 			type: 'text/csv;charset=utf-8;',
 		});
@@ -508,30 +506,31 @@ export default function QuestionnaireResponses() {
 	if (!eventDateId) {
 		return (
 			<div className="wrap">
-				<p>{__('No event date ID provided.', 'fair-audience')}</p>
+				<p>{__('No event date ID provided.', 'fair-form')}</p>
 			</div>
 		);
 	}
 
 	return (
 		<div className="wrap">
-			<h1>{__('Questionnaire Responses', 'fair-audience')}</h1>
+			<h1>{__('Questionnaire Responses', 'fair-form')}</h1>
 
 			<p>
+				{/* TODO(phase-3): retarget back-link to fair-form grouped page once it exists. */}
 				<a href="admin.php?page=fair-audience-by-event">
-					&larr; {__('Back to Events', 'fair-audience')}
+					&larr; {__('Back to Events', 'fair-form')}
 				</a>
 				{' | '}
 				<a
 					href={`admin.php?page=fair-events-manage-event&event_date_id=${eventDateId}`}
 				>
-					{__('Event edit page', 'fair-audience')}
+					{__('Event edit page', 'fair-form')}
 				</a>
 				{postId && (
 					<>
 						{' | '}
 						<a href={`post.php?post=${postId}&action=edit`}>
-							{__('Event entry', 'fair-audience')}
+							{__('Event entry', 'fair-form')}
 						</a>
 					</>
 				)}
@@ -549,21 +548,21 @@ export default function QuestionnaireResponses() {
 					onClick={openGroupModal}
 					disabled={uniqueParticipantIds.length === 0}
 				>
-					{__('Add participants to group', 'fair-audience')}
+					{__('Add participants to group', 'fair-form')}
 				</Button>
 				<Button
 					variant="secondary"
 					onClick={exportCsv}
 					disabled={responses.length === 0}
 				>
-					{__('Export CSV', 'fair-audience')}
+					{__('Export CSV', 'fair-form')}
 				</Button>
 				<Button
 					variant="secondary"
 					onClick={copyMarkdown}
 					disabled={responses.length === 0}
 				>
-					{__('Copy Markdown', 'fair-audience')}
+					{__('Copy Markdown', 'fair-form')}
 				</Button>
 			</div>
 
@@ -578,7 +577,7 @@ export default function QuestionnaireResponses() {
 
 			{isGroupModalOpen && (
 				<Modal
-					title={__('Add participants to group', 'fair-audience')}
+					title={__('Add participants to group', 'fair-form')}
 					onRequestClose={() => setIsGroupModalOpen(false)}
 					style={{ maxWidth: '500px', width: '100%' }}
 				>
@@ -587,25 +586,22 @@ export default function QuestionnaireResponses() {
 							// translators: %d: number of unique participants
 							__(
 								'%d unique participant(s) will be added.',
-								'fair-audience'
+								'fair-form'
 							),
 							uniqueParticipantIds.length
 						)}
 					</p>
 
 					<RadioControl
-						label={__('Target group', 'fair-audience')}
+						label={__('Target group', 'fair-form')}
 						selected={groupMode}
 						options={[
 							{
-								label: __(
-									'Use existing group',
-									'fair-audience'
-								),
+								label: __('Use existing group', 'fair-form'),
 								value: 'existing',
 							},
 							{
-								label: __('Create new group', 'fair-audience'),
+								label: __('Create new group', 'fair-form'),
 								value: 'new',
 							},
 						]}
@@ -614,17 +610,14 @@ export default function QuestionnaireResponses() {
 
 					{groupMode === 'existing' && (
 						<SelectControl
-							label={__('Group', 'fair-audience')}
+							label={__('Group', 'fair-form')}
 							value={selectedGroupId}
 							onChange={setSelectedGroupId}
 							options={[
 								{
 									label: groupsLoading
-										? __('Loading...', 'fair-audience')
-										: __(
-												'— Select a group —',
-												'fair-audience'
-										  ),
+										? __('Loading...', 'fair-form')
+										: __('— Select a group —', 'fair-form'),
 									value: '',
 								},
 								...availableGroups.map((group) => ({
@@ -639,21 +632,21 @@ export default function QuestionnaireResponses() {
 					{groupMode === 'new' && (
 						<>
 							<TextControl
-								label={__('Name', 'fair-audience')}
+								label={__('Name', 'fair-form')}
 								value={newGroupName}
 								onChange={setNewGroupName}
 								placeholder={__(
 									'Enter group name...',
-									'fair-audience'
+									'fair-form'
 								)}
 							/>
 							<TextareaControl
-								label={__('Description', 'fair-audience')}
+								label={__('Description', 'fair-form')}
 								value={newGroupDescription}
 								onChange={setNewGroupDescription}
 								placeholder={__(
 									'Enter group description (optional)...',
-									'fair-audience'
+									'fair-form'
 								)}
 							/>
 						</>
@@ -680,7 +673,7 @@ export default function QuestionnaireResponses() {
 							variant="secondary"
 							onClick={() => setIsGroupModalOpen(false)}
 						>
-							{__('Close', 'fair-audience')}
+							{__('Close', 'fair-form')}
 						</Button>
 						<Button
 							variant="primary"
@@ -689,8 +682,8 @@ export default function QuestionnaireResponses() {
 							isBusy={isSubmittingGroup}
 						>
 							{groupMode === 'new'
-								? __('Create group and add', 'fair-audience')
-								: __('Add to group', 'fair-audience')}
+								? __('Create group and add', 'fair-form')
+								: __('Add to group', 'fair-form')}
 						</Button>
 					</div>
 				</Modal>

--- a/fair-form/src/Admin/questionnaire-responses/index.js
+++ b/fair-form/src/Admin/questionnaire-responses/index.js
@@ -2,7 +2,7 @@ import { createRoot } from '@wordpress/element';
 import QuestionnaireResponses from './QuestionnaireResponses.js';
 
 const rootElement = document.getElementById(
-	'fair-audience-questionnaire-responses-root'
+	'fair-form-questionnaire-responses-root'
 );
 if (rootElement) {
 	createRoot(rootElement).render(<QuestionnaireResponses />);

--- a/fair-form/src/Admin/submission-detail/SubmissionDetail.js
+++ b/fair-form/src/Admin/submission-detail/SubmissionDetail.js
@@ -39,7 +39,7 @@ function AnswerDisplay({ answer }) {
 							}}
 						/>
 					) : (
-						__('View file', 'fair-audience')
+						__('View file', 'fair-form')
 					)}
 				</a>
 			</div>
@@ -72,6 +72,7 @@ function EventField({ submission, onUpdate }) {
 		if (eventDates.length > 0) {
 			return;
 		}
+		// TODO(phase-2): replace with data-derived event source once available in fair-form.
 		apiFetch({ path: '/fair-audience/v1/custom-mail/events' })
 			.then((data) => {
 				setEventDates(data);
@@ -105,9 +106,8 @@ function EventField({ submission, onUpdate }) {
 			.catch((err) => {
 				// eslint-disable-next-line no-undef
 				alert(
-					__('Error: ', 'fair-audience') +
-						(err.message ||
-							__('Failed to update.', 'fair-audience'))
+					__('Error: ', 'fair-form') +
+						(err.message || __('Failed to update.', 'fair-form'))
 				);
 			})
 			.finally(() => {
@@ -116,7 +116,7 @@ function EventField({ submission, onUpdate }) {
 	};
 
 	const eventDateOptions = [
-		{ label: __('— None —', 'fair-audience'), value: '' },
+		{ label: __('— None —', 'fair-form'), value: '' },
 		...eventDates.map((ed) => ({
 			label: ed.display_label,
 			value: String(ed.id),
@@ -132,7 +132,7 @@ function EventField({ submission, onUpdate }) {
 					onClick={handleEdit}
 					style={{ marginLeft: '8px' }}
 				>
-					{__('Edit', 'fair-audience')}
+					{__('Edit', 'fair-form')}
 				</Button>
 			</td>
 		);
@@ -153,10 +153,10 @@ function EventField({ submission, onUpdate }) {
 					isBusy={isSaving}
 					disabled={isSaving}
 				>
-					{__('Save', 'fair-audience')}
+					{__('Save', 'fair-form')}
 				</Button>
 				<Button variant="tertiary" onClick={() => setIsEditing(false)}>
-					{__('Cancel', 'fair-audience')}
+					{__('Cancel', 'fair-form')}
 				</Button>
 			</div>
 		</td>
@@ -176,7 +176,7 @@ export default function SubmissionDetail() {
 		if (!navigator.clipboard) {
 			setCopyFeedback({
 				status: 'error',
-				message: __('Clipboard not available.', 'fair-audience'),
+				message: __('Clipboard not available.', 'fair-form'),
 			});
 			return;
 		}
@@ -187,14 +187,14 @@ export default function SubmissionDetail() {
 					status: 'success',
 					message: __(
 						'Markdown copied to clipboard. Paste into Google Docs.',
-						'fair-audience'
+						'fair-form'
 					),
 				});
 			})
 			.catch(() => {
 				setCopyFeedback({
 					status: 'error',
-					message: __('Failed to copy.', 'fair-audience'),
+					message: __('Failed to copy.', 'fair-form'),
 				});
 			});
 	};
@@ -202,7 +202,7 @@ export default function SubmissionDetail() {
 	useEffect(() => {
 		if (!submissionId) {
 			setIsLoading(false);
-			setError(__('No submission ID provided.', 'fair-audience'));
+			setError(__('No submission ID provided.', 'fair-form'));
 			return;
 		}
 
@@ -213,7 +213,7 @@ export default function SubmissionDetail() {
 				setSubmission(data);
 			})
 			.catch(() => {
-				setError(__('Submission not found.', 'fair-audience'));
+				setError(__('Submission not found.', 'fair-form'));
 			})
 			.finally(() => {
 				setIsLoading(false);
@@ -253,10 +253,10 @@ export default function SubmissionDetail() {
 				}}
 			>
 				<h1>
-					{submission.title || __('Form Submission', 'fair-audience')}
+					{submission.title || __('Form Submission', 'fair-form')}
 				</h1>
 				<Button variant="secondary" onClick={copyMarkdown}>
-					{__('Copy markdown', 'fair-audience')}
+					{__('Copy markdown', 'fair-form')}
 				</Button>
 			</div>
 
@@ -272,7 +272,7 @@ export default function SubmissionDetail() {
 			<Card style={{ marginBottom: '16px' }}>
 				<CardHeader>
 					<h2 style={{ margin: 0 }}>
-						{__('Submission Info', 'fair-audience')}
+						{__('Submission Info', 'fair-form')}
 					</h2>
 				</CardHeader>
 				<CardBody>
@@ -283,10 +283,11 @@ export default function SubmissionDetail() {
 						<tbody>
 							<tr>
 								<th style={{ width: '200px' }}>
-									{__('Submitted by', 'fair-audience')}
+									{__('Submitted by', 'fair-form')}
 								</th>
 								<td>
 									{submission.participant_id ? (
+										// TODO(phase-3): retarget to fair-form participant detail once it exists.
 										<a
 											href={`admin.php?page=fair-audience-participant-detail&participant_id=${submission.participant_id}`}
 										>
@@ -298,15 +299,15 @@ export default function SubmissionDetail() {
 								</td>
 							</tr>
 							<tr>
-								<th>{__('Email', 'fair-audience')}</th>
+								<th>{__('Email', 'fair-form')}</th>
 								<td>{submission.participant_email}</td>
 							</tr>
 							<tr>
-								<th>{__('Date', 'fair-audience')}</th>
+								<th>{__('Date', 'fair-form')}</th>
 								<td>{formatDate(submission.created_at)}</td>
 							</tr>
 							<tr>
-								<th>{__('Event', 'fair-audience')}</th>
+								<th>{__('Event', 'fair-form')}</th>
 								<EventField
 									submission={submission}
 									onUpdate={setSubmission}
@@ -319,13 +320,11 @@ export default function SubmissionDetail() {
 
 			<Card>
 				<CardHeader>
-					<h2 style={{ margin: 0 }}>
-						{__('Answers', 'fair-audience')}
-					</h2>
+					<h2 style={{ margin: 0 }}>{__('Answers', 'fair-form')}</h2>
 				</CardHeader>
 				<CardBody>
 					{submission.answers.length === 0 ? (
-						<p>{__('No answers recorded.', 'fair-audience')}</p>
+						<p>{__('No answers recorded.', 'fair-form')}</p>
 					) : (
 						<table
 							className="widefat striped"
@@ -334,9 +333,9 @@ export default function SubmissionDetail() {
 							<thead>
 								<tr>
 									<th style={{ width: '40%' }}>
-										{__('Question', 'fair-audience')}
+										{__('Question', 'fair-form')}
 									</th>
-									<th>{__('Answer', 'fair-audience')}</th>
+									<th>{__('Answer', 'fair-form')}</th>
 								</tr>
 							</thead>
 							<tbody>

--- a/fair-form/src/Admin/submission-detail/index.js
+++ b/fair-form/src/Admin/submission-detail/index.js
@@ -1,9 +1,7 @@
 import { createRoot } from '@wordpress/element';
 import SubmissionDetail from './SubmissionDetail.js';
 
-const rootElement = document.getElementById(
-	'fair-audience-submission-detail-root'
-);
+const rootElement = document.getElementById('fair-form-submission-detail-root');
 if (rootElement) {
 	createRoot(rootElement).render(<SubmissionDetail />);
 }

--- a/fair-form/src/Admin/utils/submission-markdown.js
+++ b/fair-form/src/Admin/utils/submission-markdown.js
@@ -1,0 +1,64 @@
+import { __ } from '@wordpress/i18n';
+
+// Serialize one answer to markdown lines (### heading + value/link).
+function answerToMarkdownLines(answer) {
+	const lines = [`### ${answer.question_text}`, ''];
+
+	if (answer.file_url) {
+		const alt = answer.question_text || '';
+		// is_image comes from the server mime check — single source of truth.
+		lines.push(
+			answer.is_image
+				? `![${alt}](${answer.file_url})`
+				: `[${alt}](${answer.file_url})`
+		);
+	} else if (answer.question_type === 'multiselect' && answer.answer_value) {
+		let value = answer.answer_value;
+		try {
+			const parsed = JSON.parse(answer.answer_value);
+			if (Array.isArray(parsed)) {
+				value = parsed.join(', ');
+			}
+		} catch {
+			// Keep the raw value.
+		}
+		lines.push(value);
+	} else {
+		lines.push(answer.answer_value || '');
+	}
+
+	return lines;
+}
+
+// One submission → markdown block (## respondent, submitted date, answers).
+// No leading `---` separator; callers add that when listing multiple.
+export function submissionToMarkdown(submission) {
+	const submittedLabel = __('Submitted', 'fair-audience');
+	const adminBase = `${window.location.origin}${window.location.pathname}`;
+
+	const respondent =
+		submission.participant_name ||
+		submission.participant_email ||
+		`#${submission.id}`;
+
+	const lines = [];
+	if (submission.participant_id) {
+		const participantUrl = `${adminBase}?page=fair-audience-participant-detail&participant_id=${submission.participant_id}`;
+		lines.push(`## [${respondent}](${participantUrl})`);
+	} else {
+		lines.push(`## ${respondent}`);
+	}
+	lines.push('');
+
+	if (submission.created_at) {
+		lines.push(`_${submittedLabel} ${submission.created_at}_`);
+		lines.push('');
+	}
+
+	(submission.answers || []).forEach((answer) => {
+		lines.push(...answerToMarkdownLines(answer));
+		lines.push('');
+	});
+
+	return lines.join('\n');
+}

--- a/fair-form/src/Core/Plugin.php
+++ b/fair-form/src/Core/Plugin.php
@@ -56,6 +56,8 @@ class Plugin {
 
 		add_action( 'rest_api_init', array( $this, 'register_api_endpoints' ) );
 
+		new \FairForm\Admin\AdminHooks();
+
 		$block_hooks = new \FairForm\Hooks\BlockHooks();
 	}
 

--- a/fair-form/webpack.config.cjs
+++ b/fair-form/webpack.config.cjs
@@ -1,4 +1,5 @@
 const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const path = require('path');
 const BundleOutputPlugin = require('webpack-bundle-output');
 
 const defaultEntries =
@@ -10,6 +11,19 @@ module.exports = {
 	...defaultConfig,
 	entry: () => ({
 		...defaultEntries,
+		// Admin scripts
+		'admin/form-answers/index': path.resolve(
+			process.cwd(),
+			'src/Admin/form-answers/index.js',
+		),
+		'admin/questionnaire-responses/index': path.resolve(
+			process.cwd(),
+			'src/Admin/questionnaire-responses/index.js',
+		),
+		'admin/submission-detail/index': path.resolve(
+			process.cwd(),
+			'src/Admin/submission-detail/index.js',
+		),
 	}),
 	plugins: [
 		...defaultConfig.plugins,


### PR DESCRIPTION
Closes #885 (PR 1 of N)

## Summary

- Adds a **Fair Form** top-level admin menu with three pages: Form Answers (visible), Questionnaire Responses and Submission Detail (hidden, using the `''`-parent-slug pattern to avoid PHP 8.1+ deprecation warnings).
- Moves the three JS components (`FormAnswers.js`, `QuestionnaireResponses.js`, `SubmissionDetail.js`) and their PHP page classes from `fair-audience` into `fair-form/src/Admin/`.
- Updates root element IDs (`fair-audience-*-root` → `fair-form-*-root`) and the internal cross-page slug (`fair-audience-submission-detail` → `fair-form-submission-detail`).
- Adds three webpack entries to `fair-form/webpack.config.cjs`; assets built and confirmed.
- Removes the pages, their PHP render/enqueue methods, and webpack entries from `fair-audience`. Changelog note included.
- Cross-plugin links to fair-audience (participant detail, by-event back-link, event picker endpoint `/fair-audience/v1/custom-mail/events`) are preserved with `TODO(phase-2/3)` comments — no behavior change, pages soft-depend on fair-audience.

## Test plan

- [ ] Fair Form menu appears in WP admin; Form Answers lists submissions.
- [ ] Clicking a name navigates to `fair-form-submission-detail` (not `fair-audience-submission-detail`).
- [ ] Questionnaire Responses page opens from event-participants flow and lists responses.
- [ ] Submission Detail page loads and the event picker (still backed by `/fair-audience/v1/custom-mail/events`) works.
- [ ] fair-audience no longer shows the Form Answers submenu item.
- [ ] `vendor/bin/phpcs` passes on both plugins (pre-existing errors in `AdminHooks.php` are unchanged).