### PR TITLE
Pivot standalone get-tickets to series master for recurring events

### DIFF
--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -184,11 +184,18 @@ class GetTicketsController extends WP_REST_Controller {
 			);
 		}
 
-		// Validate ticket type belongs to this event date and has not been disabled.
-		$amount = 0.00;
+		// Validate ticket type belongs to this event date (or its series master)
+		// and has not been disabled.
+		$amount               = 0.00;
+		$config_event_date_id = $this->resolve_master_event_date_id( $event_date_id );
+		if ( ! $config_event_date_id ) {
+			$config_event_date_id = $event_date_id;
+		}
 		if ( $ticket_type_id && class_exists( \FairEvents\Models\TicketType::class ) ) {
 			$ticket_type = \FairEvents\Models\TicketType::get_by_id( $ticket_type_id );
-			if ( ! $ticket_type || (int) $ticket_type->event_date_id !== (int) $event_date_id ) {
+			if ( ! $ticket_type
+				|| ( (int) $ticket_type->event_date_id !== (int) $event_date_id
+					&& (int) $ticket_type->event_date_id !== (int) $config_event_date_id ) ) {
 				return new WP_Error(
 					'invalid_ticket_type',
 					__( 'Invalid ticket type.', 'fair-events' ),
@@ -213,11 +220,11 @@ class GetTicketsController extends WP_REST_Controller {
 
 			// Resolve price from the active sale period (server-side; client amount is ignored).
 			if ( class_exists( \FairEvents\Models\TicketSalePeriod::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
-				$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $event_date_id );
+				$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $config_event_date_id );
 				$now          = current_time( 'mysql' );
 				foreach ( $sale_periods as $period ) {
 					if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
-						$prices = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $event_date_id );
+						$prices = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $config_event_date_id );
 						foreach ( $prices as $price ) {
 							if ( (int) $price->ticket_type_id === (int) $ticket_type_id
 								&& (int) $price->sale_period_id === (int) $period->id ) {

--- a/fair-events/src/API/__tests__/GetTicketsRecurringMaster.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsRecurringMaster.api.spec.js
@@ -1,0 +1,192 @@
+/**
+ * Playwright API tests for the get-tickets fallback endpoint's master-pivot
+ * support for recurring events (#983).
+ *
+ * This endpoint only serves signups when fair-audience is NOT active
+ * (fair-events/src/blocks/get-tickets/render.php defers to the Event Signup
+ * block otherwise), so these tests skip gracefully when fair-audience is
+ * active in the test environment.
+ *
+ * Covers:
+ *   - a ticket type configured on the series master is accepted when
+ *     purchasing a non-first (child) occurrence.
+ *   - the resulting signup row persists against the child occurrence, not
+ *     the master.
+ *   - a price configured on the master resolves for a purchase against a
+ *     child occurrence.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('GetTicketsController — recurring series master pivot', () => {
+	let api;
+	let fairAudienceActive = false;
+	let eventPostId;
+	let masterEventDateId;
+	let occurrenceIds;
+	let childEventDateId;
+	let ticketTypeId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		// Detect whether fair-audience is active — the get-tickets block (and
+		// this controller's public behaviour) is a no-op fallback when it is.
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+		if (fairAudienceActive) {
+			return;
+		}
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Get-tickets recurring master test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2035-06-01 10:00:00',
+				end_datetime: '2035-06-01 12:00:00',
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		masterEventDateId = (await edRes.json()).id;
+
+		const occRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
+			{ headers: adminHeaders }
+		);
+		expect(occRes.ok()).toBeTruthy();
+		occurrenceIds = (await occRes.json()).map((o) => o.id).sort();
+		expect(occurrenceIds.length).toBe(3);
+		// A non-first occurrence — the case that was previously broken.
+		childEventDateId = occurrenceIds[1];
+
+		const ticketsRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'Single session',
+							capacity: null,
+							seats_per_ticket: 1,
+							invitation_only: false,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'single_instance',
+							group_ids: [],
+						},
+					],
+					sale_periods: [
+						{
+							name: 'Always on',
+							sale_start: '2020-01-01 00:00:00',
+							sale_end: '2099-01-01 00:00:00',
+						},
+					],
+					prices: [
+						{
+							ticket_type_index: 0,
+							sale_period_index: 0,
+							price: 12.5,
+						},
+					],
+					settings: {},
+				},
+			}
+		);
+		expect(ticketsRes.ok()).toBeTruthy();
+		const ticketsBody = await ticketsRes.json();
+		ticketTypeId = ticketsBody.ticket_types?.[0]?.id;
+		expect(ticketTypeId).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (fairAudienceActive) {
+			return;
+		}
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+		await api.dispose();
+	});
+
+	test('master-owned ticket type is accepted for a child occurrence and priced', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: childEventDateId,
+				name: 'Recurring Master Tester',
+				email: `recurring-master-${Date.now()}@example.test`,
+				ticket_type_id: ticketTypeId,
+				quantity: 1,
+			},
+		});
+		// Today's bug returns 400 invalid_ticket_type here — must succeed instead.
+		expect(res.ok()).toBeTruthy();
+	});
+
+	test('the signup persists against the child occurrence, priced from the master, not the master row', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const signupsRes = await api.get(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				headers: adminHeaders,
+				params: { event_date: childEventDateId },
+			}
+		);
+		expect(signupsRes.ok()).toBeTruthy();
+		const signups = await signupsRes.json();
+		const signup = signups.find((s) => s.ticket_type_id === ticketTypeId);
+		expect(signup).toBeTruthy();
+		// Server-resolved amount confirms the price lookup pivoted to the master.
+		expect(parseFloat(signup.amount)).toBe(12.5);
+		expect(signup.status).toBe('pending_payment');
+
+		const masterSignupsRes = await api.get(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				headers: adminHeaders,
+				params: { event_date: masterEventDateId },
+			}
+		);
+		expect(masterSignupsRes.ok()).toBeTruthy();
+		const masterSignups = await masterSignupsRes.json();
+		expect(
+			masterSignups.some((s) => s.ticket_type_id === ticketTypeId)
+		).toBeFalsy();
+	});
+});

--- a/fair-events/src/blocks/get-tickets/render.php
+++ b/fair-events/src/blocks/get-tickets/render.php
@@ -65,10 +65,20 @@ if ( class_exists( \FairEvents\Models\EventDates::class ) ) {
 	$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
 }
 
+// Pivot config/pricing lookups to the series master for generated occurrences.
+// The form still links the signup to the specific occurrence via $event_date_id.
+$pricing_event_date_id = $event_date_id;
+if ( $event_date
+	&& 'generated' === ( $event_date->occurrence_type ?? null )
+	&& ! empty( $event_date->master_id )
+) {
+	$pricing_event_date_id = (int) $event_date->master_id;
+}
+
 // Load ticket types.
 $ticket_types = array();
 if ( class_exists( \FairEvents\Models\TicketType::class ) ) {
-	$ticket_types = \FairEvents\Models\TicketType::get_all_by_event_date_id( $event_date_id );
+	$ticket_types = \FairEvents\Models\TicketType::get_all_by_event_date_id( $pricing_event_date_id );
 }
 
 // Resolve the series master (if any) so 'multiple_instances' ticket types can
@@ -108,12 +118,12 @@ $has_instance_picker = ! empty( $occurrences_for_picker );
 $price_by_type_id   = array();
 $active_sale_period = null;
 if ( class_exists( \FairEvents\Models\TicketSalePeriod::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
-	$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $event_date_id );
+	$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $pricing_event_date_id );
 	$now          = current_time( 'mysql' );
 	foreach ( $sale_periods as $period ) {
 		if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
 			$active_sale_period = $period;
-			$prices             = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $event_date_id );
+			$prices             = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id );
 			foreach ( $prices as $price ) {
 				if ( (int) $price->sale_period_id === (int) $period->id ) {
 					$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;


### PR DESCRIPTION
## Summary

- `get-tickets/render.php` now pivots ticket-type/sale-period/price lookups to the series master for `generated` occurrences, mirroring fair-audience's `event-signup` block. The form's `data-event-date-id` still stays the specific occurrence.
- `GetTicketsController::create_signup` resolves the submitted occurrence's series master and accepts a ticket type owned by either the occurrence or its master, then resolves price from the master's sale periods/prices. The signup row is still persisted against the child occurrence.
- Whole-series / multiple-instances paths are untouched.
- Adds `GetTicketsRecurringMaster.api.spec.js` covering: a master-owned ticket type is accepted for a non-first occurrence purchase (previously rejected as `invalid_ticket_type`), the signup persists against the child (not the master), and the price resolves from the master's config.

Closes #983

## Test plan

- [x] `npx jest` (fair-events) — 49 passed
- [x] `vendor/bin/phpcs` on the two touched files — no new violations (pre-existing findings unrelated to this change remain)
- [x] `npm run build` in fair-events so `build/blocks/get-tickets/render.php` picks up the pivot
- [ ] New Playwright API spec / WP-CLI manual check — not run in this session (this checkout's docker ports conflict with an already-running WordPress environment from a sibling checkout); should be run against a live environment before merge
