### PR TITLE
Render Statistics tab inline instead of redirecting

### DIFF
--- a/fair-events-experimental/src/Admin/manage-event-ext/__tests__/index.test.jsx
+++ b/fair-events-experimental/src/Admin/manage-event-ext/__tests__/index.test.jsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../../event-statistics/EventStatistics.js', () => {
+	return function EventStatisticsMock({ eventDateId }) {
+		return (
+			<div data-testid="event-statistics">Stats for {eventDateId}</div>
+		);
+	};
+});
+
+// The tab is registered as a module side effect, and its `render` reads
+// `statisticsUrl` from a module-level closure. Use a fresh module registry
+// per scenario (including `@wordpress/hooks`) so each import sees its own
+// `window.fairEventsManageEventData` and its own filter store.
+function loadModuleWithData(data) {
+	let hooks;
+	jest.isolateModules(() => {
+		window.fairEventsManageEventData = data;
+		hooks = require('@wordpress/hooks');
+		require('../index.js');
+	});
+	return hooks;
+}
+
+describe('statistics tab registration', () => {
+	afterEach(() => {
+		delete window.fairEventsManageEventData;
+	});
+
+	it('does not register the tab when statisticsUrl is absent', () => {
+		const { applyFilters } = loadModuleWithData({});
+
+		const tabs = applyFilters('fairEvents.manageEvent.tabs', []);
+		expect(tabs).toHaveLength(0);
+	});
+
+	it('renders EventStatistics inline instead of navigating away', async () => {
+		const { applyFilters } = loadModuleWithData({
+			statisticsUrl:
+				'admin.php?page=fair-events-event-statistics&event_date_id=',
+		});
+
+		const tabs = applyFilters('fairEvents.manageEvent.tabs', []);
+		const statisticsTab = tabs.find((tab) => tab.name === 'statistics');
+		expect(statisticsTab).toBeDefined();
+
+		const originalHref = window.location.href;
+		render(statisticsTab.render({ eventDateId: 42 }));
+
+		expect(await screen.findByTestId('event-statistics')).toHaveTextContent(
+			'Stats for 42'
+		);
+		expect(window.location.href).toBe(originalHref);
+	});
+});

--- a/fair-events-experimental/src/Admin/manage-event-ext/index.js
+++ b/fair-events-experimental/src/Admin/manage-event-ext/index.js
@@ -11,6 +11,7 @@
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
+import EventStatistics from '../event-statistics/EventStatistics.js';
 
 const {
 	statisticsUrl = '',
@@ -33,10 +34,9 @@ addFilter(
 				title: __('Statistics', 'fair-events-experimental'),
 				order: 60,
 				isVisible: true,
-				render: ({ eventDateId }) => {
-					window.location.href = `${statisticsUrl}${eventDateId}`;
-					return null;
-				},
+				render: ({ eventDateId }) => (
+					<EventStatistics eventDateId={eventDateId} />
+				),
 			},
 		];
 	}


### PR DESCRIPTION
## Summary

- Clicking the Statistics tab on the Manage Event page previously
  hard-redirected the browser to the standalone statistics page, which
  dropped the tab bar and left no way back to the other tabs.
- The tab's `render` callback now renders `EventStatistics` inline (same
  pattern as every other tab) instead of setting `window.location.href`.
- The tab is still gated on `statisticsUrl` being present, which already
  mirrors the `audience-statistics` feature flag.
- The standalone `fair-events-event-statistics` page is left in place as a
  deep-linkable target.

Closes #967

## Test plan

- [x] `npm test` in `fair-events-experimental` (12 tests passing, including a
      new test verifying the Statistics tab renders `EventStatistics` inline
      and does not navigate away)
- [x] `npm run build` in `fair-events-experimental`; confirmed
      `build/admin/manage-event-ext/index.js` bundles `recharts`
- [x] `npm run format` in `fair-events-experimental`
