### PR TITLE
feat: add WP Playground blueprints for fair-events and fair-payments-connector

### DIFF
--- a/fair-events/blueprint.json
+++ b/fair-events/blueprint.json
@@ -1,0 +1,15 @@
+{
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "fair-events"
+			}
+		},
+		{
+			"step": "activatePlugin",
+			"pluginPath": "fair-events/fair-events.php"
+		}
+	]
+}

--- a/fair-payments-connector/blueprint.json
+++ b/fair-payments-connector/blueprint.json
@@ -1,0 +1,15 @@
+{
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "fair-payments-connector"
+			}
+		},
+		{
+			"step": "activatePlugin",
+			"pluginPath": "fair-payments-connector/fair-payments-connector.php"
+		}
+	]
+}


### PR DESCRIPTION
## Summary

- Add `fair-events/blueprint.json` — installs and activates the `fair-events` plugin from wordpress.org
- Add `fair-payments-connector/blueprint.json` — installs and activates the `fair-payments-connector` plugin from wordpress.org

Both follow the same pattern as the former `fair-calendar-button/blueprint.json`.

Closes #909