### PR TITLE
Enforce event titles and add untitled-event fallback

### DIFF
--- a/fair-events-shared/src/__tests__/event-utils.test.js
+++ b/fair-events-shared/src/__tests__/event-utils.test.js
@@ -1,0 +1,31 @@
+import { getEventDisplayTitle, isLinkOnlyEvent } from '../event-utils.js';
+
+describe('getEventDisplayTitle', () => {
+	test('returns the trimmed title when present', () => {
+		expect(getEventDisplayTitle('  My Event  ')).toBe('My Event');
+	});
+
+	test('falls back for an empty title', () => {
+		expect(getEventDisplayTitle('')).toBe('(untitled event)');
+	});
+
+	test('falls back for a whitespace-only title', () => {
+		expect(getEventDisplayTitle('   ')).toBe('(untitled event)');
+	});
+
+	test('falls back for a null or undefined title', () => {
+		expect(getEventDisplayTitle(null)).toBe('(untitled event)');
+		expect(getEventDisplayTitle(undefined)).toBe('(untitled event)');
+	});
+});
+
+describe('isLinkOnlyEvent', () => {
+	test('true when link_type is external', () => {
+		expect(isLinkOnlyEvent({ link_type: 'external' })).toBe(true);
+	});
+
+	test('false otherwise', () => {
+		expect(isLinkOnlyEvent({ link_type: 'post' })).toBe(false);
+		expect(isLinkOnlyEvent(undefined)).toBe(false);
+	});
+});

--- a/fair-events-shared/src/event-utils.js
+++ b/fair-events-shared/src/event-utils.js
@@ -4,6 +4,8 @@
  * @package FairEventsShared
  */
 
+import { __ } from '@wordpress/i18n';
+
 /**
  * Whether an event date is a link-only (external URL) event.
  *
@@ -16,3 +18,14 @@
  */
 export const isLinkOnlyEvent = (eventDate) =>
 	eventDate?.link_type === 'external';
+
+/**
+ * Display title for an event, falling back for legacy untitled rows.
+ *
+ * @param {string|null|undefined} title Raw event title.
+ * @return {string} The trimmed title, or a "(untitled event)" fallback.
+ */
+export const getEventDisplayTitle = (title) =>
+	title && title.trim()
+		? title.trim()
+		: __('(untitled event)', 'fair-events');

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -383,7 +383,7 @@ class EventDatesController extends WP_REST_Controller {
 		$link_type      = $request->get_param( 'link_type' ) ?? 'none';
 		$external_url   = $request->get_param( 'external_url' );
 
-		if ( empty( $title ) ) {
+		if ( empty( $title ) || '' === trim( $title ) ) {
 			return new WP_Error(
 				'rest_invalid_title',
 				__( 'Event title is required.', 'fair-events' ),
@@ -721,6 +721,13 @@ class EventDatesController extends WP_REST_Controller {
 
 		$title = $request->get_param( 'title' );
 		if ( null !== $title ) {
+			if ( '' === trim( $title ) ) {
+				return new WP_Error(
+					'rest_invalid_title',
+					__( 'Event title is required.', 'fair-events' ),
+					array( 'status' => 400 )
+				);
+			}
 			$update_data['title'] = $title;
 		}
 

--- a/fair-events/src/API/__tests__/EventDatesController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesController.api.spec.js
@@ -525,3 +525,71 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 		expect(remaining).toHaveLength(2);
 	});
 });
+
+test.describe('EventDatesController — title validation', () => {
+	let api;
+	let eventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterEach(async () => {
+		if (eventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+				{ headers: adminHeaders }
+			);
+			eventDateId = null;
+		}
+	});
+
+	test('rejects create with an empty title', async () => {
+		const res = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: '',
+				start_datetime: '2030-01-01 10:00:00',
+				end_datetime: '2030-01-01 12:00:00',
+			},
+		});
+		expect(res.status()).toBe(400);
+	});
+
+	test('rejects create with a whitespace-only title', async () => {
+		const res = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: '   ',
+				start_datetime: '2030-01-01 10:00:00',
+				end_datetime: '2030-01-01 12:00:00',
+			},
+		});
+		expect(res.status()).toBe(400);
+	});
+
+	test('rejects update that clears the title', async () => {
+		const createRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Title Validation ${Date.now()}`,
+					start_datetime: '2030-01-01 10:00:00',
+					end_datetime: '2030-01-01 12:00:00',
+				},
+			}
+		);
+		expect(createRes.ok()).toBeTruthy();
+		eventDateId = (await createRes.json()).id;
+
+		const updateRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { title: '   ' },
+			}
+		);
+		expect(updateRes.status()).toBe(400);
+	});
+});

--- a/fair-events/src/Admin/all-events/AllEvents.js
+++ b/fair-events/src/Admin/all-events/AllEvents.js
@@ -3,7 +3,10 @@ import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Card, CardBody } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
-import { formatSiteLocalDatetime } from 'fair-events-shared';
+import {
+	formatSiteLocalDatetime,
+	getEventDisplayTitle,
+} from 'fair-events-shared';
 
 const { manageEventUrl } = window.fairEventsAllEventsData || {};
 
@@ -67,7 +70,7 @@ export default function AllEvents() {
 				label: __('Name', 'fair-events'),
 				render: ({ item }) => (
 					<a href={`${manageEventUrl}&event_date_id=${item.id}`}>
-						{item.title || __('(no name)', 'fair-events')}
+						{getEventDisplayTitle(item.title)}
 					</a>
 				),
 				enableSorting: true,

--- a/fair-events/src/Admin/calendar/components/DayCell.js
+++ b/fair-events/src/Admin/calendar/components/DayCell.js
@@ -8,6 +8,7 @@
 
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { getEventDisplayTitle } from 'fair-events-shared';
 
 const MAX_VISIBLE_EVENTS = 3;
 
@@ -153,9 +154,10 @@ export default function DayCell({
 								: 'dashicons-editor-unlink';
 						const categoryNames =
 							event.categories?.map((c) => c.name) || [];
+						const displayTitle = getEventDisplayTitle(event.title);
 						const tooltip = categoryNames.length
-							? `${event.title}\n${categoryNames.join(', ')}`
-							: event.title;
+							? `${displayTitle}\n${categoryNames.join(', ')}`
+							: displayTitle;
 						const eventUrl = getEventEditUrl(event, manageEventUrl);
 						return (
 							<div
@@ -171,7 +173,7 @@ export default function DayCell({
 										<span
 											className={`dashicons ${linkTypeIcon} fair-events-calendar-event-icon`}
 										/>
-										{event.title}
+										{displayTitle}
 										{categoryNames.length > 0 && (
 											<span className="fair-events-calendar-event-categories">
 												{categoryNames.join(', ')}
@@ -186,7 +188,7 @@ export default function DayCell({
 										<span
 											className={`dashicons ${linkTypeIcon} fair-events-calendar-event-icon`}
 										/>
-										{event.title}
+										{displayTitle}
 										{categoryNames.length > 0 && (
 											<span className="fair-events-calendar-event-categories">
 												{categoryNames.join(', ')}

--- a/fair-events/src/Admin/calendar/components/QuickEventModal.js
+++ b/fair-events/src/Admin/calendar/components/QuickEventModal.js
@@ -44,6 +44,12 @@ export default function QuickEventModal({ date, onClose, onSuccess }) {
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
+
+		if (!title.trim()) {
+			setError(__('Title is required.', 'fair-events'));
+			return;
+		}
+
 		setIsSaving(true);
 		setError(null);
 
@@ -185,7 +191,7 @@ export default function QuickEventModal({ date, onClose, onSuccess }) {
 							variant="primary"
 							type="submit"
 							isBusy={isSaving}
-							disabled={isSaving || !title}
+							disabled={isSaving || !title.trim()}
 						>
 							{__('Create Event', 'fair-events')}
 						</Button>

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -39,6 +39,7 @@ import {
 	calculateDuration,
 	isLinkOnlyEvent,
 	formatSiteLocalDatetime,
+	getEventDisplayTitle,
 } from 'fair-events-shared';
 import EventFinance from './EventFinance.js';
 import EventTickets from './EventTickets.js';
@@ -406,7 +407,7 @@ export default function ManageEventApp() {
 	};
 
 	const deleteConfirmMessage = useMemo(() => {
-		const eventTitle = title || __('Untitled Event', 'fair-events');
+		const eventTitle = getEventDisplayTitle(title);
 
 		if (eventDate?.occurrence_type === 'master') {
 			const count = eventDate.generated_occurrences?.length || 0;
@@ -1255,26 +1256,22 @@ export default function ManageEventApp() {
 			</style>
 			<h1>
 				{__('Manage Event', 'fair-events')}
-				{title && (
-					<>
-						{': '}
-						{eventDate.display_url ? (
-							<a
-								href={eventDate.display_url}
-								target="_blank"
-								rel="noreferrer"
-								style={{
-									color: 'inherit',
-									textDecoration: 'none',
-									borderBottom: '1px dotted currentColor',
-								}}
-							>
-								{title}
-							</a>
-						) : (
-							title
-						)}
-					</>
+				{': '}
+				{eventDate.display_url ? (
+					<a
+						href={eventDate.display_url}
+						target="_blank"
+						rel="noreferrer"
+						style={{
+							color: 'inherit',
+							textDecoration: 'none',
+							borderBottom: '1px dotted currentColor',
+						}}
+					>
+						{getEventDisplayTitle(title)}
+					</a>
+				) : (
+					getEventDisplayTitle(title)
 				)}
 			</h1>
 
@@ -1335,7 +1332,7 @@ export default function ManageEventApp() {
 					isBusy={saving}
 					disabled={
 						activeTab === 'event-details'
-							? saving || !title
+							? saving || !title.trim()
 							: saving
 					}
 				>


### PR DESCRIPTION
## Summary

- Reject empty/whitespace-only titles server-side, on both create and update (`EventDatesController::create_item`/`update_item`) — update previously accepted a title of any non-null value, including `"   "`.
- Fix the quick-create button's disable check (`QuickEventModal`) and Manage Event's save-button disable check (`ManageEventApp`) to trim the title instead of relying on truthiness, and show an inline error if a whitespace-only title is submitted.
- Add a shared `getEventDisplayTitle()` helper in `fair-events-shared` and use it wherever an event title is rendered (calendar `DayCell`, `AllEvents` list, Manage Event header/delete-confirm message) so legacy untitled rows show `(untitled event)` instead of a blank label.
- Add a Playwright API spec covering title validation on create/update, and a Jest unit test for `getEventDisplayTitle`.

Closes #990

## Test plan

- [x] `npx jest` in `fair-events` (54 passed) and `fair-events-shared` (94 passed)
- [x] `vendor/bin/phpcs` on the modified PHP file — no new findings
- [x] `npm run build` in `fair-events`
- [ ] Manual check against a running WP instance (not run in this session)
