### PR TITLE
feat(fair-events): surface recurrence impact in UI

### DIFF
--- a/fair-events/src/Admin/event-meta-box/EventEditForm.js
+++ b/fair-events/src/Admin/event-meta-box/EventEditForm.js
@@ -24,6 +24,7 @@ import { DurationOptions, calculateDuration } from 'fair-events-shared';
  * Internal dependencies
  */
 import { STORE_NAME } from './store.js';
+import RecurrenceImpactSummary from '../manage-event/RecurrenceImpactSummary.js';
 
 /**
  * EventEditForm component
@@ -45,6 +46,7 @@ export default function EventEditForm({
 	const [error, setError] = useState(null);
 	const [success, setSuccess] = useState(null);
 	const [venues, setVenues] = useState([]);
+	const [recurrenceImpact, setRecurrenceImpact] = useState(null);
 
 	// Form state.
 	const [allDay, setAllDay] = useState(false);
@@ -306,9 +308,19 @@ export default function EventEditForm({
 				},
 			});
 			setEventData(updated);
+			setRecurrenceImpact(
+				updated.recurrence_impact
+					? { impact: updated.recurrence_impact, blocked: false }
+					: null
+			);
 			setSuccess(__('Event saved.', 'fair-events'));
 		} catch (err) {
 			setError(err.message || __('Failed to save event.', 'fair-events'));
+			setRecurrenceImpact(
+				err.data?.impact
+					? { impact: err.data.impact, blocked: true }
+					: null
+			);
 		} finally {
 			setSaving(false);
 		}
@@ -386,6 +398,14 @@ export default function EventEditForm({
 				>
 					{success}
 				</Notice>
+			)}
+
+			{recurrenceImpact && (
+				<RecurrenceImpactSummary
+					impact={recurrenceImpact.impact}
+					blocked={recurrenceImpact.blocked}
+					onDismiss={() => setRecurrenceImpact(null)}
+				/>
 			)}
 
 			<CheckboxControl

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -41,6 +41,7 @@ import EventTickets from './EventTickets.js';
 import EventPhotos from './EventPhotos.js';
 import EventMailings from './EventMailings.js';
 import RecurrenceCalendar from './RecurrenceCalendar.js';
+import RecurrenceImpactSummary from './RecurrenceImpactSummary.js';
 import EventSignups from './EventSignups.js';
 
 export default function ManageEventApp() {
@@ -111,6 +112,7 @@ export default function ManageEventApp() {
 	);
 	const ticketSaveRef = useRef(null);
 	const [togglingExdate, setTogglingExdate] = useState(null);
+	const [recurrenceImpact, setRecurrenceImpact] = useState(null);
 
 	useEffect(() => {
 		if (!eventDateId) {
@@ -367,10 +369,20 @@ export default function ManageEventApp() {
 				},
 			});
 			setEventDate(updated);
+			setRecurrenceImpact(
+				updated.recurrence_impact
+					? { impact: updated.recurrence_impact, blocked: false }
+					: null
+			);
 			setSuccess(__('Event updated successfully.', 'fair-events'));
 		} catch (err) {
 			setError(
 				err.message || __('Failed to update event.', 'fair-events')
+			);
+			setRecurrenceImpact(
+				err.data?.impact
+					? { impact: err.data.impact, blocked: true }
+					: null
 			);
 		} finally {
 			setSaving(false);
@@ -503,9 +515,19 @@ export default function ManageEventApp() {
 				data: { date },
 			});
 			setEventDate(updated);
+			setRecurrenceImpact(
+				updated.recurrence_impact
+					? { impact: updated.recurrence_impact, blocked: false }
+					: null
+			);
 		} catch (err) {
 			setError(
 				err.message || __('Failed to toggle occurrence.', 'fair-events')
+			);
+			setRecurrenceImpact(
+				err.data?.impact
+					? { impact: err.data.impact, blocked: true }
+					: null
 			);
 		} finally {
 			setTogglingExdate(null);
@@ -1351,6 +1373,14 @@ export default function ManageEventApp() {
 				>
 					{success}
 				</Notice>
+			)}
+
+			{recurrenceImpact && (
+				<RecurrenceImpactSummary
+					impact={recurrenceImpact.impact}
+					blocked={recurrenceImpact.blocked}
+					onDismiss={() => setRecurrenceImpact(null)}
+				/>
 			)}
 
 			<TabPanel

--- a/fair-events/src/Admin/manage-event/RecurrenceImpactSummary.js
+++ b/fair-events/src/Admin/manage-event/RecurrenceImpactSummary.js
@@ -1,0 +1,124 @@
+/**
+ * RecurrenceImpactSummary Component
+ *
+ * Displays the outcome of a recurrence change: either a blocked-edit warning
+ * (HTTP 409 path) listing which occurrences cannot be removed, or an
+ * informational summary of what was shifted / added / removed after a
+ * successful save.
+ *
+ * @package FairEvents
+ */
+
+import { Notice } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+function formatDate(dateStr) {
+	return new Date(dateStr).toLocaleDateString(undefined, {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+	});
+}
+
+/**
+ * @param {Object}        props
+ * @param {Object}        props.impact   Impact object from the API (unchanged/shifted/added/removed arrays).
+ * @param {boolean}       props.blocked  True when the change was rejected (HTTP 409); false when it was applied.
+ * @param {Function|null} props.onDismiss Called when the user dismisses the notice.
+ */
+export default function RecurrenceImpactSummary({
+	impact,
+	blocked,
+	onDismiss,
+}) {
+	if (!impact) return null;
+
+	const { shifted = [], added = [], removed = [] } = impact;
+
+	if (blocked) {
+		const blockedRemovals = removed.filter(
+			(r) => r.dependents > 0 || r.is_past
+		);
+
+		if (blockedRemovals.length === 0) return null;
+
+		return (
+			<Notice
+				status="warning"
+				isDismissible={!!onDismiss}
+				onRemove={onDismiss}
+			>
+				<p style={{ margin: '0 0 8px' }}>
+					{__('This change cannot be applied:', 'fair-events')}
+				</p>
+				<ul style={{ margin: 0, paddingLeft: '20px' }}>
+					{blockedRemovals.map((r) => (
+						<li key={r.id}>
+							{formatDate(r.start_datetime)}
+							{r.dependents > 0 && (
+								<>
+									{' — '}
+									{sprintf(
+										/* translators: %d: number of dependents (ticket types / signups) */
+										__('%d dependent(s)', 'fair-events'),
+										r.dependents
+									)}
+								</>
+							)}
+							{r.is_past && (
+								<>
+									{' '}
+									{'— '}
+									{__('in the past', 'fair-events')}
+								</>
+							)}
+						</li>
+					))}
+				</ul>
+			</Notice>
+		);
+	}
+
+	const hasMeaningfulChange =
+		shifted.length > 0 || added.length > 0 || removed.length > 0;
+	if (!hasMeaningfulChange) return null;
+
+	const parts = [];
+	if (shifted.length > 0) {
+		parts.push(
+			sprintf(
+				/* translators: %d: number of occurrences shifted in time */
+				__('%d shifted', 'fair-events'),
+				shifted.length
+			)
+		);
+	}
+	if (added.length > 0) {
+		parts.push(
+			sprintf(
+				/* translators: %d: number of new occurrences */
+				__('%d added', 'fair-events'),
+				added.length
+			)
+		);
+	}
+	if (removed.length > 0) {
+		parts.push(
+			sprintf(
+				/* translators: %d: number of removed occurrences */
+				__('%d removed', 'fair-events'),
+				removed.length
+			)
+		);
+	}
+
+	return (
+		<Notice status="info" isDismissible={!!onDismiss} onRemove={onDismiss}>
+			{sprintf(
+				/* translators: %s: comma-separated list of change counts, e.g. "2 shifted, 1 added" */
+				__('Recurrence updated: %s.', 'fair-events'),
+				parts.join(', ')
+			)}
+		</Notice>
+	);
+}

--- a/fair-events/src/Admin/manage-event/__tests__/RecurrenceImpactSummary.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/RecurrenceImpactSummary.test.jsx
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for RecurrenceImpactSummary (#947 PR 3).
+ *
+ * Covers:
+ *   - null impact returns nothing
+ *   - blocked=true (HTTP 409) shows the problematic removed occurrences
+ *   - blocked=false (HTTP 200 with impact) shows an applied-changes summary
+ *   - onDismiss wires up to the Notice dismissal
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RecurrenceImpactSummary from '../RecurrenceImpactSummary.js';
+
+const baseImpact = {
+	unchanged: [],
+	shifted: [],
+	added: [],
+	removed: [],
+};
+
+it('renders nothing when impact is null', () => {
+	const { container } = render(
+		<RecurrenceImpactSummary impact={null} blocked={false} />
+	);
+	expect(container).toBeEmptyDOMElement();
+});
+
+it('renders nothing when blocked and no problematic removals', () => {
+	const impact = {
+		...baseImpact,
+		removed: [
+			{
+				id: 1,
+				start_datetime: '2030-01-01 18:00:00',
+				is_past: false,
+				dependents: 0,
+			},
+		],
+	};
+	const { container } = render(
+		<RecurrenceImpactSummary impact={impact} blocked={true} />
+	);
+	expect(container).toBeEmptyDOMElement();
+});
+
+it('blocked=true: shows occurrences with dependents', () => {
+	const impact = {
+		...baseImpact,
+		removed: [
+			{
+				id: 5,
+				start_datetime: '2026-08-15 18:00:00',
+				is_past: false,
+				dependents: 3,
+			},
+		],
+	};
+	render(<RecurrenceImpactSummary impact={impact} blocked={true} />);
+
+	expect(
+		screen.getByText(/This change cannot be applied/i, { selector: 'p' })
+	).toBeInTheDocument();
+	expect(
+		screen.getByText(/3 dependent\(s\)/i, { selector: 'li' })
+	).toBeInTheDocument();
+});
+
+it('blocked=true: shows past occurrences', () => {
+	const impact = {
+		...baseImpact,
+		removed: [
+			{
+				id: 6,
+				start_datetime: '2025-03-10 10:00:00',
+				is_past: true,
+				dependents: 0,
+			},
+		],
+	};
+	render(<RecurrenceImpactSummary impact={impact} blocked={true} />);
+
+	expect(
+		screen.getByText(/This change cannot be applied/i, { selector: 'p' })
+	).toBeInTheDocument();
+	expect(
+		screen.getByText(/in the past/i, { selector: 'li' })
+	).toBeInTheDocument();
+});
+
+it('blocked=false with no changes renders nothing', () => {
+	const { container } = render(
+		<RecurrenceImpactSummary impact={baseImpact} blocked={false} />
+	);
+	expect(container).toBeEmptyDOMElement();
+});
+
+it('blocked=false: shows shifted/added/removed counts', () => {
+	const impact = {
+		unchanged: [{ id: 1, start_datetime: '2026-07-01 18:00:00' }],
+		shifted: [
+			{
+				id: 2,
+				start_datetime: '2026-07-08 18:00:00',
+				new_start_datetime: '2026-07-08 19:00:00',
+				is_past: false,
+				dependents: 1,
+			},
+		],
+		added: [{ start_datetime: '2026-09-01 18:00:00' }],
+		removed: [],
+	};
+	const { container } = render(
+		<RecurrenceImpactSummary impact={impact} blocked={false} />
+	);
+
+	// Scope to the notice content div to avoid the a11y-speak region duplicate.
+	const content = container.querySelector('.components-notice__content');
+	expect(content).not.toBeNull();
+	expect(content.textContent).toMatch(/Recurrence updated/i);
+	expect(content.textContent).toMatch(/1 shifted/i);
+	expect(content.textContent).toMatch(/1 added/i);
+});
+
+it('calls onDismiss when the notice is dismissed', () => {
+	const onDismiss = jest.fn();
+	const impact = {
+		...baseImpact,
+		removed: [
+			{
+				id: 7,
+				start_datetime: '2026-08-01 18:00:00',
+				is_past: false,
+				dependents: 2,
+			},
+		],
+	};
+	render(
+		<RecurrenceImpactSummary
+			impact={impact}
+			blocked={true}
+			onDismiss={onDismiss}
+		/>
+	);
+
+	// WP Notice dismiss button has aria-label="Close".
+	const dismissButton = screen.getByRole('button', { name: /close/i });
+	fireEvent.click(dismissButton);
+	expect(onDismiss).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## Summary

- Adds `RecurrenceImpactSummary` component that renders after a recurrence save in two modes: a **warning** listing blocked occurrences (HTTP 409 path — with dependents count and past-occurrence flag) or an **info** notice summarising counts of shifted / added / removed occurrences (HTTP 200 path, using the `recurrence_impact` payload already returned by PR 2).
- `ManageEventApp`: wires the component into both `handleSave` and `handleToggleExdate` so cancelling an occurrence with dependents shows the specific dates that are blocked rather than the generic error text.
- `EventEditForm` (meta-box): same handling for the sidebar save path.
- 7 component tests covering null impact, blocked/non-blocked paths, individual case details, and dismiss behaviour.

## Test plan

- [ ] `npx jest` passes (43 tests, 0 failures).
- [ ] Edit a recurring event master's time → save succeeds → info notice shows "N shifted" count.
- [ ] Try to cancel (via calendar) an occurrence that has a ticket sale → 409 → warning notice lists that occurrence with its dependent count.
- [ ] Try to shrink a series past a sold occurrence → 409 → warning notice lists each blocked date.
- [ ] Dismiss button clears the notice.

Refs #947
