### PR TITLE
Add fair-form-consent to parent blocks' allowed-blocks lists

### DIFF
--- a/fair-audience/src/blocks/event-signup/editor.js
+++ b/fair-audience/src/blocks/event-signup/editor.js
@@ -32,6 +32,7 @@ const ALLOWED_BLOCKS = [
 	'fair-audience/fair-form-radio',
 	'fair-audience/fair-form-multiselect',
 	'fair-audience/fair-form-file-upload',
+	'fair-audience/fair-form-consent',
 	'fair-audience/fair-form-conditional',
 ];
 

--- a/fair-form/src/blocks/fair-form-conditional/editor.js
+++ b/fair-form/src/blocks/fair-form-conditional/editor.js
@@ -22,6 +22,7 @@ const ALLOWED_BLOCKS = [
 	'fair-audience/fair-form-multiselect',
 	'fair-audience/fair-form-radio',
 	'fair-audience/fair-form-file-upload',
+	'fair-audience/fair-form-consent',
 	'fair-audience/fair-form-conditional',
 	'fair-audience/fair-form-mailing-signup',
 ];

--- a/fair-form/src/blocks/fair-form/editor.js
+++ b/fair-form/src/blocks/fair-form/editor.js
@@ -33,6 +33,7 @@ const ALLOWED_BLOCKS = [
 	'fair-audience/fair-form-multiselect',
 	'fair-audience/fair-form-radio',
 	'fair-audience/fair-form-file-upload',
+	'fair-audience/fair-form-consent',
 	'fair-audience/fair-form-conditional',
 	'fair-audience/fair-form-mailing-signup',
 ];


### PR DESCRIPTION
The consent checkbox block (added in 4bc27cb4) was registered but never
insertable: fair-form, fair-form-conditional, and event-signup all
allow-list their child question blocks explicitly, and the new block
was left off every list.
