### PR TITLE
Polish All Participants: header action, trimmed columns, Mailing

### DIFF
--- a/fair-audience/src/Admin/all-participants/AllParticipants.js
+++ b/fair-audience/src/Admin/all-participants/AllParticipants.js
@@ -29,10 +29,7 @@ const DEFAULT_VIEW = {
 	fields: [
 		'name',
 		'email',
-		'phone',
-		'instagram',
-		'email_profile',
-		'status',
+		'mailing',
 		'groups',
 		'wp_user',
 		'events_signed_up',
@@ -105,6 +102,28 @@ export default function AllParticipants() {
 				label: __('Email', 'fair-audience'),
 				render: ({ item }) => item.email || '—',
 				enableSorting: true,
+			},
+			{
+				id: 'mailing',
+				label: __('Mailing', 'fair-audience'),
+				render: ({ item }) => {
+					if ('marketing' === item.email_profile) {
+						return 'pending' === item.status
+							? __(
+									'Marketing — pending confirmation',
+									'fair-audience'
+							  )
+							: __('Marketing', 'fair-audience');
+					}
+					if ('minimal' === item.email_profile) {
+						return __('Minimal', 'fair-audience');
+					}
+					if ('declined' === item.email_profile) {
+						return __('No', 'fair-audience');
+					}
+					return item.email_profile || '—';
+				},
+				enableSorting: false,
 			},
 			{
 				id: 'phone',
@@ -515,7 +534,17 @@ export default function AllParticipants() {
 
 	return (
 		<div className="wrap">
-			<h1>{__('All Participants', 'fair-audience')}</h1>
+			<h1 className="wp-heading-inline">
+				{__('All Participants', 'fair-audience')}
+			</h1>
+			<button
+				type="button"
+				className="page-title-action"
+				onClick={openAddModal}
+			>
+				{__('Add Participant', 'fair-audience')}
+			</button>
+			<hr className="wp-header-end" />
 
 			{errorMessage && (
 				<Notice
@@ -535,12 +564,6 @@ export default function AllParticipants() {
 
 			<Card>
 				<CardBody style={{ overflowX: 'auto' }}>
-					<div style={{ marginBottom: '16px' }}>
-						<Button variant="primary" onClick={openAddModal}>
-							{__('Add Participant', 'fair-audience')}
-						</Button>
-					</div>
-
 					<DataViews
 						data={participants}
 						fields={fields}

--- a/fair-audience/src/Admin/all-participants/__tests__/AllParticipants.test.jsx
+++ b/fair-audience/src/Admin/all-participants/__tests__/AllParticipants.test.jsx
@@ -1,19 +1,109 @@
 /**
  * @jest-environment jsdom
  *
- * Tests for the confirm-then-delete flow on All Participants (#1056).
- *
- * `window.confirm` / `alert` were replaced with a state-controlled
- * `ConfirmDialog` and notices; this covers the delete confirmation dialog
- * opening, confirming (fires the DELETE requests and reloads), and
- * cancelling (fires no request).
+ * Component tests for the All Participants page:
+ *   - Header/columns polish pass (#1055): "Add Participant" renders as a
+ *     header page-title-action outside the card; default columns drop
+ *     Phone/Instagram/Status/Email Profile in favor of a single Mailing
+ *     column; profile and status filters remain available even though their
+ *     columns are hidden.
+ *   - Confirm-then-delete flow (#1056): `window.confirm` / `alert` were
+ *     replaced with a state-controlled `ConfirmDialog` and notices; this
+ *     covers the delete confirmation dialog opening, confirming (fires the
+ *     DELETE requests and reloads), and cancelling (fires no request).
  */
 import '@testing-library/jest-dom';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import {
+	render,
+	screen,
+	waitFor,
+	fireEvent,
+	within,
+} from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import AllParticipants from '../AllParticipants.js';
 
 jest.mock('@wordpress/api-fetch');
+
+const PARTICIPANTS = [
+	{
+		id: 1,
+		name: 'Jane',
+		surname: 'Doe',
+		email: 'jane@example.com',
+		phone: '',
+		instagram: '',
+		email_profile: 'marketing',
+		status: 'confirmed',
+		groups: [],
+		wp_user: null,
+		events_signed_up: 0,
+		events_collaborated: 0,
+	},
+	{
+		id: 2,
+		name: 'John',
+		surname: 'Roe',
+		email: 'john@example.com',
+		phone: '',
+		instagram: '',
+		email_profile: 'marketing',
+		status: 'pending',
+		groups: [],
+		wp_user: null,
+		events_signed_up: 0,
+		events_collaborated: 0,
+	},
+	{
+		id: 3,
+		name: 'Amy',
+		surname: 'Fox',
+		email: 'amy@example.com',
+		phone: '',
+		instagram: '',
+		email_profile: 'minimal',
+		status: 'confirmed',
+		groups: [],
+		wp_user: null,
+		events_signed_up: 0,
+		events_collaborated: 0,
+	},
+	{
+		id: 4,
+		name: 'Bo',
+		surname: 'Lee',
+		email: 'bo@example.com',
+		phone: '',
+		instagram: '',
+		email_profile: 'declined',
+		status: 'confirmed',
+		groups: [],
+		wp_user: null,
+		events_signed_up: 0,
+		events_collaborated: 0,
+	},
+];
+
+function mockApiFetch() {
+	apiFetch.mockImplementation(({ path, parse }) => {
+		if (
+			path.startsWith('/fair-audience/v1/participants') &&
+			parse === false
+		) {
+			return Promise.resolve({
+				headers: new Map([
+					['X-WP-Total', String(PARTICIPANTS.length)],
+					['X-WP-TotalPages', '1'],
+				]),
+				json: () => Promise.resolve(PARTICIPANTS),
+			});
+		}
+		if (path === '/fair-audience/v1/groups') {
+			return Promise.resolve([]);
+		}
+		return Promise.resolve([]);
+	});
+}
 
 const mockParticipant = {
 	id: 1,
@@ -40,9 +130,97 @@ function mockList(items) {
 
 beforeEach(() => {
 	window.fairAudienceAllParticipantsData = {
-		participantsUrl:
-			'admin.php?page=fair-audience-event-participants&event_date_id=',
+		participantsUrl: 'admin.php?page=fair-audience&event_date_id=',
 	};
+	jest.spyOn(console, 'error').mockImplementation(() => {});
+	mockApiFetch();
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+	jest.clearAllMocks();
+});
+
+describe('AllParticipants — header action', () => {
+	it('renders Add Participant as a page-title-action outside the card and opens the modal', async () => {
+		render(<AllParticipants />);
+
+		await screen.findByText('Jane Doe');
+
+		const addButton = screen.getByRole('button', {
+			name: 'Add Participant',
+		});
+		expect(addButton).toHaveClass('page-title-action');
+		expect(addButton.closest('.components-card')).toBeNull();
+
+		fireEvent.click(addButton);
+		expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+		// ParticipantEditModal's SelectControl pre-dates the WP 6.8 40px
+		// default-size opt-in; not part of this change, just acknowledged here.
+		expect(console).toHaveWarned();
+	});
+});
+
+describe('AllParticipants — default columns', () => {
+	it('hides Phone/Instagram/Status/Email Profile and shows Mailing', async () => {
+		render(<AllParticipants />);
+
+		await screen.findByText('Jane Doe');
+
+		expect(
+			screen.queryByRole('columnheader', { name: 'Phone' })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('columnheader', { name: 'Instagram' })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('columnheader', { name: 'Status' })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('columnheader', { name: 'Email Profile' })
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole('columnheader', { name: 'Mailing' })
+		).toBeInTheDocument();
+	});
+});
+
+describe('AllParticipants — Mailing column mapping', () => {
+	it('maps email_profile/status combinations to readable labels', async () => {
+		render(<AllParticipants />);
+
+		const janeRow = (await screen.findByText('Jane Doe')).closest('tr');
+		expect(within(janeRow).getByText('Marketing')).toBeInTheDocument();
+
+		const johnRow = screen.getByText('John Roe').closest('tr');
+		expect(
+			within(johnRow).getByText('Marketing — pending confirmation')
+		).toBeInTheDocument();
+
+		const amyRow = screen.getByText('Amy Fox').closest('tr');
+		expect(within(amyRow).getByText('Minimal')).toBeInTheDocument();
+
+		const boRow = screen.getByText('Bo Lee').closest('tr');
+		expect(within(boRow).getByText('No')).toBeInTheDocument();
+	});
+});
+
+describe('AllParticipants — filters preserved', () => {
+	it('still offers profile and status filters despite hidden columns', async () => {
+		render(<AllParticipants />);
+
+		await screen.findByText('Jane Doe');
+
+		fireEvent.click(screen.getByRole('button', { name: /add filter/i }));
+
+		expect(
+			screen.getByRole('menuitem', { name: 'Email Profile' })
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('menuitem', { name: 'Status' })
+		).toBeInTheDocument();
+	});
 });
 
 describe('confirm-then-delete flow (#1056)', () => {


### PR DESCRIPTION
## Summary

- Move "Add Participant" to the native `page-title-action` position beside the `<h1>`, out of the card.
- Trim the default All Participants view: drop `phone`, `instagram`, `email_profile`, `status` from `DEFAULT_VIEW.fields`. Phone/Instagram stay re-enableable via the view-options (gear) menu; the profile/status field definitions (and their filters) are kept, just hidden by default.
- Add a single **Mailing** column that reads `email_profile`/`status` and shows an intention-named label: "Marketing", "Marketing — pending confirmation", "Minimal", "No". Display-only — no REST/DB changes.
- Add a component test suite (`AllParticipants.test.jsx`) covering the header action, default columns, Mailing mapping, and that profile/status filters are still offered despite the hidden columns.

Catalog regeneration (`makepot`/`updatepo`) was attempted per the ticket but produced ~20k lines of unrelated pre-existing drift (stale file/line references across the whole plugin, not tied to this change), so it was left out of this PR to avoid unrelated noise. Worth a dedicated catalog-refresh PR separately.

Closes #1055

## Test plan

- [x] `npx jest src/Admin/all-participants/__tests__/AllParticipants.test.jsx` — 4/4 pass
- [x] `npx jest` (full fair-audience suite) — 5/5 pass
- [x] `npm run build` in `fair-audience` — succeeds
- [x] `npm run format` — clean, no unrelated diffs
