### PR TITLE
feat(fair-events): add manual disable/enable for sold ticket types

### DIFF
--- a/.changeset/ticket-type-disabled-flag.md
+++ b/.changeset/ticket-type-disabled-flag.md
@@ -1,0 +1,6 @@
+---
+"fair-events": minor
+"fair-audience": patch
+---
+
+Add manual disable/enable for sold ticket types: a new `disabled` boolean column on ticket types lets admins hide a type from the signup form without deleting it. The admin UI replaces the Remove button with an Enable/Disable toggle when the type has sales. The server guards against deleting sold types omitted from the payload (defense in depth). The event-signup block and the GetTickets gate both respect the flag.

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -405,8 +405,8 @@ if ( $pricing_event_date_id && class_exists( \FairEvents\Models\TicketType::clas
 			continue;
 		}
 
-		// Hide ticket types whose end date has passed.
-		if ( $tt->disable_at && strtotime( $tt->disable_at ) <= time() ) {
+		// Hide ticket types whose end date has passed or that have been manually disabled.
+		if ( $tt->disabled || ( $tt->disable_at && strtotime( $tt->disable_at ) <= time() ) ) {
 			continue;
 		}
 

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -205,7 +205,7 @@ class GetTicketsController extends WP_REST_Controller {
 					array( 'status' => 400 )
 				);
 			}
-			if ( $ticket_type->disable_at && strtotime( $ticket_type->disable_at ) <= time() ) {
+			if ( $ticket_type->disabled || ( $ticket_type->disable_at && strtotime( $ticket_type->disable_at ) <= time() ) ) {
 				return new WP_Error(
 					'ticket_type_disabled',
 					__( 'This ticket type is no longer available.', 'fair-events' ),

--- a/fair-events/src/API/TicketsController.php
+++ b/fair-events/src/API/TicketsController.php
@@ -509,6 +509,12 @@ class TicketsController extends WP_REST_Controller {
 		// Delete removed.
 		foreach ( $existing_ids as $eid ) {
 			if ( ! in_array( $eid, $incoming_ids, true ) ) {
+				$has_sales = $participant_repo
+					? $participant_repo->count_seats_for_ticket_type( $eid ) > 0
+					: false;
+				if ( $has_sales ) {
+					continue;
+				}
 				TicketPrice::delete_by_ticket_type_id( $eid );
 				if ( class_exists( \FairEventsExperimental\Models\TicketTypeGroupRestriction::class ) ) {
 					\FairEventsExperimental\Models\TicketTypeGroupRestriction::delete_by_ticket_type_id( $eid );
@@ -548,6 +554,7 @@ class TicketsController extends WP_REST_Controller {
 					'invitation_only'    => $invitation_only,
 					'minimum_activities' => $minimum_activities,
 					'disable_at'         => $disable_at,
+					'disabled'           => ! empty( $item['disabled'] ),
 					'sort_order'         => $sort_order,
 				);
 				if ( ! $has_sales ) {

--- a/fair-events/src/API/__tests__/TicketsController.api.spec.js
+++ b/fair-events/src/API/__tests__/TicketsController.api.spec.js
@@ -154,3 +154,134 @@ test.describe('TicketsController — recurrence_scope preserved when type has sa
 		);
 	});
 });
+
+test.describe('TicketsController — disabled flag and delete guard', () => {
+	let api;
+	let eventDateId;
+	let ticketTypeId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Disabled-flag test ${Date.now()}`,
+				start_datetime: '2030-07-01 10:00:00',
+				end_datetime: '2030-07-01 12:00:00',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		eventDateId = (await edRes.json()).id;
+
+		const putRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'Standard',
+							capacity: null,
+							seats_per_ticket: 1,
+							invitation_only: false,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'single_instance',
+							disabled: false,
+							group_ids: [],
+						},
+					],
+					sale_periods: [],
+					prices: [],
+					settings: {},
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+		ticketTypeId = (await putRes.json()).ticket_types?.[0]?.id;
+		expect(ticketTypeId).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (eventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+	});
+
+	test('disabled defaults to false on creation', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const type = (await res.json()).ticket_types?.find(
+			(t) => t.id === ticketTypeId
+		);
+		expect(type).toBeTruthy();
+		expect(type.disabled).toBe(false);
+	});
+
+	test('setting disabled:true persists and is returned', async () => {
+		const putRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							id: ticketTypeId,
+							name: 'Standard',
+							capacity: null,
+							seats_per_ticket: 1,
+							invitation_only: false,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'single_instance',
+							disabled: true,
+							group_ids: [],
+						},
+					],
+					sale_periods: [],
+					prices: [],
+					settings: {},
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+		const type = (await putRes.json()).ticket_types?.find(
+			(t) => t.id === ticketTypeId
+		);
+		expect(type?.disabled).toBe(true);
+
+		// Re-enable for cleanup.
+		await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							id: ticketTypeId,
+							name: 'Standard',
+							capacity: null,
+							seats_per_ticket: 1,
+							invitation_only: false,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'single_instance',
+							disabled: false,
+							group_ids: [],
+						},
+					],
+					sale_periods: [],
+					prices: [],
+					settings: {},
+				},
+			}
+		);
+	});
+});

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -22,6 +22,7 @@ import {
 	Spinner,
 	Notice,
 	TextControl,
+	ToggleControl,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
@@ -1620,6 +1621,20 @@ export default function EventTickets({
 																		)
 																	}
 																/>
+																{type.disabled && (
+																	<span
+																		style={{
+																			color: '#757575',
+																			fontSize:
+																				'0.85em',
+																		}}
+																	>
+																		{__(
+																			'Disabled — no longer on sale',
+																			'fair-events'
+																		)}
+																	</span>
+																)}
 															</td>
 															{settings.show_ticket_type_capacity && (
 																<td>
@@ -2003,21 +2018,49 @@ export default function EventTickets({
 																}
 															)}
 															<td>
-																<Button
-																	variant="tertiary"
-																	isDestructive
-																	size="small"
-																	onClick={() =>
-																		removeTicketType(
-																			tIndex
-																		)
-																	}
-																>
-																	{__(
-																		'Remove',
-																		'fair-events'
-																	)}
-																</Button>
+																{type.has_sales ? (
+																	<ToggleControl
+																		label={
+																			type.disabled
+																				? __(
+																						'Disabled',
+																						'fair-events'
+																				  )
+																				: __(
+																						'Enabled',
+																						'fair-events'
+																				  )
+																		}
+																		checked={
+																			!type.disabled
+																		}
+																		onChange={(
+																			v
+																		) =>
+																			updateTicketType(
+																				tIndex,
+																				'disabled',
+																				!v
+																			)
+																		}
+																	/>
+																) : (
+																	<Button
+																		variant="tertiary"
+																		isDestructive
+																		size="small"
+																		onClick={() =>
+																			removeTicketType(
+																				tIndex
+																			)
+																		}
+																	>
+																		{__(
+																			'Remove',
+																			'fair-events'
+																		)}
+																	</Button>
+																)}
 															</td>
 														</tr>
 													)

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -317,3 +317,74 @@ describe('EventTickets — scope lock when has_sales', () => {
 		expect(scopeSelects.length).toBeGreaterThanOrEqual(1);
 	});
 });
+
+describe('EventTickets — disable/enable when has_sales', () => {
+	it('shows Remove button when has_sales is false', () => {
+		renderTickets({ initialData: initialDataWithTicketType });
+		openEditTicketsPanel();
+		expect(
+			screen.getByRole('button', { name: /Remove/i })
+		).toBeInTheDocument();
+	});
+
+	it('shows toggle instead of Remove when has_sales is true', () => {
+		renderTickets({ initialData: initialDataWithSoldTicketType });
+		openEditTicketsPanel();
+		expect(
+			screen.queryByRole('button', { name: /Remove/i })
+		).not.toBeInTheDocument();
+		expect(screen.getByRole('checkbox')).toBeInTheDocument();
+	});
+
+	it('shows disabled label when ticket type is disabled', () => {
+		const disabledData = {
+			...emptyInitialData,
+			ticket_types: [
+				{
+					...initialDataWithSoldTicketType.ticket_types[0],
+					disabled: true,
+				},
+			],
+		};
+		renderTickets({ initialData: disabledData });
+		openEditTicketsPanel();
+		expect(
+			screen.getByText('Disabled — no longer on sale')
+		).toBeInTheDocument();
+	});
+
+	it('does not show disabled label when ticket type is enabled', () => {
+		renderTickets({ initialData: initialDataWithSoldTicketType });
+		openEditTicketsPanel();
+		expect(
+			screen.queryByText('Disabled — no longer on sale')
+		).not.toBeInTheDocument();
+	});
+
+	it('toggling disable updates the disabled field in the save payload', async () => {
+		const { onSaveRef } = renderTickets({
+			initialData: initialDataWithSoldTicketType,
+		});
+		openEditTicketsPanel();
+		const toggle = screen.getByRole('checkbox');
+		fireEvent.click(toggle);
+
+		let savedPayload = null;
+		apiFetch.mockImplementation(({ method, data }) => {
+			if (method === 'PUT') {
+				savedPayload = data;
+				return Promise.resolve({
+					...initialDataWithSoldTicketType,
+					ticket_types: [],
+				});
+			}
+			return new Promise(() => {});
+		});
+
+		await act(async () => {
+			await onSaveRef.current();
+		});
+
+		expect(savedPayload?.ticket_types?.[0]?.disabled).toBe(true);
+	});
+});

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -245,6 +245,11 @@ class Installer {
 			self::migrate_to_3_16_0();
 		}
 
+		// Run migration if upgrading from pre-3.17.0 (add disabled to ticket_types).
+		if ( version_compare( $current_version, '3.17.0', '<' ) ) {
+			self::migrate_to_3_17_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -379,6 +384,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.16.0', '<' ) ) {
 				self::migrate_to_3_16_0();
+			}
+
+			if ( version_compare( $current_version, '3.17.0', '<' ) ) {
+				self::migrate_to_3_17_0();
 			}
 
 			// Install/update tables
@@ -1503,6 +1512,34 @@ class Installer {
 			$wpdb->query(
 				$wpdb->prepare(
 					'ALTER TABLE %i DROP COLUMN google_maps_link',
+					$table_name
+				)
+			);
+		}
+	}
+
+	/**
+	 * Migrate to version 3.17.0 - Add disabled column to ticket_types table.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_17_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_events_ticket_types';
+
+		$column_exists = $wpdb->get_results(
+			$wpdb->prepare(
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'disabled' )
+			)
+		);
+
+		if ( empty( $column_exists ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD COLUMN disabled TINYINT(1) NOT NULL DEFAULT 0 AFTER recurrence_scope',
 					$table_name
 				)
 			);

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.16.0';
+	const DB_VERSION = '3.17.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -255,6 +255,7 @@ class Schema {
 			minimum_activities INT UNSIGNED NOT NULL DEFAULT 0,
 			disable_at DATETIME DEFAULT NULL,
 			recurrence_scope ENUM('single_instance','whole_series') NOT NULL DEFAULT 'single_instance',
+			disabled TINYINT(1) NOT NULL DEFAULT 0,
 			sort_order INT UNSIGNED NOT NULL DEFAULT 0,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/fair-events/src/Models/TicketType.php
+++ b/fair-events/src/Models/TicketType.php
@@ -83,6 +83,13 @@ class TicketType {
 	public $recurrence_scope = 'single_instance';
 
 	/**
+	 * Whether this ticket type has been manually disabled by an admin
+	 *
+	 * @var bool
+	 */
+	public $disabled = false;
+
+	/**
 	 * Sort order
 	 *
 	 * @var int
@@ -187,9 +194,10 @@ class TicketType {
 	 * @param int         $minimum_activities Minimum activities this type requires (0 = inherit global).
 	 * @param string|null $disable_at         Date/time after which this ticket type is unavailable (null = no end date).
 	 * @param string      $recurrence_scope   'single_instance' or 'whole_series'.
+	 * @param bool        $disabled           Whether this ticket type is manually disabled.
 	 * @return int|false The ticket type ID on success, false on failure.
 	 */
-	public static function create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket = 1, $invitation_only = false, $minimum_activities = 0, $disable_at = null, $recurrence_scope = 'single_instance' ) {
+	public static function create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket = 1, $invitation_only = false, $minimum_activities = 0, $disable_at = null, $recurrence_scope = 'single_instance', $disabled = false ) {
 		global $wpdb;
 
 		$table_name = self::get_table_name();
@@ -209,9 +217,10 @@ class TicketType {
 				'minimum_activities' => max( 0, (int) $minimum_activities ),
 				'disable_at'         => $disable_at,
 				'recurrence_scope'   => $recurrence_scope,
+				'disabled'           => $disabled ? 1 : 0,
 				'sort_order'         => $sort_order,
 			),
-			array( '%d', '%s', '%d', '%d', '%d', '%d', '%s', '%s', '%d' )
+			array( '%d', '%s', '%d', '%d', '%d', '%d', '%s', '%s', '%d', '%d' )
 		);
 
 		if ( $result ) {
@@ -272,6 +281,11 @@ class TicketType {
 				: 'single_instance';
 			$update_data['recurrence_scope'] = $scope;
 			$update_format[]                 = '%s';
+		}
+
+		if ( array_key_exists( 'disabled', $data ) ) {
+			$update_data['disabled'] = $data['disabled'] ? 1 : 0;
+			$update_format[]         = '%d';
 		}
 
 		if ( isset( $data['sort_order'] ) ) {
@@ -352,6 +366,7 @@ class TicketType {
 		$item->disable_at         = $row->disable_at ?? null;
 		$raw_scope                = $row->recurrence_scope ?? 'single_instance';
 		$item->recurrence_scope   = in_array( $raw_scope, self::RECURRENCE_SCOPES, true ) ? $raw_scope : 'single_instance';
+		$item->disabled           = ! empty( $row->disabled );
 		$item->sort_order         = (int) $row->sort_order;
 		$item->created_at         = $row->created_at;
 		$item->updated_at         = $row->updated_at;
@@ -384,6 +399,7 @@ class TicketType {
 			'minimum_activities' => $this->minimum_activities,
 			'disable_at'         => $this->disable_at,
 			'recurrence_scope'   => $this->recurrence_scope,
+			'disabled'           => (bool) $this->disabled,
 			'sort_order'         => $this->sort_order,
 			'created_at'         => $this->created_at,
 			'updated_at'         => $this->updated_at,


### PR DESCRIPTION
## Summary

- Adds `disabled` boolean column to ticket types (DB migration 3.17.0) so admins can hide a sold type from the signup form without deleting it
- Admin UI replaces the Remove button with an Enable/Disable toggle when `has_sales` is true; disabled types show a "Disabled — no longer on sale" label
- Server guards against accidental deletion of sold types omitted from the PUT payload (defense in depth)
- Event-signup block and GetTickets gate both respect the new `disabled` flag alongside the existing `disable_at`

## Test plan

- [ ] Component tests (`EventTickets.test.jsx`): Remove shown when no sales, toggle shown when has_sales, disabled label appears, toggle updates payload — all passing (`npm run test:js`)
- [ ] API tests (`TicketsController.api.spec.js`): `disabled` defaults to false, persists true/false round-trip
- [ ] Manual: create a ticket type, sell a ticket, confirm Remove disappears and Enable/Disable toggle appears; disable it and verify it vanishes from the event-signup block

Closes #931