### PR TITLE
Replace window.confirm on event delete with ConfirmDialog

### DIFF
--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -29,6 +29,7 @@ import {
 	__experimentalNumberControl as NumberControl,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
+	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
@@ -37,6 +38,7 @@ import {
 	DurationOptions,
 	calculateDuration,
 	isLinkOnlyEvent,
+	formatSiteLocalDatetime,
 } from 'fair-events-shared';
 import EventFinance from './EventFinance.js';
 import EventTickets from './EventTickets.js';
@@ -110,6 +112,7 @@ export default function ManageEventApp() {
 	const ticketSaveRef = useRef(null);
 	const [togglingExdate, setTogglingExdate] = useState(null);
 	const [recurrenceImpact, setRecurrenceImpact] = useState(null);
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
 	useEffect(() => {
 		if (!eventDateId) {
@@ -386,15 +389,7 @@ export default function ManageEventApp() {
 		}
 	};
 
-	const handleDelete = async () => {
-		if (
-			!window.confirm(
-				__('Are you sure you want to delete this event?', 'fair-events')
-			)
-		) {
-			return;
-		}
-
+	const confirmDelete = async () => {
 		try {
 			await apiFetch({
 				path: `/fair-events/v1/event-dates/${eventDateId}`,
@@ -405,8 +400,38 @@ export default function ManageEventApp() {
 			setError(
 				err.message || __('Failed to delete event.', 'fair-events')
 			);
+		} finally {
+			setDeleteDialogOpen(false);
 		}
 	};
+
+	const deleteConfirmMessage = useMemo(() => {
+		const eventTitle = title || __('Untitled Event', 'fair-events');
+
+		if (eventDate?.occurrence_type === 'master') {
+			const count = eventDate.generated_occurrences?.length || 0;
+			return sprintf(
+				/* translators: 1: event title, 2: number of occurrences */
+				_n(
+					'Delete %1$s and its %2$d occurrence? This cannot be undone.',
+					'Delete %1$s and its %2$d occurrences? This cannot be undone.',
+					count,
+					'fair-events'
+				),
+				eventTitle,
+				count
+			);
+		}
+
+		return sprintf(
+			/* translators: 1: event title, 2: event date */
+			__('Delete %1$s on %2$s? This cannot be undone.', 'fair-events'),
+			eventTitle,
+			eventDate?.start_datetime
+				? formatSiteLocalDatetime(eventDate.start_datetime)
+				: ''
+		);
+	}, [title, eventDate]);
 
 	const handleCreatePost = async () => {
 		setCreatingPost(true);
@@ -648,7 +673,9 @@ export default function ManageEventApp() {
 									<Button
 										variant="tertiary"
 										isDestructive
-										onClick={handleDelete}
+										onClick={() =>
+											setDeleteDialogOpen(true)
+										}
 									>
 										{__('Delete Event', 'fair-events')}
 									</Button>
@@ -1318,6 +1345,16 @@ export default function ManageEventApp() {
 					{__('Back to Calendar', 'fair-events')}
 				</Button>
 			</HStack>
+
+			<ConfirmDialog
+				isOpen={deleteDialogOpen}
+				onConfirm={confirmDelete}
+				onCancel={() => setDeleteDialogOpen(false)}
+				confirmButtonText={__('Delete event', 'fair-events')}
+				cancelButtonText={__('Cancel', 'fair-events')}
+			>
+				{deleteConfirmMessage}
+			</ConfirmDialog>
 		</div>
 	);
 }

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -9,7 +9,7 @@
  *   - A descriptor with isVisible:false is omitted from the tab bar.
  */
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import apiFetch from '@wordpress/api-fetch';
 import { formatSiteLocalDatetime } from 'fair-events-shared';
@@ -292,5 +292,60 @@ describe('context header (#986)', () => {
 		expect(
 			screen.getByRole('link', { name: 'open the master event' })
 		).toHaveAttribute('href', 'http://example.com/manage&event_date_id=1');
+	});
+});
+
+describe('delete confirmation dialog (#991)', () => {
+	it('shows the title and date, and no occurrence count, for a one-off event', async () => {
+		render(<ManageEventApp />);
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Admin' })
+			).toBeInTheDocument()
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Delete Event' }));
+
+		expect(
+			screen.getByText(
+				`Delete Test Event on ${formatSiteLocalDatetime(
+					mockEventDate.start_datetime
+				)}? This cannot be undone.`
+			)
+		).toBeInTheDocument();
+	});
+
+	it('shows the occurrence count for a recurring master', async () => {
+		apiFetch.mockImplementation((opts) => {
+			if (opts.path && opts.path.includes('/event-dates/')) {
+				return Promise.resolve({
+					...mockEventDate,
+					occurrence_type: 'master',
+					generated_occurrences: Array.from(
+						{ length: 9 },
+						(_, i) => ({
+							id: i + 2,
+							start_datetime: '2026-07-08 18:00:00',
+						})
+					),
+				});
+			}
+			return Promise.resolve([]);
+		});
+
+		render(<ManageEventApp />);
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Admin' })
+			).toBeInTheDocument()
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Delete Event' }));
+
+		expect(
+			screen.getByText(
+				'Delete Test Event and its 9 occurrences? This cannot be undone.'
+			)
+		).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary

- Replace `window.confirm` in the Manage Event → Admin delete flow with `@wordpress/components`' `__experimentalConfirmDialog`.
- The dialog names the event title and, for a recurring master, states the occurrence count so the blast radius of deleting a series is clear before confirming.
- One-off / generated occurrences show the title and start date instead.

Closes #991

## Test plan

- [x] `npx jest src/Admin/manage-event` — 41 tests pass, including two new cases covering the one-off and recurring-master dialog message.
- [x] `npm run format` (root)
- [x] `npm run build` in `fair-events`
