### PR TITLE
test(fair-payments-connector): lock Mollie testmode boundary with PHPUnit

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -159,6 +159,44 @@ fair-{plugin-name}/
 - Admin page workflows
 - Integration of multiple features
 
+### PHP Unit Tests (PHPUnit)
+
+**Purpose**: Test pure PHP logic in isolation — no WordPress bootstrap, no DB,
+no HTTP. Use for boundary-level regression locks (e.g. arguments reaching a
+third-party SDK) and logic that's awkward to reach through `.api.spec.js`.
+
+**Runner**: PHPUnit (plain — no Brain Monkey / WP_Mock / Mockery anywhere in
+the repo)
+**Location**: `phpunit.xml` at the plugin root, bootstrap at
+`__tests__/bootstrap.php`, tests at `__tests__/**/*Test.php`
+**Namespace**: `Fair…\Tests\…`, mirroring the `src/` namespace under test
+
+**Convention**:
+- `phpunit.xml` points `bootstrap` at `__tests__/bootstrap.php` and the
+  testsuite `<directory suffix="Test.php">./__tests__</directory>`.
+- `__tests__/bootstrap.php` loads the Composer autoloader, defines `WPINC`,
+  and hand-writes stubs for just the WordPress functions the code under test
+  calls (e.g. `get_option()` backed by `$GLOBALS['_fair_test_options']`). Add
+  stubs only as needed — don't pre-stub the whole API surface.
+- If the code under test touches `$wpdb`, stub a minimal fake in the bootstrap
+  (e.g. an `insert()` that returns success) rather than pulling in a DB
+  library.
+- Run via `npm run test:php` (→ `vendor/bin/phpunit`) or `composer test`.
+  `npm test` already chains `test:php` after `test:js`, so it runs in CI with
+  no dedicated workflow step.
+
+**When to use**:
+- Locking a regression at a boundary that's hard/unsafe to reach via `.api.spec.js`
+  (e.g. arguments passed to a third-party SDK client that has its own HTTP
+  transport, so `pre_http_request` can't intercept it — see
+  `fair-payments-connector/__tests__/Payment/MolliePaymentHandlerTest.php`).
+- Pure PHP logic (settings parsing, formatting, recurrence math) that doesn't
+  need a live WordPress instance — see `fair-events/__tests__/`.
+
+**Examples**: `fair-events`, `fair-payments-connector`,
+`fair-payments-connector-experimental`, `fair-events-experimental`,
+`fair-timetable`.
+
 ### WordPress.org Screenshot Tests
 
 **Purpose**: Generate screenshots for WordPress.org plugin directory
@@ -416,7 +454,10 @@ export default defineConfig({
 
 ### phpunit.xml
 
-Keep existing `phpunit.xml` files but don't implement PHP tests for now. They're preserved for potential future use.
+See [PHP Unit Tests (PHPUnit)](#php-unit-tests-phpunit) above for the
+convention. Not every plugin needs one — add `phpunit.xml` +
+`__tests__/bootstrap.php` only when there's boundary-level PHP logic worth
+locking down.
 
 ## Running Tests
 

--- a/fair-payments-connector/__tests__/Fair_Test_WPDB.php
+++ b/fair-payments-connector/__tests__/Fair_Test_WPDB.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Minimal fake $wpdb for PHPUnit bootstrap.
+ *
+ * @package FairPaymentsConnector
+ */
+
+/**
+ * Minimal fake $wpdb so PaymentLogRepository::log() -> PaymentLog::save() is a
+ * no-op success instead of a fatal error on the missing global.
+ */
+class Fair_Test_WPDB {
+	/**
+	 * Table prefix, mirroring the real $wpdb->prefix.
+	 *
+	 * @var string
+	 */
+	public $prefix = 'wp_';
+
+	/**
+	 * Last auto-generated insert ID, mirroring the real $wpdb->insert_id.
+	 *
+	 * @var int
+	 */
+	public $insert_id = 1;
+
+	/**
+	 * Stub of $wpdb->insert() — always succeeds.
+	 *
+	 * @param string $table  Table name.
+	 * @param array  $data   Row data.
+	 * @param array  $format Column formats.
+	 * @return int Number of rows inserted (always 1).
+	 */
+	public function insert( $table, $data, $format = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return 1;
+	}
+}

--- a/fair-payments-connector/__tests__/Payment/MolliePaymentHandlerTest.php
+++ b/fair-payments-connector/__tests__/Payment/MolliePaymentHandlerTest.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * MolliePaymentHandler test/live mode boundary tests.
+ *
+ * Guards against the class of bug fixed in #921: `testmode` silently dropped
+ * (or smuggled into the wrong SDK argument) so a test-mode checkout creates a
+ * live Mollie payment. Each test injects a faked MollieApiClient and asserts
+ * directly on the outgoing SDK request, since that's where the regression
+ * actually lives (see #922).
+ *
+ * @package FairPaymentsConnector
+ */
+
+namespace FairPaymentsConnector\Tests\Payment;
+
+use PHPUnit\Framework\TestCase;
+use FairPaymentsConnector\Payment\MolliePaymentHandler;
+use FairPaymentsConnector\Database\PaymentLogRepository;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\PendingRequest;
+use Mollie\Api\Http\Requests\CreatePaymentRequest;
+use Mollie\Api\Http\Requests\GetPaymentRequest;
+use Mollie\Api\Http\Requests\GetEnabledMethodsRequest;
+use Mollie\Api\Resources\Payment;
+use Mollie\Api\Resources\MethodCollection;
+
+/**
+ * Unit tests for MolliePaymentHandler's test/live mode handling.
+ */
+class MolliePaymentHandlerTest extends TestCase {
+
+	/**
+	 * Reset shared test state before each test.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['_fair_test_options'] = array();
+		PaymentLogRepository::reset_request_id();
+	}
+
+	/**
+	 * Find the single recorded PendingRequest for a given SDK request class.
+	 *
+	 * @param MollieApiClient $mollie        Faked client.
+	 * @param string          $request_class Fully-qualified SDK request class name.
+	 * @return PendingRequest
+	 */
+	private function sent_request( MollieApiClient $mollie, string $request_class ): PendingRequest {
+		$found = null;
+		$mollie->assertSent(
+			function ( PendingRequest $request ) use ( $request_class, &$found ) {
+				if ( get_class( $request->getRequest() ) === $request_class ) {
+					$found = $request;
+					return true;
+				}
+				return false;
+			}
+		);
+		return $found;
+	}
+
+	/**
+	 * `fair_payment_mode = test` must set `testmode = true` on the create request.
+	 */
+	public function test_create_payment_in_test_mode_sets_testmode_true() {
+		$GLOBALS['_fair_test_options']['fair_payment_mode'] = 'test';
+
+		$mollie = MollieApiClient::fake(
+			array(
+				CreatePaymentRequest::class => MockResponse::resource( Payment::class )
+					->with(
+						array(
+							'id'     => 'tr_test_1',
+							'status' => 'open',
+						)
+					)->create(),
+			)
+		);
+
+		$handler = new MolliePaymentHandler( $mollie );
+		$handler->create_payment( array( 'amount' => '10.00' ) );
+
+		$request = $this->sent_request( $mollie, CreatePaymentRequest::class );
+		$this->assertTrue( $request->getTestmode() );
+	}
+
+	/**
+	 * `fair_payment_mode = live` must set `testmode = false` on the create request.
+	 */
+	public function test_create_payment_in_live_mode_sets_testmode_false() {
+		$GLOBALS['_fair_test_options']['fair_payment_mode'] = 'live';
+
+		$mollie = MollieApiClient::fake(
+			array(
+				CreatePaymentRequest::class => MockResponse::resource( Payment::class )
+					->with(
+						array(
+							'id'     => 'tr_live_1',
+							'status' => 'open',
+						)
+					)->create(),
+			)
+		);
+
+		$handler = new MolliePaymentHandler( $mollie );
+		$handler->create_payment( array( 'amount' => '10.00' ) );
+
+		$request = $this->sent_request( $mollie, CreatePaymentRequest::class );
+		$this->assertFalse( $request->getTestmode() );
+	}
+
+	/**
+	 * Regression lock for #921: the boundary flag (`$request->getTestmode()`, set
+	 * via the SDK's third `create()` argument) is the single source of truth. If
+	 * a future change smuggles a hand-written `testmode` value into the payload
+	 * array instead of going through that argument, this value would diverge
+	 * from the boundary flag.
+	 */
+	public function test_create_payment_payload_testmode_matches_boundary_flag() {
+		$GLOBALS['_fair_test_options']['fair_payment_mode'] = 'test';
+
+		$mollie = MollieApiClient::fake(
+			array(
+				CreatePaymentRequest::class => MockResponse::resource( Payment::class )
+					->with(
+						array(
+							'id'     => 'tr_test_2',
+							'status' => 'open',
+						)
+					)->create(),
+			)
+		);
+
+		$handler = new MolliePaymentHandler( $mollie );
+		$handler->create_payment( array( 'amount' => '10.00' ) );
+
+		$request = $this->sent_request( $mollie, CreatePaymentRequest::class );
+		$payload = $request->payload();
+
+		$this->assertTrue( $request->getTestmode() );
+		$this->assertSame( $request->getTestmode(), $payload->get( 'testmode' ) );
+	}
+
+	/**
+	 * OAuth path (profile ID + application fee) must still derive testmode from
+	 * `fair_payment_mode`, same as the API-key path.
+	 */
+	public function test_oauth_path_with_application_fee_derives_testmode_from_mode() {
+		$GLOBALS['_fair_test_options']['fair_payment_mollie_connected']  = true;
+		$GLOBALS['_fair_test_options']['fair_payment_mollie_profile_id'] = 'pfl_test123';
+		$GLOBALS['_fair_test_options']['fair_payment_mode']              = 'live';
+
+		$mollie = MollieApiClient::fake(
+			array(
+				CreatePaymentRequest::class => MockResponse::resource( Payment::class )
+					->with(
+						array(
+							'id'     => 'tr_oauth_1',
+							'status' => 'open',
+						)
+					)->create(),
+			)
+		);
+
+		$handler = new MolliePaymentHandler( $mollie );
+		$handler->create_payment(
+			array(
+				'amount'          => '10.00',
+				'application_fee' => '1.00',
+			)
+		);
+
+		$request = $this->sent_request( $mollie, CreatePaymentRequest::class );
+		$payload = $request->payload();
+
+		$this->assertFalse( $request->getTestmode() );
+		$this->assertSame( 'pfl_test123', $payload->get( 'profileId' ) );
+		$this->assertNotNull( $payload->get( 'applicationFee' ) );
+	}
+
+	/**
+	 * The method-allowlist lookup must query with the same testmode as the
+	 * create call — one source of truth for a single checkout attempt.
+	 */
+	public function test_method_allowlist_uses_same_testmode_as_create() {
+		$GLOBALS['_fair_test_options']['fair_payment_mollie_connected']  = true;
+		$GLOBALS['_fair_test_options']['fair_payment_mollie_profile_id'] = 'pfl_test123';
+		$GLOBALS['_fair_test_options']['fair_payment_mode']              = 'test';
+
+		$mollie = MollieApiClient::fake(
+			array(
+				CreatePaymentRequest::class     => MockResponse::resource( Payment::class )
+					->with(
+						array(
+							'id'     => 'tr_allowlist_1',
+							'status' => 'open',
+						)
+					)->create(),
+				GetEnabledMethodsRequest::class => MockResponse::list( MethodCollection::class )
+					->add(
+						array(
+							'id'       => 'ideal',
+							'resource' => 'method',
+						)
+					)
+					->add(
+						array(
+							'id'       => 'banktransfer',
+							'resource' => 'method',
+						)
+					)
+					->create(),
+			)
+		);
+
+		$handler = new MolliePaymentHandler( $mollie );
+		$handler->create_payment(
+			array(
+				'amount'          => '10.00',
+				'disable_methods' => array( 'banktransfer' ),
+			)
+		);
+
+		$create_request    = $this->sent_request( $mollie, CreatePaymentRequest::class );
+		$allowlist_request = $this->sent_request( $mollie, GetEnabledMethodsRequest::class );
+
+		$this->assertSame( $create_request->getTestmode(), $allowlist_request->getTestmode() );
+		$this->assertTrue( $allowlist_request->getTestmode() );
+	}
+
+	/**
+	 * Regression guard for the read path: `get_payment()` must pass `testmode`
+	 * through to the query position, not silently drop it.
+	 */
+	public function test_get_payment_passes_testmode_in_query() {
+		$mollie = MollieApiClient::fake(
+			array(
+				GetPaymentRequest::class => MockResponse::resource( Payment::class )
+					->with(
+						array(
+							'id'     => 'tr_get_1',
+							'status' => 'paid',
+						)
+					)->create(),
+			)
+		);
+
+		$handler = new MolliePaymentHandler( $mollie );
+		$handler->get_payment( 'tr_get_1', array( 'testmode' => true ) );
+
+		$request = $this->sent_request( $mollie, GetPaymentRequest::class );
+
+		$this->assertTrue( $request->getTestmode() );
+		// The SDK stringifies query booleans ('true'/'false') for URL encoding.
+		$this->assertSame( 'true', $request->query()->get( 'testmode' ) );
+	}
+}

--- a/fair-payments-connector/__tests__/bootstrap.php
+++ b/fair-payments-connector/__tests__/bootstrap.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package FairPaymentsConnector
+ */
+
+// Load Composer autoloader.
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+// Define WordPress constants if not already defined.
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+
+// Minimal WordPress function stubs so MolliePaymentHandler::create_payment() can be
+// driven black-box through its public API without a full WP bootstrap. Tests seed
+// option values via $GLOBALS['_fair_test_options'].
+if ( ! function_exists( 'get_option' ) ) {
+	/**
+	 * Stub of WordPress get_option() backed by $GLOBALS['_fair_test_options'].
+	 *
+	 * @param string $name          Option name.
+	 * @param mixed  $default_value Value returned when the option is unset.
+	 * @return mixed Stored value or the default.
+	 */
+	function get_option( $name, $default_value = false ) {
+		$options = isset( $GLOBALS['_fair_test_options'] ) ? $GLOBALS['_fair_test_options'] : array();
+		return array_key_exists( $name, $options ) ? $options[ $name ] : $default_value;
+	}
+}
+
+if ( ! function_exists( 'wp_parse_args' ) ) {
+	/**
+	 * Stub of WordPress wp_parse_args().
+	 *
+	 * @param array|object $args     Values to merge with defaults.
+	 * @param array        $defaults Defaults.
+	 * @return array Merged arguments.
+	 */
+	function wp_parse_args( $args, $defaults = array() ) {
+		$parsed = is_array( $args ) ? $args : (array) $args;
+		return array_merge( $defaults, $parsed );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	/**
+	 * Stub of WordPress __() — returns the string untranslated.
+	 *
+	 * @param string $text   Text to translate.
+	 * @param string $domain Text domain (unused).
+	 * @return string
+	 */
+	function __( $text, $domain = 'default' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'esc_html__' ) ) {
+	/**
+	 * Stub of WordPress esc_html__() — returns the string untranslated.
+	 *
+	 * @param string $text   Text to translate.
+	 * @param string $domain Text domain (unused).
+	 * @return string
+	 */
+	function esc_html__( $text, $domain = 'default' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	/**
+	 * Stub of WordPress esc_html() — returns the string unescaped.
+	 *
+	 * @param string $text Text to escape.
+	 * @return string
+	 */
+	function esc_html( $text ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+	/**
+	 * Stub of WordPress home_url().
+	 *
+	 * @param string $path Path appended to the home URL.
+	 * @return string
+	 */
+	function home_url( $path = '' ) {
+		return 'https://example.test' . $path;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	/**
+	 * Stub of WordPress wp_json_encode().
+	 *
+	 * @param mixed $data Data to encode.
+	 * @return string|false
+	 */
+	function wp_json_encode( $data ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+		return json_encode( $data );
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	/**
+	 * Stub of WordPress get_current_user_id() — no logged-in user in tests.
+	 *
+	 * @return int
+	 */
+	function get_current_user_id() {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	/**
+	 * Stub of WordPress wp_generate_uuid4().
+	 *
+	 * @return string
+	 */
+	function wp_generate_uuid4() {
+		return 'test-uuid-0000-0000-000000000000';
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	/**
+	 * Stub of WordPress sanitize_text_field() — returns the string trimmed.
+	 *
+	 * @param string $str String to sanitize.
+	 * @return string
+	 */
+	function sanitize_text_field( $str ) {
+		return trim( (string) $str );
+	}
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+	/**
+	 * Stub of WordPress wp_unslash() — no-op (no magic quotes in tests).
+	 *
+	 * @param mixed $value Value to unslash.
+	 * @return mixed
+	 */
+	function wp_unslash( $value ) {
+		return $value;
+	}
+}
+
+require_once __DIR__ . '/Fair_Test_WPDB.php';
+
+// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.
+$GLOBALS['wpdb'] = new Fair_Test_WPDB();

--- a/fair-payments-connector/package.json
+++ b/fair-payments-connector/package.json
@@ -14,7 +14,7 @@
 		"clean": "rm -rf build",
 		"start": "webpack --mode=development --watch --config webpack.config.cjs",
 		"format": "wp-scripts format",
-		"test": "npm-run-all test:js",
+		"test": "npm-run-all test:js test:php",
 		"test:js": "jest",
 		"test:api": "playwright test",
 		"test:php": "vendor/bin/phpunit",

--- a/fair-payments-connector/phpunit.xml
+++ b/fair-payments-connector/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="__tests__/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite name="fair-payments-connector">
+			<directory suffix="Test.php">./__tests__</directory>
+		</testsuite>
+	</testsuites>
+	<coverage>
+		<include>
+			<directory suffix=".php">./src</directory>
+		</include>
+	</coverage>
+</phpunit>

--- a/fair-payments-connector/src/Payment/MolliePaymentHandler.php
+++ b/fair-payments-connector/src/Payment/MolliePaymentHandler.php
@@ -26,8 +26,17 @@ class MolliePaymentHandler {
 
 	/**
 	 * Constructor
+	 *
+	 * @param MollieApiClient|null $client Optional pre-authenticated client (for tests).
+	 *                                     When omitted, the real client is built and
+	 *                                     authenticated exactly as in production.
 	 */
-	public function __construct() {
+	public function __construct( ?MollieApiClient $client = null ) {
+		if ( null !== $client ) {
+			$this->mollie = $client;
+			return;
+		}
+
 		$this->mollie = new MollieApiClient();
 
 		// Prefer OAuth if connected, otherwise fall back to API keys.
@@ -375,7 +384,10 @@ class MolliePaymentHandler {
 			$parameters = array( 'amount' => $amount );
 			if ( $profile_id ) {
 				$parameters['profileId'] = $profile_id;
-				$parameters['testmode']  = $testmode ? 'true' : 'false';
+				// Pass a real bool, not a string: Utility::extractBool() only trusts
+				// is_bool() checks, so a 'false' string is truthy and always coerces
+				// to testmode=true downstream.
+				$parameters['testmode'] = $testmode;
 			}
 
 			$methods = $this->mollie->methods->allEnabled( $parameters );


### PR DESCRIPTION
## Summary

- In #921, test mode created **live** Mollie payments because `testmode` was passed in the SDK payload instead of the query/third arg of `payments->create()`. No test exercised the create-call arguments, so a Mollie SDK v2→v3 change slipped through unnoticed.
- Add a client-injection seam to `MolliePaymentHandler` (optional constructor `MollieApiClient` param) so tests can hand it the SDK's own `MollieApiClient::fake()`. Production call sites are unaffected — the constructor still builds and authenticates the real client when no client is passed.
- Lock the regression at the SDK-call boundary with PHPUnit, mirroring the existing plain-PHPUnit convention already used by `fair-events` and `fair-payments-connector-experimental` (no Brain Monkey/WP_Mock/Mockery). Covers: test vs. live mode on `create_payment()`, that `testmode` isn't smuggled with a divergent value in the payload, the OAuth + application-fee path, the method-allowlist lookup using the same testmode as the create call, and the `get_payment()` read path.
- While writing the method-allowlist test I found a **real latent bug**: `build_method_allowlist()` passed `testmode` as a `'true'`/`'false'` *string*. `Utility::extractBool()` in the Mollie SDK only trusts `is_bool()` checks, so a `'false'` string is truthy in PHP and always coerced to `testmode = true` downstream — meaning the method allowlist under OAuth always queried Mollie in test mode regardless of the actual configured mode. Fixed to pass a real bool.
- Chain `test:php` into the workspace `test` script (`package.json`) so PHPUnit runs in CI via the existing `npm test` step — the CI file named in the ticket (`.github/workflows/php-ci.yml`) doesn't exist; the real workflow already installs dev Composer deps before `npm test`, so no workflow edits are needed.
- Document the PHPUnit convention in `TESTING.md`.

Closes #922

## Test plan

- [x] `vendor/bin/phpunit` in `fair-payments-connector` — 6 tests, 18 assertions, all pass
- [x] Verified the new tests fail against a simulated pre-#921 code path (testmode smuggled in payload, no third arg) — 3 of 6 tests correctly failed
- [x] `vendor/bin/phpcs` clean on all touched PHP files
- [x] `npm run test:js` — unaffected, passes
- [x] `npx npm-run-all test:js test:php` (the `npm test` chain) — passes end-to-end
