### PR TITLE
Add weekly digest storage and backend to fair-audience

### DIFF
--- a/.changeset/weekly-digest-backend.md
+++ b/.changeset/weekly-digest-backend.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": minor
+---
+
+Add the weekly events digest backend: a `fair_audience_weekly_digest` option, `WeeklyDigestController` REST routes (config, sources, preview, test-send), a shared `WeeklyDigestRenderer`, and a `WeeklyDigestHooks` cron with `last_sent_week` idempotency (issue #916). No admin UI yet — configuration is REST-only until the admin page lands.

--- a/fair-audience/fair-audience.php
+++ b/fair-audience/fair-audience.php
@@ -766,5 +766,6 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_audience_maybe_upgrade_db'
 function fair_audience_deactivate() {
 	wp_clear_scheduled_hook( 'fair_audience_cleanup_expired_signups' );
 	wp_clear_scheduled_hook( 'fair_audience_send_scheduled_messages' );
+	wp_clear_scheduled_hook( 'fair_audience_weekly_digest_tick' );
 }
 register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\fair_audience_deactivate' );

--- a/fair-audience/src/API/WeeklyDigestController.php
+++ b/fair-audience/src/API/WeeklyDigestController.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Weekly Digest REST API Controller
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\API;
+
+use FairAudience\Services\EmailService;
+use FairAudience\Services\WeeklyDigestRenderer;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * REST API controller for the weekly events digest: config, sources, preview, test-send.
+ */
+class WeeklyDigestController extends WP_REST_Controller {
+
+	/**
+	 * REST API namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-audience/v1';
+
+	/**
+	 * REST API base route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'weekly-digest';
+
+	/**
+	 * Register REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_config' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_config' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $this->get_config_args(),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/sources',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_sources' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/preview',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'preview' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/test',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'send_test' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Only site admins may read or change the digest configuration.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to manage the weekly digest.', 'fair-audience' ),
+				array( 'status' => 403 )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * GET /weekly-digest — current config plus last-run info.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_config() {
+		$config = get_option( 'fair_audience_weekly_digest', WeeklyDigestRenderer::default_config() );
+
+		return rest_ensure_response(
+			array(
+				'config'          => $config,
+				'last_sent_week'  => get_option( 'fair_audience_weekly_digest_last_sent_week', '' ),
+				'last_run_result' => get_option( 'fair_audience_weekly_digest_last_run_result', array() ),
+			)
+		);
+	}
+
+	/**
+	 * PUT /weekly-digest — update config.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function update_config( WP_REST_Request $request ) {
+		$config = WeeklyDigestRenderer::sanitize_config( $request->get_params() );
+
+		update_option( 'fair_audience_weekly_digest', $config );
+
+		return rest_ensure_response( array( 'config' => $config ) );
+	}
+
+	/**
+	 * GET /weekly-digest/sources — enabled fair-events event sources.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_sources() {
+		if ( ! class_exists( 'FairEvents\Core\Plugin' ) ) {
+			return rest_ensure_response( array() );
+		}
+
+		$repository = new \FairEvents\Database\EventSourceRepository();
+		$sources    = $repository->get_all( true );
+
+		$items = array_map(
+			function ( $source ) {
+				return array(
+					'slug' => $source['slug'],
+					'name' => $source['name'],
+				);
+			},
+			$sources
+		);
+
+		return rest_ensure_response( $items );
+	}
+
+	/**
+	 * POST /weekly-digest/preview — render the configured week's HTML, no send.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function preview() {
+		$week = $this->get_configured_week();
+
+		if ( is_wp_error( $week ) ) {
+			return $week;
+		}
+
+		$config = get_option( 'fair_audience_weekly_digest', WeeklyDigestRenderer::default_config() );
+
+		return rest_ensure_response(
+			array(
+				'subject' => WeeklyDigestRenderer::render_subject( $config['subject'], $week ),
+				'html'    => WeeklyDigestRenderer::render( $week, $config['intro'] ),
+				'week'    => $week['week'],
+				'empty'   => WeeklyDigestRenderer::is_week_empty( $week ),
+			)
+		);
+	}
+
+	/**
+	 * POST /weekly-digest/test — render and send one mail to the current admin.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function send_test() {
+		$week = $this->get_configured_week();
+
+		if ( is_wp_error( $week ) ) {
+			return $week;
+		}
+
+		$config  = get_option( 'fair_audience_weekly_digest', WeeklyDigestRenderer::default_config() );
+		$subject = WeeklyDigestRenderer::render_subject( $config['subject'], $week );
+		$html    = WeeklyDigestRenderer::render( $week, $config['intro'] );
+
+		$current_user = wp_get_current_user();
+
+		$email_service = new EmailService();
+		$sent          = $email_service->send_html_mail_to_address( $current_user->user_email, $subject, $html );
+
+		if ( ! $sent ) {
+			return new WP_Error(
+				'send_failed',
+				__( 'Failed to send the test email.', 'fair-audience' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response( array( 'sent_to' => $current_user->user_email ) );
+	}
+
+	/**
+	 * Resolve the week for the currently configured source.
+	 *
+	 * @return array|WP_Error Week data, or WP_Error when unconfigured/unavailable.
+	 */
+	private function get_configured_week() {
+		if ( ! class_exists( 'FairEvents\Services\WeeklyEventsProvider' ) ) {
+			return new WP_Error(
+				'fair_events_inactive',
+				__( 'The Fair Events plugin must be active.', 'fair-audience' ),
+				array( 'status' => 424 )
+			);
+		}
+
+		$config = get_option( 'fair_audience_weekly_digest', WeeklyDigestRenderer::default_config() );
+
+		if ( empty( $config['source_slug'] ) ) {
+			return new WP_Error(
+				'no_source',
+				__( 'No event source configured for the weekly digest.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		list( $year, $week_num ) = WeeklyDigestRenderer::resolve_week_scope( $config['week_scope'] );
+
+		$provider = new \FairEvents\Services\WeeklyEventsProvider();
+		$week     = $provider->get_week( $config['source_slug'], $year, $week_num );
+
+		if ( is_wp_error( $week ) ) {
+			return $week;
+		}
+
+		return $week;
+	}
+
+	/**
+	 * Schema-driven args for PUT /weekly-digest.
+	 *
+	 * @return array Args definition.
+	 */
+	private function get_config_args() {
+		return array(
+			'enabled'     => array( 'type' => 'boolean' ),
+			'source_slug' => array( 'type' => 'string' ),
+			'day_of_week' => array( 'type' => 'integer' ),
+			'time_of_day' => array( 'type' => 'string' ),
+			'week_scope'  => array(
+				'type' => 'string',
+				'enum' => array( 'current', 'next' ),
+			),
+			'skip_empty'  => array( 'type' => 'boolean' ),
+			'subject'     => array( 'type' => 'string' ),
+			'intro'       => array( 'type' => 'string' ),
+		);
+	}
+}

--- a/fair-audience/src/Core/Plugin.php
+++ b/fair-audience/src/Core/Plugin.php
@@ -89,6 +89,9 @@ class Plugin {
 		// Initialize payment hooks (for fair-payments-connector webhook integration).
 		\FairAudience\Hooks\PaymentHooks::init();
 
+		// Initialize the weekly events digest cron.
+		\FairAudience\Hooks\WeeklyDigestHooks::init();
+
 		// Initialize blocks.
 		$block_hooks = new \FairAudience\Hooks\BlockHooks();
 	}
@@ -117,6 +120,9 @@ class Plugin {
 
 		$event_interest_controller = new \FairAudience\API\EventInterestController();
 		$event_interest_controller->register_routes();
+
+		$weekly_digest_controller = new \FairAudience\API\WeeklyDigestController();
+		$weekly_digest_controller->register_routes();
 	}
 
 	/**

--- a/fair-audience/src/Hooks/WeeklyDigestHooks.php
+++ b/fair-audience/src/Hooks/WeeklyDigestHooks.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Weekly Digest Hooks
+ *
+ * Drives the weekly events digest: a 5-minute cron tick checks whether the
+ * configured send day/time has arrived and dispatches at most once per ISO
+ * week, guarded by the `fair_audience_weekly_digest_last_sent_week` option.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Hooks;
+
+use FairAudience\Services\EmailService;
+use FairAudience\Services\WeeklyDigestRenderer;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Cron hooks for the weekly events digest sender.
+ */
+class WeeklyDigestHooks {
+
+	/**
+	 * Cron hook name for the recurring tick.
+	 */
+	const CRON_HOOK = 'fair_audience_weekly_digest_tick';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_filter( 'cron_schedules', array( static::class, 'add_cron_schedule' ) );
+
+		add_action( self::CRON_HOOK, array( static::class, 'run_due' ) );
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + MINUTE_IN_SECONDS, 'fair_audience_every_five_minutes', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Register the shared 5-minute cron schedule.
+	 *
+	 * Mirrors ScheduledMessageHooks::add_cron_schedule so both coexist; the
+	 * `isset()` guard makes adding the same key twice a no-op.
+	 *
+	 * @param array $schedules Existing schedules.
+	 * @return array
+	 */
+	public static function add_cron_schedule( $schedules ) {
+		if ( ! isset( $schedules['fair_audience_every_five_minutes'] ) ) {
+			$schedules['fair_audience_every_five_minutes'] = array(
+				'interval' => 5 * MINUTE_IN_SECONDS,
+				'display'  => __( 'Every 5 minutes (fair-audience)', 'fair-audience' ),
+			);
+		}
+		return $schedules;
+	}
+
+	/**
+	 * Cron tick: send the digest if it's enabled, due, and not already sent
+	 * for the current ISO week.
+	 */
+	public static function run_due() {
+		$config = get_option( 'fair_audience_weekly_digest', WeeklyDigestRenderer::default_config() );
+
+		if ( empty( $config['enabled'] ) || empty( $config['source_slug'] ) ) {
+			return;
+		}
+
+		if ( ! class_exists( 'FairEvents\Services\WeeklyEventsProvider' ) ) {
+			return;
+		}
+
+		$now              = new \DateTime( 'now', wp_timezone() );
+		$current_iso_week = $now->format( 'o' ) . '-W' . $now->format( 'W' );
+
+		if ( get_option( 'fair_audience_weekly_digest_last_sent_week', '' ) === $current_iso_week ) {
+			return;
+		}
+
+		if ( ! self::is_due( $now, (int) $config['day_of_week'], $config['time_of_day'] ) ) {
+			return;
+		}
+
+		// Write the guard before dispatch: a mid-send crash must not resend on
+		// the next tick, mirroring the at-most-once contract of ScheduledMessageHooks.
+		update_option( 'fair_audience_weekly_digest_last_sent_week', $current_iso_week );
+
+		self::dispatch( $config );
+	}
+
+	/**
+	 * Whether now (site tz) has reached this week's configured day/time.
+	 *
+	 * @param \DateTime $now         Current time in site timezone.
+	 * @param int       $day_of_week ISO day of week (1=Monday..7=Sunday).
+	 * @param string    $time_of_day 'HH:MM'.
+	 * @return bool
+	 */
+	private static function is_due( \DateTime $now, $day_of_week, $time_of_day ) {
+		list( $hour, $minute ) = array_map( 'intval', explode( ':', $time_of_day ) );
+
+		$due = clone $now;
+		$due->setISODate( (int) $now->format( 'o' ), (int) $now->format( 'W' ), $day_of_week );
+		$due->setTime( $hour, $minute, 0 );
+
+		return $now >= $due;
+	}
+
+	/**
+	 * Render and send the digest, recording the outcome.
+	 *
+	 * @param array $config Sanitized digest config.
+	 */
+	private static function dispatch( array $config ) {
+		try {
+			list( $year, $week_num ) = WeeklyDigestRenderer::resolve_week_scope( $config['week_scope'] );
+
+			$provider = new \FairEvents\Services\WeeklyEventsProvider();
+			$week     = $provider->get_week( $config['source_slug'], $year, $week_num );
+
+			if ( is_wp_error( $week ) ) {
+				self::record_result( 'failed', $week->get_error_message() );
+				return;
+			}
+
+			if ( ! empty( $config['skip_empty'] ) && WeeklyDigestRenderer::is_week_empty( $week ) ) {
+				self::record_result( 'skipped', __( 'No events scheduled this week.', 'fair-audience' ) );
+				return;
+			}
+
+			$subject = WeeklyDigestRenderer::render_subject( $config['subject'], $week );
+			$html    = WeeklyDigestRenderer::render( $week, $config['intro'] );
+
+			$email_service = new EmailService();
+			$results       = $email_service->send_bulk_custom_mail_to_all( $subject, $html, true );
+
+			self::record_result(
+				'sent',
+				sprintf(
+					/* translators: 1: sent count, 2: failed count, 3: skipped count */
+					__( 'Sent to %1$d, failed %2$d, skipped %3$d.', 'fair-audience' ),
+					count( $results['sent'] ),
+					count( $results['failed'] ),
+					count( $results['skipped'] )
+				)
+			);
+		} catch ( \Throwable $e ) {
+			self::record_result( 'failed', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Persist the outcome of the last cron run.
+	 *
+	 * @param string $status  'sent', 'failed', or 'skipped'.
+	 * @param string $message Human-readable detail.
+	 */
+	private static function record_result( $status, $message ) {
+		update_option(
+			'fair_audience_weekly_digest_last_run_result',
+			array(
+				'status'    => $status,
+				'timestamp' => current_time( 'mysql' ),
+				'message'   => $message,
+			)
+		);
+	}
+}

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -2110,6 +2110,86 @@ class EmailService {
 	}
 
 	/**
+	 * Send pre-rendered HTML content to a raw email address.
+	 *
+	 * Unlike `send_custom_mail*()`, this has no Participant to resolve
+	 * placeholders or an unsubscribe link for — used for admin-facing sends
+	 * (e.g. the weekly digest "send test to me").
+	 *
+	 * @param string $to_email Recipient email address.
+	 * @param string $subject  Email subject.
+	 * @param string $content  Email content (HTML).
+	 * @return bool Whether wp_mail() accepted the message.
+	 */
+	public function send_html_mail_to_address( $to_email, $subject, $content ) {
+		if ( empty( $to_email ) || ! is_email( $to_email ) ) {
+			return false;
+		}
+
+		$site_name = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+		$message = '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #333333; background-color: #f4f4f4;">
+	<table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f4;">
+		<tr>
+			<td align="center" style="padding: 20px 0;">
+				<table width="600" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+					<!-- Header -->
+					<tr>
+						<td style="background-color: #0073aa; color: #ffffff; padding: 30px; border-radius: 8px 8px 0 0; text-align: center;">
+							<h1 style="margin: 0; font-size: 24px; font-weight: bold;">' . esc_html( $site_name ) . '</h1>
+						</td>
+					</tr>
+
+					<!-- Content -->
+					<tr>
+						<td style="padding: 40px 30px;">
+							<div style="margin: 0; font-size: 16px;">
+								' . wp_kses_post( $content ) . '
+							</div>
+						</td>
+					</tr>
+
+					<!-- Footer -->
+					<tr>
+						<td style="background-color: #f8f8f8; padding: 20px 30px; border-radius: 0 0 8px 8px; text-align: center; font-size: 12px; color: #666666;">
+							<p style="margin: 0;">
+								' . esc_html( $site_name ) . '
+							</p>
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+</body>
+</html>';
+
+		add_filter(
+			'wp_mail_content_type',
+			function () {
+				return 'text/html';
+			}
+		);
+
+		$result = wp_mail( $to_email, $subject, $this->append_branding_footer( $message ) );
+
+		remove_filter(
+			'wp_mail_content_type',
+			function () {
+				return 'text/html';
+			}
+		);
+
+		return $result;
+	}
+
+	/**
 	 * Render questionnaire answers as `<tr>` rows for the email tables.
 	 *
 	 * Shared by signup-answers, form-confirmation, form-notification and signup

--- a/fair-audience/src/Services/WeeklyDigestRenderer.php
+++ b/fair-audience/src/Services/WeeklyDigestRenderer.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Weekly Digest Renderer
+ *
+ * Turns a WeeklyEventsProvider week ({ source, week, days }) into the inner
+ * HTML body used for the digest preview, test-send, and cron send — one
+ * renderer shared by all three so the mail participants receive always
+ * matches what an admin previewed.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Renders and sanitizes weekly digest content.
+ */
+class WeeklyDigestRenderer {
+
+	/**
+	 * Default digest configuration.
+	 *
+	 * @return array Default config.
+	 */
+	public static function default_config() {
+		return array(
+			'enabled'     => false,
+			'source_slug' => '',
+			'day_of_week' => 1,
+			'time_of_day' => '08:00',
+			'week_scope'  => 'current',
+			'skip_empty'  => true,
+			'subject'     => __( 'This week’s events: {week_start} – {week_end}', 'fair-audience' ),
+			'intro'       => '',
+		);
+	}
+
+	/**
+	 * Sanitize the `fair_audience_weekly_digest` option value.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return array Sanitized config, merged over the defaults.
+	 */
+	public static function sanitize_config( $value ) {
+		$defaults = self::default_config();
+
+		if ( ! is_array( $value ) ) {
+			return $defaults;
+		}
+
+		$day_of_week = isset( $value['day_of_week'] ) ? (int) $value['day_of_week'] : $defaults['day_of_week'];
+		if ( $day_of_week < 1 || $day_of_week > 7 ) {
+			$day_of_week = $defaults['day_of_week'];
+		}
+
+		$time_of_day = isset( $value['time_of_day'] ) ? sanitize_text_field( $value['time_of_day'] ) : $defaults['time_of_day'];
+		if ( ! preg_match( '/^([01]\d|2[0-3]):[0-5]\d$/', $time_of_day ) ) {
+			$time_of_day = $defaults['time_of_day'];
+		}
+
+		$week_scope = isset( $value['week_scope'] ) ? sanitize_text_field( $value['week_scope'] ) : $defaults['week_scope'];
+		if ( ! in_array( $week_scope, array( 'current', 'next' ), true ) ) {
+			$week_scope = $defaults['week_scope'];
+		}
+
+		return array(
+			'enabled'     => ! empty( $value['enabled'] ),
+			'source_slug' => isset( $value['source_slug'] ) ? sanitize_title( $value['source_slug'] ) : $defaults['source_slug'],
+			'day_of_week' => $day_of_week,
+			'time_of_day' => $time_of_day,
+			'week_scope'  => $week_scope,
+			'skip_empty'  => isset( $value['skip_empty'] ) ? ! empty( $value['skip_empty'] ) : $defaults['skip_empty'],
+			'subject'     => isset( $value['subject'] ) ? sanitize_text_field( $value['subject'] ) : $defaults['subject'],
+			'intro'       => isset( $value['intro'] ) ? wp_kses_post( $value['intro'] ) : $defaults['intro'],
+		);
+	}
+
+	/**
+	 * Whether a week has any events across its days.
+	 *
+	 * @param array $week Week data from WeeklyEventsProvider::get_week().
+	 * @return bool True when every day is empty.
+	 */
+	public static function is_week_empty( array $week ) {
+		foreach ( $week['days'] as $day ) {
+			if ( ! empty( $day['events'] ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Render the digest subject, replacing week placeholders.
+	 *
+	 * @param string $subject_template Subject with {week_start}/{week_end} placeholders.
+	 * @param array  $week             Week data from WeeklyEventsProvider::get_week().
+	 * @return string Rendered subject.
+	 */
+	public static function render_subject( $subject_template, array $week ) {
+		return str_replace(
+			array( '{week_start}', '{week_end}' ),
+			array( $week['week']['start'], $week['week']['end'] ),
+			$subject_template
+		);
+	}
+
+	/**
+	 * Resolve the ISO year/week for 'current' or 'next' week scope.
+	 *
+	 * @param string $week_scope 'current' or 'next'.
+	 * @return array{0:int,1:int} Year and ISO week number.
+	 */
+	public static function resolve_week_scope( $week_scope ) {
+		$now = new \DateTime( 'now', wp_timezone() );
+
+		if ( 'next' === $week_scope ) {
+			$now->modify( '+7 days' );
+		}
+
+		return array( (int) $now->format( 'o' ), (int) $now->format( 'W' ) );
+	}
+
+	/**
+	 * Render the digest's inner HTML body for a week.
+	 *
+	 * Returned HTML is the *inner* content — the caller (EmailService) wraps
+	 * it in the shared branded email template via `wp_kses_post`.
+	 *
+	 * @param array  $week  Week data from WeeklyEventsProvider::get_week().
+	 * @param string $intro Optional intro HTML (already sanitized).
+	 * @return string Inner HTML content.
+	 */
+	public static function render( array $week, $intro = '' ) {
+		$html = '';
+
+		if ( ! empty( $intro ) ) {
+			$html .= '<div style="margin: 0 0 20px 0;">' . wp_kses_post( $intro ) . '</div>';
+		}
+
+		foreach ( $week['days'] as $day ) {
+			if ( empty( $day['events'] ) ) {
+				continue;
+			}
+
+			$html .= '<h3 style="margin: 20px 0 10px 0; font-size: 16px;">'
+				. esc_html( $day['weekday'] ) . ', ' . esc_html( $day['month_name'] ) . ' ' . esc_html( $day['day_num'] )
+				. '</h3>';
+
+			$html .= '<ul style="margin: 0 0 10px 0; padding-left: 20px;">';
+
+			foreach ( $day['events'] as $event ) {
+				$html .= '<li style="margin-bottom: 6px;">';
+
+				if ( ! empty( $event['all_day'] ) ) {
+					$html .= '<strong>' . esc_html__( 'All day', 'fair-audience' ) . '</strong> — ';
+				} elseif ( ! empty( $event['start_time'] ) ) {
+					$html .= '<strong>' . esc_html( $event['start_time'] ) . '</strong> — ';
+				}
+
+				$title = $event['title'];
+				if ( ! empty( $event['url'] ) ) {
+					$html .= '<a href="' . esc_url( $event['url'] ) . '">' . esc_html( $title ) . '</a>';
+				} else {
+					$html .= esc_html( $title );
+				}
+
+				$html .= '</li>';
+			}
+
+			$html .= '</ul>';
+		}
+
+		if ( '' === $html ) {
+			$html = '<p>' . esc_html__( 'No events scheduled this week.', 'fair-audience' ) . '</p>';
+		}
+
+		return $html;
+	}
+}

--- a/fair-audience/src/Settings/Settings.php
+++ b/fair-audience/src/Settings/Settings.php
@@ -138,6 +138,70 @@ class Settings {
 			)
 		);
 
+		// Weekly digest configuration — single option object.
+		register_setting(
+			'fair_audience_settings',
+			'fair_audience_weekly_digest',
+			array(
+				'type'              => 'object',
+				'description'       => __( 'Weekly events digest configuration', 'fair-audience' ),
+				'sanitize_callback' => array( \FairAudience\Services\WeeklyDigestRenderer::class, 'sanitize_config' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'enabled'     => array( 'type' => 'boolean' ),
+							'source_slug' => array( 'type' => 'string' ),
+							'day_of_week' => array( 'type' => 'integer' ),
+							'time_of_day' => array( 'type' => 'string' ),
+							'week_scope'  => array( 'type' => 'string' ),
+							'skip_empty'  => array( 'type' => 'boolean' ),
+							'subject'     => array( 'type' => 'string' ),
+							'intro'       => array( 'type' => 'string' ),
+						),
+					),
+				),
+				'default'           => \FairAudience\Services\WeeklyDigestRenderer::default_config(),
+			)
+		);
+
+		// Runtime-written: last ISO week ('YYYY-Www') a digest was sent for.
+		register_setting(
+			'fair_audience_settings',
+			'fair_audience_weekly_digest_last_sent_week',
+			array(
+				'type'              => 'string',
+				'description'       => __( 'ISO week of the last sent weekly digest', 'fair-audience' ),
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => false,
+				'default'           => '',
+			)
+		);
+
+		// Runtime-written: outcome of the last digest cron run.
+		register_setting(
+			'fair_audience_settings',
+			'fair_audience_weekly_digest_last_run_result',
+			array(
+				'type'              => 'object',
+				'description'       => __( 'Outcome of the last weekly digest cron run', 'fair-audience' ),
+				'sanitize_callback' => function ( $value ) {
+					return is_array( $value ) ? $value : array();
+				},
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'status'    => array( 'type' => 'string' ),
+							'timestamp' => array( 'type' => 'string' ),
+							'message'   => array( 'type' => 'string' ),
+						),
+					),
+				),
+				'default'           => array(),
+			)
+		);
+
 		// Feature flag bundle toggles — UI state only, never overrides a
 		// wp-config constant (see Features::sanitize_option()).
 		register_setting(


### PR DESCRIPTION
## Summary

PR 2 of the weekly digest sequence for #916 (see [implementation plan](https://github.com/marcin-wosinek/fair-event-plugins/issues/916#issuecomment-4922823225) and [PR split](https://github.com/marcin-wosinek/fair-event-plugins/issues/916#issuecomment-4922877576)) — storage + backend on top of PR 1's `WeeklyEventsProvider`.

- Single `fair_audience_weekly_digest` option (`enabled`, `source_slug`, `day_of_week`, `time_of_day`, `week_scope`, `skip_empty`, `subject`, `intro`) plus runtime `last_sent_week` / `last_run_result` options, registered in `Settings.php`.
- `WeeklyDigestController` (`fair-audience/v1/weekly-digest`): `GET`/`PUT` config, `GET /sources` (enabled `fair-events` sources), `POST /preview` (render only), `POST /test` (send to the current admin). All routes require `manage_options`.
- `WeeklyDigestRenderer`: shared HTML/subject rendering, config sanitization, and week-scope resolution used by preview, test-send, and the cron.
- `WeeklyDigestHooks`: 5-minute cron tick, due check against the configured day/time in site timezone, `last_sent_week` written before dispatch for at-most-once delivery, skip-and-mark on an empty week when `skip_empty` is set, dispatch via `EmailService::send_bulk_custom_mail_to_all()`.
- `EmailService::send_html_mail_to_address()` — new helper for sending pre-rendered HTML to a raw address (used by the test-send route, which has no `Participant` to address).
- Deactivation now also clears `fair_audience_weekly_digest_tick`.

No admin UI in this PR — that's PR 3. No REST behavior change to any existing route.

Refs #916

## Test plan

- [x] `vendor/bin/phpcs` clean on all touched/new files
- [x] Manual WP-CLI `eval-file` check: all 4 routes register, `sanitize_config`/`default_config`/`render`/`render_subject`/`is_week_empty` behave as expected, cron tick schedules
- [ ] Automated API spec / Jest units — deferred to PR 4 per the issue's PR split
