### PR TITLE
Move category endpoint from fair-events-experimental to fair-events

### DIFF
--- a/e2e/fair-events-feature-flags.spec.js
+++ b/e2e/fair-events-feature-flags.spec.js
@@ -93,7 +93,7 @@ const BUNDLE_PAGES = {
  * resource still count as "registered").
  */
 const BUNDLE_PROBE_ROUTES = {
-	sources: '/fair-events/v1/sources/categories',
+	sources: '/fair-events/v1/sources',
 	galleries: '/fair-events/v1/event-dates/1/gallery',
 	migration: '/fair-events/v1/migration/post-types',
 };

--- a/fair-events-experimental/src/API/EventSourceController.php
+++ b/fair-events-experimental/src/API/EventSourceController.php
@@ -112,31 +112,8 @@ class EventSourceController extends WP_REST_Controller {
 			)
 		);
 
-		// GET /fair-events/v1/sources/categories - Get available categories
-		// POST /fair-events/v1/sources/categories - Create category
-		register_rest_route(
-			$this->namespace,
-			'/sources/categories',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_categories' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				),
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'create_category' ),
-					'permission_callback' => array( $this, 'create_category_permissions_check' ),
-					'args'                => array(
-						'name' => array(
-							'description' => __( 'Name of the category to create.', 'fair-events' ),
-							'type'        => 'string',
-							'required'    => true,
-						),
-					),
-				),
-			)
-		);
+		// GET /fair-events/v1/sources/categories is registered by
+		// \FairEvents\API\CategoriesController in the base plugin.
 
 		// GET /fair-events/v1/sources/{slug}/ical - Get iCal feed for source
 		register_rest_route(
@@ -350,91 +327,6 @@ class EventSourceController extends WP_REST_Controller {
 				'source'  => $existing,
 			),
 			200
-		);
-	}
-
-	/**
-	 * Get available categories for event categorization
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_REST_Response Response object.
-	 */
-	public function get_categories( $request ) {
-		$categories = get_terms(
-			array(
-				'taxonomy'   => 'category',
-				'hide_empty' => false,
-				'orderby'    => 'name',
-				'order'      => 'ASC',
-			)
-		);
-
-		if ( is_wp_error( $categories ) ) {
-			return new WP_REST_Response( array(), 200 );
-		}
-
-		$formatted = array_map(
-			function ( $category ) {
-				return array(
-					'id'   => $category->term_id,
-					'name' => $category->name,
-					'slug' => $category->slug,
-				);
-			},
-			$categories
-		);
-
-		return new WP_REST_Response( $formatted, 200 );
-	}
-
-	/**
-	 * Create a new category for event categorization
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
-	 */
-	public function create_category( $request ) {
-		$name = sanitize_text_field( $request->get_param( 'name' ) );
-
-		if ( empty( $name ) ) {
-			return new WP_Error(
-				'rest_invalid_category_name',
-				__( 'Category name is required.', 'fair-events' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		$existing = get_term_by( 'name', $name, 'category' );
-		if ( $existing ) {
-			return new WP_REST_Response(
-				array(
-					'id'   => $existing->term_id,
-					'name' => $existing->name,
-					'slug' => $existing->slug,
-				),
-				200
-			);
-		}
-
-		$result = wp_insert_term( $name, 'category' );
-
-		if ( is_wp_error( $result ) ) {
-			return new WP_Error(
-				'rest_category_creation_failed',
-				$result->get_error_message(),
-				array( 'status' => 500 )
-			);
-		}
-
-		$term = get_term( $result['term_id'], 'category' );
-
-		return new WP_REST_Response(
-			array(
-				'id'   => $term->term_id,
-				'name' => $term->name,
-				'slug' => $term->slug,
-			),
-			201
 		);
 	}
 
@@ -775,16 +667,6 @@ class EventSourceController extends WP_REST_Controller {
 	 */
 	public function create_item_permissions_check( $request ) {
 		return current_user_can( 'manage_options' );
-	}
-
-	/**
-	 * Check permissions for creating a category
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return bool True if user has permission.
-	 */
-	public function create_category_permissions_check( $request ) {
-		return current_user_can( 'manage_categories' );
 	}
 
 	/**

--- a/fair-events/src/API/CategoriesController.php
+++ b/fair-events/src/API/CategoriesController.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * REST API Controller for event categories
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\API;
+
+defined( 'WPINC' ) || die;
+
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+/**
+ * Handles the `category` taxonomy REST endpoints used by the event editor
+ */
+class CategoriesController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-events/v1';
+
+	/**
+	 * Register the routes for categories
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		// GET /fair-events/v1/sources/categories - Get available categories
+		// POST /fair-events/v1/sources/categories - Create category
+		register_rest_route(
+			$this->namespace,
+			'/sources/categories',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array(
+						'name' => array(
+							'description' => __( 'Name of the category to create.', 'fair-events' ),
+							'type'        => 'string',
+							'required'    => true,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get available categories for event categorization
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_items( $request ) {
+		$categories = get_terms(
+			array(
+				'taxonomy'   => 'category',
+				'hide_empty' => false,
+				'orderby'    => 'name',
+				'order'      => 'ASC',
+			)
+		);
+
+		if ( is_wp_error( $categories ) ) {
+			return new WP_REST_Response( array(), 200 );
+		}
+
+		$formatted = array_map(
+			function ( $category ) {
+				return array(
+					'id'   => $category->term_id,
+					'name' => $category->name,
+					'slug' => $category->slug,
+				);
+			},
+			$categories
+		);
+
+		return new WP_REST_Response( $formatted, 200 );
+	}
+
+	/**
+	 * Create a new category for event categorization
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
+	 */
+	public function create_item( $request ) {
+		$name = sanitize_text_field( $request->get_param( 'name' ) );
+
+		if ( empty( $name ) ) {
+			return new WP_Error(
+				'rest_invalid_category_name',
+				__( 'Category name is required.', 'fair-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$existing = get_term_by( 'name', $name, 'category' );
+		if ( $existing ) {
+			return new WP_REST_Response(
+				array(
+					'id'   => $existing->term_id,
+					'name' => $existing->name,
+					'slug' => $existing->slug,
+				),
+				200
+			);
+		}
+
+		$result = wp_insert_term( $name, 'category' );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error(
+				'rest_category_creation_failed',
+				$result->get_error_message(),
+				array( 'status' => 500 )
+			);
+		}
+
+		$term = get_term( $result['term_id'], 'category' );
+
+		return new WP_REST_Response(
+			array(
+				'id'   => $term->term_id,
+				'name' => $term->name,
+				'slug' => $term->slug,
+			),
+			201
+		);
+	}
+
+	/**
+	 * Check permissions for getting categories
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool True if user has permission.
+	 */
+	public function get_items_permissions_check( $request ) {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Check permissions for creating a category
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool True if user has permission.
+	 */
+	public function create_item_permissions_check( $request ) {
+		return current_user_can( 'manage_categories' );
+	}
+}

--- a/fair-events/src/API/__tests__/CategoriesController.api.spec.js
+++ b/fair-events/src/API/__tests__/CategoriesController.api.spec.js
@@ -1,5 +1,5 @@
 /**
- * Playwright API tests for EventSourceController's category endpoints.
+ * Playwright API tests for CategoriesController.
  *
  * Verifies POST /fair-events/v1/sources/categories creates a category term,
  * is idempotent for an existing name, and enforces the permission check.
@@ -17,7 +17,7 @@ const authHeader = {
 		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
 };
 
-test.describe('EventSourceController categories', () => {
+test.describe('CategoriesController', () => {
 	let api;
 	const createdCategoryIds = [];
 

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -141,6 +141,16 @@ class Plugin {
 			}
 		);
 
+		// Categories controller — registers `/fair-events/v1/sources/categories`,
+		// used by the Manage Event admin page to create categories on the fly.
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new \FairEvents\API\CategoriesController();
+				$controller->register_routes();
+			}
+		);
+
 		if ( Features::is_enabled( 'ticketing' ) ) {
 			add_action(
 				'rest_api_init',


### PR DESCRIPTION
## Summary
- `GET`/`POST /fair-events/v1/sources/categories` lived in `fair-events-experimental`'s `EventSourceController`, gated behind the `sources` feature flag.
- The base `fair-events` plugin's Manage Event admin page already calls this endpoint to create categories on the fly, so it 404'd on plain fair-events installs without the experimental plugin's `sources` feature enabled.
- Moved the endpoint into a new `fair-events/src/API/CategoriesController.php`, registered unconditionally as a core endpoint. Removed it from the experimental controller; the `/sources`, `/sources/{id}`, and `/sources/{slug}/ical` routes stay there unchanged.
- Moved the corresponding Playwright API test to `fair-events/src/API/__tests__/CategoriesController.api.spec.js`.

## Test plan
- [ ] `npm run build` in `fair-events`
- [ ] Run `npm run test:api` against a local WP instance to confirm `CategoriesController.api.spec.js` passes
- [ ] Manually verify creating categories on the fly in the Manage Event page works with only `fair-events` active (no experimental plugin)