### PR TITLE
Materialize cancellations and NULL-inherit instance fields

### DIFF
--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -456,7 +456,7 @@ class EventDatesController extends WP_REST_Controller {
 
 			// Propagate categories to generated occurrences.
 			if ( ! empty( $rrule ) ) {
-				$generated = EventDates::get_generated_by_master_id( $id );
+				$generated = EventDates::get_generated_by_master_id( $id, true );
 				foreach ( $generated as $occ ) {
 					$this->set_standalone_categories( $occ->id, $categories );
 				}
@@ -881,14 +881,15 @@ class EventDatesController extends WP_REST_Controller {
 			if ( $rrule_changed || $dates_changed_on_recurring ) {
 				$effective_rrule = $update_data['rrule'] ?? $existing->rrule;
 
-				// Classify the impact before applying, so we can reject destructive
-				// changes (removing occurrences that have dependents or are in the past).
+				// Classify the impact before applying, for informational purposes —
+				// removed occurrences are soft-cancelled (their id and any
+				// dependents survive), so this is no longer a destructive change
+				// to guard against.
 				$recurrence_impact = null;
 				if ( ! empty( $effective_rrule ) ) {
 					$proposed_start = $update_data['start_datetime'] ?? $existing->start_datetime;
 					$proposed_end   = $update_data['end_datetime'] ?? $existing->end_datetime;
-					$exdates        = RecurrenceService::parse_exdates( $existing->exdates );
-					$all_proposed   = RecurrenceService::generate_occurrences( $proposed_start, $proposed_end, $effective_rrule, null, $exdates );
+					$all_proposed   = RecurrenceService::generate_occurrences( $proposed_start, $proposed_end, $effective_rrule );
 					$proposed_gen   = array_slice( $all_proposed, 1 );
 
 					$classify_master_id = ( 'generated' === $existing->occurrence_type && $existing->master_id )
@@ -896,20 +897,6 @@ class EventDatesController extends WP_REST_Controller {
 						: $id;
 
 					$recurrence_impact = RecurrenceService::classify_change( $classify_master_id, $proposed_gen );
-
-					// A removal is destructive when the row has dependents or is in the past.
-					foreach ( $recurrence_impact['removed'] as $removed_row ) {
-						if ( $removed_row['dependents'] > 0 || $removed_row['is_past'] ) {
-							return new WP_Error(
-								'rest_destructive_recurrence_change',
-								__( 'Cannot remove occurrences that have dependents or are in the past.', 'fair-events' ),
-								array(
-									'status' => 409,
-									'impact' => $recurrence_impact,
-								)
-							);
-						}
-					}
 				}
 
 				if ( $effective_event_id ) {
@@ -919,27 +906,15 @@ class EventDatesController extends WP_REST_Controller {
 				}
 			}
 
-			// Propagate inherited fields (event_id, venue_id, address) from a
-			// master to its existing generated children. Without this, edits to
-			// these fields would only reach children when the series is fully
-			// regenerated (rrule or dates change). event_id propagation matters
+			// Propagate event_id from a master to its existing generated children.
+			// event_id is not inherited (NULL-means-inherit only applies to
+			// title/venue_id/address/link_type/external_url/capacity/signup_price,
+			// which children resolve against the master at read time) — it matters
 			// when a standalone recurring series is linked to a post after its
 			// children were already generated.
-			if ( 'master' === $existing->occurrence_type ) {
-				$propagate = array();
-				if ( array_key_exists( 'event_id', $update_data ) ) {
-					$propagate['event_id'] = $update_data['event_id'];
-				}
-				if ( array_key_exists( 'venue_id', $update_data ) ) {
-					$propagate['venue_id'] = $update_data['venue_id'];
-				}
-				if ( array_key_exists( 'address', $update_data ) ) {
-					$propagate['address'] = $update_data['address'];
-				}
-				if ( ! empty( $propagate ) ) {
-					foreach ( EventDates::get_generated_by_master_id( $id ) as $child ) {
-						EventDates::update_by_id( $child->id, $propagate );
-					}
+			if ( 'master' === $existing->occurrence_type && array_key_exists( 'event_id', $update_data ) ) {
+				foreach ( EventDates::get_generated_by_master_id( $id, true ) as $child ) {
+					EventDates::update_by_id( $child->id, array( 'event_id' => $update_data['event_id'] ) );
 				}
 			}
 
@@ -982,7 +957,7 @@ class EventDatesController extends WP_REST_Controller {
 		$current_for_propagation = EventDates::get_by_id( $id );
 		if ( 'master' === $current_for_propagation->occurrence_type && ! $current_for_propagation->event_id ) {
 			$master_cat_ids = $this->get_standalone_category_ids( $id );
-			$generated      = EventDates::get_generated_by_master_id( $id );
+			$generated      = EventDates::get_generated_by_master_id( $id, true );
 			foreach ( $generated as $occ ) {
 				$this->set_standalone_categories( $occ->id, $master_cat_ids );
 			}
@@ -1240,7 +1215,12 @@ class EventDatesController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Toggle an excluded date on a master event
+	 * Toggle the cancelled status of a date within a recurring series
+	 *
+	 * A single-row status flip: cancel sets status='cancelled' on the instance
+	 * row for that date (inserting one first if the rule never materialized a
+	 * row for it), restore sets it back to 'active'. Cancelled rows keep their
+	 * id, so ticket types/signups attached to them survive.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
@@ -1249,9 +1229,9 @@ class EventDatesController extends WP_REST_Controller {
 		$id   = (int) $request->get_param( 'id' );
 		$date = $request->get_param( 'date' );
 
-		$event_date = EventDates::get_by_id( $id );
+		$master = EventDates::get_by_id( $id );
 
-		if ( ! $event_date ) {
+		if ( ! $master ) {
 			return new WP_Error(
 				'rest_event_date_not_found',
 				__( 'Event date not found.', 'fair-events' ),
@@ -1259,91 +1239,75 @@ class EventDatesController extends WP_REST_Controller {
 			);
 		}
 
-		if ( 'master' !== $event_date->occurrence_type ) {
+		if ( 'master' !== $master->occurrence_type ) {
 			return new WP_Error(
 				'rest_not_master_event',
-				__( 'Exdates can only be set on master events.', 'fair-events' ),
+				__( 'Dates can only be cancelled on master events.', 'fair-events' ),
 				array( 'status' => 400 )
 			);
 		}
 
-		// Don't allow excluding the master's own date.
-		$master_date = ( new \DateTime( $event_date->start_datetime ) )->format( 'Y-m-d' );
+		// Don't allow cancelling the master's own date.
+		$master_date = ( new \DateTime( $master->start_datetime ) )->format( 'Y-m-d' );
 		if ( $date === $master_date ) {
 			return new WP_Error(
 				'rest_cannot_exclude_master',
-				__( 'Cannot exclude the master event date.', 'fair-events' ),
+				__( 'Cannot cancel the master event date.', 'fair-events' ),
 				array( 'status' => 400 )
 			);
 		}
 
-		// Parse current exdates.
-		$exdates = RecurrenceService::parse_exdates( $event_date->exdates );
+		$siblings = EventDates::get_all_by_master_id( $id );
 
-		// Toggle: add if not present, remove if present.
-		$key = array_search( $date, $exdates, true );
-		if ( false !== $key ) {
-			unset( $exdates[ $key ] );
-			$exdates = array_values( $exdates );
+		if ( isset( $siblings[ $date ] ) ) {
+			$row        = $siblings[ $date ];
+			$new_status = 'cancelled' === $row->status ? 'active' : 'cancelled';
+			EventDates::update_by_id( $row->id, array( 'status' => $new_status ) );
 		} else {
-			$exdates[] = $date;
-		}
+			// No row exists for this date yet (a rule occurrence that was never
+			// materialized) — insert one directly as cancelled.
+			$master_start = new \DateTime( $master->start_datetime );
+			$master_end   = $master->end_datetime ? new \DateTime( $master->end_datetime ) : clone $master_start;
+			$duration     = $master_start->diff( $master_end );
 
-		// Clean stale exdates.
-		$exdates = RecurrenceService::clean_stale_exdates(
-			$event_date->start_datetime,
-			$event_date->end_datetime,
-			$event_date->rrule,
-			$exdates
-		);
+			$occ_start = \DateTime::createFromFormat( 'Y-m-d H:i:s', $date . ' ' . $master_start->format( 'H:i:s' ) );
+			if ( ! $occ_start ) {
+				return new WP_Error(
+					'rest_invalid_date',
+					__( 'Invalid date.', 'fair-events' ),
+					array( 'status' => 400 )
+				);
+			}
+			$occ_end = ( clone $occ_start )->add( $duration );
 
-		// Classify the impact of this exdate change before applying it.
-		// An exdate addition removes one occurrence; check for dependents/past rows.
-		$recurrence_impact = null;
-		if ( ! empty( $event_date->rrule ) ) {
-			$new_proposed      = RecurrenceService::generate_occurrences(
-				$event_date->start_datetime,
-				$event_date->end_datetime,
-				$event_date->rrule,
-				null,
-				$exdates
-			);
-			$proposed_gen      = array_slice( $new_proposed, 1 );
-			$recurrence_impact = RecurrenceService::classify_change( $id, $proposed_gen );
-
-			foreach ( $recurrence_impact['removed'] as $removed_row ) {
-				if ( $removed_row['dependents'] > 0 || $removed_row['is_past'] ) {
-					return new WP_Error(
-						'rest_destructive_recurrence_change',
-						__( 'Cannot remove occurrences that have dependents or are in the past.', 'fair-events' ),
-						array(
-							'status' => 409,
-							'impact' => $recurrence_impact,
-						)
-					);
-				}
+			if ( $master->event_id ) {
+				EventDates::save_occurrence(
+					$master->event_id,
+					$occ_start->format( 'Y-m-d H:i:s' ),
+					$occ_end->format( 'Y-m-d H:i:s' ),
+					$master->all_day,
+					'generated',
+					$id,
+					$date,
+					'cancelled'
+				);
+			} else {
+				EventDates::create_standalone_occurrence(
+					array(
+						'start_datetime'    => $occ_start->format( 'Y-m-d H:i:s' ),
+						'end_datetime'      => $occ_end->format( 'Y-m-d H:i:s' ),
+						'all_day'           => $master->all_day,
+						'master_id'         => $id,
+						'recurrence_anchor' => $date,
+						'status'            => 'cancelled',
+					)
+				);
 			}
 		}
 
-		// Save exdates.
-		$exdates_string = ! empty( $exdates ) ? implode( ',', $exdates ) : null;
-		EventDates::update_by_id( $id, array( 'exdates' => $exdates_string ) );
+		$updated = EventDates::get_by_id( $id );
 
-		// Regenerate occurrences.
-		if ( $event_date->event_id ) {
-			RecurrenceService::regenerate_event_occurrences( $event_date->event_id );
-		} else {
-			RecurrenceService::regenerate_standalone_occurrences( $id );
-		}
-
-		// Return updated event date.
-		$updated       = EventDates::get_by_id( $id );
-		$response_data = $this->prepare_event_date( $updated );
-		if ( null !== $recurrence_impact ) {
-			$response_data['recurrence_impact'] = $recurrence_impact;
-		}
-
-		return new WP_REST_Response( $response_data, 200 );
+		return new WP_REST_Response( $this->prepare_event_date( $updated ), 200 );
 	}
 
 	/**
@@ -1501,14 +1465,9 @@ class EventDatesController extends WP_REST_Controller {
 			'external_url'    => $event_date->external_url,
 			'display_url'     => $event_date->get_display_url(),
 			'rrule'           => $event_date->rrule,
+			'status'          => $event_date->status,
+			'recurrence_mode' => $event_date->recurrence_mode,
 		);
-
-		// Add exdates for master events.
-		if ( 'master' === $event_date->occurrence_type ) {
-			$data['exdates'] = $event_date->exdates
-				? array_values( array_filter( array_map( 'trim', explode( ',', $event_date->exdates ) ) ) )
-				: array();
-		}
 
 		// Add master event info for generated occurrences.
 		if ( 'generated' === $event_date->occurrence_type && $event_date->master_id ) {
@@ -1522,18 +1481,34 @@ class EventDatesController extends WP_REST_Controller {
 			}
 		}
 
-		// Add generated occurrences for master events.
+		// Add generated occurrences (including cancelled, so the calendar can
+		// render cancelled cells) plus a cancelled_dates convenience list for
+		// master events.
 		if ( 'master' === $event_date->occurrence_type ) {
-			$generated                     = EventDates::get_generated_by_master_id( $event_date->id );
+			$generated                     = EventDates::get_generated_by_master_id( $event_date->id, true );
 			$data['generated_occurrences'] = array_map(
 				function ( $occ ) {
 					return array(
 						'id'             => $occ->id,
 						'start_datetime' => $occ->start_datetime,
 						'title'          => $occ->title,
+						'status'         => $occ->status,
 					);
 				},
 				$generated
+			);
+			$data['cancelled_dates']       = array_values(
+				array_map(
+					function ( $occ ) {
+						return $occ->recurrence_anchor ?? ( new \DateTime( $occ->start_datetime ) )->format( 'Y-m-d' );
+					},
+					array_filter(
+						$generated,
+						function ( $occ ) {
+							return 'cancelled' === $occ->status;
+						}
+					)
+				)
 			);
 		}
 

--- a/fair-events/src/API/PublicEventsController.php
+++ b/fair-events/src/API/PublicEventsController.php
@@ -382,14 +382,15 @@ class PublicEventsController extends WP_REST_Controller {
 				{$dates_table}.end_datetime,
 				{$dates_table}.all_day,
 				{$dates_table}.occurrence_type,
-				{$dates_table}.title as standalone_title,
-				{$dates_table}.link_type,
-				{$dates_table}.external_url,
+				COALESCE( {$dates_table}.title, master_dates.title ) as standalone_title,
+				COALESCE( {$dates_table}.link_type, master_dates.link_type ) as link_type,
+				COALESCE( {$dates_table}.external_url, master_dates.external_url ) as external_url,
 				NULL as post_title,
 				NULL as post_content,
 				NULL as post_excerpt,
 				NULL as post_status
 			FROM {$dates_table}
+			LEFT JOIN {$dates_table} master_dates ON {$dates_table}.master_id = master_dates.id
 			WHERE {$standalone_where_clause})
 			ORDER BY start_datetime ASC
 			LIMIT %d OFFSET %d",

--- a/fair-events/src/API/__tests__/EventDatesController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesController.api.spec.js
@@ -210,9 +210,9 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 		return edBody;
 	}
 
-	async function getOccurrences(api, eventId) {
+	async function getMaster(api, masterId) {
 		const res = await api.get(
-			`/wp-json/fair-events/v1/event-dates?event_id=${eventId}`,
+			`/wp-json/fair-events/v1/event-dates/${masterId}`,
 			{ headers: adminHeaders }
 		);
 		expect(res.ok()).toBeTruthy();
@@ -225,9 +225,12 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 		const localApi = await req.newContext({ baseURL: BASE_URL });
 		await createRecurringEvent(localApi, 'FREQ=WEEKLY;COUNT=3');
 
-		const before = await getOccurrences(localApi, eventPostId);
-		expect(before.length).toBe(3);
-		const idsBefore = before.map((o) => o.id).sort();
+		const before = await getMaster(localApi, masterEventDateId);
+		expect(before.generated_occurrences.length).toBe(2);
+		const idsBefore = [
+			before.id,
+			...before.generated_occurrences.map((o) => o.id),
+		].sort();
 
 		const putRes = await localApi.put(
 			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
@@ -241,26 +244,32 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 		);
 		expect(putRes.ok()).toBeTruthy();
 
-		const after = await getOccurrences(localApi, eventPostId);
-		expect(after.length).toBe(3);
-		const idsAfter = after.map((o) => o.id).sort();
+		const after = await getMaster(localApi, masterEventDateId);
+		const idsAfter = [
+			after.id,
+			...after.generated_occurrences.map((o) => o.id),
+		].sort();
 
 		expect(idsAfter).toEqual(idsBefore);
 
-		const starts = after.map((o) => o.start_datetime);
+		const starts = after.generated_occurrences.map((o) => o.start_datetime);
 		expect(starts.every((s) => s.includes('11:00:00'))).toBe(true);
 	});
 
-	test('shortening RRULE deletes only removed occurrences', async ({
+	test('shortening RRULE soft-cancels removed occurrences instead of deleting them', async ({
 		request: req,
 	}) => {
 		const localApi = await req.newContext({ baseURL: BASE_URL });
 		await createRecurringEvent(localApi, 'FREQ=WEEKLY;COUNT=4');
 
-		const before = await getOccurrences(localApi, eventPostId);
-		expect(before.length).toBe(4);
-		const keptIds = before.slice(0, 2).map((o) => o.id);
-		const removedIds = before.slice(2).map((o) => o.id);
+		const before = await getMaster(localApi, masterEventDateId);
+		expect(before.generated_occurrences.length).toBe(3);
+		const keptIds = before.generated_occurrences
+			.slice(0, 1)
+			.map((o) => o.id);
+		const cancelledIds = before.generated_occurrences
+			.slice(1)
+			.map((o) => o.id);
 
 		const putRes = await localApi.put(
 			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
@@ -271,12 +280,20 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 		);
 		expect(putRes.ok()).toBeTruthy();
 
-		const after = await getOccurrences(localApi, eventPostId);
-		expect(after.length).toBe(2);
-		const idsAfter = after.map((o) => o.id);
-
+		const after = await getMaster(localApi, masterEventDateId);
+		// Ids survive — soft-cancelled, not deleted.
+		const idsAfter = after.generated_occurrences.map((o) => o.id);
 		keptIds.forEach((id) => expect(idsAfter).toContain(id));
-		removedIds.forEach((id) => expect(idsAfter).not.toContain(id));
+		cancelledIds.forEach((id) => expect(idsAfter).toContain(id));
+
+		const byId = Object.fromEntries(
+			after.generated_occurrences.map((o) => [o.id, o])
+		);
+		keptIds.forEach((id) => expect(byId[id].status).toBe('active'));
+		cancelledIds.forEach((id) => expect(byId[id].status).toBe('cancelled'));
+		cancelledIds.forEach((id) =>
+			expect(after.cancelled_dates.length).toBeGreaterThan(0)
+		);
 	});
 
 	test('master time-of-day edit propagates to generated children', async ({
@@ -297,11 +314,119 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 		);
 		expect(putRes.ok()).toBeTruthy();
 
-		const after = await getOccurrences(localApi, eventPostId);
-		expect(after.length).toBe(3);
+		const after = await getMaster(localApi, masterEventDateId);
+		expect(after.generated_occurrences.length).toBe(2);
 
-		const starts = after.map((o) => o.start_datetime);
+		const starts = after.generated_occurrences.map((o) => o.start_datetime);
 		expect(starts.every((s) => s.includes('14:00:00'))).toBe(true);
+	});
+});
+
+test.describe('EventDatesController — cancel/restore via toggle-exdate', () => {
+	let api;
+	let masterEventDateId;
+	let eventPostId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterEach(async () => {
+		if (masterEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+				{ headers: adminHeaders }
+			);
+			masterEventDateId = null;
+		}
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+			eventPostId = null;
+		}
+	});
+
+	test('cancelling a date is a reversible status flip that keeps a dependent ticket type', async ({
+		request: req,
+	}) => {
+		const localApi = await req.newContext({ baseURL: BASE_URL });
+
+		const postRes = await localApi.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: { title: `Toggle test ${Date.now()}`, status: 'publish' },
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await localApi.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					event_id: eventPostId,
+					start_datetime: '2035-09-03 10:00:00',
+					end_datetime: '2035-09-03 12:00:00',
+					rrule: 'FREQ=WEEKLY;COUNT=3',
+				},
+			}
+		);
+		expect(edRes.ok()).toBeTruthy();
+		const master = await edRes.json();
+		masterEventDateId = master.id;
+
+		const targetOccurrence = master.generated_occurrences[0];
+
+		// Attach a ticket type to the target occurrence to prove it survives cancellation.
+		const ttRes = await localApi.post(
+			`/wp-json/fair-events/v1/event-dates/${targetOccurrence.id}/ticket-types`,
+			{
+				headers: adminHeaders,
+				data: { name: 'General', capacity: 10, sort_order: 0 },
+			}
+		);
+		const ticketCreated = ttRes.ok();
+		if (!ticketCreated) {
+			test.skip();
+			return;
+		}
+
+		const targetDate = targetOccurrence.start_datetime.split(' ')[0];
+
+		// Cancel.
+		const cancelRes = await localApi.post(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/toggle-exdate`,
+			{ headers: adminHeaders, data: { date: targetDate } }
+		);
+		expect(cancelRes.ok()).toBeTruthy();
+		const afterCancel = await cancelRes.json();
+		const cancelledOcc = afterCancel.generated_occurrences.find(
+			(o) => o.id === targetOccurrence.id
+		);
+		expect(cancelledOcc.status).toBe('cancelled');
+		expect(afterCancel.cancelled_dates).toContain(targetDate);
+
+		// The dependent ticket type must still exist — cancellation is non-destructive.
+		const ttGetRes = await localApi.get(
+			`/wp-json/fair-events/v1/event-dates/${targetOccurrence.id}/ticket-types`,
+			{ headers: adminHeaders }
+		);
+		expect(ttGetRes.ok()).toBeTruthy();
+		expect((await ttGetRes.json()).length).toBeGreaterThan(0);
+
+		// Restore.
+		const restoreRes = await localApi.post(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/toggle-exdate`,
+			{ headers: adminHeaders, data: { date: targetDate } }
+		);
+		expect(restoreRes.ok()).toBeTruthy();
+		const afterRestore = await restoreRes.json();
+		const restoredOcc = afterRestore.generated_occurrences.find(
+			(o) => o.id === targetOccurrence.id
+		);
+		expect(restoredOcc.status).toBe('active');
+		expect(afterRestore.cancelled_dates).not.toContain(targetDate);
 	});
 });
 
@@ -437,11 +562,11 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 		);
 	});
 
-	test('shortening RRULE to remove an occurrence with a ticket type returns 409', async ({
+	test('shortening RRULE to remove an occurrence with a ticket type soft-cancels it (non-destructive)', async ({
 		request: req,
 	}) => {
 		const localApi = await req.newContext({ baseURL: BASE_URL });
-		const { occurrences, lastOccurrence, ticketCreated } =
+		const { lastOccurrence, ticketCreated } =
 			await createRecurringEventWithTicket(
 				localApi,
 				'FREQ=WEEKLY;COUNT=3'
@@ -453,7 +578,8 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 			return;
 		}
 
-		// Try to shorten to COUNT=2 — this would remove the last occurrence that has a ticket type.
+		// Shorten to COUNT=2 — this removes the last occurrence from the rule,
+		// which now soft-cancels it instead of blocking the change.
 		const putRes = await localApi.put(
 			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
 			{
@@ -462,15 +588,28 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 			}
 		);
 
-		expect(putRes.status()).toBe(409);
+		expect(putRes.ok()).toBeTruthy();
 		const body = await putRes.json();
-		expect(body.data.status).toBe(409);
-		expect(body.data).toHaveProperty('impact');
-		const impact = body.data.impact;
-		expect(impact.removed.length).toBeGreaterThan(0);
-		expect(impact.removed[0].dependents).toBeGreaterThan(0);
-		expect(impact.removed[0]).toHaveProperty('id');
-		expect(impact.removed[0].id).toBe(lastOccurrence.id);
+		expect(body.recurrence_impact.removed.length).toBeGreaterThan(0);
+
+		// The removed occurrence still exists, cancelled — its ticket type survives.
+		const masterRes = await localApi.get(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{ headers: adminHeaders }
+		);
+		const masterBody = await masterRes.json();
+		const removedOcc = masterBody.generated_occurrences.find(
+			(o) => o.id === lastOccurrence.id
+		);
+		expect(removedOcc).toBeDefined();
+		expect(removedOcc.status).toBe('cancelled');
+
+		const ttRes = await localApi.get(
+			`/wp-json/fair-events/v1/event-dates/${lastOccurrence.id}/ticket-types`,
+			{ headers: adminHeaders }
+		);
+		expect(ttRes.ok()).toBeTruthy();
+		expect((await ttRes.json()).length).toBeGreaterThan(0);
 	});
 
 	test('shortening RRULE to remove an occurrence without dependents returns 200', async ({
@@ -516,13 +655,16 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 		expect(impact.removed).toHaveLength(1);
 		expect(impact.removed[0].dependents).toBe(0);
 
-		// Confirm only 2 occurrences remain.
-		const occRes = await localApi.get(
-			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
+		// Confirm only 1 occurrence is still active (2 total including the master).
+		const masterRes = await localApi.get(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
 			{ headers: adminHeaders }
 		);
-		const remaining = await occRes.json();
-		expect(remaining).toHaveLength(2);
+		const masterBody = await masterRes.json();
+		const active = masterBody.generated_occurrences.filter(
+			(o) => o.status === 'active'
+		);
+		expect(active).toHaveLength(1);
 	});
 });
 

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -1102,12 +1102,15 @@ export default function ManageEventApp() {
 								{eventDate.occurrence_type === 'master' &&
 									(eventDate.generated_occurrences?.length >
 										0 ||
-										eventDate.exdates?.length > 0) && (
+										eventDate.cancelled_dates?.length >
+											0) && (
 										<RecurrenceCalendar
 											generatedOccurrences={
 												eventDate.generated_occurrences
 											}
-											exdates={eventDate.exdates}
+											cancelledDates={
+												eventDate.cancelled_dates
+											}
 											masterDate={
 												eventDate.start_datetime?.split(
 													' '

--- a/fair-events/src/Admin/manage-event/RecurrenceCalendar.js
+++ b/fair-events/src/Admin/manage-event/RecurrenceCalendar.js
@@ -25,7 +25,7 @@ import {
 
 export default function RecurrenceCalendar({
 	generatedOccurrences,
-	exdates,
+	cancelledDates,
 	masterDate,
 	manageEventUrl,
 	onToggleExdate,
@@ -33,12 +33,15 @@ export default function RecurrenceCalendar({
 	embedded = false,
 }) {
 	const occurrences = generatedOccurrences || [];
-	const cancelledDates = exdates || [];
+	const cancelledDatesList = cancelledDates || [];
 
-	// Build lookup maps
+	// Build lookup maps. generatedOccurrences includes cancelled rows (so the
+	// API can report their id/status too) — only active ones count as
+	// "occurrences" here, cancelled ones are tracked via cancelledSet below.
 	const occurrenceByDate = useMemo(() => {
 		const map = {};
 		occurrences.forEach((occ) => {
+			if (occ.status === 'cancelled') return;
 			const date = occ.start_datetime.split(' ')[0];
 			map[date] = occ;
 		});
@@ -46,8 +49,8 @@ export default function RecurrenceCalendar({
 	}, [occurrences]);
 
 	const cancelledSet = useMemo(
-		() => new Set(cancelledDates),
-		[cancelledDates]
+		() => new Set(cancelledDatesList),
+		[cancelledDatesList]
 	);
 
 	// Determine the date range to show
@@ -56,12 +59,12 @@ export default function RecurrenceCalendar({
 		occurrences.forEach((occ) => {
 			dates.push(occ.start_datetime.split(' ')[0]);
 		});
-		cancelledDates.forEach((d) => dates.push(d));
+		cancelledDatesList.forEach((d) => dates.push(d));
 		if (masterDate) {
 			dates.push(masterDate);
 		}
 		return dates.sort();
-	}, [occurrences, cancelledDates, masterDate]);
+	}, [occurrences, cancelledDatesList, masterDate]);
 
 	// Calculate which months to show
 	const months = useMemo(() => {

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -35,7 +35,9 @@ const mockEventDate = {
 	event_id: null,
 	master: null,
 	generated_occurrences: [],
-	exdates: [],
+	cancelled_dates: [],
+	status: 'active',
+	recurrence_mode: 'none',
 };
 
 beforeEach(() => {

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -270,6 +270,11 @@ class Installer {
 			self::migrate_to_3_21_0();
 		}
 
+		// Run migration if upgrading from pre-3.22.0 (status + recurrence_mode, materialize exdates, NULL-inherit).
+		if ( version_compare( $current_version, '3.22.0', '<' ) ) {
+			self::migrate_to_3_22_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -424,6 +429,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.21.0', '<' ) ) {
 				self::migrate_to_3_21_0();
+			}
+
+			if ( version_compare( $current_version, '3.22.0', '<' ) ) {
+				self::migrate_to_3_22_0();
 			}
 
 			// Install/update tables
@@ -1740,6 +1749,174 @@ class Installer {
 			$wpdb->query(
 				$wpdb->prepare(
 					'ALTER TABLE %i DROP COLUMN seats_per_ticket',
+					$table_name
+				)
+			);
+		}
+	}
+
+	/**
+	 * Check whether a column exists on a table.
+	 *
+	 * @param string $table_name  Fully-prefixed table name.
+	 * @param string $column_name Column name.
+	 * @return bool True if the column exists.
+	 */
+	private static function column_exists( $table_name, $column_name ) {
+		global $wpdb;
+
+		$result = $wpdb->get_results(
+			$wpdb->prepare(
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$table_name,
+				$wpdb->esc_like( $column_name )
+			)
+		);
+
+		return ! empty( $result );
+	}
+
+	/**
+	 * Migrate to version 3.22.0 - Materialize cancellations, NULL-inherit instance
+	 * fields, explicit recurrence_mode.
+	 *
+	 * Replaces the `exdates` CSV blob on masters with real `status='cancelled'`
+	 * child rows (so cancelled occurrences get an id, can be queried, and cancel/
+	 * restore is a status flip instead of a destructive delete), switches
+	 * inheritable instance fields (title, venue_id, address, link_type,
+	 * external_url, capacity, signup_price) to NULL-means-inherit instead of
+	 * copy-propagated values, and adds an explicit `recurrence_mode` column so
+	 * series shape is stored rather than inferred from an empty `rrule`.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_22_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_event_dates';
+
+		if ( ! self::column_exists( $table_name, 'status' ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					"ALTER TABLE %i ADD COLUMN status ENUM('active','cancelled') NOT NULL DEFAULT 'active' AFTER recurrence_anchor",
+					$table_name
+				)
+			);
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD KEY idx_status (status)',
+					$table_name
+				)
+			);
+		}
+
+		if ( ! self::column_exists( $table_name, 'recurrence_mode' ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					"ALTER TABLE %i ADD COLUMN recurrence_mode ENUM('none','rule','manual') NOT NULL DEFAULT 'none' AFTER status",
+					$table_name
+				)
+			);
+		}
+
+		// Backfill recurrence_mode on masters/singles from rrule presence; instances take their master's mode.
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET recurrence_mode = 'rule' WHERE occurrence_type IN ('single', 'master') AND rrule IS NOT NULL AND rrule != ''",
+				$table_name
+			)
+		);
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i child JOIN %i master ON child.master_id = master.id SET child.recurrence_mode = master.recurrence_mode WHERE child.occurrence_type = 'generated'",
+				$table_name,
+				$table_name
+			)
+		);
+
+		// Materialize exdates into real cancelled child rows before dropping the column.
+		if ( self::column_exists( $table_name, 'exdates' ) ) {
+			$masters = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT * FROM %i WHERE occurrence_type = 'master' AND exdates IS NOT NULL AND exdates != ''",
+					$table_name
+				)
+			);
+
+			foreach ( $masters as $master ) {
+				$exdates = array_filter( array_map( 'trim', explode( ',', $master->exdates ) ) );
+				if ( empty( $exdates ) ) {
+					continue;
+				}
+
+				$start    = new \DateTime( $master->start_datetime );
+				$end      = $master->end_datetime ? new \DateTime( $master->end_datetime ) : clone $start;
+				$duration = $start->diff( $end );
+
+				foreach ( $exdates as $exdate ) {
+					$existing = $wpdb->get_var(
+						$wpdb->prepare(
+							'SELECT id FROM %i WHERE master_id = %d AND recurrence_anchor = %s LIMIT 1',
+							$table_name,
+							$master->id,
+							$exdate
+						)
+					);
+					if ( $existing ) {
+						continue;
+					}
+
+					$occ_start = \DateTime::createFromFormat( 'Y-m-d H:i:s', $exdate . ' ' . $start->format( 'H:i:s' ) );
+					if ( ! $occ_start ) {
+						continue;
+					}
+					$occ_end = ( clone $occ_start )->add( $duration );
+
+					$wpdb->insert(
+						$table_name,
+						array(
+							'event_id'          => $master->event_id,
+							'start_datetime'    => $occ_start->format( 'Y-m-d H:i:s' ),
+							'end_datetime'      => $occ_end->format( 'Y-m-d H:i:s' ),
+							'all_day'           => $master->all_day,
+							'occurrence_type'   => 'generated',
+							'master_id'         => $master->id,
+							'recurrence_anchor' => $exdate,
+							'status'            => 'cancelled',
+							'recurrence_mode'   => $master->recurrence_mode,
+						),
+						array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s' )
+					);
+				}
+			}
+		}
+
+		// NULL-out instance fields that still hold a copy of their master's value;
+		// genuinely different (overridden) values are left in place.
+		$inheritable_fields = array( 'title', 'venue_id', 'address', 'link_type', 'external_url', 'capacity', 'signup_price' );
+		foreach ( $inheritable_fields as $field ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $field is from a fixed internal allowlist, not request input.
+					"UPDATE %i child JOIN %i master ON child.master_id = master.id SET child.{$field} = NULL WHERE child.occurrence_type = 'generated' AND child.{$field} <=> master.{$field}",
+					$table_name,
+					$table_name
+				)
+			);
+		}
+
+		// Widen link_type to allow NULL now that instances can inherit it.
+		$wpdb->query(
+			$wpdb->prepare(
+				'ALTER TABLE %i MODIFY COLUMN link_type VARCHAR(20) DEFAULT NULL',
+				$table_name
+			)
+		);
+
+		if ( self::column_exists( $table_name, 'exdates' ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i DROP COLUMN exdates',
 					$table_name
 				)
 			);

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.21.0';
+	const DB_VERSION = '3.22.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -42,14 +42,16 @@ class Schema {
 			occurrence_type VARCHAR(20) NOT NULL DEFAULT 'single',
 			master_id BIGINT UNSIGNED DEFAULT NULL,
 			rrule VARCHAR(255) DEFAULT NULL,
-			exdates TEXT DEFAULT NULL,
+			venue_id BIGINT UNSIGNED DEFAULT NULL,
 			title VARCHAR(255) DEFAULT NULL,
 			external_url TEXT DEFAULT NULL,
-			link_type VARCHAR(20) NOT NULL DEFAULT 'post',
+			link_type VARCHAR(20) DEFAULT NULL,
 			capacity INT UNSIGNED DEFAULT NULL,
 			signup_price DECIMAL(10,2) DEFAULT NULL,
 			address TEXT DEFAULT NULL,
 			recurrence_anchor DATE DEFAULT NULL,
+			status ENUM('active','cancelled') NOT NULL DEFAULT 'active',
+			recurrence_mode ENUM('none','rule','manual') NOT NULL DEFAULT 'none',
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY (id),
@@ -61,7 +63,9 @@ class Schema {
 			KEY idx_master_id (master_id),
 			KEY idx_rrule (rrule(100)),
 			KEY idx_link_type (link_type),
-			KEY idx_recurrence_anchor (recurrence_anchor)
+			KEY idx_recurrence_anchor (recurrence_anchor),
+			KEY idx_venue_id (venue_id),
+			KEY idx_status (status)
 		) ENGINE=InnoDB {$charset_collate};";
 	}
 

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -73,11 +73,18 @@ class EventDates {
 	public $rrule;
 
 	/**
-	 * Excluded dates (comma-separated Y-m-d, only on master rows)
+	 * Status ('active' or 'cancelled')
 	 *
-	 * @var string|null
+	 * @var string
 	 */
-	public $exdates;
+	public $status = 'active';
+
+	/**
+	 * Recurrence mode ('none', 'rule', 'manual') — explicit series shape.
+	 *
+	 * @var string
+	 */
+	public $recurrence_mode = 'none';
 
 	/**
 	 * Venue ID
@@ -191,17 +198,58 @@ class EventDates {
 		$event_dates->occurrence_type   = $result->occurrence_type ?? 'single';
 		$event_dates->master_id         = $result->master_id ? (int) $result->master_id : null;
 		$event_dates->rrule             = $result->rrule ?? null;
-		$event_dates->exdates           = $result->exdates ?? null;
+		$event_dates->status            = $result->status ?? 'active';
+		$event_dates->recurrence_mode   = $result->recurrence_mode ?? 'none';
 		$event_dates->venue_id          = isset( $result->venue_id ) ? (int) $result->venue_id : null;
 		$event_dates->title             = $result->title ?? null;
 		$event_dates->external_url      = $result->external_url ?? null;
-		$event_dates->link_type         = $result->link_type ?? 'post';
+		$event_dates->link_type         = $result->link_type ?? null;
 		$event_dates->capacity          = isset( $result->capacity ) && null !== $result->capacity ? (int) $result->capacity : null;
 		$event_dates->signup_price      = isset( $result->signup_price ) && null !== $result->signup_price ? (float) $result->signup_price : null;
 		$event_dates->address           = isset( $result->address ) ? $result->address : null;
 		$event_dates->recurrence_anchor = $result->recurrence_anchor ?? null;
 
+		self::resolve_instance( $event_dates );
+
 		return $event_dates;
+	}
+
+	/**
+	 * Cache of master rows already fetched during this request, keyed by ID.
+	 * Keeps NULL-inherit resolution from re-querying the same master for
+	 * every sibling instance in a list.
+	 *
+	 * @var array<int, EventDates>
+	 */
+	private static $master_cache = array();
+
+	/**
+	 * Resolve NULL inheritable fields on an instance ('generated') row from
+	 * its master. Single/master rows and already-overridden fields are left
+	 * untouched.
+	 *
+	 * @param EventDates $event_dates Hydrated event date to resolve in place.
+	 * @return void
+	 */
+	private static function resolve_instance( $event_dates ) {
+		if ( 'generated' !== $event_dates->occurrence_type || ! $event_dates->master_id ) {
+			return;
+		}
+
+		if ( ! isset( self::$master_cache[ $event_dates->master_id ] ) ) {
+			self::$master_cache[ $event_dates->master_id ] = self::get_by_id( $event_dates->master_id );
+		}
+
+		$master = self::$master_cache[ $event_dates->master_id ];
+		if ( ! $master ) {
+			return;
+		}
+
+		foreach ( array( 'title', 'venue_id', 'address', 'link_type', 'external_url', 'capacity', 'signup_price' ) as $field ) {
+			if ( null === $event_dates->$field ) {
+				$event_dates->$field = $master->$field;
+			}
+		}
 	}
 
 	/**
@@ -268,9 +316,10 @@ class EventDates {
 	 * @param string      $occurrence_type    Occurrence type (single, master, generated).
 	 * @param int|null    $master_id          Master occurrence ID (for generated occurrences).
 	 * @param string|null $recurrence_anchor  Anchor date (Y-m-d).
+	 * @param string      $status             Row status ('active' or 'cancelled').
 	 * @return int|false The row ID on success, false on failure.
 	 */
-	public static function save_occurrence( $event_id, $start, $end, $all_day, $occurrence_type = 'single', $master_id = null, $recurrence_anchor = null ) {
+	public static function save_occurrence( $event_id, $start, $end, $all_day, $occurrence_type = 'single', $master_id = null, $recurrence_anchor = null, $status = 'active' ) {
 		global $wpdb;
 
 		$table_name = $wpdb->prefix . 'fair_event_dates';
@@ -283,9 +332,10 @@ class EventDates {
 			'occurrence_type'   => $occurrence_type,
 			'master_id'         => $master_id,
 			'recurrence_anchor' => $recurrence_anchor,
+			'status'            => $status,
 		);
 
-		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s' );
+		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s' );
 
 		$result = $wpdb->insert( $table_name, $data, $format );
 
@@ -305,9 +355,10 @@ class EventDates {
 	 * @param bool        $all_day         All day flag.
 	 * @param string      $occurrence_type Occurrence type (single or master).
 	 * @param string|null $rrule           Recurrence rule (RRULE format).
+	 * @param string|null $recurrence_mode Explicit series shape ('none', 'rule', 'manual'). Inferred from $rrule when null.
 	 * @return int|false The row ID on success, false on failure.
 	 */
-	public static function save_or_update_master( $event_id, $start, $end, $all_day, $occurrence_type = 'single', $rrule = null ) {
+	public static function save_or_update_master( $event_id, $start, $end, $all_day, $occurrence_type = 'single', $rrule = null, $recurrence_mode = null ) {
 		global $wpdb;
 
 		$table_name = $wpdb->prefix . 'fair_event_dates';
@@ -321,6 +372,10 @@ class EventDates {
 			)
 		);
 
+		if ( null === $recurrence_mode ) {
+			$recurrence_mode = empty( $rrule ) ? 'none' : 'rule';
+		}
+
 		$data = array(
 			'event_id'        => $event_id,
 			'start_datetime'  => $start,
@@ -329,9 +384,11 @@ class EventDates {
 			'occurrence_type' => $occurrence_type,
 			'master_id'       => null,
 			'rrule'           => $rrule,
+			'recurrence_mode' => $recurrence_mode,
+			'link_type'       => 'post',
 		);
 
-		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s' );
+		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s' );
 
 		if ( $existing ) {
 			$result = $wpdb->update(
@@ -594,8 +651,11 @@ class EventDates {
 		$table_name = $wpdb->prefix . 'fair_event_dates';
 
 		$results = $wpdb->get_results(
+			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- inherited_select_sql() adds 2 more %i placeholders than visible here.
 			$wpdb->prepare(
-				'SELECT * FROM %i WHERE start_datetime <= %s AND (end_datetime >= %s OR (end_datetime IS NULL AND start_datetime >= %s)) ORDER BY start_datetime ASC',
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- inherited_select_sql() is a static internal template, not user input.
+				self::inherited_select_sql() . " WHERE ed.status = 'active' AND ed.start_datetime <= %s AND (ed.end_datetime >= %s OR (ed.end_datetime IS NULL AND ed.start_datetime >= %s)) ORDER BY ed.start_datetime ASC",
+				$table_name,
 				$table_name,
 				$end_date,
 				$start_date,
@@ -613,6 +673,28 @@ class EventDates {
 		}
 
 		return $dates;
+	}
+
+	/**
+	 * SELECT clause resolving inheritable instance fields from their master
+	 * via a self-join, so instance rows that hold NULL (inherit) come back
+	 * with the master's value already applied. Used by list queries that can
+	 * return many rows, where a per-row lookup (see resolve_instance()) would
+	 * mean N+1 queries.
+	 *
+	 * @return string SELECT ... FROM %i ed LEFT JOIN %i m ... clause (two %i placeholders).
+	 */
+	private static function inherited_select_sql() {
+		return 'SELECT ed.id, ed.event_id, ed.start_datetime, ed.end_datetime, ed.all_day, ed.occurrence_type,
+			ed.master_id, ed.rrule, ed.recurrence_anchor, ed.status, ed.recurrence_mode, ed.created_at, ed.updated_at,
+			COALESCE( ed.title, m.title ) AS title,
+			COALESCE( ed.venue_id, m.venue_id ) AS venue_id,
+			COALESCE( ed.address, m.address ) AS address,
+			COALESCE( ed.link_type, m.link_type ) AS link_type,
+			COALESCE( ed.external_url, m.external_url ) AS external_url,
+			COALESCE( ed.capacity, m.capacity ) AS capacity,
+			COALESCE( ed.signup_price, m.signup_price ) AS signup_price
+			FROM %i ed LEFT JOIN %i m ON ed.master_id = m.id';
 	}
 
 	/**
@@ -637,12 +719,12 @@ class EventDates {
 			$id_placeholders = implode( ',', array_fill( 0, count( $category_ids ), '%d' ) );
 
 			$results = $wpdb->get_results(
-				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- inherited_select_sql() adds 2 more %i placeholders than visible here.
 				$wpdb->prepare(
-					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-					"SELECT ed.* FROM %i ed INNER JOIN %i edc ON ed.id = edc.event_date_id WHERE edc.term_id IN ($id_placeholders) AND ed.link_type != 'post' AND ed.event_id IS NULL AND ed.start_datetime <= %s AND (ed.end_datetime >= %s OR (ed.end_datetime IS NULL AND ed.start_datetime >= %s)) GROUP BY ed.id ORDER BY ed.start_datetime ASC",
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared -- inherited_select_sql() is a static internal template, not user input.
+					self::inherited_select_sql() . " INNER JOIN %i edc ON ed.id = edc.event_date_id WHERE edc.term_id IN ($id_placeholders) AND COALESCE( ed.link_type, m.link_type ) != 'post' AND ed.event_id IS NULL AND ed.status = 'active' AND ed.start_datetime <= %s AND (ed.end_datetime >= %s OR (ed.end_datetime IS NULL AND ed.start_datetime >= %s)) GROUP BY ed.id ORDER BY ed.start_datetime ASC",
 					array_merge(
-						array( $table_name, $cat_table ),
+						array( $table_name, $table_name, $cat_table ),
 						array_map( 'intval', $category_ids ),
 						array( $end_date, $start_date, $start_date )
 					)
@@ -650,8 +732,11 @@ class EventDates {
 			);
 		} else {
 			$results = $wpdb->get_results(
+				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- inherited_select_sql() adds 2 more %i placeholders than visible here.
 				$wpdb->prepare(
-					"SELECT * FROM %i WHERE link_type != 'post' AND event_id IS NULL AND start_datetime <= %s AND (end_datetime >= %s OR (end_datetime IS NULL AND start_datetime >= %s)) ORDER BY start_datetime ASC",
+					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- inherited_select_sql() is a static internal template, not user input.
+					self::inherited_select_sql() . " WHERE COALESCE( ed.link_type, m.link_type ) != 'post' AND ed.event_id IS NULL AND ed.status = 'active' AND ed.start_datetime <= %s AND (ed.end_datetime >= %s OR (ed.end_datetime IS NULL AND ed.start_datetime >= %s)) ORDER BY ed.start_datetime ASC",
+					$table_name,
 					$table_name,
 					$end_date,
 					$start_date,
@@ -727,7 +812,6 @@ class EventDates {
 			'occurrence_type'   => '%s',
 			'master_id'         => '%d',
 			'rrule'             => '%s',
-			'exdates'           => '%s',
 			'venue_id'          => '%d',
 			'title'             => '%s',
 			'external_url'      => '%s',
@@ -736,6 +820,8 @@ class EventDates {
 			'signup_price'      => '%f',
 			'address'           => '%s',
 			'recurrence_anchor' => '%s',
+			'status'            => '%s',
+			'recurrence_mode'   => '%s',
 		);
 
 		$update_data   = array();
@@ -857,18 +943,25 @@ class EventDates {
 	/**
 	 * Get generated occurrences by master ID
 	 *
-	 * @param int $master_id Master event date ID.
+	 * Active occurrences only by default; admin surfaces that also need
+	 * cancelled rows (e.g. rendering red calendar cells) pass true.
+	 *
+	 * @param int  $master_id        Master event date ID.
+	 * @param bool $include_cancelled Whether to include cancelled rows.
 	 * @return EventDates[] Array of generated EventDates objects.
 	 */
-	public static function get_generated_by_master_id( $master_id ) {
+	public static function get_generated_by_master_id( $master_id, $include_cancelled = false ) {
 		global $wpdb;
 
 		$table_name = $wpdb->prefix . 'fair_event_dates';
 
+		$status_sql = $include_cancelled ? '' : "AND status = 'active'";
+
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
-				'SELECT * FROM %i WHERE master_id = %d AND occurrence_type = %s ORDER BY start_datetime ASC',
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $status_sql is a fixed internal string, not request input.
+				"SELECT * FROM %i WHERE master_id = %d AND occurrence_type = %s {$status_sql} ORDER BY start_datetime ASC",
 				$table_name,
 				$master_id,
 				'generated'
@@ -967,13 +1060,14 @@ class EventDates {
 			'rrule'             => null,
 			'title'             => $data['title'] ?? null,
 			'external_url'      => $data['external_url'] ?? null,
-			'link_type'         => $data['link_type'] ?? 'none',
+			'link_type'         => $data['link_type'] ?? null,
 			'venue_id'          => $data['venue_id'] ?? null,
 			'address'           => $data['address'] ?? null,
 			'recurrence_anchor' => $data['recurrence_anchor'] ?? null,
+			'status'            => $data['status'] ?? 'active',
 		);
 
-		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%s', '%s' );
+		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s' );
 
 		$result = $wpdb->insert( $table_name, $insert_data, $format );
 
@@ -1095,7 +1189,7 @@ class EventDates {
 
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
-				'SELECT * FROM %i WHERE (id = %d OR master_id = %d) AND start_datetime >= %s ORDER BY start_datetime ASC',
+				"SELECT * FROM %i WHERE (id = %d OR master_id = %d) AND status = 'active' AND start_datetime >= %s ORDER BY start_datetime ASC",
 				$table_name,
 				$master_id,
 				$master_id,
@@ -1131,7 +1225,7 @@ class EventDates {
 
 		$result = $wpdb->get_row(
 			$wpdb->prepare(
-				'SELECT * FROM %i WHERE master_id = %d AND occurrence_type = %s AND start_datetime >= %s ORDER BY start_datetime ASC LIMIT 1',
+				"SELECT * FROM %i WHERE master_id = %d AND occurrence_type = %s AND status = 'active' AND start_datetime >= %s ORDER BY start_datetime ASC LIMIT 1",
 				$table_name,
 				$master_id,
 				'generated',

--- a/fair-events/src/Services/RecurrenceService.php
+++ b/fair-events/src/Services/RecurrenceService.php
@@ -214,26 +214,29 @@ class RecurrenceService {
 		}
 
 		if ( empty( $rrule ) ) {
-			// No recurrence: delete generated children and mark master as 'single'.
-			EventDates::delete_generated_occurrences( $event_id );
+			// No recurrence: mark the series 'none'. Only wipe children when the
+			// series is actually transitioning out of rule-based recurrence —
+			// an already-'none' master has nothing to wipe (an empty rrule alone
+			// is never itself a reason to delete children).
+			if ( 'none' !== $master->recurrence_mode ) {
+				EventDates::delete_generated_occurrences( $event_id );
+			}
 			EventDates::save_or_update_master(
 				$event_id,
 				$master->start_datetime,
 				$master->end_datetime,
 				$master->all_day,
 				'single',
-				null
+				null,
+				'none'
 			);
 			return 1;
 		}
 
-		$exdates     = self::parse_exdates( $master->exdates );
 		$occurrences = self::generate_occurrences(
 			$master->start_datetime,
 			$master->end_datetime,
-			$rrule,
-			null,
-			$exdates
+			$rrule
 		);
 
 		if ( empty( $occurrences ) ) {
@@ -248,7 +251,8 @@ class RecurrenceService {
 			$first['end'],
 			$master->all_day,
 			'master',
-			$rrule
+			$rrule,
+			'rule'
 		);
 
 		if ( ! $master_id ) {
@@ -256,19 +260,16 @@ class RecurrenceService {
 		}
 
 		// Reconcile generated children (occurrences[1..n]) against existing rows.
+		// Inheritable fields (title, venue_id, address, link_type, external_url,
+		// capacity, signup_price) are NOT propagated here — instances hold NULL
+		// for them unless explicitly overridden, and resolve against the master
+		// at read time.
 		$generated = array_slice( $occurrences, 1 );
 		return 1 + self::reconcile_occurrences(
 			$master_id,
 			$generated,
 			$master->all_day,
-			array(
-				'event_id'     => $event_id,
-				'link_type'    => $master->link_type,
-				'external_url' => $master->external_url,
-				'venue_id'     => $master->venue_id,
-				'address'      => $master->address,
-				'title'        => $master->title,
-			)
+			array( 'event_id' => $event_id )
 		);
 	}
 
@@ -294,24 +295,26 @@ class RecurrenceService {
 		}
 
 		if ( empty( $rrule ) ) {
-			EventDates::delete_generated_by_master_id( $event_date_id );
+			// An empty rrule alone is never itself a reason to delete children —
+			// only wipe when the series is actually leaving rule-based recurrence.
+			if ( 'none' !== $master->recurrence_mode ) {
+				EventDates::delete_generated_by_master_id( $event_date_id );
+			}
 			EventDates::update_by_id(
 				$event_date_id,
 				array(
 					'occurrence_type' => 'single',
 					'rrule'           => null,
+					'recurrence_mode' => 'none',
 				)
 			);
 			return 1;
 		}
 
-		$exdates     = self::parse_exdates( $master->exdates );
 		$occurrences = self::generate_occurrences(
 			$master->start_datetime,
 			$master->end_datetime,
-			$rrule,
-			null,
-			$exdates
+			$rrule
 		);
 
 		if ( empty( $occurrences ) ) {
@@ -325,41 +328,45 @@ class RecurrenceService {
 			array(
 				'occurrence_type'   => 'master',
 				'rrule'             => $rrule,
+				'recurrence_mode'   => 'rule',
 				'start_datetime'    => $first['start'],
 				'end_datetime'      => $first['end'],
 				'recurrence_anchor' => ( new \DateTime( $first['start'] ) )->format( 'Y-m-d' ),
 			)
 		);
 
+		// Inheritable fields are NOT propagated here — see regenerate_event_occurrences().
 		$generated = array_slice( $occurrences, 1 );
 		return 1 + self::reconcile_occurrences(
 			$event_date_id,
 			$generated,
 			$master->all_day,
-			array(
-				'event_id'     => $master->event_id,
-				'link_type'    => $master->link_type,
-				'external_url' => $master->external_url,
-				'venue_id'     => $master->venue_id,
-				'address'      => $master->address,
-				'title'        => $master->title,
-			)
+			array( 'event_id' => $master->event_id )
 		);
 	}
 
 	/**
 	 * Reconcile generated occurrences for a series against the desired set.
 	 *
-	 * Matches desired occurrences to existing generated rows by anchor date, then:
-	 * - Updates rows whose anchor matches (preserves id).
+	 * Matches desired occurrences to existing generated rows (active or
+	 * cancelled) by anchor date, then:
+	 * - Updates rows whose anchor matches (preserves id); a cancelled row whose
+	 *   anchor reappears in the desired set is restored to active.
 	 * - Inserts rows for new anchors.
-	 * - Deletes rows whose anchor is no longer in the desired set via
-	 *   EventDates::delete_by_id() so the fair_events_event_date_deleted hook fires.
+	 * - Soft-cancels (status='cancelled') rows whose anchor is no longer in the
+	 *   desired set instead of deleting them, so dependents (ticket types,
+	 *   signups) survive and the occurrence can come back if the anchor
+	 *   reappears later.
+	 *
+	 * Inheritable instance fields (title, venue_id, address, link_type,
+	 * external_url, capacity, signup_price) are never stamped here — instances
+	 * hold NULL for them unless explicitly overridden, and resolve against the
+	 * master at read time.
 	 *
 	 * @param int   $master_id    Master event date row ID.
 	 * @param array $desired      Desired generated occurrences — each entry has 'start' and 'end' keys.
 	 * @param bool  $all_day      All-day flag to apply to inserted/updated rows.
-	 * @param array $master_props Inherited fields (event_id, link_type, external_url, venue_id, address, title).
+	 * @param array $master_props Non-inherited fields to copy onto children (currently just event_id).
 	 * @return int Number of surviving generated children (updated + inserted).
 	 */
 	public static function reconcile_occurrences( $master_id, $desired, $all_day, $master_props = array() ) {
@@ -383,7 +390,11 @@ class RecurrenceService {
 
 		foreach ( $desired_by_anchor as $anchor => $occ ) {
 			if ( isset( $existing_by_anchor[ $anchor ] ) ) {
-				// Match — update in place, preserving id.
+				// Match — update in place, preserving id. Inheritable fields
+				// (title, venue_id, address, link_type, external_url, capacity,
+				// signup_price) are intentionally NOT touched: instances hold
+				// NULL for them unless explicitly overridden, and resolve
+				// against the master at read time.
 				$row    = $existing_by_anchor[ $anchor ];
 				$update = array(
 					'start_datetime'    => $occ['start'],
@@ -391,10 +402,13 @@ class RecurrenceService {
 					'all_day'           => $all_day ? 1 : 0,
 					'recurrence_anchor' => $anchor,
 				);
-				foreach ( array( 'event_id', 'link_type', 'external_url', 'venue_id', 'address', 'title' ) as $field ) {
-					if ( array_key_exists( $field, $master_props ) ) {
-						$update[ $field ] = $master_props[ $field ];
-					}
+				if ( array_key_exists( 'event_id', $master_props ) ) {
+					$update['event_id'] = $master_props['event_id'];
+				}
+				// Restore on regrow: a previously soft-cancelled anchor that's
+				// back in the desired set becomes active again.
+				if ( 'cancelled' === $row->status ) {
+					$update['status'] = 'active';
 				}
 				EventDates::update_by_id( $row->id, $update );
 				unset( $existing_by_anchor[ $anchor ] );
@@ -413,15 +427,12 @@ class RecurrenceService {
 					);
 				} else {
 					EventDates::create_standalone_occurrence(
-						array_merge(
-							$master_props,
-							array(
-								'start_datetime'    => $occ['start'],
-								'end_datetime'      => $occ['end'],
-								'all_day'           => $all_day,
-								'master_id'         => $master_id,
-								'recurrence_anchor' => $anchor,
-							)
+						array(
+							'start_datetime'    => $occ['start'],
+							'end_datetime'      => $occ['end'],
+							'all_day'           => $all_day,
+							'master_id'         => $master_id,
+							'recurrence_anchor' => $anchor,
 						)
 					);
 				}
@@ -429,9 +440,13 @@ class RecurrenceService {
 			}
 		}
 
-		// Delete rows whose anchor is no longer in the desired set.
+		// Soft-cancel rows whose anchor is no longer in the desired set instead
+		// of deleting them — dependents (ticket types, signups) survive, and the
+		// occurrence can come back active if the anchor reappears later.
 		foreach ( $existing_by_anchor as $stale_row ) {
-			EventDates::delete_by_id( $stale_row->id );
+			if ( 'cancelled' !== $stale_row->status ) {
+				EventDates::update_by_id( $stale_row->id, array( 'status' => 'cancelled' ) );
+			}
 		}
 
 		return $count;
@@ -567,54 +582,6 @@ class RecurrenceService {
 		return (int) apply_filters( 'fair_events_event_date_dependents', $count, (int) $event_date_id );
 	}
 
-	/**
-	 * Parse exdates string into an array of Y-m-d date strings
-	 *
-	 * @param string|null $exdates Comma-separated date string.
-	 * @return array Array of Y-m-d date strings.
-	 */
-	public static function parse_exdates( $exdates ) {
-		if ( empty( $exdates ) ) {
-			return array();
-		}
-
-		return array_filter( array_map( 'trim', explode( ',', $exdates ) ) );
-	}
-
-	/**
-	 * Clean stale exdates that no longer match any would-be occurrence date
-	 *
-	 * @param string $start_datetime Start datetime of the master event.
-	 * @param string $end_datetime   End datetime of the master event.
-	 * @param string $rrule          RRULE string.
-	 * @param array  $exdates        Current exdates array.
-	 * @return array Cleaned exdates array.
-	 */
-	public static function clean_stale_exdates( $start_datetime, $end_datetime, $rrule, $exdates ) {
-		if ( empty( $exdates ) || empty( $rrule ) ) {
-			return array();
-		}
-
-		// Generate all possible occurrences without exclusions to get valid dates.
-		$all_occurrences = self::generate_occurrences( $start_datetime, $end_datetime, $rrule );
-
-		$valid_dates = array();
-		foreach ( $all_occurrences as $occ ) {
-			$dt            = new \DateTime( $occ['start'] );
-			$valid_dates[] = $dt->format( 'Y-m-d' );
-		}
-
-		// Keep only exdates that match a would-be occurrence (skip the master's own date).
-		$master_date = ( new \DateTime( $start_datetime ) )->format( 'Y-m-d' );
-		$cleaned     = array();
-		foreach ( $exdates as $exdate ) {
-			if ( $exdate !== $master_date && in_array( $exdate, $valid_dates, true ) ) {
-				$cleaned[] = $exdate;
-			}
-		}
-
-		return $cleaned;
-	}
 
 	/**
 	 * Build an RRULE string from components


### PR DESCRIPTION
## Summary

Restructures how `fair_event_dates` stores series/recurrence data, per the
implementation plan in #996:

- **Materialized cancellations** — `status` (`active`/`cancelled`) replaces the
  `exdates` CSV blob. Cancelled occurrences are now real rows with an id, so
  cancel/restore is a status flip (`toggle-exdate` is now a single-row update,
  not a full regenerate), dependents (ticket types, signups) survive
  cancellation, and cancelled cells could later link to an instance view
  (tracked for #981).
- **NULL-means-inherit instance fields** — `title`, `venue_id`, `address`,
  `link_type`, `external_url`, `capacity`, `signup_price` are no longer
  copy-propagated onto generated children. `NULL` means inherit from the
  master; resolved via a self-join for list queries (`get_for_date_range`,
  `get_standalone_for_date_range`) and at read time for single-row lookups.
- **Explicit `recurrence_mode`** (`none`/`rule`/`manual`) replaces inferring
  series shape from an empty `rrule`. The children-wipe path now keys off an
  actual mode transition, not "rrule is empty."
- Rule shrink always soft-cancels instead of deleting; a previously-cancelled
  anchor restores to active if it reappears in the desired set on
  regeneration. The destructive-change guard shrinks accordingly, since
  removal is no longer destructive.
- Migration (`DB_VERSION` → `3.22.0`) adds the new columns, backfills
  `recurrence_mode` from `rrule` presence, materializes each master's
  `exdates` into cancelled child rows, NULLs out instance fields that match
  their master, widens `link_type` to nullable, and drops `exdates`. Also
  folds the long-missing `venue_id` column into the base `CREATE TABLE` so
  fresh installs match upgraded ones.

`occurrence_type` values are unchanged (kept over a `series_role` rename —
pure churn for no behavioral gain, per the resolved open questions in #996).

## Test plan

- [x] `vendor/bin/phpunit` in `fair-events` — 28 tests pass
- [x] `npm run test:js` in `fair-events` — 70 tests pass
- [x] `vendor/bin/phpcs` on all changed PHP files — no new violations (verified
      against the pre-change baseline; remaining findings are pre-existing)
- [x] `npm run build` — clean build, 60 files generated
- [x] Manual migration verification via WP-CLI `eval-file` against the local
      docker environment: `DESCRIBE wp_fair_event_dates` confirms `exdates`
      dropped, `status`/`recurrence_mode` added, `link_type` nullable; a
      scripted recurrence walkthrough confirms soft-cancel-on-shrink and
      restore-on-regrow behave as designed
- [ ] Playwright API specs (`EventDatesController.api.spec.js`,
      `EventDatesSiblings.api.spec.js`, `GetTicketsRecurringMaster.api.spec.js`)
      were updated for the new status/cancelled_dates response shape, but
      could not be executed end-to-end in this sandbox (Basic Auth against the
      local WP instance returns 401 here — an environment/credentials issue
      unrelated to this change). Please run `npm run test:api` in CI before
      merging.

Closes #996
