### PR TITLE
Expand fair-form question label input for long/multiline text

### DIFF
--- a/.changeset/expand-question-label-input.md
+++ b/.changeset/expand-question-label-input.md
@@ -1,0 +1,5 @@
+---
+"fair-form": patch
+---
+
+Expand the question label field in form question blocks into a full-width, resizable textarea so long or multiline questions no longer get cropped in the editor.

--- a/fair-form/src/blocks/fair-form-file-upload/editor.js
+++ b/fair-form/src/blocks/fair-form-file-upload/editor.js
@@ -85,19 +85,21 @@ registerBlockType('fair-audience/fair-form-file-upload', {
 
 				<div {...blockProps}>
 					<p>
-						<input
-							type="text"
-							value={questionText}
-							onChange={(e) =>
-								onQuestionTextChange(e.target.value)
-							}
-							placeholder={__(
-								'Enter your question...',
-								'fair-audience'
-							)}
-							className="fair-form-question-label-input"
-						/>
-						{required && <span className="required"> *</span>}
+						<span className="fair-form-question-header">
+							<textarea
+								rows={1}
+								value={questionText}
+								onChange={(e) =>
+									onQuestionTextChange(e.target.value)
+								}
+								placeholder={__(
+									'Enter your question...',
+									'fair-audience'
+								)}
+								className="fair-form-question-label-input"
+							/>
+							{required && <span className="required"> *</span>}
+						</span>
 						<br />
 						<input type="file" disabled />
 						<span className="fair-form-file-upload-help">

--- a/fair-form/src/blocks/fair-form-file-upload/style.css
+++ b/fair-form/src/blocks/fair-form-file-upload/style.css
@@ -1,11 +1,21 @@
+.fair-form-question-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 4px;
+}
+
 .fair-form-question-file-upload .fair-form-question-label-input {
+	display: block;
 	border: none;
 	border-bottom: 1px dashed #8c8f94;
 	background: transparent;
 	font-weight: 600;
+	font-family: inherit;
 	padding: 2px 0;
 	font-size: inherit;
-	width: auto;
+	flex: 1;
+	min-width: 0;
+	resize: vertical;
 }
 
 .fair-form-question-file-upload .fair-form-question-label-input:focus {

--- a/fair-form/src/blocks/fair-form-long-text/editor.js
+++ b/fair-form/src/blocks/fair-form-long-text/editor.js
@@ -86,19 +86,21 @@ registerBlockType('fair-audience/fair-form-long-text', {
 
 				<div {...blockProps}>
 					<p>
-						<input
-							type="text"
-							value={questionText}
-							onChange={(e) =>
-								onQuestionTextChange(e.target.value)
-							}
-							placeholder={__(
-								'Enter your question...',
-								'fair-audience'
-							)}
-							className="fair-form-question-label-input"
-						/>
-						{required && <span className="required"> *</span>}
+						<span className="fair-form-question-header">
+							<textarea
+								rows={1}
+								value={questionText}
+								onChange={(e) =>
+									onQuestionTextChange(e.target.value)
+								}
+								placeholder={__(
+									'Enter your question...',
+									'fair-audience'
+								)}
+								className="fair-form-question-label-input"
+							/>
+							{required && <span className="required"> *</span>}
+						</span>
 						<br />
 						<textarea
 							disabled

--- a/fair-form/src/blocks/fair-form-long-text/style.css
+++ b/fair-form/src/blocks/fair-form-long-text/style.css
@@ -1,11 +1,21 @@
+.fair-form-question-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 4px;
+}
+
 .fair-form-question-long-text .fair-form-question-label-input {
+	display: block;
 	border: none;
 	border-bottom: 1px dashed #8c8f94;
 	background: transparent;
 	font-weight: 600;
+	font-family: inherit;
 	padding: 2px 0;
 	font-size: inherit;
-	width: auto;
+	flex: 1;
+	min-width: 0;
+	resize: vertical;
 }
 
 .fair-form-question-long-text .fair-form-question-label-input:focus {

--- a/fair-form/src/blocks/fair-form-multiselect/editor.js
+++ b/fair-form/src/blocks/fair-form-multiselect/editor.js
@@ -93,19 +93,21 @@ registerBlockType('fair-audience/fair-form-multiselect', {
 
 				<div {...blockProps}>
 					<p>
-						<input
-							type="text"
-							value={questionText}
-							onChange={(e) =>
-								onQuestionTextChange(e.target.value)
-							}
-							placeholder={__(
-								'Enter your question...',
-								'fair-audience'
-							)}
-							className="fair-form-question-label-input"
-						/>
-						{required && <span className="required"> *</span>}
+						<span className="fair-form-question-header">
+							<textarea
+								rows={1}
+								value={questionText}
+								onChange={(e) =>
+									onQuestionTextChange(e.target.value)
+								}
+								placeholder={__(
+									'Enter your question...',
+									'fair-audience'
+								)}
+								className="fair-form-question-label-input"
+							/>
+							{required && <span className="required"> *</span>}
+						</span>
 					</p>
 					<div {...innerBlocksProps} />
 				</div>

--- a/fair-form/src/blocks/fair-form-multiselect/style.css
+++ b/fair-form/src/blocks/fair-form-multiselect/style.css
@@ -1,11 +1,21 @@
+.fair-form-question-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 4px;
+}
+
 .fair-form-question-multiselect .fair-form-question-label-input {
+	display: block;
 	border: none;
 	border-bottom: 1px dashed #8c8f94;
 	background: transparent;
 	font-weight: 600;
+	font-family: inherit;
 	padding: 2px 0;
 	font-size: inherit;
-	width: auto;
+	flex: 1;
+	min-width: 0;
+	resize: vertical;
 }
 
 .fair-form-question-multiselect .fair-form-question-label-input:focus {

--- a/fair-form/src/blocks/fair-form-phone/editor.js
+++ b/fair-form/src/blocks/fair-form-phone/editor.js
@@ -77,19 +77,21 @@ registerBlockType('fair-audience/fair-form-phone', {
 
 				<div {...blockProps}>
 					<p>
-						<input
-							type="text"
-							value={questionText}
-							onChange={(e) =>
-								onQuestionTextChange(e.target.value)
-							}
-							placeholder={__(
-								'Enter your question...',
-								'fair-audience'
-							)}
-							className="fair-form-question-label-input"
-						/>
-						{required && <span className="required"> *</span>}
+						<span className="fair-form-question-header">
+							<textarea
+								rows={1}
+								value={questionText}
+								onChange={(e) =>
+									onQuestionTextChange(e.target.value)
+								}
+								placeholder={__(
+									'Enter your question...',
+									'fair-audience'
+								)}
+								className="fair-form-question-label-input"
+							/>
+							{required && <span className="required"> *</span>}
+						</span>
 						<br />
 						<input
 							type="tel"

--- a/fair-form/src/blocks/fair-form-phone/style.css
+++ b/fair-form/src/blocks/fair-form-phone/style.css
@@ -1,11 +1,21 @@
+.fair-form-question-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 4px;
+}
+
 .fair-form-question-phone .fair-form-question-label-input {
+	display: block;
 	border: none;
 	border-bottom: 1px dashed #8c8f94;
 	background: transparent;
 	font-weight: 600;
+	font-family: inherit;
 	padding: 2px 0;
 	font-size: inherit;
-	width: auto;
+	flex: 1;
+	min-width: 0;
+	resize: vertical;
 }
 
 .fair-form-question-phone .fair-form-question-label-input:focus {

--- a/fair-form/src/blocks/fair-form-radio/editor.js
+++ b/fair-form/src/blocks/fair-form-radio/editor.js
@@ -93,19 +93,21 @@ registerBlockType('fair-audience/fair-form-radio', {
 
 				<div {...blockProps}>
 					<p>
-						<input
-							type="text"
-							value={questionText}
-							onChange={(e) =>
-								onQuestionTextChange(e.target.value)
-							}
-							placeholder={__(
-								'Enter your question...',
-								'fair-audience'
-							)}
-							className="fair-form-question-label-input"
-						/>
-						{required && <span className="required"> *</span>}
+						<span className="fair-form-question-header">
+							<textarea
+								rows={1}
+								value={questionText}
+								onChange={(e) =>
+									onQuestionTextChange(e.target.value)
+								}
+								placeholder={__(
+									'Enter your question...',
+									'fair-audience'
+								)}
+								className="fair-form-question-label-input"
+							/>
+							{required && <span className="required"> *</span>}
+						</span>
 					</p>
 					<div {...innerBlocksProps} />
 				</div>

--- a/fair-form/src/blocks/fair-form-radio/style.css
+++ b/fair-form/src/blocks/fair-form-radio/style.css
@@ -1,11 +1,21 @@
+.fair-form-question-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 4px;
+}
+
 .fair-form-question-radio .fair-form-question-label-input {
+	display: block;
 	border: none;
 	border-bottom: 1px dashed #8c8f94;
 	background: transparent;
 	font-weight: 600;
+	font-family: inherit;
 	padding: 2px 0;
 	font-size: inherit;
-	width: auto;
+	flex: 1;
+	min-width: 0;
+	resize: vertical;
 }
 
 .fair-form-question-radio .fair-form-question-label-input:focus {

--- a/fair-form/src/blocks/fair-form-select-one/editor.js
+++ b/fair-form/src/blocks/fair-form-select-one/editor.js
@@ -93,19 +93,21 @@ registerBlockType('fair-audience/fair-form-select-one', {
 
 				<div {...blockProps}>
 					<p>
-						<input
-							type="text"
-							value={questionText}
-							onChange={(e) =>
-								onQuestionTextChange(e.target.value)
-							}
-							placeholder={__(
-								'Enter your question...',
-								'fair-audience'
-							)}
-							className="fair-form-question-label-input"
-						/>
-						{required && <span className="required"> *</span>}
+						<span className="fair-form-question-header">
+							<textarea
+								rows={1}
+								value={questionText}
+								onChange={(e) =>
+									onQuestionTextChange(e.target.value)
+								}
+								placeholder={__(
+									'Enter your question...',
+									'fair-audience'
+								)}
+								className="fair-form-question-label-input"
+							/>
+							{required && <span className="required"> *</span>}
+						</span>
 					</p>
 					<div {...innerBlocksProps} />
 				</div>

--- a/fair-form/src/blocks/fair-form-select-one/style.css
+++ b/fair-form/src/blocks/fair-form-select-one/style.css
@@ -1,11 +1,21 @@
+.fair-form-question-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 4px;
+}
+
 .fair-form-question-select-one .fair-form-question-label-input {
+	display: block;
 	border: none;
 	border-bottom: 1px dashed #8c8f94;
 	background: transparent;
 	font-weight: 600;
+	font-family: inherit;
 	padding: 2px 0;
 	font-size: inherit;
-	width: auto;
+	flex: 1;
+	min-width: 0;
+	resize: vertical;
 }
 
 .fair-form-question-select-one .fair-form-question-label-input:focus {

--- a/fair-form/src/blocks/fair-form-short-text/editor.js
+++ b/fair-form/src/blocks/fair-form-short-text/editor.js
@@ -83,19 +83,21 @@ registerBlockType('fair-audience/fair-form-short-text', {
 
 				<div {...blockProps}>
 					<p>
-						<input
-							type="text"
-							value={questionText}
-							onChange={(e) =>
-								onQuestionTextChange(e.target.value)
-							}
-							placeholder={__(
-								'Enter your question...',
-								'fair-audience'
-							)}
-							className="fair-form-question-label-input"
-						/>
-						{required && <span className="required"> *</span>}
+						<span className="fair-form-question-header">
+							<textarea
+								rows={1}
+								value={questionText}
+								onChange={(e) =>
+									onQuestionTextChange(e.target.value)
+								}
+								placeholder={__(
+									'Enter your question...',
+									'fair-audience'
+								)}
+								className="fair-form-question-label-input"
+							/>
+							{required && <span className="required"> *</span>}
+						</span>
 						<br />
 						<input
 							type="text"

--- a/fair-form/src/blocks/fair-form-short-text/style.css
+++ b/fair-form/src/blocks/fair-form-short-text/style.css
@@ -1,11 +1,21 @@
+.fair-form-question-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 4px;
+}
+
 .fair-form-question-short-text .fair-form-question-label-input {
+	display: block;
 	border: none;
 	border-bottom: 1px dashed #8c8f94;
 	background: transparent;
 	font-weight: 600;
+	font-family: inherit;
 	padding: 2px 0;
 	font-size: inherit;
-	width: auto;
+	flex: 1;
+	min-width: 0;
+	resize: vertical;
 }
 
 .fair-form-question-short-text .fair-form-question-label-input:focus {


### PR DESCRIPTION
## Summary
- The admin question-label field in fair-form question blocks (short-text, long-text, phone, select-one, radio, multiselect, file-upload) was a single-line text input with a fixed width, which cropped longer questions.
- Replaced it with a full-width, vertically resizable textarea, keeping the required-asterisk indicator aligned next to it in a flex row.

## Test plan
- [x] `npm run build` compiles cleanly with no errors
- [ ] Manually verify in wp-admin: add a long/multi-line custom question to a fair-form block and confirm it displays fully and can be resized