### PR TITLE
Fix Instagram posting: serve schedule image from media library

### DIFF
--- a/fair-audience-experimental/src/API/InstagramPostsController.php
+++ b/fair-audience-experimental/src/API/InstagramPostsController.php
@@ -52,6 +52,17 @@ class InstagramPostsController extends WP_REST_Controller {
 	private $posting_service;
 
 	/**
+	 * Post meta key marking an attachment as a temporary Instagram upload,
+	 * safe to delete after a successful publish or by the cleanup sweep.
+	 */
+	const TEMP_ATTACHMENT_META_KEY = '_fair_audience_instagram_temp';
+
+	/**
+	 * Maximum size, in bytes, accepted for a base64-decoded image blob.
+	 */
+	const MAX_BLOB_SIZE = 5 * 1024 * 1024;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -87,24 +98,30 @@ class InstagramPostsController extends WP_REST_Controller {
 					'callback'            => array( $this, 'create_item' ),
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 					'args'                => array(
-						'image_url' => array(
+						'image_url'     => array(
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => 'esc_url_raw',
 							'description'       => __( 'Publicly accessible image URL.', 'fair-audience-experimental' ),
 						),
-						'caption'   => array(
+						'caption'       => array(
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => 'sanitize_textarea_field',
 							'description'       => __( 'Post caption.', 'fair-audience-experimental' ),
+						),
+						'attachment_id' => array(
+							'type'              => 'integer',
+							'required'          => false,
+							'sanitize_callback' => 'absint',
+							'description'       => __( 'Temporary attachment to delete after a successful publish.', 'fair-audience-experimental' ),
 						),
 					),
 				),
 			)
 		);
 
-		// POST /fair-audience/v1/instagram/upload-image - Upload attachment to tmpfiles.org.
+		// POST /fair-audience/v1/instagram/upload-image - Resolve an attachment's public media-library URL.
 		register_rest_route(
 			$this->namespace,
 			'/instagram/upload-image',
@@ -125,7 +142,7 @@ class InstagramPostsController extends WP_REST_Controller {
 			)
 		);
 
-		// POST /fair-audience/v1/instagram/upload-blob - Upload base64 image to tmpfiles.org.
+		// POST /fair-audience/v1/instagram/upload-blob - Store base64 image as a media-library attachment.
 		register_rest_route(
 			$this->namespace,
 			'/instagram/upload-blob',
@@ -203,8 +220,9 @@ class InstagramPostsController extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object or error.
 	 */
 	public function create_item( $request ) {
-		$image_url = $request->get_param( 'image_url' );
-		$caption   = $request->get_param( 'caption' );
+		$image_url     = $request->get_param( 'image_url' );
+		$caption       = $request->get_param( 'caption' );
+		$attachment_id = $request->get_param( 'attachment_id' );
 
 		// Validate image URL.
 		if ( empty( $image_url ) ) {
@@ -271,6 +289,13 @@ class InstagramPostsController extends WP_REST_Controller {
 			);
 		}
 
+		// Publish succeeded: the temp attachment has been ingested by Instagram
+		// and is no longer needed. Only ever delete attachments carrying our
+		// own marker, so this can't be used to delete unrelated media.
+		if ( $attachment_id && get_post_meta( $attachment_id, self::TEMP_ATTACHMENT_META_KEY, true ) ) {
+			wp_delete_attachment( $attachment_id, true );
+		}
+
 		return rest_ensure_response(
 			array(
 				'message' => __( 'Post published successfully!', 'fair-audience-experimental' ),
@@ -323,7 +348,7 @@ class InstagramPostsController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Upload a WordPress attachment to tmpfiles.org.
+	 * Resolve a WordPress attachment's public media-library URL.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response|WP_Error Response with public URL or error.
@@ -349,76 +374,23 @@ class InstagramPostsController extends WP_REST_Controller {
 			);
 		}
 
-		$filename  = basename( $file_path );
-		$mime_type = get_post_mime_type( $attachment_id );
-		$boundary  = wp_generate_password( 24, false );
-
-		// Build multipart body.
-		$body  = '--' . $boundary . "\r\n";
-		$body .= 'Content-Disposition: form-data; name="file"; filename="' . $filename . '"' . "\r\n";
-		$body .= 'Content-Type: ' . $mime_type . "\r\n\r\n";
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local file.
-		$body .= file_get_contents( $file_path ) . "\r\n";
-		$body .= '--' . $boundary . '--' . "\r\n";
-
-		$response = wp_remote_post(
-			'https://tmpfiles.org/api/v1/upload',
-			array(
-				'timeout' => 60,
-				'headers' => array(
-					'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-				),
-				'body'    => $body,
-			)
-		);
-
-		if ( is_wp_error( $response ) ) {
-			error_log( 'Fair Audience: tmpfiles.org upload failed - ' . $response->get_error_message() );
-			return new WP_Error(
-				'upload_failed',
-				sprintf(
-					/* translators: %s: error message */
-					__( 'Failed to upload image: %s', 'fair-audience-experimental' ),
-					$response->get_error_message()
-				),
-				array( 'status' => 500 )
-			);
-		}
-
-		$status_code   = wp_remote_retrieve_response_code( $response );
-		$response_body = wp_remote_retrieve_body( $response );
-		$data          = json_decode( $response_body, true );
-
-		if ( 200 !== $status_code || empty( $data['data']['url'] ) ) {
-			error_log( "Fair Audience: tmpfiles.org upload failed - status: {$status_code}, response: {$response_body}" );
-			return new WP_Error(
-				'upload_failed',
-				__( 'Failed to upload image to temporary storage.', 'fair-audience-experimental' ),
-				array( 'status' => 500 )
-			);
-		}
-
-		// Transform URL: tmpfiles.org/12345/file.jpg -> tmpfiles.org/dl/12345/file.jpg
-		$url          = $data['data']['url'];
-		$download_url = str_replace( 'tmpfiles.org/', 'tmpfiles.org/dl/', $url );
-
-		// Ensure HTTPS.
-		$download_url = str_replace( 'http://', 'https://', $download_url );
-
 		return rest_ensure_response(
 			array(
-				'url' => $download_url,
+				'url' => wp_get_attachment_url( $attachment_id ),
 			)
 		);
 	}
 
 	/**
-	 * Upload a base64-encoded image to tmpfiles.org.
+	 * Store a base64-encoded image as a media-library attachment.
 	 *
-	 * Used for client-generated images (e.g., schedule SVG → PNG).
+	 * Used for client-generated images (e.g., schedule SVG → PNG) that need a
+	 * publicly reachable URL for the Instagram Graph API. The attachment is
+	 * tagged as temporary so it can be cleaned up after a successful publish
+	 * (see create_item()) or by the stale-attachment cron sweep.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response|WP_Error Response with public URL or error.
+	 * @return WP_REST_Response|WP_Error Response with public URL and attachment ID, or error.
 	 */
 	public function upload_blob( $request ) {
 		$image_data = $request->get_param( 'image_data' );
@@ -438,64 +410,70 @@ class InstagramPostsController extends WP_REST_Controller {
 			);
 		}
 
-		$filename  = 'schedule-' . gmdate( 'Y-m-d-His' ) . '.png';
-		$mime_type = 'image/png';
-		$boundary  = wp_generate_password( 24, false );
+		if ( strlen( $binary ) > self::MAX_BLOB_SIZE ) {
+			return new WP_Error(
+				'file_too_large',
+				__( 'Image is too large.', 'fair-audience-experimental' ),
+				array( 'status' => 400 )
+			);
+		}
 
-		// Build multipart body directly from binary data.
-		$body  = '--' . $boundary . "\r\n";
-		$body .= 'Content-Disposition: form-data; name="file"; filename="' . $filename . '"' . "\r\n";
-		$body .= 'Content-Type: ' . $mime_type . "\r\n\r\n";
-		$body .= $binary . "\r\n";
-		$body .= '--' . $boundary . '--' . "\r\n";
+		// Validate the decoded bytes are actually a PNG image; never trust
+		// the client-declared type.
+		$image_info = @getimagesizefromstring( $binary ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- getimagesizefromstring() warns on invalid data; we handle the false return instead.
+		if ( false === $image_info || IMAGETYPE_PNG !== $image_info[2] ) {
+			return new WP_Error(
+				'invalid_image_data',
+				__( 'Uploaded data is not a valid PNG image.', 'fair-audience-experimental' ),
+				array( 'status' => 400 )
+			);
+		}
 
-		$response = wp_remote_post(
-			'https://tmpfiles.org/api/v1/upload',
-			array(
-				'timeout' => 60,
-				'headers' => array(
-					'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-				),
-				'body'    => $body,
-			)
-		);
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+		require_once ABSPATH . 'wp-admin/includes/media.php';
 
-		if ( is_wp_error( $response ) ) {
-			error_log( 'Fair Audience: tmpfiles.org blob upload failed - ' . $response->get_error_message() );
+		$filename = 'schedule-' . gmdate( 'Y-m-d-His' ) . '.png';
+		$upload   = wp_upload_bits( $filename, null, $binary );
+
+		if ( ! empty( $upload['error'] ) ) {
 			return new WP_Error(
 				'upload_failed',
 				sprintf(
 					/* translators: %s: error message */
-					__( 'Failed to upload image: %s', 'fair-audience-experimental' ),
-					$response->get_error_message()
+					__( 'Failed to store image: %s', 'fair-audience-experimental' ),
+					$upload['error']
 				),
 				array( 'status' => 500 )
 			);
 		}
 
-		$status_code   = wp_remote_retrieve_response_code( $response );
-		$response_body = wp_remote_retrieve_body( $response );
-		$data          = json_decode( $response_body, true );
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_mime_type' => 'image/png',
+				'post_title'     => sanitize_file_name( $filename ),
+				'post_content'   => '',
+				'post_status'    => 'inherit',
+			),
+			$upload['file']
+		);
 
-		if ( 200 !== $status_code || empty( $data['data']['url'] ) ) {
-			error_log( "Fair Audience: tmpfiles.org blob upload failed - status: {$status_code}, response: {$response_body}" );
+		if ( is_wp_error( $attachment_id ) ) {
 			return new WP_Error(
-				'upload_failed',
-				__( 'Failed to upload image to temporary storage.', 'fair-audience-experimental' ),
+				'attachment_failed',
+				__( 'Failed to save uploaded image.', 'fair-audience-experimental' ),
 				array( 'status' => 500 )
 			);
 		}
 
-		// Transform URL: tmpfiles.org/12345/file.png -> tmpfiles.org/dl/12345/file.png
-		$url          = $data['data']['url'];
-		$download_url = str_replace( 'tmpfiles.org/', 'tmpfiles.org/dl/', $url );
-
-		// Ensure HTTPS.
-		$download_url = str_replace( 'http://', 'https://', $download_url );
+		$attachment_metadata = wp_generate_attachment_metadata( $attachment_id, $upload['file'] );
+		wp_update_attachment_metadata( $attachment_id, $attachment_metadata );
+		update_post_meta( $attachment_id, self::TEMP_ATTACHMENT_META_KEY, 1 );
 
 		return rest_ensure_response(
 			array(
-				'url' => $download_url,
+				'url'           => wp_get_attachment_url( $attachment_id ),
+				'attachment_id' => $attachment_id,
 			)
 		);
 	}

--- a/fair-audience-experimental/src/API/__tests__/InstagramPostsController.api.spec.js
+++ b/fair-audience-experimental/src/API/__tests__/InstagramPostsController.api.spec.js
@@ -1,0 +1,120 @@
+/**
+ * Playwright API tests for InstagramPostsController's upload-blob endpoint.
+ *
+ * Covers the #1063 fix: the schedule PNG is now stored as a WordPress
+ * media-library attachment instead of being round-tripped through
+ * tmpfiles.org (which stopped serving raw image bytes).
+ *
+ *   POST /fair-audience/v1/instagram/upload-blob
+ *
+ * Out of HTTP scope (validated manually per TESTING.md's WP-CLI eval-file
+ * recipe): the live Instagram Graph API round-trip, and the temp-attachment
+ * cleanup that happens inside create_item() after a successful publish
+ * (requires configured Instagram credentials).
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+// Well-known 1x1 transparent PNG.
+const VALID_PNG_BASE64 =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+test.describe('InstagramPostsController – upload-blob', () => {
+	let api;
+	const createdAttachmentIds = [];
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		for (const id of createdAttachmentIds) {
+			await api.delete(`/wp-json/wp/v2/media/${id}`, {
+				headers: authHeaders,
+				params: { force: true },
+			});
+		}
+		await api.dispose();
+	});
+
+	test('stores a valid PNG as a local media-library attachment', async () => {
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/instagram/upload-blob',
+			{
+				headers: authHeaders,
+				data: { image_data: VALID_PNG_BASE64 },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+
+		const body = await res.json();
+		expect(typeof body.attachment_id).toBe('number');
+		createdAttachmentIds.push(body.attachment_id);
+
+		// Not tmpfiles.org — a URL on this same WordPress origin.
+		expect(body.url.startsWith(BASE_URL)).toBe(true);
+		expect(body.url).toContain('/wp-content/uploads/');
+
+		// The Graph API needs a URL that actually serves image bytes.
+		const imageRes = await api.get(body.url);
+		expect(imageRes.ok()).toBeTruthy();
+		expect(imageRes.headers()['content-type']).toBe('image/png');
+	});
+
+	test('rejects data that is not a valid image', async () => {
+		const notAnImage = Buffer.from('this is not an image').toString(
+			'base64'
+		);
+
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/instagram/upload-blob',
+			{
+				headers: authHeaders,
+				data: { image_data: notAnImage },
+			}
+		);
+		expect(res.status()).toBe(400);
+
+		const body = await res.json();
+		expect(body.code).toBe('invalid_image_data');
+	});
+
+	test('rejects a blob over the size cap', async () => {
+		// MAX_BLOB_SIZE is 5 MiB in InstagramPostsController.
+		const oversized = Buffer.alloc(5 * 1024 * 1024 + 1, 'a').toString(
+			'base64'
+		);
+
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/instagram/upload-blob',
+			{
+				headers: authHeaders,
+				data: { image_data: oversized },
+			}
+		);
+		expect(res.status()).toBe(400);
+
+		const body = await res.json();
+		expect(body.code).toBe('file_too_large');
+	});
+
+	test('rejects unauthenticated requests', async () => {
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/instagram/upload-blob',
+			{
+				data: { image_data: VALID_PNG_BASE64 },
+			}
+		);
+		expect(res.status()).toBe(401);
+	});
+});

--- a/fair-audience-experimental/src/Admin/instagram-posts/InstagramPosts.js
+++ b/fair-audience-experimental/src/Admin/instagram-posts/InstagramPosts.js
@@ -20,7 +20,7 @@ import {
 	loadInstagramPosts,
 	createInstagramPost,
 	deleteInstagramPost,
-	uploadImageToTmpFiles,
+	getAttachmentUrl,
 } from './instagram-posts-api.js';
 
 /**
@@ -187,9 +187,9 @@ export default function InstagramPosts() {
 		setIsPosting(true);
 		setNotice(null);
 
-		// If we have an attachment ID, upload to tmpfiles.org first.
+		// If we have an attachment ID, resolve its media-library URL first.
 		const getPublicUrl = attachmentId
-			? uploadImageToTmpFiles(attachmentId).then((result) => result.url)
+			? getAttachmentUrl(attachmentId).then((result) => result.url)
 			: Promise.resolve(imageUrl.trim());
 
 		getPublicUrl

--- a/fair-audience-experimental/src/Admin/instagram-posts/instagram-posts-api.js
+++ b/fair-audience-experimental/src/Admin/instagram-posts/instagram-posts-api.js
@@ -23,6 +23,7 @@ export function loadInstagramPosts(status = null) {
  * @param {Object} data Post data
  * @param {string} data.image_url Publicly accessible image URL
  * @param {string} data.caption Post caption
+ * @param {number} [data.attachment_id] Temporary attachment to delete after a successful publish
  * @return {Promise<Object>} Promise resolving to created post
  */
 export function createInstagramPost(data) {
@@ -34,12 +35,12 @@ export function createInstagramPost(data) {
 }
 
 /**
- * Upload a WordPress attachment to tmpfiles.org for public access
+ * Resolve a WordPress attachment's public media-library URL
  *
  * @param {number} attachmentId WordPress attachment ID
  * @return {Promise<Object>} Promise resolving to { url: string }
  */
-export function uploadImageToTmpFiles(attachmentId) {
+export function getAttachmentUrl(attachmentId) {
 	return apiFetch({
 		path: '/fair-audience/v1/instagram/upload-image',
 		method: 'POST',
@@ -48,10 +49,10 @@ export function uploadImageToTmpFiles(attachmentId) {
 }
 
 /**
- * Upload a base64-encoded image blob to tmpfiles.org via the REST API
+ * Store a base64-encoded image blob as a media-library attachment
  *
- * @param {string} base64Data Base64-encoded image data (with or without data URI prefix)
- * @return {Promise<Object>} Promise resolving to { url: string }
+ * @param {string} base64Data Base64-encoded PNG image data (with or without data URI prefix)
+ * @return {Promise<Object>} Promise resolving to { url: string, attachment_id: number }
  */
 export function uploadImageBlob(base64Data) {
 	return apiFetch({

--- a/fair-audience-experimental/src/Admin/weekly-schedule/WeeklySchedule.js
+++ b/fair-audience-experimental/src/Admin/weekly-schedule/WeeklySchedule.js
@@ -241,10 +241,13 @@ export default function WeeklySchedule() {
 		try {
 			const svg = generateScheduleSvg(data);
 			const base64 = await svgToBase64Png(svg);
-			const { url } = await uploadImageBlob(base64);
+			const { url, attachment_id: attachmentId } = await uploadImageBlob(
+				base64
+			);
 			const result = await createInstagramPost({
 				image_url: url,
 				caption: message,
+				attachment_id: attachmentId,
 			});
 			setPostSuccess(result.post?.permalink || true);
 		} catch (err) {

--- a/fair-audience-experimental/src/Core/Plugin.php
+++ b/fair-audience-experimental/src/Core/Plugin.php
@@ -101,9 +101,10 @@ class Plugin {
 	}
 
 	/**
-	 * Initialize hook-only bundles that don't register admin pages or REST
-	 * routes of their own: the media library integration (`galleries`) and
-	 * the scheduled-message cron/reschedule hooks (`messaging`).
+	 * Initialize hook-only bundles that ride alongside admin pages or REST
+	 * routes registered elsewhere: the media library integration
+	 * (`galleries`), the scheduled-message cron/reschedule hooks
+	 * (`messaging`), and the stale-attachment cleanup sweep (`instagram`).
 	 *
 	 * @return void
 	 */
@@ -115,6 +116,10 @@ class Plugin {
 
 		if ( Features::is_enabled( 'messaging' ) ) {
 			\FairAudienceExperimental\Hooks\ScheduledMessageHooks::init();
+		}
+
+		if ( Features::is_enabled( 'instagram' ) ) {
+			\FairAudienceExperimental\Hooks\InstagramCleanupHooks::init();
 		}
 	}
 

--- a/fair-audience-experimental/src/Hooks/InstagramCleanupHooks.php
+++ b/fair-audience-experimental/src/Hooks/InstagramCleanupHooks.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Instagram Cleanup Hooks
+ *
+ * @package FairAudienceExperimental
+ */
+
+namespace FairAudienceExperimental\Hooks;
+
+use FairAudienceExperimental\API\InstagramPostsController;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Safety-net cron sweep for temporary Instagram-upload attachments.
+ *
+ * The upload and publish endpoints clean these up in the normal flow (publish
+ * success deletes them, publish failure keeps them for retry), but an
+ * abandoned publish (browser closed mid-flow, request timeout) can leave one
+ * behind. This sweeps anything still tagged as temporary after the retry
+ * window has passed.
+ */
+class InstagramCleanupHooks {
+
+	/**
+	 * Cron hook name.
+	 */
+	const CRON_HOOK = 'fair_audience_cleanup_instagram_temp_attachments';
+
+	/**
+	 * How long a temporary attachment is kept before the sweep removes it.
+	 */
+	const STALE_HOURS = 24;
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( self::CRON_HOOK, array( static::class, 'sweep' ) );
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'hourly', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Delete temporary Instagram attachments older than the stale threshold.
+	 */
+	public static function sweep() {
+		$cutoff = gmdate( 'Y-m-d H:i:s', time() - self::STALE_HOURS * HOUR_IN_SECONDS );
+
+		$attachment_ids = get_posts(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'posts_per_page' => 50,
+				'fields'         => 'ids',
+				'date_query'     => array(
+					array( 'before' => $cutoff ),
+				),
+				'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded, hourly cron sweep; no user-facing request depends on this.
+					array(
+						'key'   => InstagramPostsController::TEMP_ATTACHMENT_META_KEY,
+						'value' => 1,
+					),
+				),
+			)
+		);
+
+		foreach ( $attachment_ids as $attachment_id ) {
+			wp_delete_attachment( $attachment_id, true );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- tmpfiles.org stopped serving raw image bytes — every URL variant now 302s to an HTML viewer page — so Instagram's Graph API rejected the schedule image with an "unrecognized format" error. Instagram posting was 100% broken.
- `upload_blob()` now stores the client-generated schedule PNG directly as a WordPress media-library attachment (`wp_upload_bits()` + `wp_insert_attachment()`) and returns its `wp-content/uploads` URL — no third-party hop.
- The attachment is validated (`getimagesizefromstring()` confirms real PNG bytes, never trusting the client-declared type) and size-capped at 5 MiB before it's written, and tagged `_fair_audience_instagram_temp`.
- `create_item()` deletes the temp attachment right after a successful publish (Instagram has already ingested the bytes); a failed publish keeps it for retry. Deletion only ever targets attachments carrying the temp marker.
- New hourly cron sweep (`InstagramCleanupHooks`) deletes any temp attachment older than 24h, as a safety net for an abandoned publish (browser closed mid-flow, timeout).
- `upload_image()` (the existing-attachment variant) simplified to `wp_get_attachment_url()` — it already had a real attachment on hand and only used tmpfiles.org to bounce it through a public URL.
- Frontend: `uploadImageToTmpFiles` renamed to `getAttachmentUrl` (it no longer uploads anywhere); `uploadImageBlob` now also returns `attachment_id`, threaded through `WeeklySchedule.js` into `createInstagramPost()` for cleanup.
- All `tmpfiles.org` references removed from the plugin.

Closes #1063

## Test plan

- [x] `vendor/bin/phpcs` clean on changed PHP files
- [x] `npx jest` in `fair-audience-experimental` — all pass
- [x] `npm run build` in `fair-audience-experimental`
- [x] Manual WP-CLI `eval-file` check (TESTING.md) against a live bootstrapped WordPress: valid PNG → real attachment with correct mime, on-disk file, same-origin URL, temp marker set; non-image data rejected; oversized blob rejected; `create_item()`'s cleanup step leaves an attachment alone when it isn't marked temp
- [ ] `npx playwright test src/API/__tests__/InstagramPostsController.api.spec.js` — written per TESTING.md's `.api.spec.js` convention (mirrors `TimelineController.api.spec.js`), but Basic Auth against the local `docker compose` WordPress (Apache image) doesn't authenticate on this machine — same pre-existing failure as the existing `TimelineController.api.spec.js` on this environment, and `.api.spec.js` files aren't run by CI (`npm test` only runs `test:js`). Logic covered manually instead (above); the spec should pass once run against an environment with working REST Basic Auth.
- [ ] Posting to Instagram end-to-end against a live site — needs configured Instagram credentials, not available in this environment; recommend a manual check before/after merge.
