### PR TITLE
Fix All Events showing wrong time vs Manage Event/DB

### DIFF
--- a/fair-events/src/Admin/all-events/AllEvents.js
+++ b/fair-events/src/Admin/all-events/AllEvents.js
@@ -7,6 +7,20 @@ import { dateI18n, getSettings } from '@wordpress/date';
 
 const { manageEventUrl } = window.fairEventsAllEventsData || {};
 
+/**
+ * Format a naive "Y-m-d H:i:s" site-local datetime for display without
+ * re-applying the site timezone offset (it's already wall-clock local, the
+ * same value Manage Event shows). Treating it as UTC and formatting with
+ * gmdateI18n (timezone=true) skips that second conversion.
+ *
+ * @param {string} datetime Naive datetime string, e.g. "2026-09-01 10:00:00".
+ * @return {string} Formatted date/time in the site's format.
+ */
+export function formatSiteLocalDatetime(datetime) {
+	const { formats } = getSettings();
+	return dateI18n(formats.datetime, `${datetime.replace(' ', 'T')}Z`, true);
+}
+
 const LINK_TYPE_OPTIONS = [
 	{ value: 'post', label: __('Post', 'fair-events') },
 	{ value: 'external', label: __('External', 'fair-events') },
@@ -81,8 +95,7 @@ export default function AllEvents() {
 					if (!item.start_datetime) {
 						return '—';
 					}
-					const { formats } = getSettings();
-					return dateI18n(formats.datetime, item.start_datetime);
+					return formatSiteLocalDatetime(item.start_datetime);
 				},
 				enableSorting: true,
 				getValue: ({ item }) => item.start_datetime || '',

--- a/fair-events/src/Admin/all-events/__tests__/AllEvents.test.js
+++ b/fair-events/src/Admin/all-events/__tests__/AllEvents.test.js
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression test for #993: All Events must show the same wall-clock time
+ * as Manage Event / the DB for a given `start_datetime`, regardless of the
+ * site timezone.
+ */
+// Pin the "browser" timezone so the assertion doesn't depend on the
+// machine running the test — the bug only reproduces when this differs
+// from the site timezone set below.
+process.env.TZ = 'UTC';
+
+import { getSettings, setSettings } from '@wordpress/date';
+import { formatSiteLocalDatetime } from '../AllEvents.js';
+
+it('formats a naive datetime without applying the site timezone offset', () => {
+	const settings = getSettings();
+
+	setSettings({
+		...settings,
+		timezone: {
+			...settings.timezone,
+			offset: 2,
+			offsetFormatted: '+2',
+			string: 'Europe/Madrid',
+		},
+	});
+
+	try {
+		expect(formatSiteLocalDatetime('2026-09-01 10:00:00')).toBe(
+			'September 1, 2026 10:00 am'
+		);
+	} finally {
+		setSettings(settings);
+	}
+});


### PR DESCRIPTION
## Summary

- `AllEvents.js` formatted `start_datetime` with `dateI18n`'s default timezone handling, which parses the naive site-local string in the browser's zone and then re-applies the site timezone offset — a double conversion that made the list show a different time than Manage Event/the DB whenever the two zones differ.
- Now formats it via `gmdateI18n` (tagging the naive string as UTC) so the wall-clock value passes through unchanged, matching Manage Event.
- Backend (`prepare_event_date()`) and the admin Calendar (`DayCell.js`, which doesn't render times) were audited and are unaffected.

Closes #993

## Test plan

- [x] Added `AllEvents.test.js`, pinning `TZ=UTC` and setting the site timezone to `Europe/Madrid` via `@wordpress/date`'s `setSettings`; confirms the old code shifted the time by the offset and the fix renders it unchanged.
- [x] `npx jest` — all 50 tests pass.
- [x] Manually verified in the Docker WP instance: set `timezone_string` to `Europe/Madrid`, rebuilt, and confirmed All Events row `id=11` now shows "September 1, 2026 10:00 am", matching the DB (`2026-09-01 10:00:00`) and Manage Event.
