### PR TITLE
feat(fair-events): reconcile recurrence occurrences to preserve row IDs

### DIFF
--- a/fair-events/__tests__/Services/RecurrenceServiceTest.php
+++ b/fair-events/__tests__/Services/RecurrenceServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * RecurrenceService unit tests
+ *
+ * Covers generate_occurrences() behaviour (no DB) and the anchor-date
+ * matching logic that reconcile_occurrences() depends on.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Services\RecurrenceService;
+
+/**
+ * Tests for RecurrenceService
+ */
+class RecurrenceServiceTest extends TestCase {
+
+	// -----------------------------------------------------------------------
+	// generate_occurrences — basic invariants
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Weekly COUNT=3 produces exactly 3 occurrences on consecutive weeks.
+	 */
+	public function test_generate_weekly_count() {
+		$occurrences = RecurrenceService::generate_occurrences(
+			'2035-03-01 10:00:00',
+			'2035-03-01 12:00:00',
+			'FREQ=WEEKLY;COUNT=3'
+		);
+
+		$this->assertCount( 3, $occurrences );
+		$this->assertSame( '2035-03-01T10:00:00', $occurrences[0]['start'] );
+		$this->assertSame( '2035-03-08T10:00:00', $occurrences[1]['start'] );
+		$this->assertSame( '2035-03-15T10:00:00', $occurrences[2]['start'] );
+	}
+
+	/**
+	 * Anchor date (Y-m-d of the start) is invariant under time-of-day shift.
+	 *
+	 * If the master time shifts from 10:00 to 11:00, the anchor dates for a
+	 * weekly COUNT=3 series must still be 2035-03-01, 2035-03-08, 2035-03-15.
+	 * This is what lets reconcile_occurrences() match existing rows after a shift.
+	 */
+	public function test_anchor_dates_unchanged_by_time_shift() {
+		$before = RecurrenceService::generate_occurrences(
+			'2035-03-01 10:00:00',
+			'2035-03-01 12:00:00',
+			'FREQ=WEEKLY;COUNT=3'
+		);
+		$after  = RecurrenceService::generate_occurrences(
+			'2035-03-01 11:00:00',
+			'2035-03-01 13:00:00',
+			'FREQ=WEEKLY;COUNT=3'
+		);
+
+		$anchors_before = array_map(
+			fn( $occ ) => ( new \DateTime( $occ['start'] ) )->format( 'Y-m-d' ),
+			$before
+		);
+		$anchors_after  = array_map(
+			fn( $occ ) => ( new \DateTime( $occ['start'] ) )->format( 'Y-m-d' ),
+			$after
+		);
+
+		$this->assertSame( $anchors_before, $anchors_after );
+	}
+
+	/**
+	 * Shortening COUNT from 4 to 2 removes the last 2 anchors.
+	 *
+	 * Reconcile_occurrences() uses exactly this difference to know which rows
+	 * to delete: the anchors in the existing set but not in the desired set.
+	 */
+	public function test_shorten_rrule_drops_tail_anchors() {
+		$full  = RecurrenceService::generate_occurrences(
+			'2035-03-01 10:00:00',
+			'2035-03-01 12:00:00',
+			'FREQ=WEEKLY;COUNT=4'
+		);
+		$short = RecurrenceService::generate_occurrences(
+			'2035-03-01 10:00:00',
+			'2035-03-01 12:00:00',
+			'FREQ=WEEKLY;COUNT=2'
+		);
+
+		$anchors_full  = array_map( fn( $o ) => ( new \DateTime( $o['start'] ) )->format( 'Y-m-d' ), $full );
+		$anchors_short = array_map( fn( $o ) => ( new \DateTime( $o['start'] ) )->format( 'Y-m-d' ), $short );
+
+		// Short set must be a leading subset of the full set.
+		$this->assertSame( array_slice( $anchors_full, 0, 2 ), $anchors_short );
+
+		// The anchors that would be removed are the tail.
+		$removed = array_diff( $anchors_full, $anchors_short );
+		$this->assertCount( 2, $removed );
+	}
+
+	/**
+	 * Exdates reduce the occurrence count but keep anchor dates consistent.
+	 */
+	public function test_exdate_skips_occurrence() {
+		$occurrences = RecurrenceService::generate_occurrences(
+			'2035-03-01 10:00:00',
+			'2035-03-01 12:00:00',
+			'FREQ=WEEKLY;COUNT=3',
+			null,
+			array( '2035-03-08' )
+		);
+
+		// Second occurrence excluded — only 2 returned.
+		$this->assertCount( 2, $occurrences );
+
+		$starts = array_map( fn( $o ) => substr( $o['start'], 0, 10 ), $occurrences );
+		$this->assertNotContains( '2035-03-08', $starts );
+		$this->assertContains( '2035-03-01', $starts );
+		$this->assertContains( '2035-03-15', $starts );
+	}
+}

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -802,7 +802,13 @@ class EventDatesController extends WP_REST_Controller {
 			}
 
 			// Regenerate recurrence occurrences when rrule or dates change.
-			$rrule_changed              = isset( $update_data['rrule'] );
+			$rrule_changed = isset( $update_data['rrule'] );
+
+			$new_start     = $update_data['start_datetime'] ?? null;
+			$new_end       = $update_data['end_datetime'] ?? null;
+			$dates_changed = ( null !== $new_start && $new_start !== $existing->start_datetime )
+				|| ( null !== $new_end && $new_end !== $existing->end_datetime );
+
 			$dates_changed_on_recurring = $dates_changed && ( $existing->occurrence_type === 'master' || $rrule_changed );
 
 			if ( $rrule_changed || $dates_changed_on_recurring ) {

--- a/fair-events/src/API/__tests__/EventDatesController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesController.api.spec.js
@@ -1,9 +1,11 @@
 /**
- * Playwright API tests for EventDatesController — standalone category copy on first link.
+ * Playwright API tests for EventDatesController.
  *
- * Covers the $newly_linked fix: when a standalone event date that has categories
- * in the junction table is linked to a post for the first time, those categories
- * must be copied to the post taxonomy and the junction rows must be cleared.
+ * Covers:
+ * - Standalone category copy on first link ($newly_linked fix).
+ * - Recurrence reconciliation: occurrence IDs are preserved on time/venue edits,
+ *   RRULE shortening only deletes removed rows, and master time edits propagate
+ *   to generated children.
  */
 
 import { test, expect, request } from '@playwright/test';
@@ -152,5 +154,153 @@ test.describe('EventDatesController — standalone category copy on first link',
 				}
 			);
 		}
+	});
+});
+
+test.describe('EventDatesController — recurrence reconciliation', () => {
+	let api;
+	let masterEventDateId;
+	let eventPostId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterEach(async () => {
+		if (masterEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+				{ headers: adminHeaders }
+			);
+			masterEventDateId = null;
+		}
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+			eventPostId = null;
+		}
+	});
+
+	async function createRecurringEvent(
+		api,
+		rrule,
+		start = '2035-03-01 10:00:00'
+	) {
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: { title: `Recurrence test ${Date.now()}`, status: 'publish' },
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: start,
+				end_datetime: start.replace('10:00:00', '12:00:00'),
+				rrule,
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		const edBody = await edRes.json();
+		masterEventDateId = edBody.id;
+		return edBody;
+	}
+
+	async function getOccurrences(api, eventId) {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates?event_id=${eventId}`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		return await res.json();
+	}
+
+	test('time-of-day shift preserves occurrence IDs', async ({
+		request: req,
+	}) => {
+		const localApi = await req.newContext({ baseURL: BASE_URL });
+		await createRecurringEvent(localApi, 'FREQ=WEEKLY;COUNT=3');
+
+		const before = await getOccurrences(localApi, eventPostId);
+		expect(before.length).toBe(3);
+		const idsBefore = before.map((o) => o.id).sort();
+
+		const putRes = await localApi.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: {
+					start_datetime: '2035-03-01 11:00:00',
+					end_datetime: '2035-03-01 13:00:00',
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+
+		const after = await getOccurrences(localApi, eventPostId);
+		expect(after.length).toBe(3);
+		const idsAfter = after.map((o) => o.id).sort();
+
+		expect(idsAfter).toEqual(idsBefore);
+
+		const starts = after.map((o) => o.start_datetime);
+		expect(starts.every((s) => s.includes('11:00:00'))).toBe(true);
+	});
+
+	test('shortening RRULE deletes only removed occurrences', async ({
+		request: req,
+	}) => {
+		const localApi = await req.newContext({ baseURL: BASE_URL });
+		await createRecurringEvent(localApi, 'FREQ=WEEKLY;COUNT=4');
+
+		const before = await getOccurrences(localApi, eventPostId);
+		expect(before.length).toBe(4);
+		const keptIds = before.slice(0, 2).map((o) => o.id);
+		const removedIds = before.slice(2).map((o) => o.id);
+
+		const putRes = await localApi.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { rrule: 'FREQ=WEEKLY;COUNT=2' },
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+
+		const after = await getOccurrences(localApi, eventPostId);
+		expect(after.length).toBe(2);
+		const idsAfter = after.map((o) => o.id);
+
+		keptIds.forEach((id) => expect(idsAfter).toContain(id));
+		removedIds.forEach((id) => expect(idsAfter).not.toContain(id));
+	});
+
+	test('master time-of-day edit propagates to generated children', async ({
+		request: req,
+	}) => {
+		const localApi = await req.newContext({ baseURL: BASE_URL });
+		await createRecurringEvent(localApi, 'FREQ=WEEKLY;COUNT=3');
+
+		const putRes = await localApi.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: {
+					start_datetime: '2035-03-01 14:00:00',
+					end_datetime: '2035-03-01 16:00:00',
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+
+		const after = await getOccurrences(localApi, eventPostId);
+		expect(after.length).toBe(3);
+
+		const starts = after.map((o) => o.start_datetime);
+		expect(starts.every((s) => s.includes('14:00:00'))).toBe(true);
 	});
 });

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -255,6 +255,11 @@ class Installer {
 			self::migrate_to_3_18_0();
 		}
 
+		// Run migration if upgrading from pre-3.19.0 (add recurrence_anchor to event_dates).
+		if ( version_compare( $current_version, '3.19.0', '<' ) ) {
+			self::migrate_to_3_19_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -397,6 +402,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.18.0', '<' ) ) {
 				self::migrate_to_3_18_0();
+			}
+
+			if ( version_compare( $current_version, '3.19.0', '<' ) ) {
+				self::migrate_to_3_19_0();
 			}
 
 			// Install/update tables
@@ -1599,6 +1608,53 @@ class Installer {
 				$table,
 				$table,
 				'generated'
+			)
+		);
+	}
+
+	/**
+	 * Migrate to version 3.19.0 - Add recurrence_anchor column to event_dates table.
+	 *
+	 * Stores the originally-generated date for each master/generated row so
+	 * a time-of-day or whole-series shift can match existing rows by anchor
+	 * date and update them in place rather than delete+recreate.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_19_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_event_dates';
+
+		$column_exists = $wpdb->get_results(
+			$wpdb->prepare(
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'recurrence_anchor' )
+			)
+		);
+
+		if ( empty( $column_exists ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD COLUMN recurrence_anchor DATE DEFAULT NULL AFTER address',
+					$table_name
+				)
+			);
+
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD KEY idx_recurrence_anchor (recurrence_anchor)',
+					$table_name
+				)
+			);
+		}
+
+		// Backfill anchor for existing master/generated rows from their stored start date.
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET recurrence_anchor = DATE(start_datetime) WHERE recurrence_anchor IS NULL AND occurrence_type IN ('master', 'generated')",
+				$table_name
 			)
 		);
 	}

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.18.0';
+	const DB_VERSION = '3.19.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -49,6 +49,7 @@ class Schema {
 			capacity INT UNSIGNED DEFAULT NULL,
 			signup_price DECIMAL(10,2) DEFAULT NULL,
 			address TEXT DEFAULT NULL,
+			recurrence_anchor DATE DEFAULT NULL,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY (id),
@@ -59,7 +60,8 @@ class Schema {
 			KEY idx_occurrence_type (occurrence_type),
 			KEY idx_master_id (master_id),
 			KEY idx_rrule (rrule(100)),
-			KEY idx_link_type (link_type)
+			KEY idx_link_type (link_type),
+			KEY idx_recurrence_anchor (recurrence_anchor)
 		) ENGINE=InnoDB {$charset_collate};";
 	}
 

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -122,6 +122,14 @@ class EventDates {
 	public $address;
 
 	/**
+	 * Anchor date (Y-m-d) pinning this row to its originally-generated date.
+	 * Set on master and generated rows; null for single occurrences.
+	 *
+	 * @var string|null
+	 */
+	public $recurrence_anchor;
+
+	/**
 	 * Get event dates by event ID
 	 *
 	 * Checks the direct event_id column first (primary post), then falls back
@@ -174,22 +182,24 @@ class EventDates {
 	 * @return EventDates Hydrated EventDates object.
 	 */
 	private static function hydrate( $result ) {
-		$event_dates                  = new self();
-		$event_dates->id              = (int) $result->id;
-		$event_dates->event_id        = $result->event_id ? (int) $result->event_id : null;
-		$event_dates->start_datetime  = $result->start_datetime;
-		$event_dates->end_datetime    = $result->end_datetime;
-		$event_dates->all_day         = (bool) $result->all_day;
-		$event_dates->occurrence_type = $result->occurrence_type ?? 'single';
-		$event_dates->master_id       = $result->master_id ? (int) $result->master_id : null;
-		$event_dates->rrule           = $result->rrule ?? null;
-		$event_dates->exdates         = $result->exdates ?? null;
-		$event_dates->venue_id        = isset( $result->venue_id ) ? (int) $result->venue_id : null;
-		$event_dates->title           = $result->title ?? null;
-		$event_dates->external_url    = $result->external_url ?? null;
-		$event_dates->link_type       = $result->link_type ?? 'post';
-		$event_dates->capacity        = isset( $result->capacity ) && null !== $result->capacity ? (int) $result->capacity : null;
-		$event_dates->address         = isset( $result->address ) ? $result->address : null;
+		$event_dates                    = new self();
+		$event_dates->id                = (int) $result->id;
+		$event_dates->event_id          = $result->event_id ? (int) $result->event_id : null;
+		$event_dates->start_datetime    = $result->start_datetime;
+		$event_dates->end_datetime      = $result->end_datetime;
+		$event_dates->all_day           = (bool) $result->all_day;
+		$event_dates->occurrence_type   = $result->occurrence_type ?? 'single';
+		$event_dates->master_id         = $result->master_id ? (int) $result->master_id : null;
+		$event_dates->rrule             = $result->rrule ?? null;
+		$event_dates->exdates           = $result->exdates ?? null;
+		$event_dates->venue_id          = isset( $result->venue_id ) ? (int) $result->venue_id : null;
+		$event_dates->title             = $result->title ?? null;
+		$event_dates->external_url      = $result->external_url ?? null;
+		$event_dates->link_type         = $result->link_type ?? 'post';
+		$event_dates->capacity          = isset( $result->capacity ) && null !== $result->capacity ? (int) $result->capacity : null;
+		$event_dates->signup_price      = isset( $result->signup_price ) && null !== $result->signup_price ? (float) $result->signup_price : null;
+		$event_dates->address           = isset( $result->address ) ? $result->address : null;
+		$event_dates->recurrence_anchor = $result->recurrence_anchor ?? null;
 
 		return $event_dates;
 	}
@@ -251,29 +261,31 @@ class EventDates {
 	/**
 	 * Save a single occurrence
 	 *
-	 * @param int      $event_id        Event post ID.
-	 * @param string   $start           Start datetime.
-	 * @param string   $end             End datetime.
-	 * @param bool     $all_day         All day flag.
-	 * @param string   $occurrence_type Occurrence type (single, master, generated).
-	 * @param int|null $master_id       Master occurrence ID (for generated occurrences).
+	 * @param int         $event_id           Event post ID.
+	 * @param string      $start              Start datetime.
+	 * @param string      $end                End datetime.
+	 * @param bool        $all_day            All day flag.
+	 * @param string      $occurrence_type    Occurrence type (single, master, generated).
+	 * @param int|null    $master_id          Master occurrence ID (for generated occurrences).
+	 * @param string|null $recurrence_anchor  Anchor date (Y-m-d).
 	 * @return int|false The row ID on success, false on failure.
 	 */
-	public static function save_occurrence( $event_id, $start, $end, $all_day, $occurrence_type = 'single', $master_id = null ) {
+	public static function save_occurrence( $event_id, $start, $end, $all_day, $occurrence_type = 'single', $master_id = null, $recurrence_anchor = null ) {
 		global $wpdb;
 
 		$table_name = $wpdb->prefix . 'fair_event_dates';
 
 		$data = array(
-			'event_id'        => $event_id,
-			'start_datetime'  => $start,
-			'end_datetime'    => $end,
-			'all_day'         => $all_day ? 1 : 0,
-			'occurrence_type' => $occurrence_type,
-			'master_id'       => $master_id,
+			'event_id'          => $event_id,
+			'start_datetime'    => $start,
+			'end_datetime'      => $end,
+			'all_day'           => $all_day ? 1 : 0,
+			'occurrence_type'   => $occurrence_type,
+			'master_id'         => $master_id,
+			'recurrence_anchor' => $recurrence_anchor,
 		);
 
-		$format = array( '%d', '%s', '%s', '%d', '%s', '%d' );
+		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s' );
 
 		$result = $wpdb->insert( $table_name, $data, $format );
 
@@ -691,20 +703,22 @@ class EventDates {
 		$table_name = $wpdb->prefix . 'fair_event_dates';
 
 		$allowed_fields = array(
-			'event_id'        => '%d',
-			'start_datetime'  => '%s',
-			'end_datetime'    => '%s',
-			'all_day'         => '%d',
-			'occurrence_type' => '%s',
-			'master_id'       => '%d',
-			'rrule'           => '%s',
-			'exdates'         => '%s',
-			'venue_id'        => '%d',
-			'title'           => '%s',
-			'external_url'    => '%s',
-			'link_type'       => '%s',
-			'capacity'        => '%d',
-			'address'         => '%s',
+			'event_id'          => '%d',
+			'start_datetime'    => '%s',
+			'end_datetime'      => '%s',
+			'all_day'           => '%d',
+			'occurrence_type'   => '%s',
+			'master_id'         => '%d',
+			'rrule'             => '%s',
+			'exdates'           => '%s',
+			'venue_id'          => '%d',
+			'title'             => '%s',
+			'external_url'      => '%s',
+			'link_type'         => '%s',
+			'capacity'          => '%d',
+			'signup_price'      => '%f',
+			'address'           => '%s',
+			'recurrence_anchor' => '%s',
 		);
 
 		$update_data   = array();
@@ -853,6 +867,42 @@ class EventDates {
 	}
 
 	/**
+	 * Get all rows belonging to a recurring series (the master row itself plus
+	 * every generated child), keyed by recurrence_anchor (falling back to
+	 * DATE(start_datetime) for un-backfilled rows).
+	 *
+	 * Used by RecurrenceService::reconcile_occurrences() to match desired
+	 * occurrences against existing rows without churning IDs.
+	 *
+	 * @param int $master_id Master event date ID.
+	 * @return array<string, EventDates> Map of anchor-date string → EventDates.
+	 */
+	public static function get_all_by_master_id( $master_id ) {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_event_dates';
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE id = %d OR master_id = %d ORDER BY start_datetime ASC',
+				$table_name,
+				$master_id,
+				$master_id
+			)
+		);
+
+		$map = array();
+		foreach ( $results as $result ) {
+			$row    = self::hydrate( $result );
+			$anchor = $row->recurrence_anchor ?? ( new \DateTime( $row->start_datetime ) )->format( 'Y-m-d' );
+
+			$map[ $anchor ] = $row;
+		}
+
+		return $map;
+	}
+
+	/**
 	 * Delete generated occurrences by master ID
 	 *
 	 * Used for standalone events that have no event_id.
@@ -891,21 +941,22 @@ class EventDates {
 		$table_name = $wpdb->prefix . 'fair_event_dates';
 
 		$insert_data = array(
-			'event_id'        => $data['event_id'] ?? null,
-			'start_datetime'  => $data['start_datetime'],
-			'end_datetime'    => $data['end_datetime'] ?? null,
-			'all_day'         => isset( $data['all_day'] ) && $data['all_day'] ? 1 : 0,
-			'occurrence_type' => 'generated',
-			'master_id'       => $data['master_id'],
-			'rrule'           => null,
-			'title'           => $data['title'] ?? null,
-			'external_url'    => $data['external_url'] ?? null,
-			'link_type'       => $data['link_type'] ?? 'none',
-			'venue_id'        => $data['venue_id'] ?? null,
-			'address'         => $data['address'] ?? null,
+			'event_id'          => $data['event_id'] ?? null,
+			'start_datetime'    => $data['start_datetime'],
+			'end_datetime'      => $data['end_datetime'] ?? null,
+			'all_day'           => isset( $data['all_day'] ) && $data['all_day'] ? 1 : 0,
+			'occurrence_type'   => 'generated',
+			'master_id'         => $data['master_id'],
+			'rrule'             => null,
+			'title'             => $data['title'] ?? null,
+			'external_url'      => $data['external_url'] ?? null,
+			'link_type'         => $data['link_type'] ?? 'none',
+			'venue_id'          => $data['venue_id'] ?? null,
+			'address'           => $data['address'] ?? null,
+			'recurrence_anchor' => $data['recurrence_anchor'] ?? null,
 		);
 
-		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%s' );
+		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%s', '%s' );
 
 		$result = $wpdb->insert( $table_name, $insert_data, $format );
 

--- a/fair-events/src/Services/RecurrenceService.php
+++ b/fair-events/src/Services/RecurrenceService.php
@@ -194,30 +194,28 @@ class RecurrenceService {
 	/**
 	 * Regenerate all occurrences for an event
 	 *
+	 * Uses reconcile_occurrences() so existing row IDs are preserved when
+	 * dates shift, avoiding id-churn that breaks attached ticket types and signups.
+	 *
 	 * @param int         $event_id Event post ID.
 	 * @param string|null $rrule    Optional RRULE to use. Pass null to read from database,
 	 *                              pass empty string to explicitly clear recurrence.
 	 * @return int Number of occurrences generated.
 	 */
 	public static function regenerate_event_occurrences( $event_id, $rrule = null ) {
-		// Get the master/single occurrence.
 		$master = EventDates::get_by_event_id( $event_id );
 
 		if ( ! $master ) {
 			return 0;
 		}
 
-		// Get the recurrence rule from database only if not provided (null).
-		// Empty string means "explicitly no recurrence".
 		if ( null === $rrule ) {
 			$rrule = EventDates::get_rrule_by_event_id( $event_id );
 		}
 
-		// Delete existing generated occurrences.
-		EventDates::delete_generated_occurrences( $event_id );
-
-		// If no RRULE, ensure the existing record is marked as 'single'.
 		if ( empty( $rrule ) ) {
+			// No recurrence: delete generated children and mark master as 'single'.
+			EventDates::delete_generated_occurrences( $event_id );
 			EventDates::save_or_update_master(
 				$event_id,
 				$master->start_datetime,
@@ -229,10 +227,7 @@ class RecurrenceService {
 			return 1;
 		}
 
-		// Parse exdates from master.
-		$exdates = self::parse_exdates( $master->exdates );
-
-		// Generate occurrences.
+		$exdates     = self::parse_exdates( $master->exdates );
 		$occurrences = self::generate_occurrences(
 			$master->start_datetime,
 			$master->end_datetime,
@@ -245,8 +240,8 @@ class RecurrenceService {
 			return 0;
 		}
 
-		// Update master occurrence (first one).
-		$first     = array_shift( $occurrences );
+		// Ensure master row exists / is up to date with the new rrule and first occurrence time.
+		$first     = $occurrences[0];
 		$master_id = EventDates::save_or_update_master(
 			$event_id,
 			$first['start'],
@@ -260,29 +255,27 @@ class RecurrenceService {
 			return 0;
 		}
 
-		$count = 1;
-
-		// Create generated occurrences.
-		foreach ( $occurrences as $occurrence ) {
-			$result = EventDates::save_occurrence(
-				$event_id,
-				$occurrence['start'],
-				$occurrence['end'],
-				$master->all_day,
-				'generated',
-				$master_id
-			);
-
-			if ( $result ) {
-				++$count;
-			}
-		}
-
-		return $count;
+		// Reconcile generated children (occurrences[1..n]) against existing rows.
+		$generated = array_slice( $occurrences, 1 );
+		return 1 + self::reconcile_occurrences(
+			$master_id,
+			$generated,
+			$master->all_day,
+			array(
+				'event_id'     => $event_id,
+				'link_type'    => $master->link_type,
+				'external_url' => $master->external_url,
+				'venue_id'     => $master->venue_id,
+				'address'      => $master->address,
+				'title'        => $master->title,
+			)
+		);
 	}
 
 	/**
 	 * Regenerate occurrences for a standalone event date (no linked post)
+	 *
+	 * Uses reconcile_occurrences() to preserve existing row IDs.
 	 *
 	 * @param int         $event_date_id Event date row ID.
 	 * @param string|null $rrule         RRULE string. Pass null to read from DB,
@@ -296,16 +289,12 @@ class RecurrenceService {
 			return 0;
 		}
 
-		// Read rrule from DB if not provided.
 		if ( null === $rrule ) {
 			$rrule = $master->rrule;
 		}
 
-		// Delete existing generated occurrences.
-		EventDates::delete_generated_by_master_id( $event_date_id );
-
-		// If no RRULE, mark as single and return.
 		if ( empty( $rrule ) ) {
+			EventDates::delete_generated_by_master_id( $event_date_id );
 			EventDates::update_by_id(
 				$event_date_id,
 				array(
@@ -316,10 +305,7 @@ class RecurrenceService {
 			return 1;
 		}
 
-		// Parse exdates from master.
-		$exdates = self::parse_exdates( $master->exdates );
-
-		// Generate occurrences from the master's start/end.
+		$exdates     = self::parse_exdates( $master->exdates );
 		$occurrences = self::generate_occurrences(
 			$master->start_datetime,
 			$master->end_datetime,
@@ -332,40 +318,120 @@ class RecurrenceService {
 			return 0;
 		}
 
-		// Update master row: set as master with rrule.
+		// Update master row time and mark as master (first occurrence is the master itself).
+		$first = $occurrences[0];
 		EventDates::update_by_id(
 			$event_date_id,
 			array(
-				'occurrence_type' => 'master',
-				'rrule'           => $rrule,
+				'occurrence_type'   => 'master',
+				'rrule'             => $rrule,
+				'start_datetime'    => $first['start'],
+				'end_datetime'      => $first['end'],
+				'recurrence_anchor' => ( new \DateTime( $first['start'] ) )->format( 'Y-m-d' ),
 			)
 		);
 
-		// Skip first occurrence (that's the master itself).
-		array_shift( $occurrences );
+		$generated = array_slice( $occurrences, 1 );
+		return 1 + self::reconcile_occurrences(
+			$event_date_id,
+			$generated,
+			$master->all_day,
+			array(
+				'event_id'     => $master->event_id,
+				'link_type'    => $master->link_type,
+				'external_url' => $master->external_url,
+				'venue_id'     => $master->venue_id,
+				'address'      => $master->address,
+				'title'        => $master->title,
+			)
+		);
+	}
 
-		$count = 1;
+	/**
+	 * Reconcile generated occurrences for a series against the desired set.
+	 *
+	 * Matches desired occurrences to existing generated rows by anchor date, then:
+	 * - Updates rows whose anchor matches (preserves id).
+	 * - Inserts rows for new anchors.
+	 * - Deletes rows whose anchor is no longer in the desired set via
+	 *   EventDates::delete_by_id() so the fair_events_event_date_deleted hook fires.
+	 *
+	 * @param int   $master_id    Master event date row ID.
+	 * @param array $desired      Desired generated occurrences — each entry has 'start' and 'end' keys.
+	 * @param bool  $all_day      All-day flag to apply to inserted/updated rows.
+	 * @param array $master_props Inherited fields (event_id, link_type, external_url, venue_id, address, title).
+	 * @return int Number of surviving generated children (updated + inserted).
+	 */
+	public static function reconcile_occurrences( $master_id, $desired, $all_day, $master_props = array() ) {
+		// Build the desired set keyed by anchor date.
+		$desired_by_anchor = array();
+		foreach ( $desired as $occ ) {
+			$anchor                       = ( new \DateTime( $occ['start'] ) )->format( 'Y-m-d' );
+			$desired_by_anchor[ $anchor ] = $occ;
+		}
 
-		// Create generated occurrences copying master properties.
-		foreach ( $occurrences as $occurrence ) {
-			$result = EventDates::create_standalone_occurrence(
-				array(
-					'event_id'       => $master->event_id,
-					'start_datetime' => $occurrence['start'],
-					'end_datetime'   => $occurrence['end'],
-					'all_day'        => $master->all_day,
-					'master_id'      => $event_date_id,
-					'title'          => $master->title,
-					'link_type'      => $master->link_type,
-					'external_url'   => $master->external_url,
-					'venue_id'       => $master->venue_id,
-					'address'        => $master->address,
-				)
-			);
+		// Load existing generated rows keyed by anchor.
+		$existing_by_anchor = EventDates::get_all_by_master_id( $master_id );
+		// Remove the master row itself — reconcile only touches generated children.
+		unset(
+			$existing_by_anchor[ ( new \DateTime(
+				EventDates::get_by_id( $master_id )->start_datetime
+			) )->format( 'Y-m-d' ) ]
+		);
 
-			if ( $result ) {
+		$count = 0;
+
+		foreach ( $desired_by_anchor as $anchor => $occ ) {
+			if ( isset( $existing_by_anchor[ $anchor ] ) ) {
+				// Match — update in place, preserving id.
+				$row    = $existing_by_anchor[ $anchor ];
+				$update = array(
+					'start_datetime'    => $occ['start'],
+					'end_datetime'      => $occ['end'],
+					'all_day'           => $all_day ? 1 : 0,
+					'recurrence_anchor' => $anchor,
+				);
+				foreach ( array( 'event_id', 'link_type', 'external_url', 'venue_id', 'address', 'title' ) as $field ) {
+					if ( array_key_exists( $field, $master_props ) ) {
+						$update[ $field ] = $master_props[ $field ];
+					}
+				}
+				EventDates::update_by_id( $row->id, $update );
+				unset( $existing_by_anchor[ $anchor ] );
+				++$count;
+			} else {
+				// New anchor — insert.
+				if ( ! empty( $master_props['event_id'] ) ) {
+					EventDates::save_occurrence(
+						$master_props['event_id'],
+						$occ['start'],
+						$occ['end'],
+						$all_day,
+						'generated',
+						$master_id,
+						$anchor
+					);
+				} else {
+					EventDates::create_standalone_occurrence(
+						array_merge(
+							$master_props,
+							array(
+								'start_datetime'    => $occ['start'],
+								'end_datetime'      => $occ['end'],
+								'all_day'           => $all_day,
+								'master_id'         => $master_id,
+								'recurrence_anchor' => $anchor,
+							)
+						)
+					);
+				}
 				++$count;
 			}
+		}
+
+		// Delete rows whose anchor is no longer in the desired set.
+		foreach ( $existing_by_anchor as $stale_row ) {
+			EventDates::delete_by_id( $stale_row->id );
 		}
 
 		return $count;


### PR DESCRIPTION
## Summary

- Adds `recurrence_anchor DATE` column to `fair_event_dates` (migration 3.18.0) with backfill from `DATE(start_datetime)` for existing master/generated rows.
- Replaces delete+recreate in `RecurrenceService` with `reconcile_occurrences()`: matches desired occurrences to existing DB rows by anchor date, updates matches in place (preserving `id`), inserts new anchors, deletes stale rows via `delete_by_id()` so `fair_events_event_date_deleted` fires per removed row.
- Fixes the undefined `$dates_changed` bug in `EventDatesController::update_item()` (~line 818): the variable was referenced but never computed, so master time-of-day edits never triggered regeneration.

## Test plan

- [ ] PHP unit tests (`vendor/bin/phpunit __tests__/Services/`): anchor-date invariance under time shift, tail removal on RRULE shortening, exdate skipping — all pass.
- [ ] Playwright API spec (`EventDatesController.api.spec.js`): time-of-day shift preserves occurrence IDs; RRULE shortening only deletes removed rows; master time edit propagates to generated children.
- [ ] Run `docker compose up` and verify manual WP behaviour: create a weekly recurring event, edit start time → occurrence IDs unchanged in DB; shorten RRULE → only tail rows removed.

Closes #947 (PR 1 of 3 — data integrity / reconcile update)