### PR TITLE
Move Mailings tab from fair-events to fair-audience

### DIFF
--- a/fair-audience/src/Admin/manage-event-ext/AnchorOffsetPicker.js
+++ b/fair-audience/src/Admin/manage-event-ext/AnchorOffsetPicker.js
@@ -6,7 +6,7 @@
  * before/after) into the `{ anchor_type, anchor_ref_id, offset_minutes }` the
  * scheduled-messages API expects. Shows the resulting send time as a preview.
  *
- * @package FairEvents
+ * @package FairAudience
  */
 
 import { SelectControl, RadioControl } from '@wordpress/components';
@@ -121,15 +121,15 @@ export default function AnchorOffsetPicker({
 	return (
 		<div style={{ marginBottom: '16px' }}>
 			<SelectControl
-				label={__('Anchor', 'fair-events')}
+				label={__('Anchor', 'fair-audience')}
 				value={anchorType}
 				options={[
 					{
-						label: __('Event date start', 'fair-events'),
+						label: __('Event date start', 'fair-audience'),
 						value: 'event_date_start',
 					},
 					{
-						label: __('Event date end', 'fair-events'),
+						label: __('Event date end', 'fair-audience'),
 						value: 'event_date_end',
 					},
 				]}
@@ -140,7 +140,7 @@ export default function AnchorOffsetPicker({
 
 			{eventDates.length > 1 && (
 				<SelectControl
-					label={__('Which date', 'fair-events')}
+					label={__('Which date', 'fair-audience')}
 					value={String(anchorRefId)}
 					options={eventDates.map((d) => ({
 						label: d.display_label || `#${d.id}`,
@@ -160,7 +160,7 @@ export default function AnchorOffsetPicker({
 				style={{ marginTop: '8px' }}
 			>
 				<NumberControl
-					label={__('Offset', 'fair-events')}
+					label={__('Offset', 'fair-audience')}
 					min={0}
 					value={offsetValue}
 					onChange={(value) =>
@@ -170,15 +170,15 @@ export default function AnchorOffsetPicker({
 					__nextHasNoMarginBottom
 				/>
 				<SelectControl
-					label={__('Unit', 'fair-events')}
+					label={__('Unit', 'fair-audience')}
 					value={offsetUnit}
 					options={[
 						{
-							label: __('minutes', 'fair-events'),
+							label: __('minutes', 'fair-audience'),
 							value: 'minutes',
 						},
-						{ label: __('hours', 'fair-events'), value: 'hours' },
-						{ label: __('days', 'fair-events'), value: 'days' },
+						{ label: __('hours', 'fair-audience'), value: 'hours' },
+						{ label: __('days', 'fair-audience'), value: 'days' },
 					]}
 					onChange={(value) => onChange({ offsetUnit: value })}
 					disabled={disabled}
@@ -187,8 +187,11 @@ export default function AnchorOffsetPicker({
 				<RadioControl
 					selected={direction}
 					options={[
-						{ label: __('before', 'fair-events'), value: 'before' },
-						{ label: __('after', 'fair-events'), value: 'after' },
+						{
+							label: __('before', 'fair-audience'),
+							value: 'before',
+						},
+						{ label: __('after', 'fair-audience'), value: 'after' },
 					]}
 					onChange={(value) => onChange({ direction: value })}
 				/>
@@ -198,12 +201,12 @@ export default function AnchorOffsetPicker({
 				{preview
 					? sprintf(
 							/* translators: %s: computed send date/time */
-							__('Will send around: %s', 'fair-events'),
+							__('Will send around: %s', 'fair-audience'),
 							preview
 					  )
 					: __(
 							'Send time will be computed from the chosen date.',
-							'fair-events'
+							'fair-audience'
 					  )}
 			</p>
 		</div>

--- a/fair-audience/src/Admin/manage-event-ext/EventMailings.js
+++ b/fair-audience/src/Admin/manage-event-ext/EventMailings.js
@@ -1,12 +1,12 @@
 /**
  * Event Mailings Tab
  *
- * Schedule and manage per-event mailings from the ManageEventApp. Mirrors the
+ * Schedule and manage per-event mailings, registered as a tab on fair-events'
+ * ManageEventApp via the fairEvents.manageEvent.tabs filter. Mirrors the
  * custom-mail page UX where it makes sense; scheduled sends intentionally drop
  * the per-send skip list and immediate-send (stated in the form, not hidden).
- * Data is owned by fair-audience and reached over its REST API.
  *
- * @package FairEvents
+ * @package FairAudience
  */
 
 import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
@@ -41,9 +41,9 @@ import {
 } from './mailings-api.js';
 
 const LABEL_OPTIONS = [
-	{ key: 'signed_up', label: __('Registered', 'fair-events') },
-	{ key: 'interested', label: __('Interested', 'fair-events') },
-	{ key: 'collaborator', label: __('Collaborators', 'fair-events') },
+	{ key: 'signed_up', label: __('Registered', 'fair-audience') },
+	{ key: 'interested', label: __('Interested', 'fair-audience') },
+	{ key: 'collaborator', label: __('Collaborators', 'fair-audience') },
 ];
 
 const STATUS_COLORS = {
@@ -143,7 +143,10 @@ export default function EventMailings({
 				if (active) {
 					setNotice({
 						status: 'error',
-						message: __('Could not load mailings.', 'fair-events'),
+						message: __(
+							'Could not load mailings.',
+							'fair-audience'
+						),
 					});
 				}
 			})
@@ -226,14 +229,14 @@ export default function EventMailings({
 		if (!form.subject.trim()) {
 			setNotice({
 				status: 'error',
-				message: __('Please enter a subject.', 'fair-events'),
+				message: __('Please enter a subject.', 'fair-audience'),
 			});
 			return;
 		}
 		if (!form.body.trim()) {
 			setNotice({
 				status: 'error',
-				message: __('Please enter a body.', 'fair-events'),
+				message: __('Please enter a body.', 'fair-audience'),
 			});
 			return;
 		}
@@ -242,7 +245,7 @@ export default function EventMailings({
 				status: 'error',
 				message: __(
 					'Please select at least one recipient type.',
-					'fair-events'
+					'fair-audience'
 				),
 			});
 			return;
@@ -273,8 +276,8 @@ export default function EventMailings({
 				setNotice({
 					status: 'success',
 					message: form.editingId
-						? __('Mailing updated.', 'fair-events')
-						: __('Mailing scheduled.', 'fair-events'),
+						? __('Mailing updated.', 'fair-audience')
+						: __('Mailing scheduled.', 'fair-audience'),
 				});
 				resetForm();
 			})
@@ -283,7 +286,7 @@ export default function EventMailings({
 					status: 'error',
 					message:
 						err?.message ||
-						__('Could not save the mailing.', 'fair-events'),
+						__('Could not save the mailing.', 'fair-audience'),
 				});
 			})
 			.finally(() => setIsSaving(false));
@@ -297,13 +300,16 @@ export default function EventMailings({
 			.then(() =>
 				setNotice({
 					status: 'success',
-					message: __('Mailing canceled.', 'fair-events'),
+					message: __('Mailing canceled.', 'fair-audience'),
 				})
 			)
 			.catch(() =>
 				setNotice({
 					status: 'error',
-					message: __('Could not cancel the mailing.', 'fair-events'),
+					message: __(
+						'Could not cancel the mailing.',
+						'fair-audience'
+					),
 				})
 			);
 	};
@@ -344,14 +350,14 @@ export default function EventMailings({
 				<CardHeader>
 					<h2 style={{ margin: 0 }}>
 						{form.editingId
-							? __('Edit scheduled mailing', 'fair-events')
-							: __('Schedule new mailing', 'fair-events')}
+							? __('Edit scheduled mailing', 'fair-audience')
+							: __('Schedule new mailing', 'fair-audience')}
 					</h2>
 				</CardHeader>
 				<CardBody>
 					<form onSubmit={handleSubmit}>
 						<TextControl
-							label={__('Subject', 'fair-events')}
+							label={__('Subject', 'fair-audience')}
 							value={form.subject}
 							onChange={(value) => updateForm({ subject: value })}
 							disabled={isSaving}
@@ -377,7 +383,7 @@ export default function EventMailings({
 
 						<fieldset style={{ marginBottom: '16px' }}>
 							<legend style={{ fontWeight: 600 }}>
-								{__('Recipients', 'fair-events')}
+								{__('Recipients', 'fair-audience')}
 							</legend>
 							{LABEL_OPTIONS.map((opt) => (
 								<CheckboxControl
@@ -402,7 +408,7 @@ export default function EventMailings({
 									<FormTokenField
 										label={__(
 											'Limit to groups (optional)',
-											'fair-events'
+											'fair-audience'
 										)}
 										value={form.groupIds.map(groupNameById)}
 										suggestions={groups.map((g) => g.name)}
@@ -421,7 +427,7 @@ export default function EventMailings({
 							<ToggleControl
 								label={__(
 									'Marketing email (respect opt-out)',
-									'fair-events'
+									'fair-audience'
 								)}
 								checked={form.isMarketing}
 								onChange={(checked) =>
@@ -435,13 +441,13 @@ export default function EventMailings({
 								{recipientCount === null
 									? __(
 											'Recipient count unavailable.',
-											'fair-events'
+											'fair-audience'
 									  )
 									: sprintf(
 											/* translators: %d: recipient count */
 											__(
 												'%d recipient(s) match right now.',
-												'fair-events'
+												'fair-audience'
 											),
 											recipientCount
 									  )}{' '}
@@ -453,8 +459,8 @@ export default function EventMailings({
 										}
 									>
 										{showRecipients
-											? __('Hide list', 'fair-events')
-											: __('View list', 'fair-events')}
+											? __('Hide list', 'fair-audience')
+											: __('View list', 'fair-audience')}
 									</Button>
 								)}
 							</p>
@@ -473,12 +479,12 @@ export default function EventMailings({
 										<li key={r.participant_id}>
 											{r.name} {r.surname} &lt;
 											{r.email ||
-												__('no email', 'fair-events')}
+												__('no email', 'fair-audience')}
 											&gt;
 											{r.would_skip_marketing &&
 												` — ${__(
 													'will skip (opted out)',
-													'fair-events'
+													'fair-audience'
 												)}`}
 										</li>
 									))}
@@ -489,7 +495,7 @@ export default function EventMailings({
 						<p style={{ color: '#757575', fontStyle: 'italic' }}>
 							{__(
 								'Scheduled mailings send automatically at the computed time. There is no per-send skip list or immediate send here — use the Custom Mail page for ad-hoc sends.',
-								'fair-events'
+								'fair-audience'
 							)}
 						</p>
 
@@ -501,8 +507,8 @@ export default function EventMailings({
 								disabled={isSaving}
 							>
 								{form.editingId
-									? __('Update mailing', 'fair-events')
-									: __('Schedule mailing', 'fair-events')}
+									? __('Update mailing', 'fair-audience')
+									: __('Schedule mailing', 'fair-audience')}
 							</Button>
 							{form.editingId && (
 								<Button
@@ -510,7 +516,7 @@ export default function EventMailings({
 									onClick={resetForm}
 									disabled={isSaving}
 								>
-									{__('Cancel edit', 'fair-events')}
+									{__('Cancel edit', 'fair-audience')}
 								</Button>
 							)}
 						</HStack>
@@ -522,12 +528,12 @@ export default function EventMailings({
 			<Card>
 				<CardHeader>
 					<h2 style={{ margin: 0 }}>
-						{__('Scheduled & past mailings', 'fair-events')}
+						{__('Scheduled & past mailings', 'fair-audience')}
 					</h2>
 				</CardHeader>
 				<CardBody>
 					{messages.length === 0 ? (
-						<p>{__('No mailings yet.', 'fair-events')}</p>
+						<p>{__('No mailings yet.', 'fair-audience')}</p>
 					) : (
 						<VStack spacing={3}>
 							{messages.map((m) => (
@@ -563,20 +569,20 @@ export default function EventMailings({
 													/* translators: %s: send date/time */
 													__(
 														'Sends: %s',
-														'fair-events'
+														'fair-audience'
 													),
 													m.scheduled_for
 											  )
 											: __(
 													'Send time pending',
-													'fair-events'
+													'fair-audience'
 											  )}
 										{m.status === 'sent' &&
 											sprintf(
 												/* translators: 1: sent, 2: failed, 3: skipped */
 												__(
 													' · sent %1$d, failed %2$d, skipped %3$d',
-													'fair-events'
+													'fair-audience'
 												),
 												m.sent_count,
 												m.failed_count,
@@ -596,7 +602,10 @@ export default function EventMailings({
 													isSmall
 													onClick={() => startEdit(m)}
 												>
-													{__('Edit', 'fair-events')}
+													{__(
+														'Edit',
+														'fair-audience'
+													)}
 												</Button>
 												<Button
 													variant="tertiary"
@@ -608,7 +617,7 @@ export default function EventMailings({
 												>
 													{__(
 														'Cancel',
-														'fair-events'
+														'fair-audience'
 													)}
 												</Button>
 											</>
@@ -623,7 +632,7 @@ export default function EventMailings({
 													setDetailMessage(m)
 												}
 											>
-												{__('View', 'fair-events')}
+												{__('View', 'fair-audience')}
 											</Button>
 										)}
 										{m.status === 'failed' && (
@@ -632,7 +641,10 @@ export default function EventMailings({
 												isSmall
 												onClick={() => duplicate(m)}
 											>
-												{__('Duplicate', 'fair-events')}
+												{__(
+													'Duplicate',
+													'fair-audience'
+												)}
 											</Button>
 										)}
 									</HStack>
@@ -645,7 +657,7 @@ export default function EventMailings({
 
 			{cancelTarget && (
 				<Modal
-					title={__('Cancel mailing?', 'fair-events')}
+					title={__('Cancel mailing?', 'fair-audience')}
 					onRequestClose={() => setCancelTarget(null)}
 				>
 					<p>
@@ -653,7 +665,7 @@ export default function EventMailings({
 							/* translators: %s: mailing subject */
 							__(
 								'Cancel the scheduled mailing "%s"? It will not be sent.',
-								'fair-events'
+								'fair-audience'
 							),
 							cancelTarget.subject
 						)}
@@ -663,14 +675,14 @@ export default function EventMailings({
 							variant="tertiary"
 							onClick={() => setCancelTarget(null)}
 						>
-							{__('Keep it', 'fair-events')}
+							{__('Keep it', 'fair-audience')}
 						</Button>
 						<Button
 							variant="primary"
 							isDestructive
 							onClick={confirmCancel}
 						>
-							{__('Cancel mailing', 'fair-events')}
+							{__('Cancel mailing', 'fair-audience')}
 						</Button>
 					</HStack>
 				</Modal>
@@ -684,7 +696,7 @@ export default function EventMailings({
 					<p style={{ color: '#666' }}>
 						{sprintf(
 							/* translators: 1: status, 2: send time */
-							__('Status: %1$s · %2$s', 'fair-events'),
+							__('Status: %1$s · %2$s', 'fair-audience'),
 							detailMessage.status,
 							detailMessage.sent_at ||
 								detailMessage.scheduled_for ||
@@ -697,7 +709,7 @@ export default function EventMailings({
 								/* translators: 1: sent, 2: failed, 3: skipped */
 								__(
 									'Sent %1$d · failed %2$d · skipped %3$d',
-									'fair-events'
+									'fair-audience'
 								),
 								detailMessage.sent_count,
 								detailMessage.failed_count,

--- a/fair-audience/src/Admin/manage-event-ext/MailBodyEditor.js
+++ b/fair-audience/src/Admin/manage-event-ext/MailBodyEditor.js
@@ -4,11 +4,9 @@
  * Controlled textarea for composing a scheduled-message body, with the same
  * placeholder-insertion affordances as fair-audience's custom-mail page (photo
  * upload link, manage-subscription link, tokenized page link) plus the
- * per-recipient/per-message tokens scheduled mailings support. Copied rather
- * than shared because the source lives in another plugin and pulls in page
- * search + @wordpress/components.
+ * per-recipient/per-message tokens scheduled mailings support.
  *
- * @package FairEvents
+ * @package FairAudience
  */
 
 import { useRef, useState } from '@wordpress/element';
@@ -21,10 +19,10 @@ import apiFetch from '@wordpress/api-fetch';
  * at send time).
  */
 const TOKEN_CHIPS = [
-	{ token: '{participant_name}', label: __('Name', 'fair-events') },
-	{ token: '{event_name}', label: __('Event name', 'fair-events') },
-	{ token: '{event_date}', label: __('Event date', 'fair-events') },
-	{ token: '{unsubscribe_link}', label: __('Unsubscribe', 'fair-events') },
+	{ token: '{participant_name}', label: __('Name', 'fair-audience') },
+	{ token: '{event_name}', label: __('Event name', 'fair-audience') },
+	{ token: '{event_date}', label: __('Event date', 'fair-audience') },
+	{ token: '{unsubscribe_link}', label: __('Unsubscribe', 'fair-audience') },
 ];
 
 /**
@@ -117,7 +115,7 @@ export default function MailBodyEditor({ value, onChange, disabled }) {
 					fontWeight: '600',
 				}}
 			>
-				{__('Body', 'fair-events')}
+				{__('Body', 'fair-audience')}
 			</label>
 			<textarea
 				id="fair-events-mail-body"
@@ -144,12 +142,12 @@ export default function MailBodyEditor({ value, onChange, disabled }) {
 					onClick={() =>
 						insertPlaceholderLink(
 							'{photo_upload_url}',
-							__('Upload photos', 'fair-events')
+							__('Upload photos', 'fair-audience')
 						)
 					}
 					disabled={disabled}
 				>
-					{__('Insert photo upload link', 'fair-events')}
+					{__('Insert photo upload link', 'fair-audience')}
 				</Button>
 				<Button
 					variant="secondary"
@@ -157,12 +155,12 @@ export default function MailBodyEditor({ value, onChange, disabled }) {
 					onClick={() =>
 						insertPlaceholderLink(
 							'{event_page_url}',
-							__('Open event page', 'fair-events')
+							__('Open event page', 'fair-audience')
 						)
 					}
 					disabled={disabled}
 				>
-					{__('Insert event page link', 'fair-events')}
+					{__('Insert event page link', 'fair-audience')}
 				</Button>
 
 				<span
@@ -174,7 +172,7 @@ export default function MailBodyEditor({ value, onChange, disabled }) {
 					}}
 				>
 					<TextControl
-						placeholder={__('Search page…', 'fair-events')}
+						placeholder={__('Search page…', 'fair-audience')}
 						value={
 							selectedPage
 								? selectedPage.title.rendered
@@ -236,7 +234,7 @@ export default function MailBodyEditor({ value, onChange, disabled }) {
 						}}
 						disabled={disabled || !selectedPage}
 					>
-						{__('Insert token link', 'fair-events')}
+						{__('Insert token link', 'fair-audience')}
 					</Button>
 				</span>
 			</div>
@@ -251,7 +249,7 @@ export default function MailBodyEditor({ value, onChange, disabled }) {
 				}}
 			>
 				<span style={{ color: '#666', fontSize: '12px' }}>
-					{__('Insert token:', 'fair-events')}
+					{__('Insert token:', 'fair-audience')}
 				</span>
 				{TOKEN_CHIPS.map((chip) => (
 					<Button

--- a/fair-audience/src/Admin/manage-event-ext/index.js
+++ b/fair-audience/src/Admin/manage-event-ext/index.js
@@ -1,0 +1,42 @@
+/**
+ * Manage Event tab extensions - Entry Point
+ *
+ * Registers fair-audience's Mailings tab with the fair-events manage-event
+ * tab registry via a filter, instead of fair-events hardcoding it.
+ *
+ * @package FairAudience
+ */
+
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+import EventMailings from './EventMailings.js';
+
+const { audienceUrl = '' } = window.fairEventsManageEventData || {};
+
+addFilter(
+	'fairEvents.manageEvent.tabs',
+	'fair-audience/mailings-tab',
+	(tabs, { eventDate, eventDateId, enabledFeatures = {} }) => {
+		if (!audienceUrl || !enabledFeatures.mailings) {
+			return tabs;
+		}
+
+		return [
+			...tabs,
+			{
+				name: 'mailings',
+				title: __('Mailings', 'fair-audience'),
+				order: 55,
+				isVisible: true,
+				render: () => (
+					<EventMailings
+						eventDateId={eventDateId}
+						startDatetime={eventDate.start_datetime}
+						endDatetime={eventDate.end_datetime}
+						allDay={eventDate.all_day}
+					/>
+				),
+			},
+		];
+	}
+);

--- a/fair-audience/src/Admin/manage-event-ext/mailings-api.js
+++ b/fair-audience/src/Admin/manage-event-ext/mailings-api.js
@@ -1,8 +1,7 @@
 /**
  * REST client for scheduled per-event mailings.
  *
- * All calls hit fair-audience's scheduled-messages endpoints (the Mailings tab
- * lives in fair-events but the data model is owned by fair-audience). Paths are
+ * All calls hit fair-audience's scheduled-messages endpoints. Paths are
  * hardcoded and start with '/' per the project's apiFetch conventions.
  */
 

--- a/fair-audience/src/Core/Plugin.php
+++ b/fair-audience/src/Core/Plugin.php
@@ -67,6 +67,12 @@ class Plugin {
 		add_action( 'template_redirect', array( $this, 'handle_photo_upload' ) );
 		add_action( 'template_redirect', array( $this, 'handle_unsubscribe_event_interest' ) );
 
+		// Register the Mailings tab on fair-events' manage-event page via its
+		// tab-registry filter, rather than fair-events importing this bundle
+		// directly. See enqueue_manage_event_ext_assets() for the dependency
+		// ordering that avoids a first-render flicker.
+		add_action( 'fair_events_manage_event_enqueue_assets', array( $this, 'enqueue_manage_event_ext_assets' ) );
+
 		// Instagram token refresh cron.
 		add_action( 'fair_audience_refresh_instagram_token', array( $this, 'refresh_instagram_token' ) );
 
@@ -103,6 +109,30 @@ class Plugin {
 
 		// Initialize blocks.
 		$block_hooks = new \FairAudience\Hooks\BlockHooks();
+	}
+
+	/**
+	 * Enqueue this plugin's manage-event tab extension (Mailings) on the
+	 * fair-events manage-event page.
+	 *
+	 * Declares `fair-events-manage-event` as a script dependency so its
+	 * `addFilter()` call runs before the host bundle's `domReady()` mount,
+	 * avoiding a first-render flicker where the tab pops in late.
+	 *
+	 * @return void
+	 */
+	public function enqueue_manage_event_ext_assets() {
+		$asset_file = include FAIR_AUDIENCE_PLUGIN_DIR . 'build/admin/manage-event-ext/index.asset.php';
+
+		wp_enqueue_script(
+			'fair-audience-manage-event-ext',
+			FAIR_AUDIENCE_PLUGIN_URL . 'build/admin/manage-event-ext/index.js',
+			array_merge( $asset_file['dependencies'], array( 'fair-events-manage-event' ) ),
+			$asset_file['version'],
+			true
+		);
+
+		wp_set_script_translations( 'fair-audience-manage-event-ext', 'fair-audience' );
 	}
 
 	/**

--- a/fair-audience/webpack.config.cjs
+++ b/fair-audience/webpack.config.cjs
@@ -98,6 +98,10 @@ const customConfig = {
 			process.cwd(),
 			'src/Admin/media-library-filter.js',
 		),
+		'admin/manage-event-ext/index': path.resolve(
+			process.cwd(),
+			'src/Admin/manage-event-ext/index.js',
+		),
 		// Public scripts
 		'public/poll-response/index': path.resolve(
 			process.cwd(),

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -39,7 +39,6 @@ import EventAudience from './EventAudience.js';
 import GroupRules from './GroupRules.js';
 import EventTickets from './EventTickets.js';
 import EventPhotos from './EventPhotos.js';
-import EventMailings from './EventMailings.js';
 import RecurrenceCalendar from './RecurrenceCalendar.js';
 import RecurrenceImpactSummary from './RecurrenceImpactSummary.js';
 import EventSignups from './EventSignups.js';
@@ -61,7 +60,6 @@ export default function ManageEventApp() {
 	const galleriesEnabled = !!enabledFeatures.galleries;
 	const ticketingEnabled = !!enabledFeatures.ticketing;
 	const venuesEnabled = !!enabledFeatures.venues;
-	const mailingsEnabled = !!enabledFeatures.mailings;
 
 	const [eventDate, setEventDate] = useState(null);
 	const [loading, setLoading] = useState(true);
@@ -623,20 +621,6 @@ export default function ManageEventApp() {
 					eventDateId={eventDateId}
 					audienceUrl={audienceUrl}
 					eventTitle={title}
-				/>
-			),
-		},
-		{
-			name: 'mailings',
-			title: __('Mailings', 'fair-events'),
-			order: 55,
-			isVisible: !!(audienceUrl && mailingsEnabled),
-			render: () => (
-				<EventMailings
-					eventDateId={eventDateId}
-					startDatetime={eventDate.start_datetime}
-					endDatetime={eventDate.end_datetime}
-					allDay={eventDate.all_day}
 				/>
 			),
 		},


### PR DESCRIPTION
## Summary

- Third PR of the manage-event tab-registry decoupling described in #919 (comment https://github.com/marcin-wosinek/fair-event-plugins/issues/919#issuecomment-4843164877): moves the **Mailings** tab out of fair-events into fair-audience, since the data model was already owned by fair-audience.
- fair-audience now registers its own tab via `fairEvents.manageEvent.tabs` (`src/Admin/manage-event-ext/index.js`), mirroring the pattern fair-events-experimental already uses for Statistics/Duplicate/Merge, including declaring `fair-events-manage-event` as a script dependency so the filter runs before `domReady()` (no first-render flicker).
- Moved `EventMailings.js`, `MailBodyEditor.js`, `mailings-api.js`, `AnchorOffsetPicker.js` from fair-events to `fair-audience/src/Admin/manage-event-ext/`, retargeting all `__()` calls to the `fair-audience` textdomain.
- fair-events' `ManageEventApp.js` no longer imports or hardcodes the Mailings tab.

Refs #919

## Test plan

- [x] `npm run build` in fair-events and fair-audience
- [x] `npm run format` in both plugins
- [x] `vendor/bin/phpcs` on changed PHP files (no new warnings/errors introduced)
- [x] `npx jest` — full suite passes in both plugins (fair-events: 44 tests, fair-audience: 1 test)
