### PR TITLE
Centralize ticket price calculation in one pricing service

### DIFF
--- a/.changeset/centralize-ticket-pricing.md
+++ b/.changeset/centralize-ticket-pricing.md
@@ -1,0 +1,8 @@
+---
+"fair-events": patch
+"fair-events-experimental": patch
+"fair-audience": patch
+"fair-events-shared": patch
+---
+
+Centralize ticket price resolution in a new `FairEvents\Services\TicketPricing` service and a shared `ticket-pricing.js` module, so the fair-events get-tickets purchase paths and the fair-audience event-signup pricing agree on price. Previously get-tickets used a closed `[sale_start, sale_end]` sale-period interval while fair-audience used a half-open `[sale_start, sale_end)` interval with a `continues_pricing_period` fallback — the two could charge different prices for the same ticket type on a sale period's end day. get-tickets now uses the half-open convention too.

--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -8,6 +8,8 @@ import {
 	setButtonLoading,
 	onDomReady,
 	wireNotYouButton,
+	computeTicketTotal,
+	formatPrice,
 } from 'fair-events-shared';
 import {
 	collectQuestionAnswers,
@@ -285,7 +287,12 @@ const CSS_PREFIX = 'fair-audience-signup';
 					? sprintf(
 							/* translators: %s: formatted total price */
 							__('Total: €%s', 'fair-audience'),
-							(price * checked).toFixed(2)
+							formatPrice(
+								computeTicketTotal({
+									unitPrice: price,
+									count: checked,
+								})
+							)
 					  )
 					: '';
 		}
@@ -406,9 +413,10 @@ const CSS_PREFIX = 'fair-audience-signup';
 			basePrice = parseFloat(selectedTicketType.dataset.ticketPrice || 0);
 		}
 
+		let instanceCount = 1;
 		if (isMultipleInstancesSelected(block)) {
 			const instanceMin = Math.max(1, getInstanceMinimum(block));
-			const instanceCount = getCheckedInstanceCount(block);
+			instanceCount = getCheckedInstanceCount(block);
 			if (instanceCount < instanceMin) {
 				// Not enough occurrences chosen yet — show the bare action label
 				// until the selection is valid, same treatment as the
@@ -433,18 +441,21 @@ const CSS_PREFIX = 'fair-audience-signup';
 				}
 				return;
 			}
-			basePrice = basePrice * instanceCount;
 		}
 
 		const checkedOptions = block.querySelectorAll(
 			'input[name="ticket_option_ids[]"]:checked'
 		);
-		let optionsTotal = 0;
+		const optionPrices = [];
 		checkedOptions.forEach(function (input) {
-			optionsTotal += parseFloat(input.dataset.optionPrice || 0);
+			optionPrices.push(parseFloat(input.dataset.optionPrice || 0));
 		});
 
-		const total = basePrice + optionsTotal;
+		const total = computeTicketTotal({
+			unitPrice: basePrice,
+			count: instanceCount,
+			optionPrices,
+		});
 		const signupBaseText =
 			block.dataset.signupBaseText || __('Sign Up', 'fair-audience');
 		const registerBaseText =
@@ -473,7 +484,7 @@ const CSS_PREFIX = 'fair-audience-signup';
 
 		let signupText, registerText;
 		if (total > 0) {
-			const formatted = total.toFixed(2);
+			const formatted = formatPrice(total);
 			signupText = signupBaseText + ' \u2014 \u20ac' + formatted;
 			registerText = registerBaseText + ' \u2014 \u20ac' + formatted;
 		} else {
@@ -1299,17 +1310,18 @@ const CSS_PREFIX = 'fair-audience-signup';
 
 		const baseText = __('Add activities', 'fair-audience');
 		const updateButton = function () {
-			let total = 0;
+			const optionPrices = [];
 			let anyChecked = false;
 			checkboxes.forEach(function (cb) {
 				if (cb.checked) {
 					anyChecked = true;
-					total += parseFloat(cb.dataset.optionPrice || 0);
+					optionPrices.push(parseFloat(cb.dataset.optionPrice || 0));
 				}
 			});
+			const total = computeTicketTotal({ unitPrice: 0, optionPrices });
 			button.disabled = !anyChecked;
 			button.textContent =
-				total > 0 ? baseText + ' — €' + total.toFixed(2) : baseText;
+				total > 0 ? baseText + ' — €' + formatPrice(total) : baseText;
 		};
 
 		checkboxes.forEach(function (cb) {

--- a/fair-events-experimental/src/Services/EventSignupPricing.php
+++ b/fair-events-experimental/src/Services/EventSignupPricing.php
@@ -11,8 +11,7 @@ use FairEvents\Models\EventDates;
 use FairEvents\Models\EventDateSetting;
 use FairEventsExperimental\Models\GroupPricingRule;
 use FairEvents\Models\TicketType;
-use FairEvents\Models\TicketSalePeriod;
-use FairEvents\Models\TicketPrice;
+use FairEvents\Services\TicketPricing;
 use FairEventsExperimental\Models\TicketOptionCollaborator;
 
 defined( 'WPINC' ) || die;
@@ -201,16 +200,10 @@ class EventSignupPricing {
 			return null;
 		}
 
-		$active_period = self::resolve_active_sale_period( $ticket_type->event_date_id );
-		if ( ! $active_period ) {
+		$base_price = TicketPricing::resolve_unit_price( $ticket_type_id );
+		if ( null === $base_price ) {
 			return null;
 		}
-
-		$price_row = TicketPrice::get_by_type_and_period( $ticket_type_id, $active_period->id );
-		if ( ! $price_row ) {
-			return null;
-		}
-		$base_price = (float) $price_row->price;
 
 		if ( empty( $participant_id ) ) {
 			return $base_price;
@@ -256,16 +249,8 @@ class EventSignupPricing {
 	 */
 	public static function has_paid_price_configured( int $event_date_id, ?int $ticket_type_id = null ): bool {
 		if ( $ticket_type_id ) {
-			$ticket_type = TicketType::get_by_id( $ticket_type_id );
-			if ( ! $ticket_type ) {
-				return false;
-			}
-			$active_period = self::resolve_active_sale_period( (int) $ticket_type->event_date_id );
-			if ( ! $active_period ) {
-				return false;
-			}
-			$price_row = TicketPrice::get_by_type_and_period( $ticket_type_id, $active_period->id );
-			return $price_row && (float) $price_row->price > 0;
+			$price = TicketPricing::resolve_unit_price( $ticket_type_id );
+			return null !== $price && $price > 0;
 		}
 
 		$event_date = EventDates::get_by_id( $event_date_id );
@@ -289,37 +274,15 @@ class EventSignupPricing {
 	/**
 	 * Resolve the currently active sale period for an event date.
 	 *
-	 * Periods use a half-open day range [sale_start, sale_end) in the site
-	 * timezone: sale_start is the first day on sale (00:00:00 site time) and
-	 * sale_end is the first day no longer on sale (00:00:00 site time).
-	 *
-	 * When no period matches and the per-event-date `continues_pricing_period`
-	 * setting is on, falls back to the last period whose start is already in
-	 * the past.
+	 * Delegates to the fair-events \FairEvents\Services\TicketPricing service,
+	 * the canonical home of sale-period resolution (fair-events owns the
+	 * pricing models).
 	 *
 	 * @param int $event_date_id Event date ID.
-	 * @return TicketSalePeriod|null Active period or null.
+	 * @return \FairEvents\Models\TicketSalePeriod|null Active period or null.
 	 */
 	public static function resolve_active_sale_period( $event_date_id ) {
-		$now           = current_time( 'mysql' );
-		$sale_periods  = TicketSalePeriod::get_all_by_event_date_id( $event_date_id );
-		$active_period = null;
-
-		$continues  = class_exists( EventDateSetting::class )
-			&& '1' === EventDateSetting::get( $event_date_id, 'continues_pricing_period' );
-		$last_index = count( $sale_periods ) - 1;
-
-		foreach ( $sale_periods as $index => $period ) {
-			// Half-open interval: sale_start <= now < sale_end.
-			if ( $period->sale_start <= $now && $period->sale_end > $now ) {
-				return $period;
-			}
-			if ( $continues && $index === $last_index && $period->sale_start <= $now ) {
-				$active_period = $period;
-			}
-		}
-
-		return $active_period;
+		return TicketPricing::resolve_active_sale_period( $event_date_id );
 	}
 
 	/**

--- a/fair-events-shared/__tests__/ticket-pricing.test.js
+++ b/fair-events-shared/__tests__/ticket-pricing.test.js
@@ -1,0 +1,35 @@
+import { computeTicketTotal, formatPrice } from '../src/ticket-pricing.js';
+
+describe('computeTicketTotal', () => {
+	it('multiplies unit price by count', () => {
+		expect(computeTicketTotal({ unitPrice: 10, count: 3 })).toBe(30);
+	});
+
+	it('defaults count to 1', () => {
+		expect(computeTicketTotal({ unitPrice: 10 })).toBe(10);
+	});
+
+	it('sums in selected option prices', () => {
+		expect(
+			computeTicketTotal({
+				unitPrice: 10,
+				count: 2,
+				optionPrices: [2.5, 1.5],
+			})
+		).toBe(24);
+	});
+
+	it('returns 0 for a free ticket with no options', () => {
+		expect(computeTicketTotal({ unitPrice: 0 })).toBe(0);
+	});
+});
+
+describe('formatPrice', () => {
+	it('formats to two decimal places', () => {
+		expect(formatPrice(12)).toBe('12.00');
+	});
+
+	it('rounds to two decimal places', () => {
+		expect(formatPrice(9.999)).toBe('10.00');
+	});
+});

--- a/fair-events-shared/src/index.js
+++ b/fair-events-shared/src/index.js
@@ -18,3 +18,4 @@ export * from './form-utils.js';
 export * from './question-utils.js';
 export * from './payment-flow.js';
 export * from './event-utils.js';
+export * from './ticket-pricing.js';

--- a/fair-events-shared/src/ticket-pricing.js
+++ b/fair-events-shared/src/ticket-pricing.js
@@ -1,0 +1,31 @@
+/**
+ * Ticket pricing display math shared between the get-tickets and
+ * event-signup blocks' frontend scripts.
+ *
+ * @package FairEventsShared
+ */
+
+/**
+ * Compute a ticket purchase total: unit price times count, plus any
+ * selected add-on option prices.
+ *
+ * @param {Object}   params               Options.
+ * @param {number}   params.unitPrice     Per-unit/base ticket price.
+ * @param {number}   [params.count]       Quantity or instance count (default 1).
+ * @param {number[]} [params.optionPrices] Selected add-on option prices to sum in.
+ * @return {number} The computed total.
+ */
+export function computeTicketTotal({ unitPrice, count = 1, optionPrices = [] }) {
+	const optionsTotal = optionPrices.reduce((sum, price) => sum + price, 0);
+	return unitPrice * count + optionsTotal;
+}
+
+/**
+ * Format a price amount as a fixed 2-decimal string (e.g. '12.00').
+ *
+ * @param {number} amount Amount to format.
+ * @return {string} Formatted amount.
+ */
+export function formatPrice(amount) {
+	return amount.toFixed(2);
+}

--- a/fair-events-shared/src/ticket-pricing.js
+++ b/fair-events-shared/src/ticket-pricing.js
@@ -15,7 +15,11 @@
  * @param {number[]} [params.optionPrices] Selected add-on option prices to sum in.
  * @return {number} The computed total.
  */
-export function computeTicketTotal({ unitPrice, count = 1, optionPrices = [] }) {
+export function computeTicketTotal({
+	unitPrice,
+	count = 1,
+	optionPrices = [],
+}) {
 	const optionsTotal = optionPrices.reduce((sum, price) => sum + price, 0);
 	return unitPrice * count + optionsTotal;
 }

--- a/fair-events/__tests__/Services/TicketPricingTest.php
+++ b/fair-events/__tests__/Services/TicketPricingTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * TicketPricing sale-period boundary tests
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Services\TicketPricing;
+
+/**
+ * Validates the pure period-selection math used by resolve_active_sale_period().
+ * Database-backed lookups are exercised via API integration tests, not here.
+ */
+class TicketPricingTest extends TestCase {
+
+	/**
+	 * Build a sale period stub with the given boundaries.
+	 *
+	 * @param string $sale_start Sale start datetime.
+	 * @param string $sale_end   Sale end datetime.
+	 * @return object Anonymous period object exposing sale_start/sale_end.
+	 */
+	private function period( $sale_start, $sale_end ) {
+		return (object) array(
+			'sale_start' => $sale_start,
+			'sale_end'   => $sale_end,
+		);
+	}
+
+	/**
+	 * No periods configured at all.
+	 */
+	public function test_no_periods_returns_null() {
+		$this->assertNull( TicketPricing::pick_active_period( array(), '2026-01-15 00:00:00', false ) );
+	}
+
+	/**
+	 * Now falls inside a period's range.
+	 */
+	public function test_period_containing_now_is_active() {
+		$period = $this->period( '2026-01-01 00:00:00', '2026-02-01 00:00:00' );
+		$this->assertSame( $period, TicketPricing::pick_active_period( array( $period ), '2026-01-15 00:00:00', false ) );
+	}
+
+	/**
+	 * The sale_end day is the first day no longer on sale.
+	 */
+	public function test_end_day_is_exclusive() {
+		$period = $this->period( '2026-01-01 00:00:00', '2026-02-01 00:00:00' );
+		// Half-open interval: sale_end itself is no longer on sale.
+		$this->assertNull( TicketPricing::pick_active_period( array( $period ), '2026-02-01 00:00:00', false ) );
+	}
+
+	/**
+	 * The sale_start day is the first day on sale.
+	 */
+	public function test_start_day_is_inclusive() {
+		$period = $this->period( '2026-01-01 00:00:00', '2026-02-01 00:00:00' );
+		$this->assertSame( $period, TicketPricing::pick_active_period( array( $period ), '2026-01-01 00:00:00', false ) );
+	}
+
+	/**
+	 * Without continues_pricing_period, nothing sells after the last period ends.
+	 */
+	public function test_after_last_period_without_continues_returns_null() {
+		$period = $this->period( '2026-01-01 00:00:00', '2026-02-01 00:00:00' );
+		$this->assertNull( TicketPricing::pick_active_period( array( $period ), '2026-03-01 00:00:00', false ) );
+	}
+
+	/**
+	 * With continues_pricing_period, the last period keeps selling after its own end.
+	 */
+	public function test_after_last_period_with_continues_falls_back_to_it() {
+		$period = $this->period( '2026-01-01 00:00:00', '2026-02-01 00:00:00' );
+		$this->assertSame( $period, TicketPricing::pick_active_period( array( $period ), '2026-03-01 00:00:00', true ) );
+	}
+
+	/**
+	 * The fallback never jumps ahead to a period that hasn't started yet.
+	 */
+	public function test_continues_fallback_only_applies_to_last_period_after_its_own_start() {
+		$earlier = $this->period( '2026-01-01 00:00:00', '2026-01-15 00:00:00' );
+		$later   = $this->period( '2026-02-01 00:00:00', '2026-02-15 00:00:00' );
+		// Now is between the two periods, before the last period's own start —
+		// continues_pricing_period should not jump ahead to a future period.
+		$this->assertNull( TicketPricing::pick_active_period( array( $earlier, $later ), '2026-01-20 00:00:00', true ) );
+	}
+
+	/**
+	 * The fallback only ever considers the last period, never an earlier one.
+	 */
+	public function test_continues_fallback_ignores_non_last_period() {
+		$earlier = $this->period( '2026-01-01 00:00:00', '2026-01-15 00:00:00' );
+		$later   = $this->period( '2026-02-01 00:00:00', '2026-02-15 00:00:00' );
+		// Now is after the earlier period's own end but the later period hasn't
+		// started yet — the fallback only ever considers the last period.
+		$this->assertNull( TicketPricing::pick_active_period( array( $earlier, $later ), '2026-01-16 00:00:00', true ) );
+	}
+}

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -219,22 +219,9 @@ class GetTicketsController extends WP_REST_Controller {
 			}
 
 			// Resolve price from the active sale period (server-side; client amount is ignored).
-			if ( class_exists( \FairEvents\Models\TicketSalePeriod::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
-				$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $config_event_date_id );
-				$now          = current_time( 'mysql' );
-				foreach ( $sale_periods as $period ) {
-					if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
-						$prices = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $config_event_date_id );
-						foreach ( $prices as $price ) {
-							if ( (int) $price->ticket_type_id === (int) $ticket_type_id
-								&& (int) $price->sale_period_id === (int) $period->id ) {
-								$amount = (float) $price->price * $quantity;
-								break 2;
-							}
-						}
-						break;
-					}
-				}
+			$unit_price = \FairEvents\Services\TicketPricing::resolve_unit_price( $ticket_type_id );
+			if ( null !== $unit_price ) {
+				$amount = $unit_price * $quantity;
 			}
 		}
 
@@ -461,24 +448,8 @@ class GetTicketsController extends WP_REST_Controller {
 		}
 
 		// Resolve the per-instance price from the active sale period (server-side; client amount is ignored).
-		$unit_price = 0.0;
-		if ( class_exists( \FairEvents\Models\TicketSalePeriod::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
-			$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $series_page_id );
-			$now          = current_time( 'mysql' );
-			foreach ( $sale_periods as $period ) {
-				if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
-					$prices = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $series_page_id );
-					foreach ( $prices as $price ) {
-						if ( (int) $price->ticket_type_id === (int) $ticket_type->id
-							&& (int) $price->sale_period_id === (int) $period->id ) {
-							$unit_price = (float) $price->price;
-							break 2;
-						}
-					}
-					break;
-				}
-			}
-		}
+		$unit_price = \FairEvents\Services\TicketPricing::resolve_unit_price( $ticket_type->id );
+		$unit_price = null !== $unit_price ? $unit_price : 0.0;
 
 		$count        = count( $occurrences );
 		$total_amount = $unit_price * $count;

--- a/fair-events/src/Services/TicketPricing.php
+++ b/fair-events/src/Services/TicketPricing.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Ticket Pricing Service
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Services;
+
+use FairEvents\Models\EventDateSetting;
+use FairEvents\Models\TicketPrice;
+use FairEvents\Models\TicketSalePeriod;
+use FairEvents\Models\TicketType;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Resolves ticket sale periods and prices for a ticket type. Single source
+ * of truth shared by the fair-events get-tickets purchase paths and the
+ * fair-events-experimental / fair-audience event-signup pricing service.
+ */
+class TicketPricing {
+
+	/**
+	 * Resolve the currently active sale period for an event date.
+	 *
+	 * Periods use a half-open day range [sale_start, sale_end) in the site
+	 * timezone: sale_start is the first day on sale (00:00:00 site time) and
+	 * sale_end is the first day no longer on sale (00:00:00 site time).
+	 *
+	 * When no period matches and the per-event-date `continues_pricing_period`
+	 * setting is on, falls back to the last period whose start is already in
+	 * the past.
+	 *
+	 * @param int $event_date_id Event date ID.
+	 * @return TicketSalePeriod|null Active period or null.
+	 */
+	public static function resolve_active_sale_period( $event_date_id ) {
+		$now          = current_time( 'mysql' );
+		$sale_periods = TicketSalePeriod::get_all_by_event_date_id( $event_date_id );
+
+		$continues = class_exists( EventDateSetting::class )
+			&& '1' === EventDateSetting::get( $event_date_id, 'continues_pricing_period' );
+
+		return self::pick_active_period( $sale_periods, $now, $continues );
+	}
+
+	/**
+	 * Pure period-selection math, split out from resolve_active_sale_period()
+	 * for unit testing without a database.
+	 *
+	 * @param object[] $periods   Sale periods with sale_start/sale_end strings, in sort order.
+	 * @param string   $now       Current datetime string ('Y-m-d H:i:s'), comparable lexically.
+	 * @param bool     $continues Whether the continues_pricing_period fallback is enabled.
+	 * @return object|null Active period, the fallback period, or null.
+	 */
+	public static function pick_active_period( $periods, $now, $continues ) {
+		$active_period = null;
+		$last_index    = count( $periods ) - 1;
+
+		foreach ( $periods as $index => $period ) {
+			// Half-open interval: sale_start <= now < sale_end.
+			if ( $period->sale_start <= $now && $period->sale_end > $now ) {
+				return $period;
+			}
+			if ( $continues && $index === $last_index && $period->sale_start <= $now ) {
+				$active_period = $period;
+			}
+		}
+
+		return $active_period;
+	}
+
+	/**
+	 * Resolve the unit price for a ticket type from its currently active
+	 * sale period.
+	 *
+	 * @param int $ticket_type_id Ticket type ID.
+	 * @return float|null Unit price, or null when not purchasable right now
+	 *                     (unknown ticket type, no active sale period, or no
+	 *                     price row configured for it).
+	 */
+	public static function resolve_unit_price( $ticket_type_id ) {
+		$ticket_type = TicketType::get_by_id( $ticket_type_id );
+		if ( ! $ticket_type ) {
+			return null;
+		}
+
+		$active_period = self::resolve_active_sale_period( $ticket_type->event_date_id );
+		if ( ! $active_period ) {
+			return null;
+		}
+
+		$price_row = TicketPrice::get_by_type_and_period( $ticket_type_id, $active_period->id );
+		if ( ! $price_row ) {
+			return null;
+		}
+
+		/**
+		 * Filters the resolved unit price for a ticket type before it's charged.
+		 *
+		 * Lets discount providers (e.g. group pricing) layer on without this
+		 * service knowing about them. Not currently hooked from anywhere —
+		 * get-tickets purchases are anonymous, so participant-based discounts
+		 * can't resolve here yet.
+		 *
+		 * @param float $price          Resolved unit price.
+		 * @param int   $ticket_type_id Ticket type ID.
+		 * @param array $context        Extra context: 'event_date_id', 'sale_period_id'.
+		 */
+		return (float) apply_filters(
+			'fair_events_resolve_ticket_price',
+			(float) $price_row->price,
+			$ticket_type_id,
+			array(
+				'event_date_id'  => $ticket_type->event_date_id,
+				'sale_period_id' => $active_period->id,
+			)
+		);
+	}
+}

--- a/fair-events/src/blocks/get-tickets/frontend.js
+++ b/fair-events/src/blocks/get-tickets/frontend.js
@@ -10,6 +10,8 @@ import {
 	onDomReady,
 	initiatePayment,
 	handlePaymentCallback,
+	computeTicketTotal,
+	formatPrice,
 } from 'fair-events-shared';
 import './frontend.css';
 
@@ -191,7 +193,12 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 					? sprintf(
 							/* translators: %s: formatted total price */
 							__('Total: €%s', 'fair-events'),
-							(price * checked).toFixed(2)
+							formatPrice(
+								computeTicketTotal({
+									unitPrice: price,
+									count: checked,
+								})
+							)
 					  )
 					: '';
 		}


### PR DESCRIPTION
## Summary

- Add `FairEvents\Services\TicketPricing` (`fair-events/src/Services/TicketPricing.php`), the single source of truth for sale-period and unit-price resolution, using the half-open `[sale_start, sale_end)` convention plus the `continues_pricing_period` fallback.
- `GetTicketsController::create_signup()` and `::create_multi_instance_signup()` now resolve prices through `TicketPricing::resolve_unit_price()` instead of their own inline sale-period/price-row loops — this replaces get-tickets' previous closed-interval math, so it now agrees with fair-audience on a sale period's end day.
- `EventSignupPricing` (fair-events-experimental) delegates its sale-period and price-row lookups to `TicketPricing`, keeping its public API (discounts, sliding scale, invitation pricing) unchanged.
- Add shared `fair-events-shared/src/ticket-pricing.js` (`computeTicketTotal`, `formatPrice`) and switch the get-tickets and event-signup block frontends over to it, replacing four copies of inline `price * count + ... .toFixed(2)` math.
- Add a changeset covering `fair-events`, `fair-events-experimental`, `fair-audience`, and `fair-events-shared`.

Closes #1002

## Test plan

- [x] `fair-events`: `vendor/bin/phpunit` (28 tests, including new `TicketPricingTest` boundary/fallback cases)
- [x] `fair-events-experimental`: `vendor/bin/phpunit` (pre-existing unrelated `VenueTest` failure confirmed present on `main` too)
- [x] `fair-events-shared`, `fair-events`, `fair-audience`: `npx jest` all green, including new `ticket-pricing.test.js`
- [x] `vendor/bin/phpcs` on touched PHP files — no new findings (pre-existing short-ternary warnings in `GetTicketsController.php` untouched by this change)
- [x] `npm run build` in `fair-events` and `fair-audience`
