### PR TITLE
feat(fair-events-experimental): move Statistics/Duplicate/Merge into tab registry

### DIFF
--- a/fair-events-experimental/src/Admin/manage-event-ext/index.js
+++ b/fair-events-experimental/src/Admin/manage-event-ext/index.js
@@ -1,0 +1,95 @@
+/**
+ * Manage Event tab extensions - Entry Point
+ *
+ * Registers this plugin's manage-event tabs (Statistics) and admin-tab
+ * actions (Duplicate/Merge) with the fair-events tab registry via filters,
+ * instead of fair-events hardcoding them.
+ *
+ * @package FairEventsExperimental
+ */
+
+import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+
+const {
+	statisticsUrl = '',
+	duplicateEventUrl = '',
+	mergeEventUrl = '',
+} = window.fairEventsManageEventData || {};
+
+addFilter(
+	'fairEvents.manageEvent.tabs',
+	'fair-events-experimental/statistics-tab',
+	(tabs) => {
+		if (!statisticsUrl) {
+			return tabs;
+		}
+
+		return [
+			...tabs,
+			{
+				name: 'statistics',
+				title: __('Statistics', 'fair-events-experimental'),
+				order: 60,
+				isVisible: true,
+				render: ({ eventDateId }) => {
+					window.location.href = `${statisticsUrl}${eventDateId}`;
+					return null;
+				},
+			},
+		];
+	}
+);
+
+addFilter(
+	'fairEvents.manageEvent.adminActions',
+	'fair-events-experimental/duplicate-merge-actions',
+	(actions, { eventDateId }) => {
+		const extraActions = [];
+
+		if (duplicateEventUrl) {
+			extraActions.push(
+				<VStack spacing={2} key="duplicate-event">
+					<p style={{ color: '#666' }}>
+						{__(
+							'Create a copy of this event with the same details, links, and settings.',
+							'fair-events-experimental'
+						)}
+					</p>
+					<div>
+						<Button
+							variant="secondary"
+							href={`${duplicateEventUrl}${eventDateId}`}
+						>
+							{__('Duplicate Event', 'fair-events-experimental')}
+						</Button>
+					</div>
+				</VStack>
+			);
+		}
+
+		if (mergeEventUrl) {
+			extraActions.push(
+				<VStack spacing={2} key="merge-event">
+					<p style={{ color: '#666' }}>
+						{__(
+							'Merge this event into another event date, moving or cleaning up all linked data.',
+							'fair-events-experimental'
+						)}
+					</p>
+					<div>
+						<Button
+							variant="secondary"
+							href={`${mergeEventUrl}${eventDateId}`}
+						>
+							{__('Merge Event', 'fair-events-experimental')}
+						</Button>
+					</div>
+				</VStack>
+			);
+		}
+
+		return [...actions, ...extraActions];
+	}
+);

--- a/fair-events-experimental/src/Core/Plugin.php
+++ b/fair-events-experimental/src/Core/Plugin.php
@@ -70,7 +70,35 @@ class Plugin {
 				\FairEventsExperimental\Admin\MediaLibraryHooks::init();
 				\FairEventsExperimental\Admin\MediaBatchActions::init();
 			}
+
+			if ( Features::is_enabled( 'audience-statistics' ) || Features::is_enabled( 'event-tools' ) ) {
+				add_action( 'fair_events_manage_event_enqueue_assets', array( $this, 'enqueue_manage_event_ext_assets' ) );
+			}
 		}
+	}
+
+	/**
+	 * Enqueue this plugin's manage-event tab extensions (Statistics,
+	 * Duplicate/Merge admin actions) on the fair-events manage-event page.
+	 *
+	 * Declares `fair-events-manage-event` as a script dependency so its
+	 * `addFilter()` calls run before the host bundle's `domReady()`
+	 * mount, avoiding a first-render flicker where these tabs pop in late.
+	 *
+	 * @return void
+	 */
+	public function enqueue_manage_event_ext_assets() {
+		$asset_file = include FAIR_EVENTS_EXPERIMENTAL_PLUGIN_DIR . 'build/admin/manage-event-ext/index.asset.php';
+
+		wp_enqueue_script(
+			'fair-events-experimental-manage-event-ext',
+			FAIR_EVENTS_EXPERIMENTAL_PLUGIN_URL . 'build/admin/manage-event-ext/index.js',
+			array_merge( $asset_file['dependencies'], array( 'fair-events-manage-event' ) ),
+			$asset_file['version'],
+			true
+		);
+
+		wp_set_script_translations( 'fair-events-experimental-manage-event-ext', 'fair-events-experimental' );
 	}
 
 	/**

--- a/fair-events-experimental/webpack.config.cjs
+++ b/fair-events-experimental/webpack.config.cjs
@@ -45,6 +45,10 @@ module.exports = {
       process.cwd(),
       "src/Admin/merge-event/index.js",
     ),
+    "admin/manage-event-ext/index": path.resolve(
+      process.cwd(),
+      "src/Admin/manage-event-ext/index.js",
+    ),
     "admin/event-gallery": path.resolve(
       process.cwd(),
       "src/Admin/event-gallery.js",

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -52,10 +52,6 @@ export default function ManageEventApp() {
 	const enabledPostTypes =
 		window.fairEventsManageEventData?.enabledPostTypes || [];
 	const audienceUrl = window.fairEventsManageEventData?.audienceUrl || '';
-	const statisticsUrl = window.fairEventsManageEventData?.statisticsUrl || '';
-	const duplicateEventUrl =
-		window.fairEventsManageEventData?.duplicateEventUrl || '';
-	const mergeEventUrl = window.fairEventsManageEventData?.mergeEventUrl || '';
 	const paymentEntriesUrl =
 		window.fairEventsManageEventData?.paymentEntriesUrl || '';
 	// Per-bundle feature gates from the PHP registry. Empty object → treat
@@ -645,16 +641,6 @@ export default function ManageEventApp() {
 			),
 		},
 		{
-			name: 'statistics',
-			title: __('Statistics', 'fair-events'),
-			order: 60,
-			isVisible: !!statisticsUrl,
-			render: () => {
-				window.location.href = `${statisticsUrl}${eventDateId}`;
-				return null;
-			},
-		},
-		{
 			name: 'finance',
 			title: __('Finance', 'fair-events'),
 			order: 70,
@@ -671,52 +657,17 @@ export default function ManageEventApp() {
 			title: __('Admin', 'fair-events'),
 			order: 100,
 			isVisible: true,
-			render: () => (
+			render: (renderCtx) => (
 				<Card style={{ marginTop: '16px' }}>
 					<CardHeader>
 						<h2>{__('Event Administration', 'fair-events')}</h2>
 					</CardHeader>
 					<CardBody>
 						<VStack spacing={6}>
-							{duplicateEventUrl && (
-								<VStack spacing={2}>
-									<p style={{ color: '#666' }}>
-										{__(
-											'Create a copy of this event with the same details, links, and settings.',
-											'fair-events'
-										)}
-									</p>
-									<div>
-										<Button
-											variant="secondary"
-											href={`${duplicateEventUrl}${eventDateId}`}
-										>
-											{__(
-												'Duplicate Event',
-												'fair-events'
-											)}
-										</Button>
-									</div>
-								</VStack>
-							)}
-
-							{mergeEventUrl && (
-								<VStack spacing={2}>
-									<p style={{ color: '#666' }}>
-										{__(
-											'Merge this event into another event date, moving or cleaning up all linked data.',
-											'fair-events'
-										)}
-									</p>
-									<div>
-										<Button
-											variant="secondary"
-											href={`${mergeEventUrl}${eventDateId}`}
-										>
-											{__('Merge Event', 'fair-events')}
-										</Button>
-									</div>
-								</VStack>
+							{applyFilters(
+								'fairEvents.manageEvent.adminActions',
+								[],
+								renderCtx
 							)}
 
 							<VStack spacing={2}>

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -102,6 +102,22 @@ it('renders a tab registered via addFilter', async () => {
 	removeFilter('fairEvents.manageEvent.tabs', NAMESPACE);
 });
 
+it('renders extra admin actions registered via addFilter', async () => {
+	const NAMESPACE = 'test/admin-action-919';
+	addFilter('fairEvents.manageEvent.adminActions', NAMESPACE, (actions) => [
+		...actions,
+		<div key="custom-action">Custom action</div>,
+	]);
+
+	render(<ManageEventApp />);
+	await waitFor(() =>
+		expect(screen.getByRole('tab', { name: 'Admin' })).toBeInTheDocument()
+	);
+	expect(screen.getByText('Custom action')).toBeInTheDocument();
+
+	removeFilter('fairEvents.manageEvent.adminActions', NAMESPACE);
+});
+
 it('omits a descriptor with isVisible: false', async () => {
 	const NAMESPACE = 'test/hidden-tab-919';
 	addFilter('fairEvents.manageEvent.tabs', NAMESPACE, (descriptors) => [


### PR DESCRIPTION
## Summary

- fair-events no longer hardcodes the Statistics tab or the Duplicate/Merge buttons on the Admin tab — both moved to fair-events-experimental, which registers them via the `fairEvents.manageEvent.tabs` filter (added in #962) and a new `fairEvents.manageEvent.adminActions` filter.
- The built-in Admin tab in fair-events now only owns Delete; extras render via the new filter.
- fair-events-experimental enqueues a new `admin/manage-event-ext` bundle off the `fair_events_manage_event_enqueue_assets` action, declaring `fair-events-manage-event` as a script dependency so its `addFilter()` calls run before the host bundle's `domReady()` — no first-render flicker.
- This is PR2 of the phased plan from #919 (comment [4843164877](https://github.com/marcin-wosinek/fair-event-plugins/issues/919#issuecomment-4843164877)); PR1 (#962) added the registry mechanism itself.

Refs #919

## Test plan

- [x] `npx jest` in `fair-events` — 44/44 tests pass, including a new test asserting a filter-registered admin action renders
- [x] `npx jest` in `fair-events-experimental` — 10/10 tests pass
- [x] `vendor/bin/phpcs` on changed PHP files — 0 new errors/warnings
- [x] `npm run build` in both `fair-events` and `fair-events-experimental`
- [ ] Manual check in WP admin: Manage Event → Admin tab shows Duplicate/Merge (when `event-tools` enabled) and a Statistics tab appears (when `audience-statistics` enabled), both behaving as before
