### PR TITLE
Decouple fair-form from fair-audience; add fair-form-email block (#911)

### DIFF
--- a/.changeset/fair-form-empty-canvas-decouple-audience.md
+++ b/.changeset/fair-form-empty-canvas-decouple-audience.md
@@ -1,0 +1,5 @@
+---
+"fair-form": major
+---
+
+Make fair-form an empty canvas: remove hardcoded First Name / Last Name / Email / Keep Informed fields from the block; add fair-form-email field block with built-in validation; decouple submissions from fair-audience (participant_id is now nullable, submissions succeed without fair-audience active).

--- a/fair-events-shared/src/questionnaire.js
+++ b/fair-events-shared/src/questionnaire.js
@@ -292,6 +292,30 @@ export function validateQuestions(form) {
 		}
 	}
 
+	// Validate email questions (format check).
+	const emailQuestions = form.querySelectorAll(
+		'[data-fair-form-question][data-question-type="email"]'
+	);
+	for (const el of emailQuestions) {
+		if (!isQuestionVisible(el)) {
+			continue;
+		}
+		const input = el.querySelector('input[type="email"]');
+		const value = input ? input.value.trim() : '';
+		if (!value) {
+			continue;
+		}
+		if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+			const questionText = el.dataset.questionText || '';
+			return (
+				__(
+					'Please enter a valid email address for: ',
+					'fair-audience'
+				) + questionText
+			);
+		}
+	}
+
 	// Validate file upload constraints (size), skip hidden ones.
 	const fileUploadQuestions = form.querySelectorAll(
 		'[data-fair-form-question][data-question-type="file_upload"]'

--- a/fair-form/fair-form.php
+++ b/fair-form/fair-form.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fair Form
  * Plugin URI: https://github.com/marcin-wosinek/fair-event-plugins
  * Description: Form blocks and answer data layer for Fair Event Plugins.
- * Version: 0.1.0
+ * Version: 0.2.0
  * Author: Marcin Wosinek
  * Author URI: https://github.com/marcin-wosinek
  * License: Private
@@ -20,7 +20,7 @@ namespace FairForm;
 defined( 'ABSPATH' ) || die;
 
 // Plugin constants.
-define( 'FAIR_FORM_VERSION', '0.1.0' );
+define( 'FAIR_FORM_VERSION', '0.2.0' );
 define( 'FAIR_FORM_FILE', __FILE__ );
 define( 'FAIR_FORM_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FAIR_FORM_URL', plugin_dir_url( __FILE__ ) );
@@ -40,6 +40,10 @@ function fair_form_activate() {
 	dbDelta( \FairForm\Database\Schema::get_questionnaire_submissions_table_sql() );
 	dbDelta( \FairForm\Database\Schema::get_questionnaire_answers_table_sql() );
 	Plugin::activate();
+
+	// Record the DB version set during activation so maybe_upgrade_db knows
+	// that existing steps are already applied on fresh installs.
+	update_option( 'fair_form_db_version', FAIR_FORM_VERSION );
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\\fair_form_activate' );
 
@@ -50,3 +54,35 @@ function fair_form_deactivate() {
 	Plugin::deactivate();
 }
 register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\fair_form_deactivate' );
+
+/**
+ * Apply incremental database migrations for existing installs.
+ *
+ * DbDelta cannot reliably flip NOT NULL to NULL on existing columns; those
+ * changes are applied here with guarded ALTER TABLE statements instead.
+ */
+function fair_form_maybe_upgrade_db() {
+	$db_version = get_option( 'fair_form_db_version', '0' );
+
+	if ( version_compare( $db_version, '0.2.0', '<' ) ) {
+		global $wpdb;
+
+		$submissions_table = $wpdb->prefix . 'fair_audience_questionnaire_submissions';
+		$answers_table     = $wpdb->prefix . 'fair_audience_questionnaire_answers';
+
+		// Make participant_id nullable so submissions can exist without a Participant.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query(
+			$wpdb->prepare( 'ALTER TABLE %i MODIFY participant_id BIGINT UNSIGNED NULL', $submissions_table )
+		);
+
+		// Add 'email' to the question_type ENUM so email-field answers persist correctly.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query(
+			$wpdb->prepare( "ALTER TABLE %i MODIFY question_type ENUM('radio','checkbox','short_text','long_text','select','number','date','multiselect','file_upload','email') NOT NULL DEFAULT 'short_text'", $answers_table )
+		);
+
+		update_option( 'fair_form_db_version', '0.2.0' );
+	}
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_form_maybe_upgrade_db' );

--- a/fair-form/src/API/FairFormController.php
+++ b/fair-form/src/API/FairFormController.php
@@ -43,7 +43,7 @@ class FairFormController extends WP_REST_Controller {
 	private $questionnaire_service;
 
 	/**
-	 * Rate limit: max requests per email per hour.
+	 * Rate limit: max requests per identifier per hour.
 	 */
 	const RATE_LIMIT_MAX = 3;
 
@@ -73,31 +73,6 @@ class FairFormController extends WP_REST_Controller {
 					// Public endpoint: anonymous form submissions are allowed.
 					'permission_callback' => '__return_true',
 					'args'                => array(
-						'name'                  => array(
-							'type'              => 'string',
-							'required'          => true,
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-						'surname'               => array(
-							'type'              => 'string',
-							'required'          => false,
-							'default'           => '',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-						'email'                 => array(
-							'type'              => 'string',
-							'required'          => true,
-							'sanitize_callback' => 'sanitize_email',
-							'validate_callback' => function ( $value ) {
-								return is_email( $value );
-							},
-						),
-						'keep_informed'         => array(
-							'type'              => 'boolean',
-							'required'          => false,
-							'default'           => false,
-							'sanitize_callback' => 'rest_sanitize_boolean',
-						),
 						'event_date_id'         => array(
 							'type'     => 'integer',
 							'required' => false,
@@ -156,10 +131,6 @@ class FairFormController extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object or error.
 	 */
 	public function create_item( $request ) {
-		$name          = $request->get_param( 'name' );
-		$surname       = $request->get_param( 'surname' );
-		$email         = $request->get_param( 'email' );
-		$keep_informed = $request->get_param( 'keep_informed' );
 		$event_date_id = $request->get_param( 'event_date_id' );
 		$post_id       = $request->get_param( 'post_id' );
 
@@ -172,65 +143,58 @@ class FairFormController extends WP_REST_Controller {
 			return $questionnaire_answers;
 		}
 
-		// Validate email.
-		if ( ! is_email( $email ) ) {
-			return new WP_Error(
-				'invalid_email',
-				__( 'Please enter a valid email address.', 'fair-form' ),
-				array( 'status' => 400 )
-			);
-		}
+		// Extract email from questionnaire answers (question_type='email'), if present.
+		$email = $this->extract_email_from_answers( $questionnaire_answers );
 
-		// Check rate limit.
-		if ( $this->is_rate_limited( $email ) ) {
+		// Apply rate limiting keyed on email when available, IP address as fallback.
+		$rate_limit_key = $this->get_rate_limit_key( $email );
+		if ( $this->is_rate_limited( $rate_limit_key ) ) {
 			return new WP_Error(
 				'rate_limited',
 				__( 'Too many requests. Please try again later.', 'fair-form' ),
 				array( 'status' => 429 )
 			);
 		}
+		$this->increment_rate_limit( $rate_limit_key );
 
-		// Increment rate limit counter.
-		$this->increment_rate_limit( $email );
+		// Participant creation is an opt-in enhancement: only run when
+		// fair-audience is active AND an email field was submitted.
+		$participant    = null;
+		$participant_id = null;
 
-		// Find or create participant (requires fair-audience).
-		if ( ! class_exists( '\FairAudience\Database\ParticipantRepository' ) ) {
-			return new WP_Error(
-				'fair_audience_missing',
-				__( 'Participant management plugin is required.', 'fair-form' ),
-				array( 'status' => 500 )
-			);
-		}
+		if ( null !== $email
+			&& class_exists( '\FairAudience\Database\ParticipantRepository' )
+			&& class_exists( '\FairAudience\Models\Participant' ) ) {
+			$participant_repo = new \FairAudience\Database\ParticipantRepository();
+			$existing         = $participant_repo->get_by_email( $email );
 
-		$participant_repo = new \FairAudience\Database\ParticipantRepository();
-		$existing         = $participant_repo->get_by_email( $email );
-
-		if ( $existing ) {
-			$participant = $existing;
-		} else {
-			$participant = new \FairAudience\Models\Participant();
-			$participant->populate(
-				array(
-					'name'          => $name,
-					'surname'       => $surname,
-					'email'         => $email,
-					'email_profile' => $keep_informed ? 'marketing' : 'minimal',
-					'status'        => 'confirmed',
-				)
-			);
-
-			if ( ! $participant->save() ) {
-				return new WP_Error(
-					'creation_failed',
-					__( 'Failed to process submission. Please try again.', 'fair-form' ),
-					array( 'status' => 500 )
+			if ( $existing ) {
+				$participant = $existing;
+			} else {
+				$participant = new \FairAudience\Models\Participant();
+				$participant->populate(
+					array(
+						'email'         => $email,
+						'email_profile' => 'minimal',
+						'status'        => 'confirmed',
+					)
 				);
+
+				if ( ! $participant->save() ) {
+					return new WP_Error(
+						'creation_failed',
+						__( 'Failed to process submission. Please try again.', 'fair-form' ),
+						array( 'status' => 500 )
+					);
+				}
 			}
+
+			$participant_id = $participant->id;
 		}
 
 		// Handle mailing signup if opted in — trigger email confirmation workflow.
 		$mailing_signup = $request->get_param( 'mailing_signup' );
-		if ( $mailing_signup && '0' !== $mailing_signup
+		if ( null !== $participant && $mailing_signup && '0' !== $mailing_signup
 			&& class_exists( '\FairAudience\Database\EmailConfirmationTokenRepository' )
 			&& class_exists( '\FairAudience\Services\EmailService' ) ) {
 			if ( 'marketing' !== $participant->email_profile ) {
@@ -259,15 +223,15 @@ class FairFormController extends WP_REST_Controller {
 		}
 
 		// Process file uploads and update answer values with attachment IDs.
-		$file_result = $this->questionnaire_service->process_file_uploads( $request, $questionnaire_answers, $event_date_id, $participant->id );
+		$file_result = $this->questionnaire_service->process_file_uploads( $request, $questionnaire_answers, $event_date_id, $participant_id );
 		if ( is_wp_error( $file_result ) ) {
 			return $file_result;
 		}
 		$questionnaire_answers = $file_result;
 
-		// Save questionnaire answers.
+		// Save questionnaire answers (participant_id may be null for anonymous submissions).
 		$this->questionnaire_service->save_answers(
-			$participant->id,
+			$participant_id,
 			$questionnaire_answers,
 			$event_date_id,
 			$post_id,
@@ -277,9 +241,8 @@ class FairFormController extends WP_REST_Controller {
 			$request->get_param( 'form_title' )
 		);
 
-		// Send confirmation email to the submitter (deferred so a slow mail
-		// transport can't make this request time out).
-		if ( class_exists( '\FairAudience\Services\EmailService' ) ) {
+		// Send confirmation email to the submitter when participant exists (deferred).
+		if ( null !== $participant && class_exists( '\FairAudience\Services\EmailService' ) ) {
 			\FairAudience\Services\EmailService::defer(
 				'send_form_confirmation',
 				array( $participant, $questionnaire_answers, $post_id )
@@ -290,7 +253,7 @@ class FairFormController extends WP_REST_Controller {
 			if ( ! empty( $notification_email ) && is_email( $notification_email ) ) {
 				\FairAudience\Services\EmailService::defer(
 					'send_form_notification',
-					array( $notification_email, $name, $surname, $email, $questionnaire_answers, $post_id )
+					array( $notification_email, '', '', $email ?? '', $questionnaire_answers, $post_id )
 				);
 			}
 		}
@@ -301,6 +264,39 @@ class FairFormController extends WP_REST_Controller {
 				'message' => __( 'Thank you for your submission!', 'fair-form' ),
 			)
 		);
+	}
+
+	/**
+	 * Extract the first email value from questionnaire answers.
+	 *
+	 * @param array $answers Sanitized questionnaire answers.
+	 * @return string|null Email string, or null if no email answer present.
+	 */
+	private function extract_email_from_answers( $answers ) {
+		foreach ( $answers as $answer ) {
+			if ( 'email' === ( $answer['question_type'] ?? '' ) && ! empty( $answer['answer_value'] ) ) {
+				return sanitize_email( $answer['answer_value'] );
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Build the transient key used for rate limiting.
+	 *
+	 * Keys on email when available; falls back to hashed IP address.
+	 *
+	 * @param string|null $email Submitter email, or null.
+	 * @return string Transient key.
+	 */
+	private function get_rate_limit_key( $email ) {
+		if ( null !== $email && '' !== $email ) {
+			return 'fair_form_submit_' . md5( $email );
+		}
+
+		// Best-effort IP-based fallback when no email field is present.
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : 'unknown';
+		return 'fair_form_submit_ip_' . md5( $ip );
 	}
 
 	/**
@@ -328,31 +324,28 @@ class FairFormController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Check if email is rate limited.
+	 * Check if a rate-limit key is exhausted.
 	 *
-	 * @param string $email Email address.
+	 * @param string $key Transient key.
 	 * @return bool True if rate limited.
 	 */
-	private function is_rate_limited( $email ) {
-		$transient_key = 'fair_form_submit_' . md5( $email );
-		$count         = get_transient( $transient_key );
-
+	private function is_rate_limited( $key ) {
+		$count = get_transient( $key );
 		return $count && (int) $count >= self::RATE_LIMIT_MAX;
 	}
 
 	/**
-	 * Increment rate limit counter.
+	 * Increment the rate-limit counter for a key.
 	 *
-	 * @param string $email Email address.
+	 * @param string $key Transient key.
 	 */
-	private function increment_rate_limit( $email ) {
-		$transient_key = 'fair_form_submit_' . md5( $email );
-		$count         = get_transient( $transient_key );
+	private function increment_rate_limit( $key ) {
+		$count = get_transient( $key );
 
 		if ( $count ) {
-			set_transient( $transient_key, (int) $count + 1, self::RATE_LIMIT_WINDOW );
+			set_transient( $key, (int) $count + 1, self::RATE_LIMIT_WINDOW );
 		} else {
-			set_transient( $transient_key, 1, self::RATE_LIMIT_WINDOW );
+			set_transient( $key, 1, self::RATE_LIMIT_WINDOW );
 		}
 	}
 }

--- a/fair-form/src/Database/Schema.php
+++ b/fair-form/src/Database/Schema.php
@@ -31,7 +31,7 @@ class Schema {
 
 		return "CREATE TABLE $table_name (
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-			participant_id BIGINT UNSIGNED NOT NULL,
+			participant_id BIGINT UNSIGNED NULL,
 			event_date_id BIGINT UNSIGNED DEFAULT NULL,
 			post_id BIGINT UNSIGNED DEFAULT NULL,
 			title VARCHAR(255) DEFAULT '',
@@ -62,7 +62,7 @@ class Schema {
 			submission_id BIGINT UNSIGNED NOT NULL,
 			question_key VARCHAR(100) DEFAULT '',
 			question_text VARCHAR(500) NOT NULL,
-			question_type ENUM('radio','checkbox','short_text','long_text','select','number','date','multiselect','file_upload') NOT NULL DEFAULT 'short_text',
+			question_type ENUM('radio','checkbox','short_text','long_text','select','number','date','multiselect','file_upload','email') NOT NULL DEFAULT 'short_text',
 			answer_value TEXT NOT NULL,
 			display_order INT DEFAULT 0,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/fair-form/src/Hooks/BlockHooks.php
+++ b/fair-form/src/Hooks/BlockHooks.php
@@ -35,6 +35,7 @@ class BlockHooks {
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-short-text' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-long-text' );
+		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-email' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-phone' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-select-one' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-multiselect' );
@@ -51,6 +52,7 @@ class BlockHooks {
 		wp_set_script_translations( 'fair-form-fair-form-view-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-short-text-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-long-text-editor-script', 'fair-audience', $translations_path );
+		wp_set_script_translations( 'fair-form-fair-form-email-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-phone-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-select-one-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-multiselect-editor-script', 'fair-audience', $translations_path );

--- a/fair-form/src/Models/QuestionnaireSubmission.php
+++ b/fair-form/src/Models/QuestionnaireSubmission.php
@@ -22,9 +22,9 @@ class QuestionnaireSubmission {
 	public $id;
 
 	/**
-	 * Participant ID.
+	 * Participant ID (nullable — submissions without a linked participant are allowed).
 	 *
-	 * @var int
+	 * @var int|null
 	 */
 	public $participant_id;
 
@@ -87,14 +87,21 @@ class QuestionnaireSubmission {
 	 * @param array $data Data array.
 	 */
 	public function populate( $data ) {
-		$this->id             = isset( $data['id'] ) ? (int) $data['id'] : null;
-		$this->participant_id = isset( $data['participant_id'] ) ? (int) $data['participant_id'] : 0;
-		$this->event_date_id  = isset( $data['event_date_id'] ) ? (int) $data['event_date_id'] : null;
-		$this->post_id        = isset( $data['post_id'] ) ? (int) $data['post_id'] : null;
-		$this->title          = isset( $data['title'] ) ? $data['title'] : '';
-		$this->form_id        = isset( $data['form_id'] ) ? $data['form_id'] : null;
-		$this->form_title     = isset( $data['form_title'] ) ? $data['form_title'] : null;
-		$this->created_at     = isset( $data['created_at'] ) ? $data['created_at'] : '';
+		$this->id = isset( $data['id'] ) ? (int) $data['id'] : null;
+
+		// Participant ID is nullable: null means no linked participant.
+		if ( array_key_exists( 'participant_id', $data ) ) {
+			$this->participant_id = null !== $data['participant_id'] ? (int) $data['participant_id'] : null;
+		} else {
+			$this->participant_id = null;
+		}
+
+		$this->event_date_id = isset( $data['event_date_id'] ) ? (int) $data['event_date_id'] : null;
+		$this->post_id       = isset( $data['post_id'] ) ? (int) $data['post_id'] : null;
+		$this->title         = isset( $data['title'] ) ? $data['title'] : '';
+		$this->form_id       = isset( $data['form_id'] ) ? $data['form_id'] : null;
+		$this->form_title    = isset( $data['form_title'] ) ? $data['form_title'] : null;
+		$this->created_at    = isset( $data['created_at'] ) ? $data['created_at'] : '';
 	}
 
 	/**
@@ -107,21 +114,35 @@ class QuestionnaireSubmission {
 
 		$table_name = $wpdb->prefix . 'fair_audience_questionnaire_submissions';
 
-		// Validate required fields.
-		if ( empty( $this->participant_id ) ) {
-			return false;
+		// Build data array, omitting participant_id when null so the DB
+		// stores NULL (the column default after the 0.2.0 migration).
+		$data   = array( 'title' => $this->title );
+		$format = array( '%s' );
+
+		if ( null !== $this->participant_id ) {
+			$data   = array_merge( array( 'participant_id' => (int) $this->participant_id ), $data );
+			$format = array_merge( array( '%d' ), $format );
 		}
 
-		$data = array(
-			'participant_id' => $this->participant_id,
-			'event_date_id'  => $this->event_date_id,
-			'post_id'        => $this->post_id,
-			'title'          => $this->title,
-			'form_id'        => $this->form_id,
-			'form_title'     => $this->form_title,
-		);
+		if ( null !== $this->event_date_id ) {
+			$data['event_date_id'] = (int) $this->event_date_id;
+			$format[]              = '%d';
+		}
 
-		$format = array( '%d', '%d', '%d', '%s', '%s', '%s' );
+		if ( null !== $this->post_id ) {
+			$data['post_id'] = (int) $this->post_id;
+			$format[]        = '%d';
+		}
+
+		if ( null !== $this->form_id ) {
+			$data['form_id'] = $this->form_id;
+			$format[]        = '%s';
+		}
+
+		if ( null !== $this->form_title ) {
+			$data['form_title'] = $this->form_title;
+			$format[]           = '%s';
+		}
 
 		if ( $this->id ) {
 			// Update existing.

--- a/fair-form/src/Services/QuestionnaireService.php
+++ b/fair-form/src/Services/QuestionnaireService.php
@@ -50,7 +50,7 @@ class QuestionnaireService {
 	 *
 	 * @var array
 	 */
-	const VALID_TYPES = array( 'radio', 'checkbox', 'short_text', 'long_text', 'select', 'number', 'date', 'multiselect', 'file_upload', 'phone' );
+	const VALID_TYPES = array( 'radio', 'checkbox', 'short_text', 'long_text', 'select', 'number', 'date', 'multiselect', 'file_upload', 'phone', 'email' );
 
 	/**
 	 * Questionnaire submission repository instance.
@@ -113,6 +113,21 @@ class QuestionnaireService {
 			$question_type = in_array( $answer['question_type'] ?? '', self::VALID_TYPES, true ) ? $answer['question_type'] : 'short_text';
 			$answer_value  = sanitize_text_field( $answer['answer_value'] ?? '' );
 			$question_text = sanitize_text_field( $answer['question_text'] ?? '' );
+
+			if ( 'email' === $question_type && '' !== $answer_value ) {
+				$answer_value = sanitize_email( $answer_value );
+				if ( '' !== $answer_value && ! is_email( $answer_value ) ) {
+					return new WP_Error(
+						'invalid_email',
+						sprintf(
+							/* translators: %s: question text */
+							__( 'Please enter a valid email address for: %s', 'fair-form' ),
+							$question_text
+						),
+						array( 'status' => 400 )
+					);
+				}
+			}
 
 			if ( 'phone' === $question_type && '' !== $answer_value && ! preg_match( '/^\+[1-9][0-9]{6,14}$/', $answer_value ) ) {
 				return new WP_Error(
@@ -260,17 +275,17 @@ class QuestionnaireService {
 	/**
 	 * Save questionnaire answers for a participant.
 	 *
-	 * @param int    $participant_id Participant ID.
-	 * @param array  $answers        Questionnaire answers to persist.
-	 * @param int    $event_date_id  Optional event date ID.
-	 * @param int    $post_id        Optional post ID.
-	 * @param string $title          Submission title (e.g. "Fair Form", "Event Signup").
-	 * @param bool   $reuse_existing When true, an existing submission with the same
-	 *                               participant, event date and title is reused
-	 *                               (its answers replaced) instead of inserting a
-	 *                               new one. Keeps re-submits/payment retries idempotent.
-	 * @param string $form_id        Stable UUID from the block attribute (empty for non-block submissions).
-	 * @param string $form_title     Human-readable form label from the block attribute.
+	 * @param int|null $participant_id Participant ID, or null for anonymous submissions.
+	 * @param array    $answers        Questionnaire answers to persist.
+	 * @param int      $event_date_id  Optional event date ID.
+	 * @param int      $post_id        Optional post ID.
+	 * @param string   $title          Submission title (e.g. "Fair Form", "Event Signup").
+	 * @param bool     $reuse_existing When true, an existing submission with the same
+	 *                                 participant, event date and title is reused
+	 *                                 (its answers replaced) instead of inserting a
+	 *                                 new one. Keeps re-submits/payment retries idempotent.
+	 * @param string   $form_id        Stable UUID from the block attribute (empty for non-block submissions).
+	 * @param string   $form_title     Human-readable form label from the block attribute.
 	 * @return int Submission ID, or 0 on failure.
 	 */
 	public function save_answers( $participant_id, $answers, $event_date_id = 0, $post_id = 0, $title = '', $reuse_existing = false, $form_id = '', $form_title = '' ) {
@@ -278,7 +293,8 @@ class QuestionnaireService {
 
 		$submission = null;
 
-		if ( $reuse_existing && $event_date_id > 0 ) {
+		// Reuse is only possible when we have a participant to match against.
+		if ( $reuse_existing && $event_date_id > 0 && null !== $participant_id ) {
 			$existing = $this->submission_repository->get_by_filters(
 				array(
 					'participant_id' => $participant_id,

--- a/fair-form/src/blocks/fair-form-email/block.json
+++ b/fair-form/src/blocks/fair-form-email/block.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "fair-audience/fair-form-email",
+	"version": "1.0.0",
+	"title": "Email Question",
+	"category": "widgets",
+	"icon": "email",
+	"description": "An email input question with built-in format validation for Fair Form",
+	"keywords": ["question", "email", "input"],
+	"textdomain": "fair-audience",
+	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
+	"supports": {
+		"html": false
+	},
+	"attributes": {
+		"questionText": {
+			"type": "string",
+			"default": ""
+		},
+		"questionKey": {
+			"type": "string",
+			"default": ""
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		},
+		"placeholder": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"editorScript": "file:./editor.js",
+	"render": "file:./render.php",
+	"style": "file:./style-editor.css"
+}

--- a/fair-form/src/blocks/fair-form-email/editor.js
+++ b/fair-form/src/blocks/fair-form-email/editor.js
@@ -1,0 +1,92 @@
+import './style.css';
+
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { generateQuestionKey } from 'fair-events-shared';
+
+registerBlockType('fair-audience/fair-form-email', {
+	edit: ({ attributes, setAttributes }) => {
+		const { questionText, questionKey, required, placeholder } = attributes;
+
+		const onQuestionTextChange = (value) => {
+			const updates = { questionText: value };
+			if (
+				!questionKey ||
+				questionKey === generateQuestionKey(questionText)
+			) {
+				updates.questionKey = generateQuestionKey(value);
+			}
+			setAttributes(updates);
+		};
+
+		const blockProps = useBlockProps({
+			className: 'fair-form-question fair-form-question-email',
+		});
+
+		return (
+			<>
+				<InspectorControls>
+					<PanelBody title={__('Question Settings', 'fair-audience')}>
+						<TextControl
+							label={__('Question Key', 'fair-audience')}
+							value={questionKey}
+							onChange={(value) =>
+								setAttributes({ questionKey: value })
+							}
+							help={__(
+								'A unique identifier for this question (e.g. "email"). Used internally.',
+								'fair-audience'
+							)}
+						/>
+						<ToggleControl
+							label={__('Required', 'fair-audience')}
+							checked={required}
+							onChange={(value) =>
+								setAttributes({ required: value })
+							}
+						/>
+						<TextControl
+							label={__('Placeholder', 'fair-audience')}
+							value={placeholder}
+							onChange={(value) =>
+								setAttributes({ placeholder: value })
+							}
+						/>
+					</PanelBody>
+				</InspectorControls>
+
+				<div {...blockProps}>
+					<p>
+						<input
+							type="text"
+							value={questionText}
+							onChange={(e) =>
+								onQuestionTextChange(e.target.value)
+							}
+							placeholder={__(
+								'Enter your question...',
+								'fair-audience'
+							)}
+							className="fair-form-question-label-input"
+						/>
+						{required && <span className="required"> *</span>}
+						<br />
+						<input
+							type="email"
+							disabled
+							placeholder={
+								placeholder ||
+								__('your@email.com', 'fair-audience')
+							}
+						/>
+					</p>
+				</div>
+			</>
+		);
+	},
+	save: () => {
+		return null;
+	},
+});

--- a/fair-form/src/blocks/fair-form-email/render.php
+++ b/fair-form/src/blocks/fair-form-email/render.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Render callback for the Fair Form Email question block
+ *
+ * @package FairForm
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block content.
+ * @param WP_Block $block      Block instance.
+ * @return string Rendered block HTML.
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ * Variables in block render templates are scoped to the template and don't need prefixing.
+ */
+
+defined( 'WPINC' ) || die;
+
+$question_text = $attributes['questionText'] ?? '';
+$question_key  = $attributes['questionKey'] ?? '';
+$required      = ! empty( $attributes['required'] );
+$placeholder   = $attributes['placeholder'] ?? '';
+
+// Skip rendering if no question text is set.
+if ( empty( $question_text ) ) {
+	return '';
+}
+
+// Generate unique ID for this input.
+$input_id = 'fair-form-q-' . sanitize_title( $question_key ) . '-' . wp_unique_id();
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class'                   => 'fair-form-question fair-form-question-email',
+		'data-fair-form-question' => '',
+		'data-question-key'       => esc_attr( $question_key ),
+		'data-question-text'      => esc_attr( $question_text ),
+		'data-question-type'      => 'email',
+		'data-required'           => $required ? '1' : '0',
+	)
+);
+?>
+
+<div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
+	<label for="<?php echo esc_attr( $input_id ); ?>">
+		<?php echo esc_html( $question_text ); ?>
+		<?php if ( $required ) : ?>
+			<span class="required">*</span>
+		<?php endif; ?>
+	</label>
+	<input
+		type="email"
+		id="<?php echo esc_attr( $input_id ); ?>"
+		name="<?php echo esc_attr( 'fair_form_q_' . $question_key ); ?>"
+		<?php if ( $required ) : ?>
+			required
+		<?php endif; ?>
+		<?php if ( ! empty( $placeholder ) ) : ?>
+			placeholder="<?php echo esc_attr( $placeholder ); ?>"
+		<?php endif; ?>
+	/>
+</div>

--- a/fair-form/src/blocks/fair-form-email/style.css
+++ b/fair-form/src/blocks/fair-form-email/style.css
@@ -1,0 +1,24 @@
+.fair-form-question-email .fair-form-question-label-input {
+	border: none;
+	border-bottom: 1px dashed #8c8f94;
+	background: transparent;
+	font-weight: 600;
+	padding: 2px 0;
+	font-size: inherit;
+	width: auto;
+}
+
+.fair-form-question-email .fair-form-question-label-input:focus {
+	outline: none;
+	border-bottom-color: #2271b1;
+}
+
+.fair-form-question-email input[type="email"]:disabled {
+	width: 100%;
+	padding: 8px 12px;
+	border: 1px solid #8c8f94;
+	border-radius: 4px;
+	font-size: inherit;
+	line-height: 1.5;
+	background: #f0f0f0;
+}

--- a/fair-form/src/blocks/fair-form/block.json
+++ b/fair-form/src/blocks/fair-form/block.json
@@ -26,10 +26,6 @@
 			"type": "string",
 			"default": "Thank you for your submission!"
 		},
-		"showKeepInformed": {
-			"type": "boolean",
-			"default": false
-		},
 		"eventDateId": {
 			"type": "integer",
 			"default": 0

--- a/fair-form/src/blocks/fair-form/editor.js
+++ b/fair-form/src/blocks/fair-form/editor.js
@@ -27,6 +27,8 @@ const ALLOWED_BLOCKS = [
 	'core/list',
 	'fair-audience/fair-form-short-text',
 	'fair-audience/fair-form-long-text',
+	'fair-audience/fair-form-email',
+	'fair-audience/fair-form-phone',
 	'fair-audience/fair-form-select-one',
 	'fair-audience/fair-form-multiselect',
 	'fair-audience/fair-form-radio',
@@ -111,7 +113,6 @@ registerBlockType('fair-audience/fair-form', {
 		const {
 			submitButtonText,
 			successMessage,
-			showKeepInformed,
 			eventDateId,
 			notificationEmail,
 			formId,
@@ -177,20 +178,6 @@ registerBlockType('fair-audience/fair-form', {
 								'fair-audience'
 							)}
 						/>
-						<ToggleControl
-							label={__(
-								'Show "Keep me informed" checkbox',
-								'fair-audience'
-							)}
-							checked={showKeepInformed}
-							onChange={(value) =>
-								setAttributes({ showKeepInformed: value })
-							}
-							help={__(
-								'Adds a marketing opt-in checkbox to the form.',
-								'fair-audience'
-							)}
-						/>
 						<EventDateSelect
 							eventDateId={eventDateId}
 							onChange={(value) =>
@@ -231,33 +218,6 @@ registerBlockType('fair-audience/fair-form', {
 				</InspectorControls>
 
 				<div {...blockProps}>
-					<div className="fair-form-editor-header">
-						<span className="fair-form-editor-label">
-							{__('Fair Form', 'fair-audience')}
-						</span>
-					</div>
-					<div className="fair-form-editor-fields">
-						<div className="fair-form-editor-field">
-							<label>{__('First Name', 'fair-audience')} *</label>
-							<input type="text" disabled />
-						</div>
-						<div className="fair-form-editor-field">
-							<label>{__('Last Name', 'fair-audience')}</label>
-							<input type="text" disabled />
-						</div>
-						<div className="fair-form-editor-field">
-							<label>{__('Email', 'fair-audience')} *</label>
-							<input type="email" disabled />
-						</div>
-						{showKeepInformed && (
-							<div className="fair-form-editor-field">
-								<label>
-									<input type="checkbox" disabled />
-									{__('Keep me informed', 'fair-audience')}
-								</label>
-							</div>
-						)}
-					</div>
 					<div {...innerBlocksProps} />
 					<div className="fair-form-editor-footer">
 						<div className="wp-block-button">

--- a/fair-form/src/blocks/fair-form/frontend.js
+++ b/fair-form/src/blocks/fair-form/frontend.js
@@ -32,35 +32,13 @@ function setupFormSubmission(form) {
 	setupQuestionnaire(form);
 }
 
-function validateForm(form) {
-	const name = form.querySelector('input[name="fair_form_name"]');
-	const email = form.querySelector('input[name="fair_form_email"]');
-
-	if (!name || !name.value.trim()) {
-		return __('Please enter your first name.', 'fair-audience');
-	}
-
-	if (!email || !email.value.trim()) {
-		return __('Please enter your email address.', 'fair-audience');
-	}
-
-	// Basic email validation.
-	const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-	if (!emailPattern.test(email.value.trim())) {
-		return __('Please enter a valid email address.', 'fair-audience');
-	}
-
-	// Validate the nested question blocks (required/phone/file constraints).
-	return validateQuestions(form);
-}
-
 function submitForm(form) {
 	const wrapper = form.closest('.fair-form');
 	const messageContainer = form.querySelector('.fair-form-message');
 	const submitButton = form.querySelector('.fair-form-submit-button');
 
-	// Validate.
-	const validationError = validateForm(form);
+	// Validate all question blocks (required, phone format, file sizes, email format).
+	const validationError = validateQuestions(form);
 	if (validationError) {
 		showMessage(messageContainer, validationError, 'error', 'fair-form');
 		return;
@@ -71,18 +49,6 @@ function submitForm(form) {
 		__('Submitting...', 'fair-audience')
 	);
 
-	const nameValue = form
-		.querySelector('input[name="fair_form_name"]')
-		.value.trim();
-	const surnameValue = (
-		form.querySelector('input[name="fair_form_surname"]')?.value || ''
-	).trim();
-	const emailValue = form
-		.querySelector('input[name="fair_form_email"]')
-		.value.trim();
-	const keepInformed =
-		form.querySelector('input[name="fair_form_keep_informed"]')?.checked ||
-		false;
 	const mailingSignup =
 		form.querySelector('input[name="fair_form_mailing_signup"]')?.checked ||
 		false;
@@ -106,10 +72,6 @@ function submitForm(form) {
 	if (hasFileUploads(form)) {
 		// Use FormData for multipart submission with files.
 		const formData = new FormData();
-		formData.append('name', nameValue);
-		formData.append('surname', surnameValue);
-		formData.append('email', emailValue);
-		formData.append('keep_informed', keepInformed ? '1' : '0');
 		formData.append('mailing_signup', mailingSignup ? '1' : '0');
 		formData.append(
 			'mailing_category_ids',
@@ -147,10 +109,6 @@ function submitForm(form) {
 	} else {
 		// Use JSON for submissions without files.
 		const requestData = {
-			name: nameValue,
-			surname: surnameValue,
-			email: emailValue,
-			keep_informed: keepInformed,
 			mailing_signup: mailingSignup,
 			mailing_category_ids: mailingCategories,
 			questionnaire_answers: questionnaireAnswers,

--- a/fair-form/src/blocks/fair-form/render.php
+++ b/fair-form/src/blocks/fair-form/render.php
@@ -16,14 +16,10 @@ defined( 'WPINC' ) || die;
 
 $submit_text        = ! empty( $attributes['submitButtonText'] ) ? $attributes['submitButtonText'] : __( 'Submit', 'fair-audience' );
 $success_message    = ! empty( $attributes['successMessage'] ) ? $attributes['successMessage'] : __( 'Thank you for your submission!', 'fair-audience' );
-$show_keep_informed = ! empty( $attributes['showKeepInformed'] );
 $event_date_id      = (int) ( $attributes['eventDateId'] ?? 0 );
 $notification_email = ! empty( $attributes['notificationEmail'] ) ? sanitize_email( $attributes['notificationEmail'] ) : '';
 $block_form_id      = ! empty( $attributes['formId'] ) ? sanitize_text_field( $attributes['formId'] ) : '';
 $block_form_title   = ! empty( $attributes['formTitle'] ) ? sanitize_text_field( $attributes['formTitle'] ) : '';
-
-// Generate unique ID for this form instance.
-$form_id = 'fair-form-' . wp_unique_id();
 
 // Get wrapper attributes.
 $wrapper_data = array(
@@ -47,52 +43,7 @@ $wrapper_attributes = get_block_wrapper_attributes( $wrapper_data );
 
 <div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
 	<form class="fair-form-form" novalidate>
-		<p>
-			<label for="<?php echo esc_attr( $form_id ); ?>-name">
-				<?php echo esc_html__( 'First Name', 'fair-audience' ); ?> <span class="required">*</span>
-			</label>
-			<input
-				type="text"
-				id="<?php echo esc_attr( $form_id ); ?>-name"
-				name="fair_form_name"
-				required
-				placeholder="<?php echo esc_attr__( 'Enter your first name', 'fair-audience' ); ?>"
-			/>
-		</p>
-		<p>
-			<label for="<?php echo esc_attr( $form_id ); ?>-surname">
-				<?php echo esc_html__( 'Last Name', 'fair-audience' ); ?>
-			</label>
-			<input
-				type="text"
-				id="<?php echo esc_attr( $form_id ); ?>-surname"
-				name="fair_form_surname"
-				placeholder="<?php echo esc_attr__( 'Enter your last name', 'fair-audience' ); ?>"
-			/>
-		</p>
-		<p>
-			<label for="<?php echo esc_attr( $form_id ); ?>-email">
-				<?php echo esc_html__( 'Email', 'fair-audience' ); ?> <span class="required">*</span>
-			</label>
-			<input
-				type="email"
-				id="<?php echo esc_attr( $form_id ); ?>-email"
-				name="fair_form_email"
-				required
-				placeholder="<?php echo esc_attr__( 'Enter your email', 'fair-audience' ); ?>"
-			/>
-		</p>
-
 		<?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner blocks content is already escaped by WordPress. ?>
-
-		<?php if ( $show_keep_informed ) : ?>
-		<p class="fair-form-keep-informed">
-			<label>
-				<input type="checkbox" name="fair_form_keep_informed" value="1" />
-				<?php echo esc_html__( 'Keep me informed about future events and updates', 'fair-audience' ); ?>
-			</label>
-		</p>
-		<?php endif; ?>
 
 		<div class="wp-block-button">
 			<button type="submit" class="wp-block-button__link wp-element-button fair-form-submit-button">


### PR DESCRIPTION
## Summary

- Removes hardcoded First Name / Last Name / Email / Keep Informed inputs from the `fair-form` container block; the form now renders only its composed inner field-blocks plus the submit button (empty canvas)
- Adds new `fair-form-email` field block (mirrors `fair-form-short-text`) with built-in email-format validation on both the frontend (`validateQuestions`) and the backend (`sanitize_answers` / `is_email`)
- Decouples submissions from `fair-audience`: `participant_id` is now nullable; `FairFormController` saves answers with `participant_id = null` when fair-audience is inactive or no email field is present; Participant find/create and all mailing-confirmation logic become conditional enhancements

## Key changes

| Area | Change |
|---|---|
| `fair-form/render.php` | Remove hardcoded name/surname/email/keep-informed markup |
| `fair-form/editor.js` | Remove field previews and `showKeepInformed` toggle; add `fair-form-email` to ALLOWED_BLOCKS |
| `fair-form/frontend.js` | Remove hardcoded validation and payload; delegate all validation to `validateQuestions` |
| `fair-form-email/` | New block: email input with `data-question-type="email"` |
| `questionnaire.js` (shared) | Add email format validation loop in `validateQuestions` |
| `FairFormController.php` | Remove `required` on name/email; extract email from answers; IP fallback rate-limiting; conditional participant/mailing logic |
| `QuestionnaireSubmission.php` | Nullable `participant_id`; build INSERT data conditionally |
| `QuestionnaireService.php` | Add `email` to VALID_TYPES; sanitize with `sanitize_email()`; skip reuse-existing when participant is null |
| `Schema.php` | `participant_id BIGINT UNSIGNED NULL`; add `email` to question_type ENUM |
| `fair-form.php` | Bump to 0.2.0; add `fair_form_maybe_upgrade_db()` with guarded ALTER TABLE migrations |
| `BlockHooks.php` | Register `fair-form-email` block |
| Changeset | Major bump (removes hardcoded fields — breaking for existing forms) |

## Test plan

- [ ] Place a `fair-form` block with only a `fair-form-email` + `fair-form-short-text` — form renders without name/surname/email hardcoded inputs; submits successfully with fair-audience inactive (`participant_id = null` in DB)
- [ ] With fair-audience active and an email block present — Participant is found/created and linked; mailing-signup confirmation flow still triggers
- [ ] Email field shows validation error for invalid format before submit
- [ ] Required email field shows "required" error when empty
- [ ] File-upload submissions still work (FormData path)
- [ ] Rate limiting: email-keyed when email block present; IP-keyed otherwise
- [ ] `phpcs` passes (zero errors)
- [ ] `fair_form_maybe_upgrade_db()` runs once and sets `fair_form_db_version` option to `0.2.0`

Closes #911