### PR TITLE
Add Weekly Digest admin page to fair-audience

### DIFF
--- a/.changeset/weekly-digest-admin-page.md
+++ b/.changeset/weekly-digest-admin-page.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": minor
+---
+
+Add the Weekly Digest admin page: configure the enable toggle, event source, send day/time, week scope, skip-empty, subject, and intro text, with a live preview pane, send-test-to-me button, and a last-run summary.

--- a/fair-audience/src/Admin/AdminHooks.php
+++ b/fair-audience/src/Admin/AdminHooks.php
@@ -162,6 +162,18 @@ class AdminHooks {
 		// Hidden submenu page - Participant Detail.
 		$this->register_hidden_page( 'fair-audience-participant-detail' );
 
+		// Submenu page - Weekly Digest (requires stable fair-events).
+		if ( class_exists( 'FairEvents\Core\Plugin' ) ) {
+			add_submenu_page(
+				'fair-audience',
+				__( 'Weekly Digest', 'fair-audience' ),
+				__( 'Weekly Digest', 'fair-audience' ),
+				'manage_options',
+				'fair-audience-weekly-digest',
+				array( $this, 'render_weekly_digest_page' )
+			);
+		}
+
 		// Submenu page - Settings.
 		add_submenu_page(
 			'fair-audience',
@@ -214,6 +226,14 @@ class AdminHooks {
 	}
 
 	/**
+	 * Render Weekly Digest page.
+	 */
+	public function render_weekly_digest_page() {
+		$page = new WeeklyDigestPage();
+		$page->render();
+	}
+
+	/**
 	 * Enqueue admin scripts.
 	 *
 	 * @param string $hook Page hook.
@@ -259,6 +279,11 @@ class AdminHooks {
 					'features' => \FairAudience\Core\Features::all(),
 				)
 			);
+		}
+
+		// Weekly Digest page.
+		if ( 'fair-audience_page_fair-audience-weekly-digest' === $hook ) {
+			$this->enqueue_page_script( 'weekly-digest', $plugin_dir );
 		}
 	}
 

--- a/fair-audience/src/Admin/WeeklyDigestPage.php
+++ b/fair-audience/src/Admin/WeeklyDigestPage.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Weekly Digest Page
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Admin;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Weekly Digest admin page.
+ */
+class WeeklyDigestPage {
+	/**
+	 * Render page.
+	 */
+	public function render() {
+		?>
+		<div id="fair-audience-weekly-digest-root"></div>
+		<?php
+	}
+}

--- a/fair-audience/src/Admin/weekly-digest/WeeklyDigest.js
+++ b/fair-audience/src/Admin/weekly-digest/WeeklyDigest.js
@@ -1,0 +1,368 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	Notice,
+	Spinner,
+	ToggleControl,
+	SelectControl,
+	TextControl,
+	TextareaControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getDigestConfig,
+	saveDigestConfig,
+	getDigestSources,
+	previewDigest,
+	sendTestDigest,
+} from './weekly-digest-api.js';
+
+const WEEKDAY_LABELS = [
+	__('Monday', 'fair-audience'),
+	__('Tuesday', 'fair-audience'),
+	__('Wednesday', 'fair-audience'),
+	__('Thursday', 'fair-audience'),
+	__('Friday', 'fair-audience'),
+	__('Saturday', 'fair-audience'),
+	__('Sunday', 'fair-audience'),
+];
+
+/**
+ * Weekly Digest admin page.
+ *
+ * Lets admins configure and preview/test the weekly events digest email.
+ *
+ * @return {JSX.Element} The weekly digest page
+ */
+export default function WeeklyDigest() {
+	const [loading, setLoading] = useState(true);
+	const [saving, setSaving] = useState(false);
+	const [previewing, setPreviewing] = useState(false);
+	const [sendingTest, setSendingTest] = useState(false);
+	const [notice, setNotice] = useState(null);
+	const [config, setConfig] = useState(null);
+	const [lastSentWeek, setLastSentWeek] = useState('');
+	const [lastRunResult, setLastRunResult] = useState(null);
+	const [sources, setSources] = useState([]);
+	const [preview, setPreview] = useState(null);
+
+	useEffect(() => {
+		Promise.all([getDigestConfig(), getDigestSources()])
+			.then(([digest, sourceList]) => {
+				setConfig(digest.config);
+				setLastSentWeek(digest.last_sent_week);
+				setLastRunResult(digest.last_run_result);
+				setSources(sourceList);
+			})
+			.catch((err) => {
+				setNotice({
+					status: 'error',
+					message:
+						__(
+							'Failed to load the weekly digest: ',
+							'fair-audience'
+						) + (err.message || 'Unknown error'),
+				});
+			})
+			.finally(() => setLoading(false));
+	}, []);
+
+	const updateField = (field, value) => {
+		setConfig((prev) => ({ ...prev, [field]: value }));
+	};
+
+	const handleSave = () => {
+		setSaving(true);
+		saveDigestConfig(config)
+			.then((response) => {
+				setConfig(response.config);
+				setNotice({
+					status: 'success',
+					message: __(
+						'Weekly digest settings saved.',
+						'fair-audience'
+					),
+				});
+			})
+			.catch((err) => {
+				setNotice({
+					status: 'error',
+					message:
+						__('Failed to save: ', 'fair-audience') +
+						(err.message || 'Unknown error'),
+				});
+			})
+			.finally(() => setSaving(false));
+	};
+
+	const handlePreview = () => {
+		setPreviewing(true);
+		setPreview(null);
+		previewDigest()
+			.then((result) => setPreview(result))
+			.catch((err) => {
+				setNotice({
+					status: 'error',
+					message:
+						__('Failed to build the preview: ', 'fair-audience') +
+						(err.message || 'Unknown error'),
+				});
+			})
+			.finally(() => setPreviewing(false));
+	};
+
+	const handleSendTest = () => {
+		setSendingTest(true);
+		sendTestDigest()
+			.then((result) => {
+				setNotice({
+					status: 'success',
+					message: sprintf(
+						/* translators: %s: email address the test digest was sent to */
+						__('Test digest sent to %s.', 'fair-audience'),
+						result.sent_to
+					),
+				});
+			})
+			.catch((err) => {
+				setNotice({
+					status: 'error',
+					message:
+						__(
+							'Failed to send the test digest: ',
+							'fair-audience'
+						) + (err.message || 'Unknown error'),
+				});
+			})
+			.finally(() => setSendingTest(false));
+	};
+
+	if (loading || !config) {
+		return (
+			<div className="wrap">
+				<h1>{__('Weekly Digest', 'fair-audience')}</h1>
+				<Spinner />
+			</div>
+		);
+	}
+
+	const sourceOptions = [
+		{ value: '', label: __('Select a source…', 'fair-audience') },
+		...sources.map((source) => ({
+			value: source.slug,
+			label: source.name,
+		})),
+	];
+
+	const dayOptions = WEEKDAY_LABELS.map((label, index) => ({
+		value: String(index + 1),
+		label,
+	}));
+
+	return (
+		<div className="wrap">
+			<h1>{__('Weekly Digest', 'fair-audience')}</h1>
+
+			{notice && (
+				<Notice
+					status={notice.status}
+					isDismissible={true}
+					onRemove={() => setNotice(null)}
+				>
+					{notice.message}
+				</Notice>
+			)}
+
+			<Card style={{ marginTop: '1rem' }}>
+				<CardHeader>
+					<h2 style={{ margin: 0 }}>
+						{__('Settings', 'fair-audience')}
+					</h2>
+				</CardHeader>
+				<CardBody>
+					<ToggleControl
+						label={__('Send the weekly digest', 'fair-audience')}
+						help={__(
+							'When enabled, an email with this week’s events is sent automatically on the day and time below.',
+							'fair-audience'
+						)}
+						checked={config.enabled}
+						onChange={(value) => updateField('enabled', value)}
+					/>
+
+					<SelectControl
+						label={__('Event source', 'fair-audience')}
+						value={config.source_slug}
+						options={sourceOptions}
+						onChange={(value) => updateField('source_slug', value)}
+					/>
+
+					<SelectControl
+						label={__('Day of week', 'fair-audience')}
+						value={String(config.day_of_week)}
+						options={dayOptions}
+						onChange={(value) =>
+							updateField('day_of_week', parseInt(value, 10))
+						}
+					/>
+
+					<TextControl
+						label={__('Time of day', 'fair-audience')}
+						type="time"
+						value={config.time_of_day}
+						onChange={(value) => updateField('time_of_day', value)}
+					/>
+
+					<SelectControl
+						label={__('Which week to include', 'fair-audience')}
+						value={config.week_scope}
+						options={[
+							{
+								value: 'current',
+								label: __('Current week', 'fair-audience'),
+							},
+							{
+								value: 'next',
+								label: __('Next week', 'fair-audience'),
+							},
+						]}
+						onChange={(value) => updateField('week_scope', value)}
+					/>
+
+					<ToggleControl
+						label={__(
+							'Skip sending when the week has no events',
+							'fair-audience'
+						)}
+						checked={config.skip_empty}
+						onChange={(value) => updateField('skip_empty', value)}
+					/>
+
+					<TextControl
+						label={__('Subject', 'fair-audience')}
+						help={__(
+							'Use {week_start} and {week_end} to insert the week’s dates.',
+							'fair-audience'
+						)}
+						value={config.subject}
+						onChange={(value) => updateField('subject', value)}
+					/>
+
+					<TextareaControl
+						label={__('Intro text', 'fair-audience')}
+						help={__(
+							'Optional text shown above the list of events.',
+							'fair-audience'
+						)}
+						value={config.intro}
+						onChange={(value) => updateField('intro', value)}
+					/>
+
+					<Button
+						variant="primary"
+						onClick={handleSave}
+						isBusy={saving}
+						disabled={saving}
+					>
+						{__('Save settings', 'fair-audience')}
+					</Button>
+				</CardBody>
+			</Card>
+
+			<Card style={{ marginTop: '1rem' }}>
+				<CardHeader>
+					<h2 style={{ margin: 0 }}>
+						{__('Last run', 'fair-audience')}
+					</h2>
+				</CardHeader>
+				<CardBody>
+					{!lastSentWeek && !lastRunResult?.timestamp ? (
+						<p>
+							{__('The digest has not run yet.', 'fair-audience')}
+						</p>
+					) : (
+						<p>
+							{sprintf(
+								/* translators: 1: ISO week that was last sent, 2: result status (sent, failed, or skipped) */
+								__(
+									'Last sent for week %1$s — %2$s',
+									'fair-audience'
+								),
+								lastSentWeek || __('n/a', 'fair-audience'),
+								lastRunResult?.status ||
+									__('unknown', 'fair-audience')
+							)}
+						</p>
+					)}
+				</CardBody>
+			</Card>
+
+			<Card style={{ marginTop: '1rem' }}>
+				<CardHeader>
+					<h2 style={{ margin: 0 }}>
+						{__('Preview & test', 'fair-audience')}
+					</h2>
+				</CardHeader>
+				<CardBody>
+					<Button
+						variant="secondary"
+						onClick={handlePreview}
+						isBusy={previewing}
+						disabled={previewing}
+						style={{ marginRight: '8px' }}
+					>
+						{__('Preview', 'fair-audience')}
+					</Button>
+
+					<Button
+						variant="secondary"
+						onClick={handleSendTest}
+						isBusy={sendingTest}
+						disabled={sendingTest}
+					>
+						{__('Send test to me', 'fair-audience')}
+					</Button>
+
+					{preview && (
+						<div style={{ marginTop: '16px' }}>
+							{preview.empty && (
+								<Notice status="warning" isDismissible={false}>
+									{__(
+										'The selected week has no events.',
+										'fair-audience'
+									)}
+								</Notice>
+							)}
+							<p>
+								<strong>
+									{__('Subject:', 'fair-audience')}
+								</strong>{' '}
+								{preview.subject}
+							</p>
+							<div
+								style={{
+									border: '1px solid #ddd',
+									padding: '16px',
+									background: '#fff',
+								}}
+								dangerouslySetInnerHTML={{
+									__html: preview.html,
+								}}
+							/>
+						</div>
+					)}
+				</CardBody>
+			</Card>
+		</div>
+	);
+}

--- a/fair-audience/src/Admin/weekly-digest/index.js
+++ b/fair-audience/src/Admin/weekly-digest/index.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import WeeklyDigest from './WeeklyDigest.js';
+
+/**
+ * Initialize the weekly digest page
+ */
+domReady(() => {
+	const container = document.getElementById(
+		'fair-audience-weekly-digest-root'
+	);
+	if (container) {
+		const root = createRoot(container);
+		root.render(<WeeklyDigest />);
+	}
+});

--- a/fair-audience/src/Admin/weekly-digest/weekly-digest-api.js
+++ b/fair-audience/src/Admin/weekly-digest/weekly-digest-api.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Load the weekly digest config plus last-run info.
+ *
+ * @return {Promise<Object>} Promise resolving to `{ config, last_sent_week, last_run_result }`.
+ */
+export function getDigestConfig() {
+	return apiFetch({ path: '/fair-audience/v1/weekly-digest' });
+}
+
+/**
+ * Save the weekly digest config.
+ *
+ * @param {Object} config Config fields to update.
+ * @return {Promise<Object>} Promise resolving to `{ config }`.
+ */
+export function saveDigestConfig(config) {
+	return apiFetch({
+		path: '/fair-audience/v1/weekly-digest',
+		method: 'PUT',
+		data: config,
+	});
+}
+
+/**
+ * Load the enabled fair-events sources available to pick from.
+ *
+ * @return {Promise<Array>} Promise resolving to a list of `{ slug, name }`.
+ */
+export function getDigestSources() {
+	return apiFetch({ path: '/fair-audience/v1/weekly-digest/sources' });
+}
+
+/**
+ * Render the configured week's digest HTML without sending it.
+ *
+ * @return {Promise<Object>} Promise resolving to `{ subject, html, week, empty }`.
+ */
+export function previewDigest() {
+	return apiFetch({
+		path: '/fair-audience/v1/weekly-digest/preview',
+		method: 'POST',
+	});
+}
+
+/**
+ * Render and send one digest email to the current admin.
+ *
+ * @return {Promise<Object>} Promise resolving to `{ sent_to }`.
+ */
+export function sendTestDigest() {
+	return apiFetch({
+		path: '/fair-audience/v1/weekly-digest/test',
+		method: 'POST',
+	});
+}

--- a/fair-audience/webpack.config.cjs
+++ b/fair-audience/webpack.config.cjs
@@ -34,6 +34,10 @@ const customConfig = {
 			process.cwd(),
 			'src/Admin/participant-detail/index.js',
 		),
+		'admin/weekly-digest/index': path.resolve(
+			process.cwd(),
+			'src/Admin/weekly-digest/index.js',
+		),
 	}),
 	plugins: [
 		...defaultConfig.plugins,


### PR DESCRIPTION
## Summary
- PR 3 of the weekly digest sequence ([plan](https://github.com/marcin-wosinek/fair-event-plugins/issues/916#issuecomment-4922823225)) — Layer 4, the admin page.
- New `fair-audience/src/Admin/weekly-digest/` React page: enable toggle, event source picker, day-of-week/time, week scope, skip-empty, subject (with `{week_start}`/`{week_end}` placeholders), intro text, a live preview pane, "Send test to me", and a last-run summary.
- `WeeklyDigestPage.php` renders the mount point; `AdminHooks.php` registers the submenu (gated on `class_exists('FairEvents\Core\Plugin')`, no feature flag — the digest ships stable) and enqueues the built script.
- New webpack entry `admin/weekly-digest/index`.
- Depends on #1070 (PR 2 — digest storage + backend); based on that branch.

## Test plan
- [x] `npm run build` in `fair-audience`
- [x] `npm run format` in `fair-audience`
- [x] `vendor/bin/phpcs` on changed PHP files (no new errors; pre-existing ones in `AdminHooks.php` untouched)
- [x] `npm run test:js` in `fair-audience` — passing
- [x] Verified in the local WP env: `Weekly Digest` submenu registers between "By Event" and "Settings", REST routes resolve, built asset loads

Refs #916
