### PR TITLE
Render calendar links for standalone events linked to a post

### DIFF
--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -536,7 +536,8 @@ class EventDates {
 	 *
 	 * Returns the external URL for external events,
 	 * the post permalink for post-linked events,
-	 * or null for unlinked events.
+	 * or the permalink of a post linked via the junction table
+	 * (recurring instances linked from the post editor), if any.
 	 *
 	 * @return string|null The display URL, or null if no link.
 	 */
@@ -548,8 +549,24 @@ class EventDates {
 				return $this->event_id ? get_permalink( $this->event_id ) : null;
 			case 'none':
 			default:
-				return null;
+				$linked_post_id = $this->get_primary_linked_post_id();
+				return $linked_post_id ? get_permalink( $linked_post_id ) : null;
 		}
+	}
+
+	/**
+	 * Get the first post linked to this event date via the junction table
+	 *
+	 * Links are stored on the master event date (see EventDatesController::link_post()),
+	 * so generated occurrences look up their master's linked posts.
+	 *
+	 * @return int|null Post ID, or null if no linked post.
+	 */
+	public function get_primary_linked_post_id() {
+		$lookup_id       = ( 'generated' === $this->occurrence_type && $this->master_id ) ? $this->master_id : $this->id;
+		$linked_post_ids = self::get_linked_post_ids( $lookup_id );
+
+		return ! empty( $linked_post_ids ) ? $linked_post_ids[0] : null;
 	}
 
 	/**

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -131,7 +131,7 @@ if ( ! function_exists( 'fair_events_render_calendar_event_item' ) ) {
 			</div>
 			<?php
 		} elseif ( $is_standalone ) {
-			// Standalone event rendering (external/unlinked)
+			// Standalone event rendering (external/linked-post/unlinked).
 			$event_title = $event_data['title'] ?? '';
 			$event_url   = $event_data['permalink'] ?? '';
 			$link_type   = $event_data['link_type'] ?? 'none';
@@ -140,6 +140,8 @@ if ( ! function_exists( 'fair_events_render_calendar_event_item' ) ) {
 			$item_classes = array( 'event-item', 'is-standalone' );
 			if ( $is_external ) {
 				$item_classes[] = 'is-external';
+			} elseif ( ! empty( $event_url ) ) {
+				$item_classes[] = 'is-linked-post';
 			} else {
 				$item_classes[] = 'is-unlinked';
 			}
@@ -152,6 +154,10 @@ if ( ! function_exists( 'fair_events_render_calendar_event_item' ) ) {
 						class="event-title"
 						target="_blank"
 						rel="noopener noreferrer">
+						<?php echo esc_html( $event_title ); ?>
+					</a>
+				<?php elseif ( ! empty( $event_url ) ) : ?>
+					<a href="<?php echo esc_url( $event_url ); ?>" class="event-title">
 						<?php echo esc_html( $event_title ); ?>
 					</a>
 				<?php else : ?>


### PR DESCRIPTION
## Summary
- Recurring standalone occurrences that get linked to a post via the post editor's "Link Existing Event" feature were stored in the `fair_event_date_posts` junction table but never consulted by the calendar block, so they rendered as a plain unstyled `<span>` instead of the usual button link.
- `EventDates::get_display_url()` now falls back to the junction-linked post's permalink when `link_type` is `none`.
- The calendar's standalone-event rendering now shows a link whenever a URL is available (external or linked-post), not only for `link_type === 'external'`.

## Test plan
- [ ] Link a standalone recurring instance to a post via the post editor "Link Existing Event" option and confirm it now renders as a clickable button link in the calendar block, matching the styling of directly-linked WP events
- [ ] Confirm unlinked standalone instances (no post, no external URL) still render as plain text
- [ ] Confirm external-link standalone instances still open in a new tab