### PR TITLE
Add purchase-flow e2e coverage and fix the two payment bugs it caught

### DIFF
--- a/.changeset/get-tickets-return-url-fix.md
+++ b/.changeset/get-tickets-return-url-fix.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix paid get-tickets purchases dumping the buyer on the homepage after checkout. The redirect URL was built with `get_permalink()` inside the REST request, where there is no post context, so it always fell back to `home_url()` — a page without the block, so the buyer never saw a confirmation. The controller now resolves the return URL from the same-site referer (preserving `?event_date=` on standalone pages), falling back to the event's own page, then the homepage.

--- a/.changeset/simple-payment-block-id-fix.md
+++ b/.changeset/simple-payment-block-id-fix.md
@@ -1,0 +1,5 @@
+---
+"fair-payments-connector": patch
+---
+
+Fix the simple-payment block rejecting every purchase with "Block not found." Since the block-id/amount verification was added to the payment endpoint, render.php overwrote the saved blockId attribute with a per-render `wp_unique_id()` before printing the button's `data-block-id`, so the submitted id could never match the block in post content and the endpoint returned 403. The unique id is now used only for the wrapper's DOM id; the button submits the real blockId attribute. Caught by the new simple-payment e2e spec — the API specs only covered the rejection paths.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -129,6 +129,21 @@ Each prints a single `MARKER:{json}` line (`E2E_SEED`, `E2E_STATE`,
 - **`signup-state.php <email> <event_date_id>`** — reports the participant's
   `email_profile`/`status`, the event-participant `label`, and the mail captured
   for that buyer.
+- **`get-tickets-state.php <event_date_id>`** — reports the fair-events
+  `fair_events_signups` rows (the standalone get-tickets purchase path) with
+  each row's status and, when paid, its transaction status + Mollie payment id.
+- **`seed-payment-page.php [amount] [description]`** / **`cleanup-payment-page.php <pageId>`**
+  — create/delete a published page carrying a simple-payment block (with the
+  editor-style UUID `blockId` attribute the payment endpoint matches on);
+  cleanup also removes the transactions the page created (matched by
+  `post_id`).
+- **`transaction-state.php <transaction_id>`** — reports one
+  `fair_payment_transactions` row (status, testmode, amount, Mollie id).
+
+The event seeded by `seed-event.php` carries the fair-audience event-signup
+block by default; pass `{"block":"get-tickets"}` in the JSON overrides to seed
+it with the fair-events get-tickets block instead (used by the spec that runs
+with fair-audience deactivated).
 
 ## Playwright fixture: `seedEvent`
 

--- a/e2e/fair-payments-connector-admin-menu.spec.js
+++ b/e2e/fair-payments-connector-admin-menu.spec.js
@@ -1,0 +1,67 @@
+/**
+ * Fair Payments Connector admin pages — mount smoke.
+ *
+ * Mirrors fair-events-admin-menu.spec.js for the connector: every admin page
+ * must render its React root AND mount something into it. An empty root with
+ * no children is the exact failure mode of a broken asset enqueue (the page
+ * renders `<div id="…-root">` but no JS loads) — which a PHP-only check would
+ * miss.
+ *
+ * Run: `npm run test:e2e -- fair-payments-connector-admin-menu`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './support/wp-cli.js';
+
+/** Every Fair Payments Connector admin page and its React root element id. */
+const PAGES = [
+	{
+		slug: 'fair-payments-connector-transactions',
+		root: 'fair-payments-connector-transactions-root',
+	},
+	{
+		slug: 'fair-payments-connector-fee-dashboard',
+		root: 'fair-payments-connector-fee-dashboard-root',
+	},
+	{
+		slug: 'fair-payments-connector-settings',
+		root: 'fair-payments-connector-settings-root',
+	},
+];
+
+test.describe('Fair Payments Connector admin menu', () => {
+	test('top-level menu is present with Transactions, Fee Dashboard and Settings', async ({
+		page,
+	}) => {
+		await loginAsAdmin(page);
+		await page.goto('/wp-admin/');
+
+		const menu = page.locator(
+			'#toplevel_page_fair-payments-connector-transactions'
+		);
+		await expect(menu).toBeVisible();
+
+		for (const { slug } of PAGES) {
+			await expect(
+				menu.locator(`a[href*="page=${slug}"]`).first(),
+				`menu link for ${slug} missing`
+			).toBeAttached();
+		}
+	});
+
+	test('every page mounts its React root', async ({ page }) => {
+		await loginAsAdmin(page);
+
+		for (const { slug, root } of PAGES) {
+			await page.goto(`/wp-admin/admin.php?page=${slug}`);
+			await expect(
+				page.locator(`#${root}`),
+				`${slug}: React root element missing`
+			).toBeAttached();
+			await expect(
+				page.locator(`#${root} > *`).first(),
+				`${slug}: root is empty — admin bundle did not load`
+			).toBeAttached({ timeout: 15000 });
+		}
+	});
+});

--- a/e2e/mu-plugins/lib/event-factory.php
+++ b/e2e/mu-plugins/lib/event-factory.php
@@ -23,18 +23,21 @@ use FairEventsExperimental\Models\TicketOption;
 
 if ( ! function_exists( 'fair_e2e_create_event' ) ) {
 	/**
-	 * Create a published fair_event post carrying the event-signup block.
+	 * Create a published fair_event post carrying a signup/purchase block.
 	 *
-	 * @param string $title Post title (callers pass a timestamped unique title).
+	 * @param string $title   Post title (callers pass a timestamped unique title).
+	 * @param string $content Post content; defaults to the fair-audience
+	 *                        event-signup block. Pass the fair-events get-tickets
+	 *                        block for specs that run without fair-audience.
 	 * @return int Event post ID.
 	 */
-	function fair_e2e_create_event( $title ) {
+	function fair_e2e_create_event( $title, $content = '<!-- wp:fair-audience/event-signup /-->' ) {
 		$event_id = wp_insert_post(
 			array(
 				'post_type'    => 'fair_event',
 				'post_status'  => 'publish',
 				'post_title'   => $title,
-				'post_content' => '<!-- wp:fair-audience/event-signup /-->',
+				'post_content' => $content,
 			),
 			true
 		);

--- a/e2e/mu-plugins/scripts/cleanup-event.php
+++ b/e2e/mu-plugins/scripts/cleanup-event.php
@@ -118,6 +118,11 @@ $deleted['sale_periods'] = (int) $wpdb->query(
 	$wpdb->prepare( 'DELETE FROM %i WHERE event_date_id = %d', $sale_periods_table, $event_date_id )
 );
 
+// Get-tickets signup rows (fair-events standalone purchase path).
+$deleted['get_tickets_signups'] = (int) $wpdb->query(
+	$wpdb->prepare( 'DELETE FROM %i WHERE event_date_id = %d', $wpdb->prefix . 'fair_events_signups', $event_date_id )
+);
+
 $deleted['event_dates'] = (int) $wpdb->query(
 	$wpdb->prepare( 'DELETE FROM %i WHERE event_id = %d', $dates_table, $event_id )
 );

--- a/e2e/mu-plugins/scripts/cleanup-payment-page.php
+++ b/e2e/mu-plugins/scripts/cleanup-payment-page.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Delete an E2E-seeded simple-payment page and the transactions it created.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/cleanup-payment-page.php <pageId>
+ *
+ * Transactions are matched by their post_id column (set by PaymentEndpoint from
+ * the block's post context), so repeated local runs don't accumulate paid rows
+ * that would skew the fee dashboard.
+ *
+ * Prints a single `E2E_PAYMENT_CLEANUP:{json}` line with row counts.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+global $wpdb;
+
+$page_id = isset( $args[0] ) ? (int) $args[0] : 0;
+if ( ! $page_id ) {
+	WP_CLI::error( 'Usage: cleanup-payment-page.php <pageId>' );
+}
+
+$transactions_table = $wpdb->prefix . 'fair_payment_transactions';
+$line_items_table   = $wpdb->prefix . 'fair_payment_line_items';
+
+$deleted = array();
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off teardown script, no cache to honour.
+$transaction_ids = $wpdb->get_col(
+	$wpdb->prepare( 'SELECT id FROM %i WHERE post_id = %d', $transactions_table, $page_id )
+);
+
+if ( $transaction_ids ) {
+	$placeholders = implode( ', ', array_fill( 0, count( $transaction_ids ), '%d' ) );
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is a safe list of %d.
+	$deleted['line_items'] = (int) $wpdb->query(
+		$wpdb->prepare(
+			"DELETE FROM %i WHERE transaction_id IN ({$placeholders})",
+			array_merge( array( $line_items_table ), $transaction_ids )
+		)
+	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+}
+
+$deleted['transactions'] = (int) $wpdb->query(
+	$wpdb->prepare( 'DELETE FROM %i WHERE post_id = %d', $transactions_table, $page_id )
+);
+// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+$deleted['page'] = wp_delete_post( $page_id, true ) ? 1 : 0;
+
+echo 'E2E_PAYMENT_CLEANUP:' . wp_json_encode( $deleted ) . "\n";

--- a/e2e/mu-plugins/scripts/get-tickets-state.php
+++ b/e2e/mu-plugins/scripts/get-tickets-state.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Report the get-tickets signup rows (and their transactions) for an event date.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/get-tickets-state.php <event_date_id>
+ *
+ * Prints a single `E2E_GT_STATE:{json}` line with one entry per
+ * fair_events_signups row: name, email, quantity, amount, status, and — when a
+ * transaction is attached — its status, testmode flag, and Mollie payment id
+ * from fair_payment_transactions.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+global $wpdb;
+
+$event_date_id = isset( $args[0] ) ? (int) $args[0] : 0;
+if ( ! $event_date_id ) {
+	WP_CLI::error( 'Usage: get-tickets-state.php <event_date_id>' );
+}
+
+$signups_table      = $wpdb->prefix . 'fair_events_signups';
+$transactions_table = $wpdb->prefix . 'fair_payment_transactions';
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off state dump for the spec, no cache to honour.
+$rows = $wpdb->get_results(
+	$wpdb->prepare( 'SELECT * FROM %i WHERE event_date_id = %d ORDER BY id ASC', $signups_table, $event_date_id )
+);
+
+$signups = array();
+foreach ( $rows as $row ) {
+	$entry = array(
+		'id'             => (int) $row->id,
+		'name'           => (string) $row->name,
+		'email'          => (string) $row->email,
+		'quantity'       => (int) $row->quantity,
+		'amount'         => (float) $row->amount,
+		'status'         => (string) $row->status,
+		'transaction_id' => $row->transaction_id ? (int) $row->transaction_id : null,
+	);
+
+	if ( $row->transaction_id ) {
+		$tx = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT status, testmode, mollie_payment_id FROM %i WHERE id = %d', $transactions_table, (int) $row->transaction_id )
+		);
+		if ( $tx ) {
+			$entry['transaction_status']   = (string) $tx->status;
+			$entry['transaction_testmode'] = (bool) $tx->testmode;
+			$entry['mollie_payment_id']    = (string) $tx->mollie_payment_id;
+		}
+	}
+
+	$signups[] = $entry;
+}
+// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+echo 'E2E_GT_STATE:' . wp_json_encode( array( 'signups' => $signups ) ) . "\n";

--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -43,7 +43,15 @@ $ticket_type_id = 0;
 $option_ids     = array();
 $is_paid        = true;
 
-$event_id       = fair_e2e_create_event( 'E2E ' . $flavour . ' Event ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ) );
+// Which purchase block the event page carries. Default: fair-audience
+// event-signup. Override {"block":"get-tickets"} for specs that exercise the
+// fair-events standalone purchase path (with fair-audience deactivated).
+$block_content = '<!-- wp:fair-audience/event-signup /-->';
+if ( isset( $overrides['block'] ) && 'get-tickets' === $overrides['block'] ) {
+	$block_content = '<!-- wp:fair-events/get-tickets /-->';
+}
+
+$event_id       = fair_e2e_create_event( 'E2E ' . $flavour . ' Event ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ), $block_content );
 $event_date_id  = fair_e2e_add_date( $event_id );
 $sale_period_id = fair_e2e_add_sale_period( $event_date_id );
 

--- a/e2e/mu-plugins/scripts/seed-payment-page.php
+++ b/e2e/mu-plugins/scripts/seed-payment-page.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Seed a published page carrying the simple-payment block for the E2E specs.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-payment-page.php [amount] [description]
+ *
+ * Prints a single `E2E_PAYMENT_PAGE:{json}` line with the page id + permalink.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$amount      = isset( $args[0] ) && '' !== $args[0] ? (string) (float) $args[0] : '12.50';
+$description = isset( $args[1] ) && '' !== $args[1] ? (string) $args[1] : 'E2E simple payment';
+
+// The editor assigns every simple-payment block a UUID blockId attribute;
+// the payment endpoint derives the authoritative amount by matching it, so
+// the seeded block must carry one too.
+$block_attrs = wp_json_encode(
+	array(
+		'blockId'     => wp_generate_uuid4(),
+		'amount'      => $amount,
+		'description' => $description,
+	)
+);
+
+$page_id = wp_insert_post(
+	array(
+		'post_type'    => 'page',
+		'post_status'  => 'publish',
+		'post_title'   => 'E2E Simple Payment ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ),
+		'post_content' => '<!-- wp:fair-payment/simple-payment ' . $block_attrs . ' /-->',
+	),
+	true
+);
+
+if ( is_wp_error( $page_id ) ) {
+	WP_CLI::error( 'Failed to create payment page: ' . $page_id->get_error_message() );
+}
+
+echo 'E2E_PAYMENT_PAGE:' . wp_json_encode(
+	array(
+		'pageId'      => (int) $page_id,
+		'pageUrl'     => get_permalink( $page_id ),
+		'amount'      => (float) $amount,
+		'description' => $description,
+	)
+) . "\n";

--- a/e2e/mu-plugins/scripts/transaction-state.php
+++ b/e2e/mu-plugins/scripts/transaction-state.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Report a fair-payments-connector transaction row for the E2E specs.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/transaction-state.php <transaction_id>
+ *
+ * Prints a single `E2E_TX_STATE:{json}` line with the row's status, testmode
+ * flag, amount, currency, mollie_payment_id, and post_id.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+global $wpdb;
+
+$transaction_id = isset( $args[0] ) ? (int) $args[0] : 0;
+if ( ! $transaction_id ) {
+	WP_CLI::error( 'Usage: transaction-state.php <transaction_id>' );
+}
+
+$transactions_table = $wpdb->prefix . 'fair_payment_transactions';
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off state dump for the spec, no cache to honour.
+$tx = $wpdb->get_row(
+	$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $transactions_table, $transaction_id )
+);
+// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+if ( ! $tx ) {
+	echo 'E2E_TX_STATE:' . wp_json_encode( array( 'found' => false ) ) . "\n";
+	return;
+}
+
+echo 'E2E_TX_STATE:' . wp_json_encode(
+	array(
+		'found'             => true,
+		'id'                => (int) $tx->id,
+		'status'            => (string) $tx->status,
+		'testmode'          => (bool) $tx->testmode,
+		'amount'            => (float) $tx->amount,
+		'currency'          => (string) $tx->currency,
+		'mollie_payment_id' => (string) $tx->mollie_payment_id,
+		'post_id'           => $tx->post_id ? (int) $tx->post_id : null,
+	)
+) . "\n";

--- a/e2e/user-flows/get-tickets-purchase.spec.js
+++ b/e2e/user-flows/get-tickets-purchase.spec.js
@@ -1,0 +1,162 @@
+/**
+ * E2E: fair-events standalone ticket purchase via the get-tickets block.
+ *
+ * The get-tickets block (fair-events 1.7.0) is the purchase path for sites
+ * running fair-events WITHOUT fair-audience — the block render defers to the
+ * Event Signup block whenever fair-audience is active, and the
+ * GetTicketsController REST route is only registered when fair-audience's
+ * EventSignupController class is absent. So this suite deactivates
+ * fair-audience for its duration (and reactivates it afterwards; the whole
+ * Playwright run is single-worker/serial, so no other spec runs in between).
+ *
+ * Covers both branches of the block:
+ *   - free ticket type → immediate confirmation, signup row 'confirmed' with
+ *     no transaction;
+ *   - paid ticket type → payment_required, redirect through the Mollie double
+ *     back to the callback URL, webhook flips the transaction to paid (the
+ *     production path — Mollie calls /webhook; the redirect page itself only
+ *     polls), fair_payment_paid → FairEvents PaymentHooks confirms the signup,
+ *     and the block UI shows the success message.
+ *
+ * The get-tickets endpoint rate-limits by IP (3/hour), so transients are
+ * cleared before each test to keep repeated local runs deterministic.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+import { wpCli, runScript } from '../support/wp-cli.js';
+
+test.describe('get-tickets block purchase (fair-audience inactive)', () => {
+	test.beforeAll(() => {
+		wpCli('plugin deactivate fair-audience');
+	});
+
+	test.afterAll(() => {
+		wpCli('plugin activate fair-audience');
+	});
+
+	test.beforeEach(() => {
+		// Reset the get-tickets per-IP rate limit (3 requests/hour).
+		wpCli('transient delete --all');
+	});
+
+	test('paid ticket: checkout via the Mollie double, webhook confirms the signup', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('paid', { block: 'get-tickets' });
+
+		const stamp = Date.now();
+		const buyerName = `E2E GetTickets Paid ${stamp}`;
+		const email = `get-tickets.paid.${stamp}@example.test`;
+
+		await page.goto(event.pageUrl);
+
+		// The standalone form must render — not the "fair-audience is active"
+		// deferral notice (which would mean the deactivation didn't take).
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+		await expect(
+			page.locator('.fair-events-get-tickets-notice')
+		).toHaveCount(0);
+
+		await form.locator('input[name="name"]').fill(buyerName);
+		await form.locator('input[name="email"]').fill(email);
+		await form
+			.locator('select[name="ticket_type_id"]')
+			.selectOption(String(event.ticketTypeId));
+
+		// Submit → payment_required with a checkout_url that (via the Mollie
+		// double) is the callback URL itself, so the browser lands straight on
+		// ?fair_payment_callback=true&transaction_id=…&token=…. Wait for the
+		// rendered processing state rather than the navigation itself
+		// (waitForURL can abort when a redirect supersedes it — see
+		// ticket-purchase-confirmation.spec.js), then assert the URL by polling.
+		await form.locator('button[type="submit"]').click();
+		await expect(page.locator('.message-processing')).toBeVisible({
+			timeout: 30000,
+		});
+		await expect(page).toHaveURL(/fair_payment_callback=true/);
+
+		// The signup row is pending and its transaction still open — the
+		// redirect page only polls; Mollie's webhook is what flips the status.
+		let state = runScript(
+			'get-tickets-state.php',
+			'E2E_GT_STATE',
+			String(event.eventDateId)
+		);
+		expect(state.signups).toHaveLength(1);
+		expect(state.signups[0].email).toBe(email);
+		expect(state.signups[0].status).toBe('pending_payment');
+		expect(state.signups[0].amount).toBe(event.price);
+		expect(state.signups[0].mollie_payment_id).toBeTruthy();
+
+		// Simulate Mollie's webhook call (production path). The handler fetches
+		// the payment from the double, which reports it paid, and fires the real
+		// fair_payment_paid → FairEvents\Hooks\PaymentHooks chain.
+		const webhookResponse = await page.request.post(
+			'/wp-json/fair-payments-connector/v1/webhook',
+			{ form: { id: state.signups[0].mollie_payment_id } }
+		);
+		expect(webhookResponse.ok()).toBe(true);
+
+		// The block's callback poller picks the paid status up and swaps the
+		// form for the success message.
+		await expect(
+			page.getByText('Your ticket purchase was successful', {
+				exact: false,
+			})
+		).toBeVisible({ timeout: 30000 });
+
+		// Server-side: signup confirmed, transaction paid (in test mode).
+		state = runScript(
+			'get-tickets-state.php',
+			'E2E_GT_STATE',
+			String(event.eventDateId)
+		);
+		expect(state.signups[0].status).toBe('confirmed');
+		expect(state.signups[0].transaction_status).toBe('paid');
+		expect(state.signups[0].transaction_testmode).toBe(true);
+	});
+
+	test('free ticket: immediate confirmation without any transaction', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('free', { block: 'get-tickets' });
+
+		const stamp = Date.now();
+		const email = `get-tickets.free.${stamp}@example.test`;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		await form
+			.locator('input[name="name"]')
+			.fill(`E2E GetTickets Free ${stamp}`);
+		await form.locator('input[name="email"]').fill(email);
+		await form
+			.locator('select[name="ticket_type_id"]')
+			.selectOption(String(event.ticketTypeId));
+
+		await form.locator('button[type="submit"]').click();
+
+		// Free path confirms in place — no redirect, form hidden.
+		await expect(
+			page.getByText('You have successfully registered', { exact: false })
+		).toBeVisible({ timeout: 15000 });
+		await expect(form).toBeHidden();
+
+		const state = runScript(
+			'get-tickets-state.php',
+			'E2E_GT_STATE',
+			String(event.eventDateId)
+		);
+		expect(state.signups).toHaveLength(1);
+		expect(state.signups[0].email).toBe(email);
+		expect(state.signups[0].status).toBe('confirmed');
+		expect(state.signups[0].amount).toBe(0);
+		expect(state.signups[0].transaction_id).toBeNull();
+	});
+});

--- a/e2e/user-flows/simple-payment-purchase.spec.js
+++ b/e2e/user-flows/simple-payment-purchase.spec.js
@@ -1,0 +1,96 @@
+/**
+ * E2E: fair-payments-connector simple-payment block — full purchase lifecycle.
+ *
+ * The PaymentEndpoint's security checks are covered by API specs; this drives
+ * the real browser flow: the block renders its Pay Now button (Mollie
+ * configured via the e2e dummy key), the click fetches a fresh nonce and
+ * creates a payment, the Mollie double's checkout link sends the buyer
+ * straight back to the callback URL, and — as in production — Mollie's
+ * webhook flips the transaction to paid, which the block's status poller
+ * picks up and renders as the confirmed message.
+ *
+ * This is the spec that caught the render.php blockId clobbering (the button
+ * submitted a per-render wp_unique_id() instead of the saved blockId
+ * attribute, so the endpoint's amount verification 403'd every purchase):
+ * the API specs only covered the rejection paths, never a successful buy.
+ */
+
+import { test, expect } from '@playwright/test';
+import { runScript } from '../support/wp-cli.js';
+
+let seed;
+
+test.beforeAll(() => {
+	seed = runScript('seed-payment-page.php', 'E2E_PAYMENT_PAGE', '12.50');
+});
+
+test.afterAll(() => {
+	if (seed) {
+		runScript(
+			'cleanup-payment-page.php',
+			'E2E_PAYMENT_CLEANUP',
+			String(seed.pageId)
+		);
+	}
+});
+
+test.describe('simple-payment block purchase', () => {
+	test('pay → callback → webhook → confirmed message and paid transaction', async ({
+		page,
+	}) => {
+		await page.goto(seed.pageUrl);
+
+		// Mollie is configured (dummy e2e key), so the button renders — not the
+		// "gateway is not configured" fallback.
+		const payButton = page.locator('.fair-payments-connector-button');
+		await expect(payButton).toBeVisible();
+		await expect(
+			page.locator('.fair-payments-connector-not-configured')
+		).toHaveCount(0);
+
+		// Click → nonce fetch + POST /payments → redirect through the Mollie
+		// double back to ?fair_payment_callback=true&transaction_id=…&token=….
+		// Wait for the rendered processing state rather than the navigation
+		// itself (waitForURL can abort when a redirect supersedes it — see
+		// ticket-purchase-confirmation.spec.js), then assert the URL by polling.
+		await payButton.click();
+		await expect(
+			page.locator('.fair-payments-connector-processing')
+		).toBeVisible({ timeout: 30000 });
+		await expect(page).toHaveURL(/fair_payment_callback=true/);
+
+		const url = new URL(page.url());
+		const transactionId = url.searchParams.get('transaction_id');
+		expect(transactionId).toBeTruthy();
+
+		let tx = runScript(
+			'transaction-state.php',
+			'E2E_TX_STATE',
+			transactionId
+		);
+		expect(tx.found).toBe(true);
+		expect(tx.post_id).toBe(seed.pageId);
+		expect(tx.amount).toBe(seed.amount);
+		expect(tx.mollie_payment_id).toBeTruthy();
+
+		// Simulate Mollie's webhook call (production path): the handler fetches
+		// the payment from the double, which reports it paid.
+		const webhookResponse = await page.request.post(
+			'/wp-json/fair-payments-connector/v1/webhook',
+			{ form: { id: tx.mollie_payment_id } }
+		);
+		expect(webhookResponse.ok()).toBe(true);
+
+		// The block's poller flips the UI to the confirmed message.
+		await expect(
+			page.getByText('Your payment has been received and confirmed', {
+				exact: false,
+			})
+		).toBeVisible({ timeout: 30000 });
+
+		// Server-side: the transaction row is paid, in test mode.
+		tx = runScript('transaction-state.php', 'E2E_TX_STATE', transactionId);
+		expect(tx.status).toBe('paid');
+		expect(tx.testmode).toBe(true);
+	});
+});

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -324,7 +324,7 @@ class GetTicketsController extends WP_REST_Controller {
 				'transaction_id'        => $transaction_id,
 				'token'                 => $transaction ? $transaction->access_token : '',
 			),
-			get_permalink() ?: home_url( '/' )
+			$this->resolve_return_url( $event_date_id )
 		);
 
 		$payment = \FairPaymentsConnector\API\TransactionAPI::initiate_payment(
@@ -345,6 +345,40 @@ class GetTicketsController extends WP_REST_Controller {
 				'currency'       => $currency,
 			)
 		);
+	}
+
+	/**
+	 * Resolve the page the buyer should return to after checkout.
+	 *
+	 * This runs inside a REST request, which carries no post context —
+	 * get_permalink() is always false here, so it must never be used for the
+	 * redirect. Prefer the page the purchase was made from (same-site referer,
+	 * which also preserves ?event_date= on standalone pages), then the event's
+	 * own page, then the homepage.
+	 *
+	 * @param int $event_date_id Event-date ID the purchase targets.
+	 * @return string Absolute same-site URL.
+	 */
+	private function resolve_return_url( $event_date_id ) {
+		$referer = wp_get_referer();
+		if ( $referer ) {
+			$validated = wp_validate_redirect( $referer, '' );
+			if ( $validated ) {
+				return $validated;
+			}
+		}
+
+		if ( class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+			if ( $event_date && ! empty( $event_date->event_id ) ) {
+				$permalink = get_permalink( (int) $event_date->event_id );
+				if ( $permalink ) {
+					return $permalink;
+				}
+			}
+		}
+
+		return home_url( '/' );
 	}
 
 	/**
@@ -546,7 +580,7 @@ class GetTicketsController extends WP_REST_Controller {
 				'transaction_id'        => $transaction_id,
 				'token'                 => $transaction ? $transaction->access_token : '',
 			),
-			get_permalink() ?: home_url( '/' )
+			$this->resolve_return_url( $series_page_id )
 		);
 
 		$payment = \FairPaymentsConnector\API\TransactionAPI::initiate_payment(

--- a/fair-payments-connector/src/blocks/simple-payment/render.php
+++ b/fair-payments-connector/src/blocks/simple-payment/render.php
@@ -43,13 +43,17 @@ if ( $is_callback && class_exists( \FairPaymentsConnector\API\TransactionAPI::cl
 // Check if Mollie is configured.
 $is_configured = \FairPaymentsConnector\Payment\MolliePaymentHandler::is_configured();
 
-$block_id = 'fair-payments-connector-' . wp_unique_id();
+// DOM id for the wrapper only. Must NOT reuse $block_id: the payment endpoint
+// derives the authoritative amount by matching the saved blockId attribute in
+// post content, so the button has to submit the attribute value, not a
+// per-render unique id.
+$wrapper_id = 'fair-payments-connector-' . wp_unique_id();
 ?>
 
 <div
 <?php
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() returns pre-escaped HTML attributes.
-	echo get_block_wrapper_attributes( array( 'id' => $block_id ) );
+	echo get_block_wrapper_attributes( array( 'id' => $wrapper_id ) );
 ?>
 >
 	<div class="fair-payments-connector-block">


### PR DESCRIPTION
## Summary

Pre-go-live review showed neither plugin's revenue path had a test driving a **successful** purchase — the API specs cover the rejection branches only. This PR adds three e2e suites, and the very first runs caught two production bugs in the purchase flows, fixed here.

### Bugs found & fixed

- **fair-payments-connector**: every simple-payment purchase failed with 403 "Block not found." — `render.php` overwrote the saved `blockId` attribute with a per-render `wp_unique_id()`, so the payment endpoint's block/amount verification could never match. The unique id now names only the wrapper element; the button submits the real attribute.
- **fair-events**: paid get-tickets buyers were redirected to the **homepage** after checkout — `get_permalink()` is always false inside a REST request, so the `?: home_url('/')` fallback always won and the buyer never saw a confirmation. The return URL now resolves from the validated same-site referer (preserving `?event_date=` on standalone pages), then the event's own page, then home.

Changesets included for both (patch).

### New e2e suites

- `e2e/user-flows/get-tickets-purchase.spec.js` — fair-events standalone purchase (block defers to fair-audience when active, so the suite deactivates/reactivates it): free path confirms in place; paid path runs Mollie double → callback → simulated webhook → real `fair_payment_paid` → signup `confirmed`.
- `e2e/user-flows/simple-payment-purchase.spec.js` — full pay → callback → webhook → confirmed UI + paid transaction row.
- `e2e/fair-payments-connector-admin-menu.spec.js` — Transactions / Fee Dashboard / Settings mount their React roots.

### Harness

`seed-event.php` accepts `{"block":"get-tickets"}`; `cleanup-event.php` also removes `fair_events_signups` rows; new WP-CLI scripts (`get-tickets-state`, `seed-payment-page`, `cleanup-payment-page`, `transaction-state`); e2e README updated.

## Test plan

- [x] `npm run test:e2e` (all suites except plugin-check): 22 passed + 1 pre-existing login flake that passes on re-run
- [x] New suites individually green; paid flows verified down to DB state (signup `confirmed`, transaction `paid`, testmode)
- [x] PHPUnit: fair-events 20 tests OK, fair-payments-connector 15 tests OK