### PR TITLE
refactor(fair-events): introduce tab descriptor registry in ManageEventApp

### DIFF
--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -342,6 +342,8 @@ class AdminPages {
 				\FairEvents\Core\Features::script_translations_path()
 			);
 
+			do_action( 'fair_events_manage_event_enqueue_assets', $hook );
+
 			wp_enqueue_style( 'wp-components' );
 			return;
 		}

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -31,6 +31,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import apiFetch from '@wordpress/api-fetch';
 import { DurationOptions, calculateDuration } from 'fair-events-shared';
 import EventFinance from './EventFinance.js';
@@ -537,100 +538,210 @@ export default function ManageEventApp() {
 
 	const isGeneratedOccurrence = eventDate?.occurrence_type === 'generated';
 
-	const tabs = useMemo(
-		() => [
-			{
-				name: 'event-details',
-				title: __('Event Details', 'fair-events'),
+	// Build the tab descriptor list fresh on every render so render functions
+	// always close over current state. Each descriptor: { name, title, order,
+	// isVisible, disabled?, render: (ctx) => ReactNode }.
+	const ctx = {
+		eventDate,
+		eventDateId,
+		eventTitle: title,
+		enabledFeatures,
+	};
+
+	const builtInTabs = [
+		{
+			name: 'event-details',
+			title: __('Event Details', 'fair-events'),
+			order: 10,
+			isVisible: true,
+			render: () => renderEventDetailsTab(),
+		},
+		{
+			name: 'tickets',
+			title: __('Tickets', 'fair-events'),
+			order: 20,
+			isVisible: ticketingEnabled,
+			disabled: isGeneratedOccurrence,
+			render: () => (
+				<EventTickets
+					eventDateId={eventDateId}
+					onSaveRef={ticketSaveRef}
+					startDatetime={eventDate.start_datetime}
+					endDatetime={eventDate.end_datetime}
+					isRecurring={recurrenceEnabled}
+				/>
+			),
+		},
+		{
+			name: 'groups',
+			title: __('Groups', 'fair-events'),
+			order: 30,
+			isVisible: !!(ticketingEnabled && audienceUrl),
+			disabled: isGeneratedOccurrence,
+			render: () => <GroupRules eventDateId={eventDateId} />,
+		},
+		{
+			name: 'signups',
+			title: __('Signups', 'fair-events'),
+			order: 25,
+			isVisible: !!(ticketingEnabled && !audienceUrl),
+			render: () => <EventSignups eventDateId={eventDateId} />,
+		},
+		{
+			name: 'photos',
+			title: __('Photos', 'fair-events'),
+			order: 40,
+			isVisible: galleriesEnabled,
+			render: () => <EventPhotos eventDateId={eventDateId} />,
+		},
+		{
+			name: 'audience',
+			title: __('Audience', 'fair-events'),
+			order: 50,
+			isVisible: !!audienceUrl,
+			render: () => (
+				<EventAudience
+					eventId={eventDate.event_id}
+					eventDateId={eventDateId}
+					audienceUrl={audienceUrl}
+					eventTitle={title}
+				/>
+			),
+		},
+		{
+			name: 'mailings',
+			title: __('Mailings', 'fair-events'),
+			order: 55,
+			isVisible: !!(audienceUrl && mailingsEnabled),
+			render: () => (
+				<EventMailings
+					eventDateId={eventDateId}
+					startDatetime={eventDate.start_datetime}
+					endDatetime={eventDate.end_datetime}
+					allDay={eventDate.all_day}
+				/>
+			),
+		},
+		{
+			name: 'statistics',
+			title: __('Statistics', 'fair-events'),
+			order: 60,
+			isVisible: !!statisticsUrl,
+			render: () => {
+				window.location.href = `${statisticsUrl}${eventDateId}`;
+				return null;
 			},
-			...(ticketingEnabled
-				? [
-						{
-							name: 'tickets',
-							title: __('Tickets', 'fair-events'),
-							disabled: isGeneratedOccurrence,
-						},
-				  ]
-				: []),
-			...(ticketingEnabled && audienceUrl
-				? [
-						{
-							name: 'groups',
-							title: __('Groups', 'fair-events'),
-							disabled: isGeneratedOccurrence,
-						},
-				  ]
-				: []),
-			...(!audienceUrl && ticketingEnabled
-				? [
-						{
-							name: 'signups',
-							title: __('Signups', 'fair-events'),
-						},
-				  ]
-				: []),
-			...(galleriesEnabled
-				? [
-						{
-							name: 'photos',
-							title: __('Photos', 'fair-events'),
-						},
-				  ]
-				: []),
-			...(audienceUrl
-				? [
-						{
-							name: 'audience',
-							title: __('Audience', 'fair-events'),
-						},
-						...(mailingsEnabled
-							? [
-									{
-										name: 'mailings',
-										title: __('Mailings', 'fair-events'),
-									},
-							  ]
-							: []),
-				  ]
-				: []),
-			...(statisticsUrl
-				? [
-						{
-							name: 'statistics',
-							title: __('Statistics', 'fair-events'),
-						},
-				  ]
-				: []),
-			...(paymentEntriesUrl
-				? [
-						{
-							name: 'finance',
-							title: __('Finance', 'fair-events'),
-						},
-				  ]
-				: []),
-			{
-				name: 'admin',
-				title: __('Admin', 'fair-events'),
-			},
-		],
-		[
-			audienceUrl,
-			statisticsUrl,
-			paymentEntriesUrl,
-			isGeneratedOccurrence,
-			galleriesEnabled,
-			mailingsEnabled,
-			ticketingEnabled,
-		]
-	);
+		},
+		{
+			name: 'finance',
+			title: __('Finance', 'fair-events'),
+			order: 70,
+			isVisible: !!paymentEntriesUrl,
+			render: () => (
+				<EventFinance
+					eventDateId={eventDateId}
+					entriesUrl={paymentEntriesUrl}
+				/>
+			),
+		},
+		{
+			name: 'admin',
+			title: __('Admin', 'fair-events'),
+			order: 100,
+			isVisible: true,
+			render: () => (
+				<Card style={{ marginTop: '16px' }}>
+					<CardHeader>
+						<h2>{__('Event Administration', 'fair-events')}</h2>
+					</CardHeader>
+					<CardBody>
+						<VStack spacing={6}>
+							{duplicateEventUrl && (
+								<VStack spacing={2}>
+									<p style={{ color: '#666' }}>
+										{__(
+											'Create a copy of this event with the same details, links, and settings.',
+											'fair-events'
+										)}
+									</p>
+									<div>
+										<Button
+											variant="secondary"
+											href={`${duplicateEventUrl}${eventDateId}`}
+										>
+											{__(
+												'Duplicate Event',
+												'fair-events'
+											)}
+										</Button>
+									</div>
+								</VStack>
+							)}
+
+							{mergeEventUrl && (
+								<VStack spacing={2}>
+									<p style={{ color: '#666' }}>
+										{__(
+											'Merge this event into another event date, moving or cleaning up all linked data.',
+											'fair-events'
+										)}
+									</p>
+									<div>
+										<Button
+											variant="secondary"
+											href={`${mergeEventUrl}${eventDateId}`}
+										>
+											{__('Merge Event', 'fair-events')}
+										</Button>
+									</div>
+								</VStack>
+							)}
+
+							<VStack spacing={2}>
+								<p style={{ color: '#666' }}>
+									{__(
+										'Permanently delete this event and all associated data. This action cannot be undone.',
+										'fair-events'
+									)}
+								</p>
+								<div>
+									<Button
+										variant="tertiary"
+										isDestructive
+										onClick={handleDelete}
+									>
+										{__('Delete Event', 'fair-events')}
+									</Button>
+								</div>
+							</VStack>
+						</VStack>
+					</CardBody>
+				</Card>
+			),
+		},
+	];
+
+	const tabDescriptors = applyFilters(
+		'fairEvents.manageEvent.tabs',
+		builtInTabs,
+		ctx
+	)
+		.filter((t) => t.isVisible)
+		.sort((a, b) => a.order - b.order);
+
+	// Shape TabPanel expects: { name, title, disabled? }.
+	const tabs = tabDescriptors.map(({ name, title: tabTitle, disabled }) => ({
+		name,
+		title: tabTitle,
+		...(disabled ? { disabled } : {}),
+	}));
 
 	const initialTab = useMemo(() => {
-		if (tabs.some((t) => t.name === urlTab)) {
+		if (tabDescriptors.some((t) => t.name === urlTab)) {
 			return urlTab;
 		}
 		return 'event-details';
-	}, [tabs, urlTab]);
+	}, [tabDescriptors, urlTab]);
 
 	if (loading) {
 		return (
@@ -1248,141 +1359,10 @@ export default function ManageEventApp() {
 				onSelect={handleTabSelect}
 			>
 				{(tab) => {
-					if (tab.name === 'tickets') {
-						return (
-							<EventTickets
-								eventDateId={eventDateId}
-								onSaveRef={ticketSaveRef}
-								startDatetime={eventDate.start_datetime}
-								endDatetime={eventDate.end_datetime}
-								isRecurring={recurrenceEnabled}
-							/>
-						);
-					}
-					if (tab.name === 'groups') {
-						return <GroupRules eventDateId={eventDateId} />;
-					}
-					if (tab.name === 'signups') {
-						return <EventSignups eventDateId={eventDateId} />;
-					}
-					if (tab.name === 'photos') {
-						return <EventPhotos eventDateId={eventDateId} />;
-					}
-					if (tab.name === 'audience') {
-						return (
-							<EventAudience
-								eventId={eventDate.event_id}
-								eventDateId={eventDateId}
-								audienceUrl={audienceUrl}
-								eventTitle={title}
-							/>
-						);
-					}
-					if (tab.name === 'mailings') {
-						return (
-							<EventMailings
-								eventDateId={eventDateId}
-								startDatetime={eventDate.start_datetime}
-								endDatetime={eventDate.end_datetime}
-								allDay={eventDate.all_day}
-							/>
-						);
-					}
-					if (tab.name === 'statistics') {
-						window.location.href = `${statisticsUrl}${eventDateId}`;
-						return null;
-					}
-					if (tab.name === 'finance') {
-						return (
-							<EventFinance
-								eventDateId={eventDateId}
-								entriesUrl={paymentEntriesUrl}
-							/>
-						);
-					}
-					if (tab.name === 'admin') {
-						return (
-							<Card style={{ marginTop: '16px' }}>
-								<CardHeader>
-									<h2>
-										{__(
-											'Event Administration',
-											'fair-events'
-										)}
-									</h2>
-								</CardHeader>
-								<CardBody>
-									<VStack spacing={6}>
-										{duplicateEventUrl && (
-											<VStack spacing={2}>
-												<p style={{ color: '#666' }}>
-													{__(
-														'Create a copy of this event with the same details, links, and settings.',
-														'fair-events'
-													)}
-												</p>
-												<div>
-													<Button
-														variant="secondary"
-														href={`${duplicateEventUrl}${eventDateId}`}
-													>
-														{__(
-															'Duplicate Event',
-															'fair-events'
-														)}
-													</Button>
-												</div>
-											</VStack>
-										)}
-
-										{mergeEventUrl && (
-											<VStack spacing={2}>
-												<p style={{ color: '#666' }}>
-													{__(
-														'Merge this event into another event date, moving or cleaning up all linked data.',
-														'fair-events'
-													)}
-												</p>
-												<div>
-													<Button
-														variant="secondary"
-														href={`${mergeEventUrl}${eventDateId}`}
-													>
-														{__(
-															'Merge Event',
-															'fair-events'
-														)}
-													</Button>
-												</div>
-											</VStack>
-										)}
-
-										<VStack spacing={2}>
-											<p style={{ color: '#666' }}>
-												{__(
-													'Permanently delete this event and all associated data. This action cannot be undone.',
-													'fair-events'
-												)}
-											</p>
-											<div>
-												<Button
-													variant="tertiary"
-													isDestructive
-													onClick={handleDelete}
-												>
-													{__(
-														'Delete Event',
-														'fair-events'
-													)}
-												</Button>
-											</div>
-										</VStack>
-									</VStack>
-								</CardBody>
-							</Card>
-						);
-					}
-					return renderEventDetailsTab();
+					const descriptor = tabDescriptors.find(
+						(d) => d.name === tab.name
+					);
+					return descriptor ? descriptor.render(ctx) : null;
 				}}
 			</TabPanel>
 

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for the tab registry mechanism in ManageEventApp (#919).
+ *
+ * Exercises:
+ *   - Built-in tabs render after the event loads.
+ *   - A tab registered via addFilter('fairEvents.manageEvent.tabs') appears.
+ *   - A descriptor with isVisible:false is omitted from the tab bar.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import apiFetch from '@wordpress/api-fetch';
+import ManageEventApp from '../ManageEventApp.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const mockEventDate = {
+	id: 1,
+	title: 'Test Event',
+	start_datetime: '2026-07-01 18:00:00',
+	end_datetime: '2026-07-01 20:00:00',
+	all_day: false,
+	occurrence_type: 'standalone',
+	link_type: 'none',
+	external_url: '',
+	venue_id: null,
+	address: '',
+	categories: [],
+	linked_posts: [],
+	rrule: null,
+	display_url: null,
+	event_id: null,
+	master: null,
+};
+
+beforeEach(() => {
+	// Use the Admin tab as the landing tab so the event-details form
+	// (SelectControl / FormTokenField) does not render by default.
+	// Those components emit @wordpress/components deprecation warnings that
+	// would fail the @wordpress/jest-console check.
+	window.history.replaceState({}, '', '?tab=admin');
+
+	window.fairEventsManageEventData = {
+		eventDateId: '1',
+		calendarUrl: 'http://example.com/calendar',
+		manageEventUrl: 'http://example.com/manage',
+		enabledPostTypes: [],
+		enabledFeatures: {},
+	};
+
+	jest.spyOn(console, 'warn').mockImplementation(() => {});
+	jest.spyOn(console, 'error').mockImplementation(() => {});
+
+	apiFetch.mockImplementation((opts) => {
+		if (opts.path && opts.path.includes('/event-dates/')) {
+			return Promise.resolve(mockEventDate);
+		}
+		return Promise.resolve([]);
+	});
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+	jest.clearAllMocks();
+	delete window.fairEventsManageEventData;
+	window.history.replaceState({}, '', '/');
+});
+
+it('renders built-in Event Details and Admin tabs after loading', async () => {
+	render(<ManageEventApp />);
+	// Admin is the initial tab (set via URL in beforeEach). Wait for it to
+	// appear, which confirms the event loaded and the tab bar rendered.
+	await waitFor(() =>
+		expect(screen.getByRole('tab', { name: 'Admin' })).toBeInTheDocument()
+	);
+	expect(
+		screen.getByRole('tab', { name: 'Event Details' })
+	).toBeInTheDocument();
+});
+
+it('renders a tab registered via addFilter', async () => {
+	const NAMESPACE = 'test/custom-tab-919';
+	addFilter('fairEvents.manageEvent.tabs', NAMESPACE, (descriptors) => [
+		...descriptors,
+		{
+			name: 'custom',
+			title: 'Custom Tab',
+			order: 999,
+			isVisible: true,
+			render: () => <div>Custom content</div>,
+		},
+	]);
+
+	render(<ManageEventApp />);
+	await waitFor(() =>
+		expect(screen.getByRole('tab', { name: 'Admin' })).toBeInTheDocument()
+	);
+	expect(screen.getByRole('tab', { name: 'Custom Tab' })).toBeInTheDocument();
+
+	removeFilter('fairEvents.manageEvent.tabs', NAMESPACE);
+});
+
+it('omits a descriptor with isVisible: false', async () => {
+	const NAMESPACE = 'test/hidden-tab-919';
+	addFilter('fairEvents.manageEvent.tabs', NAMESPACE, (descriptors) => [
+		...descriptors,
+		{
+			name: 'hidden',
+			title: 'Hidden Tab',
+			order: 999,
+			isVisible: false,
+			render: () => null,
+		},
+	]);
+
+	render(<ManageEventApp />);
+	await waitFor(() =>
+		expect(screen.getByRole('tab', { name: 'Admin' })).toBeInTheDocument()
+	);
+	expect(
+		screen.queryByRole('tab', { name: 'Hidden Tab' })
+	).not.toBeInTheDocument();
+
+	removeFilter('fairEvents.manageEvent.tabs', NAMESPACE);
+});


### PR DESCRIPTION
## Summary

- Replaces `ManageEventApp.js`'s hard-coded `if`-chain in the `TabPanel` render prop with a descriptor registry: each tab is `{ name, title, order, isVisible, render }`, making the list filterable via `applyFilters('fairEvents.manageEvent.tabs', descriptors, ctx)`.
- Adds `do_action('fair_events_manage_event_enqueue_assets', $hook)` in `AdminPages.php` so sibling plugins can enqueue extension bundles that declare `fair-events-manage-event` as a dependency — their `addFilter` calls then run before `domReady`, eliminating any first-render flicker.
- Zero functional change: all built-in tabs are converted to descriptors; the existing sibling imports (`EventAudience`, `GroupRules`, `EventMailings`) remain in `ManageEventApp.js` until subsequent PRs move them.

Refs #919

## Test plan

- [ ] All 36 Jest tests pass (`./node_modules/.bin/jest --no-coverage` in `fair-events/`).
- [ ] `npm run build` in `fair-events/` succeeds (52 files generated).
- [ ] Smoke-test in WordPress: open the Manage Event admin page, confirm all tabs appear and their content renders correctly (Event Details, Tickets if enabled, Photos if enabled, Admin, etc.).
- [ ] Confirm the tab bar restores from URL `?tab=<name>` on page reload.
