### PR TITLE
Add e2e for audience session cookies

### DIFF
--- a/e2e/mu-plugins/scripts/cleanup-participant.php
+++ b/e2e/mu-plugins/scripts/cleanup-participant.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Delete a single fair_audience_participants row by id.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/cleanup-participant.php <participantId>
+ *
+ * Companion to seed-known-participant.php: those participants never sign up
+ * for anything (or, for the "recognised email" one, may or may not depending
+ * on how far the spec got before failing), so cleanup-event.php's
+ * event_participants-driven cleanup can't be relied on to catch them.
+ * Deleting by id is a no-op (0 rows) if the row is already gone.
+ *
+ * Prints a single `E2E_PARTICIPANT_CLEANUP:{json}` line with the deleted row count.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+global $wpdb;
+
+$participant_id = isset( $args[0] ) ? (int) $args[0] : 0;
+if ( ! $participant_id ) {
+	WP_CLI::error( 'Usage: cleanup-participant.php <participantId>' );
+}
+
+$participants_table = $wpdb->prefix . 'fair_audience_participants';
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off teardown script, no cache to honour.
+$deleted = (int) $wpdb->query(
+	$wpdb->prepare( 'DELETE FROM %i WHERE id = %d', $participants_table, $participant_id )
+);
+// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+echo 'E2E_PARTICIPANT_CLEANUP:' . wp_json_encode( array( 'participants' => $deleted ) ) . "\n";

--- a/e2e/mu-plugins/scripts/seed-audience-session-cookie.php
+++ b/e2e/mu-plugins/scripts/seed-audience-session-cookie.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Mint a valid fair_audience_session cookie value for a participant, for the
+ * resume-anonymous-signup-on-recognised-email E2E spec.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-audience-session-cookie.php <participant_id>
+ *
+ * AudienceSession::set() can't be used directly from a CLI script — it calls
+ * setcookie(), which is a no-op outside a real HTTP response — so this
+ * reproduces its signing scheme (see FairAudience\Services\AudienceSession)
+ * to hand the spec a cookie value it can inject into the browser context
+ * with context.addCookies().
+ *
+ * Used to simulate a browser that already holds an active session for one
+ * participant when it then types a *different*, known participant's email
+ * into the anonymous signup form — the register endpoint's anti-enumeration
+ * check (`$session_pid !== $participant->id`) must still stash-and-email a
+ * resume link rather than silently acting on the session's identity.
+ *
+ * Prints a single `E2E_COOKIE:{json}` line with the cookie value.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$participant_id = isset( $args[0] ) ? (int) $args[0] : 0;
+
+if ( ! $participant_id ) {
+	WP_CLI::error( 'Usage: seed-audience-session-cookie.php <participant_id>' );
+}
+
+$expires_at = time() + HOUR_IN_SECONDS;
+$data       = $participant_id . '.' . $expires_at;
+$secret     = 'fair_audience_session_' . wp_salt( 'auth' );
+$signature  = hash_hmac( 'sha256', $data, $secret );
+$value      = $data . '.' . $signature;
+
+echo 'E2E_COOKIE:' . wp_json_encode( array( 'value' => $value ) ) . "\n";

--- a/e2e/mu-plugins/scripts/seed-known-participant.php
+++ b/e2e/mu-plugins/scripts/seed-known-participant.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Create a standalone participant (no event signup) for the resume-anonymous
+ * -signup-on-recognised-email E2E spec.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-known-participant.php <name> <email>
+ *
+ * Used to create two distinct participants: the one whose email the spec
+ * later "recognises" (triggering the register endpoint's anti-enumeration
+ * resume flow), and a second one the spec binds an unrelated
+ * fair_audience_session cookie to (via seed-audience-session-cookie.php) so
+ * the browser looks like it already has an active session for someone else
+ * when it submits the first participant's email.
+ *
+ * Prints a single `E2E_PARTICIPANT:{json}` line with the participant id.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use FairAudience\Models\Participant;
+
+$name  = isset( $args[0] ) ? (string) $args[0] : '';
+$email = isset( $args[1] ) ? (string) $args[1] : '';
+
+if ( ! $name || ! $email ) {
+	WP_CLI::error( 'Usage: seed-known-participant.php <name> <email>' );
+}
+
+$participant = new Participant(
+	array(
+		'name'          => $name,
+		'email'         => $email,
+		'email_profile' => 'minimal',
+		'status'        => 'confirmed',
+	)
+);
+if ( ! $participant->save() ) {
+	WP_CLI::error( 'Failed to create participant.' );
+}
+
+echo 'E2E_PARTICIPANT:' . wp_json_encode(
+	array(
+		'participantId' => (int) $participant->id,
+		'email'         => $email,
+	)
+) . "\n";

--- a/e2e/mu-plugins/scripts/signup-state.php
+++ b/e2e/mu-plugins/scripts/signup-state.php
@@ -6,10 +6,11 @@
  *   wp eval-file wp-content/mu-plugins/scripts/signup-state.php <email> <event_date_id>
  *
  * Prints a single `E2E_STATE:{json}` line with the participant's marketing
- * profile, the event-participant label, and the mail captured for this buyer,
- * so the spec can assert that consent was recorded only when opted in, that
- * payment flipped the row to signed_up, and that the confirmation email was
- * delivered.
+ * profile, the event-participant label, and the mail captured for this buyer
+ * (including the HTML body, so a spec can pull a link out of it, e.g. a
+ * resume-registration URL), so the spec can assert that consent was recorded
+ * only when opted in, that payment flipped the row to signed_up, and that the
+ * confirmation email was delivered.
  *
  * @package FairEventsE2E
  */
@@ -48,6 +49,7 @@ foreach ( get_option( 'fair_e2e_captured_mail', array() ) as $entry ) {
 		$mail[] = array(
 			'to'      => $entry['to'] ?? '',
 			'subject' => $entry['subject'] ?? '',
+			'body'    => $entry['body'] ?? '',
 		);
 	}
 }

--- a/e2e/user-flows/resume-signup-recognised-email.spec.js
+++ b/e2e/user-flows/resume-signup-recognised-email.spec.js
@@ -1,0 +1,175 @@
+/**
+ * E2E: resume an anonymous signup on a recognised email (#1004), including
+ * the anti-enumeration guard when the browser already holds a session for a
+ * *different* participant.
+ *
+ * The API spec (EventSignupResume.api.spec.js) covers the register/resume
+ * endpoints in isolation but only from a cookie-less request context, and
+ * can't drive the emailed resume link at all. Here we go through the real
+ * browser UI end to end:
+ *
+ *   1. The browser already has a fair_audience_session cookie for an
+ *      unrelated participant (seeded directly — AudienceSession::set() can't
+ *      be called from a CLI script, see seed-audience-session-cookie.php).
+ *      That session pre-fills the anonymous form, proving the cookie is
+ *      read, but its identity must NOT be reused for a different email.
+ *   2. Typing a second, already-registered participant's email submits the
+ *      form; since the session belongs to someone else, the server must
+ *      stash the submission and email a resume link instead of signing
+ *      anyone up (anti-enumeration — a guessed email can't be hijacked via
+ *      an unrelated active session either).
+ *   3. The resume link (extracted from the captured mail, since the dev
+ *      stack has no real inbox) is visited for real; the form must restore
+ *      into the authenticated "with_token" state and let the visitor
+ *      complete the (paid) signup they originally filled in — through the
+ *      real Mollie-double checkout/callback round trip, same as
+ *      ticket-purchase-confirmation.spec.js.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+import { runScript } from '../support/wp-cli.js';
+
+test.describe('event-signup block: resume anonymous signup on recognised email', () => {
+	test('a session for another participant does not bypass the resume-by-email flow', async ({
+		page,
+		context,
+		seedEvent,
+	}) => {
+		const event = seedEvent('paid');
+		const stamp = Date.now();
+
+		const recognisedEmail = `resume.recognised.${stamp}@example.test`;
+		const recognised = runScript(
+			'seed-known-participant.php',
+			'E2E_PARTICIPANT',
+			`'Resume Recognised ${stamp}' ${recognisedEmail}`
+		);
+
+		const sessionOwnerEmail = `resume.session-owner.${stamp}@example.test`;
+		const sessionOwner = runScript(
+			'seed-known-participant.php',
+			'E2E_PARTICIPANT',
+			`'Resume Session Owner ${stamp}' ${sessionOwnerEmail}`
+		);
+
+		const cookie = runScript(
+			'seed-audience-session-cookie.php',
+			'E2E_COOKIE',
+			String(sessionOwner.participantId)
+		);
+
+		try {
+			const pageUrl = new URL(event.pageUrl);
+			await context.addCookies([
+				{
+					name: 'fair_audience_session',
+					value: cookie.value,
+					domain: pageUrl.hostname,
+					path: '/',
+				},
+			]);
+
+			// The session cookie pre-fills the anonymous form with the session
+			// owner's details — proves the cookie is actually being read.
+			await page.goto(event.pageUrl);
+			const form = page.locator('.fair-audience-signup-register');
+			await expect(form).toBeVisible();
+			await expect(
+				form.locator('input[name="signup_email"]')
+			).toHaveValue(sessionOwnerEmail);
+
+			// Overwrite with the OTHER, already-registered participant's email —
+			// the session belongs to someone else, so this must not be treated
+			// as an authenticated resubmission of that session's identity.
+			await form
+				.locator('input[name="signup_name"]')
+				.fill('Resume Recognised Visitor');
+			await form
+				.locator('input[name="signup_email"]')
+				.fill(recognisedEmail);
+			const ticket = form.locator('input[name="ticket_type_id"]');
+			await ticket.check();
+			expect(
+				Number(await ticket.getAttribute('data-ticket-price'))
+			).toBeGreaterThan(0);
+
+			await form.locator('.fair-audience-signup-submit-button').click();
+
+			// Anti-enumeration response: generic "check your inbox" message, no
+			// signup created, no session hijack.
+			await expect(
+				page.getByText('check your inbox', { exact: false })
+			).toBeVisible();
+
+			const state = runScript(
+				'signup-state.php',
+				'E2E_STATE',
+				`${recognisedEmail} ${event.eventDateId}`
+			);
+			expect(state.label).not.toBe('signed_up');
+
+			// Pull the resume link out of the captured mail (no real inbox in
+			// this stack) and follow it as the visitor would from their email
+			// client.
+			const resumeMail = state.mail.find((m) =>
+				m.subject.includes('Continue registering')
+			);
+			expect(
+				resumeMail,
+				'a "Continue registering" resume email should be captured'
+			).toBeTruthy();
+
+			const participantTokenMatch = resumeMail.body.match(
+				/participant_token=([^"&#]+)/
+			);
+			const resumeTokenMatch = resumeMail.body.match(/resume=([^"&#]+)/);
+			expect(
+				participantTokenMatch,
+				'participant_token in resume email'
+			).toBeTruthy();
+			expect(
+				resumeTokenMatch,
+				'resume token in resume email'
+			).toBeTruthy();
+
+			await page.goto(
+				`${event.pageUrl}?participant_token=${participantTokenMatch[1]}&resume=${resumeTokenMatch[1]}`
+			);
+
+			// The restored, authenticated form shows the "welcome back" notice
+			// and lets the visitor finish the signup they originally filled in.
+			await expect(
+				page.getByText('restored your answers', { exact: false })
+			).toBeVisible();
+
+			// Complete the paid signup: the double's checkout link sends the
+			// buyer straight back to the callback URL, which syncs "paid" from
+			// the double on the reload (see ticket-purchase-confirmation.spec.js).
+			const signupButton = page.locator('.fair-audience-signup-button');
+			await expect(signupButton).toBeVisible();
+			await signupButton.click();
+			await expect(
+				page.getByText('Payment confirmed', { exact: false })
+			).toBeVisible({ timeout: 30000 });
+			await expect(page).toHaveURL(/fair_payment_callback=true/);
+
+			const finalState = runScript(
+				'signup-state.php',
+				'E2E_STATE',
+				`${recognisedEmail} ${event.eventDateId}`
+			);
+			expect(finalState.label).toBe('signed_up');
+		} finally {
+			runScript(
+				'cleanup-participant.php',
+				'E2E_PARTICIPANT_CLEANUP',
+				String(recognised.participantId)
+			);
+			runScript(
+				'cleanup-participant.php',
+				'E2E_PARTICIPANT_CLEANUP',
+				String(sessionOwner.participantId)
+			);
+		}
+	});
+});


### PR DESCRIPTION
Lets the signup-cancel-and-restart spec inject a valid fair_audience_session cookie via context.addCookies(), since AudienceSession::set() can't be called directly from a CLI script.