### PR TITLE
Show transaction status marker in participant Events table

### DIFF
--- a/.changeset/transaction-status-marker.md
+++ b/.changeset/transaction-status-marker.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": patch
+---
+
+Show a paid/pending/failed status marker next to the transaction link in the participant detail Events table, so an admin can tell a successful payment from a failed or abandoned one without opening each transaction.

--- a/fair-audience/src/API/ParticipantsController.php
+++ b/fair-audience/src/API/ParticipantsController.php
@@ -9,6 +9,7 @@ namespace FairAudience\API;
 
 use FairAudience\Database\ParticipantRepository;
 use FairAudience\Database\EventParticipantRepository;
+use FairAudience\Database\EventParticipantTransactionRepository;
 use FairAudience\Database\GroupParticipantRepository;
 use FairAudience\Database\EmailConfirmationTokenRepository;
 use FairAudience\Models\Participant;
@@ -63,12 +64,20 @@ class ParticipantsController extends WP_REST_Controller {
 	private $group_participant_repository;
 
 	/**
+	 * Event participant transaction ledger repository instance.
+	 *
+	 * @var EventParticipantTransactionRepository
+	 */
+	private $event_participant_transaction_repository;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->repository                   = new ParticipantRepository();
-		$this->event_participant_repository = new EventParticipantRepository();
-		$this->group_participant_repository = new GroupParticipantRepository();
+		$this->repository                               = new ParticipantRepository();
+		$this->event_participant_repository             = new EventParticipantRepository();
+		$this->group_participant_repository             = new GroupParticipantRepository();
+		$this->event_participant_transaction_repository = new EventParticipantTransactionRepository();
 	}
 
 	/**
@@ -347,10 +356,17 @@ class ParticipantsController extends WP_REST_Controller {
 		}
 
 		$has_event_dates = class_exists( '\FairEvents\Models\EventDates' );
+		$has_payments    = class_exists( '\FairPaymentsConnector\Models\Transaction' );
 
 		// Build events list.
 		$events        = array();
 		$relationships = $this->event_participant_repository->get_by_participant( $id );
+
+		$transaction_ids = array_filter( array_map( fn( $rel ) => (int) $rel->transaction_id, $relationships ) );
+		$statuses        = $has_payments && $transaction_ids
+			? $this->event_participant_transaction_repository->get_statuses_by_transaction_ids( array_unique( $transaction_ids ) )
+			: array();
+
 		foreach ( $relationships as $rel ) {
 			$event_title    = $rel->event_id ? get_the_title( (int) $rel->event_id ) : '';
 			$start_datetime = '';
@@ -361,15 +377,20 @@ class ParticipantsController extends WP_REST_Controller {
 				}
 			}
 
+			$transaction_id = $rel->transaction_id ? (int) $rel->transaction_id : null;
+
 			$events[] = array(
-				'id'             => (int) $rel->id,
-				'event_id'       => (int) $rel->event_id,
-				'event_date_id'  => (int) $rel->event_date_id,
-				'event_title'    => $event_title,
-				'start_datetime' => $start_datetime,
-				'label'          => $rel->label,
-				'created_at'     => $rel->created_at,
-				'transaction_id' => $rel->transaction_id ? (int) $rel->transaction_id : null,
+				'id'                 => (int) $rel->id,
+				'event_id'           => (int) $rel->event_id,
+				'event_date_id'      => (int) $rel->event_date_id,
+				'event_title'        => $event_title,
+				'start_datetime'     => $start_datetime,
+				'label'              => $rel->label,
+				'created_at'         => $rel->created_at,
+				'transaction_id'     => $transaction_id,
+				'transaction_status' => $transaction_id
+					? $this->normalize_transaction_status( $statuses[ $transaction_id ] ?? null )
+					: null,
 			);
 		}
 
@@ -410,6 +431,31 @@ class ParticipantsController extends WP_REST_Controller {
 				'submissions' => $submissions,
 			)
 		);
+	}
+
+	/**
+	 * Normalize a fair-payments-connector transaction status into the three
+	 * display states used in the Events table. Unrecognized statuses map to
+	 * 'pending' rather than 'failed' so a new connector status doesn't get
+	 * mislabeled as a failure.
+	 *
+	 * @param string|null $status Raw transaction status.
+	 * @return string|null 'success', 'pending', 'failed', or null when there's no status to report.
+	 */
+	private function normalize_transaction_status( $status ) {
+		if ( null === $status ) {
+			return null;
+		}
+
+		if ( in_array( $status, array( 'paid', 'success' ), true ) ) {
+			return 'success';
+		}
+
+		if ( 'failed' === $status ) {
+			return 'failed';
+		}
+
+		return 'pending';
 	}
 
 	/**

--- a/fair-audience/src/API/__tests__/ParticipantsActivityTransactionStatus.api.spec.js
+++ b/fair-audience/src/API/__tests__/ParticipantsActivityTransactionStatus.api.spec.js
@@ -1,0 +1,124 @@
+/**
+ * Playwright API tests for transaction status on the participant activity
+ * endpoint (issue #984): GET /fair-audience/v1/participants/{id}/activity.
+ *
+ * Each event entry now carries a `transaction_status` derived from the
+ * matching fair-payments-connector transaction ('success' | 'pending' |
+ * 'failed' | null). Seeding a real paid/pending/failed transaction requires
+ * routing a signup through the Mollie flow, so — mirroring
+ * TimelineController.api.spec.js — this suite covers the shape contract that
+ * is reachable over HTTP: a free (no-transaction) signup must report
+ * transaction_id/transaction_status as null. The paid/pending/failed status
+ * mapping itself is exercised via the WP-CLI eval-file manual check
+ * (TESTING.md).
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+test.describe('ParticipantsController activity — transaction_status', () => {
+	let api;
+	let participantId;
+	let eventId;
+	let eventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const partRes = await api.post(
+			'/wp-json/fair-audience/v1/participants',
+			{
+				headers: authHeaders,
+				data: {
+					name: 'Transaction Status Tester',
+					email: uniqueEmail('transaction-status'),
+				},
+			}
+		);
+		expect(partRes.ok()).toBeTruthy();
+		participantId = (await partRes.json()).id;
+
+		const eventRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: authHeaders,
+			data: {
+				title: `Transaction Status Event ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(eventRes.ok()).toBeTruthy();
+		eventId = (await eventRes.json()).id;
+
+		const eventsRes = await api.get('/wp-json/fair-audience/v1/events', {
+			headers: authHeaders,
+			params: { per_page: 100 },
+		});
+		expect(eventsRes.ok()).toBeTruthy();
+		const match = (await eventsRes.json()).find(
+			(e) => e.event_id === eventId
+		);
+		expect(match, 'event-date row for the test event').toBeTruthy();
+		eventDateId = match.event_date_id;
+
+		const linkRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants`,
+			{
+				headers: authHeaders,
+				data: { participant_id: participantId, label: 'signed_up' },
+			}
+		);
+		expect(linkRes.ok()).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (participantId) {
+			await api.delete(
+				`/wp-json/fair-audience/v1/participants/${participantId}`,
+				{ headers: authHeaders }
+			);
+		}
+		if (eventId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${eventId}`, {
+				headers: authHeaders,
+				params: { force: 'true' },
+			});
+		}
+		await api.dispose();
+	});
+
+	test('unauthenticated request is rejected', async () => {
+		const res = await api.get(
+			`/wp-json/fair-audience/v1/participants/${participantId}/activity`
+		);
+		expect(res.status()).toBe(401);
+	});
+
+	test('a signup with no transaction reports null transaction_status', async () => {
+		const res = await api.get(
+			`/wp-json/fair-audience/v1/participants/${participantId}/activity`,
+			{ headers: authHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		expect(Array.isArray(body.events)).toBe(true);
+
+		const event = body.events.find((ev) => ev.event_id === eventId);
+		expect(event, 'linked event in the activity response').toBeTruthy();
+		expect(event.transaction_id).toBeNull();
+		expect(event.transaction_status).toBeNull();
+	});
+});

--- a/fair-audience/src/Admin/participant-detail/ParticipantDetail.js
+++ b/fair-audience/src/Admin/participant-detail/ParticipantDetail.js
@@ -36,6 +36,12 @@ const LABEL_DISPLAY = {
 	interested: __('Interested', 'fair-audience'),
 };
 
+const TRANSACTION_STATUS_DISPLAY = {
+	success: { color: '#00a32a', label: __('Paid', 'fair-audience') },
+	pending: { color: '#dba617', label: __('Pending', 'fair-audience') },
+	failed: { color: '#d63638', label: __('Failed', 'fair-audience') },
+};
+
 const EMAIL_PROFILE_DISPLAY = {
 	minimal: __('Minimal', 'fair-audience'),
 	marketing: __('Marketing', 'fair-audience'),
@@ -318,9 +324,42 @@ export default function ParticipantDetail() {
 											</td>
 											<td>
 												{transactionUrl ? (
-													<a href={transactionUrl}>
-														{`#${ev.transaction_id}`}
-													</a>
+													<>
+														<a
+															href={
+																transactionUrl
+															}
+														>
+															{`#${ev.transaction_id}`}
+														</a>
+														{ev.transaction_status && (
+															<span
+																title={
+																	TRANSACTION_STATUS_DISPLAY[
+																		ev
+																			.transaction_status
+																	]?.label
+																}
+																style={{
+																	marginLeft:
+																		'6px',
+																	color: TRANSACTION_STATUS_DISPLAY[
+																		ev
+																			.transaction_status
+																	]?.color,
+																	fontWeight:
+																		'bold',
+																}}
+															>
+																{
+																	TRANSACTION_STATUS_DISPLAY[
+																		ev
+																			.transaction_status
+																	]?.label
+																}
+															</span>
+														)}
+													</>
 												) : (
 													'—'
 												)}

--- a/fair-audience/src/Database/EventParticipantTransactionRepository.php
+++ b/fair-audience/src/Database/EventParticipantTransactionRepository.php
@@ -98,6 +98,44 @@ class EventParticipantTransactionRepository {
 	}
 
 	/**
+	 * Batched status lookup for a list of fair-payments-connector transaction
+	 * IDs, keyed by transaction_id. Used to enrich rows that already carry a
+	 * transaction_id (e.g. event_participant.transaction_id) without a
+	 * per-row query. Returns an empty array when fair-payments-connector's
+	 * table isn't present (plugin inactive).
+	 *
+	 * @param array $transaction_ids Transaction IDs to look up.
+	 * @return array Associative array: transaction_id => status.
+	 */
+	public function get_statuses_by_transaction_ids( $transaction_ids ) {
+		global $wpdb;
+
+		if ( empty( $transaction_ids ) ) {
+			return array();
+		}
+
+		$transactions_table = $wpdb->prefix . 'fair_payment_transactions';
+		$placeholders       = implode( ',', array_fill( 0, count( $transaction_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $placeholders is safely constructed.
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id, status FROM %i WHERE id IN ($placeholders)",
+				array_merge( array( $transactions_table ), array_map( 'intval', $transaction_ids ) )
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		$statuses = array();
+		foreach ( $results as $row ) {
+			$statuses[ (int) $row['id'] ] = $row['status'];
+		}
+
+		return $statuses;
+	}
+
+	/**
 	 * Full transaction history for a registration, newest first. Joins
 	 * fair-payments-connector for status/amount/currency.
 	 *


### PR DESCRIPTION
## Summary

- The participant detail page's Events table linked each signup to its transaction as a bare `#<id>`, with no indication of whether the payment actually succeeded, so verifying "did this person pay?" required a click-through per row.
- `ParticipantsController::get_activity()` now batch-fetches the status of every linked transaction (`EventParticipantTransactionRepository::get_statuses_by_transaction_ids()`, a single `WHERE id IN (...)` query — no N+1) and normalizes it into `success` / `pending` / `failed`, guarding for fair-payments-connector being inactive.
- `ParticipantDetail.js` renders a color-coded marker (with a `title` label, not color alone) next to the `#<id>` link, mirroring the status pill convention from `FeeDetail.js`. Free-event rows with no transaction still show plain `—`.

Closes #984

## Test plan

- [x] `npm run format` / `npm run build` in `fair-audience`
- [x] `npm test` (Jest) passes
- [x] `vendor/bin/phpcs` clean on changed PHP files
- [x] New API spec test (`ParticipantsActivityTransactionStatus.api.spec.js`) covers the reachable-over-HTTP shape contract: a free signup with no transaction reports `transaction_id`/`transaction_status` as `null`. Seeding a real paid/pending/failed transaction requires routing a signup through the Mollie flow (no REST endpoint accepts an arbitrary transaction id), so — mirroring the existing `TimelineController.api.spec.js` precedent — the paid/pending/failed status mapping itself should be spot-checked via the WP-CLI `eval-file` manual recipe in TESTING.md before release.
