### PR TITLE
Add WP-CLI script to mint audience session cookies for E2E tests

### DIFF
--- a/e2e/fair-events-feature-flags.spec.js
+++ b/e2e/fair-events-feature-flags.spec.js
@@ -93,7 +93,7 @@ const BUNDLE_PAGES = {
  * resource still count as "registered").
  */
 const BUNDLE_PROBE_ROUTES = {
-	sources: '/fair-events/v1/sources/categories',
+	sources: '/fair-events/v1/sources',
 	galleries: '/fair-events/v1/event-dates/1/gallery',
 	migration: '/fair-events/v1/migration/post-types',
 };

--- a/e2e/mu-plugins/scripts/cleanup-participant.php
+++ b/e2e/mu-plugins/scripts/cleanup-participant.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Delete a single fair_audience_participants row by id.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/cleanup-participant.php <participantId>
+ *
+ * Companion to seed-known-participant.php: those participants never sign up
+ * for anything (or, for the "recognised email" one, may or may not depending
+ * on how far the spec got before failing), so cleanup-event.php's
+ * event_participants-driven cleanup can't be relied on to catch them.
+ * Deleting by id is a no-op (0 rows) if the row is already gone.
+ *
+ * Prints a single `E2E_PARTICIPANT_CLEANUP:{json}` line with the deleted row count.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+global $wpdb;
+
+$participant_id = isset( $args[0] ) ? (int) $args[0] : 0;
+if ( ! $participant_id ) {
+	WP_CLI::error( 'Usage: cleanup-participant.php <participantId>' );
+}
+
+$participants_table = $wpdb->prefix . 'fair_audience_participants';
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off teardown script, no cache to honour.
+$deleted = (int) $wpdb->query(
+	$wpdb->prepare( 'DELETE FROM %i WHERE id = %d', $participants_table, $participant_id )
+);
+// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+echo 'E2E_PARTICIPANT_CLEANUP:' . wp_json_encode( array( 'participants' => $deleted ) ) . "\n";

--- a/e2e/mu-plugins/scripts/seed-audience-session-cookie.php
+++ b/e2e/mu-plugins/scripts/seed-audience-session-cookie.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Mint a valid fair_audience_session cookie value for a participant, for the
+ * resume-anonymous-signup-on-recognised-email E2E spec.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-audience-session-cookie.php <participant_id>
+ *
+ * AudienceSession::set() can't be used directly from a CLI script — it calls
+ * setcookie(), which is a no-op outside a real HTTP response — so this
+ * reproduces its signing scheme (see FairAudience\Services\AudienceSession)
+ * to hand the spec a cookie value it can inject into the browser context
+ * with context.addCookies().
+ *
+ * Used to simulate a browser that already holds an active session for one
+ * participant when it then types a *different*, known participant's email
+ * into the anonymous signup form — the register endpoint's anti-enumeration
+ * check (`$session_pid !== $participant->id`) must still stash-and-email a
+ * resume link rather than silently acting on the session's identity.
+ *
+ * Prints a single `E2E_COOKIE:{json}` line with the cookie value.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$participant_id = isset( $args[0] ) ? (int) $args[0] : 0;
+
+if ( ! $participant_id ) {
+	WP_CLI::error( 'Usage: seed-audience-session-cookie.php <participant_id>' );
+}
+
+$expires_at = time() + HOUR_IN_SECONDS;
+$data       = $participant_id . '.' . $expires_at;
+$secret     = 'fair_audience_session_' . wp_salt( 'auth' );
+$signature  = hash_hmac( 'sha256', $data, $secret );
+$value      = $data . '.' . $signature;
+
+echo 'E2E_COOKIE:' . wp_json_encode( array( 'value' => $value ) ) . "\n";

--- a/e2e/mu-plugins/scripts/seed-known-participant.php
+++ b/e2e/mu-plugins/scripts/seed-known-participant.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Create a standalone participant (no event signup) for the resume-anonymous
+ * -signup-on-recognised-email E2E spec.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-known-participant.php <name> <email>
+ *
+ * Used to create two distinct participants: the one whose email the spec
+ * later "recognises" (triggering the register endpoint's anti-enumeration
+ * resume flow), and a second one the spec binds an unrelated
+ * fair_audience_session cookie to (via seed-audience-session-cookie.php) so
+ * the browser looks like it already has an active session for someone else
+ * when it submits the first participant's email.
+ *
+ * Prints a single `E2E_PARTICIPANT:{json}` line with the participant id.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use FairAudience\Models\Participant;
+
+$name  = isset( $args[0] ) ? (string) $args[0] : '';
+$email = isset( $args[1] ) ? (string) $args[1] : '';
+
+if ( ! $name || ! $email ) {
+	WP_CLI::error( 'Usage: seed-known-participant.php <name> <email>' );
+}
+
+$participant = new Participant(
+	array(
+		'name'          => $name,
+		'email'         => $email,
+		'email_profile' => 'minimal',
+		'status'        => 'confirmed',
+	)
+);
+if ( ! $participant->save() ) {
+	WP_CLI::error( 'Failed to create participant.' );
+}
+
+echo 'E2E_PARTICIPANT:' . wp_json_encode(
+	array(
+		'participantId' => (int) $participant->id,
+		'email'         => $email,
+	)
+) . "\n";

--- a/e2e/mu-plugins/scripts/signup-state.php
+++ b/e2e/mu-plugins/scripts/signup-state.php
@@ -6,10 +6,11 @@
  *   wp eval-file wp-content/mu-plugins/scripts/signup-state.php <email> <event_date_id>
  *
  * Prints a single `E2E_STATE:{json}` line with the participant's marketing
- * profile, the event-participant label, and the mail captured for this buyer,
- * so the spec can assert that consent was recorded only when opted in, that
- * payment flipped the row to signed_up, and that the confirmation email was
- * delivered.
+ * profile, the event-participant label, and the mail captured for this buyer
+ * (including the HTML body, so a spec can pull a link out of it, e.g. a
+ * resume-registration URL), so the spec can assert that consent was recorded
+ * only when opted in, that payment flipped the row to signed_up, and that the
+ * confirmation email was delivered.
  *
  * @package FairEventsE2E
  */
@@ -48,6 +49,7 @@ foreach ( get_option( 'fair_e2e_captured_mail', array() ) as $entry ) {
 		$mail[] = array(
 			'to'      => $entry['to'] ?? '',
 			'subject' => $entry['subject'] ?? '',
+			'body'    => $entry['body'] ?? '',
 		);
 	}
 }

--- a/e2e/user-flows/resume-signup-recognised-email.spec.js
+++ b/e2e/user-flows/resume-signup-recognised-email.spec.js
@@ -1,0 +1,175 @@
+/**
+ * E2E: resume an anonymous signup on a recognised email (#1004), including
+ * the anti-enumeration guard when the browser already holds a session for a
+ * *different* participant.
+ *
+ * The API spec (EventSignupResume.api.spec.js) covers the register/resume
+ * endpoints in isolation but only from a cookie-less request context, and
+ * can't drive the emailed resume link at all. Here we go through the real
+ * browser UI end to end:
+ *
+ *   1. The browser already has a fair_audience_session cookie for an
+ *      unrelated participant (seeded directly — AudienceSession::set() can't
+ *      be called from a CLI script, see seed-audience-session-cookie.php).
+ *      That session pre-fills the anonymous form, proving the cookie is
+ *      read, but its identity must NOT be reused for a different email.
+ *   2. Typing a second, already-registered participant's email submits the
+ *      form; since the session belongs to someone else, the server must
+ *      stash the submission and email a resume link instead of signing
+ *      anyone up (anti-enumeration — a guessed email can't be hijacked via
+ *      an unrelated active session either).
+ *   3. The resume link (extracted from the captured mail, since the dev
+ *      stack has no real inbox) is visited for real; the form must restore
+ *      into the authenticated "with_token" state and let the visitor
+ *      complete the (paid) signup they originally filled in — through the
+ *      real Mollie-double checkout/callback round trip, same as
+ *      ticket-purchase-confirmation.spec.js.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+import { runScript } from '../support/wp-cli.js';
+
+test.describe('event-signup block: resume anonymous signup on recognised email', () => {
+	test('a session for another participant does not bypass the resume-by-email flow', async ({
+		page,
+		context,
+		seedEvent,
+	}) => {
+		const event = seedEvent('paid');
+		const stamp = Date.now();
+
+		const recognisedEmail = `resume.recognised.${stamp}@example.test`;
+		const recognised = runScript(
+			'seed-known-participant.php',
+			'E2E_PARTICIPANT',
+			`'Resume Recognised ${stamp}' ${recognisedEmail}`
+		);
+
+		const sessionOwnerEmail = `resume.session-owner.${stamp}@example.test`;
+		const sessionOwner = runScript(
+			'seed-known-participant.php',
+			'E2E_PARTICIPANT',
+			`'Resume Session Owner ${stamp}' ${sessionOwnerEmail}`
+		);
+
+		const cookie = runScript(
+			'seed-audience-session-cookie.php',
+			'E2E_COOKIE',
+			String(sessionOwner.participantId)
+		);
+
+		try {
+			const pageUrl = new URL(event.pageUrl);
+			await context.addCookies([
+				{
+					name: 'fair_audience_session',
+					value: cookie.value,
+					domain: pageUrl.hostname,
+					path: '/',
+				},
+			]);
+
+			// The session cookie pre-fills the anonymous form with the session
+			// owner's details — proves the cookie is actually being read.
+			await page.goto(event.pageUrl);
+			const form = page.locator('.fair-audience-signup-register');
+			await expect(form).toBeVisible();
+			await expect(
+				form.locator('input[name="signup_email"]')
+			).toHaveValue(sessionOwnerEmail);
+
+			// Overwrite with the OTHER, already-registered participant's email —
+			// the session belongs to someone else, so this must not be treated
+			// as an authenticated resubmission of that session's identity.
+			await form
+				.locator('input[name="signup_name"]')
+				.fill('Resume Recognised Visitor');
+			await form
+				.locator('input[name="signup_email"]')
+				.fill(recognisedEmail);
+			const ticket = form.locator('input[name="ticket_type_id"]');
+			await ticket.check();
+			expect(
+				Number(await ticket.getAttribute('data-ticket-price'))
+			).toBeGreaterThan(0);
+
+			await form.locator('.fair-audience-signup-submit-button').click();
+
+			// Anti-enumeration response: generic "check your inbox" message, no
+			// signup created, no session hijack.
+			await expect(
+				page.getByText('check your inbox', { exact: false })
+			).toBeVisible();
+
+			const state = runScript(
+				'signup-state.php',
+				'E2E_STATE',
+				`${recognisedEmail} ${event.eventDateId}`
+			);
+			expect(state.label).not.toBe('signed_up');
+
+			// Pull the resume link out of the captured mail (no real inbox in
+			// this stack) and follow it as the visitor would from their email
+			// client.
+			const resumeMail = state.mail.find((m) =>
+				m.subject.includes('Continue registering')
+			);
+			expect(
+				resumeMail,
+				'a "Continue registering" resume email should be captured'
+			).toBeTruthy();
+
+			const participantTokenMatch = resumeMail.body.match(
+				/participant_token=([^"&#]+)/
+			);
+			const resumeTokenMatch = resumeMail.body.match(/resume=([^"&#]+)/);
+			expect(
+				participantTokenMatch,
+				'participant_token in resume email'
+			).toBeTruthy();
+			expect(
+				resumeTokenMatch,
+				'resume token in resume email'
+			).toBeTruthy();
+
+			await page.goto(
+				`${event.pageUrl}?participant_token=${participantTokenMatch[1]}&resume=${resumeTokenMatch[1]}`
+			);
+
+			// The restored, authenticated form shows the "welcome back" notice
+			// and lets the visitor finish the signup they originally filled in.
+			await expect(
+				page.getByText('restored your answers', { exact: false })
+			).toBeVisible();
+
+			// Complete the paid signup: the double's checkout link sends the
+			// buyer straight back to the callback URL, which syncs "paid" from
+			// the double on the reload (see ticket-purchase-confirmation.spec.js).
+			const signupButton = page.locator('.fair-audience-signup-button');
+			await expect(signupButton).toBeVisible();
+			await signupButton.click();
+			await expect(
+				page.getByText('Payment confirmed', { exact: false })
+			).toBeVisible({ timeout: 30000 });
+			await expect(page).toHaveURL(/fair_payment_callback=true/);
+
+			const finalState = runScript(
+				'signup-state.php',
+				'E2E_STATE',
+				`${recognisedEmail} ${event.eventDateId}`
+			);
+			expect(finalState.label).toBe('signed_up');
+		} finally {
+			runScript(
+				'cleanup-participant.php',
+				'E2E_PARTICIPANT_CLEANUP',
+				String(recognised.participantId)
+			);
+			runScript(
+				'cleanup-participant.php',
+				'E2E_PARTICIPANT_CLEANUP',
+				String(sessionOwner.participantId)
+			);
+		}
+	});
+});

--- a/fair-audience/src/API/EventParticipantsController.php
+++ b/fair-audience/src/API/EventParticipantsController.php
@@ -174,6 +174,34 @@ class EventParticipantsController extends WP_REST_Controller {
 			)
 		);
 
+		// POST /fair-audience/v1/event-dates/{event_date_id}/participants/{participant_id}/move.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<participant_id>\d+)/move',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'move_item' ),
+					'permission_callback' => array( $this, 'move_item_permissions_check' ),
+					'args'                => array(
+						'event_date_id'        => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'participant_id'       => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'target_event_date_id' => array(
+							'type'     => 'integer',
+							'required' => true,
+							'minimum'  => 1,
+						),
+					),
+				),
+			)
+		);
+
 		// DELETE /fair-audience/v1/event-dates/{event_date_id}/participants/batch.
 		// POST /fair-audience/v1/event-dates/{event_date_id}/participants/batch.
 		register_rest_route(
@@ -880,6 +908,75 @@ class EventParticipantsController extends WP_REST_Controller {
 	}
 
 	/**
+	 * Move a participant's signup to a sibling occurrence of the same
+	 * recurring event.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	public function move_item( $request ) {
+		$event_date_id        = (int) $request->get_param( 'event_date_id' );
+		$participant_id       = (int) $request->get_param( 'participant_id' );
+		$target_event_date_id = (int) $request->get_param( 'target_event_date_id' );
+
+		if ( ! class_exists( \FairEvents\Models\EventDates::class ) ) {
+			return new WP_Error(
+				'fair_events_unavailable',
+				__( 'The fair-events plugin is required for this action.', 'fair-audience' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+		if ( ! $event_date ) {
+			return new WP_Error(
+				'invalid_event_date',
+				__( 'Event date not found.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$master_id = ( 'generated' === $event_date->occurrence_type && $event_date->master_id )
+			? $event_date->master_id
+			: $event_date->id;
+
+		$sibling_ids = wp_list_pluck( \FairEvents\Models\EventDates::get_all_by_master_id( $master_id ), 'id' );
+
+		if ( ! in_array( $target_event_date_id, $sibling_ids, true ) ) {
+			return new WP_Error(
+				'invalid_target',
+				__( 'The target date is not another occurrence of this recurring event.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$result = $this->event_participant_repo->move_to_event_date( $event_date_id, $participant_id, $target_event_date_id );
+
+		if ( 'not_found' === $result ) {
+			return new WP_Error(
+				'not_found',
+				__( 'Signup not found on this event date.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( 'conflict' === $result ) {
+			return new WP_Error(
+				'already_signed_up',
+				__( 'This participant is already signed up on the target date.', 'fair-audience' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'message'              => __( 'Signup moved successfully.', 'fair-audience' ),
+				'target_event_date_id' => $target_event_date_id,
+			)
+		);
+	}
+
+	/**
 	 * Delete multiple participants from an event.
 	 *
 	 * @param WP_REST_Request $request Request object.
@@ -1445,6 +1542,16 @@ class EventParticipantsController extends WP_REST_Controller {
 	 * @return bool True if user has permission.
 	 */
 	public function delete_item_permissions_check( $request ) {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Check permissions for moving a signup to another occurrence.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool True if user has permission.
+	 */
+	public function move_item_permissions_check( $request ) {
 		return current_user_can( 'manage_options' );
 	}
 }

--- a/fair-audience/src/API/__tests__/EventParticipantsMove.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventParticipantsMove.api.spec.js
@@ -1,0 +1,269 @@
+/**
+ * Playwright API tests for the move-to-occurrence endpoint on
+ * EventParticipantsController.
+ *
+ * Exercises POST
+ * /fair-audience/v1/event-dates/{event_date_id}/participants/{participant_id}/move
+ * against a live WordPress instance.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+async function createParticipant(api, name) {
+	const res = await api.post('/wp-json/fair-audience/v1/participants', {
+		headers: authHeaders,
+		data: { name, email: uniqueEmail(name.replace(/\s+/g, '-')) },
+	});
+	expect(res.ok()).toBeTruthy();
+	return (await res.json()).id;
+}
+
+test.describe('EventParticipantsController — move', () => {
+	let api;
+	let eventPostId;
+	let masterEventDateId;
+	let occurrenceIds;
+	let otherEventPostId;
+	let otherEventDateId;
+	let participantAId;
+	let participantBId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: authHeaders,
+			data: { title: `Move test ${Date.now()}`, status: 'publish' },
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: authHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2036-06-01 10:00:00',
+				end_datetime: '2036-06-01 12:00:00',
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		const edBody = await edRes.json();
+		masterEventDateId = edBody.id;
+		occurrenceIds = [
+			masterEventDateId,
+			...edBody.generated_occurrences.map((o) => o.id),
+		];
+		expect(occurrenceIds.length).toBe(3);
+
+		// Unrelated event date, not part of the recurring series above.
+		const otherPostRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: authHeaders,
+			data: { title: `Unrelated event ${Date.now()}`, status: 'publish' },
+		});
+		expect(otherPostRes.ok()).toBeTruthy();
+		otherEventPostId = (await otherPostRes.json()).id;
+
+		const otherEdRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: authHeaders,
+				data: {
+					event_id: otherEventPostId,
+					start_datetime: '2036-06-15 10:00:00',
+					end_datetime: '2036-06-15 12:00:00',
+				},
+			}
+		);
+		expect(otherEdRes.ok()).toBeTruthy();
+		otherEventDateId = (await otherEdRes.json()).id;
+
+		participantAId = await createParticipant(api, 'Move Person A');
+		participantBId = await createParticipant(api, 'Move Person B');
+	});
+
+	test.afterAll(async () => {
+		for (const id of [participantAId, participantBId]) {
+			if (id) {
+				await api.delete(
+					`/wp-json/fair-audience/v1/participants/${id}`,
+					{ headers: authHeaders }
+				);
+			}
+		}
+		if (masterEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+				{ headers: authHeaders }
+			);
+		}
+		if (otherEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${otherEventDateId}`,
+				{ headers: authHeaders }
+			);
+		}
+		if (eventPostId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${eventPostId}`, {
+				headers: authHeaders,
+				params: { force: 'true' },
+			});
+		}
+		if (otherEventPostId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${otherEventPostId}`, {
+				headers: authHeaders,
+				params: { force: 'true' },
+			});
+		}
+		await api.dispose();
+	});
+
+	test('moves a signup to a sibling occurrence, preserving data', async () => {
+		const sourceId = occurrenceIds[0];
+		const targetId = occurrenceIds[1];
+
+		const addRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${sourceId}/participants`,
+			{
+				headers: authHeaders,
+				data: { participant_id: participantAId, label: 'signed_up' },
+			}
+		);
+		expect(addRes.ok()).toBeTruthy();
+
+		const updateRes = await api.put(
+			`/wp-json/fair-audience/v1/event-dates/${sourceId}/participants/${participantAId}`,
+			{
+				headers: authHeaders,
+				data: { attended: true, admin_comment: 'paid in cash' },
+			}
+		);
+		expect(updateRes.ok()).toBeTruthy();
+		const updateBody = await updateRes.json();
+		expect(updateBody.attended_at).toBeTruthy();
+
+		const moveRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${sourceId}/participants/${participantAId}/move`,
+			{
+				headers: authHeaders,
+				data: { target_event_date_id: targetId },
+			}
+		);
+		expect(moveRes.ok()).toBeTruthy();
+
+		const sourceList = await (
+			await api.get(
+				`/wp-json/fair-audience/v1/event-dates/${sourceId}/participants`,
+				{ headers: authHeaders }
+			)
+		).json();
+		expect(
+			sourceList.find((p) => p.participant_id === participantAId)
+		).toBeUndefined();
+
+		const targetList = await (
+			await api.get(
+				`/wp-json/fair-audience/v1/event-dates/${targetId}/participants`,
+				{ headers: authHeaders }
+			)
+		).json();
+		const moved = targetList.find(
+			(p) => p.participant_id === participantAId
+		);
+		expect(moved).toBeTruthy();
+		expect(moved.label).toBe('signed_up');
+		expect(moved.attended_at).toBeTruthy();
+		expect(moved.admin_comment).toBe('paid in cash');
+	});
+
+	test('moving onto a date where the participant already exists returns 409', async () => {
+		const sourceId = occurrenceIds[1];
+		const targetId = occurrenceIds[2];
+
+		// Participant A is now on occurrenceIds[1] (target of the previous test).
+		const addRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${targetId}/participants`,
+			{
+				headers: authHeaders,
+				data: { participant_id: participantAId, label: 'signed_up' },
+			}
+		);
+		expect(addRes.ok()).toBeTruthy();
+
+		const moveRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${sourceId}/participants/${participantAId}/move`,
+			{
+				headers: authHeaders,
+				data: { target_event_date_id: targetId },
+			}
+		);
+		expect(moveRes.status()).toBe(409);
+
+		// No duplicate: still exactly one row for this participant on the target.
+		const targetList = await (
+			await api.get(
+				`/wp-json/fair-audience/v1/event-dates/${targetId}/participants`,
+				{ headers: authHeaders }
+			)
+		).json();
+		expect(
+			targetList.filter((p) => p.participant_id === participantAId).length
+		).toBe(1);
+	});
+
+	test('moving a signup that does not exist on the source returns 404', async () => {
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${occurrenceIds[0]}/participants/${participantBId}/move`,
+			{
+				headers: authHeaders,
+				data: { target_event_date_id: occurrenceIds[1] },
+			}
+		);
+		expect(res.status()).toBe(404);
+	});
+
+	test('moving to a non-sibling event date returns 400', async () => {
+		const addRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${occurrenceIds[0]}/participants`,
+			{
+				headers: authHeaders,
+				data: { participant_id: participantBId, label: 'signed_up' },
+			}
+		);
+		expect(addRes.ok()).toBeTruthy();
+
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${occurrenceIds[0]}/participants/${participantBId}/move`,
+			{
+				headers: authHeaders,
+				data: { target_event_date_id: otherEventDateId },
+			}
+		);
+		expect(res.status()).toBe(400);
+	});
+
+	test('unauthenticated request is rejected', async () => {
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${occurrenceIds[0]}/participants/${participantBId}/move`,
+			{ data: { target_event_date_id: occurrenceIds[1] } }
+		);
+		expect(res.status()).toBeGreaterThanOrEqual(401);
+		expect(res.status()).toBeLessThan(404);
+	});
+});

--- a/fair-audience/src/Admin/manage-event-ext/EventAudience.js
+++ b/fair-audience/src/Admin/manage-event-ext/EventAudience.js
@@ -66,6 +66,7 @@ export default function EventAudience({
 	const [loadingParticipants, setLoadingParticipants] = useState(true);
 	const [ticketOptions, setTicketOptions] = useState([]);
 	const [ticketTypes, setTicketTypes] = useState([]);
+	const [siblings, setSiblings] = useState([]);
 	const [formsSummary, setFormsSummary] = useState([]);
 	const [loadingForms, setLoadingForms] = useState(true);
 
@@ -103,6 +104,11 @@ export default function EventAudience({
 	const [editStaleDecision, setEditStaleDecision] = useState(null);
 	const [editLabel, setEditLabel] = useState('signed_up');
 	const [isSavingOptions, setIsSavingOptions] = useState(false);
+
+	// Move-to-occurrence modal state
+	const [movingParticipant, setMovingParticipant] = useState(null);
+	const [moveTargetId, setMoveTargetId] = useState('');
+	const [isMoving, setIsMoving] = useState(false);
 
 	const [toast, setToast] = useState(null);
 	const toastTimerRef = useRef(null);
@@ -151,6 +157,19 @@ export default function EventAudience({
 			.catch(() => {
 				setTicketOptions([]);
 				setTicketTypes([]);
+			});
+	}, [eventDateId]);
+
+	useEffect(() => {
+		if (!eventDateId) return;
+		apiFetch({
+			path: `/fair-events/v1/event-dates/${eventDateId}/siblings`,
+		})
+			.then((data) => {
+				setSiblings(Array.isArray(data) ? data : []);
+			})
+			.catch(() => {
+				setSiblings([]);
 			});
 	}, [eventDateId]);
 
@@ -259,6 +278,11 @@ export default function EventAudience({
 	const stalePending = useMemo(
 		() => participants.filter(isStalePendingPayment),
 		[participants]
+	);
+
+	const otherOccurrences = useMemo(
+		() => siblings.filter((s) => Number(s.id) !== Number(eventDateId)),
+		[siblings, eventDateId]
 	);
 
 	const handleSort = (column) => {
@@ -695,6 +719,43 @@ export default function EventAudience({
 			);
 		} finally {
 			setIsSavingOptions(false);
+		}
+	};
+
+	const handleOpenMoveModal = (participant) => {
+		if (participant.is_series_pass) {
+			return;
+		}
+		setMovingParticipant(participant);
+		setMoveTargetId(
+			otherOccurrences.length > 0 ? String(otherOccurrences[0].id) : ''
+		);
+	};
+
+	const handleCloseMoveModal = () => {
+		setMovingParticipant(null);
+		setMoveTargetId('');
+	};
+
+	const handleMove = async () => {
+		if (!movingParticipant || !moveTargetId) return;
+		setIsMoving(true);
+		try {
+			await apiFetch({
+				path: `/fair-audience/v1/event-dates/${eventDateId}/participants/${movingParticipant.participant_id}/move`,
+				method: 'POST',
+				data: { target_event_date_id: Number(moveTargetId) },
+			});
+			handleCloseMoveModal();
+			loadParticipants();
+			showToast(__('Signup moved successfully.', 'fair-audience'));
+		} catch (err) {
+			showToast(
+				__('Error moving signup: ', 'fair-audience') + err.message,
+				'error'
+			);
+		} finally {
+			setIsMoving(false);
 		}
 	};
 
@@ -1220,6 +1281,7 @@ export default function EventAudience({
 									<SelectControl
 										label={__('Role', 'fair-audience')}
 										value={filterRole}
+										__next40pxDefaultSize
 										options={[
 											{
 												label: __(
@@ -1519,6 +1581,22 @@ export default function EventAudience({
 																				'fair-audience'
 																			)}
 																		</Button>
+																		{otherOccurrences.length >
+																			0 && (
+																			<Button
+																				variant="link"
+																				onClick={() =>
+																					handleOpenMoveModal(
+																						p
+																					)
+																				}
+																			>
+																				{__(
+																					'Move',
+																					'fair-audience'
+																				)}
+																			</Button>
+																		)}
 																	</HStack>
 																)}
 															</td>
@@ -2370,6 +2448,55 @@ export default function EventAudience({
 								{isSavingOptions
 									? __('Saving…', 'fair-audience')
 									: __('Save', 'fair-audience')}
+							</Button>
+						</HStack>
+					</VStack>
+				</Modal>
+			)}
+
+			{movingParticipant && (
+				<Modal
+					title={sprintf(
+						/* translators: %s: participant name */
+						__('Move signup — %s', 'fair-audience'),
+						movingParticipant.participant_name
+					)}
+					onRequestClose={handleCloseMoveModal}
+					style={{ maxWidth: '480px', width: '100%' }}
+				>
+					<VStack spacing={3}>
+						<SelectControl
+							label={__('Move to occurrence', 'fair-audience')}
+							value={moveTargetId}
+							options={otherOccurrences.map((s) => ({
+								label: new Date(
+									s.start_datetime.replace(' ', 'T')
+								).toLocaleString(),
+								value: String(s.id),
+							}))}
+							onChange={setMoveTargetId}
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+						<HStack
+							spacing={3}
+							style={{ justifyContent: 'flex-end' }}
+						>
+							<Button
+								variant="secondary"
+								onClick={handleCloseMoveModal}
+								disabled={isMoving}
+							>
+								{__('Cancel', 'fair-audience')}
+							</Button>
+							<Button
+								variant="primary"
+								onClick={handleMove}
+								disabled={!moveTargetId || isMoving}
+							>
+								{isMoving
+									? __('Moving…', 'fair-audience')
+									: __('Move', 'fair-audience')}
 							</Button>
 						</HStack>
 					</VStack>

--- a/fair-audience/src/Admin/manage-event-ext/__tests__/EventAudienceMove.test.jsx
+++ b/fair-audience/src/Admin/manage-event-ext/__tests__/EventAudienceMove.test.jsx
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Component tests for the "Move signup to another occurrence" action (#954).
+ *
+ * Exercises:
+ *   - Move button is hidden when there is only one occurrence.
+ *   - Move button appears for non-series-pass rows when siblings exist.
+ *   - Opening the modal lists the other occurrences (current one excluded).
+ *   - Confirming calls the move endpoint and refreshes the participant list.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import EventAudience from '../EventAudience.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const PARTICIPANT = {
+	id: 1,
+	participant_id: 10,
+	event_date_id: 5,
+	is_series_pass: false,
+	participant_name: 'Jane Doe',
+	name: 'Jane',
+	surname: 'Doe',
+	participant_email: 'jane@example.com',
+	email_profile: 'marketing',
+	label: 'signed_up',
+	ticket_type_id: null,
+	ticket_type_name: null,
+	attended_at: null,
+	created_at: '2026-01-01 10:00:00',
+	payment_expires_at: null,
+	ticket_option_names: [],
+	ticket_option_ids: [],
+	admin_comment: '',
+};
+
+const SIBLINGS = [
+	{ id: 5, start_datetime: '2026-01-01 10:00:00', occurrence_type: 'master' },
+	{
+		id: 6,
+		start_datetime: '2026-01-08 10:00:00',
+		occurrence_type: 'generated',
+	},
+	{
+		id: 7,
+		start_datetime: '2026-01-15 10:00:00',
+		occurrence_type: 'generated',
+	},
+];
+
+function mockApiFetchFor({ siblings }) {
+	apiFetch.mockImplementation(({ path, method }) => {
+		if (path.includes('/participants/10/move')) {
+			return Promise.resolve({
+				message: 'moved',
+				target_event_date_id: 6,
+			});
+		}
+		if (path.endsWith('/participants')) {
+			return Promise.resolve([PARTICIPANT]);
+		}
+		if (path.includes('/siblings')) {
+			return Promise.resolve(siblings);
+		}
+		if (path.includes('/tickets')) {
+			return Promise.resolve({ options: [], ticket_types: [] });
+		}
+		if (path.includes('forms-summary')) {
+			return Promise.resolve([]);
+		}
+		if (path.includes('group-permission-rules')) {
+			return Promise.resolve([]);
+		}
+		if (path.includes('/groups')) {
+			return Promise.resolve([]);
+		}
+		return Promise.resolve([]);
+	});
+}
+
+function renderAudience() {
+	render(
+		<EventAudience
+			eventId={1}
+			eventDateId={5}
+			audienceUrl="admin.php?page=fair-audience&event_date_id="
+			eventTitle="Weekly class"
+		/>
+	);
+}
+
+beforeEach(() => {
+	jest.spyOn(console, 'warn').mockImplementation(() => {});
+	jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+	jest.clearAllMocks();
+});
+
+describe('EventAudience — Move action', () => {
+	it('hides the Move button when there is only one occurrence', async () => {
+		mockApiFetchFor({ siblings: [SIBLINGS[0]] });
+		renderAudience();
+
+		expect(await screen.findByText('Jane Doe')).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Move' })
+		).not.toBeInTheDocument();
+	});
+
+	it('shows the Move button and lists sibling occurrences in the modal', async () => {
+		mockApiFetchFor({ siblings: SIBLINGS });
+		renderAudience();
+
+		const moveButton = await screen.findByRole('button', { name: 'Move' });
+		fireEvent.click(moveButton);
+
+		const modal = screen.getByRole('dialog');
+		const select = within(modal).getByRole('combobox');
+		const options = within(select).getAllByRole('option');
+
+		// Current occurrence (id 5) is excluded; the other two are listed.
+		expect(options).toHaveLength(2);
+	});
+
+	it('confirming the move calls the move endpoint with the selected target', async () => {
+		mockApiFetchFor({ siblings: SIBLINGS });
+		renderAudience();
+
+		const moveButton = await screen.findByRole('button', { name: 'Move' });
+		fireEvent.click(moveButton);
+
+		const modal = screen.getByRole('dialog');
+		fireEvent.click(within(modal).getByRole('button', { name: 'Move' }));
+
+		expect(apiFetch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				path: '/fair-audience/v1/event-dates/5/participants/10/move',
+				method: 'POST',
+				data: { target_event_date_id: 6 },
+			})
+		);
+	});
+});

--- a/fair-audience/src/Database/EventParticipantRepository.php
+++ b/fair-audience/src/Database/EventParticipantRepository.php
@@ -599,6 +599,41 @@ class EventParticipantRepository {
 	}
 
 	/**
+	 * Move a participant's signup from one event date to another.
+	 *
+	 * Re-points the link row's event_date_id in place, preserving label,
+	 * attended_at, ticket options, admin comment, and payment fields (they
+	 * reference the row id, not the event_date_id).
+	 *
+	 * @param int $event_date_id        Source event date ID.
+	 * @param int $participant_id       Participant ID.
+	 * @param int $target_event_date_id Target event date ID.
+	 * @return string 'success', 'not_found' (no source link), or 'conflict' (target already has this participant).
+	 */
+	public function move_to_event_date( $event_date_id, $participant_id, $target_event_date_id ) {
+		global $wpdb;
+
+		$relationship = $this->get_by_event_date_and_participant( $event_date_id, $participant_id );
+		if ( ! $relationship ) {
+			return 'not_found';
+		}
+
+		if ( $this->get_by_event_date_and_participant( $target_event_date_id, $participant_id ) ) {
+			return 'conflict';
+		}
+
+		$result = $wpdb->update(
+			$this->get_table_name(),
+			array( 'event_date_id' => $target_event_date_id ),
+			array( 'id' => $relationship->id ),
+			array( '%d' ),
+			array( '%d' )
+		);
+
+		return false !== $result ? 'success' : 'not_found';
+	}
+
+	/**
 	 * Get counts by label for an event date.
 	 *
 	 * @param int $event_date_id Event date ID.

--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -755,6 +755,7 @@ const SCROLL_RESTORE_KEY = 'fairAudienceOccurrenceScrollY';
 		// everything, then let them hit the (already-wired) sign up button.
 		const resumeToken = block.dataset.resumeToken || '';
 		if (resumeToken) {
+			block.scrollIntoView({ behavior: 'smooth', block: 'start' });
 			resumeStashedSignup(block, resumeToken);
 		}
 	}

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -267,8 +267,11 @@ if ( $is_valid_post_type ) {
 	// progress for this event date and synthesise a callback state from it,
 	// so the same retry / resume / pending UI shows for someone who navigated
 	// directly back to the event page instead of returning via Mollie's
-	// redirect.
-	if ( null === $callback_tx && class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
+	// redirect. Skipped when a resume_token is present: someone following the
+	// "continue where you left off" email link should always land on the
+	// friendly resume form, not a stale retry/failed-payment card from an
+	// earlier attempt.
+	if ( null === $callback_tx && empty( $resume_token ) && class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
 		$owner_participant_id = 0;
 		if ( $participant ) {
 			$owner_participant_id = (int) $participant->id;

--- a/fair-events-experimental/package.json
+++ b/fair-events-experimental/package.json
@@ -21,7 +21,8 @@
 		"makemo": "wp i18n make-mo languages/",
 		"updatepo": "wp i18n update-po languages/fair-events-experimental.pot languages/",
 		"test": "npm-run-all test:js",
-		"test:js": "jest --passWithNoTests"
+		"test:js": "jest --passWithNoTests",
+		"test:api": "playwright test src/API/__tests__/"
 	},
 	"dependencies": {
 		"fair-events-shared": "*",
@@ -35,6 +36,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.28.3",
 		"@babel/preset-env": "^7.28.3",
+		"@playwright/test": "^1.40.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",

--- a/fair-events-experimental/playwright.config.js
+++ b/fair-events-experimental/playwright.config.js
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export default defineConfig({
+	testDir: './',
+	testMatch: ['src/API/__tests__/**/*.api.spec.js'],
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: 1,
+	reporter: process.env.CI ? 'github' : 'line',
+	use: {
+		baseURL: process.env.WP_BASE_URL || 'http://localhost:8080',
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+		viewport: { width: 1200, height: 900 },
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+	webServer: process.env.CI
+		? undefined
+		: {
+				command: 'docker compose up',
+				url: 'http://localhost:8080',
+				reuseExistingServer: !process.env.CI,
+				timeout: 120 * 1000,
+		  },
+});

--- a/fair-events-experimental/src/API/EventSourceController.php
+++ b/fair-events-experimental/src/API/EventSourceController.php
@@ -113,6 +113,7 @@ class EventSourceController extends WP_REST_Controller {
 		);
 
 		// GET /fair-events/v1/sources/categories - Get available categories
+		// POST /fair-events/v1/sources/categories - Create category
 		register_rest_route(
 			$this->namespace,
 			'/sources/categories',
@@ -121,6 +122,18 @@ class EventSourceController extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_categories' ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_category' ),
+					'permission_callback' => array( $this, 'create_category_permissions_check' ),
+					'args'                => array(
+						'name' => array(
+							'description' => __( 'Name of the category to create.', 'fair-events' ),
+							'type'        => 'string',
+							'required'    => true,
+						),
+					),
 				),
 			)
 		);
@@ -372,6 +385,57 @@ class EventSourceController extends WP_REST_Controller {
 		);
 
 		return new WP_REST_Response( $formatted, 200 );
+	}
+
+	/**
+	 * Create a new category for event categorization
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
+	 */
+	public function create_category( $request ) {
+		$name = sanitize_text_field( $request->get_param( 'name' ) );
+
+		if ( empty( $name ) ) {
+			return new WP_Error(
+				'rest_invalid_category_name',
+				__( 'Category name is required.', 'fair-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$existing = get_term_by( 'name', $name, 'category' );
+		if ( $existing ) {
+			return new WP_REST_Response(
+				array(
+					'id'   => $existing->term_id,
+					'name' => $existing->name,
+					'slug' => $existing->slug,
+				),
+				200
+			);
+		}
+
+		$result = wp_insert_term( $name, 'category' );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error(
+				'rest_category_creation_failed',
+				$result->get_error_message(),
+				array( 'status' => 500 )
+			);
+		}
+
+		$term = get_term( $result['term_id'], 'category' );
+
+		return new WP_REST_Response(
+			array(
+				'id'   => $term->term_id,
+				'name' => $term->name,
+				'slug' => $term->slug,
+			),
+			201
+		);
 	}
 
 	/**
@@ -711,6 +775,16 @@ class EventSourceController extends WP_REST_Controller {
 	 */
 	public function create_item_permissions_check( $request ) {
 		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Check permissions for creating a category
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool True if user has permission.
+	 */
+	public function create_category_permissions_check( $request ) {
+		return current_user_can( 'manage_categories' );
 	}
 
 	/**

--- a/fair-events-experimental/src/API/EventSourceController.php
+++ b/fair-events-experimental/src/API/EventSourceController.php
@@ -112,31 +112,8 @@ class EventSourceController extends WP_REST_Controller {
 			)
 		);
 
-		// GET /fair-events/v1/sources/categories - Get available categories
-		// POST /fair-events/v1/sources/categories - Create category
-		register_rest_route(
-			$this->namespace,
-			'/sources/categories',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_categories' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				),
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'create_category' ),
-					'permission_callback' => array( $this, 'create_category_permissions_check' ),
-					'args'                => array(
-						'name' => array(
-							'description' => __( 'Name of the category to create.', 'fair-events' ),
-							'type'        => 'string',
-							'required'    => true,
-						),
-					),
-				),
-			)
-		);
+		// GET /fair-events/v1/sources/categories is registered by
+		// \FairEvents\API\CategoriesController in the base plugin.
 
 		// GET /fair-events/v1/sources/{slug}/ical - Get iCal feed for source
 		register_rest_route(
@@ -350,91 +327,6 @@ class EventSourceController extends WP_REST_Controller {
 				'source'  => $existing,
 			),
 			200
-		);
-	}
-
-	/**
-	 * Get available categories for event categorization
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_REST_Response Response object.
-	 */
-	public function get_categories( $request ) {
-		$categories = get_terms(
-			array(
-				'taxonomy'   => 'category',
-				'hide_empty' => false,
-				'orderby'    => 'name',
-				'order'      => 'ASC',
-			)
-		);
-
-		if ( is_wp_error( $categories ) ) {
-			return new WP_REST_Response( array(), 200 );
-		}
-
-		$formatted = array_map(
-			function ( $category ) {
-				return array(
-					'id'   => $category->term_id,
-					'name' => $category->name,
-					'slug' => $category->slug,
-				);
-			},
-			$categories
-		);
-
-		return new WP_REST_Response( $formatted, 200 );
-	}
-
-	/**
-	 * Create a new category for event categorization
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
-	 */
-	public function create_category( $request ) {
-		$name = sanitize_text_field( $request->get_param( 'name' ) );
-
-		if ( empty( $name ) ) {
-			return new WP_Error(
-				'rest_invalid_category_name',
-				__( 'Category name is required.', 'fair-events' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		$existing = get_term_by( 'name', $name, 'category' );
-		if ( $existing ) {
-			return new WP_REST_Response(
-				array(
-					'id'   => $existing->term_id,
-					'name' => $existing->name,
-					'slug' => $existing->slug,
-				),
-				200
-			);
-		}
-
-		$result = wp_insert_term( $name, 'category' );
-
-		if ( is_wp_error( $result ) ) {
-			return new WP_Error(
-				'rest_category_creation_failed',
-				$result->get_error_message(),
-				array( 'status' => 500 )
-			);
-		}
-
-		$term = get_term( $result['term_id'], 'category' );
-
-		return new WP_REST_Response(
-			array(
-				'id'   => $term->term_id,
-				'name' => $term->name,
-				'slug' => $term->slug,
-			),
-			201
 		);
 	}
 
@@ -775,16 +667,6 @@ class EventSourceController extends WP_REST_Controller {
 	 */
 	public function create_item_permissions_check( $request ) {
 		return current_user_can( 'manage_options' );
-	}
-
-	/**
-	 * Check permissions for creating a category
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return bool True if user has permission.
-	 */
-	public function create_category_permissions_check( $request ) {
-		return current_user_can( 'manage_categories' );
 	}
 
 	/**

--- a/fair-events-experimental/src/API/__tests__/EventSourceController.api.spec.js
+++ b/fair-events-experimental/src/API/__tests__/EventSourceController.api.spec.js
@@ -1,0 +1,95 @@
+/**
+ * Playwright API tests for EventSourceController's category endpoints.
+ *
+ * Verifies POST /fair-events/v1/sources/categories creates a category term,
+ * is idempotent for an existing name, and enforces the permission check.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeader = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('EventSourceController categories', () => {
+	let api;
+	const createdCategoryIds = [];
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		for (const id of createdCategoryIds) {
+			await api.delete(`/wp-json/wp/v2/categories/${id}?force=true`, {
+				headers: authHeader,
+			});
+		}
+		await api.dispose();
+	});
+
+	test('creates a new category and returns its id, name, and slug', async () => {
+		const name = `API Test Category ${Date.now()}`;
+		const res = await api.post(
+			'/wp-json/fair-events/v1/sources/categories',
+			{
+				headers: authHeader,
+				data: { name },
+			}
+		);
+
+		expect(res.status()).toBe(201);
+		const body = await res.json();
+		createdCategoryIds.push(body.id);
+
+		expect(body).toHaveProperty('id');
+		expect(body.name).toBe(name);
+		expect(body).toHaveProperty('slug');
+	});
+
+	test('is idempotent when the category name already exists', async () => {
+		const name = `API Test Category Dup ${Date.now()}`;
+
+		const first = await api.post(
+			'/wp-json/fair-events/v1/sources/categories',
+			{
+				headers: authHeader,
+				data: { name },
+			}
+		);
+		expect(first.status()).toBe(201);
+		const firstBody = await first.json();
+		createdCategoryIds.push(firstBody.id);
+
+		const second = await api.post(
+			'/wp-json/fair-events/v1/sources/categories',
+			{
+				headers: authHeader,
+				data: { name },
+			}
+		);
+		expect(second.status()).toBe(200);
+		const secondBody = await second.json();
+
+		expect(secondBody.id).toBe(firstBody.id);
+	});
+
+	test('rejects requests without permission', async () => {
+		const anonymousApi = await request.newContext({ baseURL: BASE_URL });
+		const res = await anonymousApi.post(
+			'/wp-json/fair-events/v1/sources/categories',
+			{
+				data: { name: `API Test Category Unauth ${Date.now()}` },
+			}
+		);
+
+		expect(res.status()).toBe(401);
+		await anonymousApi.dispose();
+	});
+});

--- a/fair-events/src/API/CategoriesController.php
+++ b/fair-events/src/API/CategoriesController.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * REST API Controller for event categories
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\API;
+
+defined( 'WPINC' ) || die;
+
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+/**
+ * Handles the `category` taxonomy REST endpoints used by the event editor
+ */
+class CategoriesController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-events/v1';
+
+	/**
+	 * Register the routes for categories
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		// GET /fair-events/v1/sources/categories - Get available categories
+		// POST /fair-events/v1/sources/categories - Create category
+		register_rest_route(
+			$this->namespace,
+			'/sources/categories',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array(
+						'name' => array(
+							'description' => __( 'Name of the category to create.', 'fair-events' ),
+							'type'        => 'string',
+							'required'    => true,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get available categories for event categorization
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_items( $request ) {
+		$categories = get_terms(
+			array(
+				'taxonomy'   => 'category',
+				'hide_empty' => false,
+				'orderby'    => 'name',
+				'order'      => 'ASC',
+			)
+		);
+
+		if ( is_wp_error( $categories ) ) {
+			return new WP_REST_Response( array(), 200 );
+		}
+
+		$formatted = array_map(
+			function ( $category ) {
+				return array(
+					'id'   => $category->term_id,
+					'name' => $category->name,
+					'slug' => $category->slug,
+				);
+			},
+			$categories
+		);
+
+		return new WP_REST_Response( $formatted, 200 );
+	}
+
+	/**
+	 * Create a new category for event categorization
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
+	 */
+	public function create_item( $request ) {
+		$name = sanitize_text_field( $request->get_param( 'name' ) );
+
+		if ( empty( $name ) ) {
+			return new WP_Error(
+				'rest_invalid_category_name',
+				__( 'Category name is required.', 'fair-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$existing = get_term_by( 'name', $name, 'category' );
+		if ( $existing ) {
+			return new WP_REST_Response(
+				array(
+					'id'   => $existing->term_id,
+					'name' => $existing->name,
+					'slug' => $existing->slug,
+				),
+				200
+			);
+		}
+
+		$result = wp_insert_term( $name, 'category' );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error(
+				'rest_category_creation_failed',
+				$result->get_error_message(),
+				array( 'status' => 500 )
+			);
+		}
+
+		$term = get_term( $result['term_id'], 'category' );
+
+		return new WP_REST_Response(
+			array(
+				'id'   => $term->term_id,
+				'name' => $term->name,
+				'slug' => $term->slug,
+			),
+			201
+		);
+	}
+
+	/**
+	 * Check permissions for getting categories
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool True if user has permission.
+	 */
+	public function get_items_permissions_check( $request ) {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Check permissions for creating a category
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool True if user has permission.
+	 */
+	public function create_item_permissions_check( $request ) {
+		return current_user_can( 'manage_categories' );
+	}
+}

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -201,6 +201,25 @@ class EventDatesController extends WP_REST_Controller {
 			)
 		);
 
+		// GET /fair-events/v1/event-dates/{id}/siblings - List sibling occurrences.
+		register_rest_route(
+			$this->namespace,
+			'/event-dates/(?P<id>\d+)/siblings',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_siblings' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'description' => __( 'Unique identifier for the event date.', 'fair-events' ),
+							'type'        => 'integer',
+						),
+					),
+				),
+			)
+		);
+
 		// GET /fair-events/v1/event-dates/batch - Batch lookup by IDs.
 		register_rest_route(
 			$this->namespace,
@@ -665,6 +684,46 @@ class EventDatesController extends WP_REST_Controller {
 		}
 
 		return new WP_REST_Response( $this->prepare_event_date( $event_date ), 200 );
+	}
+
+	/**
+	 * Get sibling occurrences for a recurring event
+	 *
+	 * Resolves the master occurrence for the given event date, then returns
+	 * the master plus all of its generated occurrences (single/standalone
+	 * events return just themselves).
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
+	 */
+	public function get_siblings( $request ) {
+		$id         = (int) $request->get_param( 'id' );
+		$event_date = EventDates::get_by_id( $id );
+
+		if ( ! $event_date ) {
+			return new WP_Error(
+				'rest_event_date_not_found',
+				__( 'Event date not found.', 'fair-events' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$master_id = ( 'generated' === $event_date->occurrence_type && $event_date->master_id )
+			? $event_date->master_id
+			: $event_date->id;
+
+		$siblings = EventDates::get_all_by_master_id( $master_id );
+
+		$items = array();
+		foreach ( $siblings as $sibling ) {
+			$items[] = array(
+				'id'              => $sibling->id,
+				'start_datetime'  => $sibling->start_datetime,
+				'occurrence_type' => $sibling->occurrence_type,
+			);
+		}
+
+		return new WP_REST_Response( $items, 200 );
 	}
 
 	/**

--- a/fair-events/src/API/__tests__/CategoriesController.api.spec.js
+++ b/fair-events/src/API/__tests__/CategoriesController.api.spec.js
@@ -1,5 +1,5 @@
 /**
- * Playwright API tests for EventSourceController's category endpoints.
+ * Playwright API tests for CategoriesController.
  *
  * Verifies POST /fair-events/v1/sources/categories creates a category term,
  * is idempotent for an existing name, and enforces the permission check.
@@ -17,7 +17,7 @@ const authHeader = {
 		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
 };
 
-test.describe('EventSourceController categories', () => {
+test.describe('CategoriesController', () => {
 	let api;
 	const createdCategoryIds = [];
 

--- a/fair-events/src/API/__tests__/EventDatesSiblings.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesSiblings.api.spec.js
@@ -1,0 +1,147 @@
+/**
+ * Playwright API tests for the sibling-occurrences endpoint on
+ * EventDatesController.
+ *
+ * Exercises GET /fair-events/v1/event-dates/{id}/siblings against a live
+ * WordPress instance.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('EventDatesController — siblings', () => {
+	let api;
+	let eventPostId;
+	let masterEventDateId;
+	let generatedIds;
+	let standaloneEventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: { title: `Siblings test ${Date.now()}`, status: 'publish' },
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2036-04-01 10:00:00',
+				end_datetime: '2036-04-01 12:00:00',
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		const edBody = await edRes.json();
+		masterEventDateId = edBody.id;
+		generatedIds = edBody.generated_occurrences.map((o) => o.id);
+		expect(generatedIds.length).toBe(2);
+
+		const standaloneRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Standalone sibling test ${Date.now()}`,
+					start_datetime: '2036-05-01 10:00:00',
+				},
+			}
+		);
+		expect(standaloneRes.ok()).toBeTruthy();
+		standaloneEventDateId = (await standaloneRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (masterEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (standaloneEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${standaloneEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (eventPostId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${eventPostId}`, {
+				headers: adminHeaders,
+				params: { force: 'true' },
+			});
+		}
+		await api.dispose();
+	});
+
+	test('returns master plus generated occurrences from the master id', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/siblings`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const ids = body.map((s) => s.id);
+		expect(ids).toContain(masterEventDateId);
+		generatedIds.forEach((id) => expect(ids).toContain(id));
+		expect(body.length).toBe(3);
+
+		const master = body.find((s) => s.id === masterEventDateId);
+		expect(master.occurrence_type).toBe('master');
+	});
+
+	test('returns the same set from a generated occurrence id', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${generatedIds[0]}/siblings`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const ids = body.map((s) => s.id);
+		expect(ids).toContain(masterEventDateId);
+		generatedIds.forEach((id) => expect(ids).toContain(id));
+		expect(body.length).toBe(3);
+	});
+
+	test('standalone (single) event returns only itself', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${standaloneEventDateId}/siblings`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		expect(body.length).toBe(1);
+		expect(body[0].id).toBe(standaloneEventDateId);
+	});
+
+	test('unknown event date returns 404', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/event-dates/999999999/siblings',
+			{ headers: adminHeaders }
+		);
+		expect(res.status()).toBe(404);
+	});
+
+	test('unauthenticated request is rejected', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/siblings`
+		);
+		expect(res.status()).toBeGreaterThanOrEqual(401);
+		expect(res.status()).toBeLessThan(404);
+	});
+});

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -37,6 +37,7 @@ export default function EventTickets({
 	startDatetime,
 	endDatetime: endDatetimeProp,
 	isRecurring,
+	onDirtyChange,
 }) {
 	const [capacity, setCapacity] = useState('');
 	const [endDatetime, setEndDatetime] = useState(
@@ -68,6 +69,12 @@ export default function EventTickets({
 	const [participants, setParticipants] = useState([]);
 	const fileInputRef = useRef(null);
 
+	// Dirty-state tracking (#987): snapshot the save payload right after it's
+	// loaded/saved so we can detect unsaved edits by re-serializing and
+	// comparing.
+	const [snapshot, setSnapshot] = useState(null);
+	const [loadGen, setLoadGen] = useState(0);
+
 	const manageInvitationsUrl =
 		window.fairEventsManageEventData?.manageInvitationsUrl || '';
 
@@ -91,6 +98,7 @@ export default function EventTickets({
 	const participantSuggestions = participants.map(formatParticipantLabel);
 
 	const populateFromData = useCallback((data) => {
+		setLoadGen((g) => g + 1);
 		setCapacity(
 			data.capacity !== null && data.capacity !== undefined
 				? String(data.capacity)
@@ -182,142 +190,6 @@ export default function EventTickets({
 			onSaveRef.current = handleSave;
 		}
 	});
-
-	useEffect(() => {
-		if (onDataRef) {
-			onDataRef.current = () => {
-				const pricesArray = [];
-				ticketTypes.forEach((type, tIndex) => {
-					salePeriods.forEach((period, pIndex) => {
-						const val = getPrice(type, period);
-						if (!val.enabled) return;
-						if (val.price === '' && val.capacity === '') return;
-						pricesArray.push({
-							ticket_type_index: tIndex,
-							sale_period_index: pIndex,
-							price: parseFloat(val.price) || 0,
-							capacity:
-								val.capacity !== ''
-									? parseInt(val.capacity, 10)
-									: null,
-						});
-					});
-				});
-				return {
-					capacity: capacity !== '' ? parseInt(capacity, 10) : null,
-					ticket_types: ticketTypes.map((t, i) => ({
-						...t,
-						sort_order: i,
-					})),
-					sale_periods: getEffectiveSalePeriods().map((p, i) => ({
-						...p,
-						sort_order: i,
-					})),
-					prices: pricesArray,
-					settings,
-				};
-			};
-		}
-	});
-
-	const handleSave = async () => {
-		setSaving(true);
-		setError(null);
-		setSuccess(null);
-
-		const pricesArray = [];
-		ticketTypes.forEach((type, tIndex) => {
-			salePeriods.forEach((period, pIndex) => {
-				const val = getPrice(type, period);
-				if (!val.enabled) return;
-				if (val.price === '' && val.capacity === '') return;
-				pricesArray.push({
-					ticket_type_index: tIndex,
-					sale_period_index: pIndex,
-					price: parseFloat(val.price) || 0,
-					capacity:
-						val.capacity !== '' ? parseInt(val.capacity, 10) : null,
-				});
-			});
-		});
-
-		try {
-			const data = await apiFetch({
-				path: `/fair-events/v1/event-dates/${eventDateId}/tickets`,
-				method: 'PUT',
-				data: {
-					capacity: capacity !== '' ? parseInt(capacity, 10) : null,
-					ticket_types: ticketTypes.map((t, i) => ({
-						...t,
-						sort_order: i,
-					})),
-					sale_periods: getEffectiveSalePeriods().map((p, i) => ({
-						...p,
-						sort_order: i,
-					})),
-					prices: pricesArray,
-					settings,
-					options: options.map((o, i) =>
-						serializeOptionForSave(o, i)
-					),
-				},
-			});
-
-			setCapacity(
-				data.capacity !== null && data.capacity !== undefined
-					? String(data.capacity)
-					: ''
-			);
-			setTicketTypes(data.ticket_types || []);
-			setSalePeriods(
-				(data.sale_periods || []).map((p) => ({
-					...p,
-					sale_start: p.sale_start
-						? p.sale_start.split(' ')[0].split('T')[0]
-						: '',
-					sale_end: p.sale_end
-						? p.sale_end.split(' ')[0].split('T')[0]
-						: '',
-				}))
-			);
-
-			const priceMap = {};
-			(data.ticket_types || []).forEach((type) => {
-				(data.sale_periods || []).forEach((period) => {
-					priceMap[`${type.id}-${period.id}`] = {
-						price: '',
-						capacity: '',
-						enabled: false,
-					};
-				});
-			});
-			(data.prices || []).forEach((p) => {
-				const key = `${p.ticket_type_id}-${p.sale_period_id}`;
-				priceMap[key] = {
-					price: String(p.price),
-					capacity:
-						p.capacity !== null && p.capacity !== undefined
-							? String(p.capacity)
-							: '',
-					enabled: true,
-				};
-			});
-			setPrices(priceMap);
-
-			if (data.settings) {
-				setSettings((prev) => ({ ...prev, ...data.settings }));
-			}
-			setOptions((data.options || []).map(normalizeOption));
-
-			setSuccess(__('Tickets saved successfully.', 'fair-events'));
-		} catch (err) {
-			setError(
-				err.message || __('Failed to save tickets.', 'fair-events')
-			);
-		} finally {
-			setSaving(false);
-		}
-	};
 
 	const buildExportPayload = () => {
 		const exportPrices = [];
@@ -776,6 +648,90 @@ export default function EventTickets({
 		return prices[key] || { price: '', capacity: '', enabled: true };
 	};
 
+	// Full save payload — shared by handleSave, the onDataRef consumer, and
+	// the dirty-state snapshot comparison.
+	const buildSavePayload = () => {
+		const pricesArray = [];
+		ticketTypes.forEach((type, tIndex) => {
+			salePeriods.forEach((period, pIndex) => {
+				const val = getPrice(type, period);
+				if (!val.enabled) return;
+				if (val.price === '' && val.capacity === '') return;
+				pricesArray.push({
+					ticket_type_index: tIndex,
+					sale_period_index: pIndex,
+					price: parseFloat(val.price) || 0,
+					capacity:
+						val.capacity !== '' ? parseInt(val.capacity, 10) : null,
+				});
+			});
+		});
+
+		return {
+			capacity: capacity !== '' ? parseInt(capacity, 10) : null,
+			ticket_types: ticketTypes.map((t, i) => ({
+				...t,
+				sort_order: i,
+			})),
+			sale_periods: getEffectiveSalePeriods().map((p, i) => ({
+				...p,
+				sort_order: i,
+			})),
+			prices: pricesArray,
+			settings,
+			options: options.map((o, i) => serializeOptionForSave(o, i)),
+		};
+	};
+
+	useEffect(() => {
+		if (onDataRef) {
+			onDataRef.current = buildSavePayload;
+		}
+	});
+
+	// Re-baseline the snapshot whenever populateFromData() runs (initial load
+	// or a fresh save). Gated on loadGen — a state value set in the same
+	// batch as the loaded ticketTypes/salePeriods/etc. — rather than a ref,
+	// so this effect's closure only reads those fields once React has
+	// actually committed the loaded values (a ref flip is visible to effects
+	// in the same commit, before the batched setState calls have flushed).
+	useEffect(() => {
+		setSnapshot(JSON.stringify(buildSavePayload()));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [loadGen]);
+
+	const dirty =
+		snapshot !== null && snapshot !== JSON.stringify(buildSavePayload());
+
+	useEffect(() => {
+		if (onDirtyChange) {
+			onDirtyChange(dirty);
+		}
+	}, [dirty, onDirtyChange]);
+
+	const handleSave = async () => {
+		setSaving(true);
+		setError(null);
+		setSuccess(null);
+
+		try {
+			const data = await apiFetch({
+				path: `/fair-events/v1/event-dates/${eventDateId}/tickets`,
+				method: 'PUT',
+				data: buildSavePayload(),
+			});
+
+			populateFromData(data);
+			setSuccess(__('Tickets saved successfully.', 'fair-events'));
+		} catch (err) {
+			setError(
+				err.message || __('Failed to save tickets.', 'fair-events')
+			);
+		} finally {
+			setSaving(false);
+		}
+	};
+
 	const siteCurrency = window.fairPaymentsConnector?.currency || 'EUR';
 
 	const formatCurrency = (value) => {
@@ -821,39 +777,49 @@ export default function EventTickets({
 				</Notice>
 			)}
 
-			<HStack spacing={2} justify="flex-end">
-				{(hasInvitationTickets ||
-					settings.activity_collaborator_discount) &&
-					manageInvitationsUrl && (
-						<Button
-							variant="secondary"
-							href={`${manageInvitationsUrl}${eventDateId}`}
-						>
-							{__('Manage Invitations', 'fair-events')}
-						</Button>
-					)}
+			<HStack spacing={2} justify="space-between">
 				<Button
-					variant="secondary"
-					onClick={handleExport}
-					disabled={importing || saving}
+					variant="primary"
+					onClick={handleSave}
+					isBusy={saving}
+					disabled={saving}
 				>
-					{__('Export ticket settings', 'fair-events')}
+					{__('Save tickets', 'fair-events')}
 				</Button>
-				<Button
-					variant="secondary"
-					onClick={() => fileInputRef.current?.click()}
-					disabled={importing || saving}
-					isBusy={importing}
-				>
-					{__('Import ticket settings', 'fair-events')}
-				</Button>
-				<input
-					ref={fileInputRef}
-					type="file"
-					accept="application/json,.json"
-					style={{ display: 'none' }}
-					onChange={handleImportFile}
-				/>
+				<HStack spacing={2} justify="flex-end">
+					{(hasInvitationTickets ||
+						settings.activity_collaborator_discount) &&
+						manageInvitationsUrl && (
+							<Button
+								variant="secondary"
+								href={`${manageInvitationsUrl}${eventDateId}`}
+							>
+								{__('Manage Invitations', 'fair-events')}
+							</Button>
+						)}
+					<Button
+						variant="secondary"
+						onClick={handleExport}
+						disabled={importing || saving}
+					>
+						{__('Export ticket settings', 'fair-events')}
+					</Button>
+					<Button
+						variant="secondary"
+						onClick={() => fileInputRef.current?.click()}
+						disabled={importing || saving}
+						isBusy={importing}
+					>
+						{__('Import ticket settings', 'fair-events')}
+					</Button>
+					<input
+						ref={fileInputRef}
+						type="file"
+						accept="application/json,.json"
+						style={{ display: 'none' }}
+						onChange={handleImportFile}
+					/>
+				</HStack>
 			</HStack>
 
 			{!hasAdvancedTickets && (

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -106,15 +106,19 @@ export default function ManageEventApp() {
 	const [linkingPost, setLinkingPost] = useState(false);
 	const [linkPostId, setLinkPostId] = useState('');
 	const [searchResults, setSearchResults] = useState([]);
-	const [activeTab, setActiveTab] = useState(
-		() =>
-			new URLSearchParams(window.location.search).get('tab') ||
-			'event-details'
-	);
-	const ticketSaveRef = useRef(null);
 	const [togglingExdate, setTogglingExdate] = useState(null);
 	const [recurrenceImpact, setRecurrenceImpact] = useState(null);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+	// Dirty-state tracking (#987): snapshot the saved form/ticket state so we
+	// can warn before losing edits and mark which tab holds them.
+	const [detailsSnapshot, setDetailsSnapshot] = useState(null);
+	const detailsJustLoadedRef = useRef(false);
+	const [ticketsDirty, setTicketsDirty] = useState(false);
+	const handleTicketsDirtyChange = useCallback(
+		(isDirty) => setTicketsDirty(isDirty),
+		[]
+	);
 
 	useEffect(() => {
 		if (!eventDateId) {
@@ -187,6 +191,7 @@ export default function ManageEventApp() {
 	};
 
 	const populateForm = (data) => {
+		detailsJustLoadedRef.current = true;
 		setTitle(data.title || '');
 		setAllDay(data.all_day || false);
 		setLinkType(data.link_type || 'none');
@@ -214,6 +219,55 @@ export default function ManageEventApp() {
 			setRecurrenceEnabled(false);
 		}
 	};
+
+	// Plain-object snapshot of every Event Details field, used to detect
+	// unsaved edits (#987). Keep in sync with the fields populateForm() sets.
+	const buildDetailsSnapshot = () =>
+		JSON.stringify({
+			title,
+			allDay,
+			startDate,
+			startTime,
+			endDate,
+			endTime,
+			venueId,
+			address,
+			linkType,
+			externalUrl,
+			categories: [...categories].sort(),
+			recurrenceEnabled,
+			recurrenceFrequency,
+			recurrenceEndType,
+			recurrenceCount,
+			recurrenceUntil,
+		});
+
+	// Runs after every render; only commits a new snapshot right after
+	// populateForm() flagged one (initial load or a fresh save/link/unlink),
+	// once all its setState calls have been applied.
+	useEffect(() => {
+		if (detailsJustLoadedRef.current) {
+			setDetailsSnapshot(buildDetailsSnapshot());
+			detailsJustLoadedRef.current = false;
+		}
+	});
+
+	const detailsDirty =
+		detailsSnapshot !== null && detailsSnapshot !== buildDetailsSnapshot();
+
+	// Warn before losing unsaved edits on either tab that can be dirty.
+	useEffect(() => {
+		if (!detailsDirty && !ticketsDirty) {
+			return;
+		}
+		const handleBeforeUnload = (event) => {
+			event.preventDefault();
+			event.returnValue = '';
+		};
+		window.addEventListener('beforeunload', handleBeforeUnload);
+		return () =>
+			window.removeEventListener('beforeunload', handleBeforeUnload);
+	}, [detailsDirty, ticketsDirty]);
 
 	// Duration options
 	const timedDurationOptions = useMemo(
@@ -397,6 +451,7 @@ export default function ManageEventApp() {
 					: null
 			);
 			setSuccess(__('Event updated successfully.', 'fair-events'));
+			setDetailsSnapshot(buildDetailsSnapshot());
 		} catch (err) {
 			setError(
 				err.message || __('Failed to update event.', 'fair-events')
@@ -592,7 +647,6 @@ export default function ManageEventApp() {
 	}, []);
 
 	const handleTabSelect = useCallback((tabName) => {
-		setActiveTab(tabName);
 		const url = new URL(window.location.href);
 		if (tabName === 'event-details') {
 			url.searchParams.delete('tab');
@@ -631,10 +685,10 @@ export default function ManageEventApp() {
 			render: () => (
 				<EventTickets
 					eventDateId={eventDateId}
-					onSaveRef={ticketSaveRef}
 					startDatetime={eventDate.start_datetime}
 					endDatetime={eventDate.end_datetime}
 					isRecurring={recurrenceEnabled}
+					onDirtyChange={handleTicketsDirtyChange}
 				/>
 			),
 		},
@@ -718,10 +772,16 @@ export default function ManageEventApp() {
 		.filter((t) => t.isVisible)
 		.sort((a, b) => a.order - b.order);
 
+	// Tabs whose section currently holds unsaved edits get a " •" marker.
+	const dirtyTabNames = {
+		'event-details': detailsDirty,
+		tickets: ticketsDirty,
+	};
+
 	// Shape TabPanel expects: { name, title, disabled? }.
 	const tabs = tabDescriptors.map(({ name, title: tabTitle, disabled }) => ({
 		name,
-		title: tabTitle,
+		title: dirtyTabNames[name] ? `${tabTitle} •` : tabTitle,
 		...(disabled ? { disabled } : {}),
 	}));
 
@@ -1066,6 +1126,26 @@ export default function ManageEventApp() {
 
 				{renderLinksTab()}
 			</div>
+
+			<HStack
+				spacing={2}
+				style={{ marginTop: '16px' }}
+				justify="flex-start"
+			>
+				<Button
+					variant="primary"
+					onClick={handleSave}
+					isBusy={saving}
+					disabled={saving || !title.trim()}
+				>
+					{__('Save event details', 'fair-events')}
+				</Button>
+				{!title.trim() && (
+					<span style={{ color: '#d63638' }}>
+						{__('Title is required', 'fair-events')}
+					</span>
+				)}
+			</HStack>
 		</>
 	);
 
@@ -1367,22 +1447,6 @@ export default function ManageEventApp() {
 			</TabPanel>
 
 			<HStack spacing={2} style={{ marginTop: '16px' }}>
-				<Button
-					variant="primary"
-					onClick={
-						activeTab === 'tickets'
-							? () => ticketSaveRef.current?.()
-							: handleSave
-					}
-					isBusy={saving}
-					disabled={
-						activeTab === 'event-details'
-							? saving || !title.trim()
-							: saving
-					}
-				>
-					{__('Save Changes', 'fair-events')}
-				</Button>
 				<Button variant="secondary" href={calendarUrl}>
 					{__('Back to Calendar', 'fair-events')}
 				</Button>

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -87,6 +87,7 @@ export default function ManageEventApp() {
 	const [externalUrl, setExternalUrl] = useState('');
 	const [categories, setCategories] = useState([]);
 	const [availableCategories, setAvailableCategories] = useState([]);
+	const [creatingCategories, setCreatingCategories] = useState([]);
 
 	// Recurrence state
 	const [recurrenceEnabled, setRecurrenceEnabled] = useState(false);
@@ -162,6 +163,26 @@ export default function ManageEventApp() {
 			setAvailableCategories(data);
 		} catch {
 			// Categories are optional, ignore errors.
+		}
+	};
+
+	const createCategory = async (name) => {
+		try {
+			const newCategory = await apiFetch({
+				path: '/fair-events/v1/sources/categories',
+				method: 'POST',
+				data: { name },
+			});
+			setAvailableCategories((prev) => [...prev, newCategory]);
+			setCategories((prev) => [...prev, newCategory.id]);
+		} catch (err) {
+			setError(
+				err.message || __('Failed to create category.', 'fair-events')
+			);
+		} finally {
+			setCreatingCategories((prev) =>
+				prev.filter((pending) => pending !== name)
+			);
 		}
 	};
 
@@ -844,26 +865,50 @@ export default function ManageEventApp() {
 							<VStack spacing={4}>
 								<FormTokenField
 									label={__('Categories', 'fair-events')}
-									value={categories.map((id) => {
-										const cat = availableCategories.find(
-											(c) => c.id === id
-										);
-										return cat ? cat.name : '';
-									})}
+									value={[
+										...categories
+											.map((id) => {
+												const cat =
+													availableCategories.find(
+														(c) => c.id === id
+													);
+												return cat ? cat.name : '';
+											})
+											.filter(Boolean),
+										...creatingCategories,
+									]}
 									suggestions={availableCategories.map(
 										(c) => c.name
 									)}
 									onChange={(tokens) => {
-										const ids = tokens
-											.map((token) => {
-												const cat =
-													availableCategories.find(
-														(c) => c.name === token
-													);
-												return cat ? cat.id : null;
-											})
-											.filter(Boolean);
+										const ids = [];
+										const pending = [];
+
+										tokens.forEach((token) => {
+											const cat =
+												availableCategories.find(
+													(c) => c.name === token
+												);
+											if (cat) {
+												ids.push(cat.id);
+											} else {
+												pending.push(token);
+											}
+										});
+
 										setCategories(ids);
+										setCreatingCategories(pending);
+
+										pending
+											.filter(
+												(name) =>
+													!creatingCategories.includes(
+														name
+													)
+											)
+											.forEach((name) =>
+												createCategory(name)
+											);
 									}}
 									__experimentalExpandOnFocus
 								/>

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -12,7 +12,13 @@
  *   - Changing the selector updates the save payload's recurrence_scope.
  */
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import {
+	render,
+	screen,
+	fireEvent,
+	act,
+	waitFor,
+} from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import EventTickets from '../EventTickets.js';
 
@@ -524,5 +530,51 @@ describe('EventTickets — disable/enable when has_sales', () => {
 		});
 
 		expect(savedPayload?.ticket_types?.[0]?.disabled).toBe(true);
+	});
+});
+
+describe('EventTickets — save button and dirty tracking (#987)', () => {
+	it('renders its own "Save tickets" button', () => {
+		renderTickets({ initialData: emptyInitialData });
+		expect(
+			screen.getByRole('button', { name: 'Save tickets' })
+		).toBeInTheDocument();
+	});
+
+	it('reports dirty once a field changes, and clean again after save', async () => {
+		const onDirtyChange = jest.fn();
+		renderTickets({
+			initialData: initialDataWithTicketType,
+			onDirtyChange,
+		});
+		openEditTicketsPanel();
+
+		expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+
+		const nameInput = screen.getByDisplayValue('General');
+		fireEvent.change(nameInput, { target: { value: 'General (edited)' } });
+
+		expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+		apiFetch.mockImplementation(({ method }) => {
+			if (method === 'PUT') {
+				return Promise.resolve({
+					...initialDataWithTicketType,
+					ticket_types: [
+						{
+							...initialDataWithTicketType.ticket_types[0],
+							name: 'General (edited)',
+						},
+					],
+				});
+			}
+			return new Promise(() => {});
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: 'Save tickets' }));
+
+		await waitFor(() =>
+			expect(onDirtyChange).toHaveBeenLastCalledWith(false)
+		);
 	});
 });

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -295,6 +295,56 @@ describe('context header (#986)', () => {
 	});
 });
 
+describe('create-on-the-fly categories (#992)', () => {
+	beforeEach(() => {
+		window.history.replaceState({}, '', '?tab=event-details');
+	});
+
+	it('creates and links a category typed as an unknown token', async () => {
+		apiFetch.mockImplementation((opts) => {
+			if (opts.path && opts.path.includes('/event-dates/')) {
+				return Promise.resolve(mockEventDate);
+			}
+			if (opts.path === '/fair-events/v1/sources/categories') {
+				if (opts.method === 'POST') {
+					return Promise.resolve({
+						id: 5,
+						name: 'Workshops',
+						slug: 'workshops',
+					});
+				}
+				return Promise.resolve([
+					{ id: 1, name: 'Music', slug: 'music' },
+				]);
+			}
+			return Promise.resolve([]);
+		});
+
+		render(<ManageEventApp />);
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Event Details' })
+			).toBeInTheDocument()
+		);
+
+		const input = await screen.findByLabelText('Categories');
+		fireEvent.change(input, { target: { value: 'Workshops' } });
+		fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+		await waitFor(() =>
+			expect(apiFetch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: '/fair-events/v1/sources/categories',
+					method: 'POST',
+					data: { name: 'Workshops' },
+				})
+			)
+		);
+
+		expect(await screen.findByText('Workshops')).toBeInTheDocument();
+	});
+});
+
 describe('delete confirmation dialog (#991)', () => {
 	it('shows the title and date, and no occurrence count, for a one-off event', async () => {
 		render(<ManageEventApp />);

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -399,3 +399,126 @@ describe('delete confirmation dialog (#991)', () => {
 		).toBeInTheDocument();
 	});
 });
+
+describe('per-tab save model (#987)', () => {
+	it('renders no save button on the read-only Admin tab', async () => {
+		render(<ManageEventApp />);
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Admin' })
+			).toBeInTheDocument()
+		);
+
+		expect(
+			screen.queryByRole('button', { name: 'Save event details' })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Save tickets' })
+		).not.toBeInTheDocument();
+	});
+
+	it('renders "Save event details" only on the Event Details tab', async () => {
+		window.history.replaceState({}, '', '?tab=event-details');
+		render(<ManageEventApp />);
+
+		expect(
+			await screen.findByRole('button', { name: 'Save event details' })
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Save tickets' })
+		).not.toBeInTheDocument();
+		// The old tab-dependent global button is gone.
+		expect(
+			screen.queryByRole('button', { name: 'Save Changes' })
+		).not.toBeInTheDocument();
+	});
+
+	it('disables the save button and shows an inline message when the title is empty', async () => {
+		window.history.replaceState({}, '', '?tab=event-details');
+		render(<ManageEventApp />);
+
+		const titleInput = await screen.findByLabelText('Title');
+		fireEvent.change(titleInput, { target: { value: '' } });
+
+		expect(
+			screen.getByRole('button', { name: 'Save event details' })
+		).toBeDisabled();
+		expect(screen.getByText('Title is required')).toBeInTheDocument();
+	});
+
+	it('enables the save button once a title is entered', async () => {
+		window.history.replaceState({}, '', '?tab=event-details');
+		render(<ManageEventApp />);
+
+		const titleInput = await screen.findByLabelText('Title');
+		fireEvent.change(titleInput, { target: { value: '' } });
+		fireEvent.change(titleInput, { target: { value: 'New title' } });
+
+		expect(
+			screen.getByRole('button', { name: 'Save event details' })
+		).not.toBeDisabled();
+		expect(screen.queryByText('Title is required')).not.toBeInTheDocument();
+	});
+
+	it('marks the Event Details tab dirty and guards navigation while editing', async () => {
+		window.history.replaceState({}, '', '?tab=event-details');
+		const addListenerSpy = jest.spyOn(window, 'addEventListener');
+		render(<ManageEventApp />);
+
+		const titleInput = await screen.findByLabelText('Title');
+		expect(
+			screen.getByRole('tab', { name: 'Event Details' })
+		).toBeInTheDocument();
+
+		fireEvent.change(titleInput, { target: { value: 'Edited title' } });
+
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Event Details •' })
+			).toBeInTheDocument()
+		);
+		expect(addListenerSpy).toHaveBeenCalledWith(
+			'beforeunload',
+			expect.any(Function)
+		);
+
+		addListenerSpy.mockRestore();
+	});
+
+	it('clears the dirty marker after a successful save', async () => {
+		window.history.replaceState({}, '', '?tab=event-details');
+		apiFetch.mockImplementation((opts) => {
+			if (opts.method === 'PUT') {
+				return Promise.resolve({
+					...mockEventDate,
+					title: 'Edited title',
+				});
+			}
+			if (opts.path && opts.path.includes('/event-dates/')) {
+				return Promise.resolve(mockEventDate);
+			}
+			return Promise.resolve([]);
+		});
+
+		render(<ManageEventApp />);
+
+		const titleInput = await screen.findByLabelText('Title');
+		fireEvent.change(titleInput, { target: { value: 'Edited title' } });
+
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Event Details •' })
+			).toBeInTheDocument()
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Save event details' })
+		);
+
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Event Details' })
+			).toBeInTheDocument()
+		);
+	});
+});

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -141,6 +141,16 @@ class Plugin {
 			}
 		);
 
+		// Categories controller — registers `/fair-events/v1/sources/categories`,
+		// used by the Manage Event admin page to create categories on the fly.
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new \FairEvents\API\CategoriesController();
+				$controller->register_routes();
+			}
+		);
+
 		if ( Features::is_enabled( 'ticketing' ) ) {
 			add_action(
 				'rest_api_init',

--- a/fair-payments-connector/src/API/TransactionAPI.php
+++ b/fair-payments-connector/src/API/TransactionAPI.php
@@ -376,10 +376,15 @@ class TransactionAPI {
 
 			// If Mollie status differs from our stored status, update.
 			if ( $payment->status !== $transaction->status ) {
-				Transaction::update_status( $transaction->mollie_payment_id, $payment->status );
-				self::handle_payment_status_change( $payment, $transaction );
+				// Compare-and-swap against the status we just read, so a concurrent
+				// webhook can't both win and re-fire status hooks/notifications.
+				$won_race = Transaction::update_status( $transaction->mollie_payment_id, $payment->status, $transaction->status );
 
-				// Return fresh transaction from DB.
+				if ( $won_race ) {
+					self::handle_payment_status_change( $payment, $transaction );
+				}
+
+				// Return fresh transaction from DB regardless of who won the race.
 				$updated             = Transaction::get_by_id( $transaction_id );
 				$updated->sync_debug = self::build_mollie_debug( $payment );
 				return $updated;

--- a/fair-payments-connector/src/API/WebhookEndpoint.php
+++ b/fair-payments-connector/src/API/WebhookEndpoint.php
@@ -148,10 +148,37 @@ class WebhookEndpoint extends WP_REST_Controller {
 			);
 			$payment = $handler->get_payment( $mollie_payment_id, $options );
 
-			// Update transaction status.
-			$updated = Transaction::update_status( $mollie_payment_id, $payment->status );
+			// Update transaction status. Compare-and-swap against the status we just
+			// read, so a concurrent sync (e.g. triggered by the customer's browser
+			// reloading the payment page) can't both win and re-fire status hooks.
+			$updated = Transaction::update_status( $mollie_payment_id, $payment->status, $transaction->status );
 
 			if ( ! $updated ) {
+				$current = Transaction::get_by_mollie_id( $mollie_payment_id );
+
+				if ( $current && $current->status === $payment->status ) {
+					// Another process already made this exact transition — nothing left to do.
+					$logger->log(
+						'webhook_skipped',
+						array(
+							'level'          => 'info',
+							'transaction_id' => (int) $transaction->id,
+							'message'        => 'Webhook skipped — status already updated by a concurrent request',
+							'context'        => array(
+								'mollie_payment_id' => $mollie_payment_id,
+								'status'            => $payment->status,
+							),
+						)
+					);
+					return new WP_REST_Response(
+						array(
+							'success' => true,
+							'status'  => $payment->status,
+						),
+						200
+					);
+				}
+
 				$logger->log(
 					'webhook_failed',
 					array(

--- a/fair-payments-connector/src/Models/Transaction.php
+++ b/fair-payments-connector/src/Models/Transaction.php
@@ -222,21 +222,43 @@ class Transaction {
 	/**
 	 * Update transaction status
 	 *
-	 * @param string $mollie_payment_id Mollie payment ID.
-	 * @param string $status New status.
-	 * @return bool True on success, false on failure.
+	 * When $expected_status is given, the update is a compare-and-swap: it only
+	 * writes (and returns true) if the row's current status still matches
+	 * $expected_status. This lets concurrent callers (e.g. a webhook and a
+	 * page-load sync racing on the same transaction) detect that another
+	 * process already made the transition, so only one of them proceeds to
+	 * fire status-change hooks/notifications.
+	 *
+	 * @param string      $mollie_payment_id Mollie payment ID.
+	 * @param string      $status New status.
+	 * @param string|null $expected_status If given, only update when the current status matches this value.
+	 * @return bool True if this call performed the update, false on failure or if the status no longer matched.
 	 */
-	public static function update_status( $mollie_payment_id, $status ) {
+	public static function update_status( $mollie_payment_id, $status, $expected_status = null ) {
 		global $wpdb;
 		$table_name = \FairPaymentsConnector\Database\Schema::get_payments_table_name();
 
-		return (bool) $wpdb->update(
-			$table_name,
-			array( 'status' => $status ),
-			array( 'mollie_payment_id' => $mollie_payment_id ),
-			array( '%s' ),
-			array( '%s' )
+		if ( null === $expected_status ) {
+			return (bool) $wpdb->update(
+				$table_name,
+				array( 'status' => $status ),
+				array( 'mollie_payment_id' => $mollie_payment_id ),
+				array( '%s' ),
+				array( '%s' )
+			);
+		}
+
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET status = %s WHERE mollie_payment_id = %s AND status = %s',
+				$table_name,
+				$status,
+				$mollie_payment_id,
+				$expected_status
+			)
 		);
+
+		return false !== $result && $result > 0;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Adds `e2e/mu-plugins/scripts/seed-audience-session-cookie.php`, a WP-CLI `eval-file` script that mints a signed `fair_audience_session` cookie value for a given participant ID.
- Needed for the `signup-cancel-and-restart` E2E spec, which must inject a valid session cookie via `context.addCookies()` since `AudienceSession::set()` can't be called directly from a CLI script (it relies on `setcookie()`).

## Test plan
- [ ] Run the `signup-cancel-and-restart` E2E spec and confirm the cookie seeding script produces a valid session