### PR TITLE
Fix duplicate Telegram payment notifications via status race

### DIFF
--- a/fair-payments-connector/src/API/TransactionAPI.php
+++ b/fair-payments-connector/src/API/TransactionAPI.php
@@ -376,10 +376,15 @@ class TransactionAPI {
 
 			// If Mollie status differs from our stored status, update.
 			if ( $payment->status !== $transaction->status ) {
-				Transaction::update_status( $transaction->mollie_payment_id, $payment->status );
-				self::handle_payment_status_change( $payment, $transaction );
+				// Compare-and-swap against the status we just read, so a concurrent
+				// webhook can't both win and re-fire status hooks/notifications.
+				$won_race = Transaction::update_status( $transaction->mollie_payment_id, $payment->status, $transaction->status );
 
-				// Return fresh transaction from DB.
+				if ( $won_race ) {
+					self::handle_payment_status_change( $payment, $transaction );
+				}
+
+				// Return fresh transaction from DB regardless of who won the race.
 				$updated             = Transaction::get_by_id( $transaction_id );
 				$updated->sync_debug = self::build_mollie_debug( $payment );
 				return $updated;

--- a/fair-payments-connector/src/API/WebhookEndpoint.php
+++ b/fair-payments-connector/src/API/WebhookEndpoint.php
@@ -148,10 +148,37 @@ class WebhookEndpoint extends WP_REST_Controller {
 			);
 			$payment = $handler->get_payment( $mollie_payment_id, $options );
 
-			// Update transaction status.
-			$updated = Transaction::update_status( $mollie_payment_id, $payment->status );
+			// Update transaction status. Compare-and-swap against the status we just
+			// read, so a concurrent sync (e.g. triggered by the customer's browser
+			// reloading the payment page) can't both win and re-fire status hooks.
+			$updated = Transaction::update_status( $mollie_payment_id, $payment->status, $transaction->status );
 
 			if ( ! $updated ) {
+				$current = Transaction::get_by_mollie_id( $mollie_payment_id );
+
+				if ( $current && $current->status === $payment->status ) {
+					// Another process already made this exact transition — nothing left to do.
+					$logger->log(
+						'webhook_skipped',
+						array(
+							'level'          => 'info',
+							'transaction_id' => (int) $transaction->id,
+							'message'        => 'Webhook skipped — status already updated by a concurrent request',
+							'context'        => array(
+								'mollie_payment_id' => $mollie_payment_id,
+								'status'            => $payment->status,
+							),
+						)
+					);
+					return new WP_REST_Response(
+						array(
+							'success' => true,
+							'status'  => $payment->status,
+						),
+						200
+					);
+				}
+
 				$logger->log(
 					'webhook_failed',
 					array(

--- a/fair-payments-connector/src/Models/Transaction.php
+++ b/fair-payments-connector/src/Models/Transaction.php
@@ -222,21 +222,43 @@ class Transaction {
 	/**
 	 * Update transaction status
 	 *
-	 * @param string $mollie_payment_id Mollie payment ID.
-	 * @param string $status New status.
-	 * @return bool True on success, false on failure.
+	 * When $expected_status is given, the update is a compare-and-swap: it only
+	 * writes (and returns true) if the row's current status still matches
+	 * $expected_status. This lets concurrent callers (e.g. a webhook and a
+	 * page-load sync racing on the same transaction) detect that another
+	 * process already made the transition, so only one of them proceeds to
+	 * fire status-change hooks/notifications.
+	 *
+	 * @param string      $mollie_payment_id Mollie payment ID.
+	 * @param string      $status New status.
+	 * @param string|null $expected_status If given, only update when the current status matches this value.
+	 * @return bool True if this call performed the update, false on failure or if the status no longer matched.
 	 */
-	public static function update_status( $mollie_payment_id, $status ) {
+	public static function update_status( $mollie_payment_id, $status, $expected_status = null ) {
 		global $wpdb;
 		$table_name = \FairPaymentsConnector\Database\Schema::get_payments_table_name();
 
-		return (bool) $wpdb->update(
-			$table_name,
-			array( 'status' => $status ),
-			array( 'mollie_payment_id' => $mollie_payment_id ),
-			array( '%s' ),
-			array( '%s' )
+		if ( null === $expected_status ) {
+			return (bool) $wpdb->update(
+				$table_name,
+				array( 'status' => $status ),
+				array( 'mollie_payment_id' => $mollie_payment_id ),
+				array( '%s' ),
+				array( '%s' )
+			);
+		}
+
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET status = %s WHERE mollie_payment_id = %s AND status = %s',
+				$table_name,
+				$status,
+				$mollie_payment_id,
+				$expected_status
+			)
 		);
+
+		return false !== $result && $result > 0;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Mollie webhooks and the page-load status sync (`TransactionAPI::sync_transaction_status()`) both independently read a transaction's status, fetched Mollie's live status, and wrote it back before firing `fair_payment_paid`. When both ran near-simultaneously for the same transaction (e.g. the customer's browser reloads the payment page right as Mollie's webhook arrives), both saw the old `pending_payment` status, both wrote `paid`, and both fired the hook — sending two Telegram notifications for one payment.
- `Transaction::update_status()` now accepts an optional `$expected_status` and performs a compare-and-swap `UPDATE ... WHERE status = <expected>`, only succeeding if the row still had that status.
- Both call sites (`WebhookEndpoint` and `TransactionAPI::sync_transaction_status()`) now pass the status they just read, and only fire payment-status hooks/notifications when they win the race. The loser detects the row already changed and returns the current state without re-notifying.

## Test plan

- [x] `php -l` on all three changed files
- [x] `vendor/bin/phpcs` clean on all three changed files
- [ ] Manual: trigger a webhook and a sync call concurrently for the same pending transaction against a Mollie test payment, confirm only one Telegram notification is sent