### PR TITLE
Allow upgrading a single-instance signup to a whole-series pass

### DIFF
--- a/.changeset/series-pass-upgrade.md
+++ b/.changeset/series-pass-upgrade.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": minor
+---
+
+Allow upgrading an existing single-instance signup to a whole-series pass instead of blocking it as a duplicate. The buyer is charged only the difference between the series price and what they already paid, and every transaction on a registration is now preserved in a ledger (laying the groundwork for refunds).

--- a/fair-audience/fair-audience.php
+++ b/fair-audience/fair-audience.php
@@ -69,9 +69,10 @@ function fair_audience_activate() {
 	dbDelta( \FairAudience\Database\Schema::get_event_participant_options_table_sql() );
 	dbDelta( \FairAudience\Database\Schema::get_email_consent_log_table_sql() );
 	dbDelta( \FairAudience\Database\Schema::get_event_scheduled_messages_table_sql() );
+	dbDelta( \FairAudience\Database\Schema::get_event_participant_transactions_table_sql() );
 
 	// Update database version.
-	update_option( 'fair_audience_db_version', '1.37.0' );
+	update_option( 'fair_audience_db_version', '1.38.0' );
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\\fair_audience_activate' );
 
@@ -726,6 +727,18 @@ function fair_audience_maybe_upgrade_db() {
 		);
 
 		update_option( 'fair_audience_db_version', '1.37.0' );
+	}
+
+	if ( version_compare( $db_version, '1.38.0', '<' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		// Ledger linking event_participant rows to every payment (and, later,
+		// refund) transaction they accumulate — a single registration can hold
+		// more than one transaction once single-instance signups can be upgraded
+		// to whole-series passes.
+		dbDelta( \FairAudience\Database\Schema::get_event_participant_transactions_table_sql() );
+
+		update_option( 'fair_audience_db_version', '1.38.0' );
 	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_audience_maybe_upgrade_db' );

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -9,6 +9,7 @@ namespace FairAudience\API;
 
 use FairAudience\Database\ParticipantRepository;
 use FairAudience\Database\EventParticipantRepository;
+use FairAudience\Database\EventParticipantTransactionRepository;
 use FairAudience\Database\EmailConfirmationTokenRepository;
 use FairAudience\Models\Participant;
 use FairAudience\Services\AudienceSession;
@@ -645,6 +646,18 @@ class EventSignupController extends WP_REST_Controller {
 		}
 
 		if ( $existing && 'signed_up' === $existing->label ) {
+			// A whole-series purchase over an existing single-instance signup is
+			// an upgrade, not a duplicate: proceed (charging only the difference)
+			// instead of short-circuiting. Returns null when this is not an
+			// upgrade case, so a genuine repeat still reports already_signed_up.
+			$upgrade_response = $this->maybe_start_series_upgrade_payment( $event_id, $event_date_id, $participant, $existing, $ticket_type_id );
+			if ( null !== $upgrade_response ) {
+				if ( ! is_wp_error( $upgrade_response ) ) {
+					AudienceSession::set( (int) $participant->id );
+				}
+				return $upgrade_response;
+			}
+
 			AudienceSession::set( (int) $participant->id );
 			return rest_ensure_response(
 				array(
@@ -2011,6 +2024,164 @@ class EventSignupController extends WP_REST_Controller {
 				'checkout_url'   => $payment['checkout_url'],
 				'transaction_id' => $transaction_id,
 				'amount'         => $total_amount,
+				'currency'       => get_option( 'fair_payment_currency', 'EUR' ),
+			)
+		);
+	}
+
+	/**
+	 * Upgrade an existing single-instance signup to a whole-series pass.
+	 *
+	 * Called from create_signup() when the buyer already holds a signed_up row
+	 * on the (retargeted) master date and the selected ticket type is
+	 * whole-series. The seat and prior payment stay put: like
+	 * maybe_start_addon_payment, this never mutates the existing row on the paid
+	 * path — an abandoned upgrade leaves the original single-instance signup
+	 * intact. On payment success PaymentHooks::handle_series_upgrade_paid()
+	 * flips the row's ticket_type to the series pass.
+	 *
+	 * The buyer is charged only the difference between the series price and what
+	 * they have already paid on this registration (per the transaction ledger).
+	 *
+	 * @param int                              $event_id       Event post ID.
+	 * @param int                              $event_date_id  Event date ID (already retargeted to the master).
+	 * @param \FairAudience\Models\Participant $participant    Participant doing the upgrade.
+	 * @param object                           $existing       Existing signed_up EventParticipant row.
+	 * @param int|null                         $ticket_type_id Selected whole-series ticket type ID.
+	 * @return \WP_REST_Response|\WP_Error|null Response/error for the upgrade path, null when not an upgrade.
+	 */
+	private function maybe_start_series_upgrade_payment( $event_id, $event_date_id, $participant, $existing, $ticket_type_id ) {
+		if ( ! $ticket_type_id || ! class_exists( \FairEvents\Models\TicketType::class ) ) {
+			return null;
+		}
+
+		$ticket_type = \FairEvents\Models\TicketType::get_by_id( $ticket_type_id );
+		if ( ! $ticket_type || ! $ticket_type->is_whole_series() ) {
+			return null;
+		}
+
+		// A row that already carries a whole-series ticket type is a genuine
+		// repeat purchase — fall back to the already_signed_up response.
+		if ( $existing->ticket_type_id ) {
+			$existing_tt = \FairEvents\Models\TicketType::get_by_id( (int) $existing->ticket_type_id );
+			if ( $existing_tt && $existing_tt->is_whole_series() ) {
+				return null;
+			}
+		}
+
+		$series_price = 0.0;
+		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			$resolved     = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_for_ticket_type( $ticket_type->id, $participant->id );
+			$series_price = null !== $resolved ? (float) $resolved : 0.0;
+		}
+
+		$ledger = new EventParticipantTransactionRepository();
+
+		// Backfill: rows created before the ledger existed only record their
+		// original charge in the row's own transaction_id column. Seed it so the
+		// difference is computed against what was actually paid.
+		if ( $existing->transaction_id ) {
+			$ledger->record( (int) $existing->id, (int) $existing->transaction_id, 'charge' );
+		}
+
+		$net_paid         = $ledger->get_net_paid( (int) $existing->id );
+		$delta            = max( 0.0, $series_price - $net_paid );
+		$seats_per_ticket = max( 1, (int) $ticket_type->seats_per_ticket );
+
+		// Nothing left to pay (already covered, or a free series): convert in place now.
+		if ( $delta <= 0 ) {
+			$existing->ticket_type_id = (int) $ticket_type->id;
+			$existing->seats          = $seats_per_ticket;
+			$existing->save();
+
+			return rest_ensure_response(
+				array(
+					'success' => true,
+					'status'  => 'signed_up',
+					'message' => __( 'Your series pass is now active!', 'fair-audience' ),
+				)
+			);
+		}
+
+		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class )
+			|| ! \FairPaymentsConnector\API\TransactionAPI::is_configured() ) {
+			return new WP_Error(
+				'payment_unavailable',
+				__( 'Paid signup is not available because the payment plugin is not configured.', 'fair-audience' ),
+				array( 'status' => 503 )
+			);
+		}
+
+		$line_items = array(
+			array(
+				'name'     => sprintf(
+					/* translators: %s: ticket type name */
+					__( 'Upgrade to series pass: %s', 'fair-audience' ),
+					$ticket_type->name
+				),
+				'quantity' => 1,
+				'amount'   => $delta,
+			),
+		);
+
+		$transaction_id = \FairPaymentsConnector\API\TransactionAPI::create_transaction(
+			$line_items,
+			array(
+				'currency'      => get_option( 'fair_payment_currency', 'EUR' ),
+				'description'   => sprintf(
+					/* translators: %s: event title */
+					__( 'Series pass upgrade for %s', 'fair-audience' ),
+					get_the_title( $event_id )
+				),
+				'post_id'       => $event_id,
+				'event_date_id' => $event_date_id,
+				'user_id'       => get_current_user_id() ?: null,
+				'metadata'      => array(
+					'source'               => 'fair-audience-series-upgrade',
+					'event_date_id'        => $event_date_id,
+					'event_participant_id' => (int) $existing->id,
+					'participant_id'       => (int) $participant->id,
+					'ticket_type_id'       => (int) $ticket_type->id,
+				),
+			)
+		);
+
+		if ( is_wp_error( $transaction_id ) ) {
+			return $transaction_id;
+		}
+
+		// Deliberately do NOT touch $existing here: the seat and original payment
+		// remain valid whether or not the upgrade payment completes.
+
+		$redirect_url = add_query_arg(
+			array(
+				'fair_payment_callback' => 'true',
+				'fair_signup_tx'        => $transaction_id,
+				'fst_sig'               => \FairAudience\Services\TransactionAccessToken::generate(
+					(int) $transaction_id,
+					(int) $participant->id
+				),
+			),
+			get_permalink( $event_id )
+		);
+
+		$payment = \FairPaymentsConnector\API\TransactionAPI::initiate_payment(
+			$transaction_id,
+			array( 'redirect_url' => $redirect_url )
+		);
+
+		if ( is_wp_error( $payment ) ) {
+			return $payment;
+		}
+
+		return rest_ensure_response(
+			array(
+				'success'        => true,
+				'status'         => 'payment_required',
+				'message'        => __( 'Redirecting to payment…', 'fair-audience' ),
+				'checkout_url'   => esc_url_raw( $payment['checkout_url'] ),
+				'transaction_id' => $transaction_id,
+				'amount'         => $delta,
 				'currency'       => get_option( 'fair_payment_currency', 'EUR' ),
 			)
 		);

--- a/fair-audience/src/API/__tests__/EventSignupRecurrenceScope.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupRecurrenceScope.api.spec.js
@@ -521,3 +521,134 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 		}
 	});
 });
+
+test.describe('Series-pass upgrade — single_instance → whole_series', () => {
+	let api;
+	let adminUserId;
+	let event;
+	let singleTtId;
+	let seriesTtId;
+	let participantId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const meRes = await api.get('/wp-json/wp/v2/users/me', {
+			headers: authHeaders,
+		});
+		expect(meRes.ok()).toBeTruthy();
+		adminUserId = (await meRes.json()).id;
+
+		event = await createEventWithDates(
+			api,
+			`Series Upgrade Test ${Date.now()}`
+		);
+
+		// Both ticket types live on the same master date. The tickets endpoint
+		// saves the full set per event-date, so they must be created together.
+		const res = await api.post(
+			`/wp-json/fair-events/v1/event-dates/${event.masterEventDateId}/tickets`,
+			{
+				headers: authHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'Drop-In',
+							sort_order: 0,
+							recurrence_scope: 'single_instance',
+						},
+						{
+							name: 'Series Pass',
+							sort_order: 1,
+							recurrence_scope: 'whole_series',
+						},
+					],
+					sale_periods: [],
+					prices: [],
+				},
+			}
+		);
+		expect(res.ok(), 'create both ticket types').toBeTruthy();
+		const tts = (await res.json()).ticket_types;
+		singleTtId = tts.find(
+			(t) => t.recurrence_scope === 'single_instance'
+		).id;
+		seriesTtId = tts.find((t) => t.recurrence_scope === 'whole_series').id;
+
+		participantId = await createParticipant(
+			api,
+			adminUserId,
+			'Upgrade Tester'
+		);
+	});
+
+	test.afterAll(async () => {
+		await deleteParticipant(api, participantId);
+		if (event?.eventId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${event.eventId}`, {
+				headers: authHeaders,
+				params: { force: 'true' },
+			});
+		}
+		await api.dispose();
+	});
+
+	test('whole_series purchase after a single_instance signup on the master upgrades in place instead of reporting already_signed_up', async () => {
+		// 1. Single-instance signup on the master (free).
+		const first = await api.post('/wp-json/fair-audience/v1/event-signup', {
+			headers: authHeaders,
+			data: {
+				event_id: event.eventId,
+				event_date_id: event.masterEventDateId,
+				ticket_type_id: singleTtId,
+			},
+		});
+		expect(first.ok()).toBeTruthy();
+		expect((await first.json()).status).toBe('signed_up');
+
+		// 2. Whole-series purchase over that signup must NOT short-circuit as a
+		// duplicate. Both tickets are free, so the delta is zero and the upgrade
+		// converts immediately — status signed_up, never already_signed_up.
+		const upgrade = await api.post(
+			'/wp-json/fair-audience/v1/event-signup',
+			{
+				headers: authHeaders,
+				data: {
+					event_id: event.eventId,
+					event_date_id: event.masterEventDateId,
+					ticket_type_id: seriesTtId,
+				},
+			}
+		);
+		expect(upgrade.ok()).toBeTruthy();
+		expect((await upgrade.json()).status).toBe('signed_up');
+
+		// 3. The master row now carries the whole_series ticket type.
+		const participantsRes = await api.get(
+			`/wp-json/fair-audience/v1/event-dates/${event.masterEventDateId}/participants`,
+			{ headers: authHeaders }
+		);
+		expect(participantsRes.ok()).toBeTruthy();
+		const row = (await participantsRes.json()).find(
+			(p) => p.participant_id === participantId
+		);
+		expect(row, 'upgraded row on master').toBeTruthy();
+		expect(row.label).toBe('signed_up');
+		expect(row.ticket_type_id).toBe(seriesTtId);
+
+		// 4. A further whole_series attempt is now a genuine duplicate.
+		const repeat = await api.post(
+			'/wp-json/fair-audience/v1/event-signup',
+			{
+				headers: authHeaders,
+				data: {
+					event_id: event.eventId,
+					event_date_id: event.masterEventDateId,
+					ticket_type_id: seriesTtId,
+				},
+			}
+		);
+		expect(repeat.ok()).toBeTruthy();
+		expect((await repeat.json()).status).toBe('already_signed_up');
+	});
+});

--- a/fair-audience/src/Database/EventParticipantTransactionRepository.php
+++ b/fair-audience/src/Database/EventParticipantTransactionRepository.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * EventParticipant Transaction ledger repository
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Database;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Repository for the event-participant transaction ledger (junction table).
+ *
+ * Links each registration (event_participant row) to every
+ * fair-payments-connector transaction it accumulates — the initial charge, any
+ * later upgrade charge, and, in the future, refunds. The event_participant row
+ * only keeps the most recent transaction in its own transaction_id column, so
+ * this table is the source of truth for payment history. Amounts and currency
+ * are read by joining fair_payment_transactions (single source of truth),
+ * mirroring FeePaymentTransactionRepository.
+ *
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery
+ */
+class EventParticipantTransactionRepository {
+
+	/**
+	 * Get table name.
+	 *
+	 * @return string Table name.
+	 */
+	private function get_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . 'fair_audience_event_participant_transactions';
+	}
+
+	/**
+	 * Record a transaction against a registration. Idempotent: the unique key on
+	 * (event_participant_id, transaction_id, kind) makes a repeated call (e.g. a
+	 * retried Mollie webhook) a no-op via INSERT IGNORE.
+	 *
+	 * @param int    $event_participant_id Event participant row ID.
+	 * @param int    $transaction_id       fair-payments-connector transaction ID.
+	 * @param string $kind                 'charge' or 'refund'.
+	 * @return bool True when a row was inserted or already present, false on error.
+	 */
+	public function record( $event_participant_id, $transaction_id, $kind = 'charge' ) {
+		global $wpdb;
+
+		if ( ! $event_participant_id || ! $transaction_id ) {
+			return false;
+		}
+
+		$kind = in_array( $kind, array( 'charge', 'refund' ), true ) ? $kind : 'charge';
+
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				'INSERT IGNORE INTO %i (event_participant_id, transaction_id, kind) VALUES (%d, %d, %s)',
+				$this->get_table_name(),
+				(int) $event_participant_id,
+				(int) $transaction_id,
+				$kind
+			)
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Net amount paid on a registration: SUM(charges) − SUM(refunds), counting
+	 * only transactions marked paid in fair-payments-connector.
+	 *
+	 * @param int $event_participant_id Event participant row ID.
+	 * @return float Net paid amount (>= 0 in practice).
+	 */
+	public function get_net_paid( $event_participant_id ) {
+		global $wpdb;
+
+		if ( ! $event_participant_id ) {
+			return 0.0;
+		}
+
+		$transactions_table = $wpdb->prefix . 'fair_payment_transactions';
+
+		$net = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COALESCE( SUM( CASE WHEN l.kind = 'refund' THEN -t.amount ELSE t.amount END ), 0 )
+				 FROM %i l
+				 INNER JOIN %i t ON l.transaction_id = t.id AND t.status = 'paid'
+				 WHERE l.event_participant_id = %d",
+				$this->get_table_name(),
+				$transactions_table,
+				(int) $event_participant_id
+			)
+		);
+
+		return (float) $net;
+	}
+
+	/**
+	 * Full transaction history for a registration, newest first. Joins
+	 * fair-payments-connector for status/amount/currency.
+	 *
+	 * @param int $event_participant_id Event participant row ID.
+	 * @return array Array of ledger rows with joined transaction detail.
+	 */
+	public function get_by_event_participant( $event_participant_id ) {
+		global $wpdb;
+
+		$transactions_table = $wpdb->prefix . 'fair_payment_transactions';
+
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT l.id, l.transaction_id, l.kind, l.created_at,
+					t.status, t.amount, t.currency
+				 FROM %i l
+				 LEFT JOIN %i t ON l.transaction_id = t.id
+				 WHERE l.event_participant_id = %d
+				 ORDER BY l.created_at DESC',
+				$this->get_table_name(),
+				$transactions_table,
+				(int) $event_participant_id
+			),
+			ARRAY_A
+		);
+	}
+}

--- a/fair-audience/src/Database/Schema.php
+++ b/fair-audience/src/Database/Schema.php
@@ -638,6 +638,38 @@ class Schema {
 	}
 
 	/**
+	 * Get SQL for creating the event-participant transactions ledger table.
+	 *
+	 * A registration (event_participant row) can accumulate more than one
+	 * fair-payments-connector transaction over its lifetime — e.g. an initial
+	 * single-instance charge followed by a series-pass upgrade charge, and, in
+	 * the future, refunds. The row's own transaction_id column only ever holds
+	 * the most recent transaction, so this ledger preserves the full history.
+	 * Amounts/currency are read by joining fair_payment_transactions (single
+	 * source of truth), mirroring FeePaymentTransactionRepository.
+	 *
+	 * @return string SQL statement.
+	 */
+	public static function get_event_participant_transactions_table_sql() {
+		global $wpdb;
+
+		$table_name      = $wpdb->prefix . 'fair_audience_event_participant_transactions';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		return "CREATE TABLE $table_name (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			event_participant_id BIGINT UNSIGNED NOT NULL,
+			transaction_id BIGINT UNSIGNED NOT NULL,
+			kind ENUM('charge', 'refund') NOT NULL DEFAULT 'charge',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY  (id),
+			UNIQUE KEY idx_participant_tx_kind (event_participant_id, transaction_id, kind),
+			KEY idx_event_participant_id (event_participant_id),
+			KEY idx_transaction_id (transaction_id)
+		) ENGINE=InnoDB $charset_collate;";
+	}
+
+	/**
 	 * Get SQL for creating the Instagram posts table.
 	 *
 	 * @return string SQL statement.

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -13,6 +13,7 @@ use FairAudience\Database\FeePaymentRepository;
 use FairAudience\Database\FeeAuditLogRepository;
 use FairAudience\Database\ParticipantRepository;
 use FairAudience\Database\EventParticipantRepository;
+use FairAudience\Database\EventParticipantTransactionRepository;
 use FairAudience\Services\EmailService;
 
 defined( 'WPINC' ) || die;
@@ -31,6 +32,7 @@ class PaymentHooks {
 		add_action( 'fair_payment_paid', array( static::class, 'handle_signup_paid' ), 10, 2 );
 		add_action( 'fair_payment_failed', array( static::class, 'handle_signup_failed' ), 10, 2 );
 		add_action( 'fair_payment_paid', array( static::class, 'handle_activities_added_paid' ), 10, 2 );
+		add_action( 'fair_payment_paid', array( static::class, 'handle_series_upgrade_paid' ), 10, 2 );
 
 		add_action( 'fair_audience_event_signup_paid', array( static::class, 'send_signup_confirmation_email' ), 10, 2 );
 		add_action( 'fair_audience_event_signup_failed', array( static::class, 'send_signup_payment_failed_email' ), 10, 2 );
@@ -426,6 +428,8 @@ class PaymentHooks {
 			return;
 		}
 
+		$ledger = new EventParticipantTransactionRepository();
+
 		$confirmation_participant = null;
 		foreach ( $event_participants as $event_participant ) {
 			if ( 'pending_payment' !== $event_participant->label ) {
@@ -435,6 +439,12 @@ class PaymentHooks {
 			$event_participant->label              = 'signed_up';
 			$event_participant->payment_expires_at = null;
 			$event_participant->save();
+
+			// Preserve this charge in the ledger so a registration keeps its full
+			// payment history even when its transaction_id column is later
+			// overwritten (e.g. by a series-pass upgrade). Idempotent under
+			// webhook retries via the ledger's unique key.
+			$ledger->record( (int) $event_participant->id, (int) $transaction->id, 'charge' );
 
 			if ( null === $confirmation_participant ) {
 				$confirmation_participant = $event_participant;
@@ -533,6 +543,67 @@ class PaymentHooks {
 		$repo->add_options( $event_participant_id, $options );
 
 		do_action( 'fair_audience_event_activities_added', $event_participant, $transaction, $option_ids );
+	}
+
+	/**
+	 * Convert a single-instance signup into a whole-series pass once Mollie
+	 * confirms the upgrade payment. The registration row is upgraded in place
+	 * (the unique event_date/participant key means it must stay one row): its
+	 * ticket_type becomes the whole-series type, which is all the series-pass
+	 * projection (is_occurrence_covered_by_series_pass and the admin/frontend
+	 * lists) needs to start covering every occurrence.
+	 *
+	 * Idempotent — Mollie retries the webhook, so a per-transaction transient
+	 * guards against converting (and emailing) twice.
+	 *
+	 * @param object $payment     Mollie payment object.
+	 * @param object $transaction Transaction row from fair-payments-connector.
+	 */
+	public static function handle_series_upgrade_paid( $payment, $transaction ) {
+		$metadata = ! empty( $transaction->metadata ) ? json_decode( $transaction->metadata, true ) : array();
+		if ( empty( $metadata['source'] ) || 'fair-audience-series-upgrade' !== $metadata['source'] ) {
+			return;
+		}
+
+		$dedupe_key = 'fair_audience_series_upgrade_' . (int) $transaction->id;
+		if ( get_transient( $dedupe_key ) ) {
+			return;
+		}
+
+		$event_participant_id = isset( $metadata['event_participant_id'] ) ? (int) $metadata['event_participant_id'] : 0;
+		$ticket_type_id       = isset( $metadata['ticket_type_id'] ) ? (int) $metadata['ticket_type_id'] : 0;
+
+		if ( ! $event_participant_id || ! $ticket_type_id ) {
+			return;
+		}
+
+		$repo              = new EventParticipantRepository();
+		$event_participant = $repo->get_by_id( $event_participant_id );
+		if ( ! $event_participant || 'signed_up' !== $event_participant->label ) {
+			return;
+		}
+
+		set_transient( $dedupe_key, 1, DAY_IN_SECONDS );
+
+		// Upgrade the ticket type (and seat count) in place.
+		$seats = 1;
+		if ( class_exists( \FairEvents\Models\TicketType::class ) ) {
+			$ticket_type = \FairEvents\Models\TicketType::get_by_id( $ticket_type_id );
+			if ( $ticket_type ) {
+				$seats = max( 1, (int) $ticket_type->seats_per_ticket );
+			}
+		}
+		$event_participant->ticket_type_id = $ticket_type_id;
+		$event_participant->seats          = $seats;
+		$event_participant->transaction_id = (int) $transaction->id;
+		$event_participant->save();
+
+		// Preserve the upgrade charge alongside the original payment.
+		$ledger = new EventParticipantTransactionRepository();
+		$ledger->record( (int) $event_participant->id, (int) $transaction->id, 'charge' );
+
+		// Reuse the standard paid-signup confirmation email.
+		do_action( 'fair_audience_event_signup_paid', $event_participant, $transaction );
 	}
 
 	/**


### PR DESCRIPTION
## Problem

A participant who already held a single-instance `signed_up` row on the master event-date could not buy a whole-series pass. `create_signup()` found the existing row and short-circuited with `already_signed_up`, so the series purchase never started.

## Change

Treat the whole-series purchase over an existing single-instance signup as an **in-place upgrade** (the `UNIQUE (event_date_id, participant_id)` key means it must stay one row):

- **Charge only the difference** between the series price and what the buyer already paid on this registration.
- **Non-destructive** on the paid path — the existing `signed_up` row is left untouched (same pattern as the add-activities flow), so an abandoned upgrade leaves the original signup and its seat intact. On payment, `handle_series_upgrade_paid()` flips the row's ticket type to the series pass.
- Free upgrades (delta ≤ 0) convert immediately.
- A genuine repeat (already holding a series pass) still returns `already_signed_up`.

### Preserving payment history

The registration row has a single `transaction_id` column, so an upgrade would otherwise orphan the first payment. A new `fair_audience_event_participant_transactions` ledger keeps the full history (every confirmed signup charge is recorded), with a `kind` column (`charge`/`refund`) that is **ready for refunds later** — no refund flow is built in this PR.

## Files

- `Schema.php` + `fair-audience.php` — new ledger table, `dbDelta` + `1.38.0` migration.
- `EventParticipantTransactionRepository.php` (new) — `record()` (idempotent), `get_net_paid()`, `get_by_event_participant()`.
- `EventSignupController.php` — upgrade detection + `maybe_start_series_upgrade_payment()`.
- `PaymentHooks.php` — ledger recording in `handle_signup_paid()` + `handle_series_upgrade_paid()`.
- `EventSignupRecurrenceScope.api.spec.js` — Playwright case for the upgrade unblock.

## Verification

- `php -l` clean; `phpcs` clean on new code.
- Live ledger check (WP-CLI `eval-file`): migration table created, `record()` idempotent, `get_net_paid()` nets charges − refunds correctly.
- Live end-to-end through the real REST controller (7/7): single-instance signup → whole-series purchase returns `signed_up` (not `already_signed_up`) → master row upgraded to the series ticket type → repeat returns `already_signed_up`.

### Notes for review

- The **paid-difference branch** (delta > 0) wasn't exercised through an actual checkout (Mollie isn't configured in dev); it mirrors the proven add-activities payment flow. The unblock + free conversion + ledger were verified live.
- **Mid-series coverage**: the upgraded row keeps its original `created_at`, so series coverage starts from the original signup date (consistent with difference-pricing). Easy to flip to "cover from upgrade time" if preferred.