### PR TITLE
feat(fair-audience): show test-mode ticket sales in timeline when in test mode

### DIFF
--- a/fair-audience/src/API/TimelineController.php
+++ b/fair-audience/src/API/TimelineController.php
@@ -302,8 +302,9 @@ class TimelineController extends WP_REST_Controller {
 
 		// Ticket sales (paid transactions from fair-payments-connector) – group by calendar day.
 		if ( $include_payments ) {
-			$ticket_rows   = $this->repository->get_recent_ticket_sales( $fetch_limit );
-			$ticket_groups = array();
+			$include_testmode = ( 'test' === get_option( 'fair_payment_mode', 'test' ) );
+			$ticket_rows      = $this->repository->get_recent_ticket_sales( $fetch_limit, $include_testmode );
+			$ticket_groups    = array();
 			foreach ( $ticket_rows as $row ) {
 				$day = substr( (string) $row['created_at'], 0, 10 ); // YYYY-MM-DD.
 				if ( '' === $day ) {
@@ -319,7 +320,11 @@ class TimelineController extends WP_REST_Controller {
 					);
 				}
 
-				$ticket_groups[ $day ]['total_amount'] += (float) $row['amount'];
+				$is_testmode = ! empty( $row['testmode'] );
+				// Exclude test sales from the revenue total; they still count toward the row count.
+				if ( ! $is_testmode ) {
+					$ticket_groups[ $day ]['total_amount'] += (float) $row['amount'];
+				}
 				if ( strcmp( $row['created_at'], $ticket_groups[ $day ]['latest_at'] ) > 0 ) {
 					$ticket_groups[ $day ]['latest_at'] = $row['created_at'];
 				}
@@ -338,8 +343,9 @@ class TimelineController extends WP_REST_Controller {
 					'name'           => $name,
 					'amount'         => (float) $row['amount'],
 					'event_date_id'  => ! empty( $row['event_date_id'] ) ? (int) $row['event_date_id'] : null,
-					'post_id'        => $post_id ?: null,
+					'post_id'        => $post_id ? $post_id : null,
 					'event_title'    => $event_title,
+					'testmode'       => $is_testmode,
 				);
 			}
 

--- a/fair-audience/src/API/__tests__/TimelineController.api.spec.js
+++ b/fair-audience/src/API/__tests__/TimelineController.api.spec.js
@@ -1,0 +1,123 @@
+/**
+ * Playwright API tests for the TimelineController ticket-sales branch.
+ *
+ * Exercises GET /fair-audience/v1/timeline against a live WordPress instance,
+ * focusing on the testmode flag visibility and mode-driven filtering:
+ *
+ * - The response shape always includes a `testmode` field on each ticket entry.
+ * - When fair_payment_mode = 'test', test-mode transactions appear; when 'live'
+ *   they are absent.
+ *
+ * Note: seeding real `fair_payment_transactions` rows requires the Mollie
+ * webhook flow, so mode-driven visibility is exercised via the WP-CLI eval-file
+ * manual check (TESTING.md). This spec covers the shape contract and the
+ * settings-toggle path observable from the outside.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+async function getPaymentMode(api) {
+	const res = await api.get('/wp-json/wp/v2/settings', {
+		headers: authHeaders,
+	});
+	expect(res.ok()).toBeTruthy();
+	const body = await res.json();
+	return body.fair_payment_mode;
+}
+
+async function setPaymentMode(api, mode) {
+	const res = await api.post('/wp-json/wp/v2/settings', {
+		headers: authHeaders,
+		data: { fair_payment_mode: mode },
+	});
+	expect(res.ok()).toBeTruthy();
+}
+
+test.describe('TimelineController – ticket-sales testmode', () => {
+	let api;
+	let originalMode;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+		originalMode = await getPaymentMode(api);
+	});
+
+	test.afterAll(async () => {
+		if (originalMode !== undefined) {
+			await setPaymentMode(api, originalMode);
+		}
+		await api.dispose();
+	});
+
+	test('GET /timeline returns 200 and an array', async () => {
+		const res = await api.get('/wp-json/fair-audience/v1/timeline', {
+			headers: authHeaders,
+		});
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+	});
+
+	test('ticket_sales_day items carry testmode on each ticket entry', async () => {
+		await setPaymentMode(api, 'test');
+
+		const res = await api.get('/wp-json/fair-audience/v1/timeline', {
+			headers: authHeaders,
+			params: { per_page: 50, page: 1 },
+		});
+		expect(res.ok()).toBeTruthy();
+		const items = await res.json();
+
+		const ticketDays = items.filter(
+			(item) => item.type === 'ticket_sales_day'
+		);
+
+		// If there are ticket-sale items, every ticket entry must have a boolean testmode field.
+		for (const day of ticketDays) {
+			expect(day.details).toHaveProperty('tickets');
+			for (const ticket of day.details.tickets) {
+				expect(typeof ticket.testmode).toBe('boolean');
+			}
+		}
+	});
+
+	test('switching to live mode causes the timeline endpoint to respond without error', async () => {
+		await setPaymentMode(api, 'live');
+
+		const res = await api.get('/wp-json/fair-audience/v1/timeline', {
+			headers: authHeaders,
+			params: { per_page: 50, page: 1 },
+		});
+		expect(res.status()).toBe(200);
+		const items = await res.json();
+
+		// In live mode, no ticket entry should be flagged as testmode=true.
+		const ticketDays = items.filter(
+			(item) => item.type === 'ticket_sales_day'
+		);
+		for (const day of ticketDays) {
+			for (const ticket of day.details.tickets) {
+				expect(ticket.testmode).toBe(false);
+			}
+		}
+	});
+
+	test('switching back to test mode restores connector mode', async () => {
+		await setPaymentMode(api, 'test');
+
+		const res = await api.get('/wp-json/fair-audience/v1/timeline', {
+			headers: authHeaders,
+		});
+		expect(res.status()).toBe(200);
+	});
+});

--- a/fair-audience/src/Admin/timeline/TimelineItem.js
+++ b/fair-audience/src/Admin/timeline/TimelineItem.js
@@ -362,6 +362,22 @@ function TicketSalesDayContent({ item }) {
 									{')'}
 								</>
 							)}
+							{ticket.testmode && (
+								<>
+									{' '}
+									<span
+										style={{
+											fontSize: '11px',
+											color: '#757575',
+											border: '1px solid #bdbdbd',
+											borderRadius: '3px',
+											padding: '0 3px',
+										}}
+									>
+										{__('Test', 'fair-audience')}
+									</span>
+								</>
+							)}
 						</li>
 					);
 				})}

--- a/fair-audience/src/Database/TimelineRepository.php
+++ b/fair-audience/src/Database/TimelineRepository.php
@@ -245,19 +245,42 @@ class TimelineRepository {
 	 * Returns paid transactions ordered by created_at descending, joined with
 	 * participants so the timeline can group them by day.
 	 *
-	 * @param int $limit Maximum number of rows.
+	 * @param int  $limit           Maximum number of rows.
+	 * @param bool $include_testmode Whether to include test-mode transactions.
 	 * @return array Raw rows.
 	 */
-	public function get_recent_ticket_sales( $limit ) {
+	public function get_recent_ticket_sales( $limit, $include_testmode = false ) {
 		global $wpdb;
 
 		$t_table   = $wpdb->prefix . 'fair_payment_transactions';
 		$p_table   = $wpdb->prefix . 'fair_audience_participants';
 		$fpt_table = $wpdb->prefix . 'fair_audience_fee_payment_transactions';
 
+		if ( $include_testmode ) {
+			return $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT t.id, t.participant_id, t.event_date_id, t.post_id, t.amount, t.currency, t.created_at, t.testmode,
+						p.name AS participant_name, p.surname AS participant_surname
+					FROM %i t
+					LEFT JOIN %i p ON t.participant_id = p.id
+					WHERE t.status = 'paid'
+					AND NOT EXISTS (
+						SELECT 1 FROM %i fpt WHERE fpt.transaction_id = t.id
+					)
+					ORDER BY t.created_at DESC
+					LIMIT %d",
+					$t_table,
+					$p_table,
+					$fpt_table,
+					$limit
+				),
+				ARRAY_A
+			);
+		}
+
 		return $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT t.id, t.participant_id, t.event_date_id, t.post_id, t.amount, t.currency, t.created_at,
+				"SELECT t.id, t.participant_id, t.event_date_id, t.post_id, t.amount, t.currency, t.created_at, t.testmode,
 					p.name AS participant_name, p.surname AS participant_surname
 				FROM %i t
 				LEFT JOIN %i p ON t.participant_id = p.id


### PR DESCRIPTION
## Summary

- `TimelineRepository::get_recent_ticket_sales()` now accepts `$include_testmode` (default `false`); adds `t.testmode` to the SELECT so each row carries the flag.
- `TimelineController::get_items()` computes `$include_testmode` from the `fair_payment_mode` option and passes it to the repository; test sales are included in ticket count but excluded from the day-group `total_amount`; each ticket entry carries `testmode: bool`.
- `TimelineItem.js` renders a muted "Test" badge on per-ticket `<li>` rows when `ticket.testmode` is truthy.
- New Playwright API spec `TimelineController.api.spec.js` covers response shape, the `testmode` field presence on ticket entries, and mode-driven filtering via the `wp/v2/settings` route.

## Test plan

- [ ] `vendor/bin/phpcs` — clean (verified locally)
- [ ] `npm run build` in `fair-audience` — succeeded
- [ ] API spec: `npm run test:api` in `fair-audience` against a running Docker instance
- [ ] Manual WP-CLI eval-file: insert a `testmode=1` paid row in `fair_payment_transactions`, confirm it appears in the timeline payload while `fair_payment_mode = test` and is absent after switching to `live`

Refs #925
