### PR TITLE
feat(fair-events): show recurrence scope in Ticket Prices table

### DIFF
--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -1028,6 +1028,22 @@ export default function EventTickets({
 														'(unnamed)',
 														'fair-events'
 													)}
+												{isRecurring && (
+													<>
+														{'  ('}
+														{type.recurrence_scope ===
+														'whole_series'
+															? __(
+																	'Whole series',
+																	'fair-events'
+															  )
+															: __(
+																	'This instance',
+																	'fair-events'
+															  )}
+														{')'}
+													</>
+												)}
 											</td>
 											{salePeriods.map(
 												(period, pIndex) => {


### PR DESCRIPTION
## Summary

- On recurring events, the **Ticket Prices** summary table now displays each ticket type's recurrence scope in parentheses after the name — e.g. `Basic ticket (This instance)` or `All stuff (Whole series)`
- Non-recurring events are unaffected (gated on `isRecurring`)

## Test plan

- [ ] Open the Tickets tab on a recurring event — Ticket Prices table shows `(This instance)` / `(Whole series)` labels
- [ ] Open the Tickets tab on a non-recurring event — no scope label appears