### PR TITLE
Add estruyf/github-actions-reporter to e2e for clearer failure output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 			},
 			"devDependencies": {
 				"@changesets/cli": "^2.29.6",
+				"@estruyf/github-actions-reporter": "^1.12.0",
 				"@playwright/test": "^1.60.0",
 				"@wordpress/env": "^11.8.1",
 				"baseline-browser-mapping": "^2.9.19",
@@ -34,7 +35,7 @@
 			}
 		},
 		"fair-audience": {
-			"version": "1.7.0",
+			"version": "1.8.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -852,7 +853,7 @@
 			}
 		},
 		"fair-events": {
-			"version": "1.7.0",
+			"version": "1.8.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@fortawesome/fontawesome-svg-core": "^7.0.0",
@@ -886,7 +887,7 @@
 			}
 		},
 		"fair-events-experimental": {
-			"version": "1.2.0",
+			"version": "1.3.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -1691,7 +1692,7 @@
 			}
 		},
 		"fair-events-shared": {
-			"version": "0.1.0",
+			"version": "0.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/components": "^36.0.0",
@@ -2410,7 +2411,7 @@
 			}
 		},
 		"fair-payments-connector": {
-			"version": "1.4.0",
+			"version": "1.5.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -3178,6 +3179,45 @@
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
+		},
+		"node_modules/@actions/core": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+			"integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@actions/exec": "^3.0.0",
+				"@actions/http-client": "^4.0.0"
+			}
+		},
+		"node_modules/@actions/exec": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+			"integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@actions/io": "^3.0.2"
+			}
+		},
+		"node_modules/@actions/http-client": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+			"integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tunnel": "^0.0.6",
+				"undici": "^6.23.0"
+			}
+		},
+		"node_modules/@actions/io": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+			"integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@adobe/css-tools": {
 			"version": "4.5.0",
@@ -6094,6 +6134,38 @@
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@estruyf/github-actions-reporter": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@estruyf/github-actions-reporter/-/github-actions-reporter-1.12.0.tgz",
+			"integrity": "sha512-330qmwv9EgpV93se59HoY1rj2XJxsjBREVpMh72BjCYKtyFru+YcFeDYUNPk2DCACNQQRilnm/yUMZZyosvhLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@actions/core": "^3.0.0",
+				"ansi-to-html": "^0.7.2",
+				"marked": "^12.0.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/estruyf"
+			},
+			"peerDependencies": {
+				"@playwright/test": "^1.42.1"
+			}
+		},
+		"node_modules/@estruyf/github-actions-reporter/node_modules/marked": {
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+			"integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/@floating-ui/core": {
@@ -15220,6 +15292,32 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/ansi-to-html": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.7.2.tgz",
+			"integrity": "sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^2.2.0"
+			},
+			"bin": {
+				"ansi-to-html": "bin/ansi-to-html"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/ansi-to-html/node_modules/entities": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/anymatch": {
@@ -31666,6 +31764,16 @@
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
 		},
+		"node_modules/tunnel": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+			}
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -31885,6 +31993,16 @@
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/undici": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
 			}
 		},
 		"node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 	],
 	"devDependencies": {
 		"@changesets/cli": "^2.29.6",
+		"@estruyf/github-actions-reporter": "^1.12.0",
 		"@playwright/test": "^1.60.0",
 		"@wordpress/env": "^11.8.1",
 		"baseline-browser-mapping": "^2.9.19",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -21,7 +21,20 @@ export default defineConfig({
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 0,
 	workers: 1,
-	reporter: process.env.CI ? [['github'], ['html']] : 'html',
+	reporter: process.env.CI
+		? [
+				['github'],
+				['html'],
+				[
+					'@estruyf/github-actions-reporter',
+					{
+						useDetails: true,
+						showError: true,
+						showAnnotations: false,
+					},
+				],
+		  ]
+		: 'html',
 
 	timeout: 60 * 1000,
 	expect: { timeout: 10 * 1000 },


### PR DESCRIPTION
## What

Adds [`@estruyf/github-actions-reporter`](https://github.com/estruyf/playwright-github-actions-reporter) as a third Playwright reporter, active in CI only.

## Why

The built-in `github` reporter truncates long test titles in its annotations and omits error details and screenshots, so failing e2e runs are hard to read on the run page (only cropped `[chromium] › …multi-instance-purchase.spec.js…` lines).

This reporter writes a **Job Summary** on the run page with expandable per-test blocks and full error messages — no artifact download needed.

## Changes

- `playwright.config.js` — add the reporter to the CI `reporter` array (`useDetails: true`, `showError: true`, `showAnnotations: false` to avoid duplicating the existing `github` annotations). Local runs are unchanged (`html`).
- `package.json` / `package-lock.json` — add the dev dependency.

The existing `github` annotations and uploaded `html` report artifact are kept as-is.

## Verification

- `CI=1` config load registers all three reporters: `["github","html","@estruyf/github-actions-reporter"]`.
- `prettier --check` passes on the edited files.