### PR TITLE
Replace confirm/alert with ConfirmDialog and notices

### DIFF
--- a/fair-audience/package.json
+++ b/fair-audience/package.json
@@ -46,6 +46,8 @@
 		"@babel/preset-env": "^7.28.3",
 		"@babel/preset-react": "^7.28.3",
 		"@playwright/test": "^1.40.0",
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",
 		"babel-jest": "^30.0.5",
 		"dotenv": "^16.3.1",

--- a/fair-audience/src/Admin/all-participants/AllParticipants.js
+++ b/fair-audience/src/Admin/all-participants/AllParticipants.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import {
@@ -7,10 +7,14 @@ import {
 	CardBody,
 	Spinner,
 	Popover,
+	Notice,
+	Snackbar,
+	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { Icon, caution, link, send } from '@wordpress/icons';
 import ParticipantEditModal from '../components/ParticipantEditModal.js';
+import EmailSendResultNotice from '../components/EmailSendResultNotice.js';
 
 const DEFAULT_VIEW = {
 	type: 'table',
@@ -49,6 +53,12 @@ export default function AllParticipants() {
 	const [view, setView] = useState(DEFAULT_VIEW);
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [editingParticipant, setEditingParticipant] = useState(null);
+
+	// Feedback state.
+	const [deleteItems, setDeleteItems] = useState(null);
+	const [resendResult, setResendResult] = useState(null);
+	const [snackbar, setSnackbar] = useState(null);
+	const [errorMessage, setErrorMessage] = useState(null);
 
 	// Events popover state.
 	const [eventsPopover, setEventsPopover] = useState(null);
@@ -360,23 +370,12 @@ export default function AllParticipants() {
 	};
 
 	const handleDelete = (items) => {
-		const count = items.length;
-		const message =
-			count === 1
-				? __(
-						'Are you sure you want to delete this participant?',
-						'fair-audience'
-				  )
-				: __(
-						'Are you sure you want to delete these participants?',
-						'fair-audience'
-				  );
+		setDeleteItems(items);
+	};
 
-		if (!confirm(message)) {
-			return;
-		}
+	const confirmDelete = () => {
+		const items = deleteItems;
 
-		// Delete all selected items.
 		Promise.all(
 			items.map((item) =>
 				apiFetch({
@@ -389,9 +388,37 @@ export default function AllParticipants() {
 				loadParticipants();
 			})
 			.catch((err) => {
-				alert(__('Error: ', 'fair-audience') + err.message);
+				setErrorMessage(__('Error: ', 'fair-audience') + err.message);
+			})
+			.finally(() => {
+				setDeleteItems(null);
 			});
 	};
+
+	const deleteConfirmMessage = useMemo(() => {
+		if (!deleteItems) {
+			return '';
+		}
+
+		if (deleteItems.length === 1) {
+			return sprintf(
+				/* translators: %s: participant name and surname */
+				__('Delete %s? This cannot be undone.', 'fair-audience'),
+				`${deleteItems[0].name} ${deleteItems[0].surname}`
+			);
+		}
+
+		return sprintf(
+			/* translators: %d: number of participants */
+			_n(
+				'Delete %d participant? This cannot be undone.',
+				'Delete %d participants? This cannot be undone.',
+				deleteItems.length,
+				'fair-audience'
+			),
+			deleteItems.length
+		);
+	}, [deleteItems]);
 
 	// Define actions for DataViews.
 	const actions = useMemo(
@@ -413,8 +440,11 @@ export default function AllParticipants() {
 							path: `/fair-audience/v1/participants/${item.id}/subscription-url`,
 						});
 						await navigator.clipboard.writeText(response.url);
+						setSnackbar(__('Link copied.', 'fair-audience'));
 					} catch (err) {
-						alert(__('Error: ', 'fair-audience') + err.message);
+						setErrorMessage(
+							__('Error: ', 'fair-audience') + err.message
+						);
 					}
 				},
 				supportsBulk: false,
@@ -437,33 +467,13 @@ export default function AllParticipants() {
 					);
 
 					const failures = results.filter((r) => !r.ok);
-					if (failures.length === 0) {
-						alert(
-							/* translators: %d: number of confirmation emails sent. */
-							__(
-								'Sent %d confirmation email(s).',
-								'fair-audience'
-							).replace('%d', results.length)
-						);
-						return;
-					}
-
-					const summary = failures
-						.map(
-							(r) =>
-								`${r.item.name} ${r.item.surname}: ${
-									r.err?.message || 'error'
-								}`
-						)
-						.join('\n');
-					alert(
-						__(
-							'Some confirmation emails failed:',
-							'fair-audience'
-						) +
-							'\n' +
-							summary
-					);
+					setResendResult({
+						sent_count: results.length - failures.length,
+						failed: failures.map((r) => ({
+							name: `${r.item.name} ${r.item.surname}`,
+							reason: r.err?.message,
+						})),
+					});
 				},
 				supportsBulk: true,
 			},
@@ -486,9 +496,42 @@ export default function AllParticipants() {
 		[totalItems, totalPages]
 	);
 
+	const resendResultTitle = useMemo(() => {
+		if (!resendResult) {
+			return '';
+		}
+
+		return sprintf(
+			/* translators: %d: number of confirmation emails sent */
+			_n(
+				'Sent %d confirmation email',
+				'Sent %d confirmation emails',
+				resendResult.sent_count,
+				'fair-audience'
+			),
+			resendResult.sent_count
+		);
+	}, [resendResult]);
+
 	return (
 		<div className="wrap">
 			<h1>{__('All Participants', 'fair-audience')}</h1>
+
+			{errorMessage && (
+				<Notice
+					status="error"
+					isDismissible={true}
+					onRemove={() => setErrorMessage(null)}
+				>
+					{errorMessage}
+				</Notice>
+			)}
+
+			<EmailSendResultNotice
+				result={resendResult}
+				title={resendResultTitle}
+				onDismiss={() => setResendResult(null)}
+			/>
 
 			<Card>
 				<CardBody style={{ overflowX: 'auto' }}>
@@ -565,6 +608,36 @@ export default function AllParticipants() {
 				onClose={() => setIsModalOpen(false)}
 				onSaved={loadParticipants}
 			/>
+
+			<ConfirmDialog
+				isOpen={deleteItems !== null}
+				onConfirm={confirmDelete}
+				onCancel={() => setDeleteItems(null)}
+				confirmButtonText={_n(
+					'Delete participant',
+					'Delete participants',
+					deleteItems?.length || 0,
+					'fair-audience'
+				)}
+				cancelButtonText={__('Cancel', 'fair-audience')}
+			>
+				{deleteConfirmMessage}
+			</ConfirmDialog>
+
+			{snackbar && (
+				<div
+					style={{
+						position: 'fixed',
+						bottom: '16px',
+						left: '16px',
+						zIndex: 100000,
+					}}
+				>
+					<Snackbar onRemove={() => setSnackbar(null)}>
+						{snackbar}
+					</Snackbar>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/fair-audience/src/Admin/all-participants/__tests__/AllParticipants.test.jsx
+++ b/fair-audience/src/Admin/all-participants/__tests__/AllParticipants.test.jsx
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for the confirm-then-delete flow on All Participants (#1056).
+ *
+ * `window.confirm` / `alert` were replaced with a state-controlled
+ * `ConfirmDialog` and notices; this covers the delete confirmation dialog
+ * opening, confirming (fires the DELETE requests and reloads), and
+ * cancelling (fires no request).
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import AllParticipants from '../AllParticipants.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const mockParticipant = {
+	id: 1,
+	name: 'John',
+	surname: 'Doe',
+	email: 'john@example.com',
+	status: 'pending',
+};
+
+function mockList(items) {
+	apiFetch.mockImplementation((opts) => {
+		if (opts.parse === false) {
+			return Promise.resolve({
+				headers: new Map([
+					['X-WP-Total', String(items.length)],
+					['X-WP-TotalPages', '1'],
+				]),
+				json: () => Promise.resolve(items),
+			});
+		}
+		return Promise.resolve({});
+	});
+}
+
+beforeEach(() => {
+	window.fairAudienceAllParticipantsData = {
+		participantsUrl:
+			'admin.php?page=fair-audience-event-participants&event_date_id=',
+	};
+});
+
+describe('confirm-then-delete flow (#1056)', () => {
+	it('names the participant and requires confirmation before deleting', async () => {
+		mockList([mockParticipant]);
+
+		render(<AllParticipants />);
+		await waitFor(() =>
+			expect(screen.getByText('John Doe')).toBeInTheDocument()
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+		fireEvent.click(await screen.findByText('Delete'));
+
+		expect(
+			screen.getByText('Delete John Doe? This cannot be undone.')
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'Delete participant' })
+		).toBeInTheDocument();
+	});
+
+	it('fires no DELETE request when cancelled', async () => {
+		mockList([mockParticipant]);
+
+		render(<AllParticipants />);
+		await waitFor(() =>
+			expect(screen.getByText('John Doe')).toBeInTheDocument()
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+		fireEvent.click(await screen.findByText('Delete'));
+		await screen.findByText('Delete John Doe? This cannot be undone.');
+		fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+		await waitFor(() =>
+			expect(
+				screen.queryByText('Delete John Doe? This cannot be undone.')
+			).not.toBeInTheDocument()
+		);
+
+		expect(apiFetch).not.toHaveBeenCalledWith(
+			expect.objectContaining({ method: 'DELETE' })
+		);
+	});
+
+	it('fires a DELETE request and reloads when confirmed', async () => {
+		mockList([mockParticipant]);
+
+		render(<AllParticipants />);
+		await waitFor(() =>
+			expect(screen.getByText('John Doe')).toBeInTheDocument()
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+		fireEvent.click(await screen.findByText('Delete'));
+		await screen.findByText('Delete John Doe? This cannot be undone.');
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Delete participant' })
+		);
+
+		await waitFor(() =>
+			expect(apiFetch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: '/fair-audience/v1/participants/1',
+					method: 'DELETE',
+				})
+			)
+		);
+
+		await waitFor(() =>
+			expect(
+				screen.queryByText('Delete John Doe? This cannot be undone.')
+			).not.toBeInTheDocument()
+		);
+	});
+});

--- a/fair-audience/src/Admin/components/EmailSendResultNotice.js
+++ b/fair-audience/src/Admin/components/EmailSendResultNotice.js
@@ -1,24 +1,23 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 
-export default function EmailSendResultNotice({ result, onDismiss }) {
+export default function EmailSendResultNotice({ result, onDismiss, title }) {
 	if (!result) {
 		return null;
 	}
 
+	const heading =
+		title ||
+		sprintf(
+			/* translators: %d: number of emails sent */
+			__('Invitations sent to %d participants', 'fair-audience'),
+			result.sent_count
+		);
+
 	return (
 		<Notice status="success" isDismissible={true} onRemove={onDismiss}>
 			<p>
-				<strong>
-					{sprintf(
-						/* translators: %d: number of emails sent */
-						__(
-							'Invitations sent to %d participants',
-							'fair-audience'
-						),
-						result.sent_count
-					)}
-				</strong>
+				<strong>{heading}</strong>
 			</p>
 			{result.skipped_count > 0 && (
 				<p>


### PR DESCRIPTION
## Summary

- `AllParticipants.js` used `window.confirm`/`alert` for delete, resend, and copy-link feedback — banned by UI_GUIDELINES.md's "Destructive actions" rule since a blocking dialog can't name the object/count or show partial-failure detail.
- Delete now opens a state-controlled `ConfirmDialog` naming the participant (or count via `_n()`), with a named confirm button.
- Resend results reuse `EmailSendResultNotice` (extended with an optional `title` override) instead of `alert`, including the per-participant failure list.
- Copy-subscription-link now surfaces a "Link copied." `Snackbar` on success (previously silent) and errors surface a dismissible `Notice` instead of `alert`.
- Added `AllParticipants.test.jsx` covering the confirm-then-delete flow (open → cancel fires no DELETE, open → confirm fires DELETE + reloads); added `@testing-library/react`/`jest-dom` to `fair-audience`'s devDependencies (already hoisted at the repo root, mirroring `fair-events`).

Closes #1056

## Test plan

- [x] `npx jest` in `fair-audience` — 4/4 tests pass (new + existing)
- [x] `npm run build` in `fair-audience`
- [x] `npm run format` (repo root)
- [x] Manually explored the DataViews action menu in jsdom to confirm the row-actions dropdown → Delete → dialog flow is reachable via RTL before writing the assertions
