### PR TITLE
Make fair-form long-text answers full width and auto-expanding

### DIFF
--- a/fair-events-shared/src/questionnaire.js
+++ b/fair-events-shared/src/questionnaire.js
@@ -444,6 +444,36 @@ export function handleFilePreview(input) {
 }
 
 /**
+ * Grow a textarea's height to fit its content, removing the need for manual
+ * resizing.
+ *
+ * @param {HTMLTextAreaElement} textarea The textarea to resize.
+ */
+export function autosizeTextarea(textarea) {
+	if (!textarea) {
+		return;
+	}
+	textarea.style.height = 'auto';
+	textarea.style.height = textarea.scrollHeight + 'px';
+}
+
+/**
+ * Wire up auto-expanding behavior for long-text question textareas: they grow
+ * with their content instead of relying on the browser's manual resize handle.
+ *
+ * @param {HTMLElement} form The form (or container) element.
+ */
+function setupAutosizeTextareas(form) {
+	const textareas = form.querySelectorAll(
+		'[data-question-type="long_text"] textarea'
+	);
+	textareas.forEach((textarea) => {
+		autosizeTextarea(textarea);
+		textarea.addEventListener('input', () => autosizeTextarea(textarea));
+	});
+}
+
+/**
  * Wire up question behavior on a form: file previews and conditional logic.
  *
  * @param {HTMLElement} form The form (or container) element.
@@ -461,4 +491,6 @@ export function setupQuestionnaire(form) {
 	evaluateConditionals(form);
 	form.addEventListener('input', () => evaluateConditionals(form));
 	form.addEventListener('change', () => evaluateConditionals(form));
+
+	setupAutosizeTextareas(form);
 }

--- a/fair-form/src/blocks/fair-form-consent/editor.js
+++ b/fair-form/src/blocks/fair-form-consent/editor.js
@@ -4,7 +4,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { generateQuestionKey } from 'fair-events-shared';
+import { autosizeTextarea, generateQuestionKey } from 'fair-events-shared';
 
 registerBlockType('fair-audience/fair-form-consent', {
 	edit: ({ attributes, setAttributes }) => {
@@ -56,10 +56,12 @@ registerBlockType('fair-audience/fair-form-consent', {
 						<span className="fair-form-question-header">
 							<textarea
 								rows={1}
+								ref={autosizeTextarea}
 								value={questionText}
-								onChange={(e) =>
-									onQuestionTextChange(e.target.value)
-								}
+								onChange={(e) => {
+									autosizeTextarea(e.target);
+									onQuestionTextChange(e.target.value);
+								}}
 								placeholder={__(
 									'I have read and accept the terms and conditions',
 									'fair-audience'

--- a/fair-form/src/blocks/fair-form-file-upload/editor.js
+++ b/fair-form/src/blocks/fair-form-file-upload/editor.js
@@ -9,7 +9,7 @@ import {
 	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { generateQuestionKey } from 'fair-events-shared';
+import { autosizeTextarea, generateQuestionKey } from 'fair-events-shared';
 
 registerBlockType('fair-audience/fair-form-file-upload', {
 	edit: ({ attributes, setAttributes }) => {
@@ -88,10 +88,12 @@ registerBlockType('fair-audience/fair-form-file-upload', {
 						<span className="fair-form-question-header">
 							<textarea
 								rows={1}
+								ref={autosizeTextarea}
 								value={questionText}
-								onChange={(e) =>
-									onQuestionTextChange(e.target.value)
-								}
+								onChange={(e) => {
+									autosizeTextarea(e.target);
+									onQuestionTextChange(e.target.value);
+								}}
 								placeholder={__(
 									'Enter your question...',
 									'fair-audience'

--- a/fair-form/src/blocks/fair-form-long-text/editor.js
+++ b/fair-form/src/blocks/fair-form-long-text/editor.js
@@ -9,7 +9,7 @@ import {
 	RangeControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { generateQuestionKey } from 'fair-events-shared';
+import { autosizeTextarea, generateQuestionKey } from 'fair-events-shared';
 
 registerBlockType('fair-audience/fair-form-long-text', {
 	transforms: {
@@ -89,10 +89,12 @@ registerBlockType('fair-audience/fair-form-long-text', {
 						<span className="fair-form-question-header">
 							<textarea
 								rows={1}
+								ref={autosizeTextarea}
 								value={questionText}
-								onChange={(e) =>
-									onQuestionTextChange(e.target.value)
-								}
+								onChange={(e) => {
+									autosizeTextarea(e.target);
+									onQuestionTextChange(e.target.value);
+								}}
 								placeholder={__(
 									'Enter your question...',
 									'fair-audience'

--- a/fair-form/src/blocks/fair-form-long-text/style.css
+++ b/fair-form/src/blocks/fair-form-long-text/style.css
@@ -6,6 +6,7 @@
 
 .fair-form-question-long-text .fair-form-question-label-input {
 	display: block;
+	box-sizing: border-box;
 	border: none;
 	border-bottom: 1px dashed #8c8f94;
 	background: transparent;
@@ -24,6 +25,7 @@
 }
 
 .fair-form-question-long-text textarea:disabled {
+	box-sizing: border-box;
 	width: 100%;
 	padding: 8px 12px;
 	border: 1px solid #8c8f94;

--- a/fair-form/src/blocks/fair-form-multiselect/editor.js
+++ b/fair-form/src/blocks/fair-form-multiselect/editor.js
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { generateQuestionKey } from 'fair-events-shared';
+import { autosizeTextarea, generateQuestionKey } from 'fair-events-shared';
 
 const ALLOWED_BLOCKS = ['fair-audience/fair-form-option'];
 
@@ -96,10 +96,12 @@ registerBlockType('fair-audience/fair-form-multiselect', {
 						<span className="fair-form-question-header">
 							<textarea
 								rows={1}
+								ref={autosizeTextarea}
 								value={questionText}
-								onChange={(e) =>
-									onQuestionTextChange(e.target.value)
-								}
+								onChange={(e) => {
+									autosizeTextarea(e.target);
+									onQuestionTextChange(e.target.value);
+								}}
 								placeholder={__(
 									'Enter your question...',
 									'fair-audience'

--- a/fair-form/src/blocks/fair-form-phone/editor.js
+++ b/fair-form/src/blocks/fair-form-phone/editor.js
@@ -4,7 +4,7 @@ import { registerBlockType, createBlock } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { generateQuestionKey } from 'fair-events-shared';
+import { autosizeTextarea, generateQuestionKey } from 'fair-events-shared';
 
 registerBlockType('fair-audience/fair-form-phone', {
 	transforms: {
@@ -80,10 +80,12 @@ registerBlockType('fair-audience/fair-form-phone', {
 						<span className="fair-form-question-header">
 							<textarea
 								rows={1}
+								ref={autosizeTextarea}
 								value={questionText}
-								onChange={(e) =>
-									onQuestionTextChange(e.target.value)
-								}
+								onChange={(e) => {
+									autosizeTextarea(e.target);
+									onQuestionTextChange(e.target.value);
+								}}
 								placeholder={__(
 									'Enter your question...',
 									'fair-audience'

--- a/fair-form/src/blocks/fair-form-radio/editor.js
+++ b/fair-form/src/blocks/fair-form-radio/editor.js
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { generateQuestionKey } from 'fair-events-shared';
+import { autosizeTextarea, generateQuestionKey } from 'fair-events-shared';
 
 const ALLOWED_BLOCKS = ['fair-audience/fair-form-option'];
 
@@ -96,10 +96,12 @@ registerBlockType('fair-audience/fair-form-radio', {
 						<span className="fair-form-question-header">
 							<textarea
 								rows={1}
+								ref={autosizeTextarea}
 								value={questionText}
-								onChange={(e) =>
-									onQuestionTextChange(e.target.value)
-								}
+								onChange={(e) => {
+									autosizeTextarea(e.target);
+									onQuestionTextChange(e.target.value);
+								}}
 								placeholder={__(
 									'Enter your question...',
 									'fair-audience'

--- a/fair-form/src/blocks/fair-form-select-one/editor.js
+++ b/fair-form/src/blocks/fair-form-select-one/editor.js
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { generateQuestionKey } from 'fair-events-shared';
+import { autosizeTextarea, generateQuestionKey } from 'fair-events-shared';
 
 const ALLOWED_BLOCKS = ['fair-audience/fair-form-option'];
 
@@ -96,10 +96,12 @@ registerBlockType('fair-audience/fair-form-select-one', {
 						<span className="fair-form-question-header">
 							<textarea
 								rows={1}
+								ref={autosizeTextarea}
 								value={questionText}
-								onChange={(e) =>
-									onQuestionTextChange(e.target.value)
-								}
+								onChange={(e) => {
+									autosizeTextarea(e.target);
+									onQuestionTextChange(e.target.value);
+								}}
 								placeholder={__(
 									'Enter your question...',
 									'fair-audience'

--- a/fair-form/src/blocks/fair-form-short-text/editor.js
+++ b/fair-form/src/blocks/fair-form-short-text/editor.js
@@ -4,7 +4,7 @@ import { registerBlockType, createBlock } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { generateQuestionKey } from 'fair-events-shared';
+import { autosizeTextarea, generateQuestionKey } from 'fair-events-shared';
 
 registerBlockType('fair-audience/fair-form-short-text', {
 	transforms: {
@@ -86,10 +86,12 @@ registerBlockType('fair-audience/fair-form-short-text', {
 						<span className="fair-form-question-header">
 							<textarea
 								rows={1}
+								ref={autosizeTextarea}
 								value={questionText}
-								onChange={(e) =>
-									onQuestionTextChange(e.target.value)
-								}
+								onChange={(e) => {
+									autosizeTextarea(e.target);
+									onQuestionTextChange(e.target.value);
+								}}
 								placeholder={__(
 									'Enter your question...',
 									'fair-audience'

--- a/fair-form/src/blocks/fair-form/style.css
+++ b/fair-form/src/blocks/fair-form/style.css
@@ -17,12 +17,18 @@
 .fair-form-form input[type="tel"],
 .fair-form-form textarea,
 .fair-form-form select {
+	box-sizing: border-box;
 	width: 100%;
 	padding: 8px 12px;
 	border: 1px solid #8c8f94;
 	border-radius: 4px;
 	font-size: inherit;
 	line-height: 1.5;
+}
+
+.fair-form-form textarea {
+	resize: none;
+	overflow: hidden;
 }
 
 .fair-form-form input[type="text"]:focus,


### PR DESCRIPTION
Textareas overflowed their container by the padding/border because of
content-box sizing, and required manual dragging to fit longer answers.
