### PR TITLE
e2e: cover multiple_instances ticket purchase amount bug

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -119,9 +119,14 @@ Each prints a single `MARKER:{json}` line (`E2E_SEED`, `E2E_STATE`,
   - `paid-with-options` — `paid` plus `TicketOption` rows (override
     `{"options":["dinner","tshirt"]}`).
   - `capacity-1` — a paid ticket type with capacity 1 (sold-out/waitlist).
+  - `multiple-instances` — a 3-occurrence weekly series with a
+    `multiple_instances` ticket type priced per instance (default `10.00`;
+    override `{"price":N}`), `minimum_instances` default `2` (override
+    `{"minimumInstances":N}`).
 
   Emits the event permalink + ids: `flavour`, `eventId`, `eventDateId`,
-  `salePeriodId`, `ticketTypeId`, `optionIds`, `price`.
+  `salePeriodId`, `ticketTypeId`, `optionIds`, `occurrenceIds`,
+  `minimumInstances`, `price`.
 - **`cleanup-event.php <eventId> <eventDateId>`** — deletes a seeded event and
   everything off it (signed-up participants + their option rows, the
   event-participant rows, ticket types/prices/options/sale periods/dates, and

--- a/e2e/mu-plugins/lib/event-factory.php
+++ b/e2e/mu-plugins/lib/event-factory.php
@@ -19,6 +19,7 @@ use FairEvents\Models\EventDates;
 use FairEvents\Models\TicketSalePeriod;
 use FairEvents\Models\TicketType;
 use FairEvents\Models\TicketPrice;
+use FairEvents\Services\RecurrenceService;
 use FairEventsExperimental\Models\TicketOption;
 
 if ( ! function_exists( 'fair_e2e_create_event' ) ) {
@@ -72,6 +73,35 @@ if ( ! function_exists( 'fair_e2e_create_event' ) ) {
 	}
 
 	/**
+	 * Turn an event's single occurrence into a weekly recurring series (master +
+	 * generated occurrences), all linked to the event post like production
+	 * recurring events — as opposed to the standalone event-dates created via
+	 * the REST `/event-dates` endpoint, which never carry an `event_id`.
+	 *
+	 * @param int $event_id Event post ID (must already have one occurrence, see
+	 *                      fair_e2e_add_date()).
+	 * @param int $count    Number of occurrences in the series (including the master).
+	 * @return int[] Occurrence event_date ids, ordered by start_datetime (master first).
+	 */
+	function fair_e2e_add_series( $event_id, $count = 3 ) {
+		$rrule = 'FREQ=WEEKLY;COUNT=' . (int) $count;
+
+		EventDates::save_rrule( $event_id, $rrule );
+		RecurrenceService::regenerate_event_occurrences( $event_id, $rrule );
+
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'fair_event_dates';
+		$ids        = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT id FROM {$table_name} WHERE event_id = %d ORDER BY start_datetime", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$event_id
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+
+	/**
 	 * Add an active "Standard" sale period (open from yesterday for 30 days).
 	 *
 	 * @param int $event_date_id Event date ID.
@@ -106,6 +136,37 @@ if ( ! function_exists( 'fair_e2e_create_event' ) ) {
 
 		if ( ! $ticket_type_id ) {
 			WP_CLI::error( 'Failed to create ticket type.' );
+		}
+
+		return (int) $ticket_type_id;
+	}
+
+	/**
+	 * Add a 'multiple_instances' ticket type (buyer picks N occurrences of the
+	 * series, priced per instance) on the series master.
+	 *
+	 * @param int    $master_event_date_id The series master's event_date_id.
+	 * @param string $name                 Ticket type name.
+	 * @param int    $minimum_instances    Minimum number of occurrences the buyer must pick.
+	 * @return int Ticket type ID.
+	 */
+	function fair_e2e_add_multi_instance_ticket_type( $master_event_date_id, $name, $minimum_instances = 1 ) {
+		$ticket_type_id = TicketType::create(
+			$master_event_date_id,
+			$name,
+			null, // capacity.
+			0, // sort_order.
+			1, // seats_per_ticket.
+			false, // invitation_only.
+			0, // minimum_activities.
+			null, // disable_at.
+			'multiple_instances',
+			false, // disabled.
+			$minimum_instances
+		);
+
+		if ( ! $ticket_type_id ) {
+			WP_CLI::error( 'Failed to create multiple_instances ticket type.' );
 		}
 
 		return (int) $ticket_type_id;

--- a/e2e/mu-plugins/scripts/cleanup-event.php
+++ b/e2e/mu-plugins/scripts/cleanup-event.php
@@ -34,18 +34,38 @@ $options_table       = $wpdb->prefix . 'fair_events_ticket_options';
 $option_prices_table = $wpdb->prefix . 'fair_events_ticket_option_prices';
 $sale_periods_table  = $wpdb->prefix . 'fair_events_ticket_sale_periods';
 $dates_table         = $wpdb->prefix . 'fair_event_dates';
+$payments_table      = $wpdb->prefix . 'fair_payment_transactions';
 
 $deleted = array();
 
-// Event-participant rows for this event date, and the participants they
-// reference (the buyers — seeded events create no participants themselves).
+// All occurrences belonging to this event (a 'multiple_instances' purchase
+// creates one event-participant row per chosen occurrence, not just on the
+// master $event_date_id).
 // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off teardown script, no cache to honour.
+$series_event_date_ids = $wpdb->get_col(
+	$wpdb->prepare( 'SELECT id FROM %i WHERE event_id = %d', $dates_table, $event_id )
+);
+if ( ! in_array( $event_date_id, array_map( 'intval', $series_event_date_ids ), true ) ) {
+	$series_event_date_ids[] = $event_date_id;
+}
+$series_placeholders = implode( ', ', array_fill( 0, count( $series_event_date_ids ), '%d' ) );
+
+// Event-participant rows for every occurrence, and the participants they
+// reference (the buyers — seeded events create no participants themselves).
+// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $series_placeholders is a safe list of %d.
 $event_participant_ids = $wpdb->get_col(
-	$wpdb->prepare( 'SELECT id FROM %i WHERE event_date_id = %d', $event_parts_table, $event_date_id )
+	$wpdb->prepare(
+		"SELECT id FROM %i WHERE event_date_id IN ({$series_placeholders})",
+		array_merge( array( $event_parts_table ), $series_event_date_ids )
+	)
 );
 $participant_ids       = $wpdb->get_col(
-	$wpdb->prepare( 'SELECT participant_id FROM %i WHERE event_date_id = %d', $event_parts_table, $event_date_id )
+	$wpdb->prepare(
+		"SELECT participant_id FROM %i WHERE event_date_id IN ({$series_placeholders})",
+		array_merge( array( $event_parts_table ), $series_event_date_ids )
+	)
 );
+// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 if ( $event_participant_ids ) {
 	$placeholders = implode( ', ', array_fill( 0, count( $event_participant_ids ), '%d' ) );
@@ -59,9 +79,14 @@ if ( $event_participant_ids ) {
 	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 }
 
+// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $series_placeholders is a safe list of %d.
 $deleted['event_participants'] = (int) $wpdb->query(
-	$wpdb->prepare( 'DELETE FROM %i WHERE event_date_id = %d', $event_parts_table, $event_date_id )
+	$wpdb->prepare(
+		"DELETE FROM %i WHERE event_date_id IN ({$series_placeholders})",
+		array_merge( array( $event_parts_table ), $series_event_date_ids )
+	)
 );
+// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 if ( $participant_ids ) {
 	$participant_ids = array_values( array_unique( array_map( 'intval', $participant_ids ) ) );
@@ -122,6 +147,15 @@ $deleted['sale_periods'] = (int) $wpdb->query(
 $deleted['get_tickets_signups'] = (int) $wpdb->query(
 	$wpdb->prepare( 'DELETE FROM %i WHERE event_date_id = %d', $wpdb->prefix . 'fair_events_signups', $event_date_id )
 );
+
+// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $series_placeholders is a safe list of %d.
+$deleted['transactions'] = (int) $wpdb->query(
+	$wpdb->prepare(
+		"DELETE FROM %i WHERE event_date_id IN ({$series_placeholders})",
+		array_merge( array( $payments_table ), $series_event_date_ids )
+	)
+);
+// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 $deleted['event_dates'] = (int) $wpdb->query(
 	$wpdb->prepare( 'DELETE FROM %i WHERE event_id = %d', $dates_table, $event_id )

--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -6,15 +6,20 @@
  *   wp eval-file wp-content/mu-plugins/scripts/seed-event.php <flavour> [json-overrides]
  *
  * Flavours (presets composing lib/event-factory.php):
- *   free               event + date + sale period + a free ticket type (no price row).
- *   paid               free, plus a TicketPrice (default 25.00; override {"price":N}).
- *   paid-with-options  paid, plus TicketOption rows (override {"options":["dinner",...]}).
- *   capacity-1         paid with a capacity-1 ticket type, for sold-out/waitlist scenarios.
+ *   free                 event + date + sale period + a free ticket type (no price row).
+ *   paid                 free, plus a TicketPrice (default 25.00; override {"price":N}).
+ *   paid-with-options    paid, plus TicketOption rows (override {"options":["dinner",...]}).
+ *   capacity-1           paid with a capacity-1 ticket type, for sold-out/waitlist scenarios.
+ *   multiple-instances   a 3-occurrence weekly series with a 'multiple_instances'
+ *                        ticket type priced per instance (default 10.00; override
+ *                        {"price":N}), minimum_instances default 2 (override
+ *                        {"minimumInstances":N}).
  *
  * Examples:
  *   wp eval-file .../seed-event.php paid
  *   wp eval-file .../seed-event.php paid '{"price":40}'
  *   wp eval-file .../seed-event.php paid-with-options '{"options":["dinner","tshirt"]}'
+ *   wp eval-file .../seed-event.php multiple-instances
  *
  * Prints a single `E2E_SEED:{json}` line the spec/fixture parses for the event
  * permalink and ids (incl. the ids cleanup-event.php needs).
@@ -36,12 +41,14 @@ if ( isset( $args[1] ) && '' !== $args[1] ) {
 	$overrides = $decoded;
 }
 
-$price          = isset( $overrides['price'] ) ? (float) $overrides['price'] : 25.00;
-$option_names   = isset( $overrides['options'] ) ? (array) $overrides['options'] : array( 'dinner', 'tshirt' );
-$option_price   = isset( $overrides['optionPrice'] ) ? (float) $overrides['optionPrice'] : 10.00;
-$ticket_type_id = 0;
-$option_ids     = array();
-$is_paid        = true;
+$price             = isset( $overrides['price'] ) ? (float) $overrides['price'] : 25.00;
+$option_names      = isset( $overrides['options'] ) ? (array) $overrides['options'] : array( 'dinner', 'tshirt' );
+$option_price      = isset( $overrides['optionPrice'] ) ? (float) $overrides['optionPrice'] : 10.00;
+$minimum_instances = isset( $overrides['minimumInstances'] ) ? (int) $overrides['minimumInstances'] : 2;
+$ticket_type_id    = 0;
+$option_ids        = array();
+$occurrence_ids    = array();
+$is_paid           = true;
 
 // Which purchase block the event page carries. Default: fair-audience
 // event-signup. Override {"block":"get-tickets"} for specs that exercise the
@@ -86,19 +93,31 @@ switch ( $flavour ) {
 		fair_e2e_add_price( $ticket_type_id, $sale_period_id, $price, 1 );
 		break;
 
+	case 'multiple-instances':
+		$price = isset( $overrides['price'] ) ? (float) $overrides['price'] : 10.00;
+		// Turns the single occurrence already created above into the series
+		// master (same event_date_id/sale_period_id) plus 2 generated siblings.
+		// Ticket types and sale periods always attach to the master.
+		$occurrence_ids = fair_e2e_add_series( $event_id, 3 );
+		$ticket_type_id = fair_e2e_add_multi_instance_ticket_type( $event_date_id, 'Pick your sessions', $minimum_instances );
+		fair_e2e_add_price( $ticket_type_id, $sale_period_id, $price, null );
+		break;
+
 	default:
-		WP_CLI::error( "Unknown flavour '{$flavour}'. Use one of: free, paid, paid-with-options, capacity-1." );
+		WP_CLI::error( "Unknown flavour '{$flavour}'. Use one of: free, paid, paid-with-options, capacity-1, multiple-instances." );
 }
 
 echo 'E2E_SEED:' . wp_json_encode(
 	array(
-		'flavour'      => $flavour,
-		'pageUrl'      => get_permalink( $event_id ),
-		'eventId'      => (int) $event_id,
-		'eventDateId'  => (int) $event_date_id,
-		'salePeriodId' => (int) $sale_period_id,
-		'ticketTypeId' => (int) $ticket_type_id,
-		'optionIds'    => array_map( 'intval', $option_ids ),
-		'price'        => $is_paid ? $price : 0.00,
+		'flavour'          => $flavour,
+		'pageUrl'          => get_permalink( $event_id ),
+		'eventId'          => (int) $event_id,
+		'eventDateId'      => (int) $event_date_id,
+		'salePeriodId'     => (int) $sale_period_id,
+		'ticketTypeId'     => (int) $ticket_type_id,
+		'optionIds'        => array_map( 'intval', $option_ids ),
+		'occurrenceIds'    => array_map( 'intval', $occurrence_ids ),
+		'minimumInstances' => (int) $minimum_instances,
+		'price'            => $is_paid ? $price : 0.00,
 	)
 ) . "\n";

--- a/e2e/user-flows/multi-instance-purchase.spec.js
+++ b/e2e/user-flows/multi-instance-purchase.spec.js
@@ -1,0 +1,92 @@
+/**
+ * E2E: 'multiple_instances' ticket type purchase — pick-N occurrences at a
+ * per-instance price, through the public (anonymous, first-time buyer)
+ * registration form.
+ *
+ * Reproduces a reported bug: the buyer picks 3 occurrences of a series priced
+ * at 10.00 each. The frontend total (basePrice * checked count, see
+ * frontend.js updateButtonTotal()/updateInstancePickerHint()) correctly shows
+ * 30.00 — but the amount actually charged (the transaction row, and therefore
+ * what's sent to Mollie) is only 10.00, the per-instance price for a single
+ * occurrence.
+ *
+ * Root cause (not fixed here — this spec documents the bug; the fix is a
+ * separate change): EventSignupController::create_signup() dispatches
+ * 'multiple_instances' ticket types to create_multi_instance_signup(), which
+ * correctly sums the per-instance price across every chosen occurrence. But
+ * EventSignupController::register_and_signup() — the endpoint the public
+ * "I'm new" form submits to, used by every first-time buyer — has no such
+ * dispatch. It always falls through to maybe_start_paid_signup(), which
+ * resolves a single per-instance price and ignores event_date_ids entirely.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+import { runScript } from '../support/wp-cli.js';
+
+test.describe('multiple_instances ticket type purchase (new buyer)', () => {
+	test('charges the sum of all chosen occurrences, not just one', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('multiple-instances');
+		expect(event.occurrenceIds.length).toBe(3);
+
+		await page.goto(event.pageUrl);
+		const form = page.locator('.fair-audience-signup-register');
+		await expect(form).toBeVisible();
+
+		const ticket = form.locator('input[name="ticket_type_id"]');
+		await ticket.check();
+		expect(await ticket.getAttribute('data-recurrence-scope')).toBe(
+			'multiple_instances'
+		);
+
+		const instancePicker = form.locator('.fair-audience-instance-picker');
+		await expect(instancePicker).toBeVisible();
+
+		for (const occurrenceId of event.occurrenceIds) {
+			await form
+				.locator(
+					`input[name="event_date_ids[]"][value="${occurrenceId}"]`
+				)
+				.check();
+		}
+
+		// Frontend total already reflects all 3 chosen occurrences.
+		const expectedTotal = (
+			event.price * event.occurrenceIds.length
+		).toFixed(2);
+		await expect(
+			instancePicker.locator('.fair-audience-instance-picker-total')
+		).toHaveText(`Total: €${expectedTotal}`);
+
+		const stamp = Date.now();
+		await form
+			.locator('input[name="signup_name"]')
+			.fill(`E2E Multi Instance ${stamp}`);
+		await form
+			.locator('input[name="signup_email"]')
+			.fill(`multi-instance-${stamp}@example.test`);
+
+		// Submit → register REST call. Via the Mollie double, the checkout URL
+		// points back at the signup callback with the transaction id.
+		await form.locator('.fair-audience-signup-submit-button').click();
+		await expect(page).toHaveURL(/fair_signup_tx=/, { timeout: 30000 });
+
+		const url = new URL(page.url());
+		const transactionId = url.searchParams.get('fair_signup_tx');
+		expect(transactionId).toBeTruthy();
+
+		const tx = runScript(
+			'transaction-state.php',
+			'E2E_TX_STATE',
+			transactionId
+		);
+		expect(tx.found).toBe(true);
+
+		// This is the bug: today the transaction is created for a single
+		// instance's price (10.00) instead of the sum across all 3 chosen
+		// occurrences (30.00) that the buyer was shown and agreed to pay.
+		expect(tx.amount).toBe(Number(expectedTotal));
+	});
+});


### PR DESCRIPTION
## Summary
- A buyer picking N occurrences of a `multiple_instances` ticket type sees the correct total (per-instance price × N) in the frontend, but `EventSignupController::register_and_signup()` — the endpoint the public "I'm new" registration form submits to — charges only a single occurrence's price. It never dispatches to `create_multi_instance_signup()` the way the already-registered path (`create_signup()`) does, so it falls through to `maybe_start_paid_signup()` and ignores `event_date_ids` entirely.
- Adds a `multiple-instances` seed flavour (3-occurrence weekly series + per-instance-priced ticket type) to the e2e harness (`event-factory.php`, `seed-event.php`, `cleanup-event.php`, `README.md`).
- Adds `e2e/user-flows/multi-instance-purchase.spec.js`, driving the real browser flow (form fill → ticket type + 3 occurrence checkboxes → submit → Mollie double → callback) and asserting the charged transaction amount matches the displayed total.
- This is a test-only change. The spec currently fails (expected 30.00, transaction shows 10.00), documenting the bug; the fix is a separate change.

## Test plan
- [x] `npx playwright test e2e/user-flows/multi-instance-purchase.spec.js` — fails, reproducing the bug (asserted total 30.00 vs actual 10.00 charged)
- [x] `npx playwright test e2e/user-flows/ticket-purchase-confirmation.spec.js e2e/user-flows/simple-payment-purchase.spec.js e2e/user-flows/get-tickets-purchase.spec.js` — still pass (no regressions from harness changes)