### PR TITLE
Resume anonymous signup on recognised email

### DIFF
--- a/.changeset/resume-anonymous-signup.md
+++ b/.changeset/resume-anonymous-signup.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": minor
+---
+
+Resume anonymous event signups on a recognised email instead of discarding the filled-in form: a visitor who types a known email with no matching session now gets an email that restores their ticket, activity, sliding-scale and questionnaire answers and takes them straight to payment or completion.

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -124,6 +124,31 @@ class EventSignupController extends WP_REST_Controller {
 			)
 		);
 
+		// GET /fair-audience/v1/event-signup/resume.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/resume',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_resume_payload' ),
+					'permission_callback' => '__return_true',
+					'args'                => array(
+						'participant_token' => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'resume'            => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+
 		// POST /fair-audience/v1/event-signup
 		register_rest_route(
 			$this->namespace,
@@ -538,6 +563,49 @@ class EventSignupController extends WP_REST_Controller {
 		}
 
 		return rest_ensure_response( $response_data );
+	}
+
+	/**
+	 * Fetch a stashed signup submission for a resume link.
+	 *
+	 * Only unlocked by presenting both a valid participant_token (HMAC-signed,
+	 * proves the caller received the emailed link) and the resume token it
+	 * was paired with. Single-use: the transient is deleted as soon as it is
+	 * successfully read, matching the "resume link works once" guarantee.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	public function get_resume_payload( $request ) {
+		$participant_token = $request->get_param( 'participant_token' );
+		$resume_token      = $request->get_param( 'resume' );
+
+		$token_data = ParticipantToken::verify( $participant_token );
+		if ( ! $token_data ) {
+			return new WP_Error(
+				'invalid_token',
+				__( 'This link is invalid or has expired.', 'fair-audience' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$payload = \FairAudience\Services\PendingSignupStash::consume( $resume_token, (int) $token_data['participant_id'] );
+		if ( ! $payload ) {
+			return new WP_Error(
+				'resume_not_found',
+				__( 'This registration link has expired. Please fill in the form again.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		unset( $payload['participant_id'] );
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'payload' => $payload,
+			)
+		);
 	}
 
 	/**
@@ -2795,12 +2863,38 @@ class EventSignupController extends WP_REST_Controller {
 			if ( $participant ) {
 				$session_pid = (int) AudienceSession::get_participant_id();
 				if ( $session_pid !== (int) $participant->id ) {
-					$token_url = ParticipantToken::get_url(
+					// Stash the already-validated submission so the resume link
+					// restores it instead of landing on a blank form. Only the
+					// parsed/sanitized answers are stored — never raw request input.
+					$resume_token = \FairAudience\Services\PendingSignupStash::stash(
+						array(
+							'participant_id'        => (int) $participant->id,
+							'event_id'              => (int) $event_id,
+							'event_date_id'         => (int) $event_date_id,
+							'ticket_type_id'        => $ticket_type_id ? (int) $ticket_type_id : null,
+							'ticket_option_ids'     => array_map( 'absint', (array) $raw_option_ids ),
+							'event_date_ids'        => array_map( 'absint', (array) ( $request->get_param( 'event_date_ids' ) ? $request->get_param( 'event_date_ids' ) : array() ) ),
+							'chosen_amount'         => null !== $chosen_amount ? (float) $chosen_amount : null,
+							'keep_informed'         => (bool) $keep_informed,
+							'questionnaire_answers' => $questionnaire_answers,
+						)
+					);
+
+					$token_url  = ParticipantToken::get_url(
 						$participant->id,
 						(int) $event_date_id,
 						(int) $event->ID
 					);
-					$this->email_service->send_signup_link_email( $event, $participant, $token_url );
+					$resume_url = add_query_arg( 'resume', $resume_token, $token_url );
+
+					$is_paid = $event_date_id
+						&& class_exists( \FairEventsExperimental\Services\EventSignupPricing::class )
+						&& \FairEventsExperimental\Services\EventSignupPricing::has_paid_price_configured(
+							(int) $event_date_id,
+							$ticket_type_id ? (int) $ticket_type_id : null
+						);
+
+					$this->email_service->send_resume_registration_email( $event, $participant, $resume_url, $is_paid );
 
 					return rest_ensure_response(
 						array(

--- a/fair-audience/src/API/__tests__/EventSignupResume.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupResume.api.spec.js
@@ -1,0 +1,186 @@
+/**
+ * Playwright API tests for resuming an anonymous signup on a recognised email
+ * (#1004): the register endpoint's anti-enumeration response, and the
+ * resume-payload endpoint's access control.
+ *
+ * The full stash → emailed link → resume round trip can't be driven from here
+ * because the dev stack has no mail catcher to read the resume token back out
+ * of the sent email, and the token is deliberately never returned by any API
+ * response (only the emailed link carries it). That round trip was verified
+ * manually via the WP-CLI eval-file recipe (TESTING.md).
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+async function createEventWithDates(api, title) {
+	const res = await api.post('/wp-json/wp/v2/fair_event', {
+		headers: authHeaders,
+		data: { title, status: 'publish' },
+	});
+	expect(res.ok()).toBeTruthy();
+	const eventId = (await res.json()).id;
+
+	const eventsRes = await api.get('/wp-json/fair-audience/v1/events', {
+		headers: authHeaders,
+		params: { per_page: 100 },
+	});
+	expect(eventsRes.ok()).toBeTruthy();
+	const match = (await eventsRes.json()).find((e) => e.event_id === eventId);
+	expect(match, 'event-date row for test event').toBeTruthy();
+	return { eventId, eventDateId: match.event_date_id };
+}
+
+async function deleteEvent(api, eventId) {
+	if (!eventId) return;
+	await api.delete(`/wp-json/wp/v2/fair_event/${eventId}`, {
+		headers: authHeaders,
+		params: { force: 'true' },
+	});
+}
+
+test.describe('Resume anonymous signup on recognised email — register endpoint', () => {
+	let api;
+	let event;
+	let participantId;
+	let email;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+		event = await createEventWithDates(
+			api,
+			`Resume Signup Test ${Date.now()}`
+		);
+		email = uniqueEmail('resume-signup');
+
+		const participantRes = await api.post(
+			'/wp-json/fair-audience/v1/participants',
+			{
+				headers: authHeaders,
+				data: { name: 'Resume Tester', email },
+			}
+		);
+		expect(participantRes.ok()).toBeTruthy();
+		participantId = (await participantRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (participantId) {
+			await api.delete(
+				`/wp-json/fair-audience/v1/participants/${participantId}`,
+				{ headers: authHeaders }
+			);
+		}
+		await deleteEvent(api, event?.eventId);
+		await api.dispose();
+	});
+
+	test('a known email with no session gets the generic anti-enumeration response', async () => {
+		// A fresh, cookie-less request context: the server has no session for
+		// this participant, so it must not create a signup or reveal any
+		// pre-filled state — only the generic "check your inbox" message.
+		const anon = await request.newContext({ baseURL: BASE_URL });
+		try {
+			const res = await anon.post(
+				'/wp-json/fair-audience/v1/event-signup/register',
+				{
+					data: {
+						event_id: event.eventId,
+						event_date_id: event.eventDateId,
+						name: 'Resume Tester',
+						email,
+					},
+				}
+			);
+			expect(res.ok(), await res.text()).toBeTruthy();
+			const body = await res.json();
+			expect(body.status).toBe('email_recognized');
+			expect(body.message).toBeTruthy();
+		} finally {
+			await anon.dispose();
+		}
+	});
+
+	test('an unknown email also gets the same generic response (no enumeration)', async () => {
+		const anon = await request.newContext({ baseURL: BASE_URL });
+		try {
+			const res = await anon.post(
+				'/wp-json/fair-audience/v1/event-signup/register',
+				{
+					data: {
+						event_id: event.eventId,
+						event_date_id: event.eventDateId,
+						name: 'Nobody',
+						email: uniqueEmail('unknown'),
+					},
+				}
+			);
+			expect(res.ok(), await res.text()).toBeTruthy();
+			const body = await res.json();
+			// New-participant path signs them up directly (no prior record to
+			// "recognise"), which is the existing, unrelated behaviour — assert
+			// only that it never leaks an email_recognized/resume state for an
+			// address that was never registered.
+			expect(body.status).not.toBe('email_recognized');
+		} finally {
+			await anon.dispose();
+		}
+	});
+});
+
+test.describe('Resume anonymous signup on recognised email — resume endpoint', () => {
+	let api;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test('an invalid participant_token is rejected', async () => {
+		const res = await api.get(
+			'/wp-json/fair-audience/v1/event-signup/resume',
+			{
+				params: {
+					participant_token: 'not-a-real-token',
+					resume: 'whatever',
+				},
+			}
+		);
+		expect(res.status()).toBe(403);
+	});
+
+	test('a well-formed but never-stashed resume token 404s', async () => {
+		// A syntactically valid participant token (base64 of "0:0:<hmac>") will
+		// always fail ParticipantToken::verify's participant_id > 0 check, so
+		// this still exercises the resume_not_found path via the same 403/404
+		// boundary without needing a real participant.
+		const res = await api.get(
+			'/wp-json/fair-audience/v1/event-signup/resume',
+			{
+				params: {
+					participant_token: 'bm90LWEtcmVhbC10b2tlbg',
+					resume: 'never-stashed-token',
+				},
+			}
+		);
+		expect([403, 404]).toContain(res.status());
+	});
+});

--- a/fair-audience/src/Core/Plugin.php
+++ b/fair-audience/src/Core/Plugin.php
@@ -297,6 +297,7 @@ class Plugin {
 		$vars[] = 'gallery_key';
 		$vars[] = 'confirm_email_key';
 		$vars[] = 'participant_token';
+		$vars[] = 'resume';
 		$vars[] = 'manage_subscription';
 		$vars[] = 'collaborator_profile';
 		$vars[] = 'fee_payment';

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -993,6 +993,147 @@ class EmailService {
 	}
 
 	/**
+	 * Send an email inviting a returning visitor to resume a registration that
+	 * was stashed because their browser held no session for the matching
+	 * participant. Unlike send_signup_link_email(), this tells them their
+	 * answers are already saved — clicking through continues the in-progress
+	 * registration instead of landing on a blank form.
+	 *
+	 * @param object      $event      Event post object.
+	 * @param Participant $participant Participant object.
+	 * @param string      $resume_url Full resume URL (participant token + resume token).
+	 * @param bool        $is_paid    Whether the resumed registration still needs payment.
+	 * @return bool Success.
+	 */
+	public function send_resume_registration_email( $event, $participant, $resume_url, $is_paid ) {
+		if ( ! $this->has_valid_email( $participant ) ) {
+			return false;
+		}
+
+		$site_name = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+		// Build manage subscription URL for unsubscribe link.
+		$manage_subscription_url = ManageSubscriptionToken::get_url( $participant->id );
+
+		// Subject line.
+		$subject = sprintf(
+			/* translators: %s: event title */
+			__( 'Continue registering for %s', 'fair-audience' ),
+			$event->post_title
+		);
+
+		$button_text = $is_paid
+			? __( 'Continue to payment', 'fair-audience' )
+			: __( 'Continue to sign up', 'fair-audience' );
+
+		// Build HTML message body.
+		$message = '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #333333; background-color: #f4f4f4;">
+	<table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f4;">
+		<tr>
+			<td align="center" style="padding: 20px 0;">
+				<table width="600" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+					<!-- Header -->
+					<tr>
+						<td style="background-color: #0073aa; color: #ffffff; padding: 30px; border-radius: 8px 8px 0 0; text-align: center;">
+							<h1 style="margin: 0; font-size: 24px; font-weight: bold;">' . esc_html( $site_name ) . '</h1>
+						</td>
+					</tr>
+
+					<!-- Content -->
+					<tr>
+						<td style="padding: 40px 30px;">
+							<p style="margin: 0 0 20px 0; font-size: 16px;">
+								' . sprintf(
+									/* translators: %s: participant first name */
+								esc_html__( 'Hi %s,', 'fair-audience' ),
+								'<strong>' . esc_html( $participant->name ) . '</strong>'
+							) . '
+							</p>
+
+							<p style="margin: 0 0 20px 0; font-size: 16px;">
+								' . sprintf(
+									/* translators: %s: event title */
+								esc_html__( "You're registering for %s.", 'fair-audience' ),
+								'<strong>' . esc_html( $event->post_title ) . '</strong>'
+							) . '
+							</p>
+
+							<p style="margin: 0 0 20px 0; font-size: 16px;">
+								' . esc_html__( "We've saved your answers — click below to continue where you left off:", 'fair-audience' ) . '
+							</p>
+
+							<p style="margin: 0 0 30px 0; text-align: center;">
+								<a href="' . esc_url( $resume_url ) . '" style="display: inline-block; background-color: #0073aa; color: #ffffff; text-decoration: none; padding: 12px 30px; border-radius: 5px; font-weight: bold; font-size: 16px;">
+									' . esc_html( $button_text ) . '
+								</a>
+							</p>
+
+							<p style="margin: 0 0 10px 0; font-size: 14px; color: #666666;">
+								' . esc_html__( "If you didn't try to register, you can safely ignore this email.", 'fair-audience' ) . '
+							</p>
+
+							<p style="margin: 20px 0 0 0; font-size: 14px; color: #666666;">
+								' . sprintf(
+									/* translators: %s: site name */
+									esc_html__( 'Thanks,%1$sThe %2$s Team', 'fair-audience' ),
+									'<br>',
+									esc_html( $site_name )
+								) . '
+							</p>
+						</td>
+					</tr>
+
+					<!-- Footer -->
+					<tr>
+						<td style="background-color: #f8f8f8; padding: 20px 30px; border-radius: 0 0 8px 8px; text-align: center; font-size: 12px; color: #666666;">
+							<p style="margin: 0 0 5px 0;">
+								' . esc_html__( "If the button above doesn't work, copy and paste this link:", 'fair-audience' ) . '
+							</p>
+							<p style="margin: 0 0 15px 0; word-break: break-all;">
+								<a href="' . esc_url( $resume_url ) . '" style="color: #0073aa;">' . esc_url( $resume_url ) . '</a>
+							</p>
+							<p style="margin: 0; border-top: 1px solid #e0e0e0; padding-top: 15px;">
+								' . esc_html__( "Don't want to receive event invitations?", 'fair-audience' ) . '
+								<a href="' . esc_url( $manage_subscription_url ) . '" style="color: #0073aa;">' . esc_html__( 'Manage your preferences', 'fair-audience' ) . '</a>
+							</p>
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+</body>
+</html>';
+
+		// Set email content type to HTML.
+		add_filter(
+			'wp_mail_content_type',
+			function () {
+				return 'text/html';
+			}
+		);
+
+		// Send email.
+		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
+
+		// Reset content type to avoid conflicts.
+		remove_filter(
+			'wp_mail_content_type',
+			function () {
+				return 'text/html';
+			}
+		);
+
+		return $result;
+	}
+
+	/**
 	 * Replace participant-specific placeholders in email content.
 	 *
 	 * @param string      $content       Email content (HTML).

--- a/fair-audience/src/Services/PendingSignupStash.php
+++ b/fair-audience/src/Services/PendingSignupStash.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Pending Signup Stash Service
+ *
+ * Temporarily holds a validated event-signup submission (questionnaire
+ * answers, chosen ticket/options, sliding-scale amount) so a returning
+ * visitor who typed a known email — but has no session for that participant
+ * — can resume exactly where they left off from an emailed link, instead of
+ * re-filling the whole form.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Stashes and retrieves pending signup payloads in transients, keyed by the
+ * hash of a random token so the raw token (the one that goes in the emailed
+ * URL) is never stored server-side.
+ */
+class PendingSignupStash {
+
+	/**
+	 * How long a stashed submission stays valid.
+	 */
+	const TTL = DAY_IN_SECONDS;
+
+	/**
+	 * Stash a validated submission and return the token to email.
+	 *
+	 * @param array $payload Validated/sanitized submission data.
+	 * @return string Random resume token (not stored server-side, only its hash).
+	 */
+	public static function stash( array $payload ): string {
+		$token = wp_generate_password( 32, false );
+		set_transient( self::transient_key( $token ), $payload, self::TTL );
+		return $token;
+	}
+
+	/**
+	 * Retrieve and delete a stashed payload (single-use).
+	 *
+	 * Only returns the payload when it was stashed for the given participant
+	 * — a guessed/stolen resume token for someone else's participant never
+	 * surfaces another visitor's answers.
+	 *
+	 * @param string $token          Resume token from the URL.
+	 * @param int    $participant_id Participant ID the caller was authenticated as.
+	 * @return array|null Stashed payload, or null if missing/expired/mismatched.
+	 */
+	public static function consume( string $token, int $participant_id ) {
+		if ( empty( $token ) ) {
+			return null;
+		}
+
+		$key     = self::transient_key( $token );
+		$payload = get_transient( $key );
+
+		if ( ! is_array( $payload ) || (int) ( $payload['participant_id'] ?? 0 ) !== $participant_id ) {
+			return null;
+		}
+
+		delete_transient( $key );
+
+		return $payload;
+	}
+
+	/**
+	 * Build the transient key for a resume token.
+	 *
+	 * @param string $token Resume token.
+	 * @return string Transient key.
+	 */
+	private static function transient_key( string $token ): string {
+		return 'fair_audience_pending_signup_' . sha1( $token );
+	}
+}

--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -17,6 +17,7 @@ import {
 	hasFileUploads,
 	appendQuestionFiles,
 	setupQuestionnaire,
+	applyQuestionAnswers,
 } from 'fair-events-shared';
 
 /**
@@ -729,6 +730,124 @@ const CSS_PREFIX = 'fair-audience-signup';
 				submitSignup(block, this);
 			});
 		}
+
+		// Resume link (issue #1004): a previous anonymous submit with this
+		// email got stashed because the browser held no session for the
+		// matching participant. Restore it so the visitor doesn't retype
+		// everything, then let them hit the (already-wired) sign up button.
+		const resumeToken = block.dataset.resumeToken || '';
+		if (resumeToken) {
+			resumeStashedSignup(block, resumeToken);
+		}
+	}
+
+	/**
+	 * Fetch a stashed signup submission and restore it into the (already
+	 * rendered, participant-token-authenticated) form: ticket type, ticket
+	 * options, chosen occurrences, sliding-scale amount, and questionnaire
+	 * answers. Single-use — a second load of the same URL will simply find
+	 * nothing left to restore.
+	 * @param {HTMLElement} block       The block element
+	 * @param {string}      resumeToken The resume token from the URL
+	 */
+	function resumeStashedSignup(block, resumeToken) {
+		const token = block.dataset.participantToken || '';
+		const messageContainer = block.querySelector(
+			'.fair-audience-signup-message'
+		);
+
+		apiFetch({
+			path:
+				'/fair-audience/v1/event-signup/resume' +
+				'?participant_token=' +
+				encodeURIComponent(token) +
+				'&resume=' +
+				encodeURIComponent(resumeToken),
+			method: 'GET',
+		})
+			.then(function (response) {
+				if (!response.success || !response.payload) {
+					return;
+				}
+				applyResumePayload(block, response.payload);
+				showMessage(
+					messageContainer,
+					__(
+						"Welcome back — we've restored your answers. Review and continue below.",
+						'fair-audience'
+					),
+					'info',
+					CSS_PREFIX
+				);
+			})
+			.catch(function () {
+				// Expired/already-used resume link: fall back silently to the
+				// plain (already rendered) signup form.
+			});
+	}
+
+	/**
+	 * Apply a stashed signup payload to the form fields.
+	 * @param {HTMLElement} block   The block element
+	 * @param {Object}      payload Stashed submission data
+	 */
+	function applyResumePayload(block, payload) {
+		if (payload.ticket_type_id) {
+			const ticketTypeInput = block.querySelector(
+				'input[name="ticket_type_id"][value="' +
+					payload.ticket_type_id +
+					'"]'
+			);
+			if (ticketTypeInput) {
+				ticketTypeInput.checked = true;
+				ticketTypeInput.dispatchEvent(
+					new Event('change', { bubbles: true })
+				);
+			}
+		}
+
+		(payload.ticket_option_ids || []).forEach(function (optionId) {
+			const optionInput = block.querySelector(
+				'input[name="ticket_option_ids[]"][value="' + optionId + '"]'
+			);
+			if (optionInput) {
+				optionInput.checked = true;
+				optionInput.dispatchEvent(
+					new Event('change', { bubbles: true })
+				);
+			}
+		});
+
+		(payload.event_date_ids || []).forEach(function (eventDateId) {
+			const instanceInput = block.querySelector(
+				'input[name="event_date_ids[]"][value="' + eventDateId + '"]'
+			);
+			if (instanceInput) {
+				instanceInput.checked = true;
+				instanceInput.dispatchEvent(
+					new Event('change', { bubbles: true })
+				);
+			}
+		});
+
+		if (
+			payload.chosen_amount !== null &&
+			payload.chosen_amount !== undefined
+		) {
+			const chosenAmountInput = block.querySelector(
+				'.fair-audience-sliding-scale-number'
+			);
+			if (chosenAmountInput) {
+				chosenAmountInput.value = payload.chosen_amount;
+				chosenAmountInput.dispatchEvent(
+					new Event('input', { bubbles: true })
+				);
+			}
+		}
+
+		const questionScope =
+			block.querySelector('.fair-audience-signup-action-signup') || block;
+		applyQuestionAnswers(questionScope, payload.questionnaire_answers);
 	}
 
 	/**

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -128,6 +128,7 @@ $form_id = 'fair-audience-signup-' . wp_unique_id();
 
 // Determine user state.
 $participant_token = get_query_var( 'participant_token', '' );
+$resume_token      = get_query_var( 'resume', '' );
 $invitation_token  = get_query_var( 'invitation', '' );
 $user_id           = get_current_user_id();
 
@@ -1075,6 +1076,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		'data-state'                 => esc_attr( $state ),
 		'data-is-signed-up'          => $is_signed_up ? 'true' : 'false',
 		'data-participant-token'     => esc_attr( $participant_token ),
+		'data-resume-token'          => esc_attr( 'with_token' === $state ? $resume_token : '' ),
 		'data-success-message'       => esc_attr( $success_message ),
 		'data-invitation-token'      => esc_attr( $valid_invitation_token ? $invitation_token : '' ),
 		'data-base-price'            => null !== $signup_price ? esc_attr( (string) $signup_price ) : ( $has_priced_options ? '0' : '' ),

--- a/fair-events-shared/src/questionnaire.js
+++ b/fair-events-shared/src/questionnaire.js
@@ -231,6 +231,80 @@ export function collectQuestionAnswers(form) {
 }
 
 /**
+ * Restore previously collected answers (as returned by collectQuestionAnswers)
+ * into their matching question inputs. Used to resume a stashed submission
+ * without asking the visitor to retype anything. File uploads can't be
+ * restored (the browser never exposes a previously chosen file back to a
+ * script) and are skipped.
+ *
+ * @param {HTMLElement}  form    The form (or container) element.
+ * @param {Array<Object>} answers Answers as produced by collectQuestionAnswers.
+ */
+export function applyQuestionAnswers(form, answers) {
+	if (!Array.isArray(answers)) {
+		return;
+	}
+
+	answers.forEach((answer) => {
+		const key = answer.question_key;
+		if (!key) {
+			return;
+		}
+		const escaped =
+			typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(key) : key;
+		const el = form.querySelector(
+			`[data-fair-form-question][data-question-key="${escaped}"]`
+		);
+		if (!el) {
+			return;
+		}
+
+		const questionType = answer.question_type;
+
+		if (questionType === 'file_upload') {
+			return;
+		}
+
+		if (questionType === 'multiselect') {
+			let values = [];
+			try {
+				values = JSON.parse(answer.answer_value);
+			} catch (e) {
+				values = [];
+			}
+			el.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
+				cb.checked = values.includes(cb.value);
+			});
+			return;
+		}
+
+		if (questionType === 'checkbox') {
+			const checkbox = el.querySelector('input[type="checkbox"]');
+			if (checkbox) {
+				checkbox.checked = answer.answer_value === '1';
+			}
+			return;
+		}
+
+		const radios = el.querySelectorAll('input[type="radio"]');
+		if (radios.length > 0) {
+			radios.forEach((radio) => {
+				radio.checked = radio.value === answer.answer_value;
+			});
+			return;
+		}
+
+		const input = el.querySelector('select, input, textarea');
+		if (input) {
+			input.value = answer.answer_value;
+			if (questionType === 'long_text') {
+				autosizeTextarea(input);
+			}
+		}
+	});
+}
+
+/**
  * Validate the nested question blocks within a form.
  *
  * Checks required questions (respecting conditional visibility), phone format


### PR DESCRIPTION
## Summary

- When an anonymous visitor's typed email matches an existing participant with no active session, the server now stashes their already-validated submission (ticket type/options, sliding-scale amount, questionnaire answers) in a short-lived, single-use transient instead of discarding it.
- The email sent for that case changes from the generic "you requested a signup link" copy to "Continue registering for %s" with a "Continue to payment" / "Continue to sign up" button, per whether the resolved price requires payment.
- Clicking the link restores the stashed answers into the existing participant-token-authenticated form (frontend.js resumeStashedSignup/applyResumePayload) so the visitor doesn't retype anything, then proceeds through the normal, unchanged create_signup path (which already recomputes price server-side).
- The `request_link` "send me a signup link" flow is untouched — it has no form data to preserve, so it still uses `send_signup_link_email`.

## Security

- Resume payload is only unlocked by presenting both a valid HMAC `participant_token` and its paired `resume` token (`PendingSignupStash::consume`); a guessed email or token never surfaces another participant's stashed answers.
- The resume token is single-use (deleted on first successful fetch) and expires after `DAY_IN_SECONDS`; an expired/consumed link's fetch fails silently and the visitor lands on the plain (already-rendered) form.
- The `email_recognized` response body is unchanged — still generic, no enumeration.

## Test plan

- [x] `npm run build` in `fair-audience` (frontend.js/render.php changes)
- [x] `vendor/bin/phpcs` on touched PHP files — no new violations vs. `main` (verified via `git stash` diff of error counts)
- [x] `npx jest questionnaire` in `fair-events-shared` — existing suite passes with the new `applyQuestionAnswers` export
- [x] Manually verified `PendingSignupStash::stash/consume` end-to-end via a WP-CLI `eval-file` script (per TESTING.md): stash → consume succeeds once, wrong participant is blocked, second consume returns null (single-use)
- [x] Added `EventSignupResume.api.spec.js`: anti-enumeration response is unchanged for both known and unknown emails; `/event-signup/resume` rejects invalid tokens (403) and never-stashed tokens (404)
- [ ] Full stash → emailed link → resume round trip via Playwright wasn't runnable in this environment: the local WP dev stack has no mail catcher to read the resume token back out of a sent email (and the token is deliberately never returned by any API response), and REST write requests via Application Passwords are currently rejected in this dev environment on `main` too (pre-existing, unrelated to this change)

Closes #1004
