### PR TITLE
Add sliding-scale (pay-what-you-can) event pricing

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -152,6 +152,10 @@ class EventSignupController extends WP_REST_Controller {
 							'type'  => 'array',
 							'items' => array( 'type' => 'integer' ),
 						),
+						'chosen_amount'         => array(
+							'type'     => 'number',
+							'required' => false,
+						),
 						// Chosen occurrence IDs for 'multiple_instances' ticket types.
 						// Capped so a crafted request can't force an unbounded number
 						// of line items / DB rows per submission.
@@ -346,6 +350,10 @@ class EventSignupController extends WP_REST_Controller {
 							'type'  => 'array',
 							'items' => array( 'type' => 'integer' ),
 						),
+						'chosen_amount'         => array(
+							'type'     => 'number',
+							'required' => false,
+						),
 						'name'                  => array(
 							'type'              => 'string',
 							'required'          => true,
@@ -533,6 +541,7 @@ class EventSignupController extends WP_REST_Controller {
 		$invitation_token  = $request->get_param( 'invitation_token' ) ?: '';
 		$user_id           = get_current_user_id();
 		$raw_option_ids    = $request->get_param( 'ticket_option_ids' ) ?: array();
+		$chosen_amount     = $request->get_param( 'chosen_amount' );
 
 		// Validate event exists.
 		$event = get_post( $event_id );
@@ -660,7 +669,7 @@ class EventSignupController extends WP_REST_Controller {
 			return $save_error;
 		}
 
-		$paid_response = $this->maybe_start_paid_signup( $event_id, $event_date_id, $participant, $existing, $user_id, $ticket_type_id, $option_items, $invitation_token );
+		$paid_response = $this->maybe_start_paid_signup( $event_id, $event_date_id, $participant, $existing, $user_id, $ticket_type_id, $option_items, $invitation_token, $chosen_amount );
 		if ( null !== $paid_response ) {
 			if ( ! is_wp_error( $paid_response ) ) {
 				AudienceSession::set( (int) $participant->id );
@@ -1782,9 +1791,10 @@ class EventSignupController extends WP_REST_Controller {
 	 * @param int|null                                   $ticket_type_id Selected ticket type ID, or null when not using ticket types.
 	 * @param array                                      $option_items     Selected TicketOption objects.
 	 * @param string                                     $invitation_token Optional invitation token presented by the buyer.
+	 * @param float|null                                 $chosen_amount    Buyer-chosen amount for a sliding-scale price, or null.
 	 * @return \WP_REST_Response|\WP_Error|null WP_REST_Response/WP_Error on paid path, null on free path.
 	 */
-	private function maybe_start_paid_signup( $event_id, $event_date_id, $participant, $existing, $user_id, $ticket_type_id = null, $option_items = array(), $invitation_token = '' ) {
+	private function maybe_start_paid_signup( $event_id, $event_date_id, $participant, $existing, $user_id, $ticket_type_id = null, $option_items = array(), $invitation_token = '', $chosen_amount = null ) {
 		$final_price      = null;
 		$seats_per_ticket = 1;
 		if ( $event_date_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
@@ -1796,6 +1806,11 @@ class EventSignupController extends WP_REST_Controller {
 						$seats_per_ticket = max( 1, (int) $ticket_type->seats_per_ticket );
 					}
 				}
+			} elseif ( \FairEventsExperimental\Services\EventSignupPricing::resolve_sliding_scale( $event_date_id ) ) {
+				// Sliding scale replaces the fixed base-price path; group discounts
+				// (resolve_price()) do not stack on a buyer-chosen amount. Never
+				// trust the client value — always re-clamp against stored [min, max].
+				$final_price = \FairEventsExperimental\Services\EventSignupPricing::clamp_chosen_amount( $event_date_id, $chosen_amount );
 			} else {
 				$final_price = \FairEventsExperimental\Services\EventSignupPricing::resolve_price( $event_date_id, $participant->id );
 			}
@@ -2543,6 +2558,7 @@ class EventSignupController extends WP_REST_Controller {
 		$ticket_type_id   = $request->get_param( 'ticket_type_id' ) ?: null;
 		$invitation_token = $request->get_param( 'invitation_token' ) ?: '';
 		$raw_option_ids   = $request->get_param( 'ticket_option_ids' ) ?: array();
+		$chosen_amount    = $request->get_param( 'chosen_amount' );
 
 		// Validate event exists.
 		$event = get_post( $event_id );
@@ -2742,7 +2758,7 @@ class EventSignupController extends WP_REST_Controller {
 			return $save_error;
 		}
 
-		$paid_response = $this->maybe_start_paid_signup( $event_id, $event_date_id, $participant, $existing, $wp_user_id, $ticket_type_id, $option_items, $invitation_token );
+		$paid_response = $this->maybe_start_paid_signup( $event_id, $event_date_id, $participant, $existing, $wp_user_id, $ticket_type_id, $option_items, $invitation_token, $chosen_amount );
 		if ( null !== $paid_response ) {
 			if ( $is_new_participant && ! is_wp_error( $paid_response ) ) {
 				AudienceSession::set( (int) $participant->id );

--- a/fair-audience/src/API/__tests__/EventSignupSlidingScale.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupSlidingScale.api.spec.js
@@ -1,0 +1,222 @@
+/**
+ * Playwright API tests for sliding-scale (pay-what-you-can) pricing (#932):
+ * TicketsController config validation (min <= suggested <= max, decimal
+ * round-trip) and the event-signup chosen_amount contract.
+ *
+ * The dev stack has no payment connector configured, so any event date with
+ * a positive suggested price returns 503 payment_unavailable on signup — a
+ * paid event must never slip through as free. To exercise the signup path
+ * itself we use an all-zero band (min = max = suggested = 0), which is the
+ * one sliding-scale configuration that resolves to the free path regardless
+ * of environment.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+async function createEventWithDates(api, title) {
+	const res = await api.post('/wp-json/wp/v2/fair_event', {
+		headers: authHeaders,
+		data: { title, status: 'publish' },
+	});
+	expect(res.ok()).toBeTruthy();
+	const eventId = (await res.json()).id;
+
+	const eventsRes = await api.get('/wp-json/fair-audience/v1/events', {
+		headers: authHeaders,
+		params: { per_page: 100 },
+	});
+	expect(eventsRes.ok()).toBeTruthy();
+	const match = (await eventsRes.json()).find((e) => e.event_id === eventId);
+	expect(match, 'event-date row for test event').toBeTruthy();
+	return { eventId, eventDateId: match.event_date_id };
+}
+
+async function deleteEvent(api, eventId) {
+	if (!eventId) return;
+	await api.delete(`/wp-json/wp/v2/fair_event/${eventId}`, {
+		headers: authHeaders,
+		params: { force: 'true' },
+	});
+}
+
+test.describe('Sliding-scale pricing — TicketsController config validation', () => {
+	let api;
+	let event;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+		event = await createEventWithDates(
+			api,
+			`Sliding Scale Config Test ${Date.now()}`
+		);
+	});
+
+	test.afterAll(async () => {
+		await deleteEvent(api, event?.eventId);
+		await api.dispose();
+	});
+
+	test('min <= suggested <= max is saved and round-trips as decimals', async () => {
+		const res = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${event.eventDateId}/tickets`,
+			{
+				headers: authHeaders,
+				data: {
+					signup_price: 20,
+					settings: {
+						sliding_scale_enabled: true,
+						sliding_scale_min: 5.5,
+						sliding_scale_max: 50.25,
+					},
+				},
+			}
+		);
+		expect(res.ok(), await res.text()).toBeTruthy();
+		const body = await res.json();
+		expect(body.signup_price).toBe(20);
+		expect(body.settings.sliding_scale_enabled).toBe(true);
+		expect(body.settings.sliding_scale_min).toBe(5.5);
+		expect(body.settings.sliding_scale_max).toBe(50.25);
+	});
+
+	test('min > suggested is rejected with 400', async () => {
+		const res = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${event.eventDateId}/tickets`,
+			{
+				headers: authHeaders,
+				data: {
+					signup_price: 20,
+					settings: {
+						sliding_scale_enabled: true,
+						sliding_scale_min: 25,
+						sliding_scale_max: 50,
+					},
+				},
+			}
+		);
+		expect(res.status()).toBe(400);
+	});
+
+	test('suggested > max is rejected with 400', async () => {
+		const res = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${event.eventDateId}/tickets`,
+			{
+				headers: authHeaders,
+				data: {
+					signup_price: 100,
+					settings: {
+						sliding_scale_enabled: true,
+						sliding_scale_min: 5,
+						sliding_scale_max: 50,
+					},
+				},
+			}
+		);
+		expect(res.status()).toBe(400);
+	});
+
+	test('an invalid band is not persisted after a rejected save', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${event.eventDateId}/tickets`,
+			{ headers: authHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		// Still the last successfully-saved band from the first test.
+		expect(body.settings.sliding_scale_min).toBe(5.5);
+		expect(body.settings.sliding_scale_max).toBe(50.25);
+	});
+});
+
+test.describe('Sliding-scale pricing — signup with an all-zero band', () => {
+	let api;
+	let adminUserId;
+	let event;
+	let participantId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const meRes = await api.get('/wp-json/wp/v2/users/me', {
+			headers: authHeaders,
+		});
+		expect(meRes.ok()).toBeTruthy();
+		adminUserId = (await meRes.json()).id;
+
+		event = await createEventWithDates(
+			api,
+			`Sliding Scale Free Test ${Date.now()}`
+		);
+
+		const configRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${event.eventDateId}/tickets`,
+			{
+				headers: authHeaders,
+				data: {
+					signup_price: 0,
+					settings: {
+						sliding_scale_enabled: true,
+						sliding_scale_min: 0,
+						sliding_scale_max: 0,
+					},
+				},
+			}
+		);
+		expect(configRes.ok(), await configRes.text()).toBeTruthy();
+
+		const participantRes = await api.post(
+			'/wp-json/fair-audience/v1/participants',
+			{
+				headers: authHeaders,
+				data: {
+					name: 'Sliding Scale Tester',
+					email: uniqueEmail('sliding-scale'),
+					wp_user_id: adminUserId,
+				},
+			}
+		);
+		expect(participantRes.ok()).toBeTruthy();
+		participantId = (await participantRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (participantId) {
+			await api.delete(
+				`/wp-json/fair-audience/v1/participants/${participantId}`,
+				{ headers: authHeaders }
+			);
+		}
+		await deleteEvent(api, event?.eventId);
+		await api.dispose();
+	});
+
+	test('a chosen_amount outside [0, 0] still clamps to the free path', async () => {
+		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
+			headers: authHeaders,
+			data: {
+				event_id: event.eventId,
+				event_date_id: event.eventDateId,
+				chosen_amount: 999,
+			},
+		});
+		expect(res.ok(), await res.text()).toBeTruthy();
+		const body = await res.json();
+		expect(body.status).toMatch(/^(signed_up|already_signed_up)$/);
+	});
+});

--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -519,6 +519,66 @@ const CSS_PREFIX = 'fair-audience-signup';
 	}
 
 	/**
+	 * Wire the pay-what-you-can slider (+ paired number input) when sliding
+	 * scale is configured. The two inputs stay in sync; every change writes
+	 * the chosen amount into block.dataset.basePrice, which
+	 * updateButtonTotal() already reads, so the live total picks it up for
+	 * free. No-op when the block has no sliding-scale picker.
+	 * @param {HTMLElement} block The block element
+	 */
+	function initializeSlidingScalePicker(block) {
+		const picker = block.querySelector(
+			'.fair-audience-sliding-scale-picker'
+		);
+		if (!picker) {
+			return;
+		}
+
+		const range = picker.querySelector(
+			'.fair-audience-sliding-scale-range'
+		);
+		const number = picker.querySelector(
+			'.fair-audience-sliding-scale-number'
+		);
+		if (!range || !number) {
+			return;
+		}
+
+		const syncFrom = function (source, target) {
+			target.value = source.value;
+			block.dataset.basePrice = source.value;
+			updateButtonTotal(block);
+		};
+
+		range.addEventListener('input', function () {
+			syncFrom(range, number);
+		});
+		number.addEventListener('input', function () {
+			syncFrom(number, range);
+		});
+		// Clamp only once the user finishes editing so intermediate keystrokes
+		// (e.g. typing "5" on the way to "50") aren't fought by the browser.
+		number.addEventListener('change', function () {
+			const min = parseFloat(number.min);
+			const max = parseFloat(number.max);
+			let value = parseFloat(number.value);
+			if (isNaN(value)) {
+				value = parseFloat(number.defaultValue) || min || 0;
+			}
+			if (!isNaN(min) && value < min) {
+				value = min;
+			}
+			if (!isNaN(max) && value > max) {
+				value = max;
+			}
+			number.value = value;
+			syncFrom(number, range);
+		});
+
+		block.dataset.basePrice = number.value;
+	}
+
+	/**
 	 * Attach change listeners to ticket option checkboxes so the button total
 	 * stays in sync as the user checks/unchecks options.
 	 * @param {HTMLElement} block The block element
@@ -559,6 +619,7 @@ const CSS_PREFIX = 'fair-audience-signup';
 			});
 		});
 
+		initializeSlidingScalePicker(block);
 		updateInstancePickerVisibility(block);
 		updateInstancePickerHint(block);
 		updateButtonTotal(block);
@@ -796,6 +857,13 @@ const CSS_PREFIX = 'fair-audience-signup';
 			requestData.ticket_option_ids = Array.from(optionInputs).map((i) =>
 				parseInt(i.value, 10)
 			);
+		}
+
+		const chosenAmountInput = form.querySelector(
+			'.fair-audience-sliding-scale-number'
+		);
+		if (chosenAmountInput) {
+			requestData.chosen_amount = parseFloat(chosenAmountInput.value);
 		}
 
 		// Collect custom question answers.
@@ -1066,6 +1134,13 @@ const CSS_PREFIX = 'fair-audience-signup';
 			requestData.ticket_option_ids = Array.from(optionInputs).map((i) =>
 				parseInt(i.value, 10)
 			);
+		}
+
+		const chosenAmountInput = block.querySelector(
+			'.fair-audience-sliding-scale-number'
+		);
+		if (chosenAmountInput) {
+			requestData.chosen_amount = parseFloat(chosenAmountInput.value);
 		}
 
 		// Custom questions live inside the signup action container.

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -622,6 +622,20 @@ if ( $has_ticket_types ) {
 	);
 }
 
+// Sliding scale (pay-what-you-can) replaces the fixed base price with a
+// buyer-chosen amount in [min, max], defaulting to the suggested price.
+// Only offered in the non-ticket-types (Simple) pricing mode; group
+// discounts do not stack on a buyer-chosen amount.
+$sliding_scale = null;
+if ( ! $has_ticket_types && $pricing_event_date_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+	$sliding_scale = \FairEventsExperimental\Services\EventSignupPricing::resolve_sliding_scale(
+		(int) $pricing_event_date_id
+	);
+	if ( $sliding_scale ) {
+		$signup_price = $sliding_scale['suggested'];
+	}
+}
+
 if ( null !== $signup_price ) {
 	if ( $signup_price > 0 ) {
 		$signup_button_text = sprintf(
@@ -963,6 +977,45 @@ $render_occurrence_picker = static function () use ( $occurrences_for_picker, $h
 };
 
 /**
+ * Render the pay-what-you-can slider (+ accessible number input) when
+ * sliding scale is configured for this event date. Frontend.js reads the
+ * number input's value to seed the live total and the signup request's
+ * chosen_amount; the two inputs stay in sync client-side.
+ */
+$render_sliding_scale_picker = static function () use ( $sliding_scale, $form_id ) {
+	if ( ! $sliding_scale ) {
+		return;
+	}
+	$input_id = esc_attr( $form_id ) . '-sliding-scale';
+	?>
+	<div class="fair-audience-sliding-scale-picker">
+		<label for="<?php echo esc_attr( $input_id ); ?>">
+			<?php esc_html_e( 'Choose what you pay', 'fair-audience' ); ?>
+		</label>
+		<input
+			type="range"
+			class="fair-audience-sliding-scale-range"
+			min="<?php echo esc_attr( (string) $sliding_scale['min'] ); ?>"
+			max="<?php echo esc_attr( (string) $sliding_scale['max'] ); ?>"
+			step="0.01"
+			value="<?php echo esc_attr( (string) $sliding_scale['suggested'] ); ?>"
+			aria-describedby="<?php echo esc_attr( $input_id ); ?>-value"
+		/>
+		<input
+			type="number"
+			id="<?php echo esc_attr( $input_id ); ?>"
+			name="chosen_amount"
+			class="fair-audience-sliding-scale-number"
+			min="<?php echo esc_attr( (string) $sliding_scale['min'] ); ?>"
+			max="<?php echo esc_attr( (string) $sliding_scale['max'] ); ?>"
+			step="0.01"
+			value="<?php echo esc_attr( (string) $sliding_scale['suggested'] ); ?>"
+		/>
+	</div>
+	<?php
+};
+
+/**
  * Render the multi-occurrence checkbox picker for 'multiple_instances' ticket
  * types. Hidden by default; frontend.js reveals it when the buyer selects a
  * ticket type whose data-recurrence-scope is 'multiple_instances', and hides
@@ -1037,6 +1090,10 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		'data-register-base-text'    => esc_attr( $base_register_button_text ),
 		'data-min-activities'        => esc_attr( (string) $minimum_activities ),
 		'data-has-occurrence-picker' => $has_occurrence_picker ? 'true' : 'false',
+		'data-sliding-scale'         => $sliding_scale ? 'true' : 'false',
+		'data-sliding-min'           => $sliding_scale ? esc_attr( (string) $sliding_scale['min'] ) : '',
+		'data-sliding-max'           => $sliding_scale ? esc_attr( (string) $sliding_scale['max'] ) : '',
+		'data-sliding-suggested'     => $sliding_scale ? esc_attr( (string) $sliding_scale['suggested'] ) : '',
 	)
 );
 ?>
@@ -1212,6 +1269,7 @@ if ( ! $is_valid_post_type ) :
 				<?php $render_ticket_types(); ?>
 				<?php $render_instance_picker(); ?>
 				<?php $render_ticket_options(); ?>
+				<?php $render_sliding_scale_picker(); ?>
 				<?php if ( '' !== trim( $content ) ) : ?>
 					<div class="fair-audience-signup-questions">
 						<?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner blocks content is already escaped by WordPress. ?>
@@ -1286,6 +1344,7 @@ if ( ! $is_valid_post_type ) :
 				<?php $render_ticket_types(); ?>
 				<?php $render_instance_picker(); ?>
 				<?php $render_ticket_options(); ?>
+				<?php $render_sliding_scale_picker(); ?>
 				<p>
 					<label for="<?php echo esc_attr( $form_id ); ?>-name">
 						<?php echo esc_html__( 'First Name', 'fair-audience' ); ?> <span class="required">*</span>

--- a/fair-audience/src/blocks/event-signup/style.css
+++ b/fair-audience/src/blocks/event-signup/style.css
@@ -246,6 +246,22 @@
 	cursor: not-allowed;
 }
 
+/* Pay-what-you-can (sliding scale) slider */
+.fair-audience-sliding-scale-picker {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin-bottom: 20px;
+}
+
+.fair-audience-sliding-scale-range {
+	width: 100%;
+}
+
+.fair-audience-sliding-scale-number {
+	width: 100px;
+}
+
 .fair-audience-ticket-option-full input[type="checkbox"] {
 	cursor: not-allowed;
 }

--- a/fair-events-experimental/__tests__/Services/EventSignupPricingTest.php
+++ b/fair-events-experimental/__tests__/Services/EventSignupPricingTest.php
@@ -32,4 +32,62 @@ class EventSignupPricingTest extends TestCase {
 		// resolver clamps to 0 separately; this asserts raw math.
 		$this->assertEqualsWithDelta( -2.0, EventSignupPricing::apply_discount( 3.0, 'amount', 5.0 ), 0.001 );
 	}
+
+	public function test_clamp_in_band_amount_is_unchanged() {
+		$this->assertEqualsWithDelta(
+			15.0,
+			EventSignupPricing::clamp_amount_to_range( 15.0, 5.0, 50.0, 20.0 ),
+			0.001
+		);
+	}
+
+	public function test_clamp_below_min_is_raised_to_min() {
+		$this->assertEqualsWithDelta(
+			5.0,
+			EventSignupPricing::clamp_amount_to_range( 1.0, 5.0, 50.0, 20.0 ),
+			0.001
+		);
+	}
+
+	public function test_clamp_above_max_is_lowered_to_max() {
+		$this->assertEqualsWithDelta(
+			50.0,
+			EventSignupPricing::clamp_amount_to_range( 999.0, 5.0, 50.0, 20.0 ),
+			0.001
+		);
+	}
+
+	public function test_clamp_non_finite_falls_back_to_suggested() {
+		$this->assertEqualsWithDelta(
+			20.0,
+			EventSignupPricing::clamp_amount_to_range( NAN, 5.0, 50.0, 20.0 ),
+			0.001
+		);
+		$this->assertEqualsWithDelta(
+			20.0,
+			EventSignupPricing::clamp_amount_to_range( INF, 5.0, 50.0, 20.0 ),
+			0.001
+		);
+	}
+
+	public function test_clamp_non_numeric_falls_back_to_suggested() {
+		$this->assertEqualsWithDelta(
+			20.0,
+			EventSignupPricing::clamp_amount_to_range( 'not-a-number', 5.0, 50.0, 20.0 ),
+			0.001
+		);
+		$this->assertEqualsWithDelta(
+			20.0,
+			EventSignupPricing::clamp_amount_to_range( null, 5.0, 50.0, 20.0 ),
+			0.001
+		);
+	}
+
+	public function test_clamp_min_equals_max_locks_the_amount() {
+		$this->assertEqualsWithDelta(
+			10.0,
+			EventSignupPricing::clamp_amount_to_range( 3.0, 10.0, 10.0, 10.0 ),
+			0.001
+		);
+	}
 }

--- a/fair-events-experimental/src/API/TicketsController.php
+++ b/fair-events-experimental/src/API/TicketsController.php
@@ -146,6 +146,15 @@ class TicketsController extends WP_REST_Controller {
 
 		$body = $request->get_json_params();
 
+		$normalized_settings = isset( $body['settings'] ) && is_array( $body['settings'] )
+			? $this->normalize_settings( $body['settings'] )
+			: array();
+
+		$sliding_scale_error = $this->validate_sliding_scale_settings( $event_date_id, $event_date, $body, $normalized_settings );
+		if ( is_wp_error( $sliding_scale_error ) ) {
+			return $sliding_scale_error;
+		}
+
 		// 1. Update capacity + signup_price on event_dates row.
 		$event_date_updates = array();
 		if ( array_key_exists( 'capacity', $body ) ) {
@@ -187,8 +196,8 @@ class TicketsController extends WP_REST_Controller {
 		}
 
 		// 5. Save settings.
-		if ( isset( $body['settings'] ) && is_array( $body['settings'] ) ) {
-			EventDateSetting::set_multiple( $event_date_id, $this->normalize_settings( $body['settings'] ) );
+		if ( ! empty( $normalized_settings ) ) {
+			EventDateSetting::set_multiple( $event_date_id, $normalized_settings );
 		}
 
 		// 6. Sync ticket options (update existing, create new, delete removed).
@@ -608,11 +617,61 @@ class TicketsController extends WP_REST_Controller {
 			$key = sanitize_key( $key );
 			if ( in_array( $key, EventDateSetting::NUMERIC_KEYS, true ) ) {
 				$out[ $key ] = (string) max( 0, (int) $value );
+			} elseif ( in_array( $key, EventDateSetting::DECIMAL_KEYS, true ) ) {
+				$out[ $key ] = (string) max( 0.0, (float) $value );
 			} else {
 				$out[ $key ] = $value ? '1' : '0';
 			}
 		}
 		return $out;
+	}
+
+	/**
+	 * Validate min <= suggested <= max for the sliding-scale price band.
+	 *
+	 * Only runs the check when sliding scale ends up enabled after applying
+	 * the incoming settings; falls back to already-stored values for any
+	 * field not present in this request so a partial update can't bypass it.
+	 *
+	 * @param int        $event_date_id       Event date ID.
+	 * @param EventDates $event_date          Current event date row (pre-update).
+	 * @param array      $body                Raw request body.
+	 * @param array      $normalized_settings Settings already normalized via normalize_settings().
+	 * @return WP_Error|null Error on violation, null when valid.
+	 */
+	private function validate_sliding_scale_settings( $event_date_id, $event_date, $body, $normalized_settings ) {
+		$enabled = array_key_exists( 'sliding_scale_enabled', $normalized_settings )
+			? '1' === $normalized_settings['sliding_scale_enabled']
+			: '1' === (string) EventDateSetting::get( $event_date_id, 'sliding_scale_enabled' );
+
+		if ( ! $enabled ) {
+			return null;
+		}
+
+		$min = array_key_exists( 'sliding_scale_min', $normalized_settings )
+			? (float) $normalized_settings['sliding_scale_min']
+			: (float) EventDateSetting::get( $event_date_id, 'sliding_scale_min' );
+
+		$max = array_key_exists( 'sliding_scale_max', $normalized_settings )
+			? (float) $normalized_settings['sliding_scale_max']
+			: (float) EventDateSetting::get( $event_date_id, 'sliding_scale_max' );
+
+		if ( array_key_exists( 'signup_price', $body ) ) {
+			$raw_price = $body['signup_price'];
+			$suggested = ( null === $raw_price || '' === $raw_price ) ? 0.0 : (float) $raw_price;
+		} else {
+			$suggested = null !== $event_date->signup_price ? (float) $event_date->signup_price : 0.0;
+		}
+
+		if ( $min < 0 || $max < 0 || $suggested < 0 || $min > $suggested || $suggested > $max ) {
+			return new WP_Error(
+				'rest_invalid_sliding_scale',
+				__( 'Sliding-scale prices must satisfy minimum ≤ suggested ≤ maximum, all non-negative.', 'fair-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return null;
 	}
 
 	/**
@@ -644,6 +703,8 @@ class TicketsController extends WP_REST_Controller {
 		foreach ( $raw_settings as $key => $value ) {
 			if ( in_array( $key, EventDateSetting::NUMERIC_KEYS, true ) ) {
 				$settings[ $key ] = (int) $value;
+			} elseif ( in_array( $key, EventDateSetting::DECIMAL_KEYS, true ) ) {
+				$settings[ $key ] = (float) $value;
 			} else {
 				$settings[ $key ] = '1' === $value;
 			}

--- a/fair-events-experimental/src/Admin/manage-event/EventTickets.js
+++ b/fair-events-experimental/src/Admin/manage-event/EventTickets.js
@@ -48,6 +48,9 @@ export default function EventTickets({
 		show_ticket_type_minimum_activities: false,
 		activity_period_pricing: false,
 		show_ticket_type_end_date: false,
+		sliding_scale_enabled: false,
+		sliding_scale_min: 0,
+		sliding_scale_max: 0,
 	});
 	const [options, setOptions] = useState([]);
 	const [loading, setLoading] = useState(!initialData);
@@ -64,6 +67,13 @@ export default function EventTickets({
 		window.fairEventsManageEventData?.manageInvitationsUrl || '';
 
 	const hasAdvancedTickets = ticketTypes.length > 0 || salePeriods.length > 0;
+	const isSlidingScaleRangeValid =
+		!settings.sliding_scale_enabled ||
+		(parseFloat(settings.sliding_scale_min) >= 0 &&
+			parseFloat(settings.sliding_scale_min) <=
+				(parseFloat(signupPrice) || 0) &&
+			(parseFloat(signupPrice) || 0) <=
+				parseFloat(settings.sliding_scale_max));
 	const hasInvitationTickets = ticketTypes.some((t) => t.invitation_only);
 	const hasGroups = groups.length > 0;
 	const groupNameById = Object.fromEntries(groups.map((g) => [g.id, g.name]));
@@ -223,6 +233,16 @@ export default function EventTickets({
 	});
 
 	const handleSave = async () => {
+		if (!isSlidingScaleRangeValid) {
+			setError(
+				__(
+					'Fix the sliding-scale price range before saving: minimum ≤ suggested ≤ maximum.',
+					'fair-events-experimental'
+				)
+			);
+			return;
+		}
+
 		setSaving(true);
 		setError(null);
 		setSuccess(null);
@@ -1303,6 +1323,84 @@ export default function EventTickets({
 										onChange={setSignupPrice}
 										__nextHasNoMarginBottom
 									/>
+									<CheckboxControl
+										label={__(
+											'Pay what you can (sliding scale)',
+											'fair-events-experimental'
+										)}
+										help={__(
+											'Let attendees choose their own price within a min/max band instead of paying the fixed price above.',
+											'fair-events-experimental'
+										)}
+										checked={
+											!!settings.sliding_scale_enabled
+										}
+										onChange={(checked) =>
+											setSettings((prev) => ({
+												...prev,
+												sliding_scale_enabled: checked,
+											}))
+										}
+									/>
+									{settings.sliding_scale_enabled && (
+										<VStack spacing={3}>
+											<HStack spacing={3} alignment="top">
+												<TextControl
+													label={__(
+														'Minimum (EUR)',
+														'fair-events-experimental'
+													)}
+													type="number"
+													min="0"
+													step="0.01"
+													value={String(
+														settings.sliding_scale_min ??
+															0
+													)}
+													onChange={(value) =>
+														setSettings((prev) => ({
+															...prev,
+															sliding_scale_min:
+																value,
+														}))
+													}
+													__nextHasNoMarginBottom
+												/>
+												<TextControl
+													label={__(
+														'Maximum (EUR)',
+														'fair-events-experimental'
+													)}
+													type="number"
+													min="0"
+													step="0.01"
+													value={String(
+														settings.sliding_scale_max ??
+															0
+													)}
+													onChange={(value) =>
+														setSettings((prev) => ({
+															...prev,
+															sliding_scale_max:
+																value,
+														}))
+													}
+													__nextHasNoMarginBottom
+												/>
+											</HStack>
+											{!isSlidingScaleRangeValid && (
+												<Notice
+													status="error"
+													isDismissible={false}
+												>
+													{__(
+														'Minimum must be less than or equal to the suggested price above, and the suggested price must be less than or equal to the maximum.',
+														'fair-events-experimental'
+													)}
+												</Notice>
+											)}
+										</VStack>
+									)}
 									<p>
 										{__(
 											'Need multiple ticket types or time-based pricing? Switch to advanced ticketing below.',
@@ -1313,6 +1411,10 @@ export default function EventTickets({
 										<Button
 											variant="secondary"
 											onClick={() => {
+												setSettings((prev) => ({
+													...prev,
+													sliding_scale_enabled: false,
+												}));
 												addTicketType();
 												addSalePeriod();
 											}}

--- a/fair-events-experimental/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events-experimental/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Component tests for the sliding-scale (pay-what-you-can) pricing toggle
+ * in EventTickets (#932).
+ *
+ * Exercises:
+ *   - The toggle and min/max inputs are hidden until sliding scale is enabled.
+ *   - Enabling the toggle reveals the min/max inputs.
+ *   - An invalid band (min > suggested) shows a validation notice and blocks save.
+ *   - A valid band is included in the save payload with decimal values.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import EventTickets from '../EventTickets.js';
+
+jest.mock('@wordpress/api-fetch');
+
+beforeEach(() => {
+	jest.spyOn(console, 'warn').mockImplementation(() => {});
+	jest.spyOn(console, 'error').mockImplementation(() => {});
+	// Background apiFetch calls (groups, participants, group-pricing-rules)
+	// never resolve so they don't fire async state updates outside act().
+	apiFetch.mockImplementation(() => new Promise(() => {}));
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+	jest.clearAllMocks();
+});
+
+const emptyInitialData = {
+	capacity: null,
+	signup_price: null,
+	ticket_types: [],
+	sale_periods: [],
+	prices: [],
+	settings: {},
+	options: [],
+};
+
+function renderTickets(extraProps = {}) {
+	const onSaveRef = { current: null };
+	const { container } = render(
+		<EventTickets
+			eventDateId={99}
+			onSaveRef={onSaveRef}
+			initialData={emptyInitialData}
+			onDataRef={null}
+			{...extraProps}
+		/>
+	);
+	// WordPress's a11y speak() utility appends a persistent live-region node
+	// to document.body that isn't cleaned up between tests, so notice-text
+	// assertions must be scoped to this render's container rather than the
+	// whole document.
+	return { onSaveRef, container };
+}
+
+function openEditTicketsPanel() {
+	fireEvent.click(screen.getByRole('button', { name: /Edit tickets/i }));
+}
+
+describe('EventTickets — sliding scale toggle', () => {
+	it('does not show min/max inputs when the toggle is off', () => {
+		renderTickets();
+		openEditTicketsPanel();
+
+		expect(
+			screen.getByText(/Pay what you can \(sliding scale\)/i)
+		).toBeInTheDocument();
+		expect(
+			screen.queryByLabelText(/Minimum \(EUR\)/i)
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByLabelText(/Maximum \(EUR\)/i)
+		).not.toBeInTheDocument();
+	});
+
+	it('shows min/max inputs once the toggle is enabled', () => {
+		renderTickets();
+		openEditTicketsPanel();
+
+		fireEvent.click(
+			screen.getByLabelText(/Pay what you can \(sliding scale\)/i)
+		);
+
+		expect(screen.getByLabelText(/Minimum \(EUR\)/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/Maximum \(EUR\)/i)).toBeInTheDocument();
+	});
+
+	it('shows a validation notice when min > suggested and blocks save', async () => {
+		const { onSaveRef, container } = renderTickets();
+		openEditTicketsPanel();
+
+		fireEvent.click(
+			screen.getByLabelText(/Pay what you can \(sliding scale\)/i)
+		);
+		fireEvent.change(screen.getByLabelText(/Minimum \(EUR\)/i), {
+			target: { value: '25' },
+		});
+		fireEvent.change(screen.getByLabelText(/Maximum \(EUR\)/i), {
+			target: { value: '50' },
+		});
+		// Suggested price (signupPrice) stays empty (0) — below the min.
+
+		expect(
+			within(container).getByText(
+				/Minimum must be less than or equal to/i
+			)
+		).toBeInTheDocument();
+
+		let saveCalled = false;
+		apiFetch.mockImplementation(() => {
+			saveCalled = true;
+			return new Promise(() => {});
+		});
+
+		await act(async () => {
+			await onSaveRef.current();
+		});
+
+		expect(saveCalled).toBe(false);
+	});
+
+	it('save payload includes the sliding-scale settings as decimals once valid', async () => {
+		const { onSaveRef, container } = renderTickets();
+		openEditTicketsPanel();
+
+		fireEvent.change(screen.getByLabelText(/Signup price \(EUR\)/i), {
+			target: { value: '20' },
+		});
+		fireEvent.click(
+			screen.getByLabelText(/Pay what you can \(sliding scale\)/i)
+		);
+		fireEvent.change(screen.getByLabelText(/Minimum \(EUR\)/i), {
+			target: { value: '5.5' },
+		});
+		fireEvent.change(screen.getByLabelText(/Maximum \(EUR\)/i), {
+			target: { value: '50.25' },
+		});
+
+		expect(
+			within(container).queryByText(
+				/Minimum must be less than or equal to/i
+			)
+		).not.toBeInTheDocument();
+
+		let savedPayload = null;
+		apiFetch.mockImplementation(({ method, data }) => {
+			if (method === 'PUT') {
+				savedPayload = data;
+				return Promise.resolve(emptyInitialData);
+			}
+			return new Promise(() => {});
+		});
+
+		await act(async () => {
+			await onSaveRef.current();
+		});
+
+		expect(savedPayload).not.toBeNull();
+		expect(savedPayload.settings.sliding_scale_enabled).toBe(true);
+		expect(String(savedPayload.settings.sliding_scale_min)).toBe('5.5');
+		expect(String(savedPayload.settings.sliding_scale_max)).toBe('50.25');
+	});
+});

--- a/fair-events-experimental/src/Services/EventSignupPricing.php
+++ b/fair-events-experimental/src/Services/EventSignupPricing.php
@@ -90,6 +90,100 @@ class EventSignupPricing {
 	}
 
 	/**
+	 * Resolve the sliding-scale (pay-what-you-can) config for an event date.
+	 *
+	 * Mirrors resolve_price()'s generated-occurrence → master inheritance:
+	 * a generated occurrence with no signup_price of its own falls back to
+	 * its master's signup_price and settings.
+	 *
+	 * @param int $event_date_id Event date ID.
+	 * @return array{enabled:bool,min:float,max:float,suggested:float}|null
+	 *               Config array, or null when sliding scale is off or the
+	 *               event date doesn't exist.
+	 */
+	public static function resolve_sliding_scale( $event_date_id ) {
+		$event_date = EventDates::get_by_id( $event_date_id );
+
+		if ( ! $event_date ) {
+			return null;
+		}
+
+		$pricing_event_date_id = $event_date_id;
+		if ( null === $event_date->signup_price
+			&& 'generated' === $event_date->occurrence_type
+			&& $event_date->master_id ) {
+			$master = EventDates::get_by_id( $event_date->master_id );
+			if ( $master && null !== $master->signup_price ) {
+				$event_date            = $master;
+				$pricing_event_date_id = $master->id;
+			}
+		}
+
+		if ( '1' !== (string) EventDateSetting::get( $pricing_event_date_id, 'sliding_scale_enabled' ) ) {
+			return null;
+		}
+
+		if ( null === $event_date->signup_price ) {
+			return null;
+		}
+
+		return array(
+			'enabled'   => true,
+			'min'       => (float) EventDateSetting::get( $pricing_event_date_id, 'sliding_scale_min' ),
+			'max'       => (float) EventDateSetting::get( $pricing_event_date_id, 'sliding_scale_max' ),
+			'suggested' => (float) $event_date->signup_price,
+		);
+	}
+
+	/**
+	 * Clamp a buyer-chosen amount to the configured sliding-scale range.
+	 *
+	 * Never trust the client: this re-derives min/max/suggested from the
+	 * database rather than accepting them as arguments. Falls back to the
+	 * suggested price when sliding scale isn't configured or the chosen
+	 * amount isn't a finite number.
+	 *
+	 * @param int   $event_date_id Event date ID.
+	 * @param float $chosen        Buyer-chosen amount.
+	 * @return float Clamped amount.
+	 */
+	public static function clamp_chosen_amount( $event_date_id, $chosen ) {
+		$config = self::resolve_sliding_scale( $event_date_id );
+
+		if ( ! $config ) {
+			return 0.0;
+		}
+
+		return self::clamp_amount_to_range( $chosen, $config['min'], $config['max'], $config['suggested'] );
+	}
+
+	/**
+	 * Pure range-clamping math, split out from clamp_chosen_amount() for
+	 * unit testing without a database.
+	 *
+	 * @param mixed $chosen    Buyer-chosen amount (may be non-numeric).
+	 * @param float $min       Minimum allowed amount.
+	 * @param float $max       Maximum allowed amount.
+	 * @param float $suggested Fallback used when $chosen isn't a finite number.
+	 * @return float Clamped amount.
+	 */
+	public static function clamp_amount_to_range( $chosen, $min, $max, $suggested ) {
+		if ( ! is_numeric( $chosen ) || ! is_finite( (float) $chosen ) ) {
+			$chosen = $suggested;
+		}
+
+		$chosen = (float) $chosen;
+
+		if ( $chosen < $min ) {
+			return $min;
+		}
+		if ( $chosen > $max ) {
+			return $max;
+		}
+		return $chosen;
+	}
+
+	/**
 	 * Resolve the effective price for a specific ticket type.
 	 *
 	 * Looks up the currently-active sale period for the ticket type's

--- a/fair-events/src/Models/EventDateSetting.php
+++ b/fair-events/src/Models/EventDateSetting.php
@@ -76,6 +76,9 @@ class EventDateSetting {
 		'show_ticket_type_minimum_activities' => '0',
 		'activity_period_pricing'             => '0',
 		'show_ticket_type_end_date'           => '0',
+		'sliding_scale_enabled'               => '0',
+		'sliding_scale_min'                   => '0',
+		'sliding_scale_max'                   => '0',
 	);
 
 	/**
@@ -83,6 +86,11 @@ class EventDateSetting {
 	 * All other settings in DEFAULTS are treated as boolean ('0' / '1').
 	 */
 	const NUMERIC_KEYS = array( 'minimum_activities' );
+
+	/**
+	 * Setting keys whose values are decimals (not booleans or integers).
+	 */
+	const DECIMAL_KEYS = array( 'sliding_scale_min', 'sliding_scale_max' );
 
 	/**
 	 * Get table name


### PR DESCRIPTION
## Summary

- Adds a **sliding-scale (pay-what-you-can)** pricing mode for the event-date-level signup price: an organiser sets suggested/min/max, and the buyer picks their own price within that band via a slider on the `event-signup` block.
- Storage reuses the existing `signup_price` column (as "suggested") plus the per-event-date `fair_events_event_date_settings` key/value store (`sliding_scale_enabled`, `sliding_scale_min`, `sliding_scale_max`) — no schema migration.
- The buyer's chosen amount is **always re-clamped server-side** against the stored `[min, max]` in `EventSignupPricing::clamp_chosen_amount()` before it becomes the payable price; the client value is never trusted directly.
- Admin config lives in `fair-events-experimental`'s `EventTickets.js` (Simple pricing card) and persists via the existing `TicketsController`, which now validates `min ≤ suggested ≤ max` server-side (400 on violation) and round-trips the new decimal-typed settings.
- Sliding scale is mutually exclusive with Advanced ticketing and does not stack with group discounts on the buyer-chosen amount, per the design in #932.

Closes #932

## Test plan

- [x] `EventSignupPricingTest.php` — `clamp_amount_to_range()` in-band / below-min / above-max / non-finite / non-numeric / min=max cases (PHPUnit, all passing)
- [x] `EventTickets.test.jsx` — toggle visibility, validation notice + save-blocking on an invalid band, decimal round-trip in the save payload (Jest, all passing)
- [x] `EventSignupSlidingScale.api.spec.js` — `TicketsController` config validation (decimal round-trip, min>suggested rejected, suggested>max rejected) and a signup smoke test with an all-zero band (Playwright API test, written to mirror existing conventions — not executed in this session because the local docker stack isn't configured for pretty permalinks/REST auth; the underlying logic was verified instead via a WP-CLI `eval-file` manual check against the live DB, all 19 assertions passing)
- [x] `npm run build` in `fair-audience` (block assets regenerated)
- [x] `phpcs` clean on all touched PHP files (no new violations vs. pre-existing baseline)
