### PR TITLE
Add stable formId UUID and formTitle to Fair Form block

### DIFF
--- a/.changeset/fair-form-stable-form-id.md
+++ b/.changeset/fair-form-stable-form-id.md
@@ -1,0 +1,5 @@
+---
+"fair-form": minor
+---
+
+Add stable `formId` UUID and `formTitle` attributes to the Fair Form block. The UUID is minted on first insert and regenerated on paste/duplicate collision. Both values are persisted in a new `form_id` / `form_title` column on the submissions table, enabling "by form" grouping in a future release. Existing submissions land in a legacy bucket (NULL form_id).

--- a/fair-form/src/API/FairFormController.php
+++ b/fair-form/src/API/FairFormController.php
@@ -131,6 +131,18 @@ class FairFormController extends WP_REST_Controller {
 							'default'           => '',
 							'sanitize_callback' => 'sanitize_email',
 						),
+						'form_id'               => array(
+							'type'              => 'string',
+							'required'          => false,
+							'default'           => '',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'form_title'            => array(
+							'type'              => 'string',
+							'required'          => false,
+							'default'           => '',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
 					),
 				),
 			)
@@ -259,7 +271,10 @@ class FairFormController extends WP_REST_Controller {
 			$questionnaire_answers,
 			$event_date_id,
 			$post_id,
-			__( 'Fair Form', 'fair-form' )
+			__( 'Fair Form', 'fair-form' ),
+			false,
+			$request->get_param( 'form_id' ),
+			$request->get_param( 'form_title' )
 		);
 
 		// Send confirmation email to the submitter (deferred so a slow mail

--- a/fair-form/src/Database/Schema.php
+++ b/fair-form/src/Database/Schema.php
@@ -35,11 +35,14 @@ class Schema {
 			event_date_id BIGINT UNSIGNED DEFAULT NULL,
 			post_id BIGINT UNSIGNED DEFAULT NULL,
 			title VARCHAR(255) DEFAULT '',
+			form_id VARCHAR(64) DEFAULT NULL,
+			form_title VARCHAR(255) DEFAULT NULL,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY  (id),
 			KEY idx_participant_id (participant_id),
 			KEY idx_event_date_id (event_date_id),
-			KEY idx_post_id (post_id)
+			KEY idx_post_id (post_id),
+			KEY idx_form_id (form_id)
 		) ENGINE=InnoDB $charset_collate;";
 	}
 

--- a/fair-form/src/Models/QuestionnaireSubmission.php
+++ b/fair-form/src/Models/QuestionnaireSubmission.php
@@ -50,6 +50,20 @@ class QuestionnaireSubmission {
 	public $title;
 
 	/**
+	 * Stable form identity UUID (from block attribute).
+	 *
+	 * @var string|null
+	 */
+	public $form_id;
+
+	/**
+	 * Human-readable form label (from block attribute).
+	 *
+	 * @var string|null
+	 */
+	public $form_title;
+
+	/**
 	 * Created timestamp.
 	 *
 	 * @var string
@@ -78,6 +92,8 @@ class QuestionnaireSubmission {
 		$this->event_date_id  = isset( $data['event_date_id'] ) ? (int) $data['event_date_id'] : null;
 		$this->post_id        = isset( $data['post_id'] ) ? (int) $data['post_id'] : null;
 		$this->title          = isset( $data['title'] ) ? $data['title'] : '';
+		$this->form_id        = isset( $data['form_id'] ) ? $data['form_id'] : null;
+		$this->form_title     = isset( $data['form_title'] ) ? $data['form_title'] : null;
 		$this->created_at     = isset( $data['created_at'] ) ? $data['created_at'] : '';
 	}
 
@@ -101,9 +117,11 @@ class QuestionnaireSubmission {
 			'event_date_id'  => $this->event_date_id,
 			'post_id'        => $this->post_id,
 			'title'          => $this->title,
+			'form_id'        => $this->form_id,
+			'form_title'     => $this->form_title,
 		);
 
-		$format = array( '%d', '%d', '%d', '%s' );
+		$format = array( '%d', '%d', '%d', '%s', '%s', '%s' );
 
 		if ( $this->id ) {
 			// Update existing.

--- a/fair-form/src/Services/QuestionnaireService.php
+++ b/fair-form/src/Services/QuestionnaireService.php
@@ -269,9 +269,11 @@ class QuestionnaireService {
 	 *                               participant, event date and title is reused
 	 *                               (its answers replaced) instead of inserting a
 	 *                               new one. Keeps re-submits/payment retries idempotent.
+	 * @param string $form_id        Stable UUID from the block attribute (empty for non-block submissions).
+	 * @param string $form_title     Human-readable form label from the block attribute.
 	 * @return int Submission ID, or 0 on failure.
 	 */
-	public function save_answers( $participant_id, $answers, $event_date_id = 0, $post_id = 0, $title = '', $reuse_existing = false ) {
+	public function save_answers( $participant_id, $answers, $event_date_id = 0, $post_id = 0, $title = '', $reuse_existing = false, $form_id = '', $form_title = '' ) {
 		$title = '' !== $title ? $title : __( 'Fair Form', 'fair-form' );
 
 		$submission = null;
@@ -301,6 +303,14 @@ class QuestionnaireService {
 
 			if ( $post_id > 0 ) {
 				$submission_data['post_id'] = $post_id;
+			}
+
+			if ( '' !== $form_id ) {
+				$submission_data['form_id'] = $form_id;
+			}
+
+			if ( '' !== $form_title ) {
+				$submission_data['form_title'] = $form_title;
 			}
 
 			$submission = new QuestionnaireSubmission();

--- a/fair-form/src/blocks/fair-form/block.json
+++ b/fair-form/src/blocks/fair-form/block.json
@@ -37,6 +37,14 @@
 		"notificationEmail": {
 			"type": "string",
 			"default": ""
+		},
+		"formId": {
+			"type": "string",
+			"default": ""
+		},
+		"formTitle": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"editorScript": "file:./editor.js",

--- a/fair-form/src/blocks/fair-form/editor.js
+++ b/fair-form/src/blocks/fair-form/editor.js
@@ -107,14 +107,36 @@ function EventDateSelect({ eventDateId, onChange }) {
 }
 
 registerBlockType('fair-audience/fair-form', {
-	edit: ({ attributes, setAttributes }) => {
+	edit: ({ attributes, setAttributes, clientId }) => {
 		const {
 			submitButtonText,
 			successMessage,
 			showKeepInformed,
 			eventDateId,
 			notificationEmail,
+			formId,
+			formTitle,
 		} = attributes;
+
+		const allBlocks = useSelect(
+			(select) => select('core/block-editor').getBlocks(),
+			[]
+		);
+
+		// Mint a stable UUID on first insert; regenerate on paste/duplicate collision.
+		useEffect(() => {
+			const isDuplicate =
+				formId &&
+				allBlocks.some(
+					(b) =>
+						b.attributes.formId === formId &&
+						b.clientId !== clientId
+				);
+
+			if (!formId || isDuplicate) {
+				setAttributes({ formId: crypto.randomUUID() });
+			}
+		}, [formId, clientId, allBlocks, setAttributes]);
 
 		const blockProps = useBlockProps({
 			className: 'fair-form',
@@ -187,6 +209,21 @@ registerBlockType('fair-audience/fair-form', {
 							placeholder="admin@example.com"
 							help={__(
 								'Send a notification to this email when someone submits the form. Leave empty to disable.',
+								'fair-audience'
+							)}
+						/>
+						<TextControl
+							label={__('Form Title', 'fair-audience')}
+							value={formTitle}
+							onChange={(value) =>
+								setAttributes({ formTitle: value })
+							}
+							placeholder={__(
+								'e.g. Volunteer signup',
+								'fair-audience'
+							)}
+							help={__(
+								'Internal label for grouping submissions by form. Does not appear on the frontend.',
 								'fair-audience'
 							)}
 						/>

--- a/fair-form/src/blocks/fair-form/frontend.js
+++ b/fair-form/src/blocks/fair-form/frontend.js
@@ -98,6 +98,8 @@ function submitForm(form) {
 	const eventDateId = parseInt(wrapper?.dataset.eventDateId, 10) || 0;
 	const postId = parseInt(wrapper?.dataset.postId, 10) || 0;
 	const notificationEmail = wrapper?.dataset.notificationEmail || '';
+	const blockFormId = wrapper?.dataset.formId || '';
+	const blockFormTitle = wrapper?.dataset.formTitle || '';
 
 	let fetchOptions;
 
@@ -126,6 +128,12 @@ function submitForm(form) {
 		}
 		if (notificationEmail) {
 			formData.append('notification_email', notificationEmail);
+		}
+		if (blockFormId) {
+			formData.append('form_id', blockFormId);
+		}
+		if (blockFormTitle) {
+			formData.append('form_title', blockFormTitle);
 		}
 
 		// Append selected files (skip hidden questions).
@@ -156,6 +164,12 @@ function submitForm(form) {
 		}
 		if (notificationEmail) {
 			requestData.notification_email = notificationEmail;
+		}
+		if (blockFormId) {
+			requestData.form_id = blockFormId;
+		}
+		if (blockFormTitle) {
+			requestData.form_title = blockFormTitle;
 		}
 
 		fetchOptions = {

--- a/fair-form/src/blocks/fair-form/render.php
+++ b/fair-form/src/blocks/fair-form/render.php
@@ -19,20 +19,30 @@ $success_message    = ! empty( $attributes['successMessage'] ) ? $attributes['su
 $show_keep_informed = ! empty( $attributes['showKeepInformed'] );
 $event_date_id      = (int) ( $attributes['eventDateId'] ?? 0 );
 $notification_email = ! empty( $attributes['notificationEmail'] ) ? sanitize_email( $attributes['notificationEmail'] ) : '';
+$block_form_id      = ! empty( $attributes['formId'] ) ? sanitize_text_field( $attributes['formId'] ) : '';
+$block_form_title   = ! empty( $attributes['formTitle'] ) ? sanitize_text_field( $attributes['formTitle'] ) : '';
 
 // Generate unique ID for this form instance.
 $form_id = 'fair-form-' . wp_unique_id();
 
 // Get wrapper attributes.
-$wrapper_attributes = get_block_wrapper_attributes(
-	array(
-		'class'                   => 'fair-form',
-		'data-success-message'    => esc_attr( $success_message ),
-		'data-event-date-id'      => esc_attr( $event_date_id ),
-		'data-post-id'            => esc_attr( get_the_ID() ),
-		'data-notification-email' => esc_attr( $notification_email ),
-	)
+$wrapper_data = array(
+	'class'                   => 'fair-form',
+	'data-success-message'    => esc_attr( $success_message ),
+	'data-event-date-id'      => esc_attr( $event_date_id ),
+	'data-post-id'            => esc_attr( get_the_ID() ),
+	'data-notification-email' => esc_attr( $notification_email ),
 );
+
+if ( '' !== $block_form_id ) {
+	$wrapper_data['data-form-id'] = esc_attr( $block_form_id );
+}
+
+if ( '' !== $block_form_title ) {
+	$wrapper_data['data-form-title'] = esc_attr( $block_form_title );
+}
+
+$wrapper_attributes = get_block_wrapper_attributes( $wrapper_data );
 ?>
 
 <div <?php echo wp_kses_data( $wrapper_attributes ); ?>>


### PR DESCRIPTION
Implements https://github.com/marcin-wosinek/fair-event-plugins/issues/885#issuecomment-4786165482 (PR 2 of the grouped answer navigation ticket).

## Summary

- **Block attributes** — adds `formId` (UUID, stable) and `formTitle` (editable label) to `block.json`; `formTitle` appears as a new inspector control under Form Settings
- **UUID lifecycle** — minted with `crypto.randomUUID()` on first insert; collision-detected on paste/duplicate (scans `getBlocks()` for same `formId` on a different `clientId`) and regenerated
- **render.php** — emits `data-form-id` and `data-form-title` on the wrapper div when set
- **frontend.js** — reads both data attributes and includes `form_id` / `form_title` in the REST submission (both FormData and JSON paths)
- **REST controller** — accepts `form_id` and `form_title` params, passes them to `save_answers()`
- **Service** — `QuestionnaireService::save_answers()` gains two optional trailing params; populates the model when non-empty
- **Model** — `QuestionnaireSubmission` gets `$form_id` and `$form_title` properties, persisted in `save()`
- **Schema** — `form_id VARCHAR(64) DEFAULT NULL` + `form_title VARCHAR(255) DEFAULT NULL` + `KEY idx_form_id` added to the submissions table SQL (idempotent `dbDelta`)

Existing submissions are unaffected (NULL form_id = legacy bucket). No data migration required.

## Test plan

- [ ] Insert a Fair Form block — `formId` should auto-populate (inspect block attributes via the editor)
- [ ] Duplicate the block — the copy should get a new UUID
- [ ] Set a Form Title in the inspector and save; verify `data-form-title` appears in the rendered HTML
- [ ] Submit the form and check the DB `fair_audience_questionnaire_submissions` table: `form_id` and `form_title` columns should be populated
- [ ] Submit without a formId (legacy block without the attribute) — row should have NULL form_id
- [ ] `vendor/bin/phpcs fair-form/src` passes