### PR TITLE
feat(fair-events): classify recurrence impact and block destructive edits

### DIFF
--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -715,8 +715,9 @@ class EventDatesController extends WP_REST_Controller {
 			);
 		}
 
-		$update_data  = array();
-		$newly_linked = false;
+		$update_data       = array();
+		$newly_linked      = false;
+		$recurrence_impact = null;
 
 		$title = $request->get_param( 'title' );
 		if ( null !== $title ) {
@@ -814,6 +815,37 @@ class EventDatesController extends WP_REST_Controller {
 			if ( $rrule_changed || $dates_changed_on_recurring ) {
 				$effective_rrule = $update_data['rrule'] ?? $existing->rrule;
 
+				// Classify the impact before applying, so we can reject destructive
+				// changes (removing occurrences that have dependents or are in the past).
+				$recurrence_impact = null;
+				if ( ! empty( $effective_rrule ) ) {
+					$proposed_start = $update_data['start_datetime'] ?? $existing->start_datetime;
+					$proposed_end   = $update_data['end_datetime'] ?? $existing->end_datetime;
+					$exdates        = RecurrenceService::parse_exdates( $existing->exdates );
+					$all_proposed   = RecurrenceService::generate_occurrences( $proposed_start, $proposed_end, $effective_rrule, null, $exdates );
+					$proposed_gen   = array_slice( $all_proposed, 1 );
+
+					$classify_master_id = ( 'generated' === $existing->occurrence_type && $existing->master_id )
+						? $existing->master_id
+						: $id;
+
+					$recurrence_impact = RecurrenceService::classify_change( $classify_master_id, $proposed_gen );
+
+					// A removal is destructive when the row has dependents or is in the past.
+					foreach ( $recurrence_impact['removed'] as $removed_row ) {
+						if ( $removed_row['dependents'] > 0 || $removed_row['is_past'] ) {
+							return new WP_Error(
+								'rest_destructive_recurrence_change',
+								__( 'Cannot remove occurrences that have dependents or are in the past.', 'fair-events' ),
+								array(
+									'status' => 409,
+									'impact' => $recurrence_impact,
+								)
+							);
+						}
+					}
+				}
+
 				if ( $effective_event_id ) {
 					RecurrenceService::regenerate_event_occurrences( $effective_event_id, $effective_rrule );
 				} else {
@@ -892,7 +924,12 @@ class EventDatesController extends WP_REST_Controller {
 
 		$event_date = EventDates::get_by_id( $id );
 
-		return new WP_REST_Response( $this->prepare_event_date( $event_date ), 200 );
+		$response_data = $this->prepare_event_date( $event_date );
+		if ( null !== $recurrence_impact ) {
+			$response_data['recurrence_impact'] = $recurrence_impact;
+		}
+
+		return new WP_REST_Response( $response_data, 200 );
 	}
 
 	/**
@@ -1194,6 +1231,34 @@ class EventDatesController extends WP_REST_Controller {
 			$exdates
 		);
 
+		// Classify the impact of this exdate change before applying it.
+		// An exdate addition removes one occurrence; check for dependents/past rows.
+		$recurrence_impact = null;
+		if ( ! empty( $event_date->rrule ) ) {
+			$new_proposed      = RecurrenceService::generate_occurrences(
+				$event_date->start_datetime,
+				$event_date->end_datetime,
+				$event_date->rrule,
+				null,
+				$exdates
+			);
+			$proposed_gen      = array_slice( $new_proposed, 1 );
+			$recurrence_impact = RecurrenceService::classify_change( $id, $proposed_gen );
+
+			foreach ( $recurrence_impact['removed'] as $removed_row ) {
+				if ( $removed_row['dependents'] > 0 || $removed_row['is_past'] ) {
+					return new WP_Error(
+						'rest_destructive_recurrence_change',
+						__( 'Cannot remove occurrences that have dependents or are in the past.', 'fair-events' ),
+						array(
+							'status' => 409,
+							'impact' => $recurrence_impact,
+						)
+					);
+				}
+			}
+		}
+
 		// Save exdates.
 		$exdates_string = ! empty( $exdates ) ? implode( ',', $exdates ) : null;
 		EventDates::update_by_id( $id, array( 'exdates' => $exdates_string ) );
@@ -1206,9 +1271,13 @@ class EventDatesController extends WP_REST_Controller {
 		}
 
 		// Return updated event date.
-		$updated = EventDates::get_by_id( $id );
+		$updated       = EventDates::get_by_id( $id );
+		$response_data = $this->prepare_event_date( $updated );
+		if ( null !== $recurrence_impact ) {
+			$response_data['recurrence_impact'] = $recurrence_impact;
+		}
 
-		return new WP_REST_Response( $this->prepare_event_date( $updated ), 200 );
+		return new WP_REST_Response( $response_data, 200 );
 	}
 
 	/**

--- a/fair-events/src/API/__tests__/EventDatesController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesController.api.spec.js
@@ -304,3 +304,224 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 		expect(starts.every((s) => s.includes('14:00:00'))).toBe(true);
 	});
 });
+
+test.describe('EventDatesController — impact classification (PR 2)', () => {
+	let api;
+	let masterEventDateId;
+	let eventPostId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterEach(async () => {
+		if (masterEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+				{ headers: adminHeaders }
+			);
+			masterEventDateId = null;
+		}
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+			eventPostId = null;
+		}
+	});
+
+	async function createRecurringEventWithTicket(api, rrule) {
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: { title: `Impact test ${Date.now()}`, status: 'publish' },
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2035-06-01 10:00:00',
+				end_datetime: '2035-06-01 12:00:00',
+				rrule,
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		const edBody = await edRes.json();
+		masterEventDateId = edBody.id;
+
+		// Get the generated occurrences and attach a ticket type to the last one.
+		const occRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
+			{ headers: adminHeaders }
+		);
+		expect(occRes.ok()).toBeTruthy();
+		const occurrences = await occRes.json();
+		// Sort ascending and pick the last generated occurrence.
+		const sorted = [...occurrences].sort((a, b) =>
+			a.start_datetime < b.start_datetime ? -1 : 1
+		);
+		const lastOccurrence = sorted[sorted.length - 1];
+
+		// Create a ticket type on the last occurrence (makes it a "dependent").
+		const ttRes = await api.post(
+			`/wp-json/fair-events/v1/event-dates/${lastOccurrence.id}/ticket-types`,
+			{
+				headers: adminHeaders,
+				data: { name: 'General', capacity: 10, sort_order: 0 },
+			}
+		);
+		// If tickets endpoint doesn't exist in this context just skip the dependent.
+		const ticketCreated = ttRes.ok();
+
+		return { occurrences: sorted, lastOccurrence, ticketCreated };
+	}
+
+	test('time shift returns 200 with recurrence_impact summary', async ({
+		request: req,
+	}) => {
+		const localApi = await req.newContext({ baseURL: BASE_URL });
+
+		const postRes = await localApi.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Shift impact test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await localApi.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					event_id: eventPostId,
+					start_datetime: '2035-07-01 10:00:00',
+					end_datetime: '2035-07-01 12:00:00',
+					rrule: 'FREQ=WEEKLY;COUNT=3',
+				},
+			}
+		);
+		expect(edRes.ok()).toBeTruthy();
+		masterEventDateId = (await edRes.json()).id;
+
+		// Shift start time by one hour.
+		const putRes = await localApi.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: {
+					start_datetime: '2035-07-01 11:00:00',
+					end_datetime: '2035-07-01 13:00:00',
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+		const body = await putRes.json();
+
+		// Response must include a recurrence_impact summary.
+		expect(body).toHaveProperty('recurrence_impact');
+		const impact = body.recurrence_impact;
+		expect(impact).toHaveProperty('unchanged');
+		expect(impact).toHaveProperty('shifted');
+		expect(impact).toHaveProperty('added');
+		expect(impact).toHaveProperty('removed');
+		// A pure time shift with no RRULE change: all children are shifted, none removed.
+		expect(impact.removed).toHaveLength(0);
+		expect(impact.shifted.length + impact.unchanged.length).toBeGreaterThan(
+			0
+		);
+	});
+
+	test('shortening RRULE to remove an occurrence with a ticket type returns 409', async ({
+		request: req,
+	}) => {
+		const localApi = await req.newContext({ baseURL: BASE_URL });
+		const { occurrences, lastOccurrence, ticketCreated } =
+			await createRecurringEventWithTicket(
+				localApi,
+				'FREQ=WEEKLY;COUNT=3'
+			);
+
+		if (!ticketCreated) {
+			// Ticket type endpoint unavailable in this environment — skip dependent check.
+			test.skip();
+			return;
+		}
+
+		// Try to shorten to COUNT=2 — this would remove the last occurrence that has a ticket type.
+		const putRes = await localApi.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { rrule: 'FREQ=WEEKLY;COUNT=2' },
+			}
+		);
+
+		expect(putRes.status()).toBe(409);
+		const body = await putRes.json();
+		expect(body.data.status).toBe(409);
+		expect(body.data).toHaveProperty('impact');
+		const impact = body.data.impact;
+		expect(impact.removed.length).toBeGreaterThan(0);
+		expect(impact.removed[0].dependents).toBeGreaterThan(0);
+		expect(impact.removed[0]).toHaveProperty('id');
+		expect(impact.removed[0].id).toBe(lastOccurrence.id);
+	});
+
+	test('shortening RRULE to remove an occurrence without dependents returns 200', async ({
+		request: req,
+	}) => {
+		const localApi = await req.newContext({ baseURL: BASE_URL });
+
+		const postRes = await localApi.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: { title: `Safe shorten ${Date.now()}`, status: 'publish' },
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await localApi.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					event_id: eventPostId,
+					start_datetime: '2035-08-01 10:00:00',
+					end_datetime: '2035-08-01 12:00:00',
+					rrule: 'FREQ=WEEKLY;COUNT=3',
+				},
+			}
+		);
+		expect(edRes.ok()).toBeTruthy();
+		masterEventDateId = (await edRes.json()).id;
+
+		// Shorten to COUNT=2 — last occurrence has no dependents, so it should succeed.
+		const putRes = await localApi.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { rrule: 'FREQ=WEEKLY;COUNT=2' },
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+		const body = await putRes.json();
+
+		expect(body).toHaveProperty('recurrence_impact');
+		const impact = body.recurrence_impact;
+		expect(impact.removed).toHaveLength(1);
+		expect(impact.removed[0].dependents).toBe(0);
+
+		// Confirm only 2 occurrences remain.
+		const occRes = await localApi.get(
+			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
+			{ headers: adminHeaders }
+		);
+		const remaining = await occRes.json();
+		expect(remaining).toHaveLength(2);
+	});
+});

--- a/fair-events/src/Services/RecurrenceService.php
+++ b/fair-events/src/Services/RecurrenceService.php
@@ -438,6 +438,136 @@ class RecurrenceService {
 	}
 
 	/**
+	 * Classify the impact of a proposed recurrence regeneration on generated children.
+	 *
+	 * Compares the desired generated occurrence set against existing DB rows (keyed
+	 * by anchor) and returns a partition into unchanged / shifted / added / removed.
+	 * Each entry in 'shifted' and 'removed' includes a 'dependents' count (ticket
+	 * types + active signups) and an 'is_past' flag.
+	 *
+	 * Only classifies generated children — the master row is always preserved.
+	 *
+	 * @param int   $master_id         Master event date row ID.
+	 * @param array $proposed_generated Desired generated occurrences (slice after first);
+	 *                                  each entry has 'start' and 'end' keys.
+	 * @return array {
+	 *     @type array $unchanged  Rows that would remain identical.
+	 *     @type array $shifted    Rows that would be updated in place (anchor matches, times differ).
+	 *     @type array $added      New anchors with no existing row.
+	 *     @type array $removed    Existing rows whose anchor is no longer desired.
+	 * }
+	 */
+	public static function classify_change( $master_id, $proposed_generated ) {
+		$desired_by_anchor = array();
+		foreach ( $proposed_generated as $occ ) {
+			$anchor                       = ( new \DateTime( $occ['start'] ) )->format( 'Y-m-d' );
+			$desired_by_anchor[ $anchor ] = $occ;
+		}
+
+		$all_existing  = EventDates::get_all_by_master_id( $master_id );
+		$master_row    = EventDates::get_by_id( $master_id );
+		$master_anchor = $master_row->recurrence_anchor
+			?? ( new \DateTime( $master_row->start_datetime ) )->format( 'Y-m-d' );
+		unset( $all_existing[ $master_anchor ] );
+
+		$now = current_time( 'mysql' );
+
+		$result = array(
+			'unchanged' => array(),
+			'shifted'   => array(),
+			'added'     => array(),
+			'removed'   => array(),
+		);
+
+		foreach ( $desired_by_anchor as $anchor => $occ ) {
+			if ( isset( $all_existing[ $anchor ] ) ) {
+				$row            = $all_existing[ $anchor ];
+				$existing_start = ( new \DateTime( $row->start_datetime ) )->format( 'Y-m-d\TH:i:s' );
+				$proposed_start = ( new \DateTime( $occ['start'] ) )->format( 'Y-m-d\TH:i:s' );
+
+				if ( $existing_start === $proposed_start ) {
+					$result['unchanged'][] = array(
+						'id'             => $row->id,
+						'start_datetime' => $row->start_datetime,
+					);
+				} else {
+					$result['shifted'][] = array(
+						'id'                 => $row->id,
+						'start_datetime'     => $row->start_datetime,
+						'new_start_datetime' => $occ['start'],
+						'is_past'            => $row->start_datetime < $now,
+						'dependents'         => self::count_dependents( $row->id ),
+					);
+				}
+				unset( $all_existing[ $anchor ] );
+			} else {
+				$result['added'][] = array(
+					'start_datetime' => $occ['start'],
+				);
+			}
+		}
+
+		foreach ( $all_existing as $stale_row ) {
+			$result['removed'][] = array(
+				'id'             => $stale_row->id,
+				'start_datetime' => $stale_row->start_datetime,
+				'is_past'        => $stale_row->start_datetime < $now,
+				'dependents'     => self::count_dependents( $stale_row->id ),
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Count active dependents for an event date.
+	 *
+	 * Counts ticket types and active signups (status not 'cancelled') that
+	 * reference the given event date. Passes the raw count through the
+	 * 'fair_events_event_date_dependents' filter so other plugins
+	 * (fair-audience, fair-payments) can add their own references.
+	 *
+	 * @param int $event_date_id Event date row ID.
+	 * @return int Total dependent count.
+	 *
+	 * phpcs:disable WordPress.DB.DirectDatabaseQuery
+	 */
+	public static function count_dependents( $event_date_id ) {
+		global $wpdb;
+
+		$tt_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE event_date_id = %d',
+				$wpdb->prefix . 'fair_events_ticket_types',
+				(int) $event_date_id
+			)
+		);
+
+		$signup_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM %i WHERE event_date_id = %d AND status != 'cancelled'",
+				$wpdb->prefix . 'fair_events_signups',
+				(int) $event_date_id
+			)
+		);
+
+		$count = $tt_count + $signup_count;
+
+		/**
+		 * Filters the dependent count for an event date.
+		 *
+		 * Allows other plugins (fair-audience for participant/mailing counts,
+		 * fair-payments for transaction counts) to register their own references
+		 * so the impact classifier can detect all dependents without a hard
+		 * cross-plugin dependency.
+		 *
+		 * @param int $count         Raw count from fair-events own tables.
+		 * @param int $event_date_id Event date row ID.
+		 */
+		return (int) apply_filters( 'fair_events_event_date_dependents', $count, (int) $event_date_id );
+	}
+
+	/**
 	 * Parse exdates string into an array of Y-m-d date strings
 	 *
 	 * @param string|null $exdates Comma-separated date string.


### PR DESCRIPTION
## Summary

Adds impact classification for recurrence changes and blocks edits that would remove
occurrences with dependents. Refs #947.

- `RecurrenceService::classify_change()` partitions a proposed regeneration into
  **unchanged / shifted / added / removed**, counting ticket-type and active-signup
  dependents per affected row.
- A filterable hook (`fair_events_event_date_dependents`) lets fair-audience and
  fair-payments contribute their own counts without a hard cross-plugin dependency.
- `update_item()` and `toggle_exdate()` call `classify_change()` before applying
  any RRULE or date change:
  - **Destructive** (a `removed` row has dependents, or is in the past) → **HTTP 409**
    with the full impact payload in `data.impact`.
  - **Survivable** (shifts, additions) → **HTTP 200** with impact summary in
    `recurrence_impact` so the UI can surface what changed.

## Notes

- PR 1 (reconcile) and PR 3 (UI guard rails) are the other parts of this three-PR plan.
- The `is_past` check on removed rows prevents accidental deletion of historical data
  even when no ticket types or signups reference the row yet.

## Test plan

- [ ] `npm run test:api` in `fair-events/` — new "impact classification" describe block
  passes: time shift returns 200 + `recurrence_impact`; shortening RRULE with no
  dependents returns 200; shortening with a ticket type on the last occurrence returns
  409 with `data.impact.removed[0].dependents > 0`.
- [ ] Existing reconciliation tests (`EventDatesController.api.spec.js`) still pass.
- [ ] `vendor/bin/phpcs fair-events/src/Services/RecurrenceService.php` — clean.
