### PR TITLE
Disable irrelevant tabs for external-URL events

### DIFF
--- a/.changeset/disable-external-event-tabs.md
+++ b/.changeset/disable-external-event-tabs.md
@@ -1,0 +1,7 @@
+---
+"fair-events": patch
+"fair-audience": patch
+"fair-events-experimental": patch
+---
+
+Disable the Tickets, Signups, Finance, Groups, Audience, Mailings, and Statistics tabs on the Manage Event page when the event's link type is External URL, since there is no registration behind those tabs for link-only events.

--- a/fair-audience/jest.config.js
+++ b/fair-audience/jest.config.js
@@ -1,7 +1,10 @@
 export default {
 	preset: '@wordpress/jest-preset-default',
 	testEnvironment: 'jsdom',
-	testMatch: ['**/__tests__/**/*.js', '**/?(*.)+(spec|test).js'],
+	testMatch: [
+		'**/__tests__/**/*.[jt]s?(x)',
+		'**/?(*.)+(spec|test).[jt]s?(x)',
+	],
 	testPathIgnorePatterns: [
 		'/node_modules/',
 		'/vendor/',
@@ -35,6 +38,7 @@ export default {
 							},
 						},
 					],
+					['@babel/preset-react', { runtime: 'automatic' }],
 				],
 			},
 		],

--- a/fair-audience/package.json
+++ b/fair-audience/package.json
@@ -44,6 +44,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.28.3",
 		"@babel/preset-env": "^7.28.3",
+		"@babel/preset-react": "^7.28.3",
 		"@playwright/test": "^1.40.0",
 		"@wordpress/scripts": "^32.4.0",
 		"babel-jest": "^30.0.5",

--- a/fair-audience/src/Admin/manage-event-ext/__tests__/index.test.jsx
+++ b/fair-audience/src/Admin/manage-event-ext/__tests__/index.test.jsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+
+// `render` is never invoked in these tests (they only assert on the tab
+// descriptor's `disabled` flag), so the mocked components are unused stubs.
+jest.mock('../EventAudience.js', () => () => null);
+jest.mock('../GroupRules.js', () => () => null);
+jest.mock('../EventMailings.js', () => () => null);
+
+// The tabs are registered as module side effects reading module-level
+// closures (audienceUrl). Use a fresh module registry per scenario
+// (including `@wordpress/hooks`) so each import sees its own
+// `window.fairEventsManageEventData` and its own filter store.
+function loadModuleWithData(data) {
+	let hooks;
+	jest.isolateModules(() => {
+		window.fairEventsManageEventData = data;
+		hooks = require('@wordpress/hooks');
+		require('../index.js');
+	});
+	return hooks;
+}
+
+describe('audience/groups/mailings tab registration', () => {
+	afterEach(() => {
+		delete window.fairEventsManageEventData;
+	});
+
+	const eventDate = { event_id: 1, start_datetime: '', end_datetime: '' };
+
+	it('disables Audience, Groups, and Mailings tabs for external-URL events', () => {
+		const { applyFilters } = loadModuleWithData({
+			audienceUrl: 'http://example.com/audience/',
+		});
+
+		const ctx = {
+			eventDate: { ...eventDate, link_type: 'external' },
+			eventDateId: 1,
+			eventTitle: 'Test Event',
+			enabledFeatures: { ticketing: true, mailings: true },
+		};
+
+		const tabs = applyFilters('fairEvents.manageEvent.tabs', [], ctx);
+
+		expect(tabs.find((t) => t.name === 'audience').disabled).toBe(true);
+		expect(tabs.find((t) => t.name === 'groups').disabled).toBe(true);
+		expect(tabs.find((t) => t.name === 'mailings').disabled).toBe(true);
+	});
+
+	it('keeps Audience, Groups, and Mailings tabs enabled for post-linked events', () => {
+		const { applyFilters } = loadModuleWithData({
+			audienceUrl: 'http://example.com/audience/',
+		});
+
+		const ctx = {
+			eventDate: { ...eventDate, link_type: 'post' },
+			eventDateId: 1,
+			eventTitle: 'Test Event',
+			enabledFeatures: { ticketing: true, mailings: true },
+		};
+
+		const tabs = applyFilters('fairEvents.manageEvent.tabs', [], ctx);
+
+		expect(tabs.find((t) => t.name === 'audience').disabled).toBeFalsy();
+		expect(tabs.find((t) => t.name === 'groups').disabled).toBeFalsy();
+		expect(tabs.find((t) => t.name === 'mailings').disabled).toBeFalsy();
+	});
+
+	it('still disables Groups for generated occurrences regardless of link type', () => {
+		const { applyFilters } = loadModuleWithData({
+			audienceUrl: 'http://example.com/audience/',
+		});
+
+		const ctx = {
+			eventDate: {
+				...eventDate,
+				link_type: 'post',
+				occurrence_type: 'generated',
+			},
+			eventDateId: 1,
+			eventTitle: 'Test Event',
+			enabledFeatures: { ticketing: true, mailings: true },
+		};
+
+		const tabs = applyFilters('fairEvents.manageEvent.tabs', [], ctx);
+
+		expect(tabs.find((t) => t.name === 'groups').disabled).toBe(true);
+	});
+});

--- a/fair-audience/src/Admin/manage-event-ext/index.js
+++ b/fair-audience/src/Admin/manage-event-ext/index.js
@@ -10,6 +10,7 @@
 
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
+import { isLinkOnlyEvent } from 'fair-events-shared';
 import EventAudience from './EventAudience.js';
 import GroupRules from './GroupRules.js';
 import EventMailings from './EventMailings.js';
@@ -31,6 +32,7 @@ addFilter(
 				title: __('Audience', 'fair-audience'),
 				order: 50,
 				isVisible: true,
+				disabled: isLinkOnlyEvent(eventDate),
 				render: () => (
 					<EventAudience
 						eventId={eventDate.event_id}
@@ -59,7 +61,9 @@ addFilter(
 				title: __('Groups', 'fair-audience'),
 				order: 30,
 				isVisible: true,
-				disabled: eventDate?.occurrence_type === 'generated',
+				disabled:
+					eventDate?.occurrence_type === 'generated' ||
+					isLinkOnlyEvent(eventDate),
 				render: () => <GroupRules eventDateId={eventDateId} />,
 			},
 		];
@@ -81,6 +85,7 @@ addFilter(
 				title: __('Mailings', 'fair-audience'),
 				order: 55,
 				isVisible: true,
+				disabled: isLinkOnlyEvent(eventDate),
 				render: () => (
 					<EventMailings
 						eventDateId={eventDateId}

--- a/fair-events-experimental/src/Admin/manage-event-ext/index.js
+++ b/fair-events-experimental/src/Admin/manage-event-ext/index.js
@@ -11,6 +11,7 @@
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
+import { isLinkOnlyEvent } from 'fair-events-shared';
 import EventStatistics from '../event-statistics/EventStatistics.js';
 
 const {
@@ -22,7 +23,7 @@ const {
 addFilter(
 	'fairEvents.manageEvent.tabs',
 	'fair-events-experimental/statistics-tab',
-	(tabs) => {
+	(tabs, { eventDate } = {}) => {
 		if (!statisticsUrl) {
 			return tabs;
 		}
@@ -34,6 +35,7 @@ addFilter(
 				title: __('Statistics', 'fair-events-experimental'),
 				order: 60,
 				isVisible: true,
+				disabled: isLinkOnlyEvent(eventDate),
 				render: ({ eventDateId }) => (
 					<EventStatistics eventDateId={eventDateId} />
 				),

--- a/fair-events-shared/src/event-utils.js
+++ b/fair-events-shared/src/event-utils.js
@@ -1,0 +1,18 @@
+/**
+ * Shared event helpers for Fair Event plugins.
+ *
+ * @package FairEventsShared
+ */
+
+/**
+ * Whether an event date is a link-only (external URL) event.
+ *
+ * Link-only events have no registration/entry behind them, so
+ * registration-dependent UI (tickets, audience, statistics, finance, etc.)
+ * should be disabled for them.
+ *
+ * @param {Object|undefined} eventDate The event date object (or ctx.eventDate).
+ * @return {boolean} True when the event's link type is `external`.
+ */
+export const isLinkOnlyEvent = (eventDate) =>
+	eventDate?.link_type === 'external';

--- a/fair-events-shared/src/index.js
+++ b/fair-events-shared/src/index.js
@@ -17,3 +17,4 @@ export * from './questionnaire.js';
 export * from './form-utils.js';
 export * from './question-utils.js';
 export * from './payment-flow.js';
+export * from './event-utils.js';

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -33,7 +33,11 @@ import {
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 import apiFetch from '@wordpress/api-fetch';
-import { DurationOptions, calculateDuration } from 'fair-events-shared';
+import {
+	DurationOptions,
+	calculateDuration,
+	isLinkOnlyEvent,
+} from 'fair-events-shared';
 import EventFinance from './EventFinance.js';
 import EventTickets from './EventTickets.js';
 import EventPhotos from './EventPhotos.js';
@@ -575,7 +579,7 @@ export default function ManageEventApp() {
 			title: __('Tickets', 'fair-events'),
 			order: 20,
 			isVisible: ticketingEnabled,
-			disabled: isGeneratedOccurrence,
+			disabled: isGeneratedOccurrence || isLinkOnlyEvent(eventDate),
 			render: () => (
 				<EventTickets
 					eventDateId={eventDateId}
@@ -591,6 +595,7 @@ export default function ManageEventApp() {
 			title: __('Signups', 'fair-events'),
 			order: 25,
 			isVisible: !!(ticketingEnabled && !audienceUrl),
+			disabled: isLinkOnlyEvent(eventDate),
 			render: () => <EventSignups eventDateId={eventDateId} />,
 		},
 		{
@@ -605,6 +610,7 @@ export default function ManageEventApp() {
 			title: __('Finance', 'fair-events'),
 			order: 70,
 			isVisible: !!paymentEntriesUrl,
+			disabled: isLinkOnlyEvent(eventDate),
 			render: () => (
 				<EventFinance
 					eventDateId={eventDateId}
@@ -670,7 +676,7 @@ export default function ManageEventApp() {
 	}));
 
 	const initialTab = useMemo(() => {
-		if (tabDescriptors.some((t) => t.name === urlTab)) {
+		if (tabDescriptors.some((t) => t.name === urlTab && !t.disabled)) {
 			return urlTab;
 		}
 		return 'event-details';

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -118,6 +118,71 @@ it('renders extra admin actions registered via addFilter', async () => {
 	removeFilter('fairEvents.manageEvent.adminActions', NAMESPACE);
 });
 
+it('disables Tickets and Finance tabs for external-URL events', async () => {
+	window.history.replaceState({}, '', '?tab=tickets');
+	window.fairEventsManageEventData = {
+		eventDateId: '1',
+		calendarUrl: 'http://example.com/calendar',
+		manageEventUrl: 'http://example.com/manage',
+		enabledPostTypes: [],
+		enabledFeatures: { ticketing: true },
+		paymentEntriesUrl: 'http://example.com/entries',
+	};
+	apiFetch.mockImplementation((opts) => {
+		if (opts.path && opts.path.includes('/event-dates/')) {
+			return Promise.resolve({ ...mockEventDate, link_type: 'external' });
+		}
+		return Promise.resolve([]);
+	});
+
+	render(<ManageEventApp />);
+	// Tickets tab is disabled, so the initial tab falls back to Event Details.
+	await waitFor(() =>
+		expect(
+			screen.getByRole('tab', { name: 'Event Details' })
+		).toBeInTheDocument()
+	);
+	expect(screen.getByRole('tab', { name: 'Tickets' })).toHaveAttribute(
+		'aria-disabled',
+		'true'
+	);
+	expect(screen.getByRole('tab', { name: 'Finance' })).toHaveAttribute(
+		'aria-disabled',
+		'true'
+	);
+});
+
+it('keeps Tickets and Finance tabs enabled for post-linked events', async () => {
+	window.history.replaceState({}, '', '?tab=admin');
+	window.fairEventsManageEventData = {
+		eventDateId: '1',
+		calendarUrl: 'http://example.com/calendar',
+		manageEventUrl: 'http://example.com/manage',
+		enabledPostTypes: [],
+		enabledFeatures: { ticketing: true },
+		paymentEntriesUrl: 'http://example.com/entries',
+	};
+	apiFetch.mockImplementation((opts) => {
+		if (opts.path && opts.path.includes('/event-dates/')) {
+			return Promise.resolve({ ...mockEventDate, link_type: 'post' });
+		}
+		return Promise.resolve([]);
+	});
+
+	render(<ManageEventApp />);
+	await waitFor(() =>
+		expect(screen.getByRole('tab', { name: 'Admin' })).toBeInTheDocument()
+	);
+	expect(screen.getByRole('tab', { name: 'Tickets' })).not.toHaveAttribute(
+		'aria-disabled',
+		'true'
+	);
+	expect(screen.getByRole('tab', { name: 'Finance' })).not.toHaveAttribute(
+		'aria-disabled',
+		'true'
+	);
+});
+
 it('omits a descriptor with isVisible: false', async () => {
 	const NAMESPACE = 'test/hidden-tab-919';
 	addFilter('fairEvents.manageEvent.tabs', NAMESPACE, (descriptors) => [


### PR DESCRIPTION
## Summary

- On the Manage Event page, an event with **Link type = External URL** has no registration behind it, so the Tickets, Signups, Finance, Groups, Audience, Mailings, and Statistics tabs were fully clickable but pointed at empty/irrelevant screens. Grays out (disables) those tabs when `eventDate.link_type === 'external'`, reusing the existing per-tab `disabled` mechanism.
- Adds a shared `isLinkOnlyEvent(eventDate)` helper to `fair-events-shared`, consumed by `fair-events`, `fair-audience`, and `fair-events-experimental` instead of duplicating the check.
- Falls back to the Event Details tab if a deep link (`?tab=...`) points at a tab that is now disabled.
- Fixes `fair-audience`'s jest config, which was missing `@babel/preset-react` and JSX test-file matching, so no component test could previously run there.

Closes #982

## Test plan

- [x] `npm test` in `fair-events`, `fair-audience`, `fair-events-experimental`, and `fair-events-shared` — all pass.
- [x] New/extended component tests assert disabled state of built-in and extension tabs across `link_type` values (`external`, `post`) and confirm generated-occurrence disabling of Groups still works additively.
- [x] `npm run build` run in `fair-events`, `fair-audience`, and `fair-events-experimental`.
