### PR TITLE
feat(payments): waive platform fee until 2027-01-01

### DIFF
--- a/fair-payments-connector/src/API/__tests__/Transaction.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/Transaction.api.spec.js
@@ -87,6 +87,37 @@ test.describe('Transaction — fee cap enforcement', () => {
 		expect(dash.cap_remaining).toBeLessThanOrEqual(dash.fee_cap);
 	});
 
+	test('application_fee is 0 or null on new transactions during the waiver period', async () => {
+		const mollie_payment_id = 'tr_waiver_check_' + Date.now();
+		const importRes = await api.post(IMPORT_ENDPOINT, {
+			headers: adminAuth(),
+			data: {
+				transactions: [
+					{
+						mollie_payment_id,
+						amount: 100.0,
+						currency: 'EUR',
+						status: 'paid',
+					},
+				],
+			},
+		});
+		expect(importRes.status()).toBe(200);
+
+		// Retrieve the imported transaction and verify its fee is 0 or null.
+		const listRes = await api.get(TRANSACTIONS_ENDPOINT, {
+			headers: adminAuth(),
+		});
+		expect(listRes.status()).toBe(200);
+		const { transactions } = await listRes.json();
+		const txn = transactions.find(
+			(t) => t.mollie_payment_id === mollie_payment_id
+		);
+		expect(txn).toBeDefined();
+		const fee = txn?.application_fee ?? null;
+		expect(fee == null || fee === 0 || fee === '0.00').toBe(true);
+	});
+
 	test('cap_remaining is 0 when seeded fees exhaust the monthly cap', async () => {
 		const dashRes = await api.get(DASHBOARD_ENDPOINT, {
 			headers: adminAuth(),

--- a/fair-payments-connector/src/Database/Schema.php
+++ b/fair-payments-connector/src/Database/Schema.php
@@ -388,7 +388,7 @@ class Schema {
 	/**
 	 * Migrate database from v3.0 to v4.0
 	 *
-	 * Adds application_fee column to track application fees (2%) for each transaction.
+	 * Adds application_fee column to track application fees (1%) for each transaction.
 	 *
 	 * @return void
 	 */

--- a/fair-payments-connector/src/Models/Transaction.php
+++ b/fair-payments-connector/src/Models/Transaction.php
@@ -18,6 +18,23 @@ defined( 'WPINC' ) || die;
  */
 class Transaction {
 	/**
+	 * UTC datetime after which the launch fee waiver ends and the 1% rate resumes.
+	 * Delete this constant (and get_fee_rate()) after 2027-01-01.
+	 */
+	private const FEE_WAIVER_END_TS = '2027-01-01 00:00:00';
+
+	/**
+	 * Returns the current platform fee rate (0.0 during the launch waiver, 0.01 after).
+	 *
+	 * @param int|null $now Unix timestamp to evaluate against; defaults to current site time.
+	 * @return float
+	 */
+	private static function get_fee_rate( ?int $now = null ): float {
+		$now    = $now ?? current_time( 'timestamp' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested -- site TZ intentional; cutoff is midnight local time.
+		$cutoff = strtotime( self::FEE_WAIVER_END_TS );
+		return $now < $cutoff ? 0.0 : 0.01;
+	}
+	/**
 	 * Create a new transaction record
 	 *
 	 * @param array $data Transaction data.
@@ -51,10 +68,10 @@ class Transaction {
 
 		$data = wp_parse_args( $data, $defaults );
 
-		// Calculate application fee (1% of transaction amount), capped at the monthly allowance.
+		// Calculate application fee (capped at the monthly allowance). Rate is 0 during the launch waiver.
 		$application_fee = null;
 		if ( $data['amount'] > 0 ) {
-			$application_fee = round( $data['amount'] * 0.01, 2 );
+			$application_fee = round( $data['amount'] * self::get_fee_rate(), 2 );
 			$remaining       = MonthlyFeeCapService::get_remaining();
 			$application_fee = min( $application_fee, $remaining );
 		}


### PR DESCRIPTION
## Summary

Implements a launch-period fee waiver: all transactions created before 2027-01-01 (site timezone) are charged 0% platform fee. On and after that date, the standard 1% rate resumes automatically.

- Adds `FEE_WAIVER_END_TS` class constant and `get_fee_rate()` helper on `Transaction` — easy to grep and delete when the waiver expires.
- `MolliePaymentHandler` already silently drops zero fees (`application_fee > 0` guard), so no change needed there.
- Monthly fee cap accounting is unaffected (`min(0.0, remaining) = 0.0`).
- Fixes a stale "2%" in the Schema v4 migration docblock; the live rate has always been 1%.

Closes #934

## Notes

- The `$now` parameter on `get_fee_rate()` enables WP-CLI `eval-file` verification of both branches without touching live time:

  ```php
  var_dump(Transaction::get_fee_rate(strtotime('2026-12-31'))); // float(0)
  var_dump(Transaction::get_fee_rate(strtotime('2027-01-01'))); // float(0.01)
  ```

- Cutoff uses `current_time('timestamp')` (site timezone) so the switch happens at midnight local time, matching operator expectations.

## Test plan

- [ ] phpcs passes on changed files (`vendor/bin/phpcs src/Models/Transaction.php src/Database/Schema.php`)
- [ ] WP-CLI eval-file script confirms `get_fee_rate(strtotime('2026-12-31'))` → 0.0 and `get_fee_rate(strtotime('2027-01-01'))` → 0.01
- [ ] Playwright API test `application_fee is 0 or null on new transactions during the waiver period` passes against a live WordPress instance
- [ ] New transaction created via the payment flow shows `application_fee = 0.00` in the transactions list admin page
