### PR TITLE
Create categories on the fly in Manage Event

### DIFF
--- a/fair-events-experimental/package.json
+++ b/fair-events-experimental/package.json
@@ -21,7 +21,8 @@
 		"makemo": "wp i18n make-mo languages/",
 		"updatepo": "wp i18n update-po languages/fair-events-experimental.pot languages/",
 		"test": "npm-run-all test:js",
-		"test:js": "jest --passWithNoTests"
+		"test:js": "jest --passWithNoTests",
+		"test:api": "playwright test src/API/__tests__/"
 	},
 	"dependencies": {
 		"fair-events-shared": "*",
@@ -35,6 +36,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.28.3",
 		"@babel/preset-env": "^7.28.3",
+		"@playwright/test": "^1.40.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",

--- a/fair-events-experimental/playwright.config.js
+++ b/fair-events-experimental/playwright.config.js
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export default defineConfig({
+	testDir: './',
+	testMatch: ['src/API/__tests__/**/*.api.spec.js'],
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: 1,
+	reporter: process.env.CI ? 'github' : 'line',
+	use: {
+		baseURL: process.env.WP_BASE_URL || 'http://localhost:8080',
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+		viewport: { width: 1200, height: 900 },
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+	webServer: process.env.CI
+		? undefined
+		: {
+				command: 'docker compose up',
+				url: 'http://localhost:8080',
+				reuseExistingServer: !process.env.CI,
+				timeout: 120 * 1000,
+		  },
+});

--- a/fair-events-experimental/src/API/EventSourceController.php
+++ b/fair-events-experimental/src/API/EventSourceController.php
@@ -113,6 +113,7 @@ class EventSourceController extends WP_REST_Controller {
 		);
 
 		// GET /fair-events/v1/sources/categories - Get available categories
+		// POST /fair-events/v1/sources/categories - Create category
 		register_rest_route(
 			$this->namespace,
 			'/sources/categories',
@@ -121,6 +122,18 @@ class EventSourceController extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_categories' ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_category' ),
+					'permission_callback' => array( $this, 'create_category_permissions_check' ),
+					'args'                => array(
+						'name' => array(
+							'description' => __( 'Name of the category to create.', 'fair-events' ),
+							'type'        => 'string',
+							'required'    => true,
+						),
+					),
 				),
 			)
 		);
@@ -372,6 +385,57 @@ class EventSourceController extends WP_REST_Controller {
 		);
 
 		return new WP_REST_Response( $formatted, 200 );
+	}
+
+	/**
+	 * Create a new category for event categorization
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
+	 */
+	public function create_category( $request ) {
+		$name = sanitize_text_field( $request->get_param( 'name' ) );
+
+		if ( empty( $name ) ) {
+			return new WP_Error(
+				'rest_invalid_category_name',
+				__( 'Category name is required.', 'fair-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$existing = get_term_by( 'name', $name, 'category' );
+		if ( $existing ) {
+			return new WP_REST_Response(
+				array(
+					'id'   => $existing->term_id,
+					'name' => $existing->name,
+					'slug' => $existing->slug,
+				),
+				200
+			);
+		}
+
+		$result = wp_insert_term( $name, 'category' );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error(
+				'rest_category_creation_failed',
+				$result->get_error_message(),
+				array( 'status' => 500 )
+			);
+		}
+
+		$term = get_term( $result['term_id'], 'category' );
+
+		return new WP_REST_Response(
+			array(
+				'id'   => $term->term_id,
+				'name' => $term->name,
+				'slug' => $term->slug,
+			),
+			201
+		);
 	}
 
 	/**
@@ -711,6 +775,16 @@ class EventSourceController extends WP_REST_Controller {
 	 */
 	public function create_item_permissions_check( $request ) {
 		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Check permissions for creating a category
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool True if user has permission.
+	 */
+	public function create_category_permissions_check( $request ) {
+		return current_user_can( 'manage_categories' );
 	}
 
 	/**

--- a/fair-events-experimental/src/API/__tests__/EventSourceController.api.spec.js
+++ b/fair-events-experimental/src/API/__tests__/EventSourceController.api.spec.js
@@ -1,0 +1,95 @@
+/**
+ * Playwright API tests for EventSourceController's category endpoints.
+ *
+ * Verifies POST /fair-events/v1/sources/categories creates a category term,
+ * is idempotent for an existing name, and enforces the permission check.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeader = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('EventSourceController categories', () => {
+	let api;
+	const createdCategoryIds = [];
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		for (const id of createdCategoryIds) {
+			await api.delete(`/wp-json/wp/v2/categories/${id}?force=true`, {
+				headers: authHeader,
+			});
+		}
+		await api.dispose();
+	});
+
+	test('creates a new category and returns its id, name, and slug', async () => {
+		const name = `API Test Category ${Date.now()}`;
+		const res = await api.post(
+			'/wp-json/fair-events/v1/sources/categories',
+			{
+				headers: authHeader,
+				data: { name },
+			}
+		);
+
+		expect(res.status()).toBe(201);
+		const body = await res.json();
+		createdCategoryIds.push(body.id);
+
+		expect(body).toHaveProperty('id');
+		expect(body.name).toBe(name);
+		expect(body).toHaveProperty('slug');
+	});
+
+	test('is idempotent when the category name already exists', async () => {
+		const name = `API Test Category Dup ${Date.now()}`;
+
+		const first = await api.post(
+			'/wp-json/fair-events/v1/sources/categories',
+			{
+				headers: authHeader,
+				data: { name },
+			}
+		);
+		expect(first.status()).toBe(201);
+		const firstBody = await first.json();
+		createdCategoryIds.push(firstBody.id);
+
+		const second = await api.post(
+			'/wp-json/fair-events/v1/sources/categories',
+			{
+				headers: authHeader,
+				data: { name },
+			}
+		);
+		expect(second.status()).toBe(200);
+		const secondBody = await second.json();
+
+		expect(secondBody.id).toBe(firstBody.id);
+	});
+
+	test('rejects requests without permission', async () => {
+		const anonymousApi = await request.newContext({ baseURL: BASE_URL });
+		const res = await anonymousApi.post(
+			'/wp-json/fair-events/v1/sources/categories',
+			{
+				data: { name: `API Test Category Unauth ${Date.now()}` },
+			}
+		);
+
+		expect(res.status()).toBe(401);
+		await anonymousApi.dispose();
+	});
+});

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -87,6 +87,7 @@ export default function ManageEventApp() {
 	const [externalUrl, setExternalUrl] = useState('');
 	const [categories, setCategories] = useState([]);
 	const [availableCategories, setAvailableCategories] = useState([]);
+	const [creatingCategories, setCreatingCategories] = useState([]);
 
 	// Recurrence state
 	const [recurrenceEnabled, setRecurrenceEnabled] = useState(false);
@@ -162,6 +163,26 @@ export default function ManageEventApp() {
 			setAvailableCategories(data);
 		} catch {
 			// Categories are optional, ignore errors.
+		}
+	};
+
+	const createCategory = async (name) => {
+		try {
+			const newCategory = await apiFetch({
+				path: '/fair-events/v1/sources/categories',
+				method: 'POST',
+				data: { name },
+			});
+			setAvailableCategories((prev) => [...prev, newCategory]);
+			setCategories((prev) => [...prev, newCategory.id]);
+		} catch (err) {
+			setError(
+				err.message || __('Failed to create category.', 'fair-events')
+			);
+		} finally {
+			setCreatingCategories((prev) =>
+				prev.filter((pending) => pending !== name)
+			);
 		}
 	};
 
@@ -844,26 +865,50 @@ export default function ManageEventApp() {
 							<VStack spacing={4}>
 								<FormTokenField
 									label={__('Categories', 'fair-events')}
-									value={categories.map((id) => {
-										const cat = availableCategories.find(
-											(c) => c.id === id
-										);
-										return cat ? cat.name : '';
-									})}
+									value={[
+										...categories
+											.map((id) => {
+												const cat =
+													availableCategories.find(
+														(c) => c.id === id
+													);
+												return cat ? cat.name : '';
+											})
+											.filter(Boolean),
+										...creatingCategories,
+									]}
 									suggestions={availableCategories.map(
 										(c) => c.name
 									)}
 									onChange={(tokens) => {
-										const ids = tokens
-											.map((token) => {
-												const cat =
-													availableCategories.find(
-														(c) => c.name === token
-													);
-												return cat ? cat.id : null;
-											})
-											.filter(Boolean);
+										const ids = [];
+										const pending = [];
+
+										tokens.forEach((token) => {
+											const cat =
+												availableCategories.find(
+													(c) => c.name === token
+												);
+											if (cat) {
+												ids.push(cat.id);
+											} else {
+												pending.push(token);
+											}
+										});
+
 										setCategories(ids);
+										setCreatingCategories(pending);
+
+										pending
+											.filter(
+												(name) =>
+													!creatingCategories.includes(
+														name
+													)
+											)
+											.forEach((name) =>
+												createCategory(name)
+											);
 									}}
 									__experimentalExpandOnFocus
 								/>

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -295,6 +295,56 @@ describe('context header (#986)', () => {
 	});
 });
 
+describe('create-on-the-fly categories (#992)', () => {
+	beforeEach(() => {
+		window.history.replaceState({}, '', '?tab=event-details');
+	});
+
+	it('creates and links a category typed as an unknown token', async () => {
+		apiFetch.mockImplementation((opts) => {
+			if (opts.path && opts.path.includes('/event-dates/')) {
+				return Promise.resolve(mockEventDate);
+			}
+			if (opts.path === '/fair-events/v1/sources/categories') {
+				if (opts.method === 'POST') {
+					return Promise.resolve({
+						id: 5,
+						name: 'Workshops',
+						slug: 'workshops',
+					});
+				}
+				return Promise.resolve([
+					{ id: 1, name: 'Music', slug: 'music' },
+				]);
+			}
+			return Promise.resolve([]);
+		});
+
+		render(<ManageEventApp />);
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Event Details' })
+			).toBeInTheDocument()
+		);
+
+		const input = await screen.findByLabelText('Categories');
+		fireEvent.change(input, { target: { value: 'Workshops' } });
+		fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+		await waitFor(() =>
+			expect(apiFetch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: '/fair-events/v1/sources/categories',
+					method: 'POST',
+					data: { name: 'Workshops' },
+				})
+			)
+		);
+
+		expect(await screen.findByText('Workshops')).toBeInTheDocument();
+	});
+});
+
 describe('delete confirmation dialog (#991)', () => {
 	it('shows the title and date, and no occurrence count, for a one-off event', async () => {
 		render(<ManageEventApp />);


### PR DESCRIPTION
## Summary

- Typing an unknown category in Manage Event → Event Details silently dropped the token instead of creating it (`FormTokenField`'s `onChange` mapped unknown names to `null` and filtered them out).
- Adds `POST /fair-events/v1/sources/categories` in `fair-events-experimental` (idempotent by name, `manage_categories` permission check) to create a `category` term on the fly.
- Reworks the `onChange` handler in `ManageEventApp.js` so unknown tokens POST to the new endpoint, stay visible while pending, and get linked once created; failures surface via the existing error `Notice` instead of silently vanishing.

Refs #992

## Test plan

- [x] `npm test` in `fair-events` (component test for create-on-the-fly categories added)
- [x] `npm test` in `fair-events-experimental`
- [x] Verified `create_category` (create + idempotent-by-name) against a live WordPress via WP-CLI `eval-file`
- [x] Added `EventSourceController.api.spec.js` Playwright API spec (create, idempotency, permission check) plus the `test:api` script/Playwright config needed to run it — could not execute locally due to Basic Auth credentials not being configured for this dev stack
- [x] `npm run build` in `fair-events`
