### PR TITLE
Add fair-form consent checkbox question block

### DIFF
--- a/.changeset/fair-form-consent-checkbox.md
+++ b/.changeset/fair-form-consent-checkbox.md
@@ -1,0 +1,5 @@
+---
+"fair-form": minor
+---
+
+Add a consent checkbox question block so form authors can require visitors to accept terms and conditions before submitting.

--- a/fair-events-shared/jest.config.cjs
+++ b/fair-events-shared/jest.config.cjs
@@ -1,10 +1,13 @@
 module.exports = {
-  testEnvironment: "jsdom",
-  testMatch: ["<rootDir>/__tests__/**/*.test.js"],
-  transformIgnorePatterns: [
-    "/node_modules/(?!(uuid|@wordpress/components)/)",
-  ],
-  transform: {
-    "^.+\\.js$": "babel-jest",
-  },
+	testEnvironment: 'jsdom',
+	testMatch: [
+		'<rootDir>/__tests__/**/*.test.js',
+		'<rootDir>/src/**/__tests__/**/*.test.js',
+	],
+	transformIgnorePatterns: [
+		'/node_modules/(?!(uuid|@wordpress/components)/)',
+	],
+	transform: {
+		'^.+\\.js$': 'babel-jest',
+	},
 };

--- a/fair-events-shared/src/__tests__/questionnaire.test.js
+++ b/fair-events-shared/src/__tests__/questionnaire.test.js
@@ -1,7 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import { evaluateConditionals } from '../questionnaire.js';
+import {
+	evaluateConditionals,
+	getQuestionValue,
+	collectQuestionAnswers,
+	validateQuestions,
+} from '../questionnaire.js';
 
 const VISIBLE = 'fair-form-conditional-visible';
 
@@ -209,5 +214,71 @@ describe('evaluateConditionals — question source (regression)', () => {
 		);
 		const section = form.querySelector('[data-fair-form-conditional]');
 		expect(section.classList.contains(VISIBLE)).toBe(false);
+	});
+});
+
+function consentQuestion({ checked = false, required = true } = {}) {
+	return (
+		`<div data-fair-form-question data-question-key="tos" data-question-text="I accept" data-question-type="checkbox" data-required="${
+			required ? '1' : '0'
+		}">` +
+		`<input type="checkbox" name="fair_form_q_tos" value="1"${
+			checked ? ' checked' : ''
+		} /></div>`
+	);
+}
+
+describe('checkbox question type', () => {
+	describe('getQuestionValue', () => {
+		it('returns "1" when the checkbox is checked', () => {
+			const form = buildForm(consentQuestion({ checked: true }));
+			const questionEl = form.querySelector('[data-fair-form-question]');
+			expect(getQuestionValue(questionEl)).toBe('1');
+		});
+
+		it('returns "0" when the checkbox is unchecked', () => {
+			const form = buildForm(consentQuestion({ checked: false }));
+			const questionEl = form.querySelector('[data-fair-form-question]');
+			expect(getQuestionValue(questionEl)).toBe('0');
+		});
+	});
+
+	describe('collectQuestionAnswers', () => {
+		it('stores "1" for a checked box', () => {
+			const form = buildForm(consentQuestion({ checked: true }));
+			const answers = collectQuestionAnswers(form);
+			expect(answers).toHaveLength(1);
+			expect(answers[0].answer_value).toBe('1');
+		});
+
+		it('stores "0" for an unchecked box, not the input value attribute', () => {
+			const form = buildForm(consentQuestion({ checked: false }));
+			const answers = collectQuestionAnswers(form);
+			expect(answers).toHaveLength(1);
+			expect(answers[0].answer_value).toBe('0');
+		});
+	});
+
+	describe('validateQuestions', () => {
+		it('blocks submission when a required consent box is unchecked', () => {
+			const form = buildForm(
+				consentQuestion({ checked: false, required: true })
+			);
+			expect(validateQuestions(form)).toMatch(/I accept/);
+		});
+
+		it('passes when a required consent box is checked', () => {
+			const form = buildForm(
+				consentQuestion({ checked: true, required: true })
+			);
+			expect(validateQuestions(form)).toBeNull();
+		});
+
+		it('does not require an unchecked box when required is false', () => {
+			const form = buildForm(
+				consentQuestion({ checked: false, required: false })
+			);
+			expect(validateQuestions(form)).toBeNull();
+		});
 	});
 });

--- a/fair-events-shared/src/questionnaire.js
+++ b/fair-events-shared/src/questionnaire.js
@@ -28,6 +28,11 @@ export function getQuestionValue(questionEl) {
 		return JSON.stringify(Array.from(checked).map((cb) => cb.value));
 	}
 
+	if (questionType === 'checkbox') {
+		const checkbox = questionEl.querySelector('input[type="checkbox"]');
+		return checkbox && checkbox.checked ? '1' : '0';
+	}
+
 	const input = questionEl.querySelector(
 		'input:checked, select, input, textarea'
 	);
@@ -198,6 +203,9 @@ export function collectQuestionAnswers(form) {
 			);
 			const values = Array.from(checked).map((cb) => cb.value);
 			answerValue = JSON.stringify(values);
+		} else if (questionType === 'checkbox') {
+			const checkbox = el.querySelector('input[type="checkbox"]');
+			answerValue = checkbox && checkbox.checked ? '1' : '0';
 		} else {
 			// For select, radio, text, textarea - get value from first
 			// input/select/textarea.
@@ -252,6 +260,8 @@ export function validateQuestions(form) {
 			hasValue =
 				el.querySelectorAll('input[type="checkbox"]:checked').length >
 				0;
+		} else if (questionType === 'checkbox') {
+			hasValue = !!el.querySelector('input[type="checkbox"]:checked');
 		} else if (el.querySelector('input[type="radio"]')) {
 			hasValue = !!el.querySelector('input[type="radio"]:checked');
 		} else {

--- a/fair-form/src/Admin/submission-detail/SubmissionDetail.js
+++ b/fair-form/src/Admin/submission-detail/SubmissionDetail.js
@@ -57,6 +57,16 @@ function AnswerDisplay({ answer }) {
 		}
 	}
 
+	if (question_type === 'checkbox') {
+		return (
+			<span>
+				{answer_value === '1'
+					? __('Yes', 'fair-form')
+					: __('No', 'fair-form')}
+			</span>
+		);
+	}
+
 	return <span>{answer_value || '—'}</span>;
 }
 

--- a/fair-form/src/Admin/utils/submission-markdown.js
+++ b/fair-form/src/Admin/utils/submission-markdown.js
@@ -23,6 +23,12 @@ function answerToMarkdownLines(answer) {
 			// Keep the raw value.
 		}
 		lines.push(value);
+	} else if (answer.question_type === 'checkbox') {
+		lines.push(
+			answer.answer_value === '1'
+				? __('Yes', 'fair-audience')
+				: __('No', 'fair-audience')
+		);
 	} else {
 		lines.push(answer.answer_value || '');
 	}

--- a/fair-form/src/Hooks/BlockHooks.php
+++ b/fair-form/src/Hooks/BlockHooks.php
@@ -42,6 +42,7 @@ class BlockHooks {
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-radio' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-option' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-file-upload' );
+		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-consent' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-conditional' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-mailing-signup' );
 
@@ -59,6 +60,7 @@ class BlockHooks {
 		wp_set_script_translations( 'fair-form-fair-form-radio-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-option-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-file-upload-editor-script', 'fair-audience', $translations_path );
+		wp_set_script_translations( 'fair-form-fair-form-consent-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-conditional-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-mailing-signup-editor-script', 'fair-audience', $translations_path );
 	}

--- a/fair-form/src/blocks/fair-form-consent/block.json
+++ b/fair-form/src/blocks/fair-form-consent/block.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "fair-audience/fair-form-consent",
+	"version": "1.0.0",
+	"title": "Consent Checkbox Question",
+	"category": "widgets",
+	"icon": "yes-alt",
+	"description": "A single consent checkbox question for Fair Form (e.g. terms and conditions)",
+	"keywords": ["question", "checkbox", "consent", "terms"],
+	"textdomain": "fair-audience",
+	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
+	"supports": {
+		"html": false
+	},
+	"attributes": {
+		"questionText": {
+			"type": "string",
+			"default": ""
+		},
+		"questionKey": {
+			"type": "string",
+			"default": ""
+		},
+		"required": {
+			"type": "boolean",
+			"default": true
+		}
+	},
+	"editorScript": "file:./editor.js",
+	"render": "file:./render.php",
+	"style": "file:./style-editor.css"
+}

--- a/fair-form/src/blocks/fair-form-consent/editor.js
+++ b/fair-form/src/blocks/fair-form-consent/editor.js
@@ -1,0 +1,79 @@
+import './style.css';
+
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { generateQuestionKey } from 'fair-events-shared';
+
+registerBlockType('fair-audience/fair-form-consent', {
+	edit: ({ attributes, setAttributes }) => {
+		const { questionText, questionKey, required } = attributes;
+
+		const onQuestionTextChange = (value) => {
+			const updates = { questionText: value };
+			if (
+				!questionKey ||
+				questionKey === generateQuestionKey(questionText)
+			) {
+				updates.questionKey = generateQuestionKey(value);
+			}
+			setAttributes(updates);
+		};
+
+		const blockProps = useBlockProps({
+			className: 'fair-form-question fair-form-question-consent',
+		});
+
+		return (
+			<>
+				<InspectorControls>
+					<PanelBody title={__('Question Settings', 'fair-audience')}>
+						<TextControl
+							label={__('Question Key', 'fair-audience')}
+							value={questionKey}
+							onChange={(value) =>
+								setAttributes({ questionKey: value })
+							}
+							help={__(
+								'A unique identifier for this question (e.g. "favorite_color"). Used internally.',
+								'fair-audience'
+							)}
+						/>
+						<ToggleControl
+							label={__('Required', 'fair-audience')}
+							checked={required}
+							onChange={(value) =>
+								setAttributes({ required: value })
+							}
+						/>
+					</PanelBody>
+				</InspectorControls>
+
+				<div {...blockProps}>
+					<p>
+						<input type="checkbox" disabled />
+						<span className="fair-form-question-header">
+							<textarea
+								rows={1}
+								value={questionText}
+								onChange={(e) =>
+									onQuestionTextChange(e.target.value)
+								}
+								placeholder={__(
+									'I have read and accept the terms and conditions',
+									'fair-audience'
+								)}
+								className="fair-form-question-label-input"
+							/>
+							{required && <span className="required"> *</span>}
+						</span>
+					</p>
+				</div>
+			</>
+		);
+	},
+	save: () => {
+		return null;
+	},
+});

--- a/fair-form/src/blocks/fair-form-consent/render.php
+++ b/fair-form/src/blocks/fair-form-consent/render.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Render callback for the Fair Form Consent question block
+ *
+ * @package FairForm
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block content.
+ * @param WP_Block $block      Block instance.
+ * @return string Rendered block HTML.
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ * Variables in block render templates are scoped to the template and don't need prefixing.
+ */
+
+defined( 'WPINC' ) || die;
+
+$question_text = $attributes['questionText'] ?? '';
+$question_key  = $attributes['questionKey'] ?? '';
+$required      = ! empty( $attributes['required'] );
+
+// Skip rendering if no question text is set.
+if ( empty( $question_text ) ) {
+	return '';
+}
+
+// Generate unique ID for this input.
+$input_id = 'fair-form-q-' . sanitize_title( $question_key ) . '-' . wp_unique_id();
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class'                   => 'fair-form-question fair-form-question-consent',
+		'data-fair-form-question' => '',
+		'data-question-key'       => esc_attr( $question_key ),
+		'data-question-text'      => esc_attr( $question_text ),
+		'data-question-type'      => 'checkbox',
+		'data-required'           => $required ? '1' : '0',
+	)
+);
+?>
+
+<div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
+	<label for="<?php echo esc_attr( $input_id ); ?>">
+		<input
+			type="checkbox"
+			id="<?php echo esc_attr( $input_id ); ?>"
+			name="<?php echo esc_attr( 'fair_form_q_' . $question_key ); ?>"
+			value="1"
+			<?php if ( $required ) : ?>
+				required
+			<?php endif; ?>
+		/>
+		<?php echo esc_html( $question_text ); ?>
+		<?php if ( $required ) : ?>
+			<span class="required">*</span>
+		<?php endif; ?>
+	</label>
+</div>

--- a/fair-form/src/blocks/fair-form-consent/style.css
+++ b/fair-form/src/blocks/fair-form-consent/style.css
@@ -1,0 +1,28 @@
+.fair-form-question-consent .fair-form-question-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 4px;
+}
+
+.fair-form-question-consent .fair-form-question-label-input {
+	display: block;
+	border: none;
+	border-bottom: 1px dashed #8c8f94;
+	background: transparent;
+	font-weight: 600;
+	font-family: inherit;
+	padding: 2px 0;
+	font-size: inherit;
+	flex: 1;
+	min-width: 0;
+	resize: vertical;
+}
+
+.fair-form-question-consent .fair-form-question-label-input:focus {
+	outline: none;
+	border-bottom-color: #2271b1;
+}
+
+.fair-form-question-consent input[type="checkbox"] {
+	margin-top: 4px;
+}


### PR DESCRIPTION
## Summary

- Add a new `fair-form-consent` block (`fair-audience/fair-form-consent`) modeled on `fair-form-short-text`, emitting a single required-capable checkbox with `data-question-type="checkbox"`.
- Add the missing `checkbox` branch to the shared `fair-events-shared/src/questionnaire.js` helpers (`getQuestionValue`, `collectQuestionAnswers`, `validateQuestions`) — without it, an unchecked box fell through to the generic `input` selector and its `value="1"` made the required check pass incorrectly.
- Render the checkbox answer as Yes/No in the submission detail view and Markdown export instead of a raw `1`/`0`.
- Register the block and its editor script translations in `BlockHooks.php`.
- Fix `fair-events-shared/jest.config.cjs`, whose `testMatch` only covered the plugin-root `__tests__/` and silently skipped `src/__tests__/questionnaire.test.js` (present since the file was added, unrelated to this change but caught while adding new tests there).

Closes #1010

## Test plan

- [x] `npm test` in `fair-events-shared` — 88 tests pass, including new checkbox-branch coverage for `validateQuestions`, `collectQuestionAnswers`, `getQuestionValue`.
- [x] `npm test` in `fair-form` — existing suite passes.
- [x] `vendor/bin/phpcs` on the new/changed PHP files — clean.
- [x] `npm run build` in `fair-form` — new block builds to `build/blocks/fair-form-consent/`.
- [ ] Manual check in wp-env: insert the block in Fair Form / Event Signup, confirm required-unchecked blocks submission and checked submits/persists (not run — no local wp-env session in this pass).
- Note: no e2e spec added — `fair-form/e2e` has no existing specs to model a form-submission flow on yet; flagged as a follow-up rather than building that infra in this PR.
