### PR TITLE
Only append event_date query arg for multi-instance events

### DIFF
--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -371,6 +371,7 @@ if ( $events_query->have_posts() ) {
 
 		// Get ALL occurrences for this event (supports recurring events).
 		$all_occurrences = EventDates::get_all_by_event_id( $event_id );
+		$has_multiple    = count( $all_occurrences ) > 1;
 
 		foreach ( $all_occurrences as $event_dates ) {
 			$start_date = DateHelper::local_date( $event_dates->start_datetime );
@@ -387,13 +388,15 @@ if ( $events_query->have_posts() ) {
 
 				$events_by_date[ $loop_date ][] = array(
 					'id'              => $event_id,
-					'event_date_id'   => (int) $event_dates->id,
+					'event_date_id'   => $has_multiple ? (int) $event_dates->id : 0,
 					'occurrence_type' => $event_dates->occurrence_type,
 					'is_first_day'    => $loop_date === $start_date,
 					'is_last_day'     => $loop_date === $end_date,
 					'is_ical'         => false,
 					'title'           => get_the_title( $event_id ),
-					'permalink'       => add_query_arg( 'event_date', (int) $event_dates->id, get_permalink( $event_id ) ),
+					'permalink'       => $has_multiple
+						? add_query_arg( 'event_date', (int) $event_dates->id, get_permalink( $event_id ) )
+						: get_permalink( $event_id ),
 					'link_type'       => 'post',
 				);
 

--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -219,6 +219,7 @@ if ( $events_query->have_posts() ) {
 		$processed_events[ $event_id ] = true;
 
 		$all_occurrences = EventDates::get_all_by_event_id( $event_id );
+		$has_multiple    = count( $all_occurrences ) > 1;
 		$event_post      = get_post( $event_id );
 		$is_draft        = $event_post && 'draft' === $event_post->post_status;
 
@@ -240,7 +241,7 @@ if ( $events_query->have_posts() ) {
 					$events_by_date[ $loop_date ] = array();
 				}
 
-				$permalink = ! empty( $occ->id )
+				$permalink = ( $has_multiple && ! empty( $occ->id ) )
 					? add_query_arg( 'event_date', (int) $occ->id, get_permalink( $event_id ) )
 					: get_permalink( $event_id );
 


### PR DESCRIPTION
## Summary
- Calendar and week block event links included `?event_date=<id>` even for single-instance events, producing unnecessarily long URLs (e.g. `?event_date=21` on an event with only one date).
- `event_date` is now only appended when an event has more than one occurrence; single-instance events link to the plain permalink.

## Test plan
- [ ] Visit the events calendar block on a site with both single- and multi-instance events, confirm single-instance event links have no `event_date` param and multi-instance ones still do
- [ ] Same check for the events week block