### PR TITLE
Fix venue dropdown missing in event sidebar metabox

### DIFF
--- a/fair-events/src/PostTypes/Event.php
+++ b/fair-events/src/PostTypes/Event.php
@@ -194,7 +194,7 @@ class Event {
 				'postType'        => $screen->post_type,
 				'eventDateId'     => $event_date_id,
 				'manageEventUrl'  => $manage_event_url,
-				'enabledFeatures' => \FairEvents\Core\Features::public_map(),
+				'enabledFeatures' => apply_filters( 'fair_events_enabled_features_map', \FairEvents\Core\Features::public_map() ),
 			)
 		);
 


### PR DESCRIPTION
## Summary
- The Gutenberg sidebar metabox ("Detalles del evento") always showed a plain "Dirección" text field, even on sites where the venue feature is enabled.
- Root cause: `PostTypes/Event.php` localized `enabledFeatures` directly from `Features::public_map()`, without running it through the `fair_events_enabled_features_map` filter that `AdminPages.php` (Manage Event page) already applies. That filter is how `fair-events-experimental` merges in its `venues` feature flag.
- Applying the same filter in the metabox bootstrap lets the existing conditional venue `SelectControl` in `EventEditForm.js` (shared by both the sidebar and the Manage Event page) render correctly, matching the Manage Event page's "LUGAR" dropdown.

## Test plan
- [ ] On a site with `fair-events-experimental` active and the venues feature enabled, open an event in the block editor and confirm the sidebar metabox now shows a "Venue" dropdown (matching the Manage Event page) instead of the "Address" text field.
- [ ] Confirm selecting a venue and saving persists correctly (`venue_id` sent to `/fair-events/v1/event-dates/{id}`).
- [ ] On a site without the venues feature enabled, confirm the sidebar metabox still shows the plain "Address" text field (no regression).