### PR TITLE
Restructure Tickets tab around editing, not read-only summary

### DIFF
--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -328,12 +328,22 @@ class AdminPages {
 				$localized_data
 			);
 
+			$payments_connector_data = array(
+				'currency' => get_option( 'fair_payment_currency', 'EUR' ),
+			);
+
+			// Reuse the connector's own "configured" definition rather than
+			// re-reading its options here, so the notice matches the
+			// top-of-page admin notice in fair-payments-connector.
+			if ( class_exists( '\FairPaymentsConnector\Payment\MolliePaymentHandler' ) ) {
+				$payments_connector_data['paymentConfigured'] = \FairPaymentsConnector\Payment\MolliePaymentHandler::is_configured();
+				$payments_connector_data['settingsUrl']       = admin_url( 'admin.php?page=fair-payments-connector-settings' );
+			}
+
 			wp_localize_script(
 				'fair-events-manage-event',
 				'fairPaymentsConnector',
-				array(
-					'currency' => get_option( 'fair_payment_currency', 'EUR' ),
-				)
+				$payments_connector_data
 			);
 
 			wp_set_script_translations(

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -13,7 +13,10 @@ import {
 	CardBody,
 	Button,
 	CheckboxControl,
+	DropdownMenu,
 	FormTokenField,
+	MenuGroup,
+	MenuItem,
 	Modal,
 	Panel,
 	PanelBody,
@@ -27,6 +30,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { moreVertical } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 
 export default function EventTickets({
@@ -79,6 +83,8 @@ export default function EventTickets({
 		window.fairEventsManageEventData?.manageInvitationsUrl || '';
 
 	const hasAdvancedTickets = ticketTypes.length > 0 || salePeriods.length > 0;
+	const paymentNotConfigured =
+		window.fairPaymentsConnector?.paymentConfigured === false;
 	const hasInvitationTickets = ticketTypes.some((t) => t.invitation_only);
 	const hasGroups = groups.length > 0;
 	const groupNameById = Object.fromEntries(groups.map((g) => [g.id, g.name]));
@@ -734,13 +740,6 @@ export default function EventTickets({
 
 	const siteCurrency = window.fairPaymentsConnector?.currency || 'EUR';
 
-	const formatCurrency = (value) => {
-		return new Intl.NumberFormat('en-US', {
-			style: 'currency',
-			currency: siteCurrency,
-		}).format(value);
-	};
-
 	if (loading) {
 		return (
 			<Card style={{ marginTop: '16px' }}>
@@ -777,6 +776,24 @@ export default function EventTickets({
 				</Notice>
 			)}
 
+			{paymentNotConfigured && hasAdvancedTickets && (
+				<Notice
+					status="warning"
+					isDismissible={false}
+					actions={[
+						{
+							label: __('Set up Mollie', 'fair-events'),
+							url: window.fairPaymentsConnector.settingsUrl,
+						},
+					]}
+				>
+					{__(
+						"Prices are set, but payments aren't configured.",
+						'fair-events'
+					)}
+				</Notice>
+			)}
+
 			<HStack spacing={2} justify="space-between">
 				<Button
 					variant="primary"
@@ -786,41 +803,24 @@ export default function EventTickets({
 				>
 					{__('Save tickets', 'fair-events')}
 				</Button>
-				<HStack spacing={2} justify="flex-end">
-					{(hasInvitationTickets ||
-						settings.activity_collaborator_discount) &&
-						manageInvitationsUrl && (
-							<Button
-								variant="secondary"
-								href={`${manageInvitationsUrl}${eventDateId}`}
-							>
-								{__('Manage Invitations', 'fair-events')}
-							</Button>
-						)}
-					<Button
-						variant="secondary"
-						onClick={handleExport}
-						disabled={importing || saving}
-					>
-						{__('Export ticket settings', 'fair-events')}
-					</Button>
-					<Button
-						variant="secondary"
-						onClick={() => fileInputRef.current?.click()}
-						disabled={importing || saving}
-						isBusy={importing}
-					>
-						{__('Import ticket settings', 'fair-events')}
-					</Button>
-					<input
-						ref={fileInputRef}
-						type="file"
-						accept="application/json,.json"
-						style={{ display: 'none' }}
-						onChange={handleImportFile}
-					/>
-				</HStack>
+				{(hasInvitationTickets ||
+					settings.activity_collaborator_discount) &&
+					manageInvitationsUrl && (
+						<Button
+							variant="secondary"
+							href={`${manageInvitationsUrl}${eventDateId}`}
+						>
+							{__('Manage Invitations', 'fair-events')}
+						</Button>
+					)}
 			</HStack>
+			<input
+				ref={fileInputRef}
+				type="file"
+				accept="application/json,.json"
+				style={{ display: 'none' }}
+				onChange={handleImportFile}
+			/>
 
 			{!hasAdvancedTickets && (
 				<Card>
@@ -845,113 +845,6 @@ export default function EventTickets({
 								{__('+ Add Ticket Type', 'fair-events')}
 							</Button>
 						</VStack>
-					</CardBody>
-				</Card>
-			)}
-
-			{ticketTypes.length > 0 && salePeriods.length > 0 && (
-				<Card>
-					<CardHeader>
-						<strong>{__('Ticket Prices', 'fair-events')}</strong>
-					</CardHeader>
-					<CardBody>
-						<div style={{ overflowX: 'auto' }}>
-							<table className="wp-list-table widefat striped">
-								<thead>
-									<tr>
-										<th>
-											{__('Ticket Type', 'fair-events')}
-										</th>
-										{salePeriods.map((period, pIndex) => (
-											<th
-												key={
-													period.id || `new-${pIndex}`
-												}
-											>
-												{settings.multiple_pricing_periods
-													? period.name ||
-													  __(
-															'(unnamed)',
-															'fair-events'
-													  )
-													: pIndex === 0
-													? __(
-															'Advance ticket',
-															'fair-events'
-													  )
-													: __(
-															'Day of event',
-															'fair-events'
-													  )}
-											</th>
-										))}
-									</tr>
-								</thead>
-								<tbody>
-									{ticketTypes.map((type, tIndex) => (
-										<tr key={type.id || `new-${tIndex}`}>
-											<td>
-												{type.name ||
-													__(
-														'(unnamed)',
-														'fair-events'
-													)}
-												{isRecurring && (
-													<>
-														{'  ('}
-														{type.recurrence_scope ===
-														'whole_series'
-															? __(
-																	'Whole series',
-																	'fair-events'
-															  )
-															: type.recurrence_scope ===
-															  'multiple_instances'
-															? __(
-																	'Multiple instances',
-																	'fair-events'
-															  )
-															: __(
-																	'This instance',
-																	'fair-events'
-															  )}
-														{')'}
-													</>
-												)}
-											</td>
-											{salePeriods.map(
-												(period, pIndex) => {
-													const cell = getPrice(
-														type,
-														period
-													);
-													const hasPrice =
-														cell.price !== '';
-													return (
-														<td
-															key={
-																period.id ||
-																`new-${pIndex}`
-															}
-														>
-															{hasPrice
-																? formatCurrency(
-																		cell.price
-																  )
-																: '—'}
-															{!settings.unlimited_tickets_in_price_period &&
-																cell.capacity !==
-																	'' &&
-																` (${cell.capacity})`}
-														</td>
-													);
-												}
-											)}
-										</tr>
-									))}
-								</tbody>
-							</table>
-						</div>
 					</CardBody>
 				</Card>
 			)}
@@ -1259,12 +1152,45 @@ export default function EventTickets({
 				</Card>
 			)}
 
-			<Card>
-				<Panel>
-					<PanelBody
-						title={__('Edit tickets', 'fair-events')}
-						initialOpen={false}
-					>
+			{hasAdvancedTickets && (
+				<Card>
+					<CardHeader>
+						<strong>{__('Tickets', 'fair-events')}</strong>
+						<DropdownMenu
+							icon={moreVertical}
+							label={__('More actions', 'fair-events')}
+						>
+							{({ onClose }) => (
+								<MenuGroup>
+									<MenuItem
+										onClick={() => {
+											handleExport();
+											onClose();
+										}}
+										disabled={importing || saving}
+									>
+										{__(
+											'Export ticket settings',
+											'fair-events'
+										)}
+									</MenuItem>
+									<MenuItem
+										onClick={() => {
+											fileInputRef.current?.click();
+											onClose();
+										}}
+										disabled={importing || saving}
+									>
+										{__(
+											'Import ticket settings',
+											'fair-events'
+										)}
+									</MenuItem>
+								</MenuGroup>
+							)}
+						</DropdownMenu>
+					</CardHeader>
+					<CardBody>
 						<VStack spacing={4}>
 							<TextControl
 								label={__('Total capacity', 'fair-events')}
@@ -1918,9 +1844,9 @@ export default function EventTickets({
 								</div>
 							</VStack>
 						</VStack>
-					</PanelBody>
-				</Panel>
-			</Card>
+					</CardBody>
+				</Card>
+			)}
 
 			<Card>
 				<Panel>
@@ -2354,7 +2280,7 @@ export default function EventTickets({
 			<Card>
 				<Panel>
 					<PanelBody
-						title={__('Settings', 'fair-events')}
+						title={__('More options', 'fair-events')}
 						initialOpen={false}
 					>
 						<VStack spacing={4}>

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -18,6 +18,7 @@ import {
 	fireEvent,
 	act,
 	waitFor,
+	within,
 } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import EventTickets from '../EventTickets.js';
@@ -67,7 +68,7 @@ const initialDataWithTicketType = {
 
 function renderTickets(extraProps = {}) {
 	const onSaveRef = { current: null };
-	render(
+	const { container } = render(
 		<EventTickets
 			eventDateId={99}
 			onSaveRef={onSaveRef}
@@ -76,14 +77,7 @@ function renderTickets(extraProps = {}) {
 			{...extraProps}
 		/>
 	);
-	return { onSaveRef };
-}
-
-function openEditTicketsPanel() {
-	const panelButton = screen.getByRole('button', {
-		name: /Edit tickets/i,
-	});
-	fireEvent.click(panelButton);
+	return { onSaveRef, container };
 }
 
 describe('EventTickets — empty state (no advanced tickets)', () => {
@@ -129,7 +123,7 @@ describe('EventTickets — empty state (no advanced tickets)', () => {
 		expect(
 			screen.queryByText(/No ticket types configured yet/i)
 		).not.toBeInTheDocument();
-		expect(screen.getByText('Ticket Prices')).toBeInTheDocument();
+		expect(screen.getByText('Ticket Type')).toBeInTheDocument();
 	});
 });
 
@@ -139,7 +133,6 @@ describe('EventTickets — recurrence scope selector', () => {
 			isRecurring: true,
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 		expect(screen.getByText('Scope')).toBeInTheDocument();
 		// Acknowledge WordPress TextControl / SelectControl size deprecation
 		// notices emitted the first time those component types render in the suite.
@@ -151,13 +144,11 @@ describe('EventTickets — recurrence scope selector', () => {
 			isRecurring: false,
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 		expect(screen.queryByText('Scope')).not.toBeInTheDocument();
 	});
 
 	it('does not show Scope column when isRecurring is omitted', () => {
 		renderTickets({ initialData: initialDataWithTicketType });
-		openEditTicketsPanel();
 		expect(screen.queryByText('Scope')).not.toBeInTheDocument();
 	});
 
@@ -168,7 +159,6 @@ describe('EventTickets — recurrence scope selector', () => {
 			// "+ Add Ticket Type" button is visible in the table footer.
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 
 		const addButton = screen.getByRole('button', {
 			name: '+ Add Ticket Type',
@@ -199,7 +189,6 @@ describe('EventTickets — recurrence scope selector', () => {
 			isRecurring: true,
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 
 		const selects = screen.getAllByRole('combobox');
 		const scopeSelect = selects.find(
@@ -218,7 +207,6 @@ describe('EventTickets — recurrence scope selector', () => {
 			isRecurring: true,
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 
 		// Change scope to whole_series.
 		const selects = screen.getAllByRole('combobox');
@@ -259,7 +247,6 @@ describe('EventTickets — multiple_instances scope (#930)', () => {
 			isRecurring: true,
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 
 		const selects = screen.getAllByRole('combobox');
 		const scopeSelect = selects.find(
@@ -283,7 +270,6 @@ describe('EventTickets — multiple_instances scope (#930)', () => {
 			isRecurring: true,
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 
 		const selects = screen.getAllByRole('combobox');
 		const scopeSelect = selects.find(
@@ -308,7 +294,6 @@ describe('EventTickets — multiple_instances scope (#930)', () => {
 			isRecurring: true,
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 
 		const selects = screen.getAllByRole('combobox');
 		const scopeSelect = selects.find(
@@ -353,7 +338,6 @@ describe('EventTickets — scope-choice modal', () => {
 			isRecurring: true,
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 
 		fireEvent.click(
 			screen.getByRole('button', { name: '+ Add Ticket Type' })
@@ -369,7 +353,6 @@ describe('EventTickets — scope-choice modal', () => {
 			isRecurring: false,
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 
 		fireEvent.click(
 			screen.getByRole('button', { name: '+ Add Ticket Type' })
@@ -385,7 +368,6 @@ describe('EventTickets — scope-choice modal', () => {
 			isRecurring: true,
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 
 		fireEvent.click(
 			screen.getByRole('button', { name: '+ Add Ticket Type' })
@@ -431,7 +413,6 @@ describe('EventTickets — scope lock when has_sales', () => {
 			isRecurring: true,
 			initialData: initialDataWithSoldTicketType,
 		});
-		openEditTicketsPanel();
 
 		expect(screen.getByText('Whole series')).toBeInTheDocument();
 		const scopeSelects = screen
@@ -449,7 +430,6 @@ describe('EventTickets — scope lock when has_sales', () => {
 			isRecurring: true,
 			initialData: initialDataWithTicketType,
 		});
-		openEditTicketsPanel();
 
 		const scopeSelects = screen
 			.getAllByRole('combobox')
@@ -465,7 +445,6 @@ describe('EventTickets — scope lock when has_sales', () => {
 describe('EventTickets — disable/enable when has_sales', () => {
 	it('shows Remove button when has_sales is false', () => {
 		renderTickets({ initialData: initialDataWithTicketType });
-		openEditTicketsPanel();
 		expect(
 			screen.getByRole('button', { name: /Remove/i })
 		).toBeInTheDocument();
@@ -473,7 +452,6 @@ describe('EventTickets — disable/enable when has_sales', () => {
 
 	it('shows toggle instead of Remove when has_sales is true', () => {
 		renderTickets({ initialData: initialDataWithSoldTicketType });
-		openEditTicketsPanel();
 		expect(
 			screen.queryByRole('button', { name: /Remove/i })
 		).not.toBeInTheDocument();
@@ -491,7 +469,6 @@ describe('EventTickets — disable/enable when has_sales', () => {
 			],
 		};
 		renderTickets({ initialData: disabledData });
-		openEditTicketsPanel();
 		expect(
 			screen.getByText('Disabled — no longer on sale')
 		).toBeInTheDocument();
@@ -499,7 +476,6 @@ describe('EventTickets — disable/enable when has_sales', () => {
 
 	it('does not show disabled label when ticket type is enabled', () => {
 		renderTickets({ initialData: initialDataWithSoldTicketType });
-		openEditTicketsPanel();
 		expect(
 			screen.queryByText('Disabled — no longer on sale')
 		).not.toBeInTheDocument();
@@ -509,7 +485,6 @@ describe('EventTickets — disable/enable when has_sales', () => {
 		const { onSaveRef } = renderTickets({
 			initialData: initialDataWithSoldTicketType,
 		});
-		openEditTicketsPanel();
 		const toggle = screen.getByRole('checkbox');
 		fireEvent.click(toggle);
 
@@ -547,7 +522,6 @@ describe('EventTickets — save button and dirty tracking (#987)', () => {
 			initialData: initialDataWithTicketType,
 			onDirtyChange,
 		});
-		openEditTicketsPanel();
 
 		expect(onDirtyChange).toHaveBeenLastCalledWith(false);
 
@@ -576,5 +550,116 @@ describe('EventTickets — save button and dirty tracking (#987)', () => {
 		await waitFor(() =>
 			expect(onDirtyChange).toHaveBeenLastCalledWith(false)
 		);
+	});
+});
+
+describe('EventTickets — payment-not-configured notice (#988)', () => {
+	const originalFairPaymentsConnector = window.fairPaymentsConnector;
+
+	afterEach(() => {
+		window.fairPaymentsConnector = originalFairPaymentsConnector;
+	});
+
+	it('shows the notice when payments are unconfigured and tickets exist', () => {
+		window.fairPaymentsConnector = {
+			paymentConfigured: false,
+			settingsUrl:
+				'http://example.test/wp-admin/admin.php?page=fair-payments-connector-settings',
+		};
+		const { container } = renderTickets({
+			initialData: initialDataWithTicketType,
+		});
+
+		expect(
+			within(container).getByText(
+				/Prices are set, but payments aren't configured/i
+			)
+		).toBeInTheDocument();
+		const link = within(container).getByRole('link', {
+			name: 'Set up Mollie',
+		});
+		expect(link).toHaveAttribute(
+			'href',
+			window.fairPaymentsConnector.settingsUrl
+		);
+	});
+
+	it('does not show the notice when there are no tickets yet', () => {
+		window.fairPaymentsConnector = {
+			paymentConfigured: false,
+			settingsUrl:
+				'http://example.test/wp-admin/admin.php?page=fair-payments-connector-settings',
+		};
+		const { container } = renderTickets({ initialData: emptyInitialData });
+
+		expect(
+			within(container).queryByText(
+				/Prices are set, but payments aren't configured/i
+			)
+		).not.toBeInTheDocument();
+	});
+
+	it('does not show the notice when payments are configured', () => {
+		window.fairPaymentsConnector = {
+			paymentConfigured: true,
+			settingsUrl:
+				'http://example.test/wp-admin/admin.php?page=fair-payments-connector-settings',
+		};
+		const { container } = renderTickets({
+			initialData: initialDataWithTicketType,
+		});
+
+		expect(
+			within(container).queryByText(
+				/Prices are set, but payments aren't configured/i
+			)
+		).not.toBeInTheDocument();
+	});
+
+	it('does not show the notice when paymentConfigured is absent (connector inactive)', () => {
+		window.fairPaymentsConnector = { currency: 'EUR' };
+		const { container } = renderTickets({
+			initialData: initialDataWithTicketType,
+		});
+
+		expect(
+			within(container).queryByText(
+				/Prices are set, but payments aren't configured/i
+			)
+		).not.toBeInTheDocument();
+	});
+});
+
+describe('EventTickets — Export/Import moved to the ⋯ menu (#988)', () => {
+	it('does not show Export/Import as primary buttons', () => {
+		renderTickets({ initialData: initialDataWithTicketType });
+
+		expect(
+			screen.queryByRole('button', { name: 'Export ticket settings' })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Import ticket settings' })
+		).not.toBeInTheDocument();
+	});
+
+	it('reaches Export/Import through the ⋯ menu', () => {
+		renderTickets({ initialData: initialDataWithTicketType });
+
+		fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+
+		expect(
+			screen.getByRole('menuitem', { name: 'Export ticket settings' })
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('menuitem', { name: 'Import ticket settings' })
+		).toBeInTheDocument();
+	});
+});
+
+describe('EventTickets — editable table renders without expanding a panel (#988)', () => {
+	it('shows the editable ticket type field directly', () => {
+		renderTickets({ initialData: initialDataWithTicketType });
+
+		expect(screen.getByDisplayValue('General')).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary

- Make the editable ticket/price table the always-visible primary content of the Tickets tab; drop the duplicated read-only "Ticket Prices" summary card.
- Demote "Export ticket settings" / "Import ticket settings" out of the primary button row into a ⋯ dropdown menu on the editable table's card header.
- Rename the "Settings" panel to "More options" (still collapsed by default).
- Surface the existing "payments not configured" signal inline on the Tickets tab: when priced tickets exist and `fairPaymentsConnector.paymentConfigured === false`, show a warning notice with a "Set up Mollie" link to the connector's settings page.
- `fair-events` now localizes `paymentConfigured` / `settingsUrl` on the `fairPaymentsConnector` JS global, reusing `FairPaymentsConnector\Payment\MolliePaymentHandler::is_configured()` (only when the connector plugin is active).

Closes #988

## Test plan

- [x] `npm run test:js` in `fair-events` — 70/70 tests pass, including new cases for the payment notice and the demoted Export/Import menu.
- [x] `npm run build` in `fair-events`.
- [x] `vendor/bin/phpcs` on the modified PHP file — no new issues introduced.
