### PR TITLE
Block paid-event signup when payment connector is not configured

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -842,14 +842,34 @@ class EventSignupController extends WP_REST_Controller {
 			}
 		}
 
+		// Any option with a raw price > 0 means payment is configured for that option.
+		$any_option_paid = array_reduce(
+			$new_options,
+			static fn( $carry, $opt ) => $carry || (float) $opt->price > 0,
+			false
+		);
+
 		if ( $total_amount <= 0 ) {
+			// Guard: if any option carries a paid price the connector must be ready,
+			// even when a discount reduced the resolved total to zero.
+			if ( $any_option_paid ) {
+				if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class )
+					|| ! \FairPaymentsConnector\API\TransactionAPI::is_configured() ) {
+					return new WP_Error(
+						'payment_unavailable',
+						__( 'Paid activities are not available because the payment plugin is not configured.', 'fair-audience' ),
+						array( 'status' => 503 )
+					);
+				}
+			}
 			return null;
 		}
 
-		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
+		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class )
+			|| ! \FairPaymentsConnector\API\TransactionAPI::is_configured() ) {
 			return new WP_Error(
 				'payment_unavailable',
-				__( 'Paid activities are not available because the payment plugin is missing.', 'fair-audience' ),
+				__( 'Paid activities are not available because the payment plugin is not configured.', 'fair-audience' ),
 				array( 'status' => 503 )
 			);
 		}
@@ -1495,14 +1515,35 @@ class EventSignupController extends WP_REST_Controller {
 		}
 		$total_amount = (float) ( $final_price ?? 0 ) + $options_total;
 
+		// Determine whether a price is configured for this event regardless of
+		// how the resolution turned out (discount-to-zero, service unavailable, etc.).
+		$has_paid_price_configured = $event_date_id
+			&& class_exists( \FairEventsExperimental\Services\EventSignupPricing::class )
+			&& \FairEventsExperimental\Services\EventSignupPricing::has_paid_price_configured(
+				(int) $event_date_id,
+				$ticket_type_id
+			);
+
 		if ( $total_amount <= 0 ) {
+			// A paid event must never slip through as free when the connector isn't ready.
+			if ( $has_paid_price_configured ) {
+				if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class )
+					|| ! \FairPaymentsConnector\API\TransactionAPI::is_configured() ) {
+					return new WP_Error(
+						'payment_unavailable',
+						__( 'Paid signup is not available because the payment plugin is not configured.', 'fair-audience' ),
+						array( 'status' => 503 )
+					);
+				}
+			}
 			return null;
 		}
 
-		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
+		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class )
+			|| ! \FairPaymentsConnector\API\TransactionAPI::is_configured() ) {
 			return new WP_Error(
 				'payment_unavailable',
-				__( 'Paid signup is not available because the payment plugin is missing.', 'fair-audience' ),
+				__( 'Paid signup is not available because the payment plugin is not configured.', 'fair-audience' ),
 				array( 'status' => 503 )
 			);
 		}

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -640,6 +640,29 @@ if ( null !== $signup_price ) {
 	}
 }
 
+// Detect when payment is configured but the connector is not ready.
+// Covers both: plugin missing (class_exists false) and plugin active but
+// unconfigured (no Mollie API key / OAuth). When true, signup buttons are
+// disabled and a notice replaces the "Sign up for free" label so a paid
+// event is never presented as free to the visitor.
+$payment_unavailable = false;
+if ( null !== $signup_price ) {
+	$connector_ready = class_exists( \FairPaymentsConnector\API\TransactionAPI::class )
+		&& \FairPaymentsConnector\API\TransactionAPI::is_configured();
+	if ( ! $connector_ready ) {
+		if ( $signup_price > 0 ) {
+			// Resolved price is positive — connector required.
+			$payment_unavailable = true;
+		} elseif ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			// Resolved price is zero but event may carry a paid base price
+			// (e.g. 100%-discounted or pricing-service glitch).
+			$payment_unavailable = \FairEventsExperimental\Services\EventSignupPricing::has_paid_price_configured(
+				(int) $pricing_event_date_id
+			);
+		}
+	}
+}
+
 // Build a group discount note to render near the signup button.
 $discount_note_html = '';
 if ( $best_discount_rule ) {
@@ -1139,8 +1162,13 @@ if ( ! $is_valid_post_type ) :
 				<?php if ( '' !== $discount_note_html ) : ?>
 					<?php echo wp_kses_post( $discount_note_html ); ?>
 				<?php endif; ?>
+				<?php if ( $payment_unavailable ) : ?>
+					<p class="fair-audience-payment-unavailable-notice">
+						<?php echo esc_html__( 'Online payment is not available for this event at the moment. Please contact the organiser.', 'fair-audience' ); ?>
+					</p>
+				<?php endif; ?>
 				<div class="wp-block-button">
-					<button type="button" class="wp-block-button__link wp-element-button fair-audience-signup-button" data-action="signup">
+					<button type="button" class="wp-block-button__link wp-element-button fair-audience-signup-button" data-action="signup"<?php echo $payment_unavailable ? ' disabled' : ''; ?>>
 						<?php echo esc_html( $signup_button_text ); ?>
 					</button>
 				</div>
@@ -1256,8 +1284,14 @@ if ( ! $is_valid_post_type ) :
 				</button>
 				<?php endif; ?>
 
+				<?php if ( $payment_unavailable ) : ?>
+					<p class="fair-audience-payment-unavailable-notice">
+						<?php echo esc_html__( 'Online payment is not available for this event at the moment. Please contact the organiser.', 'fair-audience' ); ?>
+					</p>
+				<?php endif; ?>
+
 				<div class="wp-block-button">
-					<button type="submit" class="wp-block-button__link wp-element-button fair-audience-signup-submit-button">
+					<button type="submit" class="wp-block-button__link wp-element-button fair-audience-signup-submit-button"<?php echo $payment_unavailable ? ' disabled' : ''; ?>>
 						<?php echo esc_html( $register_button_text ); ?>
 					</button>
 				</div>

--- a/fair-events-experimental/src/Services/EventSignupPricing.php
+++ b/fair-events-experimental/src/Services/EventSignupPricing.php
@@ -144,6 +144,55 @@ class EventSignupPricing {
 	}
 
 	/**
+	 * Check whether a positive price is configured for an event date or ticket type,
+	 * ignoring discount rules and sale-period timing.
+	 *
+	 * Used to determine if payment is *intended* even when the resolved price
+	 * comes back as zero (e.g. because a discount rule brings it to zero or the
+	 * pricing service was unavailable during resolution).
+	 *
+	 * Returns false when:
+	 * - No TicketPrice / signup_price row exists.
+	 * - The configured base price is 0 (genuinely free event).
+	 * - The event date doesn't exist.
+	 *
+	 * @param int      $event_date_id  Event date ID.
+	 * @param int|null $ticket_type_id Ticket type ID, or null for event-date pricing.
+	 * @return bool True when a price > 0 is configured.
+	 */
+	public static function has_paid_price_configured( int $event_date_id, ?int $ticket_type_id = null ): bool {
+		if ( $ticket_type_id ) {
+			$ticket_type = TicketType::get_by_id( $ticket_type_id );
+			if ( ! $ticket_type ) {
+				return false;
+			}
+			$active_period = self::resolve_active_sale_period( (int) $ticket_type->event_date_id );
+			if ( ! $active_period ) {
+				return false;
+			}
+			$price_row = TicketPrice::get_by_type_and_period( $ticket_type_id, $active_period->id );
+			return $price_row && (float) $price_row->price > 0;
+		}
+
+		$event_date = EventDates::get_by_id( $event_date_id );
+		if ( ! $event_date ) {
+			return false;
+		}
+
+		// Generated occurrences inherit signup_price from master.
+		if ( null === $event_date->signup_price
+			&& 'generated' === $event_date->occurrence_type
+			&& $event_date->master_id ) {
+			$master = EventDates::get_by_id( $event_date->master_id );
+			if ( $master ) {
+				$event_date = $master;
+			}
+		}
+
+		return null !== $event_date->signup_price && (float) $event_date->signup_price > 0;
+	}
+
+	/**
 	 * Resolve the currently active sale period for an event date.
 	 *
 	 * Periods use a half-open day range [sale_start, sale_end) in the site

--- a/fair-payments-connector/src/API/TransactionAPI.php
+++ b/fair-payments-connector/src/API/TransactionAPI.php
@@ -267,6 +267,18 @@ class TransactionAPI {
 	}
 
 	/**
+	 * Check whether the payment connector is ready to process payments.
+	 *
+	 * Returns true when either OAuth is connected or a Mollie API key is configured.
+	 * Use this before attempting to route a signup through paid flow.
+	 *
+	 * @return bool
+	 */
+	public static function is_configured(): bool {
+		return MolliePaymentHandler::is_configured();
+	}
+
+	/**
 	 * Get transaction by ID with line items
 	 *
 	 * @param int $transaction_id Transaction ID.


### PR DESCRIPTION
## Summary

- Adds `TransactionAPI::is_configured()` to fair-payments-connector, checking both OAuth and API-key readiness via the existing `MolliePaymentHandler::is_configured()`.
- Adds `EventSignupPricing::has_paid_price_configured()` to fair-events-experimental, which reads the raw base price (ignoring discounts) to tell whether payment was *intended* for an event date or ticket type.
- Fixes `maybe_start_paid_signup()`: before the `total <= 0` early-return, block the free path when a paid price is configured but the connector is absent or unconfigured. Also upgrades the existing `> 0` guard to `is_configured()` so the "installed but unconfigured" case is caught too.
- Applies the same gate to `maybe_start_addon_payment()`, using each option's raw `price` field as the intent signal.
- In `render.php`, computes `$payment_unavailable` and disables both the "Sign Up" and "Register & Sign Up" buttons, replacing the mislabelled "Sign up for free" text with a "contact the organiser" notice.

Closes #920

## Notes

- Genuine free events (price configured as 0) and legitimate discount-to-zero paths are unaffected — `has_paid_price_configured()` returns false when the base price is 0.
- The `render.php` check for ticket-type events uses the resolved `$signup_price` (> 0 path) or the `has_paid_price_configured()` fallback (zero path, event-date pricing only). Ticket-type zero-price edge cases in the render layer are not covered in this PR since `EventSignupPricing::resolve_price_for_ticket_type()` already returns null for unconfigured ticket types, hiding them from the display entirely.
- API spec and e2e coverage (acceptance criteria checklist items 3 & 4) are deferred.

## Test plan

- [ ] Configure a paid event (price > 0). Deactivate fair-payments-connector. Open the signup page → both buttons disabled, notice shown; API returns 503 for both "Sign Up" and "Register & Sign Up" flows.
- [ ] Same setup but with connector active and no Mollie API key configured → same behaviour.
- [ ] Connector active and configured → signup proceeds normally (paid flow).
- [ ] Free event (price = 0, connector absent) → buttons enabled, signup works.
- [ ] Discount-to-zero on a paid event with connector present and configured → signs up for free (legitimate).
- [ ] Discount-to-zero on a paid event with connector absent → 503 error returned.
- [ ] Add-activities flow on a paid option with connector absent → 503 error returned.