### PR TITLE
Add shared payment-integration lifecycle layer

### DIFF
--- a/fair-events-shared/__tests__/payment-flow.test.js
+++ b/fair-events-shared/__tests__/payment-flow.test.js
@@ -1,0 +1,225 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests for the shared payment-integration lifecycle.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+import {
+	initiatePayment,
+	handlePaymentCallback,
+	wireRestartButton,
+} from '../src/payment-flow.js';
+
+jest.mock('@wordpress/api-fetch');
+
+function setLocationSearch(search) {
+	window.history.pushState({}, '', `/${search}`);
+}
+
+beforeEach(() => {
+	apiFetch.mockReset();
+	setLocationSearch('');
+	jest.useFakeTimers();
+});
+
+afterEach(() => {
+	jest.useRealTimers();
+});
+
+describe('initiatePayment', () => {
+	it('leaves the button in its loading state when redirecting', async () => {
+		// jsdom does not implement navigation, so `window.location.href = …`
+		// is a documented no-op there; assert the code took the redirect
+		// branch by checking it skips restoring the button, rather than by
+		// reading back window.location.
+		apiFetch.mockResolvedValue({ checkout_url: 'https://mollie.test/pay' });
+		const button = document.createElement('button');
+		button.textContent = 'Pay';
+
+		const response = await initiatePayment({
+			apiPath: '/fair-payments-connector/v1/payments',
+			data: { amount: '10' },
+			button,
+			loadingText: 'Paying…',
+		});
+
+		expect(response.checkout_url).toBe('https://mollie.test/pay');
+		expect(button.disabled).toBe(true);
+		expect(button.textContent).toBe('Paying…');
+	});
+
+	it('restores the button and resolves when there is no checkout_url', async () => {
+		apiFetch.mockResolvedValue({ status: 'confirmed' });
+		const button = document.createElement('button');
+		button.textContent = 'Submit';
+
+		const response = await initiatePayment({
+			apiPath: '/fair-events/v1/get-tickets',
+			data: {},
+			button,
+			loadingText: 'Processing…',
+		});
+
+		expect(response).toEqual({ status: 'confirmed' });
+		expect(button.disabled).toBe(false);
+		expect(button.textContent).toBe('Submit');
+	});
+
+	it('restores the button and calls onError on failure', async () => {
+		apiFetch.mockRejectedValue({ message: 'Nope' });
+		const button = document.createElement('button');
+		button.textContent = 'Pay';
+		const onError = jest.fn();
+
+		await expect(
+			initiatePayment({
+				apiPath: '/fair-payments-connector/v1/payments',
+				data: {},
+				button,
+				loadingText: 'Paying…',
+				defaultErrorMessage: 'Failed',
+				onError,
+			})
+		).rejects.toEqual({ message: 'Nope' });
+
+		expect(onError).toHaveBeenCalledWith('Nope', { message: 'Nope' });
+		expect(button.disabled).toBe(false);
+		expect(button.textContent).toBe('Pay');
+	});
+});
+
+describe('handlePaymentCallback', () => {
+	it('does nothing when fair_payment_callback is not present', () => {
+		setLocationSearch('?transaction_id=5');
+
+		handlePaymentCallback({
+			statusPath: '/fair-payments-connector/v1/payments',
+			onConfirmed: jest.fn(),
+		});
+
+		expect(apiFetch).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when there is no transaction id', () => {
+		setLocationSearch('?fair_payment_callback=true');
+
+		handlePaymentCallback({
+			statusPath: '/fair-payments-connector/v1/payments',
+			onConfirmed: jest.fn(),
+		});
+
+		expect(apiFetch).not.toHaveBeenCalled();
+	});
+
+	it('polls and calls onConfirmed once lifecycle_status is confirmed', async () => {
+		setLocationSearch(
+			'?fair_payment_callback=true&transaction_id=5&token=abc'
+		);
+		apiFetch.mockResolvedValue({ lifecycle_status: 'confirmed' });
+		const onConfirmed = jest.fn();
+
+		handlePaymentCallback({
+			statusPath: '/fair-payments-connector/v1/payments',
+			onConfirmed,
+			onFailed: jest.fn(),
+		});
+
+		await jest.advanceTimersByTimeAsync(0);
+
+		expect(apiFetch).toHaveBeenCalledWith({
+			path: '/fair-payments-connector/v1/payments/5/status?token=abc',
+		});
+		expect(onConfirmed).toHaveBeenCalledWith({
+			lifecycle_status: 'confirmed',
+		});
+	});
+
+	it('polls and calls onFailed once lifecycle_status is failed', async () => {
+		setLocationSearch('?fair_payment_callback=true&transaction_id=5');
+		apiFetch.mockResolvedValue({ lifecycle_status: 'failed' });
+		const onFailed = jest.fn();
+
+		handlePaymentCallback({
+			statusPath: '/fair-payments-connector/v1/payments',
+			onFailed,
+		});
+
+		await jest.advanceTimersByTimeAsync(0);
+
+		expect(apiFetch).toHaveBeenCalledWith({
+			path: '/fair-payments-connector/v1/payments/5/status',
+		});
+		expect(onFailed).toHaveBeenCalled();
+	});
+
+	it('reschedules while processing and calls onProcessing', async () => {
+		setLocationSearch('?fair_payment_callback=true&transaction_id=5');
+		apiFetch.mockResolvedValue({ lifecycle_status: 'processing' });
+		const onProcessing = jest.fn();
+
+		handlePaymentCallback({
+			statusPath: '/fair-payments-connector/v1/payments',
+			onProcessing,
+		});
+
+		await jest.advanceTimersByTimeAsync(0);
+		expect(onProcessing).toHaveBeenCalledTimes(1);
+		expect(apiFetch).toHaveBeenCalledTimes(1);
+
+		await jest.advanceTimersByTimeAsync(3000);
+		expect(apiFetch).toHaveBeenCalledTimes(2);
+	});
+
+	it('stops polling after MAX_ATTEMPTS', async () => {
+		setLocationSearch('?fair_payment_callback=true&transaction_id=5');
+		apiFetch.mockResolvedValue({ lifecycle_status: 'processing' });
+
+		handlePaymentCallback({
+			statusPath: '/fair-payments-connector/v1/payments',
+		});
+
+		await jest.advanceTimersByTimeAsync(0);
+		await jest.advanceTimersByTimeAsync(3000 * 12);
+
+		expect(apiFetch).toHaveBeenCalledTimes(10);
+	});
+});
+
+describe('wireRestartButton', () => {
+	it('is a no-op when button is null', () => {
+		expect(() =>
+			wireRestartButton({ button: null, form: null })
+		).not.toThrow();
+	});
+
+	it('clears callback params, resets the form, and calls onReset', () => {
+		setLocationSearch(
+			'?fair_payment_callback=true&transaction_id=5&token=abc&post_id=2'
+		);
+		const replaceState = jest.spyOn(window.history, 'replaceState');
+
+		const button = document.createElement('button');
+		const form = document.createElement('form');
+		form.style.display = 'none';
+		const reset = jest.spyOn(form, 'reset');
+		const onReset = jest.fn();
+
+		wireRestartButton({ button, form, onReset });
+		button.dispatchEvent(new window.Event('click'));
+
+		expect(reset).toHaveBeenCalled();
+		expect(form.style.display).toBe('');
+		expect(onReset).toHaveBeenCalled();
+
+		const [, , url] = replaceState.mock.calls[0];
+		expect(url).not.toContain('fair_payment_callback');
+		expect(url).not.toContain('transaction_id');
+		expect(url).not.toContain('token');
+		expect(url).toContain('post_id=2');
+
+		replaceState.mockRestore();
+	});
+});

--- a/fair-events-shared/src/index.js
+++ b/fair-events-shared/src/index.js
@@ -16,3 +16,4 @@ export { default as EventSourceSelector } from './EventSourceSelector.js';
 export * from './questionnaire.js';
 export * from './form-utils.js';
 export * from './question-utils.js';
+export * from './payment-flow.js';

--- a/fair-events-shared/src/payment-flow.js
+++ b/fair-events-shared/src/payment-flow.js
@@ -1,0 +1,177 @@
+import apiFetch from '@wordpress/api-fetch';
+import { extractErrorMessage, setButtonLoading } from './form-utils.js';
+
+/**
+ * Shared payment-integration lifecycle for blocks that create Mollie payments.
+ *
+ * Any block that creates a payment goes through the same three phases:
+ * initiate (POST + redirect to checkout), callback (poll the canonical status
+ * endpoint after the buyer returns), and restart (reset for a failed/expired
+ * attempt). This module owns that lifecycle so blocks only describe their
+ * inputs and presentation.
+ *
+ * @package FairEventsShared
+ */
+
+const MAX_ATTEMPTS = 10;
+const POLL_INTERVAL_MS = 3000;
+
+/**
+ * Create a payment via a public REST endpoint and redirect to its checkout URL.
+ *
+ * @param {Object}        args                     Options.
+ * @param {string}        args.apiPath             Hardcoded REST path to POST to.
+ * @param {Object}        args.data                Request body.
+ * @param {HTMLElement}   [args.button]             Submit button to put into a loading state while the request is in flight.
+ * @param {string}        [args.loadingText]        Text shown on the button while loading (passed to setButtonLoading).
+ * @param {string}        [args.defaultErrorMessage] Fallback error message when the API error has none.
+ * @param {Function}      [args.onError]            Called with (message, error) when the request fails.
+ * @return {Promise<Object>} Resolves with the API response. On a `checkout_url` response the browser is redirected before the promise resolves.
+ */
+export async function initiatePayment({
+	apiPath,
+	data,
+	button,
+	loadingText,
+	defaultErrorMessage,
+	onError,
+}) {
+	const restoreButton = button ? setButtonLoading(button, loadingText) : null;
+
+	try {
+		const response = await apiFetch({
+			path: apiPath,
+			method: 'POST',
+			data,
+		});
+
+		if (response && response.checkout_url) {
+			window.location.href = response.checkout_url;
+			return response;
+		}
+
+		if (restoreButton) {
+			restoreButton();
+		}
+
+		return response;
+	} catch (error) {
+		if (restoreButton) {
+			restoreButton();
+		}
+		if (onError) {
+			onError(extractErrorMessage(error, defaultErrorMessage), error);
+		}
+		throw error;
+	}
+}
+
+/**
+ * Detect a return from the payment gateway and poll the canonical status
+ * endpoint until the transaction reaches a terminal state.
+ *
+ * No-ops unless `fair_payment_callback=true` is present in the URL and a
+ * transaction id is available (either passed in or read from the
+ * `transaction_id` URL parameter).
+ *
+ * @param {Object}   args                Options.
+ * @param {string}   args.statusPath     Hardcoded REST base path for the status resource (e.g. `/fair-payments-connector/v1/payments`). Polled at `${statusPath}/${transactionId}/status`.
+ * @param {string}   [args.transactionId] Transaction id. Falls back to the `transaction_id` URL parameter.
+ * @param {string}   [args.token]        Per-transaction access token. Falls back to the `token` URL parameter.
+ * @param {Function} [args.onConfirmed]  Called with the status response once `lifecycle_status` is `confirmed`.
+ * @param {Function} [args.onFailed]     Called with the status response once `lifecycle_status` is `failed`.
+ * @param {Function} [args.onProcessing] Called with the status response on each poll while still `processing`.
+ */
+export function handlePaymentCallback({
+	statusPath,
+	transactionId,
+	token,
+	onConfirmed,
+	onFailed,
+	onProcessing,
+}) {
+	const params = new URLSearchParams(window.location.search);
+	if (params.get('fair_payment_callback') !== 'true') {
+		return;
+	}
+
+	const resolvedTransactionId = transactionId || params.get('transaction_id');
+	const resolvedToken = token || params.get('token') || '';
+
+	if (!resolvedTransactionId) {
+		return;
+	}
+
+	poll(resolvedTransactionId, 0);
+
+	function poll(txId, attempt) {
+		if (attempt >= MAX_ATTEMPTS) {
+			return;
+		}
+
+		const query = resolvedToken
+			? `?token=${encodeURIComponent(resolvedToken)}`
+			: '';
+
+		apiFetch({ path: `${statusPath}/${txId}/status${query}` })
+			.then(function (response) {
+				if (response.lifecycle_status === 'confirmed') {
+					if (onConfirmed) {
+						onConfirmed(response);
+					}
+					return;
+				}
+
+				if (response.lifecycle_status === 'failed') {
+					if (onFailed) {
+						onFailed(response);
+					}
+					return;
+				}
+
+				if (onProcessing) {
+					onProcessing(response);
+				}
+
+				setTimeout(function () {
+					poll(txId, attempt + 1);
+				}, POLL_INTERVAL_MS);
+			})
+			.catch(function () {
+				// Ignore polling errors — stop polling silently.
+			});
+	}
+}
+
+/**
+ * Wire a "try again" button that clears the callback URL params and restores
+ * the form to a fresh state so the buyer can start a new payment attempt.
+ *
+ * @param {HTMLElement|null}                  args.button  The restart button. No-op when null.
+ * @param {HTMLFormElement|HTMLElement} [args.form]  Element to reveal again. `reset()` is called on it when available.
+ * @param {Function}                    [args.onReset] Called after the URL/form have been reset.
+ */
+export function wireRestartButton({ button, form, onReset }) {
+	if (!button) {
+		return;
+	}
+
+	button.addEventListener('click', function () {
+		const url = new URL(window.location.href);
+		url.searchParams.delete('fair_payment_callback');
+		url.searchParams.delete('transaction_id');
+		url.searchParams.delete('token');
+		window.history.replaceState({}, '', url.toString());
+
+		if (form) {
+			if (typeof form.reset === 'function') {
+				form.reset();
+			}
+			form.style.display = '';
+		}
+
+		if (onReset) {
+			onReset();
+		}
+	});
+}

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -120,27 +120,6 @@ class GetTicketsController extends WP_REST_Controller {
 				),
 			)
 		);
-
-		// GET /fair-events/v1/get-tickets/status — public endpoint for callback polling.
-		// Only returns status of a known transaction; no sensitive data exposed.
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/status',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_status' ),
-					'permission_callback' => '__return_true',
-					'args'                => array(
-						'transaction_id' => array(
-							'type'              => 'integer',
-							'required'          => true,
-							'sanitize_callback' => 'absint',
-						),
-					),
-				),
-			)
-		);
 	}
 
 	/**
@@ -315,10 +294,16 @@ class GetTicketsController extends WP_REST_Controller {
 
 		\FairEvents\Models\EventSignup::update_transaction( $signup_id, (int) $transaction_id );
 
+		// Load the freshly created transaction so its access token can be attached
+		// to the redirect URL, mirroring PaymentEndpoint::create_payment. The token
+		// gates the shared /payments/{id}/status endpoint this now polls.
+		$transaction = \FairPaymentsConnector\Models\Transaction::get_by_id( $transaction_id );
+
 		$redirect_url = add_query_arg(
 			array(
 				'fair_payment_callback' => 'true',
-				'fair_get_tickets_tx'   => $transaction_id,
+				'transaction_id'        => $transaction_id,
+				'token'                 => $transaction ? $transaction->access_token : '',
 			),
 			get_permalink() ?: home_url( '/' )
 		);
@@ -353,38 +338,6 @@ class GetTicketsController extends WP_REST_Controller {
 		$event_date_id = $request->get_param( 'event_date' );
 		$signups       = \FairEvents\Models\EventSignup::get_all_by_event_date_id( $event_date_id );
 		return rest_ensure_response( $signups );
-	}
-
-	/**
-	 * Get transaction status for callback polling.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response|WP_Error
-	 */
-	public function get_status( $request ) {
-		$transaction_id = $request->get_param( 'transaction_id' );
-
-		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
-			return rest_ensure_response( array( 'status' => 'unknown' ) );
-		}
-
-		$transaction = \FairPaymentsConnector\API\TransactionAPI::get_transaction( $transaction_id );
-		if ( ! $transaction ) {
-			return new WP_Error(
-				'not_found',
-				__( 'Transaction not found.', 'fair-events' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		$tx_status = (string) $transaction->status;
-		if ( 'paid' === $tx_status ) {
-			return rest_ensure_response( array( 'status' => 'confirmed' ) );
-		}
-		if ( in_array( $tx_status, array( 'failed', 'canceled', 'expired' ), true ) ) {
-			return rest_ensure_response( array( 'status' => 'failed' ) );
-		}
-		return rest_ensure_response( array( 'status' => 'processing' ) );
 	}
 
 	/**

--- a/fair-events/src/blocks/get-tickets/frontend.js
+++ b/fair-events/src/blocks/get-tickets/frontend.js
@@ -4,17 +4,17 @@
  * @package FairEvents
  */
 
-import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import {
-	extractErrorMessage,
 	showMessage,
-	setButtonLoading,
 	onDomReady,
+	initiatePayment,
+	handlePaymentCallback,
 } from 'fair-events-shared';
 import './frontend.css';
 
 const CSS_PREFIX = 'fair-events-get-tickets';
+const STATUS_PATH = '/fair-payments-connector/v1/payments';
 
 (function () {
 	'use strict';
@@ -22,7 +22,11 @@ const CSS_PREFIX = 'fair-events-get-tickets';
 	onDomReady(initialize);
 
 	function initialize() {
-		handleCallbackReturn();
+		const container = document.querySelector('.fair-events-get-tickets');
+		handlePaymentCallback({
+			statusPath: STATUS_PATH,
+			onConfirmed: () => handleConfirmed(container),
+		});
 
 		const forms = document.querySelectorAll(
 			'.fair-events-get-tickets-form'
@@ -30,45 +34,29 @@ const CSS_PREFIX = 'fair-events-get-tickets';
 		forms.forEach(setupForm);
 	}
 
-	function handleCallbackReturn() {
-		const params = new URLSearchParams(window.location.search);
-		if (params.get('fair_payment_callback') !== 'true') {
-			return;
-		}
-		const transactionId = params.get('fair_get_tickets_tx');
-		if (!transactionId) {
+	function handleConfirmed(container) {
+		if (!container) {
 			return;
 		}
 
-		pollTransactionStatus(parseInt(transactionId, 10));
-	}
+		const messageContainer = container.querySelector('.message-container');
+		const form = container.querySelector('.fair-events-get-tickets-form');
 
-	function pollTransactionStatus(transactionId, attempt) {
-		attempt = attempt || 0;
-		const MAX_ATTEMPTS = 10;
-		const POLL_INTERVAL_MS = 3000;
-
-		if (attempt >= MAX_ATTEMPTS) {
-			return;
+		if (messageContainer) {
+			showMessage(
+				messageContainer,
+				__(
+					'Your ticket purchase was successful! Thank you.',
+					'fair-events'
+				),
+				'success',
+				CSS_PREFIX
+			);
 		}
 
-		apiFetch({
-			path: `/fair-events/v1/get-tickets/status?transaction_id=${transactionId}`,
-		})
-			.then(function (response) {
-				if (
-					response.status === 'confirmed' ||
-					response.status === 'failed'
-				) {
-					return;
-				}
-				setTimeout(function () {
-					pollTransactionStatus(transactionId, attempt + 1);
-				}, POLL_INTERVAL_MS);
-			})
-			.catch(function () {
-				// Ignore polling errors.
-			});
+		if (form) {
+			form.style.display = 'none';
+		}
 	}
 
 	function setupForm(form) {
@@ -193,22 +181,21 @@ const CSS_PREFIX = 'fair-events-get-tickets';
 		messageContainer.textContent = '';
 		messageContainer.className = 'message-container';
 
-		const restoreButton = setButtonLoading(
-			submitButton,
-			__('Processing…', 'fair-events')
-		);
-
-		apiFetch({
-			path: '/fair-events/v1/get-tickets',
-			method: 'POST',
-			data: data,
+		initiatePayment({
+			apiPath: '/fair-events/v1/get-tickets',
+			data,
+			button: submitButton,
+			loadingText: __('Processing…', 'fair-events'),
+			defaultErrorMessage: __(
+				'Failed to submit. Please try again.',
+				'fair-events'
+			),
+			onError: (message) => {
+				showMessage(messageContainer, message, 'error', CSS_PREFIX);
+			},
 		})
 			.then(function (response) {
-				if (
-					response.status === 'payment_required' &&
-					response.checkout_url
-				) {
-					window.location = response.checkout_url;
+				if (response.checkout_url) {
 					return;
 				}
 
@@ -221,18 +208,8 @@ const CSS_PREFIX = 'fair-events-get-tickets';
 				);
 				form.style.display = 'none';
 			})
-			.catch(function (error) {
-				const errorMessage = extractErrorMessage(
-					error,
-					__('Failed to submit. Please try again.', 'fair-events')
-				);
-				showMessage(
-					messageContainer,
-					errorMessage,
-					'error',
-					CSS_PREFIX
-				);
-				restoreButton();
+			.catch(function () {
+				// Error already surfaced via onError.
 			});
 	}
 })();

--- a/fair-events/src/blocks/get-tickets/render.php
+++ b/fair-events/src/blocks/get-tickets/render.php
@@ -43,21 +43,19 @@ if ( ! $event_date_id ) {
 
 // Handle fair_payment_callback return state.
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$is_payment_callback = ! empty( $_GET['fair_payment_callback'] ) && ! empty( $_GET['fair_get_tickets_tx'] );
+$is_payment_callback = ! empty( $_GET['fair_payment_callback'] ) && ! empty( $_GET['transaction_id'] );
 $callback_status     = '';
+$callback_tx_id      = 0;
+$callback_token      = '';
 if ( $is_payment_callback && class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$tx_id       = absint( $_GET['fair_get_tickets_tx'] );
-	$transaction = \FairPaymentsConnector\API\TransactionAPI::get_transaction( $tx_id );
-	if ( $transaction ) {
-		$tx_status = (string) $transaction->status;
-		if ( 'paid' === $tx_status ) {
-			$callback_status = 'confirmed';
-		} elseif ( in_array( $tx_status, array( 'failed', 'canceled', 'expired' ), true ) ) {
-			$callback_status = 'failed';
-		} else {
-			$callback_status = 'processing';
-		}
+	$callback_tx_id = absint( $_GET['transaction_id'] );
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$callback_token = isset( $_GET['token'] ) ? sanitize_text_field( wp_unslash( $_GET['token'] ) ) : '';
+	$transaction    = \FairPaymentsConnector\API\TransactionAPI::get_transaction( $callback_tx_id );
+	$expected_token = $transaction ? (string) ( $transaction->access_token ?? '' ) : '';
+	if ( $transaction && '' !== $expected_token && '' !== $callback_token && hash_equals( $expected_token, $callback_token ) ) {
+		$callback_status = \FairPaymentsConnector\Payment\PaymentStatus::from_raw_status( (string) $transaction->status );
 	}
 }
 

--- a/fair-payments-connector/__tests__/Payment/PaymentStatusTest.php
+++ b/fair-payments-connector/__tests__/Payment/PaymentStatusTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * PaymentStatus canonical-mapping tests.
+ *
+ * @package FairPaymentsConnector
+ */
+
+namespace FairPaymentsConnector\Tests\Payment;
+
+use PHPUnit\Framework\TestCase;
+use FairPaymentsConnector\Payment\PaymentStatus;
+
+/**
+ * Unit tests for the raw-transaction-status → canonical-lifecycle-status mapper.
+ */
+class PaymentStatusTest extends TestCase {
+
+	/**
+	 * Assert each raw status maps to its canonical lifecycle status.
+	 *
+	 * @dataProvider raw_status_provider
+	 *
+	 * @param string $raw_status Raw transaction status.
+	 * @param string $expected   Expected canonical lifecycle status.
+	 */
+	public function test_from_raw_status_maps_correctly( string $raw_status, string $expected ): void {
+		$this->assertSame( $expected, PaymentStatus::from_raw_status( $raw_status ) );
+	}
+
+	/**
+	 * Data provider of raw statuses and their expected canonical mapping.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function raw_status_provider(): array {
+		return array(
+			'paid maps to confirmed'                  => array( 'paid', PaymentStatus::CONFIRMED ),
+			'failed maps to failed'                   => array( 'failed', PaymentStatus::FAILED ),
+			'canceled maps to failed'                 => array( 'canceled', PaymentStatus::FAILED ),
+			'expired maps to failed'                  => array( 'expired', PaymentStatus::FAILED ),
+			'pending_payment maps to processing'      => array( 'pending_payment', PaymentStatus::PROCESSING ),
+			'draft maps to processing'                => array( 'draft', PaymentStatus::PROCESSING ),
+			'authorized maps to processing'           => array( 'authorized', PaymentStatus::PROCESSING ),
+			'unknown status falls back to processing' => array( 'some_unrecognized_status', PaymentStatus::PROCESSING ),
+			'empty string falls back to processing'   => array( '', PaymentStatus::PROCESSING ),
+		);
+	}
+}

--- a/fair-payments-connector/package.json
+++ b/fair-payments-connector/package.json
@@ -49,6 +49,7 @@
 		"@wordpress/dom-ready": "^4.2.0",
 		"@wordpress/element": "^8.0.0",
 		"@wordpress/i18n": "^6.21.0",
+		"fair-events-shared": "*",
 		"xlsx": "^0.18.5"
 	}
 }

--- a/fair-payments-connector/src/API/PaymentEndpoint.php
+++ b/fair-payments-connector/src/API/PaymentEndpoint.php
@@ -8,6 +8,7 @@
 namespace FairPaymentsConnector\API;
 
 use FairPaymentsConnector\Payment\MolliePaymentHandler;
+use FairPaymentsConnector\Payment\PaymentStatus;
 use FairPaymentsConnector\Models\Transaction;
 use FairPaymentsConnector\Database\PaymentLogRepository;
 use WP_REST_Controller;
@@ -418,10 +419,13 @@ class PaymentEndpoint extends WP_REST_Controller {
 			);
 		}
 
-		// Prepare response data.
+		// Prepare response data. `status` is kept as the raw transaction status for
+		// backward compatibility; `lifecycle_status` is the canonical
+		// confirmed|processing|failed state the shared frontend poller reads.
 		$response_data = array(
 			'transaction_id'    => $transaction->id,
 			'status'            => $transaction->status,
+			'lifecycle_status'  => PaymentStatus::from_raw_status( (string) $transaction->status ),
 			'amount'            => $transaction->amount,
 			'currency'          => $transaction->currency,
 			'description'       => $transaction->description,

--- a/fair-payments-connector/src/API/__tests__/PaymentEndpoint.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/PaymentEndpoint.api.spec.js
@@ -88,3 +88,35 @@ test.describe('PaymentEndpoint — POST /payments security checks', () => {
 		expect(body.code).toBe('invalid_block');
 	});
 });
+
+test.describe('PaymentEndpoint — GET /payments/:id/status token gating', () => {
+	let api;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	// Any caller can enumerate transaction IDs, so a missing transaction and a
+	// token mismatch on a real one must be indistinguishable (both 404) —
+	// see get_transaction_status_permissions_check().
+
+	test('returns 404 for a non-existent transaction id without a token', async () => {
+		const res = await api.get(`${PAYMENTS_ENDPOINT}/999999999/status`);
+		expect(res.status()).toBe(404);
+		const body = await res.json();
+		expect(body.code).toBe('transaction_not_found');
+	});
+
+	test('returns 404 for a non-existent transaction id with a token', async () => {
+		const res = await api.get(
+			`${PAYMENTS_ENDPOINT}/999999999/status?token=anything`
+		);
+		expect(res.status()).toBe(404);
+		const body = await res.json();
+		expect(body.code).toBe('transaction_not_found');
+	});
+});

--- a/fair-payments-connector/src/Payment/PaymentStatus.php
+++ b/fair-payments-connector/src/Payment/PaymentStatus.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Canonical payment lifecycle status mapper
+ *
+ * @package FairPaymentsConnector
+ */
+
+namespace FairPaymentsConnector\Payment;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Maps a raw Mollie transaction status to the canonical lifecycle state
+ * consumed by both server-rendered blocks and the shared frontend poller.
+ */
+final class PaymentStatus {
+
+	/**
+	 * Payment confirmed and paid.
+	 */
+	const CONFIRMED = 'confirmed';
+
+	/**
+	 * Payment failed, canceled, or expired.
+	 */
+	const FAILED = 'failed';
+
+	/**
+	 * Payment still awaiting a final outcome.
+	 */
+	const PROCESSING = 'processing';
+
+	/**
+	 * Map a raw transaction status to the canonical lifecycle status.
+	 *
+	 * @param string $raw_status Raw transaction status (e.g. 'paid', 'failed', 'pending_payment').
+	 * @return string One of self::CONFIRMED, self::FAILED, self::PROCESSING.
+	 */
+	public static function from_raw_status( string $raw_status ): string {
+		if ( 'paid' === $raw_status ) {
+			return self::CONFIRMED;
+		}
+
+		if ( in_array( $raw_status, array( 'failed', 'canceled', 'expired' ), true ) ) {
+			return self::FAILED;
+		}
+
+		return self::PROCESSING;
+	}
+}

--- a/fair-payments-connector/src/blocks/simple-payment/render.php
+++ b/fair-payments-connector/src/blocks/simple-payment/render.php
@@ -21,8 +21,24 @@ $current_post_id = get_the_ID();
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $is_callback = isset( $_GET['fair_payment_callback'] ) && 'true' === $_GET['fair_payment_callback'];
 
-// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$show_success = isset( $_GET['payment_redirect'] ) && '1' === $_GET['payment_redirect'];
+// Resolve the real transaction status via the canonical PaymentStatus mapper,
+// gated by the per-transaction access token exactly like the REST status
+// endpoint. Falls back to "processing" when the callback can't be verified
+// (e.g. missing/mismatched token) rather than guessing a specific outcome.
+$callback_status = 'processing';
+if ( $is_callback && class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$callback_transaction_id = isset( $_GET['transaction_id'] ) ? absint( $_GET['transaction_id'] ) : 0;
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$callback_token = isset( $_GET['token'] ) ? sanitize_text_field( wp_unslash( $_GET['token'] ) ) : '';
+
+	$transaction    = $callback_transaction_id ? \FairPaymentsConnector\API\TransactionAPI::get_transaction( $callback_transaction_id ) : null;
+	$expected_token = $transaction ? (string) ( $transaction->access_token ?? '' ) : '';
+
+	if ( $transaction && '' !== $expected_token && '' !== $callback_token && hash_equals( $expected_token, $callback_token ) ) {
+		$callback_status = \FairPaymentsConnector\Payment\PaymentStatus::from_raw_status( (string) $transaction->status );
+	}
+}
 
 // Check if Mollie is configured.
 $is_configured = \FairPaymentsConnector\Payment\MolliePaymentHandler::is_configured();
@@ -30,29 +46,33 @@ $is_configured = \FairPaymentsConnector\Payment\MolliePaymentHandler::is_configu
 $block_id = 'fair-payments-connector-' . wp_unique_id();
 ?>
 
-<div 
+<div
 <?php
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() returns pre-escaped HTML attributes.
 	echo get_block_wrapper_attributes( array( 'id' => $block_id ) );
 ?>
 >
 	<div class="fair-payments-connector-block">
-		<?php if ( $is_callback ) : ?>
-			<div class="fair-payments-connector-callback">
-				<div class="fair-payments-connector-success">
-					<p><?php esc_html_e( 'Thank you! Your payment has been received and is being processed.', 'fair-payments-connector' ); ?></p>
-				</div>
-				<button type="button" class="fair-payments-connector-callback-dismiss wp-element-button">
-					<?php esc_html_e( 'Continue', 'fair-payments-connector' ); ?>
-				</button>
+		<div class="fair-payments-connector-callback" style="<?php echo esc_attr( $is_callback ? '' : 'display: none;' ); ?>">
+			<div class="fair-payments-connector-success" data-status="confirmed" role="alert" style="<?php echo esc_attr( 'confirmed' === $callback_status ? '' : 'display: none;' ); ?>">
+				<p><?php esc_html_e( 'Thank you! Your payment has been received and confirmed.', 'fair-payments-connector' ); ?></p>
 			</div>
-		<?php else : ?>
-			<?php if ( $show_success ) : ?>
-				<div class="fair-payments-connector-success">
-					<p><?php esc_html_e( 'Thank you! Your payment is being processed.', 'fair-payments-connector' ); ?></p>
-				</div>
-			<?php endif; ?>
+			<div class="fair-payments-connector-processing" data-status="processing" role="alert" style="<?php echo esc_attr( 'processing' === $callback_status ? '' : 'display: none;' ); ?>">
+				<p><?php esc_html_e( 'Thank you! Your payment is being processed.', 'fair-payments-connector' ); ?></p>
+			</div>
+			<div class="fair-payments-connector-failed" data-status="failed" role="alert" style="<?php echo esc_attr( 'failed' === $callback_status ? '' : 'display: none;' ); ?>">
+				<p><?php esc_html_e( 'Your payment was not completed. Please try again.', 'fair-payments-connector' ); ?></p>
+			</div>
 
+			<button type="button" class="fair-payments-connector-callback-dismiss wp-element-button" style="<?php echo esc_attr( 'failed' === $callback_status ? 'display: none;' : '' ); ?>">
+				<?php esc_html_e( 'Continue', 'fair-payments-connector' ); ?>
+			</button>
+			<button type="button" class="fair-payments-connector-restart wp-element-button" style="<?php echo esc_attr( 'failed' === $callback_status ? '' : 'display: none;' ); ?>">
+				<?php esc_html_e( 'Try Again', 'fair-payments-connector' ); ?>
+			</button>
+		</div>
+
+		<div class="fair-payments-connector-payment-form" style="<?php echo esc_attr( $is_callback ? 'display: none;' : '' ); ?>">
 			<div class="fair-payments-connector-amount">
 				<strong><?php echo esc_html( $amount ); ?> <?php echo esc_html( $currency ); ?></strong>
 				<?php if ( ! empty( $description ) ) : ?>
@@ -80,6 +100,6 @@ $block_id = 'fair-payments-connector-' . wp_unique_id();
 					<em><?php esc_html_e( 'Payment gateway is not configured. Please configure your Mollie API keys.', 'fair-payments-connector' ); ?></em>
 				</p>
 			<?php endif; ?>
-		<?php endif; ?>
+		</div>
 	</div>
 </div>

--- a/fair-payments-connector/src/blocks/simple-payment/view.js
+++ b/fair-payments-connector/src/blocks/simple-payment/view.js
@@ -5,6 +5,14 @@
  */
 
 import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+import {
+	initiatePayment,
+	handlePaymentCallback,
+	wireRestartButton,
+} from 'fair-events-shared';
+
+const STATUS_PATH = '/fair-payments-connector/v1/payments';
 
 (function () {
 	'use strict';
@@ -19,6 +27,8 @@ import apiFetch from '@wordpress/api-fetch';
 	function init() {
 		initPaymentButtons();
 		initCallbackDismiss();
+		initRestart();
+		initCallbackPolling();
 	}
 
 	function initPaymentButtons() {
@@ -54,16 +64,77 @@ import apiFetch from '@wordpress/api-fetch';
 		const callback = button.closest('.fair-payments-connector-callback');
 
 		if (callback) {
-			callback.remove();
+			callback.style.display = 'none';
 		}
 
 		const url = new URL(window.location.href);
 		url.searchParams.delete('fair_payment_callback');
 		url.searchParams.delete('transaction_id');
+		url.searchParams.delete('token');
 		window.history.replaceState({}, '', url.toString());
 	}
 
-	async function handlePaymentClick(event, noncePromise) {
+	function initRestart() {
+		const callbackEl = document.querySelector(
+			'.fair-payments-connector-callback'
+		);
+		const restartButton = document.querySelector(
+			'.fair-payments-connector-restart'
+		);
+		const paymentForm = document.querySelector(
+			'.fair-payments-connector-payment-form'
+		);
+
+		wireRestartButton({
+			button: restartButton,
+			form: paymentForm,
+			onReset: () => {
+				if (callbackEl) {
+					callbackEl.style.display = 'none';
+				}
+			},
+		});
+	}
+
+	function initCallbackPolling() {
+		const callbackEl = document.querySelector(
+			'.fair-payments-connector-callback'
+		);
+		if (!callbackEl) {
+			return;
+		}
+
+		handlePaymentCallback({
+			statusPath: STATUS_PATH,
+			onConfirmed: () => updateCallbackState(callbackEl, 'confirmed'),
+			onFailed: () => updateCallbackState(callbackEl, 'failed'),
+		});
+	}
+
+	function updateCallbackState(callbackEl, status) {
+		callbackEl.querySelectorAll('[data-status]').forEach(function (el) {
+			el.style.display =
+				el.getAttribute('data-status') === status ? 'block' : 'none';
+		});
+
+		const restartButton = callbackEl.querySelector(
+			'.fair-payments-connector-restart'
+		);
+		const dismissButton = callbackEl.querySelector(
+			'.fair-payments-connector-callback-dismiss'
+		);
+
+		if (restartButton) {
+			restartButton.style.display =
+				status === 'failed' ? 'block' : 'none';
+		}
+		if (dismissButton) {
+			dismissButton.style.display =
+				status === 'failed' ? 'none' : 'block';
+		}
+	}
+
+	function handlePaymentClick(event, noncePromise) {
 		const button = event.target;
 		const paymentBlock = button.closest('.fair-payments-connector-block');
 		const loadingEl = paymentBlock.querySelector(
@@ -89,46 +160,36 @@ import apiFetch from '@wordpress/api-fetch';
 		}
 		button.disabled = true;
 
-		try {
-			const nonce = await noncePromise;
-
-			// Create payment via REST API using WordPress apiFetch
-			const data = await apiFetch({
-				path: '/fair-payments-connector/v1/payments',
-				method: 'POST',
-				data: {
-					amount: amount,
-					currency: currency,
-					description: description,
-					post_id: postId,
-					block_id: blockId,
-					nonce: nonce,
-				},
+		noncePromise
+			.then((nonce) =>
+				initiatePayment({
+					apiPath: '/fair-payments-connector/v1/payments',
+					data: {
+						amount,
+						currency,
+						description,
+						post_id: postId,
+						block_id: blockId,
+						nonce,
+					},
+					defaultErrorMessage: __(
+						'Failed to create payment',
+						'fair-payments-connector'
+					),
+					onError: (message) => {
+						if (errorEl) {
+							errorEl.textContent = message;
+							errorEl.style.display = 'block';
+						}
+						if (loadingEl) {
+							loadingEl.style.display = 'none';
+						}
+						button.disabled = false;
+					},
+				})
+			)
+			.catch(() => {
+				// Error already surfaced via onError.
 			});
-
-			// Redirect to Mollie checkout
-			if (data.checkout_url) {
-				window.location.href = data.checkout_url;
-			} else {
-				throw new Error('No checkout URL received');
-			}
-		} catch (error) {
-			// Show error message
-			if (errorEl) {
-				// apiFetch errors may have a message property directly or nested in data
-				const errorMessage =
-					error.message ||
-					(error.data && error.data.message) ||
-					'Failed to create payment';
-				errorEl.textContent = errorMessage;
-				errorEl.style.display = 'block';
-			}
-			if (loadingEl) {
-				loadingEl.style.display = 'none';
-			}
-			button.disabled = false;
-
-			console.error('Payment error:', error);
-		}
 	}
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2420,6 +2420,7 @@
 				"@wordpress/dom-ready": "^4.2.0",
 				"@wordpress/element": "^8.0.0",
 				"@wordpress/i18n": "^6.21.0",
+				"fair-events-shared": "*",
 				"xlsx": "^0.18.5"
 			},
 			"devDependencies": {


### PR DESCRIPTION
## Summary

`simple-payment` (fair-payments-connector) and `get-tickets` (fair-events) each
hand-rolled their own create/redirect/poll payment lifecycle, with different
redirect query-arg names, different status endpoints (one token-gated, one
not), and duplicated raw-status→UI mapping. `simple-payment` never actually
polled for a real outcome — buyers only ever saw a static "being processed"
banner, even after failure.

This implements the plan from #928 (comment
[4850499914](https://github.com/marcin-wosinek/fair-event-plugins/issues/928#issuecomment-4850499914)):

- **`PaymentStatus`** (`fair-payments-connector/src/Payment/PaymentStatus.php`) — single
  static mapper from raw transaction status to canonical `confirmed | processing | failed`.
- **`/payments/{id}/status`** now also returns `lifecycle_status` (the raw `status`
  field is kept for backward compatibility).
- **get-tickets now routes through the token-gated `/payments/{id}/status`
  endpoint** instead of its own ungated `/get-tickets/status` route, which is
  removed. Its redirect now carries `transaction_id` + `token` like
  `simple-payment` already did.
- **`fair-events-shared/src/payment-flow.js`** — `initiatePayment`,
  `handlePaymentCallback`, `wireRestartButton`, with unit tests.
- Both blocks' JS/PHP are refactored onto the shared module and mapper.
  `simple-payment` now shows real confirmed/processing/failed states (not a
  static banner) and offers a restart button on failure.

## Test plan

- [x] `fair-events-shared`: `npm test` — 71/71 passing, including new
      `payment-flow.test.js` (11 tests covering redirect, poll→confirmed/failed/processing,
      MAX_ATTEMPTS cap, restart).
- [x] `fair-payments-connector`: `npm run test:js`, `npm run test:php` — all
      passing, including a new `PaymentStatusTest.php`.
- [x] `fair-events`: `npm run test:js` — all passing.
- [x] `vendor/bin/phpcs` clean on all changed PHP files.
- [x] `npm run build` in both `fair-events` and `fair-payments-connector`.
- [x] Manually verified the live `/payments/{id}/status` endpoint against a
      seeded transaction: no token → 404, wrong token → 404, correct token →
      200 with `lifecycle_status: "confirmed"`.
- [ ] e2e coverage (deferred — coordinated with #922's test-mode work, and
      needs Mollie test credentials not available in this environment).
- Not verified in-browser: the local WP dev environment currently doesn't
  render page content for *any* page (pre-existing, unrelated to this
  change — confirmed against an untouched page), so the block UI itself
  wasn't visually exercised.

Closes #928
