### PR TITLE
Prioritize resume flow over stale payment retry card

### DIFF
--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -755,6 +755,7 @@ const SCROLL_RESTORE_KEY = 'fairAudienceOccurrenceScrollY';
 		// everything, then let them hit the (already-wired) sign up button.
 		const resumeToken = block.dataset.resumeToken || '';
 		if (resumeToken) {
+			block.scrollIntoView({ behavior: 'smooth', block: 'start' });
 			resumeStashedSignup(block, resumeToken);
 		}
 	}

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -267,8 +267,11 @@ if ( $is_valid_post_type ) {
 	// progress for this event date and synthesise a callback state from it,
 	// so the same retry / resume / pending UI shows for someone who navigated
 	// directly back to the event page instead of returning via Mollie's
-	// redirect.
-	if ( null === $callback_tx && class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
+	// redirect. Skipped when a resume_token is present: someone following the
+	// "continue where you left off" email link should always land on the
+	// friendly resume form, not a stale retry/failed-payment card from an
+	// earlier attempt.
+	if ( null === $callback_tx && empty( $resume_token ) && class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
 		$owner_participant_id = 0;
 		if ( $participant ) {
 			$owner_participant_id = (int) $participant->id;


### PR DESCRIPTION
## Summary
- Following the "continue where you left off" email link (resume token) could land on a stale failed-payment retry card instead of the friendly resume form, whenever the participant also had an old `pending_payment` hold on record.
- `render.php`'s synthesized-callback lookup now skips when a `resume_token` is present, letting the `with_token` branch render (greeting + restored answers) instead.
- The signup block now auto-scrolls into view when arriving via a resume link.

## Test plan
- [ ] Trigger the anonymous-signup-with-recognized-email flow (issue #1004) for a participant that also has a stale/failed `pending_payment` hold, click the resume link from the email, and confirm the friendly resume form (with restored answers) renders instead of the retry card.
- [ ] Confirm a genuine Mollie return-from-checkout (`fair_payment_callback=true`) still shows the correct paid/pending/retry state.
- [ ] Confirm the page auto-scrolls to the signup block on resume-link arrival.