### PR TITLE
fair-payments-connector: pass testmode as SDK v3 query arg

### DIFF
--- a/fair-payments-connector/src/Payment/MolliePaymentHandler.php
+++ b/fair-payments-connector/src/Payment/MolliePaymentHandler.php
@@ -265,8 +265,9 @@ class MolliePaymentHandler {
 			}
 
 			// Set test mode based on settings (required for OAuth).
-			$mode                     = get_option( 'fair_payment_mode', 'test' );
-			$payment_data['testmode'] = ( 'live' === $mode ) ? false : true;
+			// SDK v3: testmode must go in the query/third arg, not the payload.
+			$mode     = get_option( 'fair_payment_mode', 'test' );
+			$testmode = ( 'live' !== $mode );
 
 			// Build a method allowlist when callers want to suppress specific methods.
 			// Mollie has no "exclude" parameter; the supported way is to pass `method`
@@ -277,7 +278,7 @@ class MolliePaymentHandler {
 					$payment_data['amount'],
 					$args['disable_methods'],
 					$profile_id,
-					$payment_data['testmode']
+					$testmode
 				);
 				if ( ! empty( $allowed ) ) {
 					$payment_data['method'] = array_values( $allowed );
@@ -293,18 +294,18 @@ class MolliePaymentHandler {
 						'Calling Mollie API to create payment (%s %s, testmode=%s)',
 						number_format( (float) $args['amount'], 2 ),
 						$args['currency'],
-						$payment_data['testmode'] ? 'true' : 'false'
+						$testmode ? 'true' : 'false'
 					),
 					'context'        => array(
 						'amount'      => $payment_data['amount'],
 						'description' => $args['description'],
-						'testmode'    => $payment_data['testmode'],
+						'testmode'    => $testmode,
 						'has_profile' => (bool) $profile_id,
 					),
 				)
 			);
 
-			$payment = $this->mollie->payments->create( $payment_data );
+			$payment = $this->mollie->payments->create( $payment_data, array(), $testmode );
 
 			$logger->log(
 				'mollie_call_succeeded',


### PR DESCRIPTION
## Summary

- Fixes a bug where test-mode payments were created as **live** in Mollie.
- Mollie PHP SDK v3 requires `testmode` in the query/third argument of `payments->create()`, not in the payload body. The old code placed it in `$payment_data`, which SDK v3 silently ignores, defaulting to live mode.
- Move `testmode` out of the payload and pass it as the third argument: `payments->create( $payment_data, array(), $testmode )`.
- Wire `build_method_allowlist()` to the same `$testmode` local so both Mollie calls share one source of truth.

Closes #921

## Notes

- `payments->get()` and `iterate_primary_balance_transactions()` already pass `testmode` in the query position — no change needed there.
- This is a v2→v3 SDK API break. The `composer.json` constraint is already `^3.0`, so all builds are affected until this is deployed.
- Merchants should check their Mollie dashboard for any live payments created while in test mode and refund/cancel as appropriate.

## Test plan

- [ ] Set `fair_payment_mode` to `test`, create a payment, confirm the resulting Mollie payment shows `mode: test` in the dashboard.
- [ ] Set `fair_payment_mode` to `live`, create a payment, confirm the resulting Mollie payment shows `mode: live`.
- [ ] Confirm local transaction `testmode` column matches the Mollie payment `mode` in both cases.