### PR TITLE
Remove simple ticket pricing; advanced ticketing only

### DIFF
--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -333,11 +333,6 @@ class EventDatesController extends WP_REST_Controller {
 				'required'          => false,
 				'sanitize_callback' => 'esc_url_raw',
 			),
-			'signup_price'   => array(
-				'description' => __( 'Signup price (null = free).', 'fair-events' ),
-				'type'        => array( 'number', 'null' ),
-				'required'    => false,
-			),
 			'event_id'       => array(
 				'description' => __( 'Linked post ID.', 'fair-events' ),
 				'type'        => array( 'integer', 'null' ),
@@ -760,13 +755,6 @@ class EventDatesController extends WP_REST_Controller {
 		$external_url = $request->get_param( 'external_url' );
 		if ( null !== $external_url ) {
 			$update_data['external_url'] = $external_url;
-		}
-
-		if ( $request->has_param( 'signup_price' ) ) {
-			$raw_signup_price            = $request->get_param( 'signup_price' );
-			$update_data['signup_price'] = ( null === $raw_signup_price || '' === $raw_signup_price )
-				? null
-				: (float) $raw_signup_price;
 		}
 
 		$event_id = $request->get_param( 'event_id' );
@@ -1372,7 +1360,6 @@ class EventDatesController extends WP_REST_Controller {
 			'external_url'    => $event_date->external_url,
 			'display_url'     => $event_date->get_display_url(),
 			'rrule'           => $event_date->rrule,
-			'signup_price'    => null !== $event_date->signup_price ? (float) $event_date->signup_price : null,
 		);
 
 		// Add exdates for master events.

--- a/fair-events/src/API/TicketsController.php
+++ b/fair-events/src/API/TicketsController.php
@@ -142,16 +142,10 @@ class TicketsController extends WP_REST_Controller {
 
 		$body = $request->get_json_params();
 
-		// 1. Update capacity + signup_price on event_dates row.
+		// 1. Update capacity on event_dates row.
 		$event_date_updates = array();
 		if ( array_key_exists( 'capacity', $body ) ) {
 			$event_date_updates['capacity'] = null !== $body['capacity'] ? absint( $body['capacity'] ) : null;
-		}
-		if ( array_key_exists( 'signup_price', $body ) ) {
-			$raw_price                          = $body['signup_price'];
-			$event_date_updates['signup_price'] = ( null === $raw_price || '' === $raw_price )
-				? null
-				: (float) $raw_price;
 		}
 		if ( ! empty( $event_date_updates ) ) {
 			EventDates::update_by_id( $event_date_id, $event_date_updates );
@@ -308,18 +302,12 @@ class TicketsController extends WP_REST_Controller {
 			);
 		}
 
-		// 1. Update capacity + signup_price on event_dates row.
+		// 1. Update capacity on event_dates row.
 		$event_date_updates = array();
 		if ( array_key_exists( 'capacity', $body ) ) {
 			$event_date_updates['capacity'] = null !== $body['capacity'] && '' !== $body['capacity']
 				? absint( $body['capacity'] )
 				: null;
-		}
-		if ( array_key_exists( 'signup_price', $body ) ) {
-			$raw_price                          = $body['signup_price'];
-			$event_date_updates['signup_price'] = ( null === $raw_price || '' === $raw_price )
-				? null
-				: (float) $raw_price;
 		}
 		if ( ! empty( $event_date_updates ) ) {
 			EventDates::update_by_id( $event_date_id, $event_date_updates );
@@ -703,7 +691,6 @@ class TicketsController extends WP_REST_Controller {
 
 		return array(
 			'capacity'     => $event_date->capacity,
-			'signup_price' => null !== $event_date->signup_price ? (float) $event_date->signup_price : null,
 			'end_datetime' => $event_date->end_datetime,
 			'ticket_types' => array_map(
 				function ( $t ) use ( $restrictions, $participant_repo ) {

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -39,7 +39,6 @@ export default function EventTickets({
 	isRecurring,
 }) {
 	const [capacity, setCapacity] = useState('');
-	const [signupPrice, setSignupPrice] = useState('');
 	const [endDatetime, setEndDatetime] = useState(
 		endDatetimeProp ? endDatetimeProp.split(' ')[0].split('T')[0] : ''
 	);
@@ -64,12 +63,10 @@ export default function EventTickets({
 	const [importing, setImporting] = useState(false);
 	const [error, setError] = useState(null);
 	const [success, setSuccess] = useState(null);
-	const [pricingRules, setPricingRules] = useState([]);
 	const [groups, setGroups] = useState([]);
 	const [showScopeModal, setShowScopeModal] = useState(false);
 	const [pendingScope, setPendingScope] = useState('single_instance');
 	const [participants, setParticipants] = useState([]);
-	const [hasFairAudience, setHasFairAudience] = useState(false);
 	const fileInputRef = useRef(null);
 
 	const manageInvitationsUrl =
@@ -98,11 +95,6 @@ export default function EventTickets({
 		setCapacity(
 			data.capacity !== null && data.capacity !== undefined
 				? String(data.capacity)
-				: ''
-		);
-		setSignupPrice(
-			data.signup_price !== null && data.signup_price !== undefined
-				? String(data.signup_price)
 				: ''
 		);
 		if (data.end_datetime) {
@@ -175,20 +167,8 @@ export default function EventTickets({
 	}, [initialData, loadTickets, populateFromData]);
 
 	useEffect(() => {
-		if (!eventDateId) return;
-		apiFetch({
-			path: `/fair-events/v1/event-dates/${eventDateId}/group-pricing-rules`,
-		})
-			.then((rules) => setPricingRules(rules || []))
-			.catch(() => setPricingRules([]));
-	}, [eventDateId]);
-
-	useEffect(() => {
 		apiFetch({ path: '/fair-audience/v1/groups' })
-			.then((data) => {
-				setGroups(data || []);
-				setHasFairAudience(true);
-			})
+			.then((data) => setGroups(data || []))
 			.catch(() => setGroups([]));
 	}, []);
 
@@ -226,11 +206,6 @@ export default function EventTickets({
 				});
 				return {
 					capacity: capacity !== '' ? parseInt(capacity, 10) : null,
-					signup_price: hasAdvancedTickets
-						? null
-						: signupPrice.trim() === ''
-						? null
-						: parseFloat(signupPrice),
 					ticket_types: ticketTypes.map((t, i) => ({
 						...t,
 						sort_order: i,
@@ -273,11 +248,6 @@ export default function EventTickets({
 				method: 'PUT',
 				data: {
 					capacity: capacity !== '' ? parseInt(capacity, 10) : null,
-					signup_price: hasAdvancedTickets
-						? null
-						: signupPrice.trim() === ''
-						? null
-						: parseFloat(signupPrice),
 					ticket_types: ticketTypes.map((t, i) => ({
 						...t,
 						sort_order: i,
@@ -297,11 +267,6 @@ export default function EventTickets({
 			setCapacity(
 				data.capacity !== null && data.capacity !== undefined
 					? String(data.capacity)
-					: ''
-			);
-			setSignupPrice(
-				data.signup_price !== null && data.signup_price !== undefined
-					? String(data.signup_price)
 					: ''
 			);
 			setTicketTypes(data.ticket_types || []);
@@ -378,11 +343,6 @@ export default function EventTickets({
 			type: 'fair-events-tickets',
 			exported_at: new Date().toISOString(),
 			capacity: capacity !== '' ? parseInt(capacity, 10) : null,
-			signup_price: hasAdvancedTickets
-				? null
-				: signupPrice.trim() === ''
-				? null
-				: parseFloat(signupPrice),
 			settings,
 			ticket_types: ticketTypes.map((t) => ({
 				name: t.name || '',
@@ -822,21 +782,6 @@ export default function EventTickets({
 		}).format(value);
 	};
 
-	const applyDiscount = (basePrice, type, value) => {
-		const discounted =
-			type === 'percentage'
-				? basePrice * (1 - value / 100)
-				: basePrice - value;
-		return Math.max(0, discounted);
-	};
-
-	const formatDiscount = (type, value) => {
-		if (type === 'percentage') {
-			return `${value}%`;
-		}
-		return formatCurrency(value);
-	};
-
 	if (loading) {
 		return (
 			<Card style={{ marginTop: '16px' }}>
@@ -911,73 +856,26 @@ export default function EventTickets({
 			{!hasAdvancedTickets && (
 				<Card>
 					<CardHeader>
-						<strong>{__('Signup price', 'fair-events')}</strong>
+						<strong>{__('Tickets', 'fair-events')}</strong>
 					</CardHeader>
 					<CardBody>
-						<p>
-							{signupPrice.trim() === ''
-								? __(
-										'Free signup. Enter a price below to charge for this event, or switch to advanced ticketing for multiple ticket types.',
-										'fair-events'
-								  )
-								: hasFairAudience
-								? sprintf(
-										/* translators: %s: formatted price */
-										__(
-											'Signup price: %s. Group discounts configured in the Groups tab still apply.',
-											'fair-events'
-										),
-										formatCurrency(
-											parseFloat(signupPrice) || 0
-										)
-								  )
-								: sprintf(
-										/* translators: %s: formatted price */
-										__('Signup price: %s.', 'fair-events'),
-										formatCurrency(
-											parseFloat(signupPrice) || 0
-										)
-								  )}
-						</p>
-						{signupPrice.trim() !== '' &&
-							pricingRules.length > 0 && (
-								<ul
-									style={{
-										margin: '8px 0 0',
-										paddingLeft: '20px',
-									}}
-								>
-									{pricingRules.map((rule) => {
-										const base =
-											parseFloat(signupPrice) || 0;
-										const finalPrice = applyDiscount(
-											base,
-											rule.discount_type,
-											parseFloat(rule.discount_value) || 0
-										);
-										return (
-											<li key={rule.id}>
-												{sprintf(
-													/* translators: 1: group name, 2: discount, 3: final price */
-													__(
-														'%1$s: %2$s discount → %3$s',
-														'fair-events'
-													),
-													rule.group_name ||
-														`#${rule.group_id}`,
-													formatDiscount(
-														rule.discount_type,
-														parseFloat(
-															rule.discount_value
-														) || 0
-													),
-													formatCurrency(finalPrice)
-												)}
-											</li>
-										);
-									})}
-								</ul>
-							)}
+						<VStack spacing={3} alignment="flex-start">
+							<p style={{ margin: 0 }}>
+								{__(
+									'No ticket types configured yet. Add a ticket type to start selling tickets for this event.',
+									'fair-events'
+								)}
+							</p>
+							<Button
+								variant="primary"
+								onClick={() => {
+									seedDefaultSalePeriods();
+									openAddTicketModal();
+								}}
+							>
+								{__('+ Add Ticket Type', 'fair-events')}
+							</Button>
+						</VStack>
 					</CardBody>
 				</Card>
 			)}
@@ -1402,713 +1300,635 @@ export default function EventTickets({
 									'fair-events'
 								)}
 							/>
-							{!hasAdvancedTickets ? (
-								<VStack spacing={3}>
-									<TextControl
-										/* translators: %s: currency code, e.g. EUR */
-										label={sprintf(
-											__(
-												'Signup price (%s)',
-												'fair-events'
-											),
-											siteCurrency
-										)}
-										help={
-											hasFairAudience
-												? __(
-														'Leave empty for free signup. Group discounts (Groups tab) apply to this base price.',
+							<VStack spacing={4}>
+								<div style={{ overflowX: 'auto' }}>
+									<table className="wp-list-table widefat striped">
+										<thead>
+											<tr>
+												<th>
+													{__(
+														'Ticket Type',
 														'fair-events'
-												  )
-												: __(
-														'Leave empty for free signup.',
-														'fair-events'
-												  )
-										}
-										type="number"
-										min="0"
-										step="0.01"
-										value={signupPrice}
-										onChange={setSignupPrice}
-										__nextHasNoMarginBottom
-									/>
-									<p>
-										{__(
-											'Need multiple ticket types or time-based pricing? Switch to advanced ticketing below.',
-											'fair-events'
-										)}
-									</p>
-									<HStack spacing={2}>
-										<Button
-											variant="secondary"
-											onClick={() => {
-												addTicketType();
-												seedDefaultSalePeriods();
-											}}
-										>
-											{__(
-												'Switch to advanced ticketing',
-												'fair-events'
-											)}
-										</Button>
-									</HStack>
-								</VStack>
-							) : (
-								<VStack spacing={4}>
-									<div style={{ overflowX: 'auto' }}>
-										<table className="wp-list-table widefat striped">
-											<thead>
-												<tr>
+													)}
+												</th>
+												{settings.show_ticket_type_capacity && (
 													<th>
 														{__(
-															'Ticket Type',
+															'Capacity',
 															'fair-events'
 														)}
 													</th>
-													{settings.show_ticket_type_capacity && (
+												)}
+												{settings.show_seats_per_ticket && (
+													<th>
+														{__(
+															'Seats',
+															'fair-events'
+														)}
+													</th>
+												)}
+												{hasGroups && (
+													<th>
+														{__(
+															'Groups',
+															'fair-events'
+														)}
+													</th>
+												)}
+												{hasGroups && (
+													<th>
+														{__(
+															'Invitation only',
+															'fair-events'
+														)}
+													</th>
+												)}
+												{settings.show_ticket_type_minimum_activities &&
+													options.length > 0 && (
 														<th>
 															{__(
-																'Capacity',
+																'Min. activities',
 																'fair-events'
 															)}
 														</th>
+													)}
+												{settings.show_ticket_type_end_date && (
+													<th>
+														{__(
+															'End date',
+															'fair-events'
+														)}
+													</th>
+												)}
+												{isRecurring && (
+													<th>
+														{__(
+															'Scope',
+															'fair-events'
+														)}
+													</th>
+												)}
+												{salePeriods.map(
+													(period, pIndex) => {
+														const isContinuous =
+															settings.continues_pricing_period;
+														const isFirst =
+															pIndex === 0;
+														const isLast =
+															pIndex ===
+															salePeriods.length -
+																1;
+														const fromValue =
+															isContinuous &&
+															!isFirst
+																? salePeriods[
+																		pIndex -
+																			1
+																  ]?.sale_end ||
+																  ''
+																: period.sale_start ||
+																  '';
+														const untilValue =
+															isContinuous &&
+															isLast
+																? period.sale_end ||
+																  (endDatetime
+																		? dayAfterDate(
+																				endDatetime
+																		  )
+																		: '')
+																: period.sale_end ||
+																  '';
+														const dateTooltip = `${
+															fromValue || '?'
+														} → ${
+															untilValue || '?'
+														}`;
+
+														return (
+															<th
+																key={
+																	period.id ||
+																	`new-${pIndex}`
+																}
+																title={
+																	dateTooltip
+																}
+															>
+																{settings.multiple_pricing_periods
+																	? period.name ||
+																	  __(
+																			'(unnamed)',
+																			'fair-events'
+																	  )
+																	: pIndex ===
+																	  0
+																	? __(
+																			'Advance ticket',
+																			'fair-events'
+																	  )
+																	: __(
+																			'Day of event',
+																			'fair-events'
+																	  )}
+															</th>
+														);
+													}
+												)}
+											</tr>
+										</thead>
+										<tbody>
+											{ticketTypes.map((type, tIndex) => (
+												<tr
+													key={
+														type.id ||
+														`new-${tIndex}`
+													}
+												>
+													<td>
+														<TextControl
+															placeholder={__(
+																'Type name',
+																'fair-events'
+															)}
+															value={
+																type.name || ''
+															}
+															onChange={(v) =>
+																updateTicketType(
+																	tIndex,
+																	'name',
+																	v
+																)
+															}
+														/>
+														{type.disabled && (
+															<span
+																style={{
+																	color: '#757575',
+																	fontSize:
+																		'0.85em',
+																}}
+															>
+																{__(
+																	'Disabled — no longer on sale',
+																	'fair-events'
+																)}
+															</span>
+														)}
+													</td>
+													{settings.show_ticket_type_capacity && (
+														<td>
+															<TextControl
+																type="number"
+																min="0"
+																placeholder={__(
+																	'Unlimited',
+																	'fair-events'
+																)}
+																value={
+																	type.capacity !==
+																		null &&
+																	type.capacity !==
+																		undefined
+																		? String(
+																				type.capacity
+																		  )
+																		: ''
+																}
+																onChange={(v) =>
+																	updateTicketType(
+																		tIndex,
+																		'capacity',
+																		v !== ''
+																			? parseInt(
+																					v,
+																					10
+																			  )
+																			: null
+																	)
+																}
+															/>
+														</td>
 													)}
 													{settings.show_seats_per_ticket && (
-														<th>
-															{__(
-																'Seats',
-																'fair-events'
-															)}
-														</th>
+														<td>
+															<TextControl
+																type="number"
+																min="1"
+																value={String(
+																	type.seats_per_ticket ||
+																		1
+																)}
+																onChange={(v) =>
+																	updateTicketType(
+																		tIndex,
+																		'seats_per_ticket',
+																		Math.max(
+																			1,
+																			parseInt(
+																				v,
+																				10
+																			) ||
+																				1
+																		)
+																	)
+																}
+																help={__(
+																	'How many capacity slots this ticket consumes (1 = single, 2 = pair/+1).',
+																	'fair-events'
+																)}
+															/>
+														</td>
 													)}
 													{hasGroups && (
-														<th>
-															{__(
-																'Groups',
-																'fair-events'
-															)}
-														</th>
+														<td>
+															<FormTokenField
+																value={(
+																	type.group_ids ||
+																	[]
+																).map(
+																	(id) =>
+																		groupNameById[
+																			id
+																		] ||
+																		`#${id}`
+																)}
+																suggestions={
+																	groupSuggestions
+																}
+																onChange={(
+																	tokens
+																) => {
+																	const ids =
+																		tokens
+																			.map(
+																				(
+																					name
+																				) =>
+																					groupIdByName[
+																						name
+																					]
+																			)
+																			.filter(
+																				Boolean
+																			);
+																	updateTicketType(
+																		tIndex,
+																		'group_ids',
+																		ids
+																	);
+																}}
+																__experimentalExpandOnFocus
+																__experimentalAutoSelectFirstMatch
+																placeholder={__(
+																	'All participants',
+																	'fair-events'
+																)}
+															/>
+														</td>
 													)}
 													{hasGroups && (
-														<th>
-															{__(
-																'Invitation only',
-																'fair-events'
-															)}
-														</th>
+														<td>
+															<CheckboxControl
+																checked={
+																	type.invitation_only ||
+																	false
+																}
+																onChange={(v) =>
+																	updateTicketType(
+																		tIndex,
+																		'invitation_only',
+																		v
+																	)
+																}
+															/>
+														</td>
 													)}
 													{settings.show_ticket_type_minimum_activities &&
 														options.length > 0 && (
-															<th>
-																{__(
-																	'Min. activities',
-																	'fair-events'
-																)}
-															</th>
-														)}
-													{settings.show_ticket_type_end_date && (
-														<th>
-															{__(
-																'End date',
-																'fair-events'
-															)}
-														</th>
-													)}
-													{isRecurring && (
-														<th>
-															{__(
-																'Scope',
-																'fair-events'
-															)}
-														</th>
-													)}
-													{salePeriods.map(
-														(period, pIndex) => {
-															const isContinuous =
-																settings.continues_pricing_period;
-															const isFirst =
-																pIndex === 0;
-															const isLast =
-																pIndex ===
-																salePeriods.length -
-																	1;
-															const fromValue =
-																isContinuous &&
-																!isFirst
-																	? salePeriods[
-																			pIndex -
-																				1
-																	  ]
-																			?.sale_end ||
-																	  ''
-																	: period.sale_start ||
-																	  '';
-															const untilValue =
-																isContinuous &&
-																isLast
-																	? period.sale_end ||
-																	  (endDatetime
-																			? dayAfterDate(
-																					endDatetime
-																			  )
-																			: '')
-																	: period.sale_end ||
-																	  '';
-															const dateTooltip = `${
-																fromValue || '?'
-															} → ${
-																untilValue ||
-																'?'
-															}`;
-
-															return (
-																<th
-																	key={
-																		period.id ||
-																		`new-${pIndex}`
-																	}
-																	title={
-																		dateTooltip
-																	}
-																>
-																	{settings.multiple_pricing_periods
-																		? period.name ||
-																		  __(
-																				'(unnamed)',
-																				'fair-events'
-																		  )
-																		: pIndex ===
-																		  0
-																		? __(
-																				'Advance ticket',
-																				'fair-events'
-																		  )
-																		: __(
-																				'Day of event',
-																				'fair-events'
-																		  )}
-																</th>
-															);
-														}
-													)}
-												</tr>
-											</thead>
-											<tbody>
-												{ticketTypes.map(
-													(type, tIndex) => (
-														<tr
-															key={
-																type.id ||
-																`new-${tIndex}`
-															}
-														>
 															<td>
 																<TextControl
-																	placeholder={__(
-																		'Type name',
-																		'fair-events'
+																	type="number"
+																	min="0"
+																	placeholder="0"
+																	value={String(
+																		type.minimum_activities ||
+																			0
 																	)}
-																	value={
-																		type.name ||
-																		''
-																	}
 																	onChange={(
 																		v
 																	) =>
 																		updateTicketType(
 																			tIndex,
-																			'name',
+																			'minimum_activities',
+																			v !==
+																				''
+																				? Math.max(
+																						0,
+																						parseInt(
+																							v,
+																							10
+																						) ||
+																							0
+																				  )
+																				: 0
+																		)
+																	}
+																	help={__(
+																		'Only raises the event-wide minimum for this ticket type. Leave 0 to inherit.',
+																		'fair-events'
+																	)}
+																/>
+															</td>
+														)}
+													{settings.show_ticket_type_end_date && (
+														<td>
+															<TextControl
+																type="datetime-local"
+																value={
+																	type.disable_at
+																		? type.disable_at.replace(
+																				' ',
+																				'T'
+																		  )
+																		: ''
+																}
+																onChange={(v) =>
+																	updateTicketType(
+																		tIndex,
+																		'disable_at',
+																		v
+																			? v.replace(
+																					'T',
+																					' '
+																			  )
+																			: null
+																	)
+																}
+															/>
+														</td>
+													)}
+													{isRecurring && (
+														<td>
+															{type.has_sales ? (
+																<span>
+																	{type.recurrence_scope ===
+																	'whole_series'
+																		? __(
+																				'Whole series',
+																				'fair-events'
+																		  )
+																		: __(
+																				'This instance',
+																				'fair-events'
+																		  )}
+																</span>
+															) : (
+																<SelectControl
+																	value={
+																		type.recurrence_scope ||
+																		'single_instance'
+																	}
+																	options={[
+																		{
+																			value: 'single_instance',
+																			label: __(
+																				'This instance',
+																				'fair-events'
+																			),
+																		},
+																		{
+																			value: 'whole_series',
+																			label: __(
+																				'Whole series',
+																				'fair-events'
+																			),
+																		},
+																	]}
+																	onChange={(
+																		v
+																	) =>
+																		updateTicketType(
+																			tIndex,
+																			'recurrence_scope',
 																			v
 																		)
 																	}
+																	__nextHasNoMarginBottom
 																/>
-																{type.disabled && (
-																	<span
-																		style={{
-																			color: '#757575',
-																			fontSize:
-																				'0.85em',
-																		}}
+															)}
+														</td>
+													)}
+													{salePeriods.map(
+														(period, pIndex) => {
+															const cell =
+																getPrice(
+																	type,
+																	period
+																);
+															return (
+																<td
+																	key={
+																		period.id ||
+																		`new-${pIndex}`
+																	}
+																>
+																	<VStack
+																		spacing={
+																			1
+																		}
 																	>
-																		{__(
-																			'Disabled — no longer on sale',
-																			'fair-events'
-																		)}
-																	</span>
-																)}
-															</td>
-															{settings.show_ticket_type_capacity && (
-																<td>
-																	<TextControl
-																		type="number"
-																		min="0"
-																		placeholder={__(
-																			'Unlimited',
-																			'fair-events'
-																		)}
-																		value={
-																			type.capacity !==
-																				null &&
-																			type.capacity !==
-																				undefined
-																				? String(
-																						type.capacity
-																				  )
-																				: ''
-																		}
-																		onChange={(
-																			v
-																		) =>
-																			updateTicketType(
-																				tIndex,
-																				'capacity',
-																				v !==
-																					''
-																					? parseInt(
-																							v,
-																							10
-																					  )
-																					: null
-																			)
-																		}
-																	/>
-																</td>
-															)}
-															{settings.show_seats_per_ticket && (
-																<td>
-																	<TextControl
-																		type="number"
-																		min="1"
-																		value={String(
-																			type.seats_per_ticket ||
-																				1
-																		)}
-																		onChange={(
-																			v
-																		) =>
-																			updateTicketType(
-																				tIndex,
-																				'seats_per_ticket',
-																				Math.max(
-																					1,
-																					parseInt(
-																						v,
-																						10
-																					) ||
-																						1
-																				)
-																			)
-																		}
-																		help={__(
-																			'How many capacity slots this ticket consumes (1 = single, 2 = pair/+1).',
-																			'fair-events'
-																		)}
-																	/>
-																</td>
-															)}
-															{hasGroups && (
-																<td>
-																	<FormTokenField
-																		value={(
-																			type.group_ids ||
-																			[]
-																		).map(
-																			(
-																				id
-																			) =>
-																				groupNameById[
-																					id
-																				] ||
-																				`#${id}`
-																		)}
-																		suggestions={
-																			groupSuggestions
-																		}
-																		onChange={(
-																			tokens
-																		) => {
-																			const ids =
-																				tokens
-																					.map(
-																						(
-																							name
-																						) =>
-																							groupIdByName[
-																								name
-																							]
-																					)
-																					.filter(
-																						Boolean
-																					);
-																			updateTicketType(
-																				tIndex,
-																				'group_ids',
-																				ids
-																			);
-																		}}
-																		__experimentalExpandOnFocus
-																		__experimentalAutoSelectFirstMatch
-																		placeholder={__(
-																			'All participants',
-																			'fair-events'
-																		)}
-																	/>
-																</td>
-															)}
-															{hasGroups && (
-																<td>
-																	<CheckboxControl
-																		checked={
-																			type.invitation_only ||
-																			false
-																		}
-																		onChange={(
-																			v
-																		) =>
-																			updateTicketType(
-																				tIndex,
-																				'invitation_only',
-																				v
-																			)
-																		}
-																	/>
-																</td>
-															)}
-															{settings.show_ticket_type_minimum_activities &&
-																options.length >
-																	0 && (
-																	<td>
-																		<TextControl
-																			type="number"
-																			min="0"
-																			placeholder="0"
-																			value={String(
-																				type.minimum_activities ||
-																					0
-																			)}
-																			onChange={(
-																				v
-																			) =>
-																				updateTicketType(
-																					tIndex,
-																					'minimum_activities',
-																					v !==
-																						''
-																						? Math.max(
-																								0,
-																								parseInt(
-																									v,
-																									10
-																								) ||
-																									0
-																						  )
-																						: 0
-																				)
-																			}
-																			help={__(
-																				'Only raises the event-wide minimum for this ticket type. Leave 0 to inherit.',
+																		<CheckboxControl
+																			__nextHasNoMarginBottom
+																			label={__(
+																				'Available',
 																				'fair-events'
 																			)}
-																		/>
-																	</td>
-																)}
-															{settings.show_ticket_type_end_date && (
-																<td>
-																	<TextControl
-																		type="datetime-local"
-																		value={
-																			type.disable_at
-																				? type.disable_at.replace(
-																						' ',
-																						'T'
-																				  )
-																				: ''
-																		}
-																		onChange={(
-																			v
-																		) =>
-																			updateTicketType(
-																				tIndex,
-																				'disable_at',
-																				v
-																					? v.replace(
-																							'T',
-																							' '
-																					  )
-																					: null
-																			)
-																		}
-																	/>
-																</td>
-															)}
-															{isRecurring && (
-																<td>
-																	{type.has_sales ? (
-																		<span>
-																			{type.recurrence_scope ===
-																			'whole_series'
-																				? __(
-																						'Whole series',
-																						'fair-events'
-																				  )
-																				: __(
-																						'This instance',
-																						'fair-events'
-																				  )}
-																		</span>
-																	) : (
-																		<SelectControl
-																			value={
-																				type.recurrence_scope ||
-																				'single_instance'
+																			checked={
+																				cell.enabled !==
+																				false
 																			}
-																			options={[
-																				{
-																					value: 'single_instance',
-																					label: __(
-																						'This instance',
-																						'fair-events'
-																					),
-																				},
-																				{
-																					value: 'whole_series',
-																					label: __(
-																						'Whole series',
-																						'fair-events'
-																					),
-																				},
-																			]}
 																			onChange={(
 																				v
 																			) =>
-																				updateTicketType(
-																					tIndex,
-																					'recurrence_scope',
+																				updatePrice(
+																					type,
+																					period,
+																					'enabled',
 																					v
 																				)
 																			}
-																			__nextHasNoMarginBottom
 																		/>
-																	)}
-																</td>
-															)}
-															{salePeriods.map(
-																(
-																	period,
-																	pIndex
-																) => {
-																	const cell =
-																		getPrice(
-																			type,
-																			period
-																		);
-																	return (
-																		<td
-																			key={
-																				period.id ||
-																				`new-${pIndex}`
-																			}
-																		>
-																			<VStack
-																				spacing={
-																					1
-																				}
-																			>
-																				<CheckboxControl
-																					__nextHasNoMarginBottom
-																					label={__(
-																						'Available',
-																						'fair-events'
-																					)}
-																					checked={
-																						cell.enabled !==
-																						false
+																		{cell.enabled !==
+																			false && (
+																			<>
+																				<HStack
+																					alignment="center"
+																					spacing={
+																						2
 																					}
-																					onChange={(
-																						v
-																					) =>
-																						updatePrice(
-																							type,
-																							period,
-																							'enabled',
-																							v
-																						)
-																					}
-																				/>
-																				{cell.enabled !==
-																					false && (
-																					<>
-																						<HStack
-																							alignment="center"
-																							spacing={
-																								2
-																							}
-																						>
-																							<span
-																								style={{
-																									whiteSpace:
-																										'nowrap',
-																								}}
-																							>
-																								{__(
-																									'Price',
-																									'fair-events'
-																								)}
-																							</span>
-																							<TextControl
-																								type="number"
-																								step="0.01"
-																								min="0"
-																								value={
-																									cell.price
-																								}
-																								onChange={(
-																									v
-																								) =>
-																									updatePrice(
-																										type,
-																										period,
-																										'price',
-																										v
-																									)
-																								}
-																							/>
-																						</HStack>
-																						{!settings.unlimited_tickets_in_price_period && (
-																							<HStack
-																								alignment="center"
-																								spacing={
-																									2
-																								}
-																							>
-																								<span
-																									style={{
-																										whiteSpace:
-																											'nowrap',
-																									}}
-																								>
-																									{__(
-																										'Cap',
-																										'fair-events'
-																									)}
-																								</span>
-																								<TextControl
-																									type="number"
-																									min="0"
-																									value={
-																										cell.capacity
-																									}
-																									onChange={(
-																										v
-																									) =>
-																										updatePrice(
-																											type,
-																											period,
-																											'capacity',
-																											v
-																										)
-																									}
-																								/>
-																							</HStack>
+																				>
+																					<span
+																						style={{
+																							whiteSpace:
+																								'nowrap',
+																						}}
+																					>
+																						{__(
+																							'Price',
+																							'fair-events'
 																						)}
-																					</>
+																					</span>
+																					<TextControl
+																						type="number"
+																						step="0.01"
+																						min="0"
+																						value={
+																							cell.price
+																						}
+																						onChange={(
+																							v
+																						) =>
+																							updatePrice(
+																								type,
+																								period,
+																								'price',
+																								v
+																							)
+																						}
+																					/>
+																				</HStack>
+																				{!settings.unlimited_tickets_in_price_period && (
+																					<HStack
+																						alignment="center"
+																						spacing={
+																							2
+																						}
+																					>
+																						<span
+																							style={{
+																								whiteSpace:
+																									'nowrap',
+																							}}
+																						>
+																							{__(
+																								'Cap',
+																								'fair-events'
+																							)}
+																						</span>
+																						<TextControl
+																							type="number"
+																							min="0"
+																							value={
+																								cell.capacity
+																							}
+																							onChange={(
+																								v
+																							) =>
+																								updatePrice(
+																									type,
+																									period,
+																									'capacity',
+																									v
+																								)
+																							}
+																						/>
+																					</HStack>
 																				)}
-																			</VStack>
-																		</td>
-																	);
-																}
-															)}
-															<td>
-																{type.has_sales ? (
-																	<ToggleControl
-																		label={
-																			type.disabled
-																				? __(
-																						'Disabled',
-																						'fair-events'
-																				  )
-																				: __(
-																						'Enabled',
-																						'fair-events'
-																				  )
-																		}
-																		checked={
-																			!type.disabled
-																		}
-																		onChange={(
-																			v
-																		) =>
-																			updateTicketType(
-																				tIndex,
-																				'disabled',
-																				!v
-																			)
-																		}
-																	/>
-																) : (
-																	<Button
-																		variant="tertiary"
-																		isDestructive
-																		size="small"
-																		onClick={() =>
-																			removeTicketType(
-																				tIndex
-																			)
-																		}
-																	>
-																		{__(
-																			'Remove',
-																			'fair-events'
+																			</>
 																		)}
-																	</Button>
-																)}
-															</td>
-														</tr>
-													)
-												)}
-											</tbody>
-											<tfoot>
-												<tr>
-													<td
-														colSpan={
-															salePeriods.length +
-															1 +
-															(settings.show_ticket_type_capacity
-																? 1
-																: 0) +
-															(settings.show_seats_per_ticket
-																? 1
-																: 0) +
-															(hasGroups
-																? 2
-																: 0) +
-															(settings.show_ticket_type_minimum_activities &&
-															options.length > 0
-																? 1
-																: 0) +
-															(settings.show_ticket_type_end_date
-																? 1
-																: 0)
+																	</VStack>
+																</td>
+															);
 														}
-													>
-														<Button
-															variant="secondary"
-															size="small"
-															onClick={
-																openAddTicketModal
-															}
-														>
-															{__(
-																'+ Add Ticket Type',
-																'fair-events'
-															)}
-														</Button>
+													)}
+													<td>
+														{type.has_sales ? (
+															<ToggleControl
+																label={
+																	type.disabled
+																		? __(
+																				'Disabled',
+																				'fair-events'
+																		  )
+																		: __(
+																				'Enabled',
+																				'fair-events'
+																		  )
+																}
+																checked={
+																	!type.disabled
+																}
+																onChange={(v) =>
+																	updateTicketType(
+																		tIndex,
+																		'disabled',
+																		!v
+																	)
+																}
+															/>
+														) : (
+															<Button
+																variant="tertiary"
+																isDestructive
+																size="small"
+																onClick={() =>
+																	removeTicketType(
+																		tIndex
+																	)
+																}
+															>
+																{__(
+																	'Remove',
+																	'fair-events'
+																)}
+															</Button>
+														)}
 													</td>
 												</tr>
-											</tfoot>
-										</table>
-									</div>
-								</VStack>
-							)}
+											))}
+										</tbody>
+										<tfoot>
+											<tr>
+												<td
+													colSpan={
+														salePeriods.length +
+														1 +
+														(settings.show_ticket_type_capacity
+															? 1
+															: 0) +
+														(settings.show_seats_per_ticket
+															? 1
+															: 0) +
+														(hasGroups ? 2 : 0) +
+														(settings.show_ticket_type_minimum_activities &&
+														options.length > 0
+															? 1
+															: 0) +
+														(settings.show_ticket_type_end_date
+															? 1
+															: 0)
+													}
+												>
+													<Button
+														variant="secondary"
+														size="small"
+														onClick={
+															openAddTicketModal
+														}
+													>
+														{__(
+															'+ Add Ticket Type',
+															'fair-events'
+														)}
+													</Button>
+												</td>
+											</tr>
+										</tfoot>
+									</table>
+								</div>
+							</VStack>
 						</VStack>
 					</PanelBody>
 				</Panel>
@@ -2697,44 +2517,6 @@ export default function EventTickets({
 									}))
 								}
 							/>
-							{hasAdvancedTickets ? (
-								<Button
-									variant="secondary"
-									isDestructive
-									onClick={() => {
-										if (
-											window.confirm(
-												__(
-													'Switching back to simple ticketing will remove all ticket types, sale periods, and prices. Continue?',
-													'fair-events'
-												)
-											)
-										) {
-											setTicketTypes([]);
-											setSalePeriods([]);
-											setPrices({});
-										}
-									}}
-								>
-									{__(
-										'Switch to simple ticketing',
-										'fair-events'
-									)}
-								</Button>
-							) : (
-								<Button
-									variant="secondary"
-									onClick={() => {
-										addTicketType();
-										seedDefaultSalePeriods();
-									}}
-								>
-									{__(
-										'Switch to advanced ticketing',
-										'fair-events'
-									)}
-								</Button>
-							)}
 						</VStack>
 					</PanelBody>
 				</Panel>

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -36,7 +36,6 @@ afterEach(() => {
 
 const emptyInitialData = {
 	capacity: null,
-	signup_price: null,
 	ticket_types: [],
 	sale_periods: [],
 	prices: [],
@@ -81,6 +80,53 @@ function openEditTicketsPanel() {
 	});
 	fireEvent.click(panelButton);
 }
+
+describe('EventTickets — empty state (no advanced tickets)', () => {
+	it('renders the empty state with a "+ Add Ticket Type" button', () => {
+		renderTickets({ initialData: emptyInitialData });
+		expect(
+			screen.getByText(/No ticket types configured yet/i)
+		).toBeInTheDocument();
+		// The empty-state card and the (collapsed) Edit tickets table footer
+		// both expose a "+ Add Ticket Type" affordance.
+		expect(
+			screen.getAllByRole('button', { name: '+ Add Ticket Type' }).length
+		).toBeGreaterThanOrEqual(1);
+	});
+
+	it('does not render a Signup price field', () => {
+		renderTickets({ initialData: emptyInitialData });
+		expect(screen.queryByText(/Signup price/i)).not.toBeInTheDocument();
+	});
+
+	it('does not render a simple/advanced ticketing toggle', () => {
+		renderTickets({ initialData: emptyInitialData });
+		expect(
+			screen.queryByRole('button', {
+				name: /Switch to simple ticketing/i,
+			})
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', {
+				name: /Switch to advanced ticketing/i,
+			})
+		).not.toBeInTheDocument();
+	});
+
+	it('opens the advanced editor when "+ Add Ticket Type" is clicked from the empty state', () => {
+		renderTickets({ initialData: emptyInitialData });
+		const addButton = screen.getByRole('button', {
+			name: '+ Add Ticket Type',
+		});
+		fireEvent.click(addButton);
+		// Adding a ticket type flips hasAdvancedTickets true: the empty-state
+		// message is gone and the pricing grid header appears.
+		expect(
+			screen.queryByText(/No ticket types configured yet/i)
+		).not.toBeInTheDocument();
+		expect(screen.getByText('Ticket Prices')).toBeInTheDocument();
+	});
+});
 
 describe('EventTickets — recurrence scope selector', () => {
 	it('shows Scope column when isRecurring is true', () => {

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -115,13 +115,6 @@ class EventDates {
 	public $capacity;
 
 	/**
-	 * Signup price (null = free, 0.00+ = paid)
-	 *
-	 * @var float|null
-	 */
-	public $signup_price;
-
-	/**
 	 * Free-text address (used when the Venues feature bundle is disabled).
 	 *
 	 * @var string|null
@@ -196,7 +189,6 @@ class EventDates {
 		$event_dates->external_url    = $result->external_url ?? null;
 		$event_dates->link_type       = $result->link_type ?? 'post';
 		$event_dates->capacity        = isset( $result->capacity ) && null !== $result->capacity ? (int) $result->capacity : null;
-		$event_dates->signup_price    = isset( $result->signup_price ) && null !== $result->signup_price ? (float) $result->signup_price : null;
 		$event_dates->address         = isset( $result->address ) ? $result->address : null;
 
 		return $event_dates;
@@ -712,7 +704,6 @@ class EventDates {
 			'external_url'    => '%s',
 			'link_type'       => '%s',
 			'capacity'        => '%d',
-			'signup_price'    => '%f',
 			'address'         => '%s',
 		);
 


### PR DESCRIPTION
## Summary

Closes #942

Removes the flat **signup price** ("simple ticketing") mode from the fair-events ticket editor. Advanced ticketing (ticket types × sale periods × prices) is now the only supported pricing model.

The simple `signup_price` was a half-wired path: the purchase flow never charged it — `GetTicketsController::create_signup()` resolves the amount **only** from the active sale period's `TicketPrice`, so an event configured with just a signup price collected no money. Dropping the mode removes that trap and eliminates one of two parallel pricing models (UI, save/import/export, persistence).

### Frontend (`EventTickets.js`)
- Removed `signupPrice` state and the `signup_price` keys from the save / `onDataRef` / export payloads.
- Deleted the signup-price summary card (incl. the group-discount preview list) and the now-dead `applyDiscount` / `formatDiscount` / `pricingRules` helpers.
- Deleted the signup-price `TextControl` + "Switch to advanced ticketing" branch and the bottom "Switch to simple / advanced ticketing" toggle.
- New **empty state**: a fresh event date shows a prominent "+ Add Ticket Type" card (seeds default sale periods + opens the add-ticket flow) and the tab opens straight into the advanced editor.

### Backend
- `TicketsController` and `EventDatesController` stop reading/writing `signup_price`; dropped from the `EventDates` model and REST schema.

## Notes
- **DB column kept** this milestone (no destructive migration) — `Schema.php` / `Installer.php` unchanged. The column is simply left unpopulated; dropping it is a follow-up once production is confirmed clear (per open question 1).
- **Group discounts**: already applied to real ticket prices at runtime (fair-audience `EventSignupPricing` on the resolved `TicketPrice`), so no discount behaviour is lost. The simple-mode preview list is dropped; no group-discount preview was added to the advanced grid in this milestone (possible follow-up).
- Any event currently relying solely on a signup price will need its organizer to recreate it as a ticket type.

## Test plan
- [x] `npm run test:js` (fair-events) — 33 passing, incl. new empty-state coverage
- [x] `npm run build` (fair-events)
- [x] `phpcs` on changed PHP files — no new errors vs. base
- [ ] Manual: new event date → Tickets tab opens into the advanced editor; "+ Add Ticket Type" seeds sale periods; paid signup still resolves amount from the active sale period; group discount still applies on a real ticket price via fair-audience signup