### PR TITLE
Rework Manage Event save model: per-tab scope, dirty guard

### DIFF
--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -37,6 +37,7 @@ export default function EventTickets({
 	startDatetime,
 	endDatetime: endDatetimeProp,
 	isRecurring,
+	onDirtyChange,
 }) {
 	const [capacity, setCapacity] = useState('');
 	const [endDatetime, setEndDatetime] = useState(
@@ -68,6 +69,12 @@ export default function EventTickets({
 	const [participants, setParticipants] = useState([]);
 	const fileInputRef = useRef(null);
 
+	// Dirty-state tracking (#987): snapshot the save payload right after it's
+	// loaded/saved so we can detect unsaved edits by re-serializing and
+	// comparing.
+	const [snapshot, setSnapshot] = useState(null);
+	const [loadGen, setLoadGen] = useState(0);
+
 	const manageInvitationsUrl =
 		window.fairEventsManageEventData?.manageInvitationsUrl || '';
 
@@ -91,6 +98,7 @@ export default function EventTickets({
 	const participantSuggestions = participants.map(formatParticipantLabel);
 
 	const populateFromData = useCallback((data) => {
+		setLoadGen((g) => g + 1);
 		setCapacity(
 			data.capacity !== null && data.capacity !== undefined
 				? String(data.capacity)
@@ -182,142 +190,6 @@ export default function EventTickets({
 			onSaveRef.current = handleSave;
 		}
 	});
-
-	useEffect(() => {
-		if (onDataRef) {
-			onDataRef.current = () => {
-				const pricesArray = [];
-				ticketTypes.forEach((type, tIndex) => {
-					salePeriods.forEach((period, pIndex) => {
-						const val = getPrice(type, period);
-						if (!val.enabled) return;
-						if (val.price === '' && val.capacity === '') return;
-						pricesArray.push({
-							ticket_type_index: tIndex,
-							sale_period_index: pIndex,
-							price: parseFloat(val.price) || 0,
-							capacity:
-								val.capacity !== ''
-									? parseInt(val.capacity, 10)
-									: null,
-						});
-					});
-				});
-				return {
-					capacity: capacity !== '' ? parseInt(capacity, 10) : null,
-					ticket_types: ticketTypes.map((t, i) => ({
-						...t,
-						sort_order: i,
-					})),
-					sale_periods: getEffectiveSalePeriods().map((p, i) => ({
-						...p,
-						sort_order: i,
-					})),
-					prices: pricesArray,
-					settings,
-				};
-			};
-		}
-	});
-
-	const handleSave = async () => {
-		setSaving(true);
-		setError(null);
-		setSuccess(null);
-
-		const pricesArray = [];
-		ticketTypes.forEach((type, tIndex) => {
-			salePeriods.forEach((period, pIndex) => {
-				const val = getPrice(type, period);
-				if (!val.enabled) return;
-				if (val.price === '' && val.capacity === '') return;
-				pricesArray.push({
-					ticket_type_index: tIndex,
-					sale_period_index: pIndex,
-					price: parseFloat(val.price) || 0,
-					capacity:
-						val.capacity !== '' ? parseInt(val.capacity, 10) : null,
-				});
-			});
-		});
-
-		try {
-			const data = await apiFetch({
-				path: `/fair-events/v1/event-dates/${eventDateId}/tickets`,
-				method: 'PUT',
-				data: {
-					capacity: capacity !== '' ? parseInt(capacity, 10) : null,
-					ticket_types: ticketTypes.map((t, i) => ({
-						...t,
-						sort_order: i,
-					})),
-					sale_periods: getEffectiveSalePeriods().map((p, i) => ({
-						...p,
-						sort_order: i,
-					})),
-					prices: pricesArray,
-					settings,
-					options: options.map((o, i) =>
-						serializeOptionForSave(o, i)
-					),
-				},
-			});
-
-			setCapacity(
-				data.capacity !== null && data.capacity !== undefined
-					? String(data.capacity)
-					: ''
-			);
-			setTicketTypes(data.ticket_types || []);
-			setSalePeriods(
-				(data.sale_periods || []).map((p) => ({
-					...p,
-					sale_start: p.sale_start
-						? p.sale_start.split(' ')[0].split('T')[0]
-						: '',
-					sale_end: p.sale_end
-						? p.sale_end.split(' ')[0].split('T')[0]
-						: '',
-				}))
-			);
-
-			const priceMap = {};
-			(data.ticket_types || []).forEach((type) => {
-				(data.sale_periods || []).forEach((period) => {
-					priceMap[`${type.id}-${period.id}`] = {
-						price: '',
-						capacity: '',
-						enabled: false,
-					};
-				});
-			});
-			(data.prices || []).forEach((p) => {
-				const key = `${p.ticket_type_id}-${p.sale_period_id}`;
-				priceMap[key] = {
-					price: String(p.price),
-					capacity:
-						p.capacity !== null && p.capacity !== undefined
-							? String(p.capacity)
-							: '',
-					enabled: true,
-				};
-			});
-			setPrices(priceMap);
-
-			if (data.settings) {
-				setSettings((prev) => ({ ...prev, ...data.settings }));
-			}
-			setOptions((data.options || []).map(normalizeOption));
-
-			setSuccess(__('Tickets saved successfully.', 'fair-events'));
-		} catch (err) {
-			setError(
-				err.message || __('Failed to save tickets.', 'fair-events')
-			);
-		} finally {
-			setSaving(false);
-		}
-	};
 
 	const buildExportPayload = () => {
 		const exportPrices = [];
@@ -776,6 +648,90 @@ export default function EventTickets({
 		return prices[key] || { price: '', capacity: '', enabled: true };
 	};
 
+	// Full save payload — shared by handleSave, the onDataRef consumer, and
+	// the dirty-state snapshot comparison.
+	const buildSavePayload = () => {
+		const pricesArray = [];
+		ticketTypes.forEach((type, tIndex) => {
+			salePeriods.forEach((period, pIndex) => {
+				const val = getPrice(type, period);
+				if (!val.enabled) return;
+				if (val.price === '' && val.capacity === '') return;
+				pricesArray.push({
+					ticket_type_index: tIndex,
+					sale_period_index: pIndex,
+					price: parseFloat(val.price) || 0,
+					capacity:
+						val.capacity !== '' ? parseInt(val.capacity, 10) : null,
+				});
+			});
+		});
+
+		return {
+			capacity: capacity !== '' ? parseInt(capacity, 10) : null,
+			ticket_types: ticketTypes.map((t, i) => ({
+				...t,
+				sort_order: i,
+			})),
+			sale_periods: getEffectiveSalePeriods().map((p, i) => ({
+				...p,
+				sort_order: i,
+			})),
+			prices: pricesArray,
+			settings,
+			options: options.map((o, i) => serializeOptionForSave(o, i)),
+		};
+	};
+
+	useEffect(() => {
+		if (onDataRef) {
+			onDataRef.current = buildSavePayload;
+		}
+	});
+
+	// Re-baseline the snapshot whenever populateFromData() runs (initial load
+	// or a fresh save). Gated on loadGen — a state value set in the same
+	// batch as the loaded ticketTypes/salePeriods/etc. — rather than a ref,
+	// so this effect's closure only reads those fields once React has
+	// actually committed the loaded values (a ref flip is visible to effects
+	// in the same commit, before the batched setState calls have flushed).
+	useEffect(() => {
+		setSnapshot(JSON.stringify(buildSavePayload()));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [loadGen]);
+
+	const dirty =
+		snapshot !== null && snapshot !== JSON.stringify(buildSavePayload());
+
+	useEffect(() => {
+		if (onDirtyChange) {
+			onDirtyChange(dirty);
+		}
+	}, [dirty, onDirtyChange]);
+
+	const handleSave = async () => {
+		setSaving(true);
+		setError(null);
+		setSuccess(null);
+
+		try {
+			const data = await apiFetch({
+				path: `/fair-events/v1/event-dates/${eventDateId}/tickets`,
+				method: 'PUT',
+				data: buildSavePayload(),
+			});
+
+			populateFromData(data);
+			setSuccess(__('Tickets saved successfully.', 'fair-events'));
+		} catch (err) {
+			setError(
+				err.message || __('Failed to save tickets.', 'fair-events')
+			);
+		} finally {
+			setSaving(false);
+		}
+	};
+
 	const siteCurrency = window.fairPaymentsConnector?.currency || 'EUR';
 
 	const formatCurrency = (value) => {
@@ -821,39 +777,49 @@ export default function EventTickets({
 				</Notice>
 			)}
 
-			<HStack spacing={2} justify="flex-end">
-				{(hasInvitationTickets ||
-					settings.activity_collaborator_discount) &&
-					manageInvitationsUrl && (
-						<Button
-							variant="secondary"
-							href={`${manageInvitationsUrl}${eventDateId}`}
-						>
-							{__('Manage Invitations', 'fair-events')}
-						</Button>
-					)}
+			<HStack spacing={2} justify="space-between">
 				<Button
-					variant="secondary"
-					onClick={handleExport}
-					disabled={importing || saving}
+					variant="primary"
+					onClick={handleSave}
+					isBusy={saving}
+					disabled={saving}
 				>
-					{__('Export ticket settings', 'fair-events')}
+					{__('Save tickets', 'fair-events')}
 				</Button>
-				<Button
-					variant="secondary"
-					onClick={() => fileInputRef.current?.click()}
-					disabled={importing || saving}
-					isBusy={importing}
-				>
-					{__('Import ticket settings', 'fair-events')}
-				</Button>
-				<input
-					ref={fileInputRef}
-					type="file"
-					accept="application/json,.json"
-					style={{ display: 'none' }}
-					onChange={handleImportFile}
-				/>
+				<HStack spacing={2} justify="flex-end">
+					{(hasInvitationTickets ||
+						settings.activity_collaborator_discount) &&
+						manageInvitationsUrl && (
+							<Button
+								variant="secondary"
+								href={`${manageInvitationsUrl}${eventDateId}`}
+							>
+								{__('Manage Invitations', 'fair-events')}
+							</Button>
+						)}
+					<Button
+						variant="secondary"
+						onClick={handleExport}
+						disabled={importing || saving}
+					>
+						{__('Export ticket settings', 'fair-events')}
+					</Button>
+					<Button
+						variant="secondary"
+						onClick={() => fileInputRef.current?.click()}
+						disabled={importing || saving}
+						isBusy={importing}
+					>
+						{__('Import ticket settings', 'fair-events')}
+					</Button>
+					<input
+						ref={fileInputRef}
+						type="file"
+						accept="application/json,.json"
+						style={{ display: 'none' }}
+						onChange={handleImportFile}
+					/>
+				</HStack>
 			</HStack>
 
 			{!hasAdvancedTickets && (

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -106,15 +106,19 @@ export default function ManageEventApp() {
 	const [linkingPost, setLinkingPost] = useState(false);
 	const [linkPostId, setLinkPostId] = useState('');
 	const [searchResults, setSearchResults] = useState([]);
-	const [activeTab, setActiveTab] = useState(
-		() =>
-			new URLSearchParams(window.location.search).get('tab') ||
-			'event-details'
-	);
-	const ticketSaveRef = useRef(null);
 	const [togglingExdate, setTogglingExdate] = useState(null);
 	const [recurrenceImpact, setRecurrenceImpact] = useState(null);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+	// Dirty-state tracking (#987): snapshot the saved form/ticket state so we
+	// can warn before losing edits and mark which tab holds them.
+	const [detailsSnapshot, setDetailsSnapshot] = useState(null);
+	const detailsJustLoadedRef = useRef(false);
+	const [ticketsDirty, setTicketsDirty] = useState(false);
+	const handleTicketsDirtyChange = useCallback(
+		(isDirty) => setTicketsDirty(isDirty),
+		[]
+	);
 
 	useEffect(() => {
 		if (!eventDateId) {
@@ -187,6 +191,7 @@ export default function ManageEventApp() {
 	};
 
 	const populateForm = (data) => {
+		detailsJustLoadedRef.current = true;
 		setTitle(data.title || '');
 		setAllDay(data.all_day || false);
 		setLinkType(data.link_type || 'none');
@@ -214,6 +219,55 @@ export default function ManageEventApp() {
 			setRecurrenceEnabled(false);
 		}
 	};
+
+	// Plain-object snapshot of every Event Details field, used to detect
+	// unsaved edits (#987). Keep in sync with the fields populateForm() sets.
+	const buildDetailsSnapshot = () =>
+		JSON.stringify({
+			title,
+			allDay,
+			startDate,
+			startTime,
+			endDate,
+			endTime,
+			venueId,
+			address,
+			linkType,
+			externalUrl,
+			categories: [...categories].sort(),
+			recurrenceEnabled,
+			recurrenceFrequency,
+			recurrenceEndType,
+			recurrenceCount,
+			recurrenceUntil,
+		});
+
+	// Runs after every render; only commits a new snapshot right after
+	// populateForm() flagged one (initial load or a fresh save/link/unlink),
+	// once all its setState calls have been applied.
+	useEffect(() => {
+		if (detailsJustLoadedRef.current) {
+			setDetailsSnapshot(buildDetailsSnapshot());
+			detailsJustLoadedRef.current = false;
+		}
+	});
+
+	const detailsDirty =
+		detailsSnapshot !== null && detailsSnapshot !== buildDetailsSnapshot();
+
+	// Warn before losing unsaved edits on either tab that can be dirty.
+	useEffect(() => {
+		if (!detailsDirty && !ticketsDirty) {
+			return;
+		}
+		const handleBeforeUnload = (event) => {
+			event.preventDefault();
+			event.returnValue = '';
+		};
+		window.addEventListener('beforeunload', handleBeforeUnload);
+		return () =>
+			window.removeEventListener('beforeunload', handleBeforeUnload);
+	}, [detailsDirty, ticketsDirty]);
 
 	// Duration options
 	const timedDurationOptions = useMemo(
@@ -397,6 +451,7 @@ export default function ManageEventApp() {
 					: null
 			);
 			setSuccess(__('Event updated successfully.', 'fair-events'));
+			setDetailsSnapshot(buildDetailsSnapshot());
 		} catch (err) {
 			setError(
 				err.message || __('Failed to update event.', 'fair-events')
@@ -592,7 +647,6 @@ export default function ManageEventApp() {
 	}, []);
 
 	const handleTabSelect = useCallback((tabName) => {
-		setActiveTab(tabName);
 		const url = new URL(window.location.href);
 		if (tabName === 'event-details') {
 			url.searchParams.delete('tab');
@@ -631,10 +685,10 @@ export default function ManageEventApp() {
 			render: () => (
 				<EventTickets
 					eventDateId={eventDateId}
-					onSaveRef={ticketSaveRef}
 					startDatetime={eventDate.start_datetime}
 					endDatetime={eventDate.end_datetime}
 					isRecurring={recurrenceEnabled}
+					onDirtyChange={handleTicketsDirtyChange}
 				/>
 			),
 		},
@@ -718,10 +772,16 @@ export default function ManageEventApp() {
 		.filter((t) => t.isVisible)
 		.sort((a, b) => a.order - b.order);
 
+	// Tabs whose section currently holds unsaved edits get a " •" marker.
+	const dirtyTabNames = {
+		'event-details': detailsDirty,
+		tickets: ticketsDirty,
+	};
+
 	// Shape TabPanel expects: { name, title, disabled? }.
 	const tabs = tabDescriptors.map(({ name, title: tabTitle, disabled }) => ({
 		name,
-		title: tabTitle,
+		title: dirtyTabNames[name] ? `${tabTitle} •` : tabTitle,
 		...(disabled ? { disabled } : {}),
 	}));
 
@@ -1066,6 +1126,26 @@ export default function ManageEventApp() {
 
 				{renderLinksTab()}
 			</div>
+
+			<HStack
+				spacing={2}
+				style={{ marginTop: '16px' }}
+				justify="flex-start"
+			>
+				<Button
+					variant="primary"
+					onClick={handleSave}
+					isBusy={saving}
+					disabled={saving || !title.trim()}
+				>
+					{__('Save event details', 'fair-events')}
+				</Button>
+				{!title.trim() && (
+					<span style={{ color: '#d63638' }}>
+						{__('Title is required', 'fair-events')}
+					</span>
+				)}
+			</HStack>
 		</>
 	);
 
@@ -1367,22 +1447,6 @@ export default function ManageEventApp() {
 			</TabPanel>
 
 			<HStack spacing={2} style={{ marginTop: '16px' }}>
-				<Button
-					variant="primary"
-					onClick={
-						activeTab === 'tickets'
-							? () => ticketSaveRef.current?.()
-							: handleSave
-					}
-					isBusy={saving}
-					disabled={
-						activeTab === 'event-details'
-							? saving || !title.trim()
-							: saving
-					}
-				>
-					{__('Save Changes', 'fair-events')}
-				</Button>
 				<Button variant="secondary" href={calendarUrl}>
 					{__('Back to Calendar', 'fair-events')}
 				</Button>

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -12,7 +12,13 @@
  *   - Changing the selector updates the save payload's recurrence_scope.
  */
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import {
+	render,
+	screen,
+	fireEvent,
+	act,
+	waitFor,
+} from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import EventTickets from '../EventTickets.js';
 
@@ -524,5 +530,51 @@ describe('EventTickets — disable/enable when has_sales', () => {
 		});
 
 		expect(savedPayload?.ticket_types?.[0]?.disabled).toBe(true);
+	});
+});
+
+describe('EventTickets — save button and dirty tracking (#987)', () => {
+	it('renders its own "Save tickets" button', () => {
+		renderTickets({ initialData: emptyInitialData });
+		expect(
+			screen.getByRole('button', { name: 'Save tickets' })
+		).toBeInTheDocument();
+	});
+
+	it('reports dirty once a field changes, and clean again after save', async () => {
+		const onDirtyChange = jest.fn();
+		renderTickets({
+			initialData: initialDataWithTicketType,
+			onDirtyChange,
+		});
+		openEditTicketsPanel();
+
+		expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+
+		const nameInput = screen.getByDisplayValue('General');
+		fireEvent.change(nameInput, { target: { value: 'General (edited)' } });
+
+		expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+		apiFetch.mockImplementation(({ method }) => {
+			if (method === 'PUT') {
+				return Promise.resolve({
+					...initialDataWithTicketType,
+					ticket_types: [
+						{
+							...initialDataWithTicketType.ticket_types[0],
+							name: 'General (edited)',
+						},
+					],
+				});
+			}
+			return new Promise(() => {});
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: 'Save tickets' }));
+
+		await waitFor(() =>
+			expect(onDirtyChange).toHaveBeenLastCalledWith(false)
+		);
 	});
 });

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -399,3 +399,126 @@ describe('delete confirmation dialog (#991)', () => {
 		).toBeInTheDocument();
 	});
 });
+
+describe('per-tab save model (#987)', () => {
+	it('renders no save button on the read-only Admin tab', async () => {
+		render(<ManageEventApp />);
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Admin' })
+			).toBeInTheDocument()
+		);
+
+		expect(
+			screen.queryByRole('button', { name: 'Save event details' })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Save tickets' })
+		).not.toBeInTheDocument();
+	});
+
+	it('renders "Save event details" only on the Event Details tab', async () => {
+		window.history.replaceState({}, '', '?tab=event-details');
+		render(<ManageEventApp />);
+
+		expect(
+			await screen.findByRole('button', { name: 'Save event details' })
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Save tickets' })
+		).not.toBeInTheDocument();
+		// The old tab-dependent global button is gone.
+		expect(
+			screen.queryByRole('button', { name: 'Save Changes' })
+		).not.toBeInTheDocument();
+	});
+
+	it('disables the save button and shows an inline message when the title is empty', async () => {
+		window.history.replaceState({}, '', '?tab=event-details');
+		render(<ManageEventApp />);
+
+		const titleInput = await screen.findByLabelText('Title');
+		fireEvent.change(titleInput, { target: { value: '' } });
+
+		expect(
+			screen.getByRole('button', { name: 'Save event details' })
+		).toBeDisabled();
+		expect(screen.getByText('Title is required')).toBeInTheDocument();
+	});
+
+	it('enables the save button once a title is entered', async () => {
+		window.history.replaceState({}, '', '?tab=event-details');
+		render(<ManageEventApp />);
+
+		const titleInput = await screen.findByLabelText('Title');
+		fireEvent.change(titleInput, { target: { value: '' } });
+		fireEvent.change(titleInput, { target: { value: 'New title' } });
+
+		expect(
+			screen.getByRole('button', { name: 'Save event details' })
+		).not.toBeDisabled();
+		expect(screen.queryByText('Title is required')).not.toBeInTheDocument();
+	});
+
+	it('marks the Event Details tab dirty and guards navigation while editing', async () => {
+		window.history.replaceState({}, '', '?tab=event-details');
+		const addListenerSpy = jest.spyOn(window, 'addEventListener');
+		render(<ManageEventApp />);
+
+		const titleInput = await screen.findByLabelText('Title');
+		expect(
+			screen.getByRole('tab', { name: 'Event Details' })
+		).toBeInTheDocument();
+
+		fireEvent.change(titleInput, { target: { value: 'Edited title' } });
+
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Event Details •' })
+			).toBeInTheDocument()
+		);
+		expect(addListenerSpy).toHaveBeenCalledWith(
+			'beforeunload',
+			expect.any(Function)
+		);
+
+		addListenerSpy.mockRestore();
+	});
+
+	it('clears the dirty marker after a successful save', async () => {
+		window.history.replaceState({}, '', '?tab=event-details');
+		apiFetch.mockImplementation((opts) => {
+			if (opts.method === 'PUT') {
+				return Promise.resolve({
+					...mockEventDate,
+					title: 'Edited title',
+				});
+			}
+			if (opts.path && opts.path.includes('/event-dates/')) {
+				return Promise.resolve(mockEventDate);
+			}
+			return Promise.resolve([]);
+		});
+
+		render(<ManageEventApp />);
+
+		const titleInput = await screen.findByLabelText('Title');
+		fireEvent.change(titleInput, { target: { value: 'Edited title' } });
+
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Event Details •' })
+			).toBeInTheDocument()
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Save event details' })
+		);
+
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Event Details' })
+			).toBeInTheDocument()
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Reworks the Manage Event save model per the plan in #987:

- Scope save actions per tab instead of one global button whose behavior
  changed with the active tab: **"Save event details"** lives at the bottom
  of the Event Details tab, **"Save tickets"** lives at the top of the
  Tickets tab. Read-only tabs (Signups, Photos, Finance, Admin) render no
  save button. Drops the `ticketSaveRef` indirection.
- Tracks dirty state per section (serialize-and-compare against a snapshot
  taken on load/after save): a `beforeunload` guard warns before losing
  unsaved edits, and the holding tab gets a " •" marker in its title.
- Shows an inline "Title is required" message next to the disabled Event
  Details save button instead of a bare disabled control.

No backend changes — the REST layer already enforces title-required on
update, so server-side validation was already covered.

Closes #987

## Test plan

- [x] `npm run test:js` (fair-events) — 63 tests pass, including 8 new
      component tests for the save/dirty-state behavior
- [x] `npm run build` (fair-events)
- [ ] Manually exercise the Manage Event page: confirm no save button on
      Signups/Admin, the tab marker and unload prompt while editing, and
      that saving clears both
