### PR TITLE
Add multiple_instances recurrence scope for ticket types

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -152,6 +152,17 @@ class EventSignupController extends WP_REST_Controller {
 							'type'  => 'array',
 							'items' => array( 'type' => 'integer' ),
 						),
+						// Chosen occurrence IDs for 'multiple_instances' ticket types.
+						// Capped so a crafted request can't force an unbounded number
+						// of line items / DB rows per submission.
+						'event_date_ids'        => array(
+							'type'              => 'array',
+							'items'             => array( 'type' => 'integer' ),
+							'required'          => false,
+							'validate_callback' => function ( $value ) {
+								return ! is_array( $value ) || count( $value ) <= 50;
+							},
+						),
 						'participant_token'     => array(
 							'type'              => 'string',
 							'required'          => false,
@@ -562,6 +573,17 @@ class EventSignupController extends WP_REST_Controller {
 			);
 		}
 
+		// 'multiple_instances' ticket types pick several specific occurrences
+		// instead of retargeting to the master (whole_series) or staying on one
+		// occurrence (single_instance) — handled by a dedicated path that
+		// creates one signup row per chosen occurrence.
+		if ( $ticket_type_id && class_exists( \FairEvents\Models\TicketType::class ) ) {
+			$tt_for_multi = \FairEvents\Models\TicketType::get_by_id( $ticket_type_id );
+			if ( $tt_for_multi && $tt_for_multi->is_multiple_instances() ) {
+				return $this->create_multi_instance_signup( $request, $event, $event_id, $participant, $tt_for_multi, $invitation_token );
+			}
+		}
+
 		// For whole-series ticket types, retarget event_date_id to the master so one
 		// row covers every occurrence in the series. Single-instance path is unchanged.
 		if ( $ticket_type_id && $event_date_id && class_exists( \FairEvents\Models\TicketType::class ) ) {
@@ -670,6 +692,293 @@ class EventSignupController extends WP_REST_Controller {
 				'success' => true,
 				'message' => __( 'You have successfully signed up for the event!', 'fair-audience' ),
 				'status'  => 'signed_up',
+			)
+		);
+	}
+
+	/**
+	 * Sign up for one or more specific occurrences of a recurring series
+	 * ('multiple_instances' ticket types). Unlike single_instance (one
+	 * occurrence) and whole_series (retargeted to the master), this creates
+	 * one EventParticipant row per chosen occurrence — sharing a single
+	 * transaction on the paid path, so PaymentHooks::handle_signup_paid()
+	 * confirms them together.
+	 *
+	 * @param WP_REST_Request                  $request          Request object.
+	 * @param WP_Post                          $event            Event post.
+	 * @param int                              $event_id         Event post ID.
+	 * @param \FairAudience\Models\Participant $participant      Participant doing the signup.
+	 * @param \FairEvents\Models\TicketType    $ticket_type      The 'multiple_instances' ticket type.
+	 * @param string                           $invitation_token Optional invitation token presented by the buyer.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function create_multi_instance_signup( $request, $event, $event_id, $participant, $ticket_type, $invitation_token ) {
+		$raw_ids = $request->get_param( 'event_date_ids' ) ?: array();
+		$raw_ids = array_slice( array_values( array_unique( array_map( 'absint', (array) $raw_ids ) ) ), 0, 50 );
+		$raw_ids = array_filter( $raw_ids );
+
+		if ( empty( $raw_ids ) ) {
+			return new WP_Error(
+				'no_occurrences_selected',
+				__( 'Please select at least one occurrence.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! class_exists( \FairEvents\Models\EventDates::class ) ) {
+			return new WP_Error(
+				'invalid_ticket_type',
+				__( 'Invalid ticket type.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Validate every submitted ID is a real occurrence belonging to the
+		// same series as the ticket type — never trust the client list.
+		$series_master_id = $this->resolve_master_event_date_id( (int) $ticket_type->event_date_id );
+		if ( ! $series_master_id ) {
+			return new WP_Error(
+				'invalid_ticket_type',
+				__( 'Invalid ticket type.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$occurrences = array();
+		foreach ( $raw_ids as $occ_id ) {
+			$occ = \FairEvents\Models\EventDates::get_by_id( $occ_id );
+			if ( ! $occ || $this->resolve_master_event_date_id( $occ_id ) !== $series_master_id ) {
+				return new WP_Error(
+					'invalid_occurrence',
+					__( 'One of the selected occurrences is not valid for this ticket.', 'fair-audience' ),
+					array( 'status' => 400 )
+				);
+			}
+			$occurrences[] = $occ;
+		}
+
+		$minimum_instances = max( 1, (int) $ticket_type->minimum_instances );
+		if ( count( $occurrences ) < $minimum_instances ) {
+			return new WP_Error(
+				'minimum_instances_not_met',
+				sprintf(
+					/* translators: %d: minimum number of occurrences required */
+					_n(
+						'Please select at least %d occurrence.',
+						'Please select at least %d occurrences.',
+						$minimum_instances,
+						'fair-audience'
+					),
+					$minimum_instances
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Drop occurrences the participant already holds a signed-up slot for.
+		$pending_occurrences = array();
+		foreach ( $occurrences as $occ ) {
+			$rel = $this->event_participant_repository->get_by_event_date_and_participant( (int) $occ->id, $participant->id );
+			if ( $rel && 'signed_up' === $rel->label ) {
+				continue;
+			}
+			$pending_occurrences[] = $occ;
+		}
+
+		if ( empty( $pending_occurrences ) ) {
+			AudienceSession::set( (int) $participant->id );
+			return rest_ensure_response(
+				array(
+					'success' => true,
+					'message' => __( 'You are already signed up for these occurrences.', 'fair-audience' ),
+					'status'  => 'already_signed_up',
+				)
+			);
+		}
+
+		$group_error = $this->validate_ticket_type_group_restriction( $ticket_type->id, $participant->id, $invitation_token );
+		if ( is_wp_error( $group_error ) ) {
+			return $group_error;
+		}
+
+		$capacity_error = $this->validate_ticket_type_capacity( $ticket_type->id );
+		if ( is_wp_error( $capacity_error ) ) {
+			return $capacity_error;
+		}
+
+		$disable_at_error = $this->validate_ticket_type_disable_at( $ticket_type->id );
+		if ( is_wp_error( $disable_at_error ) ) {
+			return $disable_at_error;
+		}
+
+		// Recompute the per-instance price server-side; never trust a client amount.
+		$unit_price = 0.0;
+		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			$resolved   = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_for_ticket_type( $ticket_type->id, $participant->id );
+			$unit_price = null !== $resolved ? (float) $resolved : 0.0;
+		}
+		$count            = count( $pending_occurrences );
+		$total_amount     = $unit_price * $count;
+		$seats_per_ticket = max( 1, (int) $ticket_type->seats_per_ticket );
+
+		if ( $total_amount <= 0 ) {
+			foreach ( $pending_occurrences as $occ ) {
+				$existing_occ = $this->event_participant_repository->get_by_event_date_and_participant( (int) $occ->id, $participant->id );
+				if ( $existing_occ ) {
+					$this->event_participant_repository->update_label_by_event_date( (int) $occ->id, $participant->id, 'signed_up' );
+				} else {
+					$this->event_participant_repository->add_participant_to_event( $event_id, $participant->id, 'signed_up', (int) $occ->id );
+				}
+				$this->snapshot_ticket_type_on_signup( (int) $occ->id, $participant->id, $ticket_type->id );
+			}
+
+			AudienceSession::set( (int) $participant->id );
+
+			return rest_ensure_response(
+				array(
+					'success' => true,
+					'message' => __( 'You have successfully signed up for the event!', 'fair-audience' ),
+					'status'  => 'signed_up',
+				)
+			);
+		}
+
+		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class )
+			|| ! \FairPaymentsConnector\API\TransactionAPI::is_configured() ) {
+			return new WP_Error(
+				'payment_unavailable',
+				__( 'Paid signup is not available because the payment plugin is not configured.', 'fair-audience' ),
+				array( 'status' => 503 )
+			);
+		}
+
+		// Per-occurrence capacity check.
+		foreach ( $pending_occurrences as $occ ) {
+			if ( null === $occ->capacity ) {
+				continue;
+			}
+			$active_count       = $this->event_participant_repository->count_active_for_event_date( (int) $occ->id );
+			$existing_occ       = $this->event_participant_repository->get_by_event_date_and_participant( (int) $occ->id, $participant->id );
+			$already_holds_slot = $existing_occ && in_array( $existing_occ->label, array( 'signed_up', 'pending_payment' ), true );
+			$held_seats         = $already_holds_slot ? max( 1, (int) $existing_occ->seats ) : 0;
+			$projected          = $active_count - $held_seats + $seats_per_ticket;
+			if ( $projected > (int) $occ->capacity ) {
+				return new WP_Error(
+					'event_full',
+					__( 'One of the selected occurrences is fully booked.', 'fair-audience' ),
+					array( 'status' => 409 )
+				);
+			}
+		}
+
+		$expires_at            = gmdate( 'Y-m-d H:i:s', time() + 15 * MINUTE_IN_SECONDS );
+		$event_participant_ids = array();
+		$line_items            = array();
+
+		foreach ( $pending_occurrences as $occ ) {
+			$existing_occ = $this->event_participant_repository->get_by_event_date_and_participant( (int) $occ->id, $participant->id );
+			if ( $existing_occ ) {
+				$existing_occ->label              = 'pending_payment';
+				$existing_occ->payment_expires_at = $expires_at;
+				$existing_occ->transaction_id     = null;
+				$existing_occ->ticket_type_id     = $ticket_type->id;
+				$existing_occ->seats              = $seats_per_ticket;
+				$existing_occ->save();
+				$ep = $existing_occ;
+			} else {
+				$ep = new \FairAudience\Models\EventParticipant(
+					array(
+						'event_id'           => $event_id,
+						'event_date_id'      => (int) $occ->id,
+						'participant_id'     => $participant->id,
+						'label'              => 'pending_payment',
+						'payment_expires_at' => $expires_at,
+						'ticket_type_id'     => $ticket_type->id,
+						'seats'              => $seats_per_ticket,
+					)
+				);
+				$ep->save();
+			}
+			$event_participant_ids[] = (int) $ep->id;
+
+			$occ_label    = class_exists( \FairEvents\Helpers\DateRangeFormatter::class )
+				? \FairEvents\Helpers\DateRangeFormatter::format( $occ->start_datetime, $occ->end_datetime, (bool) $occ->all_day )
+				: $occ->start_datetime;
+			$line_items[] = array(
+				'name'     => sprintf(
+					/* translators: %s: occurrence date/time label */
+					__( 'Signup for %s', 'fair-audience' ),
+					$occ_label
+				),
+				'quantity' => 1,
+				'amount'   => $unit_price,
+			);
+		}
+
+		$transaction_id = \FairPaymentsConnector\API\TransactionAPI::create_transaction(
+			$line_items,
+			array(
+				'currency'      => get_option( 'fair_payment_currency', 'EUR' ),
+				'description'   => sprintf(
+					/* translators: %s: event title */
+					__( 'Signup for %s', 'fair-audience' ),
+					get_the_title( $event_id )
+				),
+				'post_id'       => $event_id,
+				'event_date_id' => (int) $pending_occurrences[0]->id,
+				'user_id'       => get_current_user_id() ?: null,
+				'metadata'      => array(
+					'source'                => 'fair-audience-signup',
+					'event_date_id'         => (int) $pending_occurrences[0]->id,
+					'event_participant_ids' => $event_participant_ids,
+					'participant_id'        => $participant->id,
+					'ticket_type_id'        => (int) $ticket_type->id,
+				),
+			)
+		);
+
+		if ( is_wp_error( $transaction_id ) ) {
+			return $transaction_id;
+		}
+
+		foreach ( $event_participant_ids as $ep_id ) {
+			$ep = $this->event_participant_repository->get_by_id( $ep_id );
+			if ( $ep ) {
+				$ep->transaction_id = (int) $transaction_id;
+				$ep->save();
+			}
+		}
+
+		$redirect_url = add_query_arg(
+			array(
+				'fair_payment_callback' => 'true',
+				'fair_signup_tx'        => $transaction_id,
+				'fst_sig'               => \FairAudience\Services\TransactionAccessToken::generate(
+					(int) $transaction_id,
+					(int) $participant->id
+				),
+			),
+			get_permalink( $event_id )
+		);
+
+		$payment = \FairPaymentsConnector\API\TransactionAPI::initiate_payment(
+			$transaction_id,
+			array( 'redirect_url' => $redirect_url )
+		);
+
+		if ( is_wp_error( $payment ) ) {
+			return $payment;
+		}
+
+		AudienceSession::set( (int) $participant->id );
+
+		return rest_ensure_response(
+			array(
+				'status'         => 'payment_required',
+				'checkout_url'   => esc_url_raw( $payment['checkout_url'] ),
+				'transaction_id' => $transaction_id,
+				'amount'         => $total_amount,
+				'currency'       => get_option( 'fair_payment_currency', 'EUR' ),
 			)
 		);
 	}

--- a/fair-audience/src/API/__tests__/EventSignupRecurrenceScope.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupRecurrenceScope.api.spec.js
@@ -1,6 +1,6 @@
 /**
- * Playwright API tests for recurrence-scope ticket types (#663):
- * single_instance vs. whole_series signup semantics.
+ * Playwright API tests for recurrence-scope ticket types (#663, #930):
+ * single_instance vs. whole_series vs. multiple_instances signup semantics.
  *
  * Tests the core contract:
  *   - A whole_series signup is stored against the master event-date, not the
@@ -10,6 +10,10 @@
  *   - A single_instance signup is stored against the occurrence's event-date.
  *   - Capacity is enforced independently for both scopes (separate ticket types,
  *     each with capacity 1; second signup for the same scope is rejected).
+ *   - A multiple_instances signup below the configured minimum is rejected.
+ *   - A multiple_instances signup that names an occurrence outside the ticket
+ *     type's own series is rejected.
+ *   - A valid multiple_instances signup creates one row per chosen occurrence.
  */
 
 import { test, expect, request } from '@playwright/test';
@@ -319,6 +323,201 @@ test.describe('Recurrence-scope ticket types — signup semantics', () => {
 			});
 		} finally {
 			await deleteParticipant(api, secondParticipantId);
+		}
+	});
+});
+
+test.describe('multiple_instances ticket types — pick-N signup semantics (#930)', () => {
+	let api;
+	let adminUserId;
+	let participantId;
+	let event;
+	let occurrenceIds;
+	let ttId;
+
+	async function createRecurringEvent(title, rrule) {
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: authHeaders,
+			data: { title, status: 'publish' },
+		});
+		expect(postRes.ok()).toBeTruthy();
+		const eventId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: authHeaders,
+			data: {
+				event_id: eventId,
+				start_datetime: '2035-04-02 10:00:00',
+				end_datetime: '2035-04-02 12:00:00',
+				rrule,
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		const masterEventDateId = (await edRes.json()).id;
+
+		const occRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates?event_id=${eventId}`,
+			{ headers: authHeaders }
+		);
+		expect(occRes.ok()).toBeTruthy();
+		const occurrences = (await occRes.json()).map((o) => o.id).sort();
+
+		return { eventId, masterEventDateId, occurrences };
+	}
+
+	async function createMultiInstanceTicketType(
+		masterEventDateId,
+		minimumInstances
+	) {
+		const res = await api.post(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/tickets`,
+			{
+				headers: authHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'Pick your sessions',
+							capacity: null,
+							sort_order: 0,
+							recurrence_scope: 'multiple_instances',
+							minimum_instances: minimumInstances,
+						},
+					],
+					sale_periods: [],
+					prices: [],
+				},
+			}
+		);
+		expect(res.ok(), 'create multiple_instances ticket type').toBeTruthy();
+		const body = await res.json();
+		const tt = body.ticket_types?.[0];
+		expect(tt.recurrence_scope).toBe('multiple_instances');
+		expect(tt.minimum_instances).toBe(minimumInstances);
+		return tt.id;
+	}
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const meRes = await api.get('/wp-json/wp/v2/users/me', {
+			headers: authHeaders,
+		});
+		expect(meRes.ok()).toBeTruthy();
+		adminUserId = (await meRes.json()).id;
+
+		event = await createRecurringEvent(
+			`Multiple Instances Test ${Date.now()}`,
+			'FREQ=WEEKLY;COUNT=4'
+		);
+		expect(event.occurrences.length).toBe(4);
+		occurrenceIds = event.occurrences;
+
+		ttId = await createMultiInstanceTicketType(event.masterEventDateId, 2);
+
+		participantId = await createParticipant(
+			api,
+			adminUserId,
+			'Multi Instance Tester'
+		);
+	});
+
+	test.afterAll(async () => {
+		await deleteParticipant(api, participantId);
+		if (event?.eventId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${event.eventId}`, {
+				headers: authHeaders,
+				params: { force: 'true' },
+			});
+		}
+		await api.dispose();
+	});
+
+	test('below the configured minimum is rejected', async () => {
+		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
+			headers: authHeaders,
+			data: {
+				event_id: event.eventId,
+				event_date_id: event.masterEventDateId,
+				ticket_type_id: ttId,
+				event_date_ids: [occurrenceIds[0]],
+			},
+		});
+		expect(res.status()).toBe(400);
+		const body = await res.json();
+		expect(body.code).toBe('minimum_instances_not_met');
+	});
+
+	test("an occurrence outside the ticket type's series is rejected", async () => {
+		const otherEvent = await createRecurringEvent(
+			`Multiple Instances Foreign ${Date.now()}`,
+			'FREQ=WEEKLY;COUNT=2'
+		);
+		try {
+			const res = await api.post(
+				'/wp-json/fair-audience/v1/event-signup',
+				{
+					headers: authHeaders,
+					data: {
+						event_id: event.eventId,
+						event_date_id: event.masterEventDateId,
+						ticket_type_id: ttId,
+						event_date_ids: [
+							occurrenceIds[0],
+							otherEvent.occurrences[0],
+						],
+					},
+				}
+			);
+			expect(res.status()).toBe(400);
+			const body = await res.json();
+			expect(body.code).toBe('invalid_occurrence');
+		} finally {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${otherEvent.eventId}`,
+				{ headers: authHeaders, params: { force: 'true' } }
+			);
+		}
+	});
+
+	test('a valid selection creates one row per chosen occurrence', async () => {
+		const chosen = [occurrenceIds[0], occurrenceIds[1]];
+		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
+			headers: authHeaders,
+			data: {
+				event_id: event.eventId,
+				event_date_id: event.masterEventDateId,
+				ticket_type_id: ttId,
+				event_date_ids: chosen,
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		expect(body.status).toMatch(/^(signed_up|already_signed_up)$/);
+
+		for (const occId of chosen) {
+			const participantsRes = await api.get(
+				`/wp-json/fair-audience/v1/event-dates/${occId}/participants`,
+				{ headers: authHeaders }
+			);
+			expect(participantsRes.ok()).toBeTruthy();
+			const rows = await participantsRes.json();
+			const row = rows.find((p) => p.participant_id === participantId);
+			expect(row, `signup row on occurrence ${occId}`).toBeTruthy();
+			expect(row.label).toBe('signed_up');
+		}
+
+		// The unselected occurrences should have no row for this participant.
+		const untouched = occurrenceIds.filter((id) => !chosen.includes(id));
+		for (const occId of untouched) {
+			const participantsRes = await api.get(
+				`/wp-json/fair-audience/v1/event-dates/${occId}/participants`,
+				{ headers: authHeaders }
+			);
+			expect(participantsRes.ok()).toBeTruthy();
+			const rows = await participantsRes.json();
+			expect(
+				rows.find((p) => p.participant_id === participantId)
+			).toBeFalsy();
 		}
 	});
 });

--- a/fair-audience/src/Database/EventParticipantRepository.php
+++ b/fair-audience/src/Database/EventParticipantRepository.php
@@ -430,6 +430,43 @@ class EventParticipantRepository {
 	}
 
 	/**
+	 * Find all event participant rows sharing a fair-payments-connector
+	 * transaction ID. A 'multiple_instances' ticket-type purchase creates one
+	 * row per chosen occurrence under a single transaction; every other
+	 * signup path creates exactly one row, so this is a superset of
+	 * get_by_transaction_id() safe to use wherever "the rows this payment
+	 * covers" is needed.
+	 *
+	 * @param int $transaction_id fair-payments-connector transaction ID.
+	 * @return EventParticipant[] Relationships (empty array when none match).
+	 */
+	public function get_all_by_transaction_id( $transaction_id ) {
+		global $wpdb;
+
+		$table_name = $this->get_table_name();
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE transaction_id = %d',
+				$table_name,
+				$transaction_id
+			),
+			ARRAY_A
+		);
+
+		if ( empty( $results ) ) {
+			return array();
+		}
+
+		return array_map(
+			static function ( $row ) {
+				return new EventParticipant( $row );
+			},
+			$results
+		);
+	}
+
+	/**
 	 * Find an event participant row by its primary key.
 	 *
 	 * @param int $id Event participant row ID.

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -415,17 +415,35 @@ class PaymentHooks {
 			return;
 		}
 
-		$repo              = new EventParticipantRepository();
-		$event_participant = $repo->get_by_transaction_id( (int) $transaction->id );
-		if ( ! $event_participant || 'pending_payment' !== $event_participant->label ) {
+		$repo = new EventParticipantRepository();
+
+		// A 'multiple_instances' ticket-type purchase creates one pending_payment
+		// row per chosen occurrence, all sharing this transaction; every other
+		// signup path creates exactly one row. Flip every matching row so all
+		// occurrences confirm together.
+		$event_participants = $repo->get_all_by_transaction_id( (int) $transaction->id );
+		if ( empty( $event_participants ) ) {
 			return;
 		}
 
-		$event_participant->label              = 'signed_up';
-		$event_participant->payment_expires_at = null;
-		$event_participant->save();
+		$confirmation_participant = null;
+		foreach ( $event_participants as $event_participant ) {
+			if ( 'pending_payment' !== $event_participant->label ) {
+				continue;
+			}
 
-		do_action( 'fair_audience_event_signup_paid', $event_participant, $transaction );
+			$event_participant->label              = 'signed_up';
+			$event_participant->payment_expires_at = null;
+			$event_participant->save();
+
+			if ( null === $confirmation_participant ) {
+				$confirmation_participant = $event_participant;
+			}
+		}
+
+		if ( null !== $confirmation_participant ) {
+			do_action( 'fair_audience_event_signup_paid', $confirmation_participant, $transaction );
+		}
 	}
 
 	/**
@@ -450,13 +468,21 @@ class PaymentHooks {
 			return;
 		}
 
-		$repo              = new EventParticipantRepository();
-		$event_participant = $repo->get_by_transaction_id( (int) $transaction->id );
-		if ( ! $event_participant || 'pending_payment' !== $event_participant->label ) {
+		$repo = new EventParticipantRepository();
+
+		// See handle_signup_paid(): a 'multiple_instances' purchase shares one
+		// transaction across several rows. Fire the action once, using the
+		// first still-pending row, so the resume-link email is sent a single
+		// time regardless of how many occurrences were selected.
+		$event_participants = $repo->get_all_by_transaction_id( (int) $transaction->id );
+		foreach ( $event_participants as $event_participant ) {
+			if ( 'pending_payment' !== $event_participant->label ) {
+				continue;
+			}
+
+			do_action( 'fair_audience_event_signup_failed', $event_participant, $transaction );
 			return;
 		}
-
-		do_action( 'fair_audience_event_signup_failed', $event_participant, $transaction );
 	}
 
 	/**

--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -151,6 +151,135 @@ const CSS_PREFIX = 'fair-audience-signup';
 	}
 
 	/**
+	 * The currently selected ticket type radio, if any.
+	 * @param {HTMLElement} block The block element
+	 * @return {HTMLInputElement|null} The checked ticket_type_id radio.
+	 */
+	function getSelectedTicketType(block) {
+		return block.querySelector('input[name="ticket_type_id"]:checked');
+	}
+
+	/**
+	 * Whether the selected ticket type is a 'multiple_instances' scope pass.
+	 * @param {HTMLElement} block The block element
+	 * @return {boolean} True when the multi-occurrence checkbox picker applies.
+	 */
+	function isMultipleInstancesSelected(block) {
+		const selected = getSelectedTicketType(block);
+		return (
+			!!selected &&
+			selected.dataset.recurrenceScope === 'multiple_instances'
+		);
+	}
+
+	/**
+	 * Number of checked occurrence checkboxes in the multi-instance picker.
+	 * @param {HTMLElement} block The block element
+	 * @return {number} Count of checked event_date_ids[] checkboxes.
+	 */
+	function getCheckedInstanceCount(block) {
+		return block.querySelectorAll('input[name="event_date_ids[]"]:checked')
+			.length;
+	}
+
+	/**
+	 * Minimum occurrence count required by the selected ticket type.
+	 * @param {HTMLElement} block The block element
+	 * @return {number} The configured minimum_instances (0 = none).
+	 */
+	function getInstanceMinimum(block) {
+		const selected = getSelectedTicketType(block);
+		return selected
+			? parseInt(selected.dataset.minInstances || '0', 10)
+			: 0;
+	}
+
+	/**
+	 * Show the multi-occurrence checkbox picker (hiding the single-occurrence
+	 * dropdown) when a 'multiple_instances' ticket type is selected, and vice
+	 * versa. Clears stale checkbox state when switching away so a leftover
+	 * selection can't leak into a later submission for a different scope.
+	 * @param {HTMLElement} block The block element
+	 */
+	function updateInstancePickerVisibility(block) {
+		const instancePicker = block.querySelector(
+			'.fair-audience-instance-picker'
+		);
+		if (!instancePicker) {
+			return;
+		}
+		const occurrencePicker = block.querySelector(
+			'.fair-audience-occurrence-picker'
+		);
+		const active = isMultipleInstancesSelected(block);
+		instancePicker.style.display = active ? '' : 'none';
+		if (occurrencePicker) {
+			occurrencePicker.style.display = active ? 'none' : '';
+		}
+		if (!active) {
+			instancePicker
+				.querySelectorAll('input[type="checkbox"]')
+				.forEach(function (cb) {
+					cb.checked = false;
+				});
+		}
+	}
+
+	/**
+	 * Keep the instance picker's minimum hint and live total in sync as the
+	 * buyer checks/unchecks occurrences or switches ticket type.
+	 * @param {HTMLElement} block The block element
+	 */
+	function updateInstancePickerHint(block) {
+		const instancePicker = block.querySelector(
+			'.fair-audience-instance-picker'
+		);
+		if (!instancePicker || !isMultipleInstancesSelected(block)) {
+			return;
+		}
+
+		const min = getInstanceMinimum(block);
+		const checked = getCheckedInstanceCount(block);
+
+		const hint = instancePicker.querySelector(
+			'.fair-audience-instance-picker-hint'
+		);
+		if (hint) {
+			hint.textContent =
+				min > 0
+					? sprintf(
+							/* translators: %d: minimum number of occurrences required */
+							_n(
+								'Please select at least %d occurrence.',
+								'Please select at least %d occurrences.',
+								min,
+								'fair-audience'
+							),
+							min
+					  )
+					: '';
+		}
+
+		const selected = getSelectedTicketType(block);
+		const price = selected
+			? parseFloat(selected.dataset.ticketPrice || 0)
+			: 0;
+		const totalEl = instancePicker.querySelector(
+			'.fair-audience-instance-picker-total'
+		);
+		if (totalEl) {
+			totalEl.textContent =
+				checked > 0
+					? sprintf(
+							/* translators: %s: formatted total price */
+							__('Total: €%s', 'fair-audience'),
+							(price * checked).toFixed(2)
+					  )
+					: '';
+		}
+	}
+
+	/**
 	 * Compute the effective minimum number of activities for the block: the
 	 * event-date global baseline, possibly raised by the selected ticket type
 	 * (issue #625), capped at the number of options available so the requirement
@@ -212,11 +341,21 @@ const CSS_PREFIX = 'fair-audience-signup';
 			'.fair-audience-signup-button, .fair-audience-signup-submit-button'
 		);
 
+		// A 'multiple_instances' ticket type gates on its own occurrence
+		// minimum (at least 1 chosen occurrence, or more if configured),
+		// independent of the activities-minimum gate above.
+		const multiInstanceActive = isMultipleInstancesSelected(block);
+		const instanceMin = multiInstanceActive
+			? Math.max(1, getInstanceMinimum(block))
+			: 0;
+		const meetsInstanceMin =
+			!multiInstanceActive ||
+			getCheckedInstanceCount(block) >= instanceMin;
+
 		if (!effectiveMin) {
-			// No minimum in effect: never leave a button disabled by this gate.
 			buttons.forEach(function (btn) {
-				btn.disabled = false;
-				btn.classList.remove('is-disabled');
+				btn.disabled = !meetsInstanceMin;
+				btn.classList.toggle('is-disabled', !meetsInstanceMin);
 			});
 			return;
 		}
@@ -224,7 +363,7 @@ const CSS_PREFIX = 'fair-audience-signup';
 		const checkedCount = block.querySelectorAll(
 			'input[name="ticket_option_ids[]"]:checked'
 		).length;
-		const meetsMin = checkedCount >= effectiveMin;
+		const meetsMin = checkedCount >= effectiveMin && meetsInstanceMin;
 
 		buttons.forEach(function (btn) {
 			btn.disabled = !meetsMin;
@@ -253,6 +392,36 @@ const CSS_PREFIX = 'fair-audience-signup';
 			selectedTicketType.dataset.ticketPrice !== ''
 		) {
 			basePrice = parseFloat(selectedTicketType.dataset.ticketPrice || 0);
+		}
+
+		if (isMultipleInstancesSelected(block)) {
+			const instanceMin = Math.max(1, getInstanceMinimum(block));
+			const instanceCount = getCheckedInstanceCount(block);
+			if (instanceCount < instanceMin) {
+				// Not enough occurrences chosen yet — show the bare action label
+				// until the selection is valid, same treatment as the
+				// below-minimum-activities case below.
+				const signupBaseText =
+					block.dataset.signupBaseText ||
+					__('Sign Up', 'fair-audience');
+				const registerBaseText =
+					block.dataset.registerBaseText ||
+					__('Register & Sign Up', 'fair-audience');
+				const signupBtnBare = block.querySelector(
+					'.fair-audience-signup-button'
+				);
+				if (signupBtnBare) {
+					signupBtnBare.textContent = signupBaseText;
+				}
+				const submitBtnBare = block.querySelector(
+					'.fair-audience-signup-submit-button'
+				);
+				if (submitBtnBare) {
+					submitBtnBare.textContent = registerBaseText;
+				}
+				return;
+			}
+			basePrice = basePrice * instanceCount;
 		}
 
 		const checkedOptions = block.querySelectorAll(
@@ -360,6 +529,8 @@ const CSS_PREFIX = 'fair-audience-signup';
 		);
 		ticketTypeRadios.forEach(function (radio) {
 			radio.addEventListener('change', function () {
+				updateInstancePickerVisibility(block);
+				updateInstancePickerHint(block);
 				updateButtonTotal(block);
 				updateMinActivitiesGate(block);
 				updateOptionAddons(block);
@@ -377,6 +548,19 @@ const CSS_PREFIX = 'fair-audience-signup';
 			});
 		});
 
+		const instanceCheckboxes = block.querySelectorAll(
+			'input[name="event_date_ids[]"]'
+		);
+		instanceCheckboxes.forEach(function (checkbox) {
+			checkbox.addEventListener('change', function () {
+				updateInstancePickerHint(block);
+				updateButtonTotal(block);
+				updateMinActivitiesGate(block);
+			});
+		});
+
+		updateInstancePickerVisibility(block);
+		updateInstancePickerHint(block);
 		updateButtonTotal(block);
 		updateMinActivitiesGate(block);
 		updateOptionAddons(block);
@@ -591,6 +775,18 @@ const CSS_PREFIX = 'fair-audience-signup';
 		);
 		if (ticketTypeInput) {
 			requestData.ticket_type_id = parseInt(ticketTypeInput.value, 10);
+		}
+
+		if (
+			ticketTypeInput &&
+			ticketTypeInput.dataset.recurrenceScope === 'multiple_instances'
+		) {
+			const instanceInputs = form.querySelectorAll(
+				'input[name="event_date_ids[]"]:checked'
+			);
+			requestData.event_date_ids = Array.from(instanceInputs).map((i) =>
+				parseInt(i.value, 10)
+			);
 		}
 
 		const optionInputs = form.querySelectorAll(
@@ -849,6 +1045,18 @@ const CSS_PREFIX = 'fair-audience-signup';
 		);
 		if (ticketTypeInput) {
 			requestData.ticket_type_id = parseInt(ticketTypeInput.value, 10);
+		}
+
+		if (
+			ticketTypeInput &&
+			ticketTypeInput.dataset.recurrenceScope === 'multiple_instances'
+		) {
+			const instanceInputs = block.querySelectorAll(
+				'input[name="event_date_ids[]"]:checked'
+			);
+			requestData.event_date_ids = Array.from(instanceInputs).map((i) =>
+				parseInt(i.value, 10)
+			);
 		}
 
 		const optionInputs = block.querySelectorAll(

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -449,6 +449,8 @@ if ( $pricing_event_date_id && class_exists( \FairEvents\Models\TicketType::clas
 			'seats_per_ticket'   => (int) $tt->seats_per_ticket,
 			'invitation_only'    => (bool) $tt->invitation_only,
 			'minimum_activities' => (int) $tt->minimum_activities,
+			'recurrence_scope'   => $tt->recurrence_scope,
+			'minimum_instances'  => (int) $tt->minimum_instances,
 			'is_full'            => $tt_is_full,
 		);
 	}
@@ -761,7 +763,7 @@ $render_ticket_types = static function () use ( $ticket_types_for_display, $has_
 			$classes .= ' fair-audience-ticket-type-full';
 		}
 		echo '<label class="' . esc_attr( $classes ) . '" for="' . $radio_id . '">';
-		echo '<input type="radio" name="ticket_type_id" id="' . $radio_id . '" value="' . (int) $tt['id'] . '" data-ticket-price="' . ( null !== $tt['price'] ? esc_attr( number_format( (float) $tt['price'], 2, '.', '' ) ) : '' ) . '" data-min-activities="' . esc_attr( (string) ( $tt['minimum_activities'] ?? 0 ) ) . '"';
+		echo '<input type="radio" name="ticket_type_id" id="' . $radio_id . '" value="' . (int) $tt['id'] . '" data-ticket-price="' . ( null !== $tt['price'] ? esc_attr( number_format( (float) $tt['price'], 2, '.', '' ) ) : '' ) . '" data-min-activities="' . esc_attr( (string) ( $tt['minimum_activities'] ?? 0 ) ) . '" data-recurrence-scope="' . esc_attr( $tt['recurrence_scope'] ?? 'single_instance' ) . '" data-min-instances="' . esc_attr( (string) ( $tt['minimum_instances'] ?? 0 ) ) . '"';
 		if ( $tt_is_full ) {
 			echo ' disabled';
 		} elseif ( ! $default_selected ) {
@@ -960,6 +962,61 @@ $render_occurrence_picker = static function () use ( $occurrences_for_picker, $h
 	echo '</div>';
 };
 
+/**
+ * Render the multi-occurrence checkbox picker for 'multiple_instances' ticket
+ * types. Hidden by default; frontend.js reveals it when the buyer selects a
+ * ticket type whose data-recurrence-scope is 'multiple_instances', and hides
+ * the single-occurrence <select> in that case since the two pickers are
+ * mutually exclusive. Sold-out / already-signed-up occurrences are rendered
+ * disabled rather than omitted, so the picker stays a stable/complete list.
+ */
+$render_instance_picker = static function () use ( $occurrences_for_picker, $has_occurrence_picker, $form_id, $ticket_types_for_display ) {
+	if ( ! $has_occurrence_picker ) {
+		return;
+	}
+
+	$has_multi_instance_type = false;
+	foreach ( $ticket_types_for_display as $tt ) {
+		if ( 'multiple_instances' === ( $tt['recurrence_scope'] ?? '' ) ) {
+			$has_multi_instance_type = true;
+			break;
+		}
+	}
+	if ( ! $has_multi_instance_type ) {
+		return;
+	}
+
+	echo '<fieldset class="fair-audience-instance-picker" style="display: none;">';
+	echo '<legend>' . esc_html__( 'Choose occurrences', 'fair-audience' ) . '</legend>';
+	foreach ( $occurrences_for_picker as $occ_row ) {
+		$label       = \FairEvents\Helpers\DateRangeFormatter::format(
+			$occ_row['start_datetime'],
+			$occ_row['end_datetime'],
+			$occ_row['all_day']
+		);
+		$is_disabled = ! empty( $occ_row['signed_up'] );
+		$checkbox_id = esc_attr( $form_id ) . '-inst-' . (int) $occ_row['id'];
+		$classes     = 'fair-audience-instance-option';
+		if ( $is_disabled ) {
+			$classes .= ' fair-audience-instance-option-disabled';
+		}
+		echo '<label class="' . esc_attr( $classes ) . '" for="' . $checkbox_id . '">';
+		echo '<input type="checkbox" name="event_date_ids[]" id="' . $checkbox_id . '" value="' . (int) $occ_row['id'] . '"';
+		if ( $is_disabled ) {
+			echo ' disabled';
+		}
+		echo ' /> ';
+		echo esc_html( $label );
+		if ( $is_disabled ) {
+			echo ' — ' . esc_html__( 'already signed up', 'fair-audience' );
+		}
+		echo '</label>';
+	}
+	echo '<p class="fair-audience-instance-picker-hint"></p>';
+	echo '<p class="fair-audience-instance-picker-total"></p>';
+	echo '</fieldset>';
+};
+
 // Base button labels (without price suffix) for dynamic JS price updates.
 $base_signup_button_text   = __( $attributes['signupButtonText'] ?? 'Sign Up', 'fair-audience' );
 $base_register_button_text = __( $attributes['registerButtonText'] ?? 'Register & Sign Up', 'fair-audience' );
@@ -1153,6 +1210,7 @@ if ( ! $is_valid_post_type ) :
 			<?php $render_occurrence_picker(); ?>
 			<div class="fair-audience-signup-action-signup"<?php echo $is_signed_up ? ' style="display: none;"' : ''; ?>>
 				<?php $render_ticket_types(); ?>
+				<?php $render_instance_picker(); ?>
 				<?php $render_ticket_options(); ?>
 				<?php if ( '' !== trim( $content ) ) : ?>
 					<div class="fair-audience-signup-questions">
@@ -1226,6 +1284,7 @@ if ( ! $is_valid_post_type ) :
 			<!-- Registration form (new participant) -->
 			<form class="fair-audience-signup-form fair-audience-signup-register" data-tab-content="register">
 				<?php $render_ticket_types(); ?>
+				<?php $render_instance_picker(); ?>
 				<?php $render_ticket_options(); ?>
 				<p>
 					<label for="<?php echo esc_attr( $form_id ); ?>-name">

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -99,6 +99,17 @@ class GetTicketsController extends WP_REST_Controller {
 							'default'           => false,
 							'sanitize_callback' => 'rest_sanitize_boolean',
 						),
+						// Chosen occurrence IDs for 'multiple_instances' ticket types.
+						// Capped so a crafted request can't force an unbounded number
+						// of line items / DB rows per submission.
+						'event_date_ids' => array(
+							'type'              => 'array',
+							'items'             => array( 'type' => 'integer' ),
+							'required'          => false,
+							'validate_callback' => function ( $value ) {
+								return ! is_array( $value ) || count( $value ) <= 50;
+							},
+						),
 						'_honeypot'      => array(
 							'type'     => 'string',
 							'required' => false,
@@ -190,6 +201,14 @@ class GetTicketsController extends WP_REST_Controller {
 					__( 'This ticket type is no longer available.', 'fair-events' ),
 					array( 'status' => 409 )
 				);
+			}
+
+			// 'multiple_instances' ticket types pick several specific occurrences
+			// instead of the single event_date_id above — handled by a dedicated
+			// path that creates one signup row per chosen occurrence.
+			if ( $ticket_type->is_multiple_instances() ) {
+				$this->increment_rate_limit();
+				return $this->create_multi_instance_signup( $request, $ticket_type, $event_date_id, $name, $email, $mailing_opt_in );
 			}
 
 			// Resolve price from the active sale period (server-side; client amount is ignored).
@@ -326,6 +345,253 @@ class GetTicketsController extends WP_REST_Controller {
 				'currency'       => $currency,
 			)
 		);
+	}
+
+	/**
+	 * Create a ticket signup for a 'multiple_instances' ticket type: the buyer
+	 * picks several specific occurrences of the series (instead of the single
+	 * event_date_id the rest of create_signup() operates on) at a per-instance
+	 * price, subject to the ticket type's configured minimum. Creates one
+	 * EventSignup row per chosen occurrence, sharing a single transaction on
+	 * the paid path so PaymentHooks confirms them together.
+	 *
+	 * @param WP_REST_Request               $request        Request object.
+	 * @param \FairEvents\Models\TicketType $ticket_type    The 'multiple_instances' ticket type.
+	 * @param int                           $series_page_id The event_date_id the request resolved to (the ticket type's own row).
+	 * @param string                        $name           Buyer name.
+	 * @param string                        $email          Buyer email.
+	 * @param bool                          $mailing_opt_in Whether the buyer opted into mailings.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function create_multi_instance_signup( $request, $ticket_type, $series_page_id, $name, $email, $mailing_opt_in ) {
+		$raw_ids = $request->get_param( 'event_date_ids' ) ?? array();
+		$raw_ids = array_slice( array_values( array_unique( array_map( 'absint', (array) $raw_ids ) ) ), 0, 50 );
+		$raw_ids = array_filter( $raw_ids );
+
+		if ( empty( $raw_ids ) ) {
+			return new WP_Error(
+				'no_occurrences_selected',
+				__( 'Please select at least one occurrence.', 'fair-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Resolve the series master from the page's own event date (the ticket
+		// type's row) and validate every submitted ID belongs to that same
+		// series — never trust the client list.
+		$series_master_id = $this->resolve_master_event_date_id( $series_page_id );
+		if ( ! $series_master_id ) {
+			return new WP_Error(
+				'invalid_ticket_type',
+				__( 'Invalid ticket type.', 'fair-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$occurrences = array();
+		foreach ( $raw_ids as $occ_id ) {
+			$occ = \FairEvents\Models\EventDates::get_by_id( $occ_id );
+			if ( ! $occ || $this->resolve_master_event_date_id( $occ_id ) !== $series_master_id ) {
+				return new WP_Error(
+					'invalid_occurrence',
+					__( 'One of the selected occurrences is not valid for this ticket.', 'fair-events' ),
+					array( 'status' => 400 )
+				);
+			}
+			$occurrences[] = $occ;
+		}
+
+		$minimum_instances = max( 1, (int) $ticket_type->minimum_instances );
+		if ( count( $occurrences ) < $minimum_instances ) {
+			return new WP_Error(
+				'minimum_instances_not_met',
+				sprintf(
+					/* translators: %d: minimum number of occurrences required */
+					_n(
+						'Please select at least %d occurrence.',
+						'Please select at least %d occurrences.',
+						$minimum_instances,
+						'fair-events'
+					),
+					$minimum_instances
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Resolve the per-instance price from the active sale period (server-side; client amount is ignored).
+		$unit_price = 0.0;
+		if ( class_exists( \FairEvents\Models\TicketSalePeriod::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
+			$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $series_page_id );
+			$now          = current_time( 'mysql' );
+			foreach ( $sale_periods as $period ) {
+				if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
+					$prices = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $series_page_id );
+					foreach ( $prices as $price ) {
+						if ( (int) $price->ticket_type_id === (int) $ticket_type->id
+							&& (int) $price->sale_period_id === (int) $period->id ) {
+							$unit_price = (float) $price->price;
+							break 2;
+						}
+					}
+					break;
+				}
+			}
+		}
+
+		$count        = count( $occurrences );
+		$total_amount = $unit_price * $count;
+
+		// Persist one signup row per chosen occurrence (quantity fixed at 1;
+		// instance count is the only multiplier for this scope).
+		$signup_ids = array();
+		foreach ( $occurrences as $occ ) {
+			$signup_id = \FairEvents\Models\EventSignup::save(
+				array(
+					'event_date_id'  => (int) $occ->id,
+					'ticket_type_id' => $ticket_type->id,
+					'name'           => $name,
+					'email'          => $email,
+					'quantity'       => 1,
+					'mailing_opt_in' => $mailing_opt_in ? 1 : 0,
+					'amount'         => $unit_price,
+					'status'         => $total_amount > 0 ? 'pending_payment' : 'confirmed',
+				)
+			);
+			if ( ! $signup_id ) {
+				return new WP_Error(
+					'db_error',
+					__( 'Failed to save signup. Please try again.', 'fair-events' ),
+					array( 'status' => 500 )
+				);
+			}
+			$signup_ids[] = (int) $signup_id;
+		}
+
+		// Free path.
+		if ( $total_amount <= 0 ) {
+			return rest_ensure_response(
+				array(
+					'status'  => 'confirmed',
+					'message' => __( 'You have successfully registered!', 'fair-events' ),
+				)
+			);
+		}
+
+		// Paid path — fall back to confirmed if payment connector is absent.
+		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
+			foreach ( $signup_ids as $signup_id ) {
+				\FairEvents\Models\EventSignup::update_status( $signup_id, 'confirmed' );
+			}
+			return rest_ensure_response(
+				array(
+					'status'  => 'confirmed',
+					'message' => __( 'You have successfully registered!', 'fair-events' ),
+				)
+			);
+		}
+
+		$currency    = get_option( 'fair_payment_currency', 'EUR' );
+		$description = sprintf(
+			/* translators: %d: event date ID */
+			__( 'Tickets for event #%d', 'fair-events' ),
+			$series_master_id
+		);
+
+		$line_items = array();
+		foreach ( $occurrences as $occ ) {
+			$occ_label    = class_exists( \FairEvents\Helpers\DateRangeFormatter::class )
+				? \FairEvents\Helpers\DateRangeFormatter::format( $occ->start_datetime, $occ->end_datetime, (bool) $occ->all_day )
+				: $occ->start_datetime;
+			$line_items[] = array(
+				'name'     => sprintf(
+					/* translators: %s: occurrence date/time label */
+					__( 'Ticket for %s', 'fair-events' ),
+					$occ_label
+				),
+				'quantity' => 1,
+				'amount'   => $unit_price,
+			);
+		}
+
+		$user_id        = get_current_user_id();
+		$transaction_id = \FairPaymentsConnector\API\TransactionAPI::create_transaction(
+			$line_items,
+			array(
+				'currency'      => $currency,
+				'description'   => $description,
+				'event_date_id' => $series_master_id,
+				'user_id'       => $user_id ?: null,
+				'metadata'      => array(
+					'source'        => 'fair-events-get-tickets',
+					'event_date_id' => $series_master_id,
+					'signup_ids'    => $signup_ids,
+				),
+			)
+		);
+
+		if ( is_wp_error( $transaction_id ) ) {
+			return $transaction_id;
+		}
+
+		foreach ( $signup_ids as $signup_id ) {
+			\FairEvents\Models\EventSignup::update_transaction( $signup_id, (int) $transaction_id );
+		}
+
+		$transaction = \FairPaymentsConnector\Models\Transaction::get_by_id( $transaction_id );
+
+		$redirect_url = add_query_arg(
+			array(
+				'fair_payment_callback' => 'true',
+				'transaction_id'        => $transaction_id,
+				'token'                 => $transaction ? $transaction->access_token : '',
+			),
+			get_permalink() ?: home_url( '/' )
+		);
+
+		$payment = \FairPaymentsConnector\API\TransactionAPI::initiate_payment(
+			$transaction_id,
+			array( 'redirect_url' => $redirect_url )
+		);
+
+		if ( is_wp_error( $payment ) ) {
+			return $payment;
+		}
+
+		return rest_ensure_response(
+			array(
+				'status'         => 'payment_required',
+				'checkout_url'   => esc_url_raw( $payment['checkout_url'] ),
+				'transaction_id' => $transaction_id,
+				'amount'         => $total_amount,
+				'currency'       => $currency,
+			)
+		);
+	}
+
+	/**
+	 * Resolve the recurring-series master event_date_id for a given event
+	 * date row: itself when it's already the master, or its master_id when
+	 * it's a generated occurrence. Null when the row isn't part of a series.
+	 *
+	 * @param int $event_date_id Event-date ID (master or generated occurrence).
+	 * @return int|null Master event_date_id, or null when not resolvable.
+	 */
+	private function resolve_master_event_date_id( $event_date_id ) {
+		if ( ! $event_date_id || ! class_exists( \FairEvents\Models\EventDates::class ) ) {
+			return null;
+		}
+		$ed = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+		if ( ! $ed ) {
+			return null;
+		}
+		if ( 'generated' === $ed->occurrence_type && $ed->master_id ) {
+			return (int) $ed->master_id;
+		}
+		if ( 'master' === $ed->occurrence_type ) {
+			return (int) $ed->id;
+		}
+		return null;
 	}
 
 	/**

--- a/fair-events/src/API/TicketsController.php
+++ b/fair-events/src/API/TicketsController.php
@@ -348,8 +348,9 @@ class TicketsController extends WP_REST_Controller {
 			$recurrence_scope   = in_array( $item['recurrence_scope'] ?? '', TicketType::RECURRENCE_SCOPES, true )
 				? $item['recurrence_scope']
 				: 'single_instance';
+			$minimum_instances  = isset( $item['minimum_instances'] ) ? absint( $item['minimum_instances'] ) : 0;
 
-			$new_id = TicketType::create( $event_date_id, $name, $capacity, $index, $seats_per_ticket, $invitation_only, $minimum_activities, $disable_at, $recurrence_scope );
+			$new_id = TicketType::create( $event_date_id, $name, $capacity, $index, $seats_per_ticket, $invitation_only, $minimum_activities, $disable_at, $recurrence_scope, false, $minimum_instances );
 			if ( $new_id ) {
 				$type_ids_by_index[ $index ] = (int) $new_id;
 
@@ -527,6 +528,7 @@ class TicketsController extends WP_REST_Controller {
 			$recurrence_scope   = in_array( $item['recurrence_scope'] ?? '', TicketType::RECURRENCE_SCOPES, true )
 				? $item['recurrence_scope']
 				: 'single_instance';
+			$minimum_instances  = isset( $item['minimum_instances'] ) ? absint( $item['minimum_instances'] ) : 0;
 			$sort_order         = $index;
 			$group_ids          = isset( $item['group_ids'] ) && is_array( $item['group_ids'] ) ? array_map( 'absint', $item['group_ids'] ) : array();
 
@@ -541,6 +543,7 @@ class TicketsController extends WP_REST_Controller {
 					'seats_per_ticket'   => $seats_per_ticket,
 					'invitation_only'    => $invitation_only,
 					'minimum_activities' => $minimum_activities,
+					'minimum_instances'  => $minimum_instances,
 					'disable_at'         => $disable_at,
 					'disabled'           => ! empty( $item['disabled'] ),
 					'sort_order'         => $sort_order,
@@ -553,7 +556,7 @@ class TicketsController extends WP_REST_Controller {
 					\FairEventsExperimental\Models\TicketTypeGroupRestriction::sync_for_ticket_type( (int) $item['id'], $group_ids );
 				}
 			} else {
-				$new_id           = TicketType::create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket, $invitation_only, $minimum_activities, $disable_at, $recurrence_scope );
+				$new_id           = TicketType::create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket, $invitation_only, $minimum_activities, $disable_at, $recurrence_scope, false, $minimum_instances );
 				$id_map[ $index ] = (int) $new_id;
 				if ( $new_id && ! empty( $group_ids ) && class_exists( \FairEventsExperimental\Models\TicketTypeGroupRestriction::class ) ) {
 					\FairEventsExperimental\Models\TicketTypeGroupRestriction::sync_for_ticket_type( (int) $new_id, $group_ids );

--- a/fair-events/src/API/__tests__/GetTicketsMultipleInstances.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsMultipleInstances.api.spec.js
@@ -1,0 +1,197 @@
+/**
+ * Playwright API tests for the get-tickets fallback endpoint's
+ * 'multiple_instances' ticket-type support (#930).
+ *
+ * This endpoint only serves signups when fair-audience is NOT active
+ * (fair-events/src/blocks/get-tickets/render.php defers to the Event Signup
+ * block otherwise), so these tests skip gracefully when fair-audience is
+ * active in the test environment.
+ *
+ * Covers:
+ *   - below the ticket type's configured minimum_instances is rejected.
+ *   - an occurrence outside the ticket type's own series is rejected.
+ *   - a valid selection creates one confirmed EventSignup row per occurrence,
+ *     each priced at the per-instance price (quantity fixed at 1).
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('GetTicketsController — multiple_instances signup', () => {
+	let api;
+	let fairAudienceActive = false;
+	let eventPostId;
+	let masterEventDateId;
+	let occurrenceIds;
+	let ticketTypeId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		// Detect whether fair-audience is active — the get-tickets block (and
+		// this controller's public behaviour) is a no-op fallback when it is.
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+		if (fairAudienceActive) {
+			return;
+		}
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Get-tickets multi-instance test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2035-05-01 10:00:00',
+				end_datetime: '2035-05-01 12:00:00',
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		masterEventDateId = (await edRes.json()).id;
+
+		const occRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
+			{ headers: adminHeaders }
+		);
+		expect(occRes.ok()).toBeTruthy();
+		occurrenceIds = (await occRes.json()).map((o) => o.id).sort();
+		expect(occurrenceIds.length).toBe(3);
+
+		const ticketsRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'Pick your sessions',
+							capacity: null,
+							seats_per_ticket: 1,
+							invitation_only: false,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'multiple_instances',
+							minimum_instances: 2,
+							group_ids: [],
+						},
+					],
+					sale_periods: [],
+					prices: [],
+					settings: {},
+				},
+			}
+		);
+		expect(ticketsRes.ok()).toBeTruthy();
+		const ticketsBody = await ticketsRes.json();
+		ticketTypeId = ticketsBody.ticket_types?.[0]?.id;
+		expect(ticketTypeId).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (fairAudienceActive) {
+			return;
+		}
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+		await api.dispose();
+	});
+
+	test('below the configured minimum is rejected', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: masterEventDateId,
+				name: 'Below Minimum Tester',
+				email: `below-min-${Date.now()}@example.test`,
+				ticket_type_id: ticketTypeId,
+				event_date_ids: [occurrenceIds[0]],
+			},
+		});
+		expect(res.status()).toBe(400);
+		const body = await res.json();
+		expect(body.code).toBe('minimum_instances_not_met');
+	});
+
+	test("an occurrence outside the ticket type's series is rejected", async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: masterEventDateId,
+				name: 'Foreign Occurrence Tester',
+				email: `foreign-occ-${Date.now()}@example.test`,
+				ticket_type_id: ticketTypeId,
+				// Not a real event-date id — must not be accepted as valid.
+				event_date_ids: [occurrenceIds[0], 999999999],
+			},
+		});
+		expect(res.status()).toBe(400);
+		const body = await res.json();
+		expect(body.code).toBe('invalid_occurrence');
+	});
+
+	test('a valid selection creates one signup row per chosen occurrence', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const chosen = [occurrenceIds[0], occurrenceIds[1]];
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: masterEventDateId,
+				name: 'Valid Multi Tester',
+				email: `valid-multi-${Date.now()}@example.test`,
+				ticket_type_id: ticketTypeId,
+				event_date_ids: chosen,
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		// Free ticket type (no sale period configured) — confirmed immediately.
+		expect(body.status).toBe('confirmed');
+
+		for (const occId of chosen) {
+			const signupsRes = await api.get(
+				'/wp-json/fair-events/v1/get-tickets',
+				{
+					headers: adminHeaders,
+					params: { event_date: occId },
+				}
+			);
+			expect(signupsRes.ok()).toBeTruthy();
+			const signups = await signupsRes.json();
+			expect(
+				signups.some((s) => s.ticket_type_id === ticketTypeId)
+			).toBeTruthy();
+		}
+	});
+});

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -355,6 +355,7 @@ export default function EventTickets({
 				minimum_activities: t.minimum_activities || 0,
 				disable_at: t.disable_at || null,
 				recurrence_scope: t.recurrence_scope || 'single_instance',
+				minimum_instances: t.minimum_instances || 0,
 				group_ids: t.group_ids || [],
 			})),
 			sale_periods: getEffectiveSalePeriods().map((p) => ({
@@ -490,6 +491,7 @@ export default function EventTickets({
 				minimum_activities: 0,
 				disable_at: null,
 				recurrence_scope: scope,
+				minimum_instances: 0,
 				group_ids: [],
 				sort_order: ticketTypes.length,
 			},
@@ -934,6 +936,12 @@ export default function EventTickets({
 														'whole_series'
 															? __(
 																	'Whole series',
+																	'fair-events'
+															  )
+															: type.recurrence_scope ===
+															  'multiple_instances'
+															? __(
+																	'Multiple instances',
 																	'fair-events'
 															  )
 															: __(
@@ -1679,44 +1687,96 @@ export default function EventTickets({
 																				'Whole series',
 																				'fair-events'
 																		  )
+																		: type.recurrence_scope ===
+																		  'multiple_instances'
+																		? __(
+																				'Multiple instances',
+																				'fair-events'
+																		  )
 																		: __(
 																				'This instance',
 																				'fair-events'
 																		  )}
 																</span>
 															) : (
-																<SelectControl
-																	value={
-																		type.recurrence_scope ||
-																		'single_instance'
-																	}
-																	options={[
-																		{
-																			value: 'single_instance',
-																			label: __(
-																				'This instance',
-																				'fair-events'
-																			),
-																		},
-																		{
-																			value: 'whole_series',
-																			label: __(
-																				'Whole series',
-																				'fair-events'
-																			),
-																		},
-																	]}
-																	onChange={(
-																		v
-																	) =>
-																		updateTicketType(
-																			tIndex,
-																			'recurrence_scope',
+																<>
+																	<SelectControl
+																		value={
+																			type.recurrence_scope ||
+																			'single_instance'
+																		}
+																		options={[
+																			{
+																				value: 'single_instance',
+																				label: __(
+																					'This instance',
+																					'fair-events'
+																				),
+																			},
+																			{
+																				value: 'whole_series',
+																				label: __(
+																					'Whole series',
+																					'fair-events'
+																				),
+																			},
+																			{
+																				value: 'multiple_instances',
+																				label: __(
+																					'Multiple instances',
+																					'fair-events'
+																				),
+																			},
+																		]}
+																		onChange={(
 																			v
-																		)
-																	}
-																	__nextHasNoMarginBottom
-																/>
+																		) =>
+																			updateTicketType(
+																				tIndex,
+																				'recurrence_scope',
+																				v
+																			)
+																		}
+																		__nextHasNoMarginBottom
+																	/>
+																	{type.recurrence_scope ===
+																		'multiple_instances' && (
+																		<TextControl
+																			type="number"
+																			min="0"
+																			placeholder="0"
+																			label={__(
+																				'Minimum instances',
+																				'fair-events'
+																			)}
+																			value={String(
+																				type.minimum_instances ||
+																					0
+																			)}
+																			onChange={(
+																				v
+																			) =>
+																				updateTicketType(
+																					tIndex,
+																					'minimum_instances',
+																					v !==
+																						''
+																						? Math.max(
+																								0,
+																								parseInt(
+																									v,
+																									10
+																								) ||
+																									0
+																						  )
+																						: 0
+																				)
+																			}
+																			__next40pxDefaultSize
+																			__nextHasNoMarginBottom
+																		/>
+																	)}
+																</>
 															)}
 														</td>
 													)}
@@ -2540,6 +2600,13 @@ export default function EventTickets({
 								value: 'whole_series',
 								label: __(
 									'Whole series — one purchase covers every occurrence',
+									'fair-events'
+								),
+							},
+							{
+								value: 'multiple_instances',
+								label: __(
+									'Multiple instances — buyer picks several occurrences',
 									'fair-events'
 								),
 							},

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -248,6 +248,100 @@ describe('EventTickets — recurrence scope selector', () => {
 	});
 });
 
+describe('EventTickets — multiple_instances scope (#930)', () => {
+	it('offers multiple_instances as a scope option', () => {
+		renderTickets({
+			isRecurring: true,
+			initialData: initialDataWithTicketType,
+		});
+		openEditTicketsPanel();
+
+		const selects = screen.getAllByRole('combobox');
+		const scopeSelect = selects.find(
+			(el) =>
+				el.value === 'single_instance' || el.value === 'whole_series'
+		);
+		const optionValues = Array.from(scopeSelect.options).map(
+			(o) => o.value
+		);
+		expect(optionValues).toContain('multiple_instances');
+		// Acknowledge the WordPress SelectControl size deprecation notice —
+		// only fires the first time it renders in the suite (deduped globally),
+		// so only assert when this test actually triggered it.
+		if (console.warn.mock.calls.length > 0) {
+			expect(console).toHaveWarned();
+		}
+	});
+
+	it('shows a "Minimum instances" input once multiple_instances is selected', () => {
+		renderTickets({
+			isRecurring: true,
+			initialData: initialDataWithTicketType,
+		});
+		openEditTicketsPanel();
+
+		const selects = screen.getAllByRole('combobox');
+		const scopeSelect = selects.find(
+			(el) =>
+				el.value === 'single_instance' || el.value === 'whole_series'
+		);
+
+		expect(
+			screen.queryByLabelText(/Minimum instances/i)
+		).not.toBeInTheDocument();
+
+		fireEvent.change(scopeSelect, {
+			target: { value: 'multiple_instances' },
+		});
+
+		expect(scopeSelect.value).toBe('multiple_instances');
+		expect(screen.getByLabelText(/Minimum instances/i)).toBeInTheDocument();
+	});
+
+	it('save payload includes the entered minimum_instances', async () => {
+		const { onSaveRef } = renderTickets({
+			isRecurring: true,
+			initialData: initialDataWithTicketType,
+		});
+		openEditTicketsPanel();
+
+		const selects = screen.getAllByRole('combobox');
+		const scopeSelect = selects.find(
+			(el) =>
+				el.value === 'single_instance' || el.value === 'whole_series'
+		);
+		fireEvent.change(scopeSelect, {
+			target: { value: 'multiple_instances' },
+		});
+
+		const minInstancesInput = screen.getByLabelText(/Minimum instances/i);
+		fireEvent.change(minInstancesInput, { target: { value: '3' } });
+
+		let savedPayload = null;
+		apiFetch.mockImplementation(({ method, data }) => {
+			if (method === 'PUT') {
+				savedPayload = data;
+				return Promise.resolve({
+					...initialDataWithTicketType,
+					ticket_types: [],
+				});
+			}
+			return new Promise(() => {});
+		});
+
+		expect(onSaveRef.current).not.toBeNull();
+		await act(async () => {
+			await onSaveRef.current();
+		});
+
+		expect(savedPayload).not.toBeNull();
+		const savedType = savedPayload.ticket_types?.[0];
+		expect(savedType).toBeTruthy();
+		expect(savedType.recurrence_scope).toBe('multiple_instances');
+		expect(savedType.minimum_instances).toBe(3);
+	});
+});
+
 describe('EventTickets — scope-choice modal', () => {
 	it('opens a modal when "+ Add Ticket Type" is clicked on a recurring event', () => {
 		renderTickets({

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -260,6 +260,11 @@ class Installer {
 			self::migrate_to_3_19_0();
 		}
 
+		// Run migration if upgrading from pre-3.20.0 (add multiple_instances scope + minimum_instances to ticket_types).
+		if ( version_compare( $current_version, '3.20.0', '<' ) ) {
+			self::migrate_to_3_20_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -406,6 +411,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.19.0', '<' ) ) {
 				self::migrate_to_3_19_0();
+			}
+
+			if ( version_compare( $current_version, '3.20.0', '<' ) ) {
+				self::migrate_to_3_20_0();
 			}
 
 			// Install/update tables
@@ -1654,6 +1663,45 @@ class Installer {
 		$wpdb->query(
 			$wpdb->prepare(
 				"UPDATE %i SET recurrence_anchor = DATE(start_datetime) WHERE recurrence_anchor IS NULL AND occurrence_type IN ('master', 'generated')",
+				$table_name
+			)
+		);
+	}
+
+	/**
+	 * Migrate to version 3.20.0 - Add multiple_instances recurrence scope + minimum_instances column.
+	 *
+	 * Widens the recurrence_scope ENUM to allow 'multiple_instances' and adds the
+	 * minimum_instances column that stores the required occurrence count for that scope.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_20_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_events_ticket_types';
+
+		$column_exists = $wpdb->get_results(
+			$wpdb->prepare(
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( 'minimum_instances' )
+			)
+		);
+
+		if ( empty( $column_exists ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD COLUMN minimum_instances INT UNSIGNED NOT NULL DEFAULT 0 AFTER recurrence_scope',
+					$table_name
+				)
+			);
+		}
+
+		// Widen the ENUM to include 'multiple_instances'; idempotent, safe to re-run.
+		$wpdb->query(
+			$wpdb->prepare(
+				"ALTER TABLE %i MODIFY COLUMN recurrence_scope ENUM('single_instance','whole_series','multiple_instances') NOT NULL DEFAULT 'single_instance'",
 				$table_name
 			)
 		);

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.19.0';
+	const DB_VERSION = '3.20.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -256,7 +256,8 @@ class Schema {
 			invitation_only TINYINT(1) NOT NULL DEFAULT 0,
 			minimum_activities INT UNSIGNED NOT NULL DEFAULT 0,
 			disable_at DATETIME DEFAULT NULL,
-			recurrence_scope ENUM('single_instance','whole_series') NOT NULL DEFAULT 'single_instance',
+			recurrence_scope ENUM('single_instance','whole_series','multiple_instances') NOT NULL DEFAULT 'single_instance',
+			minimum_instances INT UNSIGNED NOT NULL DEFAULT 0,
 			disabled TINYINT(1) NOT NULL DEFAULT 0,
 			sort_order INT UNSIGNED NOT NULL DEFAULT 0,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/fair-events/src/Hooks/PaymentHooks.php
+++ b/fair-events/src/Hooks/PaymentHooks.php
@@ -33,29 +33,32 @@ class PaymentHooks {
 	}
 
 	/**
-	 * On payment paid: flip matching get-tickets signup to confirmed.
+	 * On payment paid: flip matching get-tickets signup(s) to confirmed.
+	 *
+	 * A 'multiple_instances' ticket-type purchase creates one signup row per
+	 * chosen occurrence under a single transaction; every other purchase
+	 * creates exactly one row, so resolve_signup_ids() always returns at
+	 * least the single-row case.
 	 *
 	 * @param object $payment     Payment object from fair-payments-connector.
 	 * @param object $transaction Transaction object from fair-payments-connector.
 	 * @return void
 	 */
 	public static function handle_payment_paid( $payment, $transaction ) {
-		$signup_id = self::resolve_signup_id( $transaction );
-		if ( $signup_id ) {
+		foreach ( self::resolve_signup_ids( $transaction ) as $signup_id ) {
 			\FairEvents\Models\EventSignup::update_status( $signup_id, 'confirmed' );
 		}
 	}
 
 	/**
-	 * On payment failed/canceled: mark the signup as failed.
+	 * On payment failed/canceled: mark the signup(s) as failed.
 	 *
 	 * @param object $payment     Payment object from fair-payments-connector.
 	 * @param object $transaction Transaction object from fair-payments-connector.
 	 * @return void
 	 */
 	public static function handle_payment_failed( $payment, $transaction ) {
-		$signup_id = self::resolve_signup_id( $transaction );
-		if ( $signup_id ) {
+		foreach ( self::resolve_signup_ids( $transaction ) as $signup_id ) {
 			\FairEvents\Models\EventSignup::update_status( $signup_id, 'failed' );
 		}
 	}
@@ -70,14 +73,15 @@ class PaymentHooks {
 	}
 
 	/**
-	 * Resolve the signup ID from a transaction, returning 0 if not a get-tickets transaction.
+	 * Resolve the signup ID(s) from a transaction, returning an empty array
+	 * if not a get-tickets transaction.
 	 *
 	 * @param object $transaction Transaction object.
-	 * @return int Signup ID or 0.
+	 * @return int[] Signup IDs (empty when none apply).
 	 */
-	private static function resolve_signup_id( $transaction ) {
+	private static function resolve_signup_ids( $transaction ) {
 		if ( ! isset( $transaction->metadata ) ) {
-			return 0;
+			return array();
 		}
 
 		$metadata = is_string( $transaction->metadata )
@@ -85,15 +89,20 @@ class PaymentHooks {
 			: (array) $transaction->metadata;
 
 		if ( ( $metadata['source'] ?? '' ) !== 'fair-events-get-tickets' ) {
-			return 0;
+			return array();
+		}
+
+		// 'multiple_instances' purchases store one signup row ID per chosen occurrence.
+		if ( ! empty( $metadata['signup_ids'] ) && is_array( $metadata['signup_ids'] ) ) {
+			return array_map( 'intval', $metadata['signup_ids'] );
 		}
 
 		if ( ! empty( $metadata['signup_id'] ) ) {
-			return (int) $metadata['signup_id'];
+			return array( (int) $metadata['signup_id'] );
 		}
 
 		// Fall back to lookup by transaction_id.
 		$signup = \FairEvents\Models\EventSignup::get_by_transaction_id( (int) $transaction->id );
-		return $signup ? (int) $signup->id : 0;
+		return $signup ? array( (int) $signup->id ) : array();
 	}
 }

--- a/fair-events/src/Models/TicketType.php
+++ b/fair-events/src/Models/TicketType.php
@@ -76,11 +76,18 @@ class TicketType {
 	public $disable_at;
 
 	/**
-	 * Whether this ticket type covers a single occurrence or the whole recurring series
+	 * Whether this ticket type covers a single occurrence, the whole recurring series, or a buyer-chosen subset
 	 *
-	 * @var string 'single_instance'|'whole_series'
+	 * @var string 'single_instance'|'whole_series'|'multiple_instances'
 	 */
 	public $recurrence_scope = 'single_instance';
+
+	/**
+	 * Minimum number of occurrences a buyer must choose when recurrence_scope is 'multiple_instances'.
+	 *
+	 * @var int
+	 */
+	public $minimum_instances = 0;
 
 	/**
 	 * Whether this ticket type has been manually disabled by an admin
@@ -180,7 +187,7 @@ class TicketType {
 	/**
 	 * Valid values for the recurrence_scope column.
 	 */
-	const RECURRENCE_SCOPES = array( 'single_instance', 'whole_series' );
+	const RECURRENCE_SCOPES = array( 'single_instance', 'whole_series', 'multiple_instances' );
 
 	/**
 	 * Create a new ticket type
@@ -193,11 +200,12 @@ class TicketType {
 	 * @param bool        $invitation_only    Whether this ticket requires an invitation token.
 	 * @param int         $minimum_activities Minimum activities this type requires (0 = inherit global).
 	 * @param string|null $disable_at         Date/time after which this ticket type is unavailable (null = no end date).
-	 * @param string      $recurrence_scope   'single_instance' or 'whole_series'.
+	 * @param string      $recurrence_scope   'single_instance', 'whole_series', or 'multiple_instances'.
 	 * @param bool        $disabled           Whether this ticket type is manually disabled.
+	 * @param int         $minimum_instances  Minimum occurrences a buyer must choose when scope is 'multiple_instances'.
 	 * @return int|false The ticket type ID on success, false on failure.
 	 */
-	public static function create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket = 1, $invitation_only = false, $minimum_activities = 0, $disable_at = null, $recurrence_scope = 'single_instance', $disabled = false ) {
+	public static function create( $event_date_id, $name, $capacity, $sort_order, $seats_per_ticket = 1, $invitation_only = false, $minimum_activities = 0, $disable_at = null, $recurrence_scope = 'single_instance', $disabled = false, $minimum_instances = 0 ) {
 		global $wpdb;
 
 		$table_name = self::get_table_name();
@@ -217,10 +225,11 @@ class TicketType {
 				'minimum_activities' => max( 0, (int) $minimum_activities ),
 				'disable_at'         => $disable_at,
 				'recurrence_scope'   => $recurrence_scope,
+				'minimum_instances'  => max( 0, (int) $minimum_instances ),
 				'disabled'           => $disabled ? 1 : 0,
 				'sort_order'         => $sort_order,
 			),
-			array( '%d', '%s', '%d', '%d', '%d', '%d', '%s', '%s', '%d', '%d' )
+			array( '%d', '%s', '%d', '%d', '%d', '%d', '%s', '%s', '%d', '%d', '%d' )
 		);
 
 		if ( $result ) {
@@ -281,6 +290,11 @@ class TicketType {
 				: 'single_instance';
 			$update_data['recurrence_scope'] = $scope;
 			$update_format[]                 = '%s';
+		}
+
+		if ( array_key_exists( 'minimum_instances', $data ) ) {
+			$update_data['minimum_instances'] = max( 0, (int) $data['minimum_instances'] );
+			$update_format[]                  = '%d';
 		}
 
 		if ( array_key_exists( 'disabled', $data ) ) {
@@ -366,6 +380,7 @@ class TicketType {
 		$item->disable_at         = $row->disable_at ?? null;
 		$raw_scope                = $row->recurrence_scope ?? 'single_instance';
 		$item->recurrence_scope   = in_array( $raw_scope, self::RECURRENCE_SCOPES, true ) ? $raw_scope : 'single_instance';
+		$item->minimum_instances  = isset( $row->minimum_instances ) ? (int) $row->minimum_instances : 0;
 		$item->disabled           = ! empty( $row->disabled );
 		$item->sort_order         = (int) $row->sort_order;
 		$item->created_at         = $row->created_at;
@@ -384,6 +399,15 @@ class TicketType {
 	}
 
 	/**
+	 * Whether this ticket type lets a buyer choose a subset of occurrences.
+	 *
+	 * @return bool
+	 */
+	public function is_multiple_instances() {
+		return 'multiple_instances' === $this->recurrence_scope;
+	}
+
+	/**
 	 * Convert to array
 	 *
 	 * @return array Data as array.
@@ -399,6 +423,7 @@ class TicketType {
 			'minimum_activities' => $this->minimum_activities,
 			'disable_at'         => $this->disable_at,
 			'recurrence_scope'   => $this->recurrence_scope,
+			'minimum_instances'  => $this->minimum_instances,
 			'disabled'           => (bool) $this->disabled,
 			'sort_order'         => $this->sort_order,
 			'created_at'         => $this->created_at,

--- a/fair-events/src/blocks/get-tickets/frontend.js
+++ b/fair-events/src/blocks/get-tickets/frontend.js
@@ -4,7 +4,7 @@
  * @package FairEvents
  */
 
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	showMessage,
 	onDomReady,
@@ -70,6 +70,131 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 			const data = collectFormData(form);
 			submitForm(form, data);
 		});
+
+		const ticketTypeField = form.querySelector(
+			'select[name="ticket_type_id"]'
+		);
+		if (ticketTypeField) {
+			ticketTypeField.addEventListener('change', function () {
+				updateInstancePicker(form);
+			});
+		}
+
+		const instancePicker = form.querySelector(
+			'.fair-events-instance-picker'
+		);
+		if (instancePicker) {
+			instancePicker
+				.querySelectorAll('input[name="event_date_ids[]"]')
+				.forEach(function (checkbox) {
+					checkbox.addEventListener('change', function () {
+						updateInstancePicker(form);
+					});
+				});
+		}
+
+		updateInstancePicker(form);
+	}
+
+	/**
+	 * Selected <option> of the ticket type <select>, if any.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 * @return {HTMLOptionElement|null} The selected option element.
+	 */
+	function getSelectedTicketTypeOption(form) {
+		const select = form.querySelector('select[name="ticket_type_id"]');
+		if (!select || !select.value) {
+			return null;
+		}
+		return select.options[select.selectedIndex] || null;
+	}
+
+	/**
+	 * Whether the selected ticket type is a 'multiple_instances' scope pass.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 * @return {boolean} True when the multi-occurrence checkbox picker applies.
+	 */
+	function isMultipleInstancesSelected(form) {
+		const option = getSelectedTicketTypeOption(form);
+		return (
+			!!option && option.dataset.recurrenceScope === 'multiple_instances'
+		);
+	}
+
+	/**
+	 * Toggle the multi-occurrence checkbox picker (and hide the quantity field,
+	 * since v1 fixes quantity to 1 for this scope — instance count is the only
+	 * multiplier) based on the selected ticket type, and keep the minimum hint
+	 * and live total in sync.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 */
+	function updateInstancePicker(form) {
+		const instancePicker = form.querySelector(
+			'.fair-events-instance-picker'
+		);
+		const quantityRow = form.querySelector('.fair-events-quantity-row');
+		const quantityField = form.querySelector('input[name="quantity"]');
+		if (!instancePicker) {
+			return;
+		}
+
+		const active = isMultipleInstancesSelected(form);
+		instancePicker.style.display = active ? '' : 'none';
+		if (quantityRow) {
+			quantityRow.style.display = active ? 'none' : '';
+		}
+		if (active && quantityField) {
+			quantityField.value = '1';
+		}
+
+		if (!active) {
+			instancePicker
+				.querySelectorAll('input[type="checkbox"]')
+				.forEach(function (cb) {
+					cb.checked = false;
+				});
+			return;
+		}
+
+		const option = getSelectedTicketTypeOption(form);
+		const min = parseInt(option.dataset.minInstances || '0', 10);
+		const price = parseFloat(option.dataset.ticketPrice || 0);
+		const checked = instancePicker.querySelectorAll(
+			'input[name="event_date_ids[]"]:checked'
+		).length;
+
+		const hint = instancePicker.querySelector(
+			'.fair-events-instance-picker-hint'
+		);
+		if (hint) {
+			hint.textContent =
+				min > 0
+					? sprintf(
+							/* translators: %d: minimum number of occurrences required */
+							_n(
+								'Please select at least %d occurrence.',
+								'Please select at least %d occurrences.',
+								min,
+								'fair-events'
+							),
+							min
+					  )
+					: '';
+		}
+
+		const totalEl = instancePicker.querySelector(
+			'.fair-events-instance-picker-total'
+		);
+		if (totalEl) {
+			totalEl.textContent =
+				checked > 0
+					? sprintf(
+							/* translators: %s: formatted total price */
+							__('Total: €%s', 'fair-events'),
+							(price * checked).toFixed(2)
+					  )
+					: '';
+		}
 	}
 
 	function validateForm(form) {
@@ -113,17 +238,46 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 			}
 		}
 
-		const quantityField = form.querySelector('input[name="quantity"]');
-		if (quantityField) {
-			const qty = parseInt(quantityField.value, 10);
-			if (isNaN(qty) || qty < 1 || qty > 10) {
+		if (isMultipleInstancesSelected(form)) {
+			const option = getSelectedTicketTypeOption(form);
+			const min = Math.max(
+				1,
+				parseInt(option.dataset.minInstances || '0', 10)
+			);
+			const checked = form.querySelectorAll(
+				'input[name="event_date_ids[]"]:checked'
+			).length;
+			if (checked < min) {
 				showMessage(
 					messageContainer,
-					__('Quantity must be between 1 and 10.', 'fair-events'),
+					sprintf(
+						/* translators: %d: minimum number of occurrences required */
+						_n(
+							'Please select at least %d occurrence.',
+							'Please select at least %d occurrences.',
+							min,
+							'fair-events'
+						),
+						min
+					),
 					'error',
 					CSS_PREFIX
 				);
 				return false;
+			}
+		} else {
+			const quantityField = form.querySelector('input[name="quantity"]');
+			if (quantityField) {
+				const qty = parseInt(quantityField.value, 10);
+				if (isNaN(qty) || qty < 1 || qty > 10) {
+					showMessage(
+						messageContainer,
+						__('Quantity must be between 1 and 10.', 'fair-events'),
+						'error',
+						CSS_PREFIX
+					);
+					return false;
+				}
 			}
 		}
 
@@ -155,12 +309,22 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 			data.ticket_type_id = parseInt(ticketTypeField.value, 10);
 		}
 
-		const quantityField = form.querySelector('input[name="quantity"]');
-		if (quantityField) {
-			data.quantity = Math.max(
-				1,
-				Math.min(10, parseInt(quantityField.value, 10) || 1)
+		if (isMultipleInstancesSelected(form)) {
+			data.quantity = 1;
+			const instanceInputs = form.querySelectorAll(
+				'input[name="event_date_ids[]"]:checked'
 			);
+			data.event_date_ids = Array.from(instanceInputs).map((i) =>
+				parseInt(i.value, 10)
+			);
+		} else {
+			const quantityField = form.querySelector('input[name="quantity"]');
+			if (quantityField) {
+				data.quantity = Math.max(
+					1,
+					Math.min(10, parseInt(quantityField.value, 10) || 1)
+				);
+			}
 		}
 
 		const mailingField = form.querySelector('input[name="mailing_opt_in"]');

--- a/fair-events/src/blocks/get-tickets/render.php
+++ b/fair-events/src/blocks/get-tickets/render.php
@@ -71,6 +71,39 @@ if ( class_exists( \FairEvents\Models\TicketType::class ) ) {
 	$ticket_types = \FairEvents\Models\TicketType::get_all_by_event_date_id( $event_date_id );
 }
 
+// Resolve the series master (if any) so 'multiple_instances' ticket types can
+// offer a checkbox picker across the recurring series' upcoming occurrences.
+$series_master_id = null;
+if ( $event_date && class_exists( \FairEvents\Models\EventDates::class ) ) {
+	if ( 'master' === ( $event_date->occurrence_type ?? null ) ) {
+		$series_master_id = (int) $event_date->id;
+	} elseif ( 'generated' === ( $event_date->occurrence_type ?? null ) && ! empty( $event_date->master_id ) ) {
+		$series_master_id = (int) $event_date->master_id;
+	}
+}
+
+$has_multiple_instances_type = false;
+foreach ( $ticket_types as $ticket_type ) {
+	if ( $ticket_type->is_multiple_instances() ) {
+		$has_multiple_instances_type = true;
+		break;
+	}
+}
+
+$occurrences_for_picker = array();
+if ( $has_multiple_instances_type && $series_master_id && class_exists( \FairEvents\Models\EventDates::class ) ) {
+	$upcoming = \FairEvents\Models\EventDates::get_upcoming_by_master_id( $series_master_id );
+	foreach ( $upcoming as $occ ) {
+		$occurrences_for_picker[] = array(
+			'id'             => (int) $occ->id,
+			'start_datetime' => $occ->start_datetime,
+			'end_datetime'   => $occ->end_datetime,
+			'all_day'        => (bool) $occ->all_day,
+		);
+	}
+}
+$has_instance_picker = ! empty( $occurrences_for_picker );
+
 // Find active sale period and load prices.
 $price_by_type_id   = array();
 $active_sale_period = null;
@@ -172,7 +205,12 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 							$label .= ' — ' . esc_html__( 'No active sale period', 'fair-events' );
 						}
 						?>
-						<option value="<?php echo esc_attr( $type_id ); ?>">
+						<option
+							value="<?php echo esc_attr( $type_id ); ?>"
+							data-ticket-price="<?php echo esc_attr( null !== $type_price ? number_format( $type_price, 2, '.', '' ) : '' ); ?>"
+							data-recurrence-scope="<?php echo esc_attr( $ticket_type->recurrence_scope ); ?>"
+							data-min-instances="<?php echo esc_attr( (string) $ticket_type->minimum_instances ); ?>"
+						>
 							<?php echo esc_html( $label ); ?>
 						</option>
 					<?php endforeach; ?>
@@ -180,7 +218,35 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 			</div>
 		<?php endif; ?>
 
-		<div class="form-row">
+		<?php if ( $has_instance_picker ) : ?>
+			<div class="form-row fair-events-instance-picker" style="display: none;">
+				<span class="form-label"><?php esc_html_e( 'Choose occurrences', 'fair-events' ); ?></span>
+				<?php foreach ( $occurrences_for_picker as $occ_row ) : ?>
+					<?php
+					$occ_label   = \FairEvents\Helpers\DateRangeFormatter::format(
+						$occ_row['start_datetime'],
+						$occ_row['end_datetime'],
+						$occ_row['all_day']
+					);
+					$checkbox_id = esc_attr( $form_id ) . '-inst-' . (int) $occ_row['id'];
+					?>
+					<label class="fair-events-instance-option" for="<?php echo $checkbox_id; ?>">
+						<input
+							type="checkbox"
+							name="event_date_ids[]"
+							id="<?php echo $checkbox_id; ?>"
+							value="<?php echo (int) $occ_row['id']; ?>"
+							class="form-checkbox"
+						/>
+						<?php echo esc_html( $occ_label ); ?>
+					</label>
+				<?php endforeach; ?>
+				<p class="fair-events-instance-picker-hint"></p>
+				<p class="fair-events-instance-picker-total"></p>
+			</div>
+		<?php endif; ?>
+
+		<div class="form-row fair-events-quantity-row">
 			<label for="<?php echo esc_attr( $form_id ); ?>-quantity" class="form-label">
 				<?php esc_html_e( 'Quantity', 'fair-events' ); ?>
 			</label>


### PR DESCRIPTION
## Summary

Adds a third recurrence scope for ticket types on recurring events: `multiple_instances` ("pick N"). Buyers choose several specific occurrences of a series instead of one drop-in (`single_instance`) or the whole series (`whole_series`), pay a per-instance price, subject to a configurable minimum number of instances.

Implemented per the plan in #930's [implementation-plan comment](https://github.com/marcin-wosinek/fair-event-plugins/issues/930#issuecomment-4850655761), across both purchase surfaces (fair-audience's Event Signup block and the fair-events get-tickets fallback for sites without fair-audience).

- **Model & schema (fair-events):** `multiple_instances` added to `TicketType::RECURRENCE_SCOPES`, new `minimum_instances` column, DB migration `3.19.0 → 3.20.0`.
- **Admin UI:** `EventTickets.js` gets the new scope option plus a "Minimum instances" input.
- **Purchase UI (both blocks):** occurrence checkboxes (date + per-instance price, live total) replace the single-occurrence picker when a `multiple_instances` ticket type is selected. Already-signed-up occurrences are disabled in the fair-audience picker.
- **Backend (both controllers):** validates every submitted occurrence ID against the ticket type's own series, enforces the minimum server-side, recomputes price server-side (never trusts client amount), and creates one signup row per chosen occurrence — sharing a single payment transaction. `PaymentHooks` in both plugins now confirm/fail every row tied to that transaction, not just one.
- **Tests:** Playwright API coverage for below-minimum rejection, foreign-occurrence rejection, and one-row-per-occurrence creation on both endpoints; a Jest component test for the new admin scope option and its minimum-instances input.

## Test plan

- [x] `npm run format` / `npm run build` in `fair-events` and `fair-audience`
- [x] `npx jest` passes in both plugins (23/23 in `fair-events` EventTickets suite, full suites green)
- [x] `vendor/bin/phpcs` on all changed PHP files — no new violations (remaining findings are pre-existing style debt unrelated to this change)
- [ ] Playwright API specs (`EventSignupRecurrenceScope.api.spec.js`, `GetTicketsMultipleInstances.api.spec.js`) — require the docker-compose WP environment; not run in this session, please run before merge
- [ ] Manual click-through of both purchase surfaces on a recurring event

Closes #930
