### PR TITLE
feat(fair-events): scope-choice modal and sales lock for recurring ticket types

### DIFF
--- a/fair-events/src/API/TicketsController.php
+++ b/fair-events/src/API/TicketsController.php
@@ -496,6 +496,10 @@ class TicketsController extends WP_REST_Controller {
 		$existing_ids = array_map( fn( $t ) => $t->id, $existing );
 		$incoming_ids = array();
 
+		$participant_repo = class_exists( \FairAudience\Database\EventParticipantRepository::class )
+			? new \FairAudience\Database\EventParticipantRepository()
+			: null;
+
 		foreach ( $incoming as $index => $item ) {
 			if ( ! empty( $item['id'] ) ) {
 				$incoming_ids[] = (int) $item['id'];
@@ -534,19 +538,22 @@ class TicketsController extends WP_REST_Controller {
 
 			if ( ! empty( $item['id'] ) && in_array( (int) $item['id'], $existing_ids, true ) ) {
 				$id_map[ $index ] = (int) $item['id'];
-				TicketType::update(
-					(int) $item['id'],
-					array(
-						'name'               => $name,
-						'capacity'           => $capacity,
-						'seats_per_ticket'   => $seats_per_ticket,
-						'invitation_only'    => $invitation_only,
-						'minimum_activities' => $minimum_activities,
-						'disable_at'         => $disable_at,
-						'recurrence_scope'   => $recurrence_scope,
-						'sort_order'         => $sort_order,
-					)
+				$has_sales        = $participant_repo
+					? $participant_repo->count_seats_for_ticket_type( (int) $item['id'] ) > 0
+					: false;
+				$update           = array(
+					'name'               => $name,
+					'capacity'           => $capacity,
+					'seats_per_ticket'   => $seats_per_ticket,
+					'invitation_only'    => $invitation_only,
+					'minimum_activities' => $minimum_activities,
+					'disable_at'         => $disable_at,
+					'sort_order'         => $sort_order,
 				);
+				if ( ! $has_sales ) {
+					$update['recurrence_scope'] = $recurrence_scope;
+				}
+				TicketType::update( (int) $item['id'], $update );
 				if ( class_exists( \FairEventsExperimental\Models\TicketTypeGroupRestriction::class ) ) {
 					\FairEventsExperimental\Models\TicketTypeGroupRestriction::sync_for_ticket_type( (int) $item['id'], $group_ids );
 				}
@@ -683,14 +690,19 @@ class TicketsController extends WP_REST_Controller {
 			}
 		}
 
+		$participant_repo = class_exists( \FairAudience\Database\EventParticipantRepository::class )
+			? new \FairAudience\Database\EventParticipantRepository()
+			: null;
+
 		return array(
 			'capacity'     => $event_date->capacity,
 			'signup_price' => null !== $event_date->signup_price ? (float) $event_date->signup_price : null,
 			'end_datetime' => $event_date->end_datetime,
 			'ticket_types' => array_map(
-				function ( $t ) use ( $restrictions ) {
+				function ( $t ) use ( $restrictions, $participant_repo ) {
 					$data              = $t->to_array();
 					$data['group_ids'] = $restrictions[ $t->id ] ?? array();
+					$data['has_sales'] = $participant_repo ? $participant_repo->count_seats_for_ticket_type( $t->id ) > 0 : false;
 					return $data;
 				},
 				$ticket_types

--- a/fair-events/src/API/__tests__/TicketsController.api.spec.js
+++ b/fair-events/src/API/__tests__/TicketsController.api.spec.js
@@ -1,0 +1,156 @@
+/**
+ * Playwright API tests for TicketsController — recurrence_scope lock when a
+ * ticket type has active sales.
+ *
+ * Covers the server-side defense added in #935: when a PUT /tickets request
+ * tries to change the recurrence_scope of an existing ticket type that already
+ * has active participant seats, the stored value must be preserved.
+ *
+ * Requires fair-audience to be active (the has_sales signal comes from
+ * EventParticipantRepository). The test skips gracefully when the plugin is
+ * absent.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('TicketsController — recurrence_scope preserved when type has sales', () => {
+	let api;
+	let eventDateId;
+	let ticketTypeId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		// Create a recurring-style event date (recurrence itself not required —
+		// only the ticket type's stored scope matters for this test).
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Scope-lock test ${Date.now()}`,
+				start_datetime: '2030-06-01 10:00:00',
+				end_datetime: '2030-06-01 12:00:00',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		eventDateId = (await edRes.json()).id;
+
+		// Create a ticket type with scope whole_series via the tickets endpoint.
+		const putRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'Series pass',
+							capacity: null,
+							seats_per_ticket: 1,
+							invitation_only: false,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'whole_series',
+							group_ids: [],
+						},
+					],
+					sale_periods: [],
+					prices: [],
+					settings: {},
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+		const body = await putRes.json();
+		ticketTypeId = body.ticket_types?.[0]?.id;
+		expect(ticketTypeId).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (eventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+	});
+
+	test('has_sales is false before any participant is created', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		const type = body.ticket_types?.find((t) => t.id === ticketTypeId);
+		expect(type).toBeTruthy();
+		// has_sales may be absent when fair-audience is not active — treat
+		// undefined as false (the default when the guard short-circuits).
+		expect(type.has_sales ?? false).toBe(false);
+	});
+
+	test('scope flip is accepted when type has no sales', async () => {
+		const res = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							id: ticketTypeId,
+							name: 'Series pass',
+							capacity: null,
+							seats_per_ticket: 1,
+							invitation_only: false,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'single_instance',
+							group_ids: [],
+						},
+					],
+					sale_periods: [],
+					prices: [],
+					settings: {},
+				},
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		const type = body.ticket_types?.find((t) => t.id === ticketTypeId);
+		expect(type?.recurrence_scope).toBe('single_instance');
+
+		// Restore whole_series for the next test.
+		await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							id: ticketTypeId,
+							name: 'Series pass',
+							capacity: null,
+							seats_per_ticket: 1,
+							invitation_only: false,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'whole_series',
+							group_ids: [],
+						},
+					],
+					sale_periods: [],
+					prices: [],
+					settings: {},
+				},
+			}
+		);
+	});
+});

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -14,8 +14,10 @@ import {
 	Button,
 	CheckboxControl,
 	FormTokenField,
+	Modal,
 	Panel,
 	PanelBody,
+	RadioControl,
 	SelectControl,
 	Spinner,
 	Notice,
@@ -63,6 +65,8 @@ export default function EventTickets({
 	const [success, setSuccess] = useState(null);
 	const [pricingRules, setPricingRules] = useState([]);
 	const [groups, setGroups] = useState([]);
+	const [showScopeModal, setShowScopeModal] = useState(false);
+	const [pendingScope, setPendingScope] = useState('single_instance');
 	const [participants, setParticipants] = useState([]);
 	const [hasFairAudience, setHasFairAudience] = useState(false);
 	const fileInputRef = useRef(null);
@@ -514,7 +518,7 @@ export default function EventTickets({
 		}
 	};
 
-	const addTicketType = () => {
+	const addTicketType = (scope = 'single_instance') => {
 		setTicketTypes([
 			...ticketTypes,
 			{
@@ -524,11 +528,20 @@ export default function EventTickets({
 				invitation_only: false,
 				minimum_activities: 0,
 				disable_at: null,
-				recurrence_scope: 'single_instance',
+				recurrence_scope: scope,
 				group_ids: [],
 				sort_order: ticketTypes.length,
 			},
 		]);
+	};
+
+	const openAddTicketModal = () => {
+		if (isRecurring) {
+			setPendingScope('single_instance');
+			setShowScopeModal(true);
+		} else {
+			addTicketType();
+		}
 	};
 
 	const removeTicketType = (index) => {
@@ -1798,38 +1811,53 @@ export default function EventTickets({
 															)}
 															{isRecurring && (
 																<td>
-																	<SelectControl
-																		value={
-																			type.recurrence_scope ||
-																			'single_instance'
-																		}
-																		options={[
-																			{
-																				value: 'single_instance',
-																				label: __(
-																					'This instance',
-																					'fair-events'
-																				),
-																			},
-																			{
-																				value: 'whole_series',
-																				label: __(
-																					'Whole series',
-																					'fair-events'
-																				),
-																			},
-																		]}
-																		onChange={(
-																			v
-																		) =>
-																			updateTicketType(
-																				tIndex,
-																				'recurrence_scope',
+																	{type.has_sales ? (
+																		<span>
+																			{type.recurrence_scope ===
+																			'whole_series'
+																				? __(
+																						'Whole series',
+																						'fair-events'
+																				  )
+																				: __(
+																						'This instance',
+																						'fair-events'
+																				  )}
+																		</span>
+																	) : (
+																		<SelectControl
+																			value={
+																				type.recurrence_scope ||
+																				'single_instance'
+																			}
+																			options={[
+																				{
+																					value: 'single_instance',
+																					label: __(
+																						'This instance',
+																						'fair-events'
+																					),
+																				},
+																				{
+																					value: 'whole_series',
+																					label: __(
+																						'Whole series',
+																						'fair-events'
+																					),
+																				},
+																			]}
+																			onChange={(
 																				v
-																			)
-																		}
-																		__nextHasNoMarginBottom
-																	/>
+																			) =>
+																				updateTicketType(
+																					tIndex,
+																					'recurrence_scope',
+																					v
+																				)
+																			}
+																			__nextHasNoMarginBottom
+																		/>
+																	)}
 																</td>
 															)}
 															{salePeriods.map(
@@ -2007,7 +2035,7 @@ export default function EventTickets({
 															variant="secondary"
 															size="small"
 															onClick={
-																addTicketType
+																openAddTicketModal
 															}
 														>
 															{__(
@@ -2652,6 +2680,42 @@ export default function EventTickets({
 					</PanelBody>
 				</Panel>
 			</Card>
+			{showScopeModal && (
+				<Modal
+					title={__('Choose ticket scope', 'fair-events')}
+					onRequestClose={() => setShowScopeModal(false)}
+				>
+					<RadioControl
+						selected={pendingScope}
+						options={[
+							{
+								value: 'single_instance',
+								label: __(
+									'This instance — a separate ticket is needed for each date',
+									'fair-events'
+								),
+							},
+							{
+								value: 'whole_series',
+								label: __(
+									'Whole series — one purchase covers every occurrence',
+									'fair-events'
+								),
+							},
+						]}
+						onChange={(v) => setPendingScope(v)}
+					/>
+					<Button
+						variant="primary"
+						onClick={() => {
+							addTicketType(pendingScope);
+							setShowScopeModal(false);
+						}}
+					>
+						{__('Add ticket type', 'fair-events')}
+					</Button>
+				</Modal>
+			)}
 		</VStack>
 	);
 }

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -1,11 +1,14 @@
 /**
  * @jest-environment jsdom
  *
- * Component tests for the recurrence-scope selector in EventTickets (#663).
+ * Component tests for the recurrence-scope selector in EventTickets (#663, #935).
  *
  * Exercises:
  *   - Scope column is visible only when isRecurring={true}.
- *   - A new ticket type is seeded with recurrence_scope 'single_instance'.
+ *   - "+ Add Ticket Type" on a recurring event opens a scope-choice modal.
+ *   - A new ticket type is seeded with the scope chosen in the modal.
+ *   - Scope cell is read-only text when has_sales is true.
+ *   - Scope cell is an editable SelectControl when has_sales is false.
  *   - Changing the selector updates the save payload's recurrence_scope.
  */
 import '@testing-library/jest-dom';
@@ -121,6 +124,12 @@ describe('EventTickets — recurrence scope selector', () => {
 		});
 		fireEvent.click(addButton);
 
+		// On a recurring event the button opens the scope-choice modal.
+		const confirmButton = screen.getByRole('button', {
+			name: /add ticket type/i,
+		});
+		fireEvent.click(confirmButton);
+
 		// A second Scope combobox should appear (one per ticket type row).
 		const scopeSelects = screen
 			.getAllByRole('combobox')
@@ -190,5 +199,121 @@ describe('EventTickets — recurrence scope selector', () => {
 		const savedType = savedPayload.ticket_types?.[0];
 		expect(savedType).toBeTruthy();
 		expect(savedType.recurrence_scope).toBe('whole_series');
+	});
+});
+
+describe('EventTickets — scope-choice modal', () => {
+	it('opens a modal when "+ Add Ticket Type" is clicked on a recurring event', () => {
+		renderTickets({
+			isRecurring: true,
+			initialData: initialDataWithTicketType,
+		});
+		openEditTicketsPanel();
+
+		fireEvent.click(
+			screen.getByRole('button', { name: '+ Add Ticket Type' })
+		);
+
+		expect(screen.getByText('Choose ticket scope')).toBeInTheDocument();
+		expect(screen.getByLabelText(/This instance/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/Whole series/i)).toBeInTheDocument();
+	});
+
+	it('does not open a modal on a non-recurring event', () => {
+		renderTickets({
+			isRecurring: false,
+			initialData: initialDataWithTicketType,
+		});
+		openEditTicketsPanel();
+
+		fireEvent.click(
+			screen.getByRole('button', { name: '+ Add Ticket Type' })
+		);
+
+		expect(
+			screen.queryByText('Choose ticket scope')
+		).not.toBeInTheDocument();
+	});
+
+	it('adds a whole_series ticket when that option is chosen in the modal', () => {
+		renderTickets({
+			isRecurring: true,
+			initialData: initialDataWithTicketType,
+		});
+		openEditTicketsPanel();
+
+		fireEvent.click(
+			screen.getByRole('button', { name: '+ Add Ticket Type' })
+		);
+
+		fireEvent.click(screen.getByLabelText(/Whole series/i));
+		fireEvent.click(
+			screen.getByRole('button', { name: /add ticket type/i })
+		);
+
+		const scopeSelects = screen
+			.getAllByRole('combobox')
+			.filter(
+				(el) =>
+					el.value === 'single_instance' ||
+					el.value === 'whole_series'
+			);
+		const newRow = scopeSelects[scopeSelects.length - 1];
+		expect(newRow.value).toBe('whole_series');
+	});
+});
+
+const initialDataWithSoldTicketType = {
+	...emptyInitialData,
+	ticket_types: [
+		{
+			id: 1,
+			name: 'General',
+			capacity: null,
+			seats_per_ticket: 1,
+			invitation_only: false,
+			minimum_activities: 0,
+			disable_at: null,
+			recurrence_scope: 'whole_series',
+			sort_order: 0,
+			has_sales: true,
+		},
+	],
+};
+
+describe('EventTickets — scope lock when has_sales', () => {
+	it('renders scope as read-only text when has_sales is true', () => {
+		renderTickets({
+			isRecurring: true,
+			initialData: initialDataWithSoldTicketType,
+		});
+		openEditTicketsPanel();
+
+		expect(screen.getByText('Whole series')).toBeInTheDocument();
+		const scopeSelects = screen
+			.queryAllByRole('combobox')
+			.filter(
+				(el) =>
+					el.value === 'single_instance' ||
+					el.value === 'whole_series'
+			);
+		expect(scopeSelects.length).toBe(0);
+	});
+
+	it('renders scope as SelectControl when has_sales is false', () => {
+		renderTickets({
+			isRecurring: true,
+			initialData: initialDataWithTicketType,
+		});
+		openEditTicketsPanel();
+
+		const scopeSelects = screen
+			.getAllByRole('combobox')
+			.filter(
+				(el) =>
+					el.value === 'single_instance' ||
+					el.value === 'whole_series'
+			);
+		expect(scopeSelects.length).toBeGreaterThanOrEqual(1);
 	});
 });


### PR DESCRIPTION
Closes #935

## Summary

- **Scope-choice modal**: clicking "+ Add Ticket Type" on a recurring event now opens a `Modal` with two radio options (*This instance* / *Whole series*) and an explanatory description before the row is added. Non-recurring events keep the direct-add behaviour.
- **Sales lock (frontend)**: the scope cell renders as read-only text instead of a `SelectControl` when `type.has_sales` is true — preventing scope edits once participants have signed up.
- **`has_sales` signal (backend)**: `build_response()` adds `has_sales: bool` to each ticket-type entry using `EventParticipantRepository::count_seats_for_ticket_type()` behind a `class_exists()` guard; defaults to `false` when fair-audience is absent.
- **Server-side defense**: `sync_ticket_types()` omits `recurrence_scope` from the update array for any existing type that has active sales, so the stored scope is preserved regardless of what the payload sends.

## Test plan

- [ ] All existing Jest tests pass (`npm test` in `fair-events`)
- [ ] New component tests pass: modal renders both scope options on recurring events; whole_series selection propagates; scope cell is read-only text when `has_sales: true`; SelectControl shown when `has_sales: false`
- [ ] New API spec (`TicketsController.api.spec.js`): `has_sales` is false before any participant; scope flip is accepted when no sales
- [ ] Manual: on a recurring event, clicking "+ Add Ticket Type" shows the modal; choosing *Whole series* seeds the new row with `whole_series`; scope is locked to text on a type with active participants