### PR TITLE
Scaffold fair-audience-experimental companion plugin

### DIFF
--- a/.changeset/audience-experimental-scaffold.md
+++ b/.changeset/audience-experimental-scaffold.md
@@ -1,0 +1,5 @@
+---
+"fair-audience-experimental": minor
+---
+
+Scaffold the fair-audience-experimental companion plugin: `plugins_loaded` bootstrap with a runtime guard on fair-audience, a `Features` registry (master constant `FAIR_AUDIENCE_EXPERIMENTAL_INTERNAL`) listing the thirteen advanced bundles (fees, polls, galleries, Instagram, groups, collaborators, messaging, image-templates, timeline, import, weekly-schedule, invitations, manage-event-ext), and a Settings page to toggle them. This is the clean-slate step of splitting fair-audience into a lean core plus this companion — feature bundles themselves still live in fair-audience and move out in follow-up changes.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,6 +43,7 @@ jobs:
                       ./fair-events-experimental/vendor
                       ./fair-payments-connector-experimental/vendor
                       ./fair-form/vendor
+                      ./fair-audience-experimental/vendor
                       ./vendor
                   key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
                   restore-keys: |
@@ -68,6 +69,7 @@ jobs:
                       ./fair-events-experimental/node_modules
                       ./fair-payments-connector-experimental/node_modules
                       ./fair-form/node_modules
+                      ./fair-audience-experimental/node_modules
                       ./fair-events-shared/node_modules
                   key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
 

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -104,7 +104,7 @@ jobs:
                   fi
 
                   if [ "$PLUGINS_TO_DEPLOY" = "all" ]; then
-                    PLUGINS="fair-events fair-payments-connector fair-audience fair-timetable fair-finance fair-events-experimental fair-payments-connector-experimental fair-form"
+                    PLUGINS="fair-events fair-payments-connector fair-audience fair-timetable fair-finance fair-events-experimental fair-payments-connector-experimental fair-form fair-audience-experimental"
                   else
                     # Convert comma-separated list to space-separated
                     PLUGINS=$(echo "$PLUGINS_TO_DEPLOY" | tr ',' ' ')

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,7 @@ on:
             - 'fair-events/**'
             - 'fair-events-experimental/**'
             - 'fair-audience/**'
+            - 'fair-audience-experimental/**'
             - 'fair-form/**'
             - 'fair-platform/**'
             - 'fair-events-shared/**'
@@ -25,6 +26,7 @@ on:
             - 'fair-events/**'
             - 'fair-events-experimental/**'
             - 'fair-audience/**'
+            - 'fair-audience-experimental/**'
             - 'fair-form/**'
             - 'fair-platform/**'
             - 'fair-events-shared/**'
@@ -56,6 +58,7 @@ jobs:
                       ./fair-events-experimental/vendor
                       ./fair-platform/vendor
                       ./fair-audience/vendor
+                      ./fair-audience-experimental/vendor
                       ./fair-form/vendor
                       ./vendor
                   key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -78,6 +81,7 @@ jobs:
                       ./fair-payments-connector/node_modules
                       ./fair-platform/node_modules
                       ./fair-audience/node_modules
+                      ./fair-audience-experimental/node_modules
                       ./fair-form/node_modules
                       ./fair-events-shared/node_modules
                       ./fair-timetable/node_modules

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,6 +6,7 @@
 		"./fair-events",
 		"./fair-events-experimental",
 		"./fair-audience",
+		"./fair-audience-experimental",
 		"./fair-form",
 		"./fair-platform"
 	],

--- a/compose.yml
+++ b/compose.yml
@@ -20,6 +20,7 @@ services:
             - ./fair-events-experimental:/var/www/html/wp-content/plugins/fair-events-experimental
             - ./fair-payments-connector-experimental:/var/www/html/wp-content/plugins/fair-payments-connector-experimental
             - ./fair-form:/var/www/html/wp-content/plugins/fair-form
+            - ./fair-audience-experimental:/var/www/html/wp-content/plugins/fair-audience-experimental
             - ./uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
 
     db:
@@ -59,6 +60,7 @@ services:
             - ./fair-events-experimental:/var/www/html/wp-content/plugins/fair-events-experimental
             - ./fair-payments-connector-experimental:/var/www/html/wp-content/plugins/fair-payments-connector-experimental
             - ./fair-form:/var/www/html/wp-content/plugins/fair-form
+            - ./fair-audience-experimental:/var/www/html/wp-content/plugins/fair-audience-experimental
 
         environment:
             WORDPRESS_DB_HOST: db

--- a/fair-audience-experimental/CHANGELOG.md
+++ b/fair-audience-experimental/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.0
+
+### Minor Changes
+
+-   Initial release — scaffolds the fair-audience-experimental companion plugin: `plugins_loaded` bootstrap with a runtime guard on `fair-audience`, a `Features` registry (master constant `FAIR_AUDIENCE_EXPERIMENTAL_INTERNAL`) listing the thirteen advanced bundles, and a Settings page to toggle them. Feature bundles themselves stay in `fair-audience` for now and move out in follow-up changes.

--- a/fair-audience-experimental/__tests__/example.test.js
+++ b/fair-audience-experimental/__tests__/example.test.js
@@ -1,0 +1,5 @@
+describe('Fair Audience Experimental Plugin', () => {
+	it('should exist', () => {
+		expect(true).toBe(true);
+	});
+});

--- a/fair-audience-experimental/composer.json
+++ b/fair-audience-experimental/composer.json
@@ -1,0 +1,28 @@
+{
+	"name": "fair-event-plugins/fair-audience-experimental",
+	"description": "Experimental feature bundles extension for Fair Audience",
+	"type": "wordpress-plugin",
+	"license": "GPL-3.0-or-later",
+	"authors": [
+		{
+			"name": "Marcin Wosinek",
+			"email": "marcin.wosinek@gmail.com"
+		}
+	],
+	"require": {
+		"php": ">=8.0 <9.0"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^9.6"
+	},
+	"config": {
+		"platform": {
+			"php": "8.3"
+		}
+	},
+	"autoload": {
+		"psr-4": {
+			"FairAudienceExperimental\\": "src/"
+		}
+	}
+}

--- a/fair-audience-experimental/composer.lock
+++ b/fair-audience-experimental/composer.lock
@@ -1,0 +1,1804 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "9e1e1ed394ee6654ce675b03b0878787",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.35"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:48:07+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.0 <9.0"
+    },
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.3"
+    },
+    "plugin-api-version": "2.9.0"
+}

--- a/fair-audience-experimental/fair-audience-experimental.php
+++ b/fair-audience-experimental/fair-audience-experimental.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Plugin Name: Fair Audience Experimental
+ * Plugin URI: https://github.com/marcin-wosinek/fair-event-plugins
+ * Description: Activates advanced feature bundles for Fair Audience (fees, polls, galleries, Instagram, groups, collaborators, messaging, image templates, timeline, import, weekly schedule, invitations, manage-event-ext). Requires fair-audience.
+ * Version: 1.0.0
+ * Requires at least: 6.7
+ * Requires PHP: 8.0
+ * Requires Plugins: fair-audience
+ * Author: Marcin Wosinek
+ * Author URI: https://github.com/marcin-wosinek
+ * License: GPLv3 or later
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ * Text Domain: fair-audience-experimental
+ * Domain Path: /languages
+ *
+ * @package FairAudienceExperimental
+ */
+
+namespace FairAudienceExperimental;
+
+defined( 'ABSPATH' ) || die;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+// Defer bootstrap to plugins_loaded so fair-audience (loaded alphabetically before
+// fair-audience-experimental) has already been included and FAIR_AUDIENCE_VERSION is defined.
+add_action(
+	'plugins_loaded',
+	function () {
+		// Runtime guard: deactivate gracefully when fair-audience is not active.
+		if ( ! defined( 'FAIR_AUDIENCE_VERSION' ) ) {
+			add_action(
+				'admin_notices',
+				function () {
+					echo '<div class="notice notice-error"><p>'
+						. esc_html__( 'Fair Audience Experimental requires the Fair Audience plugin to be active.', 'fair-audience-experimental' )
+						. '</p></div>';
+				}
+			);
+			// Deactivate self if called during activation.
+			if ( isset( $_GET['activate'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				add_action(
+					'admin_init',
+					function () {
+						deactivate_plugins( plugin_basename( __FILE__ ) );
+					}
+				);
+			}
+			return;
+		}
+
+		define( 'FAIR_AUDIENCE_EXPERIMENTAL_VERSION', '1.0.0' );
+		define( 'FAIR_AUDIENCE_EXPERIMENTAL_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+		define( 'FAIR_AUDIENCE_EXPERIMENTAL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+		\FairAudienceExperimental\Core\Plugin::instance()->init();
+	},
+	5
+);

--- a/fair-audience-experimental/jest.config.cjs
+++ b/fair-audience-experimental/jest.config.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+	preset: '@wordpress/jest-preset-default',
+	testEnvironment: 'jsdom',
+	testMatch: ['**/?(*.)+(test).[jt]s?(x)'],
+	testPathIgnorePatterns: ['/node_modules/', '/vendor/', '/build/'],
+	transformIgnorePatterns: [
+		'/node_modules/(?!(uuid|@wordpress/components)/)',
+	],
+	transform: {
+		'^.+\\.[jt]sx?$': [
+			'babel-jest',
+			{
+				presets: [
+					['@babel/preset-env', { targets: { node: 'current' } }],
+					['@babel/preset-react', { runtime: 'automatic' }],
+				],
+			},
+		],
+	},
+};

--- a/fair-audience-experimental/package.json
+++ b/fair-audience-experimental/package.json
@@ -1,0 +1,47 @@
+{
+	"name": "fair-audience-experimental",
+	"version": "1.0.0",
+	"description": "Fair Audience Experimental WordPress plugin",
+	"license": "GPL-3.0-or-later",
+	"author": "Marcin Wosinek",
+	"type": "module",
+	"main": "build/index.js",
+	"scripts": {
+		"build": "wp-scripts build --config webpack.config.cjs; npm run makejson || true",
+		"clean": "rm -rf build",
+		"prebuild": "npm run clean",
+		"start": "wp-scripts start",
+		"format": "wp-scripts format",
+		"composer:install": "composer install",
+		"composer:install:prod": "composer install --no-dev",
+		"composer:update": "composer update",
+		"composer:validate": "composer validate --strict",
+		"makepot": "wp i18n make-pot . languages/fair-audience-experimental.pot --exclude=node_modules,vendor,tests,build,svn",
+		"makejson": "wp i18n make-json languages ./build/languages --domain=fair-audience-experimental --pretty-print --no-purge --use-map=build/map.json",
+		"makemo": "wp i18n make-mo languages/",
+		"updatepo": "wp i18n update-po languages/fair-audience-experimental.pot languages/",
+		"test": "npm-run-all test:js",
+		"test:js": "jest --passWithNoTests",
+		"test:api": "playwright test src/API/__tests__/"
+	},
+	"dependencies": {
+		"fair-events-shared": "*",
+		"@wordpress/api-fetch": "^7.2.0",
+		"@wordpress/components": "^36.0.0",
+		"@wordpress/dom-ready": "^4.2.0",
+		"@wordpress/element": "^8.0.0",
+		"@wordpress/i18n": "^6.21.0"
+	},
+	"devDependencies": {
+		"@babel/core": "^7.28.3",
+		"@babel/preset-env": "^7.28.3",
+		"@playwright/test": "^1.40.0",
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/react": "^16.3.2",
+		"@wordpress/scripts": "^32.4.0",
+		"babel-jest": "^30.0.5",
+		"jest": "^30.0.0",
+		"npm-run-all2": "^9.0.2",
+		"webpack-bundle-output": "^1.1.0"
+	}
+}

--- a/fair-audience-experimental/playwright.config.js
+++ b/fair-audience-experimental/playwright.config.js
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export default defineConfig({
+	testDir: './',
+	testMatch: ['e2e/**/*.spec.js', 'src/API/__tests__/**/*.api.spec.js'],
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: 1,
+	reporter: 'html',
+	use: {
+		baseURL: process.env.WP_BASE_URL || 'http://localhost:8080',
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+	webServer: {
+		command: 'docker compose up',
+		url: 'http://localhost:8080',
+		reuseExistingServer: !process.env.CI,
+		timeout: 120 * 1000,
+	},
+});

--- a/fair-audience-experimental/readme.txt
+++ b/fair-audience-experimental/readme.txt
@@ -1,0 +1,36 @@
+=== Fair Audience Experimental ===
+Contributors: marcinwosinek
+Tags: audience, experimental
+Requires at least: 6.7
+Tested up to: 6.7
+Stable tag: 1.0.0
+Requires PHP: 8.0
+License: GPLv3 or later
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
+
+Activates advanced feature bundles for Fair Audience: fees, polls, galleries, Instagram, groups, collaborators, messaging, image templates, timeline, import, weekly schedule, invitations, manage-event-ext.
+
+== Description ==
+
+This plugin is a companion to Fair Audience. It carries the advanced feature bundles that are excluded from the public Fair Audience build:
+
+* **Fees** — Event fees, fee payments, fee audit log.
+* **Polls** — Attendee polls and responses.
+* **Galleries** — Photo participation, gallery access keys.
+* **Instagram** — Instagram post import and scheduling.
+* **Groups** — Participant groups.
+* **Collaborators** — Event collaborators.
+* **Messaging** — Custom mail, extra messages, scheduled messages.
+* **Image templates** — Generated image templates.
+* **Timeline** — Participant activity timeline.
+* **Import** — Bulk participant import.
+* **Weekly schedule** — Weekly schedule admin page.
+* **Invitations** — Event invitations (consumed by fair-events-experimental ticketing).
+* **Manage-event-ext** — The Mailings tab in the manage-event admin UI.
+
+Requires Fair Audience to be active.
+
+== Changelog ==
+
+= 1.0.0 =
+* Initial release — scaffolds the companion plugin (Features registry, Settings UI, monorepo wiring). Feature bundles are migrated out of fair-audience in follow-up changes.

--- a/fair-audience-experimental/src/Admin/AdminPages.php
+++ b/fair-audience-experimental/src/Admin/AdminPages.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Admin Pages for Fair Audience Experimental
+ *
+ * Registers the experimental settings page as a submenu under the
+ * fair-audience menu. Feature-bundle admin pages are added here as each
+ * bundle is migrated out of fair-audience.
+ *
+ * @package FairAudienceExperimental
+ */
+
+namespace FairAudienceExperimental\Admin;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Admin Pages class for registering experimental admin menu pages
+ */
+class AdminPages {
+	/**
+	 * Map of page slug => admin page hook name.
+	 *
+	 * @var array<string,string>
+	 */
+	private $page_hooks = array();
+
+	/**
+	 * Parent menu slug (owned by fair-audience).
+	 *
+	 * @return string
+	 */
+	private function get_menu_parent_slug() {
+		return 'fair-audience';
+	}
+
+	/**
+	 * Initialize admin pages
+	 *
+	 * @return void
+	 */
+	public function init() {
+		// Priority 11: run after fair-audience's own add_menu_page() call so the
+		// parent hook name is registered regardless of plugin activation order
+		// (see ADDING_NEW_PLUGIN.md "Experimental plugin admin submenus show 404").
+		add_action( 'admin_menu', array( $this, 'register_admin_pages' ), 11 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+	}
+
+	/**
+	 * Register admin menu pages
+	 *
+	 * @return void
+	 */
+	public function register_admin_pages() {
+		$parent = $this->get_menu_parent_slug();
+
+		$this->page_hooks['fair-audience-experimental-settings'] = add_submenu_page(
+			$parent,
+			__( 'Experimental Settings', 'fair-audience-experimental' ),
+			__( 'Experimental', 'fair-audience-experimental' ),
+			'manage_options',
+			'fair-audience-experimental-settings',
+			array( $this, 'render_settings_page' )
+		);
+	}
+
+	/**
+	 * Enqueue admin scripts for the plugin's admin pages
+	 *
+	 * @param string $hook Current admin page hook.
+	 * @return void
+	 */
+	public function enqueue_admin_scripts( $hook ) {
+		$slug = array_search( $hook, $this->page_hooks, true );
+		if ( false === $slug ) {
+			return;
+		}
+
+		if ( 'fair-audience-experimental-settings' === $slug ) {
+			$asset_file = include FAIR_AUDIENCE_EXPERIMENTAL_PLUGIN_DIR . 'build/admin/settings/index.asset.php';
+
+			wp_enqueue_script(
+				'fair-audience-experimental-settings',
+				FAIR_AUDIENCE_EXPERIMENTAL_PLUGIN_URL . 'build/admin/settings/index.js',
+				$asset_file['dependencies'],
+				$asset_file['version'],
+				true
+			);
+
+			wp_localize_script(
+				'fair-audience-experimental-settings',
+				'fairAudienceExperimentalSettingsData',
+				array(
+					'features' => \FairAudienceExperimental\Core\Features::all(),
+				)
+			);
+
+			wp_set_script_translations( 'fair-audience-experimental-settings', 'fair-audience-experimental' );
+			wp_enqueue_style( 'wp-components' );
+		}
+	}
+
+	/**
+	 * Render experimental settings page
+	 *
+	 * @return void
+	 */
+	public function render_settings_page() {
+		?>
+		<div id="fair-audience-experimental-settings-root"></div>
+		<?php
+	}
+}

--- a/fair-audience-experimental/src/Admin/settings/FeaturesTab.js
+++ b/fair-audience-experimental/src/Admin/settings/FeaturesTab.js
@@ -1,0 +1,180 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import {
+	Button,
+	ToggleControl,
+	Card,
+	CardHeader,
+	CardBody,
+	Notice,
+} from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Features Tab Component for Fair Audience Experimental.
+ *
+ * Per-bundle toggles backed by the `fair_audience_experimental_features` option.
+ *
+ * @param {Object}   props          Props
+ * @param {Function} props.onNotice Handler for displaying notices
+ * @return {JSX.Element} The Features settings tab
+ */
+export default function FeaturesTab({ onNotice }) {
+	const registry =
+		window.fairAudienceExperimentalSettingsData?.features || {};
+	const [values, setValues] = useState({});
+	const [isLoading, setIsLoading] = useState(true);
+	const [isSaving, setIsSaving] = useState(false);
+
+	useEffect(() => {
+		apiFetch({ path: '/wp/v2/settings' })
+			.then((settings) => {
+				const stored =
+					settings.fair_audience_experimental_features || {};
+				const next = {};
+				Object.entries(registry).forEach(([key, meta]) => {
+					if (meta.always_on || meta.forced) {
+						next[key] = meta.enabled;
+					} else {
+						next[key] =
+							typeof stored[key] === 'boolean'
+								? stored[key]
+								: meta.enabled;
+					}
+				});
+				setValues(next);
+				setIsLoading(false);
+			})
+			.catch(() => {
+				onNotice({
+					status: 'error',
+					message: __(
+						'Failed to load features.',
+						'fair-audience-experimental'
+					),
+				});
+				setIsLoading(false);
+			});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [onNotice]);
+
+	const handleToggle = (key, value) => {
+		setValues({ ...values, [key]: value });
+	};
+
+	const handleSave = () => {
+		const payload = {};
+		Object.entries(registry).forEach(([key, meta]) => {
+			if (meta.always_on || meta.forced) {
+				return;
+			}
+			payload[key] = !!values[key];
+		});
+
+		setIsSaving(true);
+		apiFetch({
+			path: '/wp/v2/settings',
+			method: 'POST',
+			data: { fair_audience_experimental_features: payload },
+		})
+			.then(() => {
+				onNotice({
+					status: 'success',
+					message: __(
+						'Features saved. Reload the page to see admin-menu changes.',
+						'fair-audience-experimental'
+					),
+				});
+				setIsSaving(false);
+			})
+			.catch(() => {
+				onNotice({
+					status: 'error',
+					message: __(
+						'Failed to save features.',
+						'fair-audience-experimental'
+					),
+				});
+				setIsSaving(false);
+			});
+	};
+
+	if (isLoading) {
+		return (
+			<Card style={{ marginTop: '16px' }}>
+				<CardBody>
+					<p>
+						{__(
+							'Loading features...',
+							'fair-audience-experimental'
+						)}
+					</p>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	const entries = Object.entries(registry);
+
+	return (
+		<Card style={{ marginTop: '16px' }}>
+			<CardHeader>
+				<h2>{__('Feature Bundles', 'fair-audience-experimental')}</h2>
+			</CardHeader>
+			<CardBody>
+				<p className="description">
+					{__(
+						'Toggle optional experimental feature bundles. Bundles fixed in wp-config (FAIR_AUDIENCE_EXPERIMENTAL_INTERNAL or FAIR_AUDIENCE_EXPERIMENTAL_FEATURE_*) are read-only here.',
+						'fair-audience-experimental'
+					)}
+				</p>
+
+				{entries.map(([key, meta]) => {
+					const help = meta.forced
+						? __(
+								'Forced by a wp-config constant — change it there.',
+								'fair-audience-experimental'
+						  )
+						: meta.description;
+
+					return (
+						<div key={key} style={{ marginBottom: '1rem' }}>
+							<ToggleControl
+								label={meta.label}
+								checked={!!values[key]}
+								onChange={(value) => handleToggle(key, value)}
+								disabled={
+									isSaving || meta.always_on || meta.forced
+								}
+								help={help}
+							/>
+						</div>
+					);
+				})}
+
+				{entries.some(([, meta]) => meta.forced) && (
+					<Notice status="info" isDismissible={false}>
+						{__(
+							'One or more bundles are forced by wp-config and cannot be toggled here.',
+							'fair-audience-experimental'
+						)}
+					</Notice>
+				)}
+
+				<Button
+					variant="primary"
+					onClick={handleSave}
+					isBusy={isSaving}
+					disabled={isSaving}
+				>
+					{isSaving
+						? __('Saving...', 'fair-audience-experimental')
+						: __('Save Features', 'fair-audience-experimental')}
+				</Button>
+			</CardBody>
+		</Card>
+	);
+}

--- a/fair-audience-experimental/src/Admin/settings/SettingsApp.js
+++ b/fair-audience-experimental/src/Admin/settings/SettingsApp.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import FeaturesTab from './FeaturesTab.js';
+
+/**
+ * Settings App Component for Fair Audience Experimental.
+ *
+ * Renders just the features tab — there are no general settings for this plugin.
+ *
+ * @return {JSX.Element} The Settings app component
+ */
+export default function SettingsApp() {
+	const [notice, setNotice] = useState(null);
+
+	return (
+		<div className="wrap fair-audience-experimental-settings">
+			<h1>
+				{__(
+					'Fair Audience Experimental Settings',
+					'fair-audience-experimental'
+				)}
+			</h1>
+
+			{notice && (
+				<Notice
+					status={notice.status}
+					isDismissible={true}
+					onRemove={() => setNotice(null)}
+				>
+					{notice.message}
+				</Notice>
+			)}
+
+			<FeaturesTab onNotice={setNotice} />
+		</div>
+	);
+}

--- a/fair-audience-experimental/src/Admin/settings/index.js
+++ b/fair-audience-experimental/src/Admin/settings/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { createRoot } from '@wordpress/element';
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * Internal dependencies
+ */
+import SettingsApp from './SettingsApp.js';
+
+domReady(() => {
+	const root = document.getElementById(
+		'fair-audience-experimental-settings-root'
+	);
+	if (root) {
+		createRoot(root).render(<SettingsApp />);
+	}
+});

--- a/fair-audience-experimental/src/Core/Features.php
+++ b/fair-audience-experimental/src/Core/Features.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Feature flag registry for Fair Audience Experimental.
+ *
+ * Manages the thirteen advanced bundles carried by this companion: fees,
+ * polls, galleries, Instagram, groups, collaborators, messaging,
+ * image-templates, timeline, import, weekly-schedule, invitations,
+ * manage-event-ext. All default to true — installing this plugin signals
+ * intent to use the full internal feature set.
+ *
+ * Resolution order (first match wins):
+ *   1. Per-feature constant `FAIR_AUDIENCE_EXPERIMENTAL_FEATURE_<UPPER>`
+ *   2. Master switch `FAIR_AUDIENCE_EXPERIMENTAL_INTERNAL` (true → all bundles on)
+ *   3. `fair_audience_experimental_feature_enabled` filter
+ *   4. Stored option `fair_audience_experimental_features`
+ *   5. Hardcoded default (true for all bundles)
+ *
+ * @package FairAudienceExperimental
+ */
+
+namespace FairAudienceExperimental\Core;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Feature flag registry for experimental bundles.
+ */
+class Features {
+
+	/**
+	 * Option key holding user-toggled feature state.
+	 */
+	public const OPTION = 'fair_audience_experimental_features';
+
+	/**
+	 * Master switch constant.
+	 */
+	public const MASTER_CONSTANT = 'FAIR_AUDIENCE_EXPERIMENTAL_INTERNAL';
+
+	/**
+	 * Canonical bundle registry.
+	 *
+	 * Labels are intentionally untranslated here; translation is applied in
+	 * {@see self::all()} which only runs in admin REST contexts.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on?:bool}>
+	 */
+	public static function registry() {
+		return array(
+			'fees'             => array(
+				'label'       => 'Fees',
+				'description' => 'Event fees, fee payments, fee audit log.',
+				'default'     => true,
+			),
+			'polls'            => array(
+				'label'       => 'Polls',
+				'description' => 'Attendee polls and responses.',
+				'default'     => true,
+			),
+			'galleries'        => array(
+				'label'       => 'Galleries',
+				'description' => 'Photo participation, gallery access keys, media library hooks.',
+				'default'     => true,
+			),
+			'instagram'        => array(
+				'label'       => 'Instagram',
+				'description' => 'Instagram post import and scheduled posting.',
+				'default'     => true,
+			),
+			'groups'           => array(
+				'label'       => 'Groups',
+				'description' => 'Participant groups.',
+				'default'     => true,
+			),
+			'collaborators'    => array(
+				'label'       => 'Collaborators',
+				'description' => 'Event collaborators.',
+				'default'     => true,
+			),
+			'messaging'        => array(
+				'label'       => 'Messaging',
+				'description' => 'Custom mail, extra messages, scheduled messages.',
+				'default'     => true,
+			),
+			'image-templates'  => array(
+				'label'       => 'Image templates',
+				'description' => 'Generated image templates.',
+				'default'     => true,
+			),
+			'timeline'         => array(
+				'label'       => 'Timeline',
+				'description' => 'Participant activity timeline.',
+				'default'     => true,
+			),
+			'import'           => array(
+				'label'       => 'Import',
+				'description' => 'Bulk participant import.',
+				'default'     => true,
+			),
+			'weekly-schedule'  => array(
+				'label'       => 'Weekly schedule',
+				'description' => 'Weekly schedule admin page.',
+				'default'     => true,
+			),
+			'invitations'      => array(
+				'label'       => 'Invitations',
+				'description' => 'Event invitations, consumed by fair-events-experimental ticketing.',
+				'default'     => true,
+			),
+			'manage-event-ext' => array(
+				'label'       => 'Manage-event extensions',
+				'description' => 'The Mailings tab in the manage-event admin UI.',
+				'default'     => true,
+			),
+		);
+	}
+
+	/**
+	 * Resolve whether a feature bundle is enabled.
+	 *
+	 * @param string $key Bundle key from registry().
+	 * @return bool
+	 */
+	public static function is_enabled( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		// 1. Per-feature constant always wins.
+		$constant = self::feature_constant_name( $key );
+		if ( defined( $constant ) ) {
+			return (bool) constant( $constant );
+		}
+
+		// 2. Master switch flips every bundle on.
+		if ( defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT ) ) {
+			$enabled = true;
+		} else {
+			// 4. Stored option, then 5. hardcoded default.
+			$stored  = get_option( self::OPTION, array() );
+			$enabled = is_array( $stored ) && array_key_exists( $key, $stored )
+				? (bool) $stored[ $key ]
+				: (bool) $registry[ $key ]['default'];
+		}
+
+		// 3. Filter runs after constants.
+		return (bool) apply_filters( 'fair_audience_experimental_feature_enabled', $enabled, $key );
+	}
+
+	/**
+	 * Whether the resolved value is forced by a constant.
+	 *
+	 * @param string $key Bundle key.
+	 * @return bool
+	 */
+	public static function is_forced( $key ) {
+		$registry = self::registry();
+		if ( ! isset( $registry[ $key ] ) ) {
+			return false;
+		}
+
+		if ( defined( self::feature_constant_name( $key ) ) ) {
+			return true;
+		}
+
+		return defined( self::MASTER_CONSTANT ) && true === constant( self::MASTER_CONSTANT );
+	}
+
+	/**
+	 * Full snapshot for the Settings UI.
+	 *
+	 * @return array<string,array{label:string,description:string,default:bool,always_on:bool,enabled:bool,forced:bool}>
+	 */
+	public static function all() {
+		$translated = array(
+			'fees'             => array(
+				'label'       => __( 'Fees', 'fair-audience-experimental' ),
+				'description' => __( 'Event fees, fee payments, fee audit log.', 'fair-audience-experimental' ),
+			),
+			'polls'            => array(
+				'label'       => __( 'Polls', 'fair-audience-experimental' ),
+				'description' => __( 'Attendee polls and responses.', 'fair-audience-experimental' ),
+			),
+			'galleries'        => array(
+				'label'       => __( 'Galleries', 'fair-audience-experimental' ),
+				'description' => __( 'Photo participation, gallery access keys, media library hooks.', 'fair-audience-experimental' ),
+			),
+			'instagram'        => array(
+				'label'       => __( 'Instagram', 'fair-audience-experimental' ),
+				'description' => __( 'Instagram post import and scheduled posting.', 'fair-audience-experimental' ),
+			),
+			'groups'           => array(
+				'label'       => __( 'Groups', 'fair-audience-experimental' ),
+				'description' => __( 'Participant groups.', 'fair-audience-experimental' ),
+			),
+			'collaborators'    => array(
+				'label'       => __( 'Collaborators', 'fair-audience-experimental' ),
+				'description' => __( 'Event collaborators.', 'fair-audience-experimental' ),
+			),
+			'messaging'        => array(
+				'label'       => __( 'Messaging', 'fair-audience-experimental' ),
+				'description' => __( 'Custom mail, extra messages, scheduled messages.', 'fair-audience-experimental' ),
+			),
+			'image-templates'  => array(
+				'label'       => __( 'Image templates', 'fair-audience-experimental' ),
+				'description' => __( 'Generated image templates.', 'fair-audience-experimental' ),
+			),
+			'timeline'         => array(
+				'label'       => __( 'Timeline', 'fair-audience-experimental' ),
+				'description' => __( 'Participant activity timeline.', 'fair-audience-experimental' ),
+			),
+			'import'           => array(
+				'label'       => __( 'Import', 'fair-audience-experimental' ),
+				'description' => __( 'Bulk participant import.', 'fair-audience-experimental' ),
+			),
+			'weekly-schedule'  => array(
+				'label'       => __( 'Weekly schedule', 'fair-audience-experimental' ),
+				'description' => __( 'Weekly schedule admin page.', 'fair-audience-experimental' ),
+			),
+			'invitations'      => array(
+				'label'       => __( 'Invitations', 'fair-audience-experimental' ),
+				'description' => __( 'Event invitations, consumed by fair-events-experimental ticketing.', 'fair-audience-experimental' ),
+			),
+			'manage-event-ext' => array(
+				'label'       => __( 'Manage-event extensions', 'fair-audience-experimental' ),
+				'description' => __( 'The Mailings tab in the manage-event admin UI.', 'fair-audience-experimental' ),
+			),
+		);
+
+		$out = array();
+		foreach ( self::registry() as $key => $entry ) {
+			$out[ $key ] = array(
+				'label'       => $translated[ $key ]['label'] ?? $entry['label'],
+				'description' => $translated[ $key ]['description'] ?? $entry['description'],
+				'default'     => (bool) $entry['default'],
+				'always_on'   => ! empty( $entry['always_on'] ),
+				'enabled'     => self::is_enabled( $key ),
+				'forced'      => self::is_forced( $key ),
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Sanitize an option payload for the known key set, dropping forced keys.
+	 *
+	 * @param mixed $value Raw option value.
+	 * @return array<string,bool>
+	 */
+	public static function sanitize_option( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$existing = get_option( self::OPTION, array() );
+		if ( ! is_array( $existing ) ) {
+			$existing = array();
+		}
+
+		$registry = self::registry();
+		$out      = array();
+		foreach ( $registry as $key => $entry ) {
+			if ( ! empty( $entry['always_on'] ) ) {
+				continue;
+			}
+
+			if ( self::is_forced( $key ) ) {
+				if ( array_key_exists( $key, $existing ) ) {
+					$out[ $key ] = (bool) $existing[ $key ];
+				}
+				continue;
+			}
+
+			if ( array_key_exists( $key, $value ) ) {
+				$out[ $key ] = (bool) $value[ $key ];
+			} elseif ( array_key_exists( $key, $existing ) ) {
+				$out[ $key ] = (bool) $existing[ $key ];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Per-feature constant name (e.g. `fees` → `FAIR_AUDIENCE_EXPERIMENTAL_FEATURE_FEES`).
+	 *
+	 * @param string $key Bundle key.
+	 * @return string
+	 */
+	private static function feature_constant_name( $key ) {
+		return 'FAIR_AUDIENCE_EXPERIMENTAL_FEATURE_' . strtoupper( str_replace( '-', '_', $key ) );
+	}
+}

--- a/fair-audience-experimental/src/Core/Plugin.php
+++ b/fair-audience-experimental/src/Core/Plugin.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Plugin core class for Fair Audience Experimental
+ *
+ * @package FairAudienceExperimental
+ */
+
+namespace FairAudienceExperimental\Core;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Main plugin class implementing singleton pattern
+ */
+class Plugin {
+	/**
+	 * Single instance of the plugin
+	 *
+	 * @var Plugin|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get singleton instance of the plugin
+	 *
+	 * @return Plugin Plugin instance
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Initialize the plugin
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->load_admin();
+		$this->load_settings();
+	}
+
+	/**
+	 * Load and initialize admin pages
+	 *
+	 * @return void
+	 */
+	private function load_admin() {
+		if ( is_admin() ) {
+			$admin = new \FairAudienceExperimental\Admin\AdminPages();
+			$admin->init();
+		}
+	}
+
+	/**
+	 * Load and initialize settings
+	 *
+	 * @return void
+	 */
+	private function load_settings() {
+		$settings = new \FairAudienceExperimental\Settings\Settings();
+		$settings->init();
+	}
+
+	/**
+	 * Private constructor to prevent instantiation
+	 */
+	private function __construct() {
+		// Prevent instantiation.
+	}
+
+	/**
+	 * Prevent cloning
+	 *
+	 * @return void
+	 */
+	private function __clone() {
+		// Prevent cloning.
+	}
+
+	/**
+	 * Prevent unserialization
+	 *
+	 * @return void
+	 */
+	public function __wakeup() {
+		// Prevent unserialization.
+	}
+}

--- a/fair-audience-experimental/src/Settings/Settings.php
+++ b/fair-audience-experimental/src/Settings/Settings.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Settings for Fair Audience Experimental
+ *
+ * @package FairAudienceExperimental
+ */
+
+namespace FairAudienceExperimental\Settings;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Settings class for registering plugin settings
+ */
+class Settings {
+	/**
+	 * Initialize settings
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action( 'init', array( $this, 'register_settings' ) );
+	}
+
+	/**
+	 * Register plugin settings
+	 *
+	 * @return void
+	 */
+	public function register_settings() {
+		register_setting(
+			'fair_audience_experimental_settings',
+			\FairAudienceExperimental\Core\Features::OPTION,
+			array(
+				'type'              => 'object',
+				'description'       => __( 'Per-bundle feature toggles for experimental features', 'fair-audience-experimental' ),
+				'sanitize_callback' => array( \FairAudienceExperimental\Core\Features::class, 'sanitize_option' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'additionalProperties' => array( 'type' => 'boolean' ),
+					),
+				),
+				'default'           => array(),
+			)
+		);
+	}
+}

--- a/fair-audience-experimental/webpack.config.cjs
+++ b/fair-audience-experimental/webpack.config.cjs
@@ -1,0 +1,20 @@
+const defaultConfig = require("@wordpress/scripts/config/webpack.config");
+const path = require("path");
+const BundleOutputPlugin = require("webpack-bundle-output");
+
+module.exports = {
+  ...defaultConfig,
+  entry: {
+    "admin/settings/index": path.resolve(
+      process.cwd(),
+      "src/Admin/settings/index.js",
+    ),
+  },
+  plugins: [
+    ...defaultConfig.plugins,
+    new BundleOutputPlugin({
+      cwd: process.cwd(),
+      output: "map.json",
+    }),
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
 				"fair-finance",
 				"fair-events-experimental",
 				"fair-payments-connector-experimental",
-				"fair-form"
+				"fair-form",
+				"fair-audience-experimental"
 			],
 			"dependencies": {
 				"@wordpress/scripts": "^32.4.0",
@@ -51,6 +52,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.28.3",
 				"@babel/preset-env": "^7.28.3",
+				"@babel/preset-react": "^7.28.3",
 				"@playwright/test": "^1.40.0",
 				"@wordpress/scripts": "^32.4.0",
 				"babel-jest": "^30.0.5",
@@ -58,6 +60,881 @@
 				"jest": "^30.0.0",
 				"npm-run-all2": "^9.0.2",
 				"webpack-bundle-output": "^1.1.0"
+			}
+		},
+		"fair-audience-experimental": {
+			"version": "1.0.0",
+			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"@wordpress/api-fetch": "^7.2.0",
+				"@wordpress/components": "^36.0.0",
+				"@wordpress/dom-ready": "^4.2.0",
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/i18n": "^6.21.0",
+				"fair-events-shared": "*"
+			},
+			"devDependencies": {
+				"@babel/core": "^7.28.3",
+				"@babel/preset-env": "^7.28.3",
+				"@playwright/test": "^1.40.0",
+				"@testing-library/jest-dom": "^6.9.1",
+				"@testing-library/react": "^16.3.2",
+				"@wordpress/scripts": "^32.4.0",
+				"babel-jest": "^30.0.5",
+				"jest": "^30.0.0",
+				"npm-run-all2": "^9.0.2",
+				"webpack-bundle-output": "^1.1.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@jest/core": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+			"integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.4.1",
+				"@jest/pattern": "30.4.0",
+				"@jest/reporters": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"exit-x": "^0.2.2",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.11",
+				"jest-changed-files": "30.4.1",
+				"jest-config": "30.4.2",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-resolve-dependencies": "30.4.2",
+				"jest-runner": "30.4.2",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"fair-audience-experimental/node_modules/@jest/test-sequencer": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+			"integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/test-result": "30.4.1",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@jest/transform": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+			"integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@jest/types": "30.4.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"babel-plugin-istanbul": "^7.0.1",
+				"chalk": "^4.1.2",
+				"convert-source-map": "^2.0.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"pirates": "^4.0.7",
+				"slash": "^3.0.0",
+				"write-file-atomic": "^5.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@jest/types": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"fair-audience-experimental/node_modules/babel-jest": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+			"integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/transform": "30.4.1",
+				"@types/babel__core": "^7.20.5",
+				"babel-plugin-istanbul": "^7.0.1",
+				"babel-preset-jest": "30.4.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0 || ^8.0.0-0"
+			}
+		},
+		"fair-audience-experimental/node_modules/babel-jest/node_modules/babel-preset-jest": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+			"integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-plugin-jest-hoist": "30.4.0",
+				"babel-preset-current-node-syntax": "^1.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+			}
+		},
+		"fair-audience-experimental/node_modules/babel-plugin-istanbul": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+			"integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"workspaces": [
+				"test/babel-8"
+			],
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-instrument": "^6.0.2",
+				"test-exclude": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"fair-audience-experimental/node_modules/babel-plugin-jest-hoist": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+			"integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/babel__core": "^7.20.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"fair-audience-experimental/node_modules/cjs-module-lexer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-audience-experimental/node_modules/isexe": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+			"integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/core": "30.4.2",
+				"@jest/types": "30.4.1",
+				"import-local": "^3.2.0",
+				"jest-cli": "30.4.2"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-changed-files": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+			"integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^5.1.1",
+				"jest-util": "30.4.1",
+				"p-limit": "^3.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-circus": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+			"integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"co": "^4.6.0",
+				"dedent": "^1.6.0",
+				"is-generator-fn": "^2.1.0",
+				"jest-each": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"p-limit": "^3.1.0",
+				"pretty-format": "30.4.1",
+				"pure-rand": "^7.0.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-cli": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+			"integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/core": "30.4.2",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"exit-x": "^0.2.2",
+				"import-local": "^3.2.0",
+				"jest-config": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-config": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+			"integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@jest/get-type": "30.1.0",
+				"@jest/pattern": "30.4.0",
+				"@jest/test-sequencer": "30.4.1",
+				"@jest/types": "30.4.1",
+				"babel-jest": "30.4.1",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"deepmerge": "^4.3.1",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-circus": "30.4.2",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-runner": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"parse-json": "^5.2.0",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@types/node": "*",
+				"esbuild-register": ">=3.4.0",
+				"ts-node": ">=9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"esbuild-register": {
+					"optional": true
+				},
+				"ts-node": {
+					"optional": true
+				}
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-diff": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+			"integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/diff-sequences": "30.4.0",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-docblock": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+			"integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"detect-newline": "^3.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-each": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+			"integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-environment-node": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+			"integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-haste-map": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+			"integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"anymatch": "^3.1.3",
+				"fb-watchman": "^2.0.2",
+				"graceful-fs": "^4.2.11",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
+				"picomatch": "^4.0.3",
+				"walker": "^1.0.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "^2.3.3"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-leak-detector": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+			"integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-matcher-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+			"integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.4.1",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-mock": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+			"integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-regex-util": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-resolve": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+			"integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-pnp-resolver": "^1.2.3",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"slash": "^3.0.0",
+				"unrs-resolver": "^1.7.11"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-resolve-dependencies": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+			"integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jest-regex-util": "30.4.0",
+				"jest-snapshot": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-runner": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+			"integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.4.1",
+				"@jest/environment": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-haste-map": "30.4.1",
+				"jest-leak-detector": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-resolve": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"jest-worker": "30.4.1",
+				"p-limit": "^3.1.0",
+				"source-map-support": "0.5.13"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-runtime": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+			"integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/globals": "30.4.1",
+				"@jest/source-map": "30.0.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"cjs-module-lexer": "^2.1.0",
+				"collect-v8-coverage": "^1.0.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+			"integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-validate": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+			"integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.4.1",
+				"camelcase": "^6.3.0",
+				"chalk": "^4.1.2",
+				"leven": "^3.1.0",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/jest-watcher": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+			"integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"jest-util": "30.4.1",
+				"string-length": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/json-parse-even-better-errors": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-6.0.0.tgz",
+			"integrity": "sha512-2/8adwnK1/+Fdjyts4r6wSpfANWw8zdNhU9U/Llk59c6O+DjSisPWPykwoL8gZmocP9Dy64S7oie2g+Mia123A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/npm-normalize-package-bin": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-6.0.0.tgz",
+			"integrity": "sha512-tdt4aFn9QamlhdN3HV2D2ccpBwO5/fyjjbXUxYA6uBjyekMZcZvDq0aSj9t5Jo+tih6AYFnt/cuIRn9013e0Uw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/npm-run-all2": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-9.0.2.tgz",
+			"integrity": "sha512-+dd4SO2jAlLE06OzmJKzIe6QvvjXezcbmobnh8usR0a8BzQCABTdqTXqVPji0ICOhSQpIIrkGd7IzNl5iDaRSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"cross-spawn": "^7.0.6",
+				"memorystream": "^0.3.1",
+				"picomatch": "^4.0.2",
+				"pidtree": "^1.0.0",
+				"read-package-json-fast": "^6.0.0",
+				"shell-quote": "^1.8.4",
+				"which": "^7.0.0"
+			},
+			"bin": {
+				"npm-run-all": "bin/npm-run-all/index.js",
+				"npm-run-all2": "bin/npm-run-all/index.js",
+				"run-p": "bin/run-p/index.js",
+				"run-s": "bin/run-s/index.js"
+			},
+			"engines": {
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+				"npm": ">= 10"
+			}
+		},
+		"fair-audience-experimental/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"fair-audience-experimental/node_modules/pidtree": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-1.0.0.tgz",
+			"integrity": "sha512-avfAvjB9Dd0wdj3rjJX//yS+G79OO0KrS5pJHFJENjYGX6N4SMgEDBBI/yFy0lloOYSaC6XQxzpOAMPfSYFV/Q==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"pidtree": "bin/pidtree.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"fair-audience-experimental/node_modules/pretty-format": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+			"integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.4.1",
+				"ansi-styles": "^5.2.0",
+				"react-is-18": "npm:react-is@^18.3.1",
+				"react-is-19": "npm:react-is@^19.2.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"fair-audience-experimental/node_modules/pure-rand": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+			"integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT"
+		},
+		"fair-audience-experimental/node_modules/read-package-json-fast": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-6.0.0.tgz",
+			"integrity": "sha512-PNaGjoCnw9DBA2Kl8D+8po957z778q/HOPuY2u3Bkw/JO3eC8MDx7jn/PgMtSgpcBbs+6UOjDbwReGpXmRvs0g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"json-parse-even-better-errors": "^6.0.0",
+				"npm-normalize-package-bin": "^6.0.0"
+			},
+			"engines": {
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/which": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-7.0.0.tgz",
+			"integrity": "sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^4.0.0"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"fair-audience/node_modules/@jest/core": {
@@ -901,6 +1778,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.28.3",
 				"@babel/preset-env": "^7.28.3",
+				"@playwright/test": "^1.40.0",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@wordpress/scripts": "^32.4.0",
@@ -1696,6 +2574,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/components": "^36.0.0",
+				"@wordpress/date": "^5.2.0",
 				"@wordpress/scripts": "^32.4.0",
 				"date-fns": "^4.0.0"
 			}
@@ -19673,6 +20552,10 @@
 		},
 		"node_modules/fair-audience": {
 			"resolved": "fair-audience",
+			"link": true
+		},
+		"node_modules/fair-audience-experimental": {
+			"resolved": "fair-audience-experimental",
 			"link": true
 		},
 		"node_modules/fair-events": {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
 		"composer:update": "npm run composer:update --workspaces --if-present",
 		"composer:update:shared": "npm run composer:update:shared --workspaces --if-present",
 		"composer:validate": "npm run composer:validate --workspaces --if-present",
-		"start": "npm run start --workspace=fair-payments-connector & npm run start --workspace=fair-events & npm run start --workspace=fair-audience & npm run start --workspace=fair-timetable & npm run start --workspace=fair-finance & npm run start --workspace=fair-events-experimental & npm run start --workspace=fair-payments-connector-experimental & npm run start --workspace=fair-form & wait",
+		"start": "npm run start --workspace=fair-payments-connector & npm run start --workspace=fair-events & npm run start --workspace=fair-audience & npm run start --workspace=fair-timetable & npm run start --workspace=fair-finance & npm run start --workspace=fair-events-experimental & npm run start --workspace=fair-payments-connector-experimental & npm run start --workspace=fair-form & npm run start --workspace=fair-audience-experimental & wait",
 		"format": "npm-run-all2 format:*",
 		"format:js": "wp-scripts format",
-		"format:php": "vendor/bin/phpcbf --standard=WordPress --extensions=php fair-payments-connector/src/ fair-events/src/ fair-events/__tests__/ fair-platform/src/ fair-audience/src/ fair-audience/__tests__/ fair-timetable/src/ fair-timetable/__tests__/ fair-finance/src/ fair-finance/__tests__/ fair-events-experimental/src/ fair-payments-connector-experimental/src/ fair-form/src/",
+		"format:php": "vendor/bin/phpcbf --standard=WordPress --extensions=php fair-payments-connector/src/ fair-events/src/ fair-events/__tests__/ fair-platform/src/ fair-audience/src/ fair-audience/__tests__/ fair-timetable/src/ fair-timetable/__tests__/ fair-finance/src/ fair-finance/__tests__/ fair-events-experimental/src/ fair-payments-connector-experimental/src/ fair-form/src/ fair-audience-experimental/src/",
 		"prepare": "husky",
 		"changeset": "changeset",
 		"changeset:add": "changeset add",
@@ -88,7 +88,8 @@
 		"fair-finance",
 		"fair-events-experimental",
 		"fair-payments-connector-experimental",
-		"fair-form"
+		"fair-form",
+		"fair-audience-experimental"
 	],
 	"devDependencies": {
 		"@changesets/cli": "^2.29.6",

--- a/scripts/deploy-local.js
+++ b/scripts/deploy-local.js
@@ -39,6 +39,7 @@ const ALL_PLUGINS = [
 	'fair-timetable',
 	'fair-finance',
 	'fair-events-experimental',
+	'fair-audience-experimental',
 ];
 const MAX_ATTEMPTS = 2;
 

--- a/scripts/sync-changelog.js
+++ b/scripts/sync-changelog.js
@@ -45,6 +45,11 @@ const plugins = [
 		changelogPath: 'fair-form/CHANGELOG.md',
 		readmeFiles: ['fair-form/readme.txt'],
 	},
+	{
+		name: 'fair-audience-experimental',
+		changelogPath: 'fair-audience-experimental/CHANGELOG.md',
+		readmeFiles: ['fair-audience-experimental/readme.txt'],
+	},
 ];
 
 /**

--- a/scripts/sync-wp-versions.js
+++ b/scripts/sync-wp-versions.js
@@ -82,6 +82,13 @@ const plugins = [
 		readmeFiles: ['fair-form/readme.txt'],
 		versionConstant: 'FAIR_FORM_VERSION',
 	},
+	{
+		name: 'fair-audience-experimental',
+		packagePath: 'fair-audience-experimental/package.json',
+		phpFiles: ['fair-audience-experimental/fair-audience-experimental.php'],
+		readmeFiles: ['fair-audience-experimental/readme.txt'],
+		versionConstant: 'FAIR_AUDIENCE_EXPERIMENTAL_VERSION',
+	},
 ];
 
 /**

--- a/scripts/tag-release.js
+++ b/scripts/tag-release.js
@@ -25,6 +25,7 @@ const ALL_PLUGINS = [
 	'fair-timetable',
 	'fair-finance',
 	'fair-events-experimental',
+	'fair-audience-experimental',
 ];
 
 function getVersion(pluginName) {


### PR DESCRIPTION
## Summary

First phase of splitting `fair-audience` into a lean, wp.org-published core
plus an internal `fair-audience-experimental` companion, mirroring the
`fair-events` / `fair-events-experimental` split (`git show 1cb25174`).

This PR only scaffolds the companion and wires it into the monorepo — it does
**not** move any feature bundles out of `fair-audience` yet. That happens in
follow-up PRs, one per bundle group, per the plan in the linked ticket.

- New `fair-audience-experimental` plugin: `plugins_loaded` (priority 5)
  bootstrap with a runtime guard on `FAIR_AUDIENCE_VERSION` and graceful
  self-deactivation, `Requires Plugins: fair-audience`.
- `Core\Features` registry (master constant
  `FAIR_AUDIENCE_EXPERIMENTAL_INTERNAL`) listing the thirteen advanced bundles
  from the ticket table (fees, polls, galleries, instagram, groups,
  collaborators, messaging, image-templates, timeline, import,
  weekly-schedule, invitations, manage-event-ext) — all default `true`.
- `Admin\AdminPages` registers an Experimental settings submenu under
  `fair-audience`'s own top-level menu, at `admin_menu` priority 11 (avoids
  the known submenu-hook-order 404 when the companion activates before the
  base plugin — documented in `ADDING_NEW_PLUGIN.md`).
- `Settings\Settings` + `Admin/settings/{FeaturesTab,SettingsApp,index}.js` —
  the Features toggle UI, copied from `fair-events-experimental`.
- Monorepo wiring: root `package.json` (workspaces, `start` fan-out,
  `format:php`), CI/e2e workflow caches and path filters,
  `deploy-to-environment.yml` plugin list, `compose.yml` volumes (both
  services), `.wp-env.json`, and `scripts/{sync-wp-versions,sync-changelog,
  deploy-local,tag-release}.js`.
- Per the ticket's explicit wiring note, `dist-archive:fair-audience-experimental`
  and `svn:*` scripts are **not** added (companion isn't published to
  wp.org) — this differs slightly from the `fair-events-experimental`
  precedent, which does have a `dist-archive` script; flagging in case that
  was meant to carry over here too.
- Changeset added for `fair-audience-experimental`.

Refs #1041

## Test plan

- [x] `composer install` + `composer validate --strict` in
      `fair-audience-experimental`
- [x] `npm install` at root (adds the new workspace)
- [x] `npm run build` — generates `build/admin/settings/index.js` +
      `index.asset.php`
- [x] `npm run format` in `fair-audience-experimental`
- [x] `vendor/bin/phpcs` clean for the new plugin's PHP files
- [x] `npx jest` — example test passes
- [x] `npm run lint:docs` passes
- [ ] Manual smoke test (activate both plugins in wp-env, confirm the
      Experimental settings submenu renders and toggles save) — not run this
      session; recommended before merge
