### PR TITLE
Verify fair-audience-experimental split and fix dist-archive wiring

### DIFF
--- a/.changeset/audience-experimental-verify.md
+++ b/.changeset/audience-experimental-verify.md
@@ -1,0 +1,6 @@
+---
+"fair-audience": patch
+"fair-audience-experimental": patch
+---
+
+Add e2e coverage for the fair-audience-experimental Features registry (all-bundles-on/off admin page and REST route checks) and wire `dist-archive:fair-audience-experimental` into the root release build, closing out the fair-audience/fair-audience-experimental split (issue #1041).

--- a/e2e/fair-audience-experimental-feature-flags.spec.js
+++ b/e2e/fair-audience-experimental-feature-flags.spec.js
@@ -1,0 +1,271 @@
+/**
+ * Fair Audience Experimental feature-flag registry (#1041).
+ *
+ * Mirrors `fair-events-feature-flags.spec.js`: two branches of the same
+ * companion plugin —
+ *   - all bundles off — only the Settings page is reachable.
+ *   - all bundles on — every migrated bundle's admin page mounts and its
+ *     REST routes register.
+ *
+ * `weekly-schedule` and `manage-event-ext` are intentionally not probed here:
+ * `weekly-schedule` has no REST routes of its own (it reads fair-events'
+ * event-dates routes), and `manage-event-ext` has no standalone admin page —
+ * it only mounts a tab inside fair-events' manage-event screen, which needs
+ * an event fixture. Both are exercised by the manual smoke checks instead
+ * (TESTING.md).
+ *
+ * Run: `npm run test:e2e -- fair-audience-experimental-feature-flags`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { wpCli, loginAsAdmin } from './support/wp-cli.js';
+
+/** Set the `fair_audience_experimental_features` option to a `{bundle: bool}` map. */
+function setExperimentalFeatures(map) {
+	const json = JSON.stringify(map).replace(/'/g, "'\\''");
+	wpCli(
+		`option update fair_audience_experimental_features '${json}' --format=json`
+	);
+}
+
+/** Clear the experimental features option — restores all-on defaults. */
+function clearExperimentalFeatures() {
+	wpCli('option delete fair_audience_experimental_features');
+}
+
+/** Bundle keys mirror FairAudienceExperimental\\Core\\Features::registry(). */
+const ALL_BUNDLES_ON = {
+	fees: true,
+	polls: true,
+	galleries: true,
+	instagram: true,
+	groups: true,
+	collaborators: true,
+	messaging: true,
+	'image-templates': true,
+	timeline: true,
+	import: true,
+	'weekly-schedule': true,
+	invitations: true,
+	'manage-event-ext': true,
+};
+
+const ALL_BUNDLES_OFF = {
+	fees: false,
+	polls: false,
+	galleries: false,
+	instagram: false,
+	groups: false,
+	collaborators: false,
+	messaging: false,
+	'image-templates': false,
+	timeline: false,
+	import: false,
+	'weekly-schedule': false,
+	invitations: false,
+	'manage-event-ext': false,
+};
+
+/**
+ * Bundle → admin page slug + React root id, for bundles with a standalone
+ * top-level admin page.
+ */
+const BUNDLE_PAGES = {
+	fees: [
+		{ slug: 'fair-audience-fees', root: 'fair-audience-fees-list-root' },
+	],
+	polls: [{ slug: 'fair-audience-polls', root: 'fair-audience-polls-root' }],
+	instagram: [
+		{
+			slug: 'fair-audience-instagram-posts',
+			root: 'fair-audience-instagram-posts-root',
+		},
+	],
+	collaborators: [
+		{
+			slug: 'fair-audience-collaborators',
+			root: 'fair-audience-collaborators-root',
+		},
+	],
+	'image-templates': [
+		{
+			slug: 'fair-audience-image-templates',
+			root: 'fair-audience-image-templates-root',
+		},
+	],
+	timeline: [
+		{ slug: 'fair-audience-timeline', root: 'fair-audience-timeline-root' },
+	],
+	import: [
+		{ slug: 'fair-audience-import', root: 'fair-audience-import-root' },
+	],
+	groups: [
+		{ slug: 'fair-audience-groups', root: 'fair-audience-groups-root' },
+	],
+	messaging: [
+		{
+			slug: 'fair-audience-custom-mail',
+			root: 'fair-audience-custom-mail-root',
+		},
+		{
+			slug: 'fair-audience-extra-messages',
+			root: 'fair-audience-extra-messages-root',
+		},
+	],
+};
+
+/**
+ * Bundle → a representative REST route. Probed with GET; a registered route
+ * returns *anything* other than `rest_no_route` (401/403/404 for missing
+ * resource still count as "registered").
+ */
+const BUNDLE_PROBE_ROUTES = {
+	fees: '/fair-audience/v1/fees',
+	polls: '/fair-audience/v1/polls',
+	instagram: '/fair-audience/v1/instagram/posts',
+	collaborators: '/fair-audience/v1/collaborators',
+	'image-templates': '/fair-audience/v1/image-templates',
+	timeline: '/fair-audience/v1/timeline',
+	import: '/fair-audience/v1/import/entradium',
+	groups: '/fair-audience/v1/groups',
+	messaging: '/fair-audience/v1/custom-mail',
+	invitations: '/fair-audience/v1/event-dates/1/event-invitations',
+	galleries: '/fair-audience/v1/gallery-access/validate',
+};
+
+async function expectRootMounts(page, slug, root) {
+	await page.goto(`/wp-admin/admin.php?page=${slug}`);
+	await expect(
+		page.locator(`#${root}`),
+		`${slug}: React root element missing`
+	).toBeAttached();
+	await expect(
+		page.locator(`#${root} > *`).first(),
+		`${slug}: root is empty — admin bundle did not load`
+	).toBeAttached({ timeout: 15000 });
+}
+
+async function expectPageMissing(page, slug) {
+	await page.goto(`/wp-admin/admin.php?page=${slug}`);
+	// WP renders a "you do not have permission" / "invalid page" notice when
+	// a submenu slug is unregistered. The hallmark is the absence of our
+	// React root rather than any specific copy.
+	const rootCount = await page
+		.locator('[id^="fair-audience-"][id$="-root"]')
+		.count();
+	expect(
+		rootCount,
+		`${slug}: should not mount a Fair Audience Experimental React root when its bundle is off`
+	).toBe(0);
+}
+
+/**
+ * True iff WordPress has a route matching `path`, regardless of which HTTP
+ * methods it accepts. A plain GET can't tell a registered POST-only route
+ * (e.g. `/import/entradium`) apart from a genuinely unregistered one — both
+ * return 404 `rest_no_route`. OPTIONS instead reports the route's schema
+ * (`{ namespace, methods, endpoints, ... }`) for any registered route and an
+ * empty array for an unregistered one, independent of the methods it allows.
+ */
+async function routeIsRegistered(request, path) {
+	const response = await request.fetch(`/wp-json${path}`, {
+		method: 'OPTIONS',
+	});
+	const body = await response.json();
+	return !Array.isArray(body);
+}
+
+test.describe('Fair Audience Experimental — all bundles off', () => {
+	test.beforeAll(() => {
+		setExperimentalFeatures(ALL_BUNDLES_OFF);
+	});
+
+	test.afterAll(() => {
+		clearExperimentalFeatures();
+	});
+
+	test('only the Settings page mounts; bundle pages are gone', async ({
+		page,
+	}) => {
+		await loginAsAdmin(page);
+
+		await expectRootMounts(
+			page,
+			'fair-audience-experimental-settings',
+			'fair-audience-experimental-settings-root'
+		);
+
+		for (const pages of Object.values(BUNDLE_PAGES)) {
+			for (const { slug } of pages) {
+				await expectPageMissing(page, slug);
+			}
+		}
+	});
+
+	test('bundle REST routes 404 with rest_no_route', async ({ request }) => {
+		for (const [bundle, path] of Object.entries(BUNDLE_PROBE_ROUTES)) {
+			expect(
+				await routeIsRegistered(request, path),
+				`${bundle}: ${path} should be unregistered when its bundle is off`
+			).toBe(false);
+		}
+	});
+
+	test('Settings page is reachable with every bundle off', async ({
+		page,
+	}) => {
+		await loginAsAdmin(page);
+		await page.goto(
+			'/wp-admin/admin.php?page=fair-audience-experimental-settings'
+		);
+		await expect(
+			page.getByRole('heading', {
+				name: 'Fair Audience Experimental Settings',
+			})
+		).toBeVisible();
+	});
+});
+
+test.describe('Fair Audience Experimental — all bundles on', () => {
+	test.beforeAll(() => {
+		setExperimentalFeatures(ALL_BUNDLES_ON);
+	});
+
+	test.afterAll(() => {
+		// Leave the suite in the all-on default so other suites (which assume
+		// the full feature set is available) inherit a clean baseline.
+		clearExperimentalFeatures();
+	});
+
+	test('every bundle page mounts its React root', async ({ page }) => {
+		await loginAsAdmin(page);
+		for (const pages of Object.values(BUNDLE_PAGES)) {
+			for (const { slug, root } of pages) {
+				await expectRootMounts(page, slug, root);
+			}
+		}
+	});
+
+	test('bundle REST routes are registered', async ({ request }) => {
+		for (const [bundle, path] of Object.entries(BUNDLE_PROBE_ROUTES)) {
+			expect(
+				await routeIsRegistered(request, path),
+				`${bundle}: ${path} should be registered when its bundle is on`
+			).toBe(true);
+		}
+	});
+
+	test('Settings page still mounts with every bundle on', async ({
+		page,
+	}) => {
+		await loginAsAdmin(page);
+		await page.goto(
+			'/wp-admin/admin.php?page=fair-audience-experimental-settings'
+		);
+		await expect(
+			page.getByRole('heading', {
+				name: 'Fair Audience Experimental Settings',
+			})
+		).toBeVisible();
+	});
+});

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"dist-archive:fair-events-experimental": "wp dist-archive fair-events-experimental dist --create-target-dir",
 		"dist-archive:fair-payments-connector-experimental": "wp dist-archive fair-payments-connector-experimental dist --create-target-dir",
 		"dist-archive:fair-form": "wp dist-archive fair-form dist --create-target-dir",
+		"dist-archive:fair-audience-experimental": "wp dist-archive fair-audience-experimental dist --create-target-dir",
 		"translation:update": "node scripts/translation/update-translations.js",
 		"translation:untranslated": "node scripts/translation/get-untranslated.js",
 		"translation:coverage": "node scripts/translation/coverage-report.js",


### PR DESCRIPTION
## Summary

PR 6 (final) of the fair-audience → fair-audience-experimental split — verification and cleanup, per the [plan for the remaining PRs](https://github.com/marcin-wosinek/fair-event-plugins/issues/1041#issuecomment-4911979190).

- Adds `e2e/fair-audience-experimental-feature-flags.spec.js`, mirroring `fair-events-feature-flags.spec.js` for the companion's Features registry: with every bundle off, only the Settings page mounts and bundle REST routes 404 with `rest_no_route`; with every bundle on, every migrated bundle's admin page mounts its React root and its REST routes register. `weekly-schedule` and `manage-event-ext` are intentionally excluded from the probe tables (no REST routes of their own / no standalone admin page — see the spec's file header) and are covered by the manual smoke checks below instead.
- Wires the missing `dist-archive:fair-audience-experimental` npm script. `deploy-to-environment.yml`'s `PLUGINS="…"` list already includes the companion (from PR 1's scaffolding), but nothing built its release zip — it would have silently been skipped on every deploy. This resolves the open question flagged in PR 1.
- `.wp-env.json`, `e2e.yml`, `compose.yml`, and the version-sync/deploy-local/tag-release scripts were already wired for the companion by earlier PRs in the sequence — verified, no changes needed there.

**Manual smoke checks** (WP-CLI against this worktree's wp-env instance, per TESTING.md):
- Core only (`fair-audience-experimental` deactivated): moved bundle REST routes (fees/polls/groups/custom-mail/…) are gone, core routes (`/participants`, `/event-dates`) still register, the moved `FairAudienceExperimental\Database\*Repository` classes are absent so cross-plugin `class_exists()` callers degrade gracefully, no PHP fatals (empty debug log, all HTTP checks 200/401/404 — never 500).
- Both active: every migrated bundle's REST route registers again.

## Test plan

- [x] `npm run format` — clean, no diff
- [x] `vendor/bin/phpcs` — no new findings from this PR's changes (pre-existing findings in moved bundle files predate this PR; confirmed via `git status` showing no PHP files touched)
- [x] `npm run test:js` — green for `fair-audience` and `fair-audience-experimental`
- [ ] `npm run test:api` — pre-existing local-environment gap: Basic Auth against `admin`/`password` isn't available in this checkout's wp-env/docker-compose instances (confirmed the same failure on unrelated, previously-merged `fair-audience` API specs — not introduced by this PR)
- [x] Manual WP-CLI smoke checks (core-only and both-active) — no fatals, routes correct, cross-plugin classes degrade gracefully
- [ ] `npm run test:e2e -- fair-audience-experimental-feature-flags` — not run locally (requires the full `test:e2e:setup` build/boot cycle); will run in CI

Closes #1041
