### PR TITLE
Add audience stat tiles to All Participants page

### DIFF
--- a/fair-audience/src/API/ParticipantsController.php
+++ b/fair-audience/src/API/ParticipantsController.php
@@ -106,6 +106,19 @@ class ParticipantsController extends WP_REST_Controller {
 			)
 		);
 
+		// GET /fair-audience/v1/participants/stats.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/stats',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_stats' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+
 		// GET /fair-audience/v1/participants/{id}.
 		// PUT /fair-audience/v1/participants/{id}.
 		// DELETE /fair-audience/v1/participants/{id}.
@@ -292,6 +305,16 @@ class ParticipantsController extends WP_REST_Controller {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Get audience stats for the stat tiles above the participants table.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_stats( $request ) {
+		return rest_ensure_response( $this->repository->get_stats() );
 	}
 
 	/**

--- a/fair-audience/src/API/__tests__/ParticipantsStats.api.spec.js
+++ b/fair-audience/src/API/__tests__/ParticipantsStats.api.spec.js
@@ -1,0 +1,90 @@
+/**
+ * Playwright API tests for the participant audience-stats endpoint (#1054):
+ * GET /fair-audience/v1/participants/stats.
+ *
+ * Exact mailing/pending totals depend on DB state shared across the test
+ * suite, so this asserts relative correctness (seeding participants
+ * increases `total` by the expected amount) rather than absolute counts,
+ * mirroring ParticipantsActivityTransactionStatus.api.spec.js.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+test.describe('ParticipantsController — GET /participants/stats', () => {
+	let api;
+	const participantIds = [];
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		for (const id of participantIds) {
+			await api.delete(`/wp-json/fair-audience/v1/participants/${id}`, {
+				headers: authHeaders,
+			});
+		}
+		await api.dispose();
+	});
+
+	test('unauthenticated request is rejected', async () => {
+		const res = await api.get(
+			'/wp-json/fair-audience/v1/participants/stats'
+		);
+		expect(res.status()).toBe(401);
+	});
+
+	test('authenticated request returns total/mailing/pending/declined counts', async () => {
+		const before = await api.get(
+			'/wp-json/fair-audience/v1/participants/stats',
+			{ headers: authHeaders }
+		);
+		expect(before.ok()).toBeTruthy();
+		const beforeBody = await before.json();
+		expect(beforeBody).toEqual(
+			expect.objectContaining({
+				total: expect.any(Number),
+				mailing: expect.any(Number),
+				pending: expect.any(Number),
+				declined: expect.any(Number),
+			})
+		);
+
+		const createRes = await api.post(
+			'/wp-json/fair-audience/v1/participants',
+			{
+				headers: authHeaders,
+				data: {
+					name: 'Stats Tester',
+					email: uniqueEmail('stats-tester'),
+				},
+			}
+		);
+		expect(createRes.ok()).toBeTruthy();
+		participantIds.push((await createRes.json()).id);
+
+		const after = await api.get(
+			'/wp-json/fair-audience/v1/participants/stats',
+			{ headers: authHeaders }
+		);
+		expect(after.ok()).toBeTruthy();
+		const afterBody = await after.json();
+		expect(afterBody.total).toBe(beforeBody.total + 1);
+	});
+});

--- a/fair-audience/src/Admin/all-participants/AllParticipants.js
+++ b/fair-audience/src/Admin/all-participants/AllParticipants.js
@@ -5,10 +5,13 @@ import {
 	Button,
 	Card,
 	CardBody,
+	Flex,
+	FlexItem,
 	Spinner,
 	Popover,
 	Notice,
 	Snackbar,
+	__experimentalText as Text,
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
@@ -47,6 +50,7 @@ export default function AllParticipants() {
 	const [totalItems, setTotalItems] = useState(0);
 	const [totalPages, setTotalPages] = useState(0);
 	const [isLoading, setIsLoading] = useState(true);
+	const [stats, setStats] = useState(null);
 	const [view, setView] = useState(DEFAULT_VIEW);
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [editingParticipant, setEditingParticipant] = useState(null);
@@ -374,9 +378,23 @@ export default function AllParticipants() {
 			});
 	}, [queryArgs]);
 
-	useEffect(() => {
+	const loadStats = useCallback(() => {
+		apiFetch({ path: '/fair-audience/v1/participants/stats' })
+			.then(setStats)
+			.catch((err) => {
+				// eslint-disable-next-line no-console
+				console.error('Error loading participant stats:', err);
+			});
+	}, []);
+
+	const refresh = useCallback(() => {
 		loadParticipants();
-	}, [loadParticipants]);
+		loadStats();
+	}, [loadParticipants, loadStats]);
+
+	useEffect(() => {
+		refresh();
+	}, [refresh]);
 
 	const openAddModal = () => {
 		setEditingParticipant(null);
@@ -404,7 +422,7 @@ export default function AllParticipants() {
 			)
 		)
 			.then(() => {
-				loadParticipants();
+				refresh();
 			})
 			.catch((err) => {
 				setErrorMessage(__('Error: ', 'fair-audience') + err.message);
@@ -515,6 +533,55 @@ export default function AllParticipants() {
 		[totalItems, totalPages]
 	);
 
+	const statTiles = useMemo(
+		() => [
+			{
+				id: 'total',
+				label: __('Audience total', 'fair-audience'),
+				value: stats?.total,
+				filters: [],
+			},
+			{
+				id: 'mailing',
+				label: __('In the mailing', 'fair-audience'),
+				value: stats?.mailing,
+				filters: [
+					{
+						field: 'email_profile',
+						operator: 'is',
+						value: 'marketing',
+					},
+					{ field: 'status', operator: 'is', value: 'confirmed' },
+				],
+			},
+			{
+				id: 'pending',
+				label: __('Pending confirmation', 'fair-audience'),
+				value: stats?.pending,
+				filters: [
+					{ field: 'status', operator: 'is', value: 'pending' },
+				],
+			},
+			{
+				id: 'declined',
+				label: __('Declined', 'fair-audience'),
+				value: stats?.declined,
+				filters: [
+					{
+						field: 'email_profile',
+						operator: 'is',
+						value: 'declined',
+					},
+				],
+			},
+		],
+		[stats]
+	);
+
+	const filterByTile = useCallback((filters) => {
+		setView((v) => ({ ...v, filters, page: 1 }));
+	}, []);
+
 	const resendResultTitle = useMemo(() => {
 		if (!resendResult) {
 			return '';
@@ -545,6 +612,32 @@ export default function AllParticipants() {
 				{__('Add Participant', 'fair-audience')}
 			</button>
 			<hr className="wp-header-end" />
+
+			<Flex wrap>
+				{statTiles.map((tile) => (
+					<FlexItem key={tile.id} style={{ minWidth: '160px' }}>
+						<Card>
+							<CardBody
+								as="button"
+								type="button"
+								onClick={() => filterByTile(tile.filters)}
+								style={{
+									cursor: 'pointer',
+									textAlign: 'left',
+									width: '100%',
+									border: 'none',
+									background: 'none',
+								}}
+							>
+								<Text size={24} weight={600} as="div">
+									{stats ? tile.value : '—'}
+								</Text>
+								<Text as="div">{tile.label}</Text>
+							</CardBody>
+						</Card>
+					</FlexItem>
+				))}
+			</Flex>
 
 			{errorMessage && (
 				<Notice
@@ -629,7 +722,7 @@ export default function AllParticipants() {
 				isOpen={isModalOpen}
 				participant={editingParticipant}
 				onClose={() => setIsModalOpen(false)}
-				onSaved={loadParticipants}
+				onSaved={refresh}
 			/>
 
 			<ConfirmDialog

--- a/fair-audience/src/Admin/all-participants/__tests__/AllParticipants.test.jsx
+++ b/fair-audience/src/Admin/all-participants/__tests__/AllParticipants.test.jsx
@@ -84,6 +84,8 @@ const PARTICIPANTS = [
 	},
 ];
 
+const STATS = { total: 4, mailing: 1, pending: 1, declined: 1 };
+
 function mockApiFetch() {
 	apiFetch.mockImplementation(({ path, parse }) => {
 		if (
@@ -97,6 +99,9 @@ function mockApiFetch() {
 				]),
 				json: () => Promise.resolve(PARTICIPANTS),
 			});
+		}
+		if (path === '/fair-audience/v1/participants/stats') {
+			return Promise.resolve(STATS);
 		}
 		if (path === '/fair-audience/v1/groups') {
 			return Promise.resolve([]);
@@ -220,6 +225,42 @@ describe('AllParticipants — filters preserved', () => {
 		expect(
 			screen.getByRole('menuitem', { name: 'Status' })
 		).toBeInTheDocument();
+	});
+});
+
+describe('AllParticipants — stat tiles (#1054)', () => {
+	it('renders the tile counts from the stats endpoint', async () => {
+		render(<AllParticipants />);
+
+		await screen.findByText('Jane Doe');
+
+		expect(screen.getByText('Audience total')).toBeInTheDocument();
+		expect(screen.getByText('In the mailing')).toBeInTheDocument();
+		expect(screen.getByText('Pending confirmation')).toBeInTheDocument();
+		expect(screen.getByText('Declined')).toBeInTheDocument();
+
+		expect(screen.getAllByText('4').length).toBeGreaterThan(0);
+		expect(screen.getAllByText('1').length).toBe(3);
+	});
+
+	it('clicking the Pending tile filters the participants list by status=pending', async () => {
+		render(<AllParticipants />);
+
+		await screen.findByText('Jane Doe');
+		apiFetch.mockClear();
+
+		fireEvent.click(
+			screen.getByText('Pending confirmation').closest('button')
+		);
+
+		await waitFor(() =>
+			expect(apiFetch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: expect.stringContaining('status=pending'),
+					parse: false,
+				})
+			)
+		);
 	});
 });
 

--- a/fair-audience/src/Database/ParticipantRepository.php
+++ b/fair-audience/src/Database/ParticipantRepository.php
@@ -403,4 +403,55 @@ class ParticipantRepository {
 			$wpdb->prepare( 'SELECT COUNT(*) FROM %i', $table_name )
 		);
 	}
+
+	/**
+	 * Get audience stats: total participants, and how many are in the
+	 * mailing (marketing + confirmed), pending confirmation, or declined.
+	 *
+	 * @return array {
+	 *     @type int $total    Total participant count.
+	 *     @type int $mailing  Confirmed marketing subscribers.
+	 *     @type int $pending  Participants pending confirmation.
+	 *     @type int $declined Participants who declined email.
+	 * }
+	 */
+	public function get_stats() {
+		global $wpdb;
+
+		$table_name = $this->get_table_name();
+		$rows       = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT email_profile, status, COUNT(*) AS cnt FROM %i GROUP BY email_profile, status',
+				$table_name
+			),
+			ARRAY_A
+		);
+
+		$stats = array(
+			'total'    => 0,
+			'mailing'  => 0,
+			'pending'  => 0,
+			'declined' => 0,
+		);
+
+		foreach ( $rows as $row ) {
+			$cnt = (int) $row['cnt'];
+
+			$stats['total'] += $cnt;
+
+			if ( 'marketing' === $row['email_profile'] && 'confirmed' === $row['status'] ) {
+				$stats['mailing'] += $cnt;
+			}
+
+			if ( 'pending' === $row['status'] ) {
+				$stats['pending'] += $cnt;
+			}
+
+			if ( 'declined' === $row['email_profile'] ) {
+				$stats['declined'] += $cnt;
+			}
+		}
+
+		return $stats;
+	}
 }


### PR DESCRIPTION
## Summary

- Add `GET /fair-audience/v1/participants/stats` to `ParticipantsController` (`manage_options`-gated, backed by a new `ParticipantRepository::get_stats()` grouped-count query) returning `{ total, mailing, pending, declined }`.
- Render a row of clickable stat tiles (Audience total / In the mailing / Pending confirmation / Declined) above the participants table in `AllParticipants.js`; clicking a tile sets the matching DataViews filter and resets to page 1.
- Refresh stats alongside the participant list on mount, after delete, and after add/edit save.

Closes #1054

## Test plan

- [x] `npm run build` (fair-audience)
- [x] `npm run format` (root, via pre-commit hook)
- [x] `vendor/bin/phpcs` clean for changed PHP files
- [x] `npm run test:js` (fair-audience) — 10/10 passing, including new stat-tile render/filter-click tests
- [ ] `npm run test:api` — not run live; this repo checkout's docker compose stack (`compose.yml`) shares ports 8080/3306/8081 with another running `fair-event-plugins` checkout, so it couldn't be brought up without disrupting that environment. The new `ParticipantsStats.api.spec.js` follows the existing `ParticipantsActivityTransactionStatus.api.spec.js` pattern and passes Playwright's static `--list` check.
