### PR TITLE
Add Move signup action for recurring event occurrences

### DIFF
--- a/fair-audience/src/API/EventParticipantsController.php
+++ b/fair-audience/src/API/EventParticipantsController.php
@@ -174,6 +174,34 @@ class EventParticipantsController extends WP_REST_Controller {
 			)
 		);
 
+		// POST /fair-audience/v1/event-dates/{event_date_id}/participants/{participant_id}/move.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<participant_id>\d+)/move',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'move_item' ),
+					'permission_callback' => array( $this, 'move_item_permissions_check' ),
+					'args'                => array(
+						'event_date_id'        => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'participant_id'       => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+						'target_event_date_id' => array(
+							'type'     => 'integer',
+							'required' => true,
+							'minimum'  => 1,
+						),
+					),
+				),
+			)
+		);
+
 		// DELETE /fair-audience/v1/event-dates/{event_date_id}/participants/batch.
 		// POST /fair-audience/v1/event-dates/{event_date_id}/participants/batch.
 		register_rest_route(
@@ -880,6 +908,75 @@ class EventParticipantsController extends WP_REST_Controller {
 	}
 
 	/**
+	 * Move a participant's signup to a sibling occurrence of the same
+	 * recurring event.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	public function move_item( $request ) {
+		$event_date_id        = (int) $request->get_param( 'event_date_id' );
+		$participant_id       = (int) $request->get_param( 'participant_id' );
+		$target_event_date_id = (int) $request->get_param( 'target_event_date_id' );
+
+		if ( ! class_exists( \FairEvents\Models\EventDates::class ) ) {
+			return new WP_Error(
+				'fair_events_unavailable',
+				__( 'The fair-events plugin is required for this action.', 'fair-audience' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+		if ( ! $event_date ) {
+			return new WP_Error(
+				'invalid_event_date',
+				__( 'Event date not found.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$master_id = ( 'generated' === $event_date->occurrence_type && $event_date->master_id )
+			? $event_date->master_id
+			: $event_date->id;
+
+		$sibling_ids = wp_list_pluck( \FairEvents\Models\EventDates::get_all_by_master_id( $master_id ), 'id' );
+
+		if ( ! in_array( $target_event_date_id, $sibling_ids, true ) ) {
+			return new WP_Error(
+				'invalid_target',
+				__( 'The target date is not another occurrence of this recurring event.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$result = $this->event_participant_repo->move_to_event_date( $event_date_id, $participant_id, $target_event_date_id );
+
+		if ( 'not_found' === $result ) {
+			return new WP_Error(
+				'not_found',
+				__( 'Signup not found on this event date.', 'fair-audience' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( 'conflict' === $result ) {
+			return new WP_Error(
+				'already_signed_up',
+				__( 'This participant is already signed up on the target date.', 'fair-audience' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'message'              => __( 'Signup moved successfully.', 'fair-audience' ),
+				'target_event_date_id' => $target_event_date_id,
+			)
+		);
+	}
+
+	/**
 	 * Delete multiple participants from an event.
 	 *
 	 * @param WP_REST_Request $request Request object.
@@ -1445,6 +1542,16 @@ class EventParticipantsController extends WP_REST_Controller {
 	 * @return bool True if user has permission.
 	 */
 	public function delete_item_permissions_check( $request ) {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Check permissions for moving a signup to another occurrence.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool True if user has permission.
+	 */
+	public function move_item_permissions_check( $request ) {
 		return current_user_can( 'manage_options' );
 	}
 }

--- a/fair-audience/src/API/__tests__/EventParticipantsMove.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventParticipantsMove.api.spec.js
@@ -1,0 +1,269 @@
+/**
+ * Playwright API tests for the move-to-occurrence endpoint on
+ * EventParticipantsController.
+ *
+ * Exercises POST
+ * /fair-audience/v1/event-dates/{event_date_id}/participants/{participant_id}/move
+ * against a live WordPress instance.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+async function createParticipant(api, name) {
+	const res = await api.post('/wp-json/fair-audience/v1/participants', {
+		headers: authHeaders,
+		data: { name, email: uniqueEmail(name.replace(/\s+/g, '-')) },
+	});
+	expect(res.ok()).toBeTruthy();
+	return (await res.json()).id;
+}
+
+test.describe('EventParticipantsController — move', () => {
+	let api;
+	let eventPostId;
+	let masterEventDateId;
+	let occurrenceIds;
+	let otherEventPostId;
+	let otherEventDateId;
+	let participantAId;
+	let participantBId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: authHeaders,
+			data: { title: `Move test ${Date.now()}`, status: 'publish' },
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: authHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2036-06-01 10:00:00',
+				end_datetime: '2036-06-01 12:00:00',
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		const edBody = await edRes.json();
+		masterEventDateId = edBody.id;
+		occurrenceIds = [
+			masterEventDateId,
+			...edBody.generated_occurrences.map((o) => o.id),
+		];
+		expect(occurrenceIds.length).toBe(3);
+
+		// Unrelated event date, not part of the recurring series above.
+		const otherPostRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: authHeaders,
+			data: { title: `Unrelated event ${Date.now()}`, status: 'publish' },
+		});
+		expect(otherPostRes.ok()).toBeTruthy();
+		otherEventPostId = (await otherPostRes.json()).id;
+
+		const otherEdRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: authHeaders,
+				data: {
+					event_id: otherEventPostId,
+					start_datetime: '2036-06-15 10:00:00',
+					end_datetime: '2036-06-15 12:00:00',
+				},
+			}
+		);
+		expect(otherEdRes.ok()).toBeTruthy();
+		otherEventDateId = (await otherEdRes.json()).id;
+
+		participantAId = await createParticipant(api, 'Move Person A');
+		participantBId = await createParticipant(api, 'Move Person B');
+	});
+
+	test.afterAll(async () => {
+		for (const id of [participantAId, participantBId]) {
+			if (id) {
+				await api.delete(
+					`/wp-json/fair-audience/v1/participants/${id}`,
+					{ headers: authHeaders }
+				);
+			}
+		}
+		if (masterEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+				{ headers: authHeaders }
+			);
+		}
+		if (otherEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${otherEventDateId}`,
+				{ headers: authHeaders }
+			);
+		}
+		if (eventPostId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${eventPostId}`, {
+				headers: authHeaders,
+				params: { force: 'true' },
+			});
+		}
+		if (otherEventPostId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${otherEventPostId}`, {
+				headers: authHeaders,
+				params: { force: 'true' },
+			});
+		}
+		await api.dispose();
+	});
+
+	test('moves a signup to a sibling occurrence, preserving data', async () => {
+		const sourceId = occurrenceIds[0];
+		const targetId = occurrenceIds[1];
+
+		const addRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${sourceId}/participants`,
+			{
+				headers: authHeaders,
+				data: { participant_id: participantAId, label: 'signed_up' },
+			}
+		);
+		expect(addRes.ok()).toBeTruthy();
+
+		const updateRes = await api.put(
+			`/wp-json/fair-audience/v1/event-dates/${sourceId}/participants/${participantAId}`,
+			{
+				headers: authHeaders,
+				data: { attended: true, admin_comment: 'paid in cash' },
+			}
+		);
+		expect(updateRes.ok()).toBeTruthy();
+		const updateBody = await updateRes.json();
+		expect(updateBody.attended_at).toBeTruthy();
+
+		const moveRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${sourceId}/participants/${participantAId}/move`,
+			{
+				headers: authHeaders,
+				data: { target_event_date_id: targetId },
+			}
+		);
+		expect(moveRes.ok()).toBeTruthy();
+
+		const sourceList = await (
+			await api.get(
+				`/wp-json/fair-audience/v1/event-dates/${sourceId}/participants`,
+				{ headers: authHeaders }
+			)
+		).json();
+		expect(
+			sourceList.find((p) => p.participant_id === participantAId)
+		).toBeUndefined();
+
+		const targetList = await (
+			await api.get(
+				`/wp-json/fair-audience/v1/event-dates/${targetId}/participants`,
+				{ headers: authHeaders }
+			)
+		).json();
+		const moved = targetList.find(
+			(p) => p.participant_id === participantAId
+		);
+		expect(moved).toBeTruthy();
+		expect(moved.label).toBe('signed_up');
+		expect(moved.attended_at).toBeTruthy();
+		expect(moved.admin_comment).toBe('paid in cash');
+	});
+
+	test('moving onto a date where the participant already exists returns 409', async () => {
+		const sourceId = occurrenceIds[1];
+		const targetId = occurrenceIds[2];
+
+		// Participant A is now on occurrenceIds[1] (target of the previous test).
+		const addRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${targetId}/participants`,
+			{
+				headers: authHeaders,
+				data: { participant_id: participantAId, label: 'signed_up' },
+			}
+		);
+		expect(addRes.ok()).toBeTruthy();
+
+		const moveRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${sourceId}/participants/${participantAId}/move`,
+			{
+				headers: authHeaders,
+				data: { target_event_date_id: targetId },
+			}
+		);
+		expect(moveRes.status()).toBe(409);
+
+		// No duplicate: still exactly one row for this participant on the target.
+		const targetList = await (
+			await api.get(
+				`/wp-json/fair-audience/v1/event-dates/${targetId}/participants`,
+				{ headers: authHeaders }
+			)
+		).json();
+		expect(
+			targetList.filter((p) => p.participant_id === participantAId).length
+		).toBe(1);
+	});
+
+	test('moving a signup that does not exist on the source returns 404', async () => {
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${occurrenceIds[0]}/participants/${participantBId}/move`,
+			{
+				headers: authHeaders,
+				data: { target_event_date_id: occurrenceIds[1] },
+			}
+		);
+		expect(res.status()).toBe(404);
+	});
+
+	test('moving to a non-sibling event date returns 400', async () => {
+		const addRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${occurrenceIds[0]}/participants`,
+			{
+				headers: authHeaders,
+				data: { participant_id: participantBId, label: 'signed_up' },
+			}
+		);
+		expect(addRes.ok()).toBeTruthy();
+
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${occurrenceIds[0]}/participants/${participantBId}/move`,
+			{
+				headers: authHeaders,
+				data: { target_event_date_id: otherEventDateId },
+			}
+		);
+		expect(res.status()).toBe(400);
+	});
+
+	test('unauthenticated request is rejected', async () => {
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${occurrenceIds[0]}/participants/${participantBId}/move`,
+			{ data: { target_event_date_id: occurrenceIds[1] } }
+		);
+		expect(res.status()).toBeGreaterThanOrEqual(401);
+		expect(res.status()).toBeLessThan(404);
+	});
+});

--- a/fair-audience/src/Admin/manage-event-ext/EventAudience.js
+++ b/fair-audience/src/Admin/manage-event-ext/EventAudience.js
@@ -66,6 +66,7 @@ export default function EventAudience({
 	const [loadingParticipants, setLoadingParticipants] = useState(true);
 	const [ticketOptions, setTicketOptions] = useState([]);
 	const [ticketTypes, setTicketTypes] = useState([]);
+	const [siblings, setSiblings] = useState([]);
 	const [formsSummary, setFormsSummary] = useState([]);
 	const [loadingForms, setLoadingForms] = useState(true);
 
@@ -103,6 +104,11 @@ export default function EventAudience({
 	const [editStaleDecision, setEditStaleDecision] = useState(null);
 	const [editLabel, setEditLabel] = useState('signed_up');
 	const [isSavingOptions, setIsSavingOptions] = useState(false);
+
+	// Move-to-occurrence modal state
+	const [movingParticipant, setMovingParticipant] = useState(null);
+	const [moveTargetId, setMoveTargetId] = useState('');
+	const [isMoving, setIsMoving] = useState(false);
 
 	const [toast, setToast] = useState(null);
 	const toastTimerRef = useRef(null);
@@ -151,6 +157,19 @@ export default function EventAudience({
 			.catch(() => {
 				setTicketOptions([]);
 				setTicketTypes([]);
+			});
+	}, [eventDateId]);
+
+	useEffect(() => {
+		if (!eventDateId) return;
+		apiFetch({
+			path: `/fair-events/v1/event-dates/${eventDateId}/siblings`,
+		})
+			.then((data) => {
+				setSiblings(Array.isArray(data) ? data : []);
+			})
+			.catch(() => {
+				setSiblings([]);
 			});
 	}, [eventDateId]);
 
@@ -259,6 +278,11 @@ export default function EventAudience({
 	const stalePending = useMemo(
 		() => participants.filter(isStalePendingPayment),
 		[participants]
+	);
+
+	const otherOccurrences = useMemo(
+		() => siblings.filter((s) => Number(s.id) !== Number(eventDateId)),
+		[siblings, eventDateId]
 	);
 
 	const handleSort = (column) => {
@@ -695,6 +719,43 @@ export default function EventAudience({
 			);
 		} finally {
 			setIsSavingOptions(false);
+		}
+	};
+
+	const handleOpenMoveModal = (participant) => {
+		if (participant.is_series_pass) {
+			return;
+		}
+		setMovingParticipant(participant);
+		setMoveTargetId(
+			otherOccurrences.length > 0 ? String(otherOccurrences[0].id) : ''
+		);
+	};
+
+	const handleCloseMoveModal = () => {
+		setMovingParticipant(null);
+		setMoveTargetId('');
+	};
+
+	const handleMove = async () => {
+		if (!movingParticipant || !moveTargetId) return;
+		setIsMoving(true);
+		try {
+			await apiFetch({
+				path: `/fair-audience/v1/event-dates/${eventDateId}/participants/${movingParticipant.participant_id}/move`,
+				method: 'POST',
+				data: { target_event_date_id: Number(moveTargetId) },
+			});
+			handleCloseMoveModal();
+			loadParticipants();
+			showToast(__('Signup moved successfully.', 'fair-audience'));
+		} catch (err) {
+			showToast(
+				__('Error moving signup: ', 'fair-audience') + err.message,
+				'error'
+			);
+		} finally {
+			setIsMoving(false);
 		}
 	};
 
@@ -1220,6 +1281,7 @@ export default function EventAudience({
 									<SelectControl
 										label={__('Role', 'fair-audience')}
 										value={filterRole}
+										__next40pxDefaultSize
 										options={[
 											{
 												label: __(
@@ -1519,6 +1581,22 @@ export default function EventAudience({
 																				'fair-audience'
 																			)}
 																		</Button>
+																		{otherOccurrences.length >
+																			0 && (
+																			<Button
+																				variant="link"
+																				onClick={() =>
+																					handleOpenMoveModal(
+																						p
+																					)
+																				}
+																			>
+																				{__(
+																					'Move',
+																					'fair-audience'
+																				)}
+																			</Button>
+																		)}
 																	</HStack>
 																)}
 															</td>
@@ -2370,6 +2448,55 @@ export default function EventAudience({
 								{isSavingOptions
 									? __('Saving…', 'fair-audience')
 									: __('Save', 'fair-audience')}
+							</Button>
+						</HStack>
+					</VStack>
+				</Modal>
+			)}
+
+			{movingParticipant && (
+				<Modal
+					title={sprintf(
+						/* translators: %s: participant name */
+						__('Move signup — %s', 'fair-audience'),
+						movingParticipant.participant_name
+					)}
+					onRequestClose={handleCloseMoveModal}
+					style={{ maxWidth: '480px', width: '100%' }}
+				>
+					<VStack spacing={3}>
+						<SelectControl
+							label={__('Move to occurrence', 'fair-audience')}
+							value={moveTargetId}
+							options={otherOccurrences.map((s) => ({
+								label: new Date(
+									s.start_datetime.replace(' ', 'T')
+								).toLocaleString(),
+								value: String(s.id),
+							}))}
+							onChange={setMoveTargetId}
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+						<HStack
+							spacing={3}
+							style={{ justifyContent: 'flex-end' }}
+						>
+							<Button
+								variant="secondary"
+								onClick={handleCloseMoveModal}
+								disabled={isMoving}
+							>
+								{__('Cancel', 'fair-audience')}
+							</Button>
+							<Button
+								variant="primary"
+								onClick={handleMove}
+								disabled={!moveTargetId || isMoving}
+							>
+								{isMoving
+									? __('Moving…', 'fair-audience')
+									: __('Move', 'fair-audience')}
 							</Button>
 						</HStack>
 					</VStack>

--- a/fair-audience/src/Admin/manage-event-ext/__tests__/EventAudienceMove.test.jsx
+++ b/fair-audience/src/Admin/manage-event-ext/__tests__/EventAudienceMove.test.jsx
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Component tests for the "Move signup to another occurrence" action (#954).
+ *
+ * Exercises:
+ *   - Move button is hidden when there is only one occurrence.
+ *   - Move button appears for non-series-pass rows when siblings exist.
+ *   - Opening the modal lists the other occurrences (current one excluded).
+ *   - Confirming calls the move endpoint and refreshes the participant list.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import EventAudience from '../EventAudience.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const PARTICIPANT = {
+	id: 1,
+	participant_id: 10,
+	event_date_id: 5,
+	is_series_pass: false,
+	participant_name: 'Jane Doe',
+	name: 'Jane',
+	surname: 'Doe',
+	participant_email: 'jane@example.com',
+	email_profile: 'marketing',
+	label: 'signed_up',
+	ticket_type_id: null,
+	ticket_type_name: null,
+	attended_at: null,
+	created_at: '2026-01-01 10:00:00',
+	payment_expires_at: null,
+	ticket_option_names: [],
+	ticket_option_ids: [],
+	admin_comment: '',
+};
+
+const SIBLINGS = [
+	{ id: 5, start_datetime: '2026-01-01 10:00:00', occurrence_type: 'master' },
+	{
+		id: 6,
+		start_datetime: '2026-01-08 10:00:00',
+		occurrence_type: 'generated',
+	},
+	{
+		id: 7,
+		start_datetime: '2026-01-15 10:00:00',
+		occurrence_type: 'generated',
+	},
+];
+
+function mockApiFetchFor({ siblings }) {
+	apiFetch.mockImplementation(({ path, method }) => {
+		if (path.includes('/participants/10/move')) {
+			return Promise.resolve({
+				message: 'moved',
+				target_event_date_id: 6,
+			});
+		}
+		if (path.endsWith('/participants')) {
+			return Promise.resolve([PARTICIPANT]);
+		}
+		if (path.includes('/siblings')) {
+			return Promise.resolve(siblings);
+		}
+		if (path.includes('/tickets')) {
+			return Promise.resolve({ options: [], ticket_types: [] });
+		}
+		if (path.includes('forms-summary')) {
+			return Promise.resolve([]);
+		}
+		if (path.includes('group-permission-rules')) {
+			return Promise.resolve([]);
+		}
+		if (path.includes('/groups')) {
+			return Promise.resolve([]);
+		}
+		return Promise.resolve([]);
+	});
+}
+
+function renderAudience() {
+	render(
+		<EventAudience
+			eventId={1}
+			eventDateId={5}
+			audienceUrl="admin.php?page=fair-audience&event_date_id="
+			eventTitle="Weekly class"
+		/>
+	);
+}
+
+beforeEach(() => {
+	jest.spyOn(console, 'warn').mockImplementation(() => {});
+	jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+	jest.clearAllMocks();
+});
+
+describe('EventAudience — Move action', () => {
+	it('hides the Move button when there is only one occurrence', async () => {
+		mockApiFetchFor({ siblings: [SIBLINGS[0]] });
+		renderAudience();
+
+		expect(await screen.findByText('Jane Doe')).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Move' })
+		).not.toBeInTheDocument();
+	});
+
+	it('shows the Move button and lists sibling occurrences in the modal', async () => {
+		mockApiFetchFor({ siblings: SIBLINGS });
+		renderAudience();
+
+		const moveButton = await screen.findByRole('button', { name: 'Move' });
+		fireEvent.click(moveButton);
+
+		const modal = screen.getByRole('dialog');
+		const select = within(modal).getByRole('combobox');
+		const options = within(select).getAllByRole('option');
+
+		// Current occurrence (id 5) is excluded; the other two are listed.
+		expect(options).toHaveLength(2);
+	});
+
+	it('confirming the move calls the move endpoint with the selected target', async () => {
+		mockApiFetchFor({ siblings: SIBLINGS });
+		renderAudience();
+
+		const moveButton = await screen.findByRole('button', { name: 'Move' });
+		fireEvent.click(moveButton);
+
+		const modal = screen.getByRole('dialog');
+		fireEvent.click(within(modal).getByRole('button', { name: 'Move' }));
+
+		expect(apiFetch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				path: '/fair-audience/v1/event-dates/5/participants/10/move',
+				method: 'POST',
+				data: { target_event_date_id: 6 },
+			})
+		);
+	});
+});

--- a/fair-audience/src/Database/EventParticipantRepository.php
+++ b/fair-audience/src/Database/EventParticipantRepository.php
@@ -599,6 +599,41 @@ class EventParticipantRepository {
 	}
 
 	/**
+	 * Move a participant's signup from one event date to another.
+	 *
+	 * Re-points the link row's event_date_id in place, preserving label,
+	 * attended_at, ticket options, admin comment, and payment fields (they
+	 * reference the row id, not the event_date_id).
+	 *
+	 * @param int $event_date_id        Source event date ID.
+	 * @param int $participant_id       Participant ID.
+	 * @param int $target_event_date_id Target event date ID.
+	 * @return string 'success', 'not_found' (no source link), or 'conflict' (target already has this participant).
+	 */
+	public function move_to_event_date( $event_date_id, $participant_id, $target_event_date_id ) {
+		global $wpdb;
+
+		$relationship = $this->get_by_event_date_and_participant( $event_date_id, $participant_id );
+		if ( ! $relationship ) {
+			return 'not_found';
+		}
+
+		if ( $this->get_by_event_date_and_participant( $target_event_date_id, $participant_id ) ) {
+			return 'conflict';
+		}
+
+		$result = $wpdb->update(
+			$this->get_table_name(),
+			array( 'event_date_id' => $target_event_date_id ),
+			array( 'id' => $relationship->id ),
+			array( '%d' ),
+			array( '%d' )
+		);
+
+		return false !== $result ? 'success' : 'not_found';
+	}
+
+	/**
 	 * Get counts by label for an event date.
 	 *
 	 * @param int $event_date_id Event date ID.

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -201,6 +201,25 @@ class EventDatesController extends WP_REST_Controller {
 			)
 		);
 
+		// GET /fair-events/v1/event-dates/{id}/siblings - List sibling occurrences.
+		register_rest_route(
+			$this->namespace,
+			'/event-dates/(?P<id>\d+)/siblings',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_siblings' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'description' => __( 'Unique identifier for the event date.', 'fair-events' ),
+							'type'        => 'integer',
+						),
+					),
+				),
+			)
+		);
+
 		// GET /fair-events/v1/event-dates/batch - Batch lookup by IDs.
 		register_rest_route(
 			$this->namespace,
@@ -665,6 +684,46 @@ class EventDatesController extends WP_REST_Controller {
 		}
 
 		return new WP_REST_Response( $this->prepare_event_date( $event_date ), 200 );
+	}
+
+	/**
+	 * Get sibling occurrences for a recurring event
+	 *
+	 * Resolves the master occurrence for the given event date, then returns
+	 * the master plus all of its generated occurrences (single/standalone
+	 * events return just themselves).
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
+	 */
+	public function get_siblings( $request ) {
+		$id         = (int) $request->get_param( 'id' );
+		$event_date = EventDates::get_by_id( $id );
+
+		if ( ! $event_date ) {
+			return new WP_Error(
+				'rest_event_date_not_found',
+				__( 'Event date not found.', 'fair-events' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$master_id = ( 'generated' === $event_date->occurrence_type && $event_date->master_id )
+			? $event_date->master_id
+			: $event_date->id;
+
+		$siblings = EventDates::get_all_by_master_id( $master_id );
+
+		$items = array();
+		foreach ( $siblings as $sibling ) {
+			$items[] = array(
+				'id'              => $sibling->id,
+				'start_datetime'  => $sibling->start_datetime,
+				'occurrence_type' => $sibling->occurrence_type,
+			);
+		}
+
+		return new WP_REST_Response( $items, 200 );
 	}
 
 	/**

--- a/fair-events/src/API/__tests__/EventDatesSiblings.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesSiblings.api.spec.js
@@ -1,0 +1,147 @@
+/**
+ * Playwright API tests for the sibling-occurrences endpoint on
+ * EventDatesController.
+ *
+ * Exercises GET /fair-events/v1/event-dates/{id}/siblings against a live
+ * WordPress instance.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('EventDatesController — siblings', () => {
+	let api;
+	let eventPostId;
+	let masterEventDateId;
+	let generatedIds;
+	let standaloneEventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: { title: `Siblings test ${Date.now()}`, status: 'publish' },
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2036-04-01 10:00:00',
+				end_datetime: '2036-04-01 12:00:00',
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		const edBody = await edRes.json();
+		masterEventDateId = edBody.id;
+		generatedIds = edBody.generated_occurrences.map((o) => o.id);
+		expect(generatedIds.length).toBe(2);
+
+		const standaloneRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Standalone sibling test ${Date.now()}`,
+					start_datetime: '2036-05-01 10:00:00',
+				},
+			}
+		);
+		expect(standaloneRes.ok()).toBeTruthy();
+		standaloneEventDateId = (await standaloneRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (masterEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (standaloneEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${standaloneEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (eventPostId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${eventPostId}`, {
+				headers: adminHeaders,
+				params: { force: 'true' },
+			});
+		}
+		await api.dispose();
+	});
+
+	test('returns master plus generated occurrences from the master id', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/siblings`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const ids = body.map((s) => s.id);
+		expect(ids).toContain(masterEventDateId);
+		generatedIds.forEach((id) => expect(ids).toContain(id));
+		expect(body.length).toBe(3);
+
+		const master = body.find((s) => s.id === masterEventDateId);
+		expect(master.occurrence_type).toBe('master');
+	});
+
+	test('returns the same set from a generated occurrence id', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${generatedIds[0]}/siblings`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const ids = body.map((s) => s.id);
+		expect(ids).toContain(masterEventDateId);
+		generatedIds.forEach((id) => expect(ids).toContain(id));
+		expect(body.length).toBe(3);
+	});
+
+	test('standalone (single) event returns only itself', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${standaloneEventDateId}/siblings`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		expect(body.length).toBe(1);
+		expect(body[0].id).toBe(standaloneEventDateId);
+	});
+
+	test('unknown event date returns 404', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/event-dates/999999999/siblings',
+			{ headers: adminHeaders }
+		);
+		expect(res.status()).toBe(404);
+	});
+
+	test('unauthenticated request is rejected', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/siblings`
+		);
+		expect(res.status()).toBeGreaterThanOrEqual(401);
+		expect(res.status()).toBeLessThan(404);
+	});
+});


### PR DESCRIPTION
## Summary

- Organisers can now move a participant's signup to a sibling occurrence of a recurring event, in one step, from the Audience tab — no more delete-and-re-add, which lost attendance state, admin comments, ticket options, and payment status.
- **fair-events**: `GET /event-dates/{id}/siblings` resolves the master and returns it plus all generated occurrences (single/standalone events return just themselves). Admin-only (`current_user_can`), never `__return_true`.
- **fair-audience**: `POST /event-dates/{event_date_id}/participants/{participant_id}/move` re-points the link row's `event_date_id` by primary key (preserves `label`, `attended_at`, ticket options, admin comment, payment fields). Validates the target is a real sibling server-side (400 otherwise), and rejects with 409 if the participant is already signed up on the target date (no merge, no duplicate).
- **EventAudience.js**: adds a "Move" row action (hidden for series-pass rows and when there's only one occurrence) that opens a modal listing the other occurrences, then calls the move endpoint and refreshes the list.

## Test plan

- [x] `npm test` in fair-audience (component test: Move button visibility, modal lists siblings, confirm calls the move endpoint)
- [x] `npm test` in fair-events (existing suite unaffected)
- [x] `npm run build` in fair-audience (frontend change)
- [x] API spec tests added: fair-events siblings endpoint (master+generated, standalone, 404, permission check); fair-audience move endpoint (happy path with data preserved, 409 conflict, 404 unknown link, 400 non-sibling target, permission check)
- [ ] Manual click-through in a running WP instance (not run in this session)

Closes #954
