### PR TITLE
Add e2e coverage for canceling a stuck purchase

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -144,6 +144,15 @@ Each prints a single `MARKER:{json}` line (`E2E_SEED`, `E2E_STATE`,
   `post_id`).
 - **`transaction-state.php <transaction_id>`** — reports one
   `fair_payment_transactions` row (status, testmode, amount, Mollie id).
+- **`seed-pending-signup.php <eventId> <eventDateId> <ticketTypeId> <price> [status]`**
+  — writes a stuck `pending_payment` event-signup directly (participant +
+  `fair_payment_transactions` row in the given status, default `failed`, +
+  `event_participants` row with an unexpired `payment_expires_at`), since the
+  Mollie double can't produce a failed/canceled payment by itself. Emits the
+  participant id, transaction id, and a real `ParticipantToken`. Pair with
+  **`cleanup-transaction.php <transactionId>`** to remove the transaction row
+  afterwards (the participant/event_participant rows are covered by
+  `cleanup-event.php`).
 
 The event seeded by `seed-event.php` carries the fair-audience event-signup
 block by default; pass `{"block":"get-tickets"}` in the JSON overrides to seed

--- a/e2e/mu-plugins/scripts/cleanup-transaction.php
+++ b/e2e/mu-plugins/scripts/cleanup-transaction.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Delete a single fair_payment_transactions row by id.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/cleanup-transaction.php <transactionId>
+ *
+ * Companion to seed-pending-signup.php: the participant + event_participant
+ * rows it creates are removed by cleanup-event.php (matched by event_date_id),
+ * but that script doesn't know about fair-payments-connector's table, so the
+ * transaction row needs its own teardown.
+ *
+ * Prints a single `E2E_TX_CLEANUP:{json}` line with the deleted row count.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+global $wpdb;
+
+$transaction_id = isset( $args[0] ) ? (int) $args[0] : 0;
+if ( ! $transaction_id ) {
+	WP_CLI::error( 'Usage: cleanup-transaction.php <transactionId>' );
+}
+
+$transactions_table = $wpdb->prefix . 'fair_payment_transactions';
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off teardown script, no cache to honour.
+$deleted = (int) $wpdb->query(
+	$wpdb->prepare( 'DELETE FROM %i WHERE id = %d', $transactions_table, $transaction_id )
+);
+// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+echo 'E2E_TX_CLEANUP:' . wp_json_encode( array( 'transactions' => $deleted ) ) . "\n";

--- a/e2e/mu-plugins/scripts/seed-pending-signup.php
+++ b/e2e/mu-plugins/scripts/seed-pending-signup.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Seed a stuck "pending_payment" signup for the E2E cancel-and-restart specs.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-pending-signup.php <eventId> <eventDateId> <ticketTypeId> <price> [status]
+ *
+ * The Mollie double always reports "paid" on GET (see lib/mollie-http-double.php),
+ * so a failed/canceled/expired transaction can't be produced by driving the real
+ * checkout — it has to be written directly, the same way a stalled real-world
+ * payment would leave the database. This creates:
+ *   - a participant (linkable via a real ParticipantToken, so the page renders
+ *     the 'with_token' authenticated state — the branch that shows the
+ *     "Cancel and start over" link);
+ *   - a fair_payment_transactions row in the given status (default 'failed',
+ *     one of the statuses event-signup/render.php treats as retriable: failed,
+ *     canceled, expired, draft);
+ *   - an event_participants row with label 'pending_payment' and a
+ *     payment_expires_at an hour out (within the hold window), so
+ *     event-signup/render.php's "no URL callback? look up an in-progress
+ *     payment" fallback (issue #554) synthesises the retry UI even when the
+ *     spec navigates straight to the plain participant-token URL, exactly as a
+ *     buyer returning to the page directly (not via Mollie's redirect) would.
+ *
+ * Prints a single `E2E_PENDING:{json}` line with the participant id,
+ * transaction id, and participant token.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use FairAudience\Models\Participant;
+use FairAudience\Models\EventParticipant;
+use FairAudience\Services\ParticipantToken;
+use FairPaymentsConnector\Models\Transaction;
+
+$event_id       = isset( $args[0] ) ? (int) $args[0] : 0;
+$event_date_id  = isset( $args[1] ) ? (int) $args[1] : 0;
+$ticket_type_id = isset( $args[2] ) ? (int) $args[2] : 0;
+$price          = isset( $args[3] ) ? (float) $args[3] : 0.0;
+$tx_status      = isset( $args[4] ) && '' !== $args[4] ? (string) $args[4] : 'failed';
+
+if ( ! $event_id || ! $event_date_id ) {
+	WP_CLI::error( 'Usage: seed-pending-signup.php <eventId> <eventDateId> <ticketTypeId> <price> [status]' );
+}
+
+$stamp = gmdate( 'YmdHis' ) . '-' . wp_rand( 1000, 9999 );
+$email = 'pending.' . $stamp . '@example.test';
+
+$participant = new Participant(
+	array(
+		'name'          => 'E2E Pending Buyer ' . $stamp,
+		'email'         => $email,
+		'email_profile' => 'minimal',
+		'status'        => 'confirmed',
+	)
+);
+if ( ! $participant->save() ) {
+	WP_CLI::error( 'Failed to create participant.' );
+}
+
+$transaction_id = Transaction::create(
+	array(
+		'mollie_payment_id' => 'tr_e2e_' . $stamp,
+		'post_id'           => $event_id,
+		'event_date_id'     => $event_date_id,
+		'participant_id'    => $participant->id,
+		'amount'            => $price,
+		'status'            => $tx_status,
+		'description'       => 'E2E pending signup',
+	)
+);
+if ( ! $transaction_id ) {
+	WP_CLI::error( 'Failed to create transaction.' );
+}
+
+$event_participant = new EventParticipant(
+	array(
+		'event_id'           => $event_id,
+		'event_date_id'      => $event_date_id,
+		'participant_id'     => $participant->id,
+		'label'              => 'pending_payment',
+		'transaction_id'     => $transaction_id,
+		'ticket_type_id'     => $ticket_type_id ? $ticket_type_id : null,
+		'payment_expires_at' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 hour' ) ),
+	)
+);
+if ( ! $event_participant->save() ) {
+	WP_CLI::error( 'Failed to create event_participant row.' );
+}
+
+$token = ParticipantToken::generate( (int) $participant->id, $event_date_id );
+
+echo 'E2E_PENDING:' . wp_json_encode(
+	array(
+		'participantId' => (int) $participant->id,
+		'transactionId' => (int) $transaction_id,
+		'token'         => $token,
+		'email'         => $email,
+	)
+) . "\n";

--- a/e2e/user-flows/get-tickets-cancel-and-restart.spec.js
+++ b/e2e/user-flows/get-tickets-cancel-and-restart.spec.js
@@ -1,0 +1,102 @@
+/**
+ * E2E: abandoning a payment and starting over (fair-events get-tickets block).
+ *
+ * Companion to signup-cancel-and-restart.spec.js, which found that the
+ * fair-audience event-signup block's "Cancel and start over" link is a no-op —
+ * clicking it re-shows the identical stuck retry screen because render.php
+ * re-derives that screen from a persistent per-participant DB row that the
+ * link never clears.
+ *
+ * The get-tickets block has no such identity to get stuck against: it doesn't
+ * link the page render to a signed-up participant/session at all (buyers
+ * aren't known until they submit name+email), so there's no server-side
+ * "resume the in-progress payment" fallback to go stale. This spec asserts
+ * that behaviour holds: a buyer who starts a paid checkout and then goes back
+ * to the event page (Mollie's redirect never followed / abandoned) sees a
+ * plain, fresh form — not stuck on the earlier processing state — and can
+ * complete a brand new purchase from it.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+import { wpCli, runScript } from '../support/wp-cli.js';
+
+test.describe('get-tickets block (fair-audience inactive): abandon and restart', () => {
+	test.beforeAll(() => {
+		wpCli('plugin deactivate fair-audience');
+	});
+
+	test.afterAll(() => {
+		wpCli('plugin activate fair-audience');
+	});
+
+	test.beforeEach(() => {
+		// Reset the get-tickets per-IP rate limit (3 requests/hour).
+		wpCli('transient delete --all');
+	});
+
+	test('going back after starting a paid checkout shows a fresh form the buyer can complete', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('paid', { block: 'get-tickets' });
+
+		const stamp = Date.now();
+		const abandonedEmail = `get-tickets.abandoned.${stamp}@example.test`;
+
+		await page.goto(event.pageUrl);
+
+		let form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		await form.locator('input[name="name"]').fill(`Abandoned ${stamp}`);
+		await form.locator('input[name="email"]').fill(abandonedEmail);
+		await form
+			.locator('select[name="ticket_type_id"]')
+			.selectOption(String(event.ticketTypeId));
+
+		// Submit → redirected through the Mollie double to the callback URL,
+		// which only polls; the buyer never lands on a confirmed state because
+		// no webhook fires here — this models an abandoned/failed attempt.
+		await form.locator('button[type="submit"]').click();
+		await expect(page.locator('.message-processing')).toBeVisible({
+			timeout: 30000,
+		});
+
+		// The buyer gives up and goes back to the plain event page instead of
+		// completing or retrying the Mollie checkout.
+		await page.goto(event.pageUrl);
+
+		form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+		// No leftover processing/error message from the abandoned attempt (the
+		// block always renders an empty `.message-container` for its JS to fill
+		// in later — only the populated status classes indicate a stuck state).
+		await expect(page.locator('.message-processing')).toHaveCount(0);
+		await expect(page.locator('.message-error')).toHaveCount(0);
+		await expect(page.locator('.message-success')).toHaveCount(0);
+
+		// A completely fresh purchase (different buyer identity) works.
+		const buyerEmail = `get-tickets.fresh.${stamp}@example.test`;
+		await form.locator('input[name="name"]').fill(`Fresh Buyer ${stamp}`);
+		await form.locator('input[name="email"]').fill(buyerEmail);
+		await form
+			.locator('select[name="ticket_type_id"]')
+			.selectOption(String(event.ticketTypeId));
+		await form.locator('button[type="submit"]').click();
+		await expect(page.locator('.message-processing')).toBeVisible({
+			timeout: 30000,
+		});
+
+		const state = runScript(
+			'get-tickets-state.php',
+			'E2E_GT_STATE',
+			String(event.eventDateId)
+		);
+		// Both the abandoned attempt and the fresh purchase left their own
+		// pending signup row — the abandoned one was never blocking the retry.
+		expect(state.signups).toHaveLength(2);
+		expect(state.signups.map((s) => s.email).sort()).toEqual(
+			[abandonedEmail, buyerEmail].sort()
+		);
+	});
+});

--- a/e2e/user-flows/signup-cancel-and-restart.spec.js
+++ b/e2e/user-flows/signup-cancel-and-restart.spec.js
@@ -1,0 +1,94 @@
+/**
+ * E2E: "Cancel and start over" on a stuck payment (fair-audience event-signup
+ * block).
+ *
+ * Reported bug: a buyer whose Mollie payment failed (or who just navigates
+ * back to the event page instead of following Mollie's redirect) sees the
+ * retry screen — "Your payment didn't go through." / Retry payment / Cancel
+ * and start over — and the "Cancel and start over" link does nothing useful.
+ *
+ * Root cause (event-signup/render.php): the link is a plain
+ * `remove_query_arg( ['fair_payment_callback', 'fair_signup_tx'] )` href — it
+ * only strips those two URL params. But render.php also re-synthesises the
+ * exact same retry state from the database whenever the visitor has a
+ * participant with an event_participants row still labelled 'pending_payment'
+ * and a transaction in a retriable status (the "no URL callback? look up an
+ * in-progress payment" fallback, issue #554). Since clicking the link never
+ * clears that DB state, reloading — with or without the query params — just
+ * re-shows the identical retry screen. It's a complete no-op whenever the
+ * buyer reached the page any way other than fresh off Mollie's own redirect
+ * (e.g. a bookmarked link, the confirmation email's link, or simply going
+ * back), which is exactly how the bug was found in production.
+ *
+ * The Mollie double (lib/mollie-http-double.php) always reports "paid" on
+ * GET, so a failed/canceled transaction can't be produced by driving a real
+ * checkout — seed-pending-signup.php writes the stuck state directly, the way
+ * a real stalled payment would leave the database.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+import { runScript } from '../support/wp-cli.js';
+
+test.describe('event-signup block: cancel a stuck payment and restart', () => {
+	test('"Cancel and start over" clears the pending payment and lets the buyer sign up again', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('paid');
+
+		const pending = runScript(
+			'seed-pending-signup.php',
+			'E2E_PENDING',
+			`${event.eventId} ${event.eventDateId} ${event.ticketTypeId} ${event.price} failed`
+		);
+
+		try {
+			// Visit the plain participant-token URL — no fair_payment_callback /
+			// fair_signup_tx query args, exactly like a buyer returning to the
+			// page directly (bookmark, email link, or hitting Back) rather than
+			// arriving fresh off Mollie's redirect.
+			await page.goto(
+				`${event.pageUrl}?participant_token=${pending.token}`
+			);
+
+			const retryPanel = page.locator('.fair-audience-signup-retry');
+			await expect(retryPanel).toBeVisible();
+			await expect(
+				page.getByText("Your payment didn't go through", {
+					exact: false,
+				})
+			).toBeVisible();
+
+			// Click "Cancel and start over".
+			await page.locator('.fair-audience-signup-retry-cancel a').click();
+			await page.waitForLoadState();
+
+			// The retry screen must be gone — the buyer should see a normal,
+			// fresh signup form they can complete, not the same stuck state.
+			await expect(
+				page.locator('.fair-audience-signup-retry')
+			).toHaveCount(0);
+			const form = page.locator(
+				'.fair-audience-signup-token-form, .fair-audience-signup-anonymous'
+			);
+			await expect(form).toBeVisible();
+
+			// Server-side: the abandoned attempt must actually be cleared, not
+			// just hidden client-side — otherwise the same stuck state would
+			// resurface on the buyer's next visit (e.g. reloading the same
+			// participant-token link, or clicking it again from an email).
+			const state = runScript(
+				'signup-state.php',
+				'E2E_STATE',
+				`${pending.email} ${event.eventDateId}`
+			);
+			expect(state.label).not.toBe('pending_payment');
+		} finally {
+			runScript(
+				'cleanup-transaction.php',
+				'E2E_TX_CLEANUP',
+				String(pending.transactionId)
+			);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Adds an e2e spec (`signup-cancel-and-restart.spec.js`) that reproduces a reported production bug: on the fair-audience event-signup block, the "Cancel and start over" link only strips two URL query params — it never clears the participant's `pending_payment` DB row, so `event-signup/render.php`'s DB-fallback (issue #554) re-derives the identical stuck retry screen on reload. The link is a complete no-op. This spec currently **fails**, confirming the bug.
- Adds a companion spec (`get-tickets-cancel-and-restart.spec.js`) for the fair-events get-tickets block, which **passes** — that block has no persistent per-visitor identity, so there's no equivalent state to get stuck in.
- New harness helpers: `seed-pending-signup.php` writes the stuck state directly (participant + failed transaction + `pending_payment` event_participant row), since the Mollie test double always reports "paid" and can't produce a failed payment through a real checkout. `cleanup-transaction.php` tears down the transaction row it creates.

## Test plan
- [x] `npx playwright test e2e/user-flows/signup-cancel-and-restart.spec.js` — fails, reproducing the bug (screenshot matches the reported production UI)
- [x] `npx playwright test e2e/user-flows/get-tickets-cancel-and-restart.spec.js` — passes
- [x] `vendor/bin/phpcs` clean on the new PHP scripts