### PR TITLE
Fix stale fair-audience-submission-detail links

### DIFF
--- a/fair-audience/src/Admin/participant-detail/ParticipantDetail.js
+++ b/fair-audience/src/Admin/participant-detail/ParticipantDetail.js
@@ -397,7 +397,7 @@ export default function ParticipantDetail() {
 							</thead>
 							<tbody>
 								{submissions.map((sub) => {
-									const detailUrl = `admin.php?page=fair-audience-submission-detail&submission_id=${sub.id}`;
+									const detailUrl = `admin.php?page=fair-form-submission-detail&submission_id=${sub.id}`;
 									return (
 										<tr key={sub.id}>
 											<td>

--- a/fair-audience/src/Admin/timeline/TimelineItem.js
+++ b/fair-audience/src/Admin/timeline/TimelineItem.js
@@ -99,7 +99,7 @@ function FormSubmissionContent({ item }) {
 		post_url: postUrl,
 	} = item.details;
 
-	const submissionUrl = `admin.php?page=fair-audience-submission-detail&submission_id=${submissionId}`;
+	const submissionUrl = `admin.php?page=fair-form-submission-detail&submission_id=${submissionId}`;
 	const participantUrl = participantId
 		? `admin.php?page=fair-audience-participant-detail&participant_id=${participantId}`
 		: null;


### PR DESCRIPTION
## Summary
- The form submission detail page moved to fair-form (`fair-form-submission-detail`), but two links in fair-audience still pointed at the old `fair-audience-submission-detail` page slug, resulting in broken admin links.
- Updated the participant timeline link and the participant detail submissions table link to use the correct `fair-form-submission-detail` slug.

## Test plan
- [ ] Visit a participant detail page in fair-audience and confirm submission links open the fair-form submission detail page correctly.
- [ ] Visit the audience timeline and confirm form submission links resolve correctly.