### PR TITLE
feat(fair-form): grouped answer navigation (by page / event / form)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,9 @@ vendor/bin/phpcbf        # Auto-fix
   (`.claude/hooks/format-edited-file.sh`, wired in `.claude/settings.json`)
   runs `wp-scripts format` (JS/CSS/JSON) or `phpcbf` (PHP) on each file you
   edit. Do **not** run `npm run format` manually after edits.
+- **Before committing**, run `npm run format` in the affected plugin to catch
+  any files touched outside the hook (manual shell edits, generated files, or
+  cross-session edits). Only stage clean, formatted files.
 - **Build is not automatic** (it is slow). After changing JS/CSS, run
   `npm run build` in the affected plugin so generated assets land before
   committing.

--- a/fair-audience/src/API/__tests__/EventSignupRecurrenceScope.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupRecurrenceScope.api.spec.js
@@ -25,7 +25,9 @@ const authHeaders = {
 };
 
 function uniqueEmail(prefix) {
-	return `${prefix}+${Date.now()}-${Math.floor(Math.random() * 1e6)}@example.test`;
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
 }
 
 async function createEventWithDates(api, title) {
@@ -89,9 +91,12 @@ async function createParticipant(api, adminUserId, label) {
 
 async function deleteParticipant(api, participantId) {
 	if (!participantId) return;
-	await api.delete(`/wp-json/fair-audience/v1/participants/${participantId}`, {
-		headers: authHeaders,
-	});
+	await api.delete(
+		`/wp-json/fair-audience/v1/participants/${participantId}`,
+		{
+			headers: authHeaders,
+		}
+	);
 }
 
 test.describe('Recurrence-scope ticket types — signup semantics', () => {
@@ -134,7 +139,11 @@ test.describe('Recurrence-scope ticket types — signup semantics', () => {
 			'single_instance'
 		);
 
-		participantId = await createParticipant(api, adminUserId, 'Scope Tester');
+		participantId = await createParticipant(
+			api,
+			adminUserId,
+			'Scope Tester'
+		);
 	});
 
 	test.afterAll(async () => {
@@ -179,7 +188,9 @@ test.describe('Recurrence-scope ticket types — signup semantics', () => {
 		);
 		expect(participantsRes.ok()).toBeTruthy();
 		const participants = await participantsRes.json();
-		const row = participants.find((p) => p.participant_id === participantId);
+		const row = participants.find(
+			(p) => p.participant_id === participantId
+		);
 		expect(row, 'signup row on master event-date').toBeTruthy();
 		expect(row.label).toBe('signed_up');
 	});
@@ -222,7 +233,9 @@ test.describe('Recurrence-scope ticket types — signup semantics', () => {
 		);
 		expect(participantsRes.ok()).toBeTruthy();
 		const participants = await participantsRes.json();
-		const row = participants.find((p) => p.participant_id === participantId);
+		const row = participants.find(
+			(p) => p.participant_id === participantId
+		);
 		expect(row, 'signup row on the event-date').toBeTruthy();
 		expect(row.label).toBe('signed_up');
 	});

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -122,14 +122,16 @@ describe('EventTickets — recurrence scope selector', () => {
 		fireEvent.click(addButton);
 
 		// A second Scope combobox should appear (one per ticket type row).
-		const scopeSelects = screen.getAllByRole('combobox').filter(
-			(el) => el.value === 'single_instance' || el.value === 'whole_series'
-		);
+		const scopeSelects = screen
+			.getAllByRole('combobox')
+			.filter(
+				(el) =>
+					el.value === 'single_instance' ||
+					el.value === 'whole_series'
+			);
 		// Both rows (original + new) should be single_instance.
 		expect(scopeSelects.length).toBeGreaterThanOrEqual(2);
-		scopeSelects.forEach((el) =>
-			expect(el.value).toBe('single_instance')
-		);
+		scopeSelects.forEach((el) => expect(el.value).toBe('single_instance'));
 	});
 
 	it('changing scope selector to whole_series updates the combobox value', () => {
@@ -141,7 +143,8 @@ describe('EventTickets — recurrence scope selector', () => {
 
 		const selects = screen.getAllByRole('combobox');
 		const scopeSelect = selects.find(
-			(el) => el.value === 'single_instance' || el.value === 'whole_series'
+			(el) =>
+				el.value === 'single_instance' || el.value === 'whole_series'
 		);
 		expect(scopeSelect).toBeTruthy();
 		expect(scopeSelect.value).toBe('single_instance');
@@ -160,7 +163,8 @@ describe('EventTickets — recurrence scope selector', () => {
 		// Change scope to whole_series.
 		const selects = screen.getAllByRole('combobox');
 		const scopeSelect = selects.find(
-			(el) => el.value === 'single_instance' || el.value === 'whole_series'
+			(el) =>
+				el.value === 'single_instance' || el.value === 'whole_series'
 		);
 		fireEvent.change(scopeSelect, { target: { value: 'whole_series' } });
 

--- a/fair-form/src/API/QuestionnaireResponsesController.php
+++ b/fair-form/src/API/QuestionnaireResponsesController.php
@@ -46,7 +46,7 @@ class QuestionnaireResponsesController extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args'                => array(
 						'event_date_id' => array(
-							'required'          => true,
+							'required'          => false,
 							'type'              => 'integer',
 							'sanitize_callback' => 'absint',
 						),
@@ -54,6 +54,11 @@ class QuestionnaireResponsesController extends WP_REST_Controller {
 							'required'          => false,
 							'type'              => 'integer',
 							'sanitize_callback' => 'absint',
+						),
+						'form_id'       => array(
+							'required'          => false,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'title'         => array(
 							'required'          => false,
@@ -78,6 +83,25 @@ class QuestionnaireResponsesController extends WP_REST_Controller {
 							'required'          => true,
 							'type'              => 'integer',
 							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/grouped',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_groups' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'by' => array(
+							'required' => true,
+							'type'     => 'string',
+							'enum'     => array( 'page', 'event', 'form' ),
 						),
 					),
 				),
@@ -144,14 +168,21 @@ class QuestionnaireResponsesController extends WP_REST_Controller {
 	public function get_items( $request ) {
 		$event_date_id = $request->get_param( 'event_date_id' );
 		$post_id       = $request->get_param( 'post_id' );
+		$form_id       = $request->get_param( 'form_id' );
 		$title         = $request->get_param( 'title' );
 
 		$submission_repo = new QuestionnaireSubmissionRepository();
 		$answer_repo     = new QuestionnaireAnswerRepository();
 
-		$filters = array( 'event_date_id' => $event_date_id );
+		$filters = array();
+		if ( ! empty( $event_date_id ) ) {
+			$filters['event_date_id'] = $event_date_id;
+		}
 		if ( $post_id ) {
 			$filters['post_id'] = $post_id;
+		}
+		if ( $form_id ) {
+			$filters['form_id'] = $form_id;
 		}
 		if ( $title ) {
 			$filters['title'] = $title;
@@ -262,6 +293,83 @@ class QuestionnaireResponsesController extends WP_REST_Controller {
 		$forms = $submission_repo->get_forms_summary_by_event_date( $event_date_id );
 
 		return new WP_REST_Response( $forms, 200 );
+	}
+
+	/**
+	 * Get submission counts grouped by page, event, or form.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return WP_REST_Response Response.
+	 */
+	public function get_groups( $request ) {
+		$by              = $request->get_param( 'by' );
+		$submission_repo = new QuestionnaireSubmissionRepository();
+		$rows            = $submission_repo->get_groups( $by );
+
+		$data = array();
+		foreach ( $rows as $row ) {
+			$group_key = $row['group_key'];
+			$count     = (int) $row['count'];
+			$label     = '';
+
+			if ( 'page' === $by ) {
+				if ( ! empty( $group_key ) ) {
+					$post = get_post( (int) $group_key );
+					if ( $post ) {
+						$label = $post->post_title;
+					} else {
+						// translators: %d: WordPress post ID.
+						$label = sprintf( __( 'Post #%d', 'fair-form' ), (int) $group_key );
+					}
+				} else {
+					$label = __( 'No page', 'fair-form' );
+				}
+				$data[] = array(
+					'post_id' => $group_key ? (int) $group_key : null,
+					'label'   => $label,
+					'count'   => $count,
+				);
+			} elseif ( 'event' === $by ) {
+				if ( ! empty( $group_key ) && class_exists( '\FairEvents\Models\EventDates' ) ) {
+					$event_date = \FairEvents\Models\EventDates::get_by_id( (int) $group_key );
+					if ( $event_date ) {
+						$event = get_post( (int) $event_date->event_id );
+						if ( $event ) {
+							$label = $event->post_title;
+						}
+					}
+				}
+				if ( empty( $label ) ) {
+					if ( $group_key ) {
+						// translators: %d: event date ID.
+						$label = sprintf( __( 'Event date #%d', 'fair-form' ), (int) $group_key );
+					} else {
+						$label = __( 'No event', 'fair-form' );
+					}
+				}
+				$data[] = array(
+					'event_date_id' => $group_key ? (int) $group_key : null,
+					'label'         => $label,
+					'count'         => $count,
+				);
+			} elseif ( 'form' === $by ) {
+				if ( null === $group_key || '' === $group_key ) {
+					$label = __( 'Legacy (no form id)', 'fair-form' );
+				} else {
+					$label = ! empty( $row['form_title'] ) ? $row['form_title'] : '';
+					if ( empty( $label ) ) {
+						$label = $group_key;
+					}
+				}
+				$data[] = array(
+					'form_id' => $group_key ? $group_key : null,
+					'label'   => $label,
+					'count'   => $count,
+				);
+			}
+		}
+
+		return new WP_REST_Response( $data, 200 );
 	}
 
 	/**

--- a/fair-form/src/Admin/AdminHooks.php
+++ b/fair-form/src/Admin/AdminHooks.php
@@ -124,24 +124,34 @@ class AdminHooks {
 	 * Register admin menu pages.
 	 */
 	public function register_admin_menu() {
-		// Main menu page.
+		// Main menu page — landing is the Answers Overview.
 		add_menu_page(
 			__( 'Fair Form', 'fair-form' ),
 			__( 'Fair Form', 'fair-form' ),
 			'manage_options',
 			'fair-form',
-			array( $this, 'render_form_answers_page' ),
+			array( $this, 'render_answers_overview_page' ),
 			'dashicons-feedback',
 			'20.4'
 		);
 
-		// Visible submenu page - Form Answers (overrides the auto-generated first item).
+		// First visible submenu overrides the auto-generated duplicate.
 		add_submenu_page(
 			'fair-form',
-			__( 'Form Answers', 'fair-form' ),
-			__( 'Form Answers', 'fair-form' ),
+			__( 'Answers Overview', 'fair-form' ),
+			__( 'Answers Overview', 'fair-form' ),
 			'manage_options',
 			'fair-form',
+			array( $this, 'render_answers_overview_page' )
+		);
+
+		// Visible submenu — flat list of all answers.
+		add_submenu_page(
+			'fair-form',
+			__( 'All Answers', 'fair-form' ),
+			__( 'All Answers', 'fair-form' ),
+			'manage_options',
+			'fair-form-form-answers',
 			array( $this, 'render_form_answers_page' )
 		);
 
@@ -150,6 +160,14 @@ class AdminHooks {
 
 		// Hidden submenu page - Submission Detail.
 		$this->register_hidden_page( 'fair-form-submission-detail' );
+	}
+
+	/**
+	 * Render Answers Overview page.
+	 */
+	public function render_answers_overview_page() {
+		$page = new AnswersOverviewPage();
+		$page->render();
 	}
 
 	/**
@@ -184,8 +202,13 @@ class AdminHooks {
 	public function enqueue_admin_scripts( $hook ) {
 		$plugin_dir = plugin_dir_path( dirname( __DIR__ ) );
 
-		// Form Answers page (top-level, hook is toplevel_page_fair-form).
+		// Answers Overview page (top-level, hook is toplevel_page_fair-form).
 		if ( 'toplevel_page_fair-form' === $hook ) {
+			$this->enqueue_page_script( 'answers-overview', $plugin_dir );
+		}
+
+		// All Answers flat list page.
+		if ( 'fair-form_page_fair-form-form-answers' === $hook ) {
 			$this->enqueue_page_script( 'form-answers', $plugin_dir );
 		}
 

--- a/fair-form/src/Admin/AnswersOverviewPage.php
+++ b/fair-form/src/Admin/AnswersOverviewPage.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Answers Overview Page
+ *
+ * @package FairForm
+ */
+
+namespace FairForm\Admin;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Renders the Answers Overview admin page.
+ */
+class AnswersOverviewPage {
+
+	/**
+	 * Render the page.
+	 */
+	public function render() {
+		echo '<div id="fair-form-answers-overview-root"></div>';
+	}
+}

--- a/fair-form/src/Admin/answers-overview/AnswersOverview.js
+++ b/fair-form/src/Admin/answers-overview/AnswersOverview.js
@@ -1,0 +1,147 @@
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect, useMemo } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Card,
+	CardBody,
+	ToggleGroupControl,
+	ToggleGroupControlOption,
+} from '@wordpress/components';
+import { DataViews } from '@wordpress/dataviews';
+
+const DEFAULT_VIEW = {
+	type: 'table',
+	perPage: 25,
+	page: 1,
+	sort: {
+		field: 'count',
+		direction: 'desc',
+	},
+	search: '',
+	filters: [],
+};
+
+const DEFAULT_LAYOUTS = {
+	table: {},
+};
+
+export default function AnswersOverview() {
+	const [groupBy, setGroupBy] = useState('page');
+	const [groups, setGroups] = useState([]);
+	const [isLoading, setIsLoading] = useState(true);
+	const [view, setView] = useState(DEFAULT_VIEW);
+
+	useEffect(() => {
+		setIsLoading(true);
+		apiFetch({
+			path: `/fair-form/v1/questionnaire-responses/grouped?by=${groupBy}`,
+		})
+			.then((data) => {
+				setGroups(data);
+				setIsLoading(false);
+			})
+			.catch((err) => {
+				// eslint-disable-next-line no-console
+				console.error('Error loading grouped responses:', err);
+				setIsLoading(false);
+			});
+	}, [groupBy]);
+
+	const fields = useMemo(() => {
+		const labelField = {
+			id: 'label',
+			label: __('Name', 'fair-form'),
+			enableSorting: true,
+			enableHiding: false,
+			getValue: ({ item }) => item.label || '',
+			render: ({ item }) => {
+				let href = 'admin.php?page=fair-form-questionnaire-responses';
+				if (groupBy === 'page' && item.post_id) {
+					href += `&post_id=${item.post_id}`;
+				} else if (groupBy === 'event' && item.event_date_id) {
+					href += `&event_date_id=${item.event_date_id}`;
+				} else if (groupBy === 'form' && item.form_id) {
+					href += `&form_id=${encodeURIComponent(item.form_id)}`;
+				}
+				return <a href={href}>{item.label || '—'}</a>;
+			},
+		};
+
+		return [
+			labelField,
+			{
+				id: 'count',
+				label: __('Submissions', 'fair-form'),
+				enableSorting: true,
+				getValue: ({ item }) => item.count,
+			},
+		];
+	}, [groupBy]);
+
+	const paginationInfo = useMemo(
+		() => ({
+			totalItems: groups.length,
+			totalPages: Math.ceil(groups.length / (view.perPage || 25)),
+		}),
+		[groups.length, view.perPage]
+	);
+
+	const groupByLabel = {
+		page: __('by Page', 'fair-form'),
+		event: __('by Event', 'fair-form'),
+		form: __('by Form', 'fair-form'),
+	};
+
+	return (
+		<div className="wrap">
+			<h1>{__('Form Answers Overview', 'fair-form')}</h1>
+
+			<div style={{ marginBottom: '16px' }}>
+				<ToggleGroupControl
+					label={__('Group by', 'fair-form')}
+					value={groupBy}
+					onChange={setGroupBy}
+					isBlock
+				>
+					<ToggleGroupControlOption
+						value="page"
+						label={__('Page', 'fair-form')}
+					/>
+					<ToggleGroupControlOption
+						value="event"
+						label={__('Event', 'fair-form')}
+					/>
+					<ToggleGroupControlOption
+						value="form"
+						label={__('Form', 'fair-form')}
+					/>
+				</ToggleGroupControl>
+			</div>
+
+			<p style={{ color: '#757575', fontStyle: 'italic' }}>
+				{groupByLabel[groupBy]}
+			</p>
+
+			<Card>
+				<CardBody>
+					<DataViews
+						data={groups}
+						fields={fields}
+						view={view}
+						onChangeView={setView}
+						paginationInfo={paginationInfo}
+						defaultLayouts={DEFAULT_LAYOUTS}
+						isLoading={isLoading}
+						getItemId={(item) =>
+							groupBy === 'page'
+								? `page-${item.post_id}`
+								: groupBy === 'event'
+								? `event-${item.event_date_id}`
+								: `form-${item.form_id}`
+						}
+					/>
+				</CardBody>
+			</Card>
+		</div>
+	);
+}

--- a/fair-form/src/Admin/answers-overview/index.js
+++ b/fair-form/src/Admin/answers-overview/index.js
@@ -1,0 +1,7 @@
+import { createRoot } from '@wordpress/element';
+import AnswersOverview from './AnswersOverview.js';
+
+const rootElement = document.getElementById('fair-form-answers-overview-root');
+if (rootElement) {
+	createRoot(rootElement).render(<AnswersOverview />);
+}

--- a/fair-form/src/Admin/form-answers/FormAnswers.js
+++ b/fair-form/src/Admin/form-answers/FormAnswers.js
@@ -57,8 +57,9 @@ export default function FormAnswers() {
 		if (eventDates.length > 0) {
 			return;
 		}
-		// TODO(phase-2): replace with data-derived event source once available in fair-form.
-		apiFetch({ path: '/fair-audience/v1/custom-mail/events' })
+		apiFetch({
+			path: '/fair-form/v1/questionnaire-responses/grouped?by=event',
+		})
 			.then((data) => {
 				setEventDates(data);
 			})
@@ -232,10 +233,12 @@ export default function FormAnswers() {
 	const eventDateOptions = useMemo(
 		() => [
 			{ label: __('— None —', 'fair-form'), value: '' },
-			...eventDates.map((ed) => ({
-				label: ed.display_label,
-				value: String(ed.id),
-			})),
+			...eventDates
+				.filter((ed) => ed.event_date_id)
+				.map((ed) => ({
+					label: `${ed.label} (${ed.count})`,
+					value: String(ed.event_date_id),
+				})),
 		],
 		[eventDates]
 	);

--- a/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
+++ b/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
@@ -53,21 +53,27 @@ export default function QuestionnaireResponses() {
 	const params = new URLSearchParams(window.location.search);
 	const eventDateId = params.get('event_date_id');
 	const postId = params.get('post_id');
+	const formId = params.get('form_id');
 	const title = params.get('title');
 
 	useEffect(() => {
-		if (!eventDateId) {
-			setIsLoading(false);
-			return;
+		const parts = [];
+		if (eventDateId) {
+			parts.push(`event_date_id=${eventDateId}`);
 		}
-
-		let apiPath = `/fair-form/v1/questionnaire-responses?event_date_id=${eventDateId}`;
 		if (postId) {
-			apiPath += `&post_id=${postId}`;
+			parts.push(`post_id=${postId}`);
+		}
+		if (formId) {
+			parts.push(`form_id=${encodeURIComponent(formId)}`);
 		}
 		if (title) {
-			apiPath += `&title=${encodeURIComponent(title)}`;
+			parts.push(`title=${encodeURIComponent(title)}`);
 		}
+
+		const apiPath = `/fair-form/v1/questionnaire-responses${
+			parts.length ? '?' + parts.join('&') : ''
+		}`;
 
 		setIsLoading(true);
 		apiFetch({
@@ -82,7 +88,7 @@ export default function QuestionnaireResponses() {
 				console.error('Error loading questionnaire responses:', err);
 				setIsLoading(false);
 			});
-	}, [eventDateId]);
+	}, [eventDateId, postId, formId]);
 
 	// Derive dynamic question columns from all responses.
 	const questionColumns = useMemo(() => {
@@ -498,39 +504,35 @@ export default function QuestionnaireResponses() {
 		const url = URL.createObjectURL(blob);
 		const link = document.createElement('a');
 		link.href = url;
-		link.download = `questionnaire-responses-${eventDateId}.csv`;
+		const contextId = eventDateId || postId || formId || 'all';
+		link.download = `questionnaire-responses-${contextId}.csv`;
 		link.click();
 		URL.revokeObjectURL(url);
 	};
-
-	if (!eventDateId) {
-		return (
-			<div className="wrap">
-				<p>{__('No event date ID provided.', 'fair-form')}</p>
-			</div>
-		);
-	}
 
 	return (
 		<div className="wrap">
 			<h1>{__('Questionnaire Responses', 'fair-form')}</h1>
 
 			<p>
-				{/* TODO(phase-3): retarget back-link to fair-form grouped page once it exists. */}
-				<a href="admin.php?page=fair-audience-by-event">
-					&larr; {__('Back to Events', 'fair-form')}
+				<a href="admin.php?page=fair-form">
+					&larr; {__('Back to Answers Overview', 'fair-form')}
 				</a>
-				{' | '}
-				<a
-					href={`admin.php?page=fair-events-manage-event&event_date_id=${eventDateId}`}
-				>
-					{__('Event edit page', 'fair-form')}
-				</a>
+				{eventDateId && (
+					<>
+						{' | '}
+						<a
+							href={`admin.php?page=fair-events-manage-event&event_date_id=${eventDateId}`}
+						>
+							{__('Event edit page', 'fair-form')}
+						</a>
+					</>
+				)}
 				{postId && (
 					<>
 						{' | '}
 						<a href={`post.php?post=${postId}&action=edit`}>
-							{__('Event entry', 'fair-form')}
+							{__('Post entry', 'fair-form')}
 						</a>
 					</>
 				)}

--- a/fair-form/src/Admin/submission-detail/SubmissionDetail.js
+++ b/fair-form/src/Admin/submission-detail/SubmissionDetail.js
@@ -72,8 +72,9 @@ function EventField({ submission, onUpdate }) {
 		if (eventDates.length > 0) {
 			return;
 		}
-		// TODO(phase-2): replace with data-derived event source once available in fair-form.
-		apiFetch({ path: '/fair-audience/v1/custom-mail/events' })
+		apiFetch({
+			path: '/fair-form/v1/questionnaire-responses/grouped?by=event',
+		})
 			.then((data) => {
 				setEventDates(data);
 			})
@@ -117,10 +118,12 @@ function EventField({ submission, onUpdate }) {
 
 	const eventDateOptions = [
 		{ label: __('— None —', 'fair-form'), value: '' },
-		...eventDates.map((ed) => ({
-			label: ed.display_label,
-			value: String(ed.id),
-		})),
+		...eventDates
+			.filter((ed) => ed.event_date_id)
+			.map((ed) => ({
+				label: `${ed.label} (${ed.count})`,
+				value: String(ed.event_date_id),
+			})),
 	];
 
 	if (!isEditing) {

--- a/fair-form/src/Database/QuestionnaireSubmissionRepository.php
+++ b/fair-form/src/Database/QuestionnaireSubmissionRepository.php
@@ -238,6 +238,11 @@ class QuestionnaireSubmissionRepository {
 			$values[] = $filters['participant_id'];
 		}
 
+		if ( ! empty( $filters['form_id'] ) ) {
+			$where[]  = 'form_id = %s';
+			$values[] = $filters['form_id'];
+		}
+
 		$sql = 'SELECT * FROM %i';
 
 		if ( ! empty( $where ) ) {
@@ -298,6 +303,46 @@ class QuestionnaireSubmissionRepository {
 			},
 			$results
 		);
+	}
+
+	/**
+	 * Get submission counts grouped by a dimension.
+	 *
+	 * @param string $by Grouping dimension: 'page', 'event', or 'form'.
+	 * @return array[] Each row: group_key (int|string|null), count (int), plus extra label columns depending on $by.
+	 */
+	public function get_groups( string $by ): array {
+		global $wpdb;
+
+		$table_name = $this->get_table_name();
+
+		$column_map = array(
+			'page'  => 'post_id',
+			'event' => 'event_date_id',
+			'form'  => 'form_id',
+		);
+
+		if ( ! isset( $column_map[ $by ] ) ) {
+			return array();
+		}
+
+		$group_column = $column_map[ $by ];
+
+		$extra_select = '';
+		if ( 'form' === $by ) {
+			$extra_select = ', form_title';
+		}
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT {$group_column} AS group_key, COUNT(*) AS count{$extra_select} FROM %i GROUP BY {$group_column} ORDER BY count DESC",
+				$table_name
+			),
+			ARRAY_A
+		);
+
+		return $results;
 	}
 
 	/**

--- a/fair-form/webpack.config.cjs
+++ b/fair-form/webpack.config.cjs
@@ -12,6 +12,10 @@ module.exports = {
 	entry: () => ({
 		...defaultEntries,
 		// Admin scripts
+		'admin/answers-overview/index': path.resolve(
+			process.cwd(),
+			'src/Admin/answers-overview/index.js',
+		),
 		'admin/form-answers/index': path.resolve(
 			process.cwd(),
 			'src/Admin/form-answers/index.js',


### PR DESCRIPTION
Closes #885 (PR 3 of 3).

## Summary

- **New `grouped` endpoint** `GET /fair-form/v1/questionnaire-responses/grouped?by=page|event|form` — returns submission counts with resolved labels for each group key; `page` resolves post title, `event` resolves event name via `FairEvents\Models\EventDates`, `form` uses `form_title` or falls back to form_id; NULL form_id groups as "Legacy (no form id)".
- **List endpoint generalized** — `event_date_id` is now optional; `form_id` filter added; `get_by_filters()` in the repository extended accordingly.
- **`QuestionnaireSubmissionRepository::get_groups()`** — new method doing `GROUP BY post_id / event_date_id / form_id` with `COUNT(*)`.
- **New Answers Overview page** (`src/Admin/answers-overview/`) — ToggleGroupControl to switch grouping dimension, DataViews table with group labels + counts; each row links to the questionnaire-responses list pre-filtered by key.
- **Fair Form top-level menu** now lands on the overview; the flat "All Answers" list moves to a `fair-form-form-answers` submenu.
- **`QuestionnaireResponses.js` generalized** — reads `event_date_id`, `post_id`, and `form_id` from URL params; back-link retargets to the overview page; "no event_date_id" guard removed.
- **Fair-audience event dependency dropped** in `FormAnswers.js` and `SubmissionDetail.js` — the `/fair-audience/v1/custom-mail/events` call is replaced by data-derived events from `grouped?by=event`.

## Test plan

- [ ] `vendor/bin/phpcs` passes on changed PHP files (confirmed clean locally)
- [ ] `npm run build` in `fair-form` succeeds (confirmed)
- [ ] Fair Form admin menu lands on the Answers Overview page
- [ ] ToggleGroupControl switches between Page / Event / Form groupings and reloads data
- [ ] Each group row links to `questionnaire-responses` list filtered by the correct key
- [ ] Questionnaire Responses page loads without `event_date_id` (e.g. `?post_id=X`)
- [ ] Questionnaire Responses back-link goes to Answers Overview, not fair-audience
- [ ] Edit event on All Answers / Submission Detail still shows the event picker (now sourced from `grouped?by=event`)
- [ ] `All Answers` submenu still renders the flat list