### PR TITLE
Deduplicate recurrence editing into shared RecurrenceControl

### DIFF
--- a/fair-events-experimental/src/Admin/manage-event/DuplicateEventWizard.js
+++ b/fair-events-experimental/src/Admin/manage-event/DuplicateEventWizard.js
@@ -25,13 +25,18 @@ import {
 	SelectControl,
 	RadioControl,
 	FormTokenField,
-	__experimentalNumberControl as NumberControl,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { DurationOptions, calculateDuration } from 'fair-events-shared';
+import {
+	DurationOptions,
+	calculateDuration,
+	parseRRule,
+	buildRRule,
+	RecurrenceControl,
+} from 'fair-events-shared';
 import { adjustTicketDates } from './adjustTicketDates.js';
 import EventTickets from './EventTickets.js';
 
@@ -57,11 +62,13 @@ export default function DuplicateEventWizard({
 	const [categories, setCategories] = useState(
 		sourceEventDate.categories?.map((c) => c.id) || []
 	);
-	const [recurrenceEnabled, setRecurrenceEnabled] = useState(false);
-	const [recurrenceFrequency, setRecurrenceFrequency] = useState('weekly');
-	const [recurrenceEndType, setRecurrenceEndType] = useState('count');
-	const [recurrenceCount, setRecurrenceCount] = useState(10);
-	const [recurrenceUntil, setRecurrenceUntil] = useState('');
+	const [recurrence, setRecurrence] = useState({
+		enabled: false,
+		frequency: 'weekly',
+		endType: 'count',
+		count: 10,
+		until: '',
+	});
 
 	// Links state
 	const [linksOption, setLinksOption] = useState('clone');
@@ -112,8 +119,10 @@ export default function DuplicateEventWizard({
 
 		// Parse recurrence from source
 		if (sourceEventDate.rrule) {
-			setRecurrenceEnabled(true);
-			parseRRule(sourceEventDate.rrule);
+			setRecurrence({
+				enabled: true,
+				...parseRRule(sourceEventDate.rrule),
+			});
 		}
 	}, [sourceEventDate]);
 
@@ -312,70 +321,6 @@ export default function DuplicateEventWizard({
 		...venues.map((v) => ({ label: v.name, value: String(v.id) })),
 	];
 
-	// Recurrence helpers
-	const parseRRule = (rrule) => {
-		const parts = {};
-		rrule.split(';').forEach((part) => {
-			const [key, val] = part.split('=');
-			parts[key] = val;
-		});
-
-		const freq = parts.FREQ || 'WEEKLY';
-		const interval = parseInt(parts.INTERVAL || '1', 10);
-
-		if (freq === 'DAILY') setRecurrenceFrequency('daily');
-		else if (freq === 'WEEKLY' && interval === 2)
-			setRecurrenceFrequency('biweekly');
-		else if (freq === 'WEEKLY') setRecurrenceFrequency('weekly');
-		else if (freq === 'MONTHLY') setRecurrenceFrequency('monthly');
-
-		if (parts.COUNT) {
-			setRecurrenceEndType('count');
-			setRecurrenceCount(parseInt(parts.COUNT, 10));
-		} else if (parts.UNTIL) {
-			setRecurrenceEndType('until');
-			const u = parts.UNTIL;
-			setRecurrenceUntil(
-				`${u.substring(0, 4)}-${u.substring(4, 6)}-${u.substring(6, 8)}`
-			);
-		} else {
-			setRecurrenceEndType('count');
-			setRecurrenceCount(10);
-		}
-	};
-
-	const buildRRule = () => {
-		if (!recurrenceEnabled) return null;
-
-		let freq = 'WEEKLY';
-		let interval = 1;
-
-		switch (recurrenceFrequency) {
-			case 'daily':
-				freq = 'DAILY';
-				break;
-			case 'weekly':
-				freq = 'WEEKLY';
-				break;
-			case 'biweekly':
-				freq = 'WEEKLY';
-				interval = 2;
-				break;
-			case 'monthly':
-				freq = 'MONTHLY';
-				break;
-		}
-
-		const ruleParts = [`FREQ=${freq}`];
-		if (interval > 1) ruleParts.push(`INTERVAL=${interval}`);
-		if (recurrenceEndType === 'count' && recurrenceCount)
-			ruleParts.push(`COUNT=${recurrenceCount}`);
-		else if (recurrenceEndType === 'until' && recurrenceUntil)
-			ruleParts.push(`UNTIL=${recurrenceUntil.replace(/-/g, '')}`);
-
-		return ruleParts.join(';');
-	};
-
 	// Build new start datetime string
 	const getNewStartDatetime = () => {
 		if (allDay) return `${startDate} 00:00:00`;
@@ -409,7 +354,7 @@ export default function DuplicateEventWizard({
 					end_datetime: getNewEndDatetime(),
 					all_day: allDay,
 					venue_id: venueId ? parseInt(venueId, 10) : null,
-					rrule: buildRRule(),
+					rrule: buildRRule(recurrence),
 					categories,
 				},
 			});
@@ -830,108 +775,10 @@ export default function DuplicateEventWizard({
 							__experimentalExpandOnFocus
 						/>
 
-						<CheckboxControl
-							label={__(
-								'Repeat this event',
-								'fair-events-experimental'
-							)}
-							checked={recurrenceEnabled}
-							onChange={setRecurrenceEnabled}
+						<RecurrenceControl
+							value={recurrence}
+							onChange={setRecurrence}
 						/>
-
-						{recurrenceEnabled && (
-							<VStack spacing={3}>
-								<SelectControl
-									label={__(
-										'Frequency',
-										'fair-events-experimental'
-									)}
-									value={recurrenceFrequency}
-									options={[
-										{
-											label: __(
-												'Daily',
-												'fair-events-experimental'
-											),
-											value: 'daily',
-										},
-										{
-											label: __(
-												'Weekly',
-												'fair-events-experimental'
-											),
-											value: 'weekly',
-										},
-										{
-											label: __(
-												'Biweekly',
-												'fair-events-experimental'
-											),
-											value: 'biweekly',
-										},
-										{
-											label: __(
-												'Monthly',
-												'fair-events-experimental'
-											),
-											value: 'monthly',
-										},
-									]}
-									onChange={setRecurrenceFrequency}
-								/>
-								<SelectControl
-									label={__(
-										'Ends',
-										'fair-events-experimental'
-									)}
-									value={recurrenceEndType}
-									options={[
-										{
-											label: __(
-												'After number of occurrences',
-												'fair-events-experimental'
-											),
-											value: 'count',
-										},
-										{
-											label: __(
-												'On a specific date',
-												'fair-events-experimental'
-											),
-											value: 'until',
-										},
-									]}
-									onChange={setRecurrenceEndType}
-								/>
-								{recurrenceEndType === 'count' && (
-									<NumberControl
-										label={__(
-											'Number of occurrences',
-											'fair-events-experimental'
-										)}
-										value={recurrenceCount}
-										onChange={(val) =>
-											setRecurrenceCount(
-												parseInt(val, 10) || 1
-											)
-										}
-										min={1}
-										max={365}
-									/>
-								)}
-								{recurrenceEndType === 'until' && (
-									<TextControl
-										label={__(
-											'End date',
-											'fair-events-experimental'
-										)}
-										type="date"
-										value={recurrenceUntil}
-										onChange={setRecurrenceUntil}
-									/>
-								)}
-							</VStack>
-						)}
 					</VStack>
 				</CardBody>
 			</Card>

--- a/fair-events-shared/babel.config.cjs
+++ b/fair-events-shared/babel.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' } }],
-    '@babel/preset-react',
+    ['@babel/preset-react', { runtime: 'automatic', importSource: 'react' }],
   ],
 };

--- a/fair-events-shared/src/RecurrenceControl.js
+++ b/fair-events-shared/src/RecurrenceControl.js
@@ -1,0 +1,79 @@
+/**
+ * Shared RecurrenceControl component
+ */
+
+import {
+	CheckboxControl,
+	SelectControl,
+	TextControl,
+	__experimentalNumberControl as NumberControl,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { RECURRENCE_FREQUENCIES, RECURRENCE_END_TYPES } from './recurrence.js';
+
+/**
+ * Controlled "Repeat this event" checkbox plus, when enabled, the
+ * Frequency / Ends / Count / Until fields. Hosts own the surrounding
+ * layout (Card, calendar, gating) and the `recurrence` state object.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.value                Recurrence state: { enabled, frequency, endType, count, until }.
+ * @param {Function} props.onChange             Callback receiving the merged recurrence object.
+ * @return {JSX.Element} The RecurrenceControl component.
+ */
+export default function RecurrenceControl({ value, onChange }) {
+	const { enabled, frequency, endType, count, until } = value;
+
+	const update = (changes) => onChange({ ...value, ...changes });
+
+	return (
+		<VStack spacing={2}>
+			<CheckboxControl
+				label={__('Repeat this event', 'fair-events')}
+				checked={enabled}
+				onChange={(checked) => update({ enabled: checked })}
+			/>
+
+			{enabled && (
+				<VStack spacing={2}>
+					<SelectControl
+						label={__('Frequency', 'fair-events')}
+						value={frequency}
+						options={RECURRENCE_FREQUENCIES}
+						onChange={(newFrequency) =>
+							update({ frequency: newFrequency })
+						}
+					/>
+					<SelectControl
+						label={__('Ends', 'fair-events')}
+						value={endType}
+						options={RECURRENCE_END_TYPES}
+						onChange={(newEndType) =>
+							update({ endType: newEndType })
+						}
+					/>
+					{endType === 'count' && (
+						<NumberControl
+							label={__('Number of occurrences', 'fair-events')}
+							value={count}
+							onChange={(val) =>
+								update({ count: parseInt(val, 10) || 1 })
+							}
+							min={1}
+							max={365}
+						/>
+					)}
+					{endType === 'until' && (
+						<TextControl
+							label={__('End date', 'fair-events')}
+							type="date"
+							value={until}
+							onChange={(newUntil) => update({ until: newUntil })}
+						/>
+					)}
+				</VStack>
+			)}
+		</VStack>
+	);
+}

--- a/fair-events-shared/src/__tests__/RecurrenceControl.test.js
+++ b/fair-events-shared/src/__tests__/RecurrenceControl.test.js
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RecurrenceControl from '../RecurrenceControl.js';
+
+// jsdom has no layout engine; @wordpress/components' VStack/HStack use
+// matchMedia for responsive spacing, which jsdom doesn't implement.
+beforeAll(() => {
+	window.matchMedia =
+		window.matchMedia ||
+		function () {
+			return {
+				matches: false,
+				addListener: () => {},
+				removeListener: () => {},
+			};
+		};
+});
+
+const baseValue = {
+	enabled: false,
+	frequency: 'weekly',
+	endType: 'count',
+	count: 10,
+	until: '',
+};
+
+describe('RecurrenceControl', () => {
+	test('hides Frequency/Ends controls when disabled', () => {
+		render(<RecurrenceControl value={baseValue} onChange={jest.fn()} />);
+		expect(
+			screen.queryByRole('combobox', { name: 'Frequency' })
+		).not.toBeInTheDocument();
+	});
+
+	test('shows Frequency/Ends controls when enabled', () => {
+		render(
+			<RecurrenceControl
+				value={{ ...baseValue, enabled: true }}
+				onChange={jest.fn()}
+			/>
+		);
+		expect(
+			screen.getByRole('combobox', { name: 'Frequency' })
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('combobox', { name: 'Ends' })
+		).toBeInTheDocument();
+	});
+
+	test('toggling the checkbox emits enabled:true with the rest of the value', () => {
+		const onChange = jest.fn();
+		render(<RecurrenceControl value={baseValue} onChange={onChange} />);
+		fireEvent.click(
+			screen.getByRole('checkbox', { name: 'Repeat this event' })
+		);
+		expect(onChange).toHaveBeenCalledWith({ ...baseValue, enabled: true });
+	});
+
+	test('shows the count field when endType is count, and the date field when until', () => {
+		render(
+			<RecurrenceControl
+				value={{ ...baseValue, enabled: true, endType: 'count' }}
+				onChange={jest.fn()}
+			/>
+		);
+		expect(
+			screen.getByRole('spinbutton', { name: 'Number of occurrences' })
+		).toBeInTheDocument();
+
+		render(
+			<RecurrenceControl
+				value={{ ...baseValue, enabled: true, endType: 'until' }}
+				onChange={jest.fn()}
+			/>
+		);
+		expect(screen.getByLabelText('End date')).toBeInTheDocument();
+	});
+
+	test('changing frequency emits the merged value', () => {
+		const onChange = jest.fn();
+		render(
+			<RecurrenceControl
+				value={{ ...baseValue, enabled: true }}
+				onChange={onChange}
+			/>
+		);
+		fireEvent.change(screen.getByRole('combobox', { name: 'Frequency' }), {
+			target: { value: 'monthly' },
+		});
+		expect(onChange).toHaveBeenCalledWith({
+			...baseValue,
+			enabled: true,
+			frequency: 'monthly',
+		});
+	});
+});

--- a/fair-events-shared/src/__tests__/recurrence.test.js
+++ b/fair-events-shared/src/__tests__/recurrence.test.js
@@ -1,0 +1,108 @@
+import { parseRRule, buildRRule } from '../recurrence.js';
+
+describe('buildRRule', () => {
+	test('returns null when disabled', () => {
+		expect(
+			buildRRule({
+				enabled: false,
+				frequency: 'weekly',
+				endType: 'count',
+				count: 10,
+				until: '',
+			})
+		).toBeNull();
+	});
+
+	test('builds a weekly rule with a count', () => {
+		expect(
+			buildRRule({
+				enabled: true,
+				frequency: 'weekly',
+				endType: 'count',
+				count: 5,
+				until: '',
+			})
+		).toBe('FREQ=WEEKLY;COUNT=5');
+	});
+
+	test('adds INTERVAL=2 for biweekly', () => {
+		expect(
+			buildRRule({
+				enabled: true,
+				frequency: 'biweekly',
+				endType: 'count',
+				count: 5,
+				until: '',
+			})
+		).toBe('FREQ=WEEKLY;INTERVAL=2;COUNT=5');
+	});
+
+	test('builds a rule ending on a specific date', () => {
+		expect(
+			buildRRule({
+				enabled: true,
+				frequency: 'monthly',
+				endType: 'until',
+				count: 10,
+				until: '2026-12-31',
+			})
+		).toBe('FREQ=MONTHLY;UNTIL=20261231');
+	});
+
+	test('builds a daily rule', () => {
+		expect(
+			buildRRule({
+				enabled: true,
+				frequency: 'daily',
+				endType: 'count',
+				count: 3,
+				until: '',
+			})
+		).toBe('FREQ=DAILY;COUNT=3');
+	});
+});
+
+describe('parseRRule', () => {
+	test('round-trips a weekly count rule', () => {
+		const rrule = 'FREQ=WEEKLY;COUNT=5';
+		expect(parseRRule(rrule)).toEqual({
+			frequency: 'weekly',
+			endType: 'count',
+			count: 5,
+			until: '',
+		});
+	});
+
+	test('round-trips a biweekly rule', () => {
+		expect(parseRRule('FREQ=WEEKLY;INTERVAL=2;COUNT=8')).toEqual({
+			frequency: 'biweekly',
+			endType: 'count',
+			count: 8,
+			until: '',
+		});
+	});
+
+	test('round-trips a rule with UNTIL', () => {
+		expect(parseRRule('FREQ=MONTHLY;UNTIL=20261231')).toEqual({
+			frequency: 'monthly',
+			endType: 'until',
+			count: 10,
+			until: '2026-12-31',
+		});
+	});
+
+	test('defaults to count/10 when neither COUNT nor UNTIL is present', () => {
+		expect(parseRRule('FREQ=DAILY')).toEqual({
+			frequency: 'daily',
+			endType: 'count',
+			count: 10,
+			until: '',
+		});
+	});
+
+	test('round trip: buildRRule(parseRRule(rrule)) === rrule', () => {
+		const rrule = 'FREQ=WEEKLY;INTERVAL=2;UNTIL=20270115';
+		const parsed = parseRRule(rrule);
+		expect(buildRRule({ enabled: true, ...parsed })).toBe(rrule);
+	});
+});

--- a/fair-events-shared/src/index.js
+++ b/fair-events-shared/src/index.js
@@ -13,6 +13,8 @@ export * from './dynamicDateRegistry.js';
 export { default as DateTimeControl } from './DateTimeControl.js';
 export { DurationOptions } from './DurationOptions.js';
 export { default as EventSourceSelector } from './EventSourceSelector.js';
+export { default as RecurrenceControl } from './RecurrenceControl.js';
+export * from './recurrence.js';
 export * from './questionnaire.js';
 export * from './form-utils.js';
 export * from './question-utils.js';

--- a/fair-events-shared/src/recurrence.js
+++ b/fair-events-shared/src/recurrence.js
@@ -1,0 +1,113 @@
+/**
+ * Shared RRULE parsing/building helpers for the recurrence editor.
+ *
+ * The frequency vocabulary here (daily/weekly/biweekly/monthly ↔
+ * FREQ/INTERVAL) is mirrored in PHP by
+ * `RecurrenceService::build_rrule()` in fair-events — keep both in sync.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+export const RECURRENCE_FREQUENCIES = [
+	{ label: __('Daily', 'fair-events'), value: 'daily' },
+	{ label: __('Weekly', 'fair-events'), value: 'weekly' },
+	{ label: __('Biweekly', 'fair-events'), value: 'biweekly' },
+	{ label: __('Monthly', 'fair-events'), value: 'monthly' },
+];
+
+export const RECURRENCE_END_TYPES = [
+	{ label: __('After number of occurrences', 'fair-events'), value: 'count' },
+	{ label: __('On a specific date', 'fair-events'), value: 'until' },
+];
+
+/**
+ * Parse an RRULE string into the app-level recurrence shape.
+ *
+ * @param {string} rrule RRULE string (e.g. "FREQ=WEEKLY;COUNT=10").
+ * @return {{frequency: string, endType: string, count: number, until: string}} Parsed recurrence fields.
+ */
+export function parseRRule(rrule) {
+	const parts = {};
+	rrule.split(';').forEach((part) => {
+		const [key, val] = part.split('=');
+		parts[key] = val;
+	});
+
+	const freq = parts.FREQ || 'WEEKLY';
+	const interval = parseInt(parts.INTERVAL || '1', 10);
+
+	let frequency = 'weekly';
+	if (freq === 'DAILY') {
+		frequency = 'daily';
+	} else if (freq === 'WEEKLY' && interval === 2) {
+		frequency = 'biweekly';
+	} else if (freq === 'WEEKLY') {
+		frequency = 'weekly';
+	} else if (freq === 'MONTHLY') {
+		frequency = 'monthly';
+	}
+
+	let endType = 'count';
+	let count = 10;
+	let until = '';
+
+	if (parts.COUNT) {
+		endType = 'count';
+		count = parseInt(parts.COUNT, 10);
+	} else if (parts.UNTIL) {
+		endType = 'until';
+		const u = parts.UNTIL;
+		until = `${u.substring(0, 4)}-${u.substring(4, 6)}-${u.substring(
+			6,
+			8
+		)}`;
+	}
+
+	return { frequency, endType, count, until };
+}
+
+/**
+ * Build an RRULE string from the app-level recurrence shape.
+ *
+ * @param {Object}  recurrence
+ * @param {boolean} recurrence.enabled   Whether recurrence is enabled.
+ * @param {string}  recurrence.frequency 'daily' | 'weekly' | 'biweekly' | 'monthly'.
+ * @param {string}  recurrence.endType   'count' | 'until'.
+ * @param {number}  recurrence.count     Number of occurrences (when endType is 'count').
+ * @param {string}  recurrence.until     End date, Y-m-d (when endType is 'until').
+ * @return {string|null} RRULE string, or null when recurrence is disabled.
+ */
+export function buildRRule({ enabled, frequency, endType, count, until }) {
+	if (!enabled) return null;
+
+	let freq = 'WEEKLY';
+	let interval = 1;
+
+	switch (frequency) {
+		case 'daily':
+			freq = 'DAILY';
+			break;
+		case 'weekly':
+			freq = 'WEEKLY';
+			break;
+		case 'biweekly':
+			freq = 'WEEKLY';
+			interval = 2;
+			break;
+		case 'monthly':
+			freq = 'MONTHLY';
+			break;
+	}
+
+	const ruleParts = [`FREQ=${freq}`];
+	if (interval > 1) {
+		ruleParts.push(`INTERVAL=${interval}`);
+	}
+	if (endType === 'count' && count) {
+		ruleParts.push(`COUNT=${count}`);
+	} else if (endType === 'until' && until) {
+		ruleParts.push(`UNTIL=${until.replace(/-/g, '')}`);
+	}
+
+	return ruleParts.join(';');
+}

--- a/fair-events/src/Admin/event-meta-box/EventEditForm.js
+++ b/fair-events/src/Admin/event-meta-box/EventEditForm.js
@@ -18,7 +18,13 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Fair Events Shared dependencies
  */
-import { DurationOptions, calculateDuration } from 'fair-events-shared';
+import {
+	DurationOptions,
+	calculateDuration,
+	parseRRule,
+	buildRRule,
+	RecurrenceControl,
+} from 'fair-events-shared';
 
 /**
  * Internal dependencies
@@ -58,11 +64,13 @@ export default function EventEditForm({
 	const [address, setAddress] = useState('');
 
 	// Recurrence state.
-	const [recurrenceEnabled, setRecurrenceEnabled] = useState(false);
-	const [recurrenceFrequency, setRecurrenceFrequency] = useState('weekly');
-	const [recurrenceEndType, setRecurrenceEndType] = useState('count');
-	const [recurrenceCount, setRecurrenceCount] = useState(10);
-	const [recurrenceUntil, setRecurrenceUntil] = useState('');
+	const [recurrence, setRecurrence] = useState({
+		enabled: false,
+		frequency: 'weekly',
+		endType: 'count',
+		count: 10,
+		until: '',
+	});
 
 	const { setEventData } = useDispatch(STORE_NAME);
 
@@ -126,10 +134,9 @@ export default function EventEditForm({
 		}
 
 		if (data.rrule) {
-			setRecurrenceEnabled(true);
-			parseRRule(data.rrule);
+			setRecurrence({ enabled: true, ...parseRRule(data.rrule) });
 		} else {
-			setRecurrenceEnabled(false);
+			setRecurrence((prev) => ({ ...prev, enabled: false }));
 		}
 	};
 
@@ -203,77 +210,6 @@ export default function EventEditForm({
 		}
 	};
 
-	// Recurrence helpers.
-	const parseRRule = (rrule) => {
-		const parts = {};
-		rrule.split(';').forEach((part) => {
-			const [key, val] = part.split('=');
-			parts[key] = val;
-		});
-
-		const freq = parts.FREQ || 'WEEKLY';
-		const interval = parseInt(parts.INTERVAL || '1', 10);
-
-		if (freq === 'DAILY') {
-			setRecurrenceFrequency('daily');
-		} else if (freq === 'WEEKLY' && interval === 2) {
-			setRecurrenceFrequency('biweekly');
-		} else if (freq === 'WEEKLY') {
-			setRecurrenceFrequency('weekly');
-		} else if (freq === 'MONTHLY') {
-			setRecurrenceFrequency('monthly');
-		}
-
-		if (parts.COUNT) {
-			setRecurrenceEndType('count');
-			setRecurrenceCount(parseInt(parts.COUNT, 10));
-		} else if (parts.UNTIL) {
-			setRecurrenceEndType('until');
-			const u = parts.UNTIL;
-			setRecurrenceUntil(
-				`${u.substring(0, 4)}-${u.substring(4, 6)}-${u.substring(6, 8)}`
-			);
-		} else {
-			setRecurrenceEndType('count');
-			setRecurrenceCount(10);
-		}
-	};
-
-	const buildRRule = () => {
-		if (!recurrenceEnabled) return null;
-
-		let freq = 'WEEKLY';
-		let interval = 1;
-
-		switch (recurrenceFrequency) {
-			case 'daily':
-				freq = 'DAILY';
-				break;
-			case 'weekly':
-				freq = 'WEEKLY';
-				break;
-			case 'biweekly':
-				freq = 'WEEKLY';
-				interval = 2;
-				break;
-			case 'monthly':
-				freq = 'MONTHLY';
-				break;
-		}
-
-		const ruleParts = [`FREQ=${freq}`];
-		if (interval > 1) {
-			ruleParts.push(`INTERVAL=${interval}`);
-		}
-		if (recurrenceEndType === 'count' && recurrenceCount) {
-			ruleParts.push(`COUNT=${recurrenceCount}`);
-		} else if (recurrenceEndType === 'until' && recurrenceUntil) {
-			ruleParts.push(`UNTIL=${recurrenceUntil.replace(/-/g, '')}`);
-		}
-
-		return ruleParts.join(';');
-	};
-
 	const handleSave = async () => {
 		setSaving(true);
 		setError(null);
@@ -304,7 +240,7 @@ export default function EventEditForm({
 							: null
 						: undefined,
 					address: venuesEnabled ? undefined : address,
-					rrule: buildRRule(),
+					rrule: buildRRule(recurrence),
 				},
 			});
 			setEventData(updated);
@@ -351,8 +287,8 @@ export default function EventEditForm({
 			all_day: allDay,
 			venue_id: venueId ? parseInt(venueId, 10) : null,
 			address,
-			rrule: buildRRule(),
-			occurrence_type: recurrenceEnabled ? 'master' : 'single',
+			rrule: buildRRule(recurrence),
+			occurrence_type: recurrence.enabled ? 'master' : 'single',
 		});
 	}, [
 		startDate,
@@ -362,11 +298,7 @@ export default function EventEditForm({
 		allDay,
 		venueId,
 		address,
-		recurrenceEnabled,
-		recurrenceFrequency,
-		recurrenceEndType,
-		recurrenceCount,
-		recurrenceUntil,
+		recurrence,
 	]);
 
 	const venueOptions = [
@@ -471,77 +403,7 @@ export default function EventEditForm({
 				/>
 			)}
 
-			<CheckboxControl
-				label={__('Repeat this event', 'fair-events')}
-				checked={recurrenceEnabled}
-				onChange={setRecurrenceEnabled}
-			/>
-
-			{recurrenceEnabled && (
-				<VStack spacing={2}>
-					<SelectControl
-						label={__('Frequency', 'fair-events')}
-						value={recurrenceFrequency}
-						options={[
-							{
-								label: __('Daily', 'fair-events'),
-								value: 'daily',
-							},
-							{
-								label: __('Weekly', 'fair-events'),
-								value: 'weekly',
-							},
-							{
-								label: __('Biweekly', 'fair-events'),
-								value: 'biweekly',
-							},
-							{
-								label: __('Monthly', 'fair-events'),
-								value: 'monthly',
-							},
-						]}
-						onChange={setRecurrenceFrequency}
-					/>
-					<SelectControl
-						label={__('Ends', 'fair-events')}
-						value={recurrenceEndType}
-						options={[
-							{
-								label: __(
-									'After number of occurrences',
-									'fair-events'
-								),
-								value: 'count',
-							},
-							{
-								label: __('On a specific date', 'fair-events'),
-								value: 'until',
-							},
-						]}
-						onChange={setRecurrenceEndType}
-					/>
-					{recurrenceEndType === 'count' && (
-						<TextControl
-							label={__('Number of occurrences', 'fair-events')}
-							type="number"
-							value={String(recurrenceCount)}
-							onChange={(val) =>
-								setRecurrenceCount(parseInt(val, 10) || 1)
-							}
-							min={1}
-							max={365}
-						/>
-					)}
-					{recurrenceEndType === 'until' && (
-						<TextControl
-							label={__('End date', 'fair-events')}
-							type="date"
-							value={recurrenceUntil}
-							onChange={setRecurrenceUntil}
-						/>
-					)}
-				</VStack>
-			)}
+			<RecurrenceControl value={recurrence} onChange={setRecurrence} />
 
 			<div
 				style={{

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -26,7 +26,6 @@ import {
 	RadioControl,
 	FormTokenField,
 	TabPanel,
-	__experimentalNumberControl as NumberControl,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	__experimentalConfirmDialog as ConfirmDialog,
@@ -40,6 +39,9 @@ import {
 	isLinkOnlyEvent,
 	formatSiteLocalDatetime,
 	getEventDisplayTitle,
+	parseRRule,
+	buildRRule,
+	RecurrenceControl,
 } from 'fair-events-shared';
 import EventFinance from './EventFinance.js';
 import EventTickets from './EventTickets.js';
@@ -90,11 +92,13 @@ export default function ManageEventApp() {
 	const [creatingCategories, setCreatingCategories] = useState([]);
 
 	// Recurrence state
-	const [recurrenceEnabled, setRecurrenceEnabled] = useState(false);
-	const [recurrenceFrequency, setRecurrenceFrequency] = useState('weekly');
-	const [recurrenceEndType, setRecurrenceEndType] = useState('count');
-	const [recurrenceCount, setRecurrenceCount] = useState(10);
-	const [recurrenceUntil, setRecurrenceUntil] = useState('');
+	const [recurrence, setRecurrence] = useState({
+		enabled: false,
+		frequency: 'weekly',
+		endType: 'count',
+		count: 10,
+		until: '',
+	});
 
 	// Post creation state
 	const [creatingPost, setCreatingPost] = useState(false);
@@ -213,10 +217,9 @@ export default function ManageEventApp() {
 
 		// Populate recurrence from rrule
 		if (data.rrule) {
-			setRecurrenceEnabled(true);
-			parseRRule(data.rrule);
+			setRecurrence({ enabled: true, ...parseRRule(data.rrule) });
 		} else {
-			setRecurrenceEnabled(false);
+			setRecurrence((prev) => ({ ...prev, enabled: false }));
 		}
 	};
 
@@ -235,11 +238,7 @@ export default function ManageEventApp() {
 			linkType,
 			externalUrl,
 			categories: [...categories].sort(),
-			recurrenceEnabled,
-			recurrenceFrequency,
-			recurrenceEndType,
-			recurrenceCount,
-			recurrenceUntil,
+			recurrence,
 		});
 
 	// Runs after every render; only commits a new snapshot right after
@@ -339,77 +338,6 @@ export default function ManageEventApp() {
 		}
 	};
 
-	// Recurrence helpers
-	const parseRRule = (rrule) => {
-		const parts = {};
-		rrule.split(';').forEach((part) => {
-			const [key, val] = part.split('=');
-			parts[key] = val;
-		});
-
-		const freq = parts.FREQ || 'WEEKLY';
-		const interval = parseInt(parts.INTERVAL || '1', 10);
-
-		if (freq === 'DAILY') {
-			setRecurrenceFrequency('daily');
-		} else if (freq === 'WEEKLY' && interval === 2) {
-			setRecurrenceFrequency('biweekly');
-		} else if (freq === 'WEEKLY') {
-			setRecurrenceFrequency('weekly');
-		} else if (freq === 'MONTHLY') {
-			setRecurrenceFrequency('monthly');
-		}
-
-		if (parts.COUNT) {
-			setRecurrenceEndType('count');
-			setRecurrenceCount(parseInt(parts.COUNT, 10));
-		} else if (parts.UNTIL) {
-			setRecurrenceEndType('until');
-			const u = parts.UNTIL;
-			setRecurrenceUntil(
-				`${u.substring(0, 4)}-${u.substring(4, 6)}-${u.substring(6, 8)}`
-			);
-		} else {
-			setRecurrenceEndType('count');
-			setRecurrenceCount(10);
-		}
-	};
-
-	const buildRRule = () => {
-		if (!recurrenceEnabled) return null;
-
-		let freq = 'WEEKLY';
-		let interval = 1;
-
-		switch (recurrenceFrequency) {
-			case 'daily':
-				freq = 'DAILY';
-				break;
-			case 'weekly':
-				freq = 'WEEKLY';
-				break;
-			case 'biweekly':
-				freq = 'WEEKLY';
-				interval = 2;
-				break;
-			case 'monthly':
-				freq = 'MONTHLY';
-				break;
-		}
-
-		const ruleParts = [`FREQ=${freq}`];
-		if (interval > 1) {
-			ruleParts.push(`INTERVAL=${interval}`);
-		}
-		if (recurrenceEndType === 'count' && recurrenceCount) {
-			ruleParts.push(`COUNT=${recurrenceCount}`);
-		} else if (recurrenceEndType === 'until' && recurrenceUntil) {
-			ruleParts.push(`UNTIL=${recurrenceUntil.replace(/-/g, '')}`);
-		}
-
-		return ruleParts.join(';');
-	};
-
 	const handleSave = async () => {
 		setSaving(true);
 		setError(null);
@@ -440,7 +368,7 @@ export default function ManageEventApp() {
 					address: venuesEnabled ? undefined : address,
 					link_type: linkType,
 					external_url: linkType === 'external' ? externalUrl : null,
-					rrule: buildRRule(),
+					rrule: buildRRule(recurrence),
 					categories,
 				},
 			});
@@ -687,7 +615,7 @@ export default function ManageEventApp() {
 					eventDateId={eventDateId}
 					startDatetime={eventDate.start_datetime}
 					endDatetime={eventDate.end_datetime}
-					isRecurring={recurrenceEnabled}
+					isRecurring={recurrence.enabled}
 					onDirtyChange={handleTicketsDirtyChange}
 				/>
 			),
@@ -999,105 +927,10 @@ export default function ManageEventApp() {
 						</CardHeader>
 						<CardBody>
 							<VStack spacing={4}>
-								<CheckboxControl
-									label={__(
-										'Repeat this event',
-										'fair-events'
-									)}
-									checked={recurrenceEnabled}
-									onChange={setRecurrenceEnabled}
+								<RecurrenceControl
+									value={recurrence}
+									onChange={setRecurrence}
 								/>
-
-								{recurrenceEnabled && (
-									<VStack spacing={3}>
-										<SelectControl
-											label={__(
-												'Frequency',
-												'fair-events'
-											)}
-											value={recurrenceFrequency}
-											options={[
-												{
-													label: __(
-														'Daily',
-														'fair-events'
-													),
-													value: 'daily',
-												},
-												{
-													label: __(
-														'Weekly',
-														'fair-events'
-													),
-													value: 'weekly',
-												},
-												{
-													label: __(
-														'Biweekly',
-														'fair-events'
-													),
-													value: 'biweekly',
-												},
-												{
-													label: __(
-														'Monthly',
-														'fair-events'
-													),
-													value: 'monthly',
-												},
-											]}
-											onChange={setRecurrenceFrequency}
-										/>
-										<SelectControl
-											label={__('Ends', 'fair-events')}
-											value={recurrenceEndType}
-											options={[
-												{
-													label: __(
-														'After number of occurrences',
-														'fair-events'
-													),
-													value: 'count',
-												},
-												{
-													label: __(
-														'On a specific date',
-														'fair-events'
-													),
-													value: 'until',
-												},
-											]}
-											onChange={setRecurrenceEndType}
-										/>
-										{recurrenceEndType === 'count' && (
-											<NumberControl
-												label={__(
-													'Number of occurrences',
-													'fair-events'
-												)}
-												value={recurrenceCount}
-												onChange={(val) =>
-													setRecurrenceCount(
-														parseInt(val, 10) || 1
-													)
-												}
-												min={1}
-												max={365}
-											/>
-										)}
-										{recurrenceEndType === 'until' && (
-											<TextControl
-												label={__(
-													'End date',
-													'fair-events'
-												)}
-												type="date"
-												value={recurrenceUntil}
-												onChange={setRecurrenceUntil}
-											/>
-										)}
-									</VStack>
-								)}
 
 								{eventDate.occurrence_type === 'master' &&
 									(eventDate.generated_occurrences?.length >

--- a/fair-events/src/Services/RecurrenceService.php
+++ b/fair-events/src/Services/RecurrenceService.php
@@ -586,6 +586,10 @@ class RecurrenceService {
 	/**
 	 * Build an RRULE string from components
 	 *
+	 * The daily/weekly/biweekly/monthly ↔ FREQ/INTERVAL vocabulary is mirrored
+	 * in JS by `fair-events-shared/src/recurrence.js` (`buildRRule`/`parseRRule`).
+	 * Keep both in sync when adding or changing frequencies.
+	 *
 	 * @param string      $frequency Frequency (DAILY, WEEKLY, MONTHLY).
 	 * @param int         $interval  Interval (1 for weekly, 2 for biweekly, etc.).
 	 * @param string      $end_type  End type ('count' or 'until').


### PR DESCRIPTION
## Summary

- Three admin components — `EventEditForm`, `ManageEventApp` (fair-events), and `DuplicateEventWizard` (fair-events-experimental) — each carried an identical copy of the recurrence `useState` hooks, `parseRRule()`/`buildRRule()` helpers, and the Frequency/Ends/Count/Until markup. Extract all of it into `fair-events-shared`: pure helpers in `src/recurrence.js` and a controlled `RecurrenceControl` component, following the existing `DateTimeControl`/`EventSourceSelector` pattern.
- Collapsed each host's five recurrence hooks into a single `recurrence` state object shaped like the shared helpers' input/output, wired through `value`/`onChange`.
- Standardized the count input on `NumberControl` (2 of 3 hosts already used it) and the text domain on `'fair-events'` for the shared component's strings, matching the `EventSourceSelector` precedent.
- Added a comment on `RecurrenceService::build_rrule()` (PHP) noting the frequency vocabulary is mirrored in the new shared JS module, since no runtime can be shared across that boundary.
- No behavior change: RRULE round-tripping (parse → UI state → build) is identical to before.

Closes #977

## Test plan

- [x] `fair-events-shared`: new `recurrence.test.js` (round-trip + edge cases: missing COUNT/UNTIL default, biweekly INTERVAL, UNTIL formatting, disabled → null) and `RecurrenceControl.test.js` (RTL: toggle show/hide, onChange shape) — full suite passes (115 tests).
- [x] `fair-events`: existing `EventEditForm.test.jsx` and `ManageEventApp.test.jsx` pass unchanged.
- [x] `fair-events`: `RecurrenceServiceTest.php` passes; `vendor/bin/phpcs` clean on changed PHP.
- [x] `npm run build` in `fair-events` and `fair-events-experimental` succeed.
