### PR TITLE
Add test coverage for the weekly digest

### DIFF
--- a/.changeset/weekly-digest-tests.md
+++ b/.changeset/weekly-digest-tests.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": patch
+---
+
+Add test coverage for the weekly events digest (issue #916): PHPUnit tests for `WeeklyDigestRenderer` (config sanitizing, HTML shaping) and `WeeklyDigestHooks` (due/idempotency guard), a REST API spec for `WeeklyDigestController`, and a component test for the Weekly Digest admin page. Also adds a PHPUnit setup (`phpunit.xml`, `__tests__/bootstrap.php`) to fair-audience, mirroring fair-events.

--- a/fair-audience/__tests__/Hooks/WeeklyDigestHooksTest.php
+++ b/fair-audience/__tests__/Hooks/WeeklyDigestHooksTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * WeeklyDigestHooks due/idempotency tests
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Tests\Hooks;
+
+use PHPUnit\Framework\TestCase;
+use FairAudience\Hooks\WeeklyDigestHooks;
+use ReflectionMethod;
+use DateTime;
+use DateTimeZone;
+
+require_once __DIR__ . '/fixtures-weekly-events-provider-stub.php';
+
+/**
+ * Validates the cron tick's week-boundary due-check and the at-most-once
+ * `last_sent_week` idempotency guard. The full render/send path is covered
+ * by the API integration tests, not here.
+ */
+class WeeklyDigestHooksTest extends TestCase {
+
+	/**
+	 * Reset the fake options store before each test.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['_fair_test_options'] = array();
+	}
+
+	/**
+	 * Invoke the private static is_due() via reflection.
+	 *
+	 * @param DateTime $now         Current time in site timezone.
+	 * @param int      $day_of_week ISO day of week (1=Monday..7=Sunday).
+	 * @param string   $time_of_day 'HH:MM'.
+	 * @return bool
+	 */
+	private function is_due( DateTime $now, $day_of_week, $time_of_day ) {
+		$method = new ReflectionMethod( WeeklyDigestHooks::class, 'is_due' );
+		return $method->invoke( null, $now, $day_of_week, $time_of_day );
+	}
+
+	/**
+	 * Not yet due: same day, one minute before the configured time.
+	 */
+	public function test_is_due_false_before_configured_time_on_the_day() {
+		// 2026-07-06 is a Monday.
+		$now = new DateTime( '2026-07-06 07:59:00', new DateTimeZone( 'UTC' ) );
+		$this->assertFalse( $this->is_due( $now, 1, '08:00' ) );
+	}
+
+	/**
+	 * Due: exactly at the configured day/time.
+	 */
+	public function test_is_due_true_at_configured_time_on_the_day() {
+		$now = new DateTime( '2026-07-06 08:00:00', new DateTimeZone( 'UTC' ) );
+		$this->assertTrue( $this->is_due( $now, 1, '08:00' ) );
+	}
+
+	/**
+	 * Due: any time after the configured day/time.
+	 */
+	public function test_is_due_true_after_configured_time_on_the_day() {
+		$now = new DateTime( '2026-07-06 12:00:00', new DateTimeZone( 'UTC' ) );
+		$this->assertTrue( $this->is_due( $now, 1, '08:00' ) );
+	}
+
+	/**
+	 * Not due yet: configured day hasn't arrived this week.
+	 */
+	public function test_is_due_false_on_an_earlier_day_of_the_same_week() {
+		// Configured for Wednesday (3); now is Monday.
+		$now = new DateTime( '2026-07-06 23:00:00', new DateTimeZone( 'UTC' ) );
+		$this->assertFalse( $this->is_due( $now, 3, '08:00' ) );
+	}
+
+	/**
+	 * A disabled digest never touches the idempotency-guard options.
+	 */
+	public function test_run_due_does_nothing_when_disabled() {
+		$GLOBALS['_fair_test_options']['fair_audience_weekly_digest'] = array(
+			'enabled'     => false,
+			'source_slug' => 'demo',
+			'day_of_week' => 1,
+			'time_of_day' => '00:00',
+			'week_scope'  => 'current',
+			'skip_empty'  => true,
+		);
+
+		WeeklyDigestHooks::run_due();
+
+		$this->assertArrayNotHasKey( 'fair_audience_weekly_digest_last_sent_week', $GLOBALS['_fair_test_options'] );
+		$this->assertArrayNotHasKey( 'fair_audience_weekly_digest_last_run_result', $GLOBALS['_fair_test_options'] );
+	}
+
+	/**
+	 * An enabled digest with no source configured never dispatches.
+	 */
+	public function test_run_due_does_nothing_without_a_configured_source() {
+		$GLOBALS['_fair_test_options']['fair_audience_weekly_digest'] = array(
+			'enabled'     => true,
+			'source_slug' => '',
+			'day_of_week' => 1,
+			'time_of_day' => '00:00',
+			'week_scope'  => 'current',
+			'skip_empty'  => true,
+		);
+
+		WeeklyDigestHooks::run_due();
+
+		$this->assertArrayNotHasKey( 'fair_audience_weekly_digest_last_sent_week', $GLOBALS['_fair_test_options'] );
+	}
+
+	/**
+	 * The last_sent_week guard wins even when the day/time check says "due".
+	 */
+	public function test_run_due_skips_a_week_already_marked_sent() {
+		$now              = new DateTime( 'now', wp_timezone() );
+		$current_iso_week = $now->format( 'o' ) . '-W' . $now->format( 'W' );
+
+		// Configure it as due (day/time comfortably in the past) but already
+		// marked sent for the current ISO week — the guard must win even
+		// though the day/time check would otherwise say "due".
+		$GLOBALS['_fair_test_options']['fair_audience_weekly_digest']                = array(
+			'enabled'     => true,
+			'source_slug' => 'demo',
+			'day_of_week' => (int) $now->format( 'N' ),
+			'time_of_day' => '00:00',
+			'week_scope'  => 'current',
+			'skip_empty'  => true,
+		);
+		$GLOBALS['_fair_test_options']['fair_audience_weekly_digest_last_sent_week'] = $current_iso_week;
+
+		WeeklyDigestHooks::run_due();
+
+		$this->assertArrayNotHasKey( 'fair_audience_weekly_digest_last_run_result', $GLOBALS['_fair_test_options'] );
+		$this->assertSame( $current_iso_week, $GLOBALS['_fair_test_options']['fair_audience_weekly_digest_last_sent_week'] );
+	}
+
+	/**
+	 * A newly-due week dispatches once, marks last_sent_week, and a second
+	 * tick in the same week is a no-op (the idempotency guard, not just
+	 * is_due, is what stops the resend).
+	 */
+	public function test_run_due_dispatches_once_for_a_new_due_week() {
+		$now = new DateTime( 'now', wp_timezone() );
+		// The exact current minute so "now >= due" holds regardless of the
+		// instant the test happens to run.
+		$time_of_day      = $now->format( 'H:i' );
+		$current_iso_week = $now->format( 'o' ) . '-W' . $now->format( 'W' );
+
+		$GLOBALS['_fair_test_options']['fair_audience_weekly_digest'] = array(
+			'enabled'     => true,
+			'source_slug' => 'demo',
+			'day_of_week' => (int) $now->format( 'N' ),
+			'time_of_day' => $time_of_day,
+			'week_scope'  => 'current',
+			'skip_empty'  => true,
+		);
+
+		WeeklyDigestHooks::run_due();
+
+		$this->assertSame( $current_iso_week, $GLOBALS['_fair_test_options']['fair_audience_weekly_digest_last_sent_week'] );
+		$this->assertSame( 'skipped', $GLOBALS['_fair_test_options']['fair_audience_weekly_digest_last_run_result']['status'] );
+
+		// A second tick in the same week must not dispatch again — record_result
+		// is only written on a dispatch, so clearing it and re-running proves
+		// the guard (not just is_due) is what stops the resend.
+		unset( $GLOBALS['_fair_test_options']['fair_audience_weekly_digest_last_run_result'] );
+		WeeklyDigestHooks::run_due();
+		$this->assertArrayNotHasKey( 'fair_audience_weekly_digest_last_run_result', $GLOBALS['_fair_test_options'] );
+	}
+}

--- a/fair-audience/__tests__/Hooks/fixtures-weekly-events-provider-stub.php
+++ b/fair-audience/__tests__/Hooks/fixtures-weekly-events-provider-stub.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Test-only stand-in for FairEvents\Services\WeeklyEventsProvider.
+ *
+ * Only used so class_exists( 'FairEvents\Services\WeeklyEventsProvider' )
+ * reports true in WeeklyDigestHooksTest without pulling in the fair-events
+ * plugin. It always reports an empty week, which — combined with the
+ * digest's default skip_empty=true — is enough to exercise
+ * WeeklyDigestHooks::run_due() end to end without reaching EmailService.
+ *
+ * @package FairAudience
+ */
+
+namespace FairEvents\Services;
+
+/**
+ * Minimal stand-in for FairEvents\Services\WeeklyEventsProvider.
+ */
+class WeeklyEventsProvider {
+
+	/**
+	 * Always returns an empty week.
+	 *
+	 * @param string $source_slug Event source slug.
+	 * @return array Week data with no events.
+	 */
+	public function get_week( $source_slug ) {
+		return array(
+			'source' => $source_slug,
+			'week'   => array(
+				'start' => '2026-07-06',
+				'end'   => '2026-07-12',
+			),
+			'days'   => array(),
+		);
+	}
+}

--- a/fair-audience/__tests__/Services/WeeklyDigestRendererTest.php
+++ b/fair-audience/__tests__/Services/WeeklyDigestRendererTest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * WeeklyDigestRenderer sanitize/render tests
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairAudience\Services\WeeklyDigestRenderer;
+
+/**
+ * Validates the pure config-sanitizing and HTML-shaping logic. Live WP
+ * rendering (EmailService wrapping, actual mail delivery) is covered by
+ * the API integration tests, not here.
+ */
+class WeeklyDigestRendererTest extends TestCase {
+
+	/**
+	 * Build a minimal week structure with the given days.
+	 *
+	 * @param array $days Day entries, each `{ weekday, month_name, day_num, events }`.
+	 * @return array Week data shaped like WeeklyEventsProvider::get_week().
+	 */
+	private function week( array $days ) {
+		return array(
+			'source' => 'demo',
+			'week'   => array(
+				'start' => '2026-07-06',
+				'end'   => '2026-07-12',
+			),
+			'days'   => $days,
+		);
+	}
+
+	/**
+	 * Non-array input falls back to the defaults untouched.
+	 */
+	public function test_sanitize_config_falls_back_to_defaults_for_non_array() {
+		$this->assertSame( WeeklyDigestRenderer::default_config(), WeeklyDigestRenderer::sanitize_config( 'not-an-array' ) );
+	}
+
+	/**
+	 * A day_of_week value outside 1-7 falls back to the default.
+	 */
+	public function test_sanitize_config_rejects_out_of_range_day_of_week() {
+		$config = WeeklyDigestRenderer::sanitize_config( array( 'day_of_week' => 9 ) );
+		$this->assertSame( 1, $config['day_of_week'] );
+	}
+
+	/**
+	 * A time_of_day value not matching HH:MM falls back to the default.
+	 */
+	public function test_sanitize_config_rejects_malformed_time_of_day() {
+		$config = WeeklyDigestRenderer::sanitize_config( array( 'time_of_day' => 'not-a-time' ) );
+		$this->assertSame( '08:00', $config['time_of_day'] );
+	}
+
+	/**
+	 * A well-formed HH:MM value is kept as-is.
+	 */
+	public function test_sanitize_config_accepts_valid_time_of_day() {
+		$config = WeeklyDigestRenderer::sanitize_config( array( 'time_of_day' => '23:45' ) );
+		$this->assertSame( '23:45', $config['time_of_day'] );
+	}
+
+	/**
+	 * A week_scope value outside 'current'/'next' falls back to the default.
+	 */
+	public function test_sanitize_config_rejects_invalid_week_scope() {
+		$config = WeeklyDigestRenderer::sanitize_config( array( 'week_scope' => 'yesterday' ) );
+		$this->assertSame( 'current', $config['week_scope'] );
+	}
+
+	/**
+	 * 'next' is a valid week_scope value.
+	 */
+	public function test_sanitize_config_accepts_next_week_scope() {
+		$config = WeeklyDigestRenderer::sanitize_config( array( 'week_scope' => 'next' ) );
+		$this->assertSame( 'next', $config['week_scope'] );
+	}
+
+	/**
+	 * Truthy/falsy scalars for enabled/skip_empty are coerced to booleans.
+	 */
+	public function test_sanitize_config_coerces_enabled_and_skip_empty_to_booleans() {
+		$config = WeeklyDigestRenderer::sanitize_config(
+			array(
+				'enabled'    => 1,
+				'skip_empty' => 0,
+			)
+		);
+		$this->assertTrue( $config['enabled'] );
+		$this->assertFalse( $config['skip_empty'] );
+	}
+
+	/**
+	 * The source_slug is run through sanitize_title().
+	 */
+	public function test_sanitize_config_slugifies_source() {
+		$config = WeeklyDigestRenderer::sanitize_config( array( 'source_slug' => 'Main Calendar' ) );
+		$this->assertSame( 'main-calendar', $config['source_slug'] );
+	}
+
+	/**
+	 * A week is empty when every day has no events.
+	 */
+	public function test_is_week_empty_true_when_no_day_has_events() {
+		$week = $this->week(
+			array(
+				array( 'events' => array() ),
+				array( 'events' => array() ),
+			)
+		);
+		$this->assertTrue( WeeklyDigestRenderer::is_week_empty( $week ) );
+	}
+
+	/**
+	 * A week is not empty when at least one day has events.
+	 */
+	public function test_is_week_empty_false_when_any_day_has_events() {
+		$week = $this->week(
+			array(
+				array( 'events' => array() ),
+				array( 'events' => array( array( 'title' => 'Meetup' ) ) ),
+			)
+		);
+		$this->assertFalse( WeeklyDigestRenderer::is_week_empty( $week ) );
+	}
+
+	/**
+	 * {week_start}/{week_end} placeholders are replaced with the week's dates.
+	 */
+	public function test_render_subject_replaces_week_placeholders() {
+		$week    = $this->week( array() );
+		$subject = WeeklyDigestRenderer::render_subject( 'Events {week_start} – {week_end}', $week );
+		$this->assertSame( 'Events 2026-07-06 – 2026-07-12', $subject );
+	}
+
+	/**
+	 * An empty week renders the "no events" fallback message.
+	 */
+	public function test_render_returns_fallback_message_for_empty_week() {
+		$week = $this->week(
+			array(
+				array( 'events' => array() ),
+			)
+		);
+		$html = WeeklyDigestRenderer::render( $week );
+		$this->assertStringContainsString( 'No events scheduled this week.', $html );
+	}
+
+	/**
+	 * A day with events renders its heading and a linked, timed event.
+	 */
+	public function test_render_includes_day_heading_and_linked_event() {
+		$week = $this->week(
+			array(
+				array(
+					'weekday'    => 'Monday',
+					'month_name' => 'July',
+					'day_num'    => '6',
+					'events'     => array(
+						array(
+							'title'      => 'Weekly Standup',
+							'url'        => 'https://example.test/event/1',
+							'start_time' => '09:00',
+						),
+					),
+				),
+			)
+		);
+
+		$html = WeeklyDigestRenderer::render( $week );
+
+		$this->assertStringContainsString( 'Monday, July 6', $html );
+		$this->assertStringContainsString( '09:00', $html );
+		$this->assertStringContainsString( '<a href="https://example.test/event/1">Weekly Standup</a>', $html );
+	}
+
+	/**
+	 * All-day events are labeled instead of showing a start time.
+	 */
+	public function test_render_marks_all_day_events() {
+		$week = $this->week(
+			array(
+				array(
+					'weekday'    => 'Monday',
+					'month_name' => 'July',
+					'day_num'    => '6',
+					'events'     => array(
+						array(
+							'title'   => 'Conference',
+							'all_day' => true,
+						),
+					),
+				),
+			)
+		);
+
+		$html = WeeklyDigestRenderer::render( $week );
+
+		$this->assertStringContainsString( 'All day', $html );
+		$this->assertStringContainsString( 'Conference', $html );
+	}
+
+	/**
+	 * Event titles are escaped, never rendered as raw HTML.
+	 */
+	public function test_render_escapes_event_titles() {
+		$week = $this->week(
+			array(
+				array(
+					'weekday'    => 'Monday',
+					'month_name' => 'July',
+					'day_num'    => '6',
+					'events'     => array(
+						array( 'title' => '<script>alert(1)</script>' ),
+					),
+				),
+			)
+		);
+
+		$html = WeeklyDigestRenderer::render( $week );
+
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
+	/**
+	 * Intro HTML is prepended above the day listing.
+	 */
+	public function test_render_prepends_intro_html() {
+		$week = $this->week( array() );
+		$html = WeeklyDigestRenderer::render( $week, '<p>Hello!</p>' );
+		$this->assertStringContainsString( '<p>Hello!</p>', $html );
+	}
+}

--- a/fair-audience/__tests__/bootstrap.php
+++ b/fair-audience/__tests__/bootstrap.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package FairAudience
+ */
+
+// Load Composer autoloader.
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+require_once __DIR__ . '/wp-error-stub.php';
+
+// Define WordPress constants if not already defined.
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+
+// Minimal WordPress function stubs so pure digest logic can be unit tested
+// without a full WP bootstrap. Tests seed values via $GLOBALS['_fair_test_options'].
+if ( ! function_exists( 'is_wp_error' ) ) {
+	/**
+	 * Stub of WordPress is_wp_error().
+	 *
+	 * @param mixed $thing Value to check.
+	 * @return bool Whether $thing is a WP_Error instance.
+	 */
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	/**
+	 * Stub of WordPress get_option() backed by $GLOBALS['_fair_test_options'].
+	 *
+	 * @param string $name          Option name.
+	 * @param mixed  $default_value Value returned when the option is unset.
+	 * @return mixed Stored value or the default.
+	 */
+	function get_option( $name, $default_value = false ) {
+		$options = isset( $GLOBALS['_fair_test_options'] ) ? $GLOBALS['_fair_test_options'] : array();
+		return array_key_exists( $name, $options ) ? $options[ $name ] : $default_value;
+	}
+}
+
+if ( ! function_exists( 'update_option' ) ) {
+	/**
+	 * Stub of WordPress update_option() backed by $GLOBALS['_fair_test_options'].
+	 *
+	 * @param string $name  Option name.
+	 * @param mixed  $value Value to store.
+	 * @return bool Always true.
+	 */
+	function update_option( $name, $value ) {
+		$GLOBALS['_fair_test_options'][ $name ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'current_time' ) ) {
+	/**
+	 * Stub of WordPress current_time(). Always returns UTC 'mysql' format.
+	 *
+	 * @return string Current time formatted for MySQL.
+	 */
+	function current_time() {
+		return gmdate( 'Y-m-d H:i:s' );
+	}
+}
+
+if ( ! function_exists( 'wp_timezone' ) ) {
+	/**
+	 * Stub of WordPress wp_timezone(), always UTC in tests.
+	 *
+	 * @return DateTimeZone
+	 */
+	function wp_timezone() {
+		return new DateTimeZone( 'UTC' );
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	/**
+	 * Stub of WordPress sanitize_text_field().
+	 *
+	 * @param string $value Raw value.
+	 * @return string Trimmed value with tags stripped.
+	 */
+	function sanitize_text_field( $value ) {
+		return trim( wp_strip_all_tags( (string) $value ) );
+	}
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+	/**
+	 * Stub of WordPress wp_strip_all_tags().
+	 *
+	 * @param string $value Raw value.
+	 * @return string Value with tags removed.
+	 */
+	function wp_strip_all_tags( $value ) {
+		return strip_tags( (string) $value ); // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- this *is* the wp_strip_all_tags() stub.
+	}
+}
+
+if ( ! function_exists( 'sanitize_title' ) ) {
+	/**
+	 * Stub of WordPress sanitize_title().
+	 *
+	 * @param string $value Raw value.
+	 * @return string Lowercased, hyphenated slug.
+	 */
+	function sanitize_title( $value ) {
+		$value = strtolower( trim( (string) $value ) );
+		$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+		return trim( $value, '-' );
+	}
+}
+
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	/**
+	 * Stub of WordPress wp_kses_post() — passthrough for test purposes.
+	 *
+	 * @param string $value Raw HTML.
+	 * @return string The same HTML, unmodified.
+	 */
+	function wp_kses_post( $value ) {
+		return (string) $value;
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	/**
+	 * Stub of WordPress esc_html().
+	 *
+	 * @param string $value Raw value.
+	 * @return string HTML-escaped value.
+	 */
+	function esc_html( $value ) {
+		return htmlspecialchars( (string) $value, ENT_QUOTES );
+	}
+}
+
+if ( ! function_exists( 'esc_html__' ) ) {
+	/**
+	 * Stub of WordPress esc_html__().
+	 *
+	 * @param string $text Text to translate/escape.
+	 * @return string HTML-escaped text.
+	 */
+	function esc_html__( $text ) {
+		return esc_html( $text );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	/**
+	 * Stub of WordPress esc_url().
+	 *
+	 * @param string $url Raw URL.
+	 * @return string Escaped URL.
+	 */
+	function esc_url( $url ) {
+		return htmlspecialchars( (string) $url, ENT_QUOTES );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	/**
+	 * Stub of WordPress __().
+	 *
+	 * @param string $text Text to translate.
+	 * @return string The untranslated text.
+	 */
+	function __( $text ) {
+		return $text;
+	}
+}

--- a/fair-audience/__tests__/wp-error-stub.php
+++ b/fair-audience/__tests__/wp-error-stub.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Minimal WP_Error stub for PHPUnit tests
+ *
+ * @package FairAudience
+ */
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	/**
+	 * Minimal stub of WordPress WP_Error.
+	 */
+	class WP_Error {
+		/**
+		 * Error message.
+		 *
+		 * @var string
+		 */
+		private $message;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string $code    Error code (unused by the stub).
+		 * @param string $message Error message.
+		 */
+		public function __construct( $code = '', $message = '' ) {
+			$this->message = $message;
+		}
+
+		/**
+		 * Get the error message.
+		 *
+		 * @return string The error message.
+		 */
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+}

--- a/fair-audience/composer.json
+++ b/fair-audience/composer.json
@@ -33,5 +33,8 @@
 		"psr-4": {
 			"FairAudience\\": "src/"
 		}
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^9.6"
 	}
 }

--- a/fair-audience/composer.lock
+++ b/fair-audience/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69da0c37d270c6f75fd6bf3d61b4eed8",
+    "content-hash": "186e6720897243bea0bcb68bcd6124ec",
     "packages": [
         {
             "name": "composer/pcre",
@@ -517,7 +517,1788 @@
             "time": "2021-10-29T13:26:27+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.35"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:48:07+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},

--- a/fair-audience/phpunit.xml
+++ b/fair-audience/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="__tests__/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite name="fair-audience">
+			<directory suffix="Test.php">./__tests__</directory>
+		</testsuite>
+	</testsuites>
+	<coverage>
+		<include>
+			<directory suffix=".php">./src</directory>
+		</include>
+	</coverage>
+</phpunit>

--- a/fair-audience/src/API/__tests__/WeeklyDigestController.api.spec.js
+++ b/fair-audience/src/API/__tests__/WeeklyDigestController.api.spec.js
@@ -1,0 +1,194 @@
+/**
+ * Playwright API tests for the weekly digest endpoints (#916, PR 4):
+ * GET/PUT /fair-audience/v1/weekly-digest, GET /weekly-digest/sources,
+ * POST /weekly-digest/preview, POST /weekly-digest/test.
+ *
+ * The digest config is a single site option, so these tests save the
+ * original config before mutating it and restore it afterwards to avoid
+ * leaking state into other suites/environments.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('WeeklyDigestController — /weekly-digest', () => {
+	let api;
+	let originalConfig;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const res = await api.get('/wp-json/fair-audience/v1/weekly-digest', {
+			headers: authHeaders,
+		});
+		if (res.ok()) {
+			originalConfig = (await res.json()).config;
+		}
+	});
+
+	test.afterAll(async () => {
+		if (originalConfig) {
+			await api.put('/wp-json/fair-audience/v1/weekly-digest', {
+				headers: authHeaders,
+				data: originalConfig,
+			});
+		}
+		await api.dispose();
+	});
+
+	test('unauthenticated GET is rejected', async () => {
+		const res = await api.get('/wp-json/fair-audience/v1/weekly-digest');
+		expect(res.ok()).toBeFalsy();
+		expect([401, 403]).toContain(res.status());
+	});
+
+	test('unauthenticated PUT is rejected', async () => {
+		const res = await api.put('/wp-json/fair-audience/v1/weekly-digest', {
+			data: { enabled: true },
+		});
+		expect(res.ok()).toBeFalsy();
+		expect([401, 403]).toContain(res.status());
+	});
+
+	test('unauthenticated preview is rejected', async () => {
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/weekly-digest/preview'
+		);
+		expect(res.ok()).toBeFalsy();
+		expect([401, 403]).toContain(res.status());
+	});
+
+	test('unauthenticated test-send is rejected', async () => {
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/weekly-digest/test'
+		);
+		expect(res.ok()).toBeFalsy();
+		expect([401, 403]).toContain(res.status());
+	});
+
+	test('authenticated GET returns config, last_sent_week, last_run_result', async () => {
+		const res = await api.get('/wp-json/fair-audience/v1/weekly-digest', {
+			headers: authHeaders,
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		expect(body).toEqual(
+			expect.objectContaining({
+				config: expect.objectContaining({
+					enabled: expect.any(Boolean),
+					source_slug: expect.any(String),
+					day_of_week: expect.any(Number),
+					time_of_day: expect.any(String),
+					week_scope: expect.any(String),
+					skip_empty: expect.any(Boolean),
+					subject: expect.any(String),
+					intro: expect.any(String),
+				}),
+				last_sent_week: expect.any(String),
+			})
+		);
+	});
+
+	test('PUT sanitizes and persists the config; GET reflects it', async () => {
+		const putRes = await api.put(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{
+				headers: authHeaders,
+				data: {
+					enabled: true,
+					source_slug: 'Test Source',
+					day_of_week: 3,
+					time_of_day: '09:30',
+					week_scope: 'next',
+					skip_empty: false,
+					subject: 'Digest {week_start} – {week_end}',
+					intro: '<p>Hello</p>',
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+		const putBody = await putRes.json();
+		expect(putBody.config).toEqual(
+			expect.objectContaining({
+				enabled: true,
+				source_slug: 'test-source',
+				day_of_week: 3,
+				time_of_day: '09:30',
+				week_scope: 'next',
+				skip_empty: false,
+			})
+		);
+
+		const getRes = await api.get(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{ headers: authHeaders }
+		);
+		expect(getRes.ok()).toBeTruthy();
+		const getBody = await getRes.json();
+		expect(getBody.config.source_slug).toBe('test-source');
+		expect(getBody.config.day_of_week).toBe(3);
+	});
+
+	test('PUT rejects out-of-range values by falling back to defaults', async () => {
+		const res = await api.put('/wp-json/fair-audience/v1/weekly-digest', {
+			headers: authHeaders,
+			data: {
+				day_of_week: 42,
+				time_of_day: 'not-a-time',
+				week_scope: 'someday',
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		expect(body.config.day_of_week).toBe(1);
+		expect(body.config.time_of_day).toBe('08:00');
+		expect(body.config.week_scope).toBe('current');
+	});
+
+	test('GET /weekly-digest/sources returns a list of { slug, name }', async () => {
+		const res = await api.get(
+			'/wp-json/fair-audience/v1/weekly-digest/sources',
+			{ headers: authHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		expect(Array.isArray(body)).toBe(true);
+		for (const source of body) {
+			expect(source).toEqual(
+				expect.objectContaining({
+					slug: expect.any(String),
+					name: expect.any(String),
+				})
+			);
+		}
+	});
+
+	test('preview without a configured source returns 400', async () => {
+		const putRes = await api.put(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{
+				headers: authHeaders,
+				data: { source_slug: '' },
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/weekly-digest/preview',
+			{ headers: authHeaders }
+		);
+		expect(res.ok()).toBeFalsy();
+		expect(res.status()).toBe(400);
+		const body = await res.json();
+		expect(body.code).toBe('no_source');
+	});
+});

--- a/fair-audience/src/Admin/weekly-digest/__tests__/WeeklyDigest.test.jsx
+++ b/fair-audience/src/Admin/weekly-digest/__tests__/WeeklyDigest.test.jsx
@@ -1,0 +1,170 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Component tests for the Weekly Digest admin page (#916, PR 4): loading the
+ * config, saving settings, previewing, and sending a test digest.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import WeeklyDigest from '../WeeklyDigest.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const CONFIG = {
+	enabled: false,
+	source_slug: '',
+	day_of_week: 1,
+	time_of_day: '08:00',
+	week_scope: 'current',
+	skip_empty: true,
+	subject: 'This week’s events: {week_start} – {week_end}',
+	intro: '',
+};
+
+const SOURCES = [
+	{ slug: 'main-calendar', name: 'Main Calendar' },
+	{ slug: 'meetups', name: 'Meetups' },
+];
+
+function mockApiFetch({
+	config = CONFIG,
+	lastSentWeek = '',
+	lastRunResult = {},
+	sources = SOURCES,
+} = {}) {
+	apiFetch.mockImplementation(({ path, method }) => {
+		if (
+			path === '/fair-audience/v1/weekly-digest' &&
+			(!method || method === 'GET')
+		) {
+			return Promise.resolve({
+				config,
+				last_sent_week: lastSentWeek,
+				last_run_result: lastRunResult,
+			});
+		}
+		if (path === '/fair-audience/v1/weekly-digest' && method === 'PUT') {
+			return Promise.resolve({ config });
+		}
+		if (path === '/fair-audience/v1/weekly-digest/sources') {
+			return Promise.resolve(sources);
+		}
+		if (path === '/fair-audience/v1/weekly-digest/preview') {
+			return Promise.resolve({
+				subject: 'Events this week',
+				html: '<p>Standup at 9am</p>',
+				week: { start: '2026-07-06', end: '2026-07-12' },
+				empty: false,
+			});
+		}
+		if (path === '/fair-audience/v1/weekly-digest/test') {
+			return Promise.resolve({ sent_to: 'admin@example.test' });
+		}
+		return Promise.reject(new Error(`Unhandled apiFetch call: ${path}`));
+	});
+}
+
+afterEach(() => {
+	jest.restoreAllMocks();
+	jest.clearAllMocks();
+});
+
+describe('WeeklyDigest — loading', () => {
+	it('loads config and sources, then renders the settings form', async () => {
+		mockApiFetch();
+		render(<WeeklyDigest />);
+
+		expect(
+			await screen.findByRole('button', { name: 'Save settings' })
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByRole('checkbox', { name: 'Send the weekly digest' })
+		).not.toBeChecked();
+		expect(
+			screen.getByText('The digest has not run yet.')
+		).toBeInTheDocument();
+
+		// SelectControl's 36px default size is deprecated as of WP 6.8;
+		// pre-existing in this component, not part of this change.
+		expect(console).toHaveWarned();
+	});
+});
+
+describe('WeeklyDigest — save settings', () => {
+	it('sends the updated config via PUT and shows a success notice', async () => {
+		mockApiFetch();
+		render(<WeeklyDigest />);
+
+		await screen.findByRole('button', { name: 'Save settings' });
+
+		fireEvent.click(
+			screen.getByRole('checkbox', { name: 'Send the weekly digest' })
+		);
+		fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
+
+		await waitFor(() =>
+			expect(apiFetch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: '/fair-audience/v1/weekly-digest',
+					method: 'PUT',
+					data: expect.objectContaining({ enabled: true }),
+				})
+			)
+		);
+
+		expect(
+			(await screen.findAllByText('Weekly digest settings saved.'))[0]
+		).toBeInTheDocument();
+	});
+});
+
+describe('WeeklyDigest — preview', () => {
+	it('renders the returned subject and HTML', async () => {
+		mockApiFetch();
+		render(<WeeklyDigest />);
+
+		await screen.findByRole('button', { name: 'Save settings' });
+
+		fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+
+		expect(await screen.findByText('Events this week')).toBeInTheDocument();
+		expect(screen.getByText('Standup at 9am')).toBeInTheDocument();
+	});
+});
+
+describe('WeeklyDigest — send test', () => {
+	it('sends a test digest and shows the recipient in the notice', async () => {
+		mockApiFetch();
+		render(<WeeklyDigest />);
+
+		await screen.findByRole('button', { name: 'Save settings' });
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Send test to me' })
+		);
+
+		expect(
+			(
+				await screen.findAllByText(
+					'Test digest sent to admin@example.test.'
+				)
+			)[0]
+		).toBeInTheDocument();
+	});
+});
+
+describe('WeeklyDigest — last run summary', () => {
+	it('shows the last-sent week and status when available', async () => {
+		mockApiFetch({
+			lastSentWeek: '2026-W27',
+			lastRunResult: { status: 'sent', timestamp: '2026-07-06 08:00:00' },
+		});
+		render(<WeeklyDigest />);
+
+		expect(
+			await screen.findByText('Last sent for week 2026-W27 — sent')
+		).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary
- PR 4 of the weekly digest sequence ([plan](https://github.com/marcin-wosinek/fair-event-plugins/issues/916#issuecomment-4922823225), [PR breakdown](https://github.com/marcin-wosinek/fair-event-plugins/issues/916#issuecomment-4922877576)) — Layer 5, tests + polish.
- **PHPUnit** (new setup for fair-audience — none existed yet, mirroring `fair-events`): `WeeklyDigestRendererTest` covers config sanitizing (day/time/scope range checks, boolean coercion, slugifying) and HTML shaping (day headings, linked/all-day events, title escaping, empty-week fallback, intro). `WeeklyDigestHooksTest` covers the week-boundary `is_due()` check via reflection and the `run_due()` idempotency guard (disabled/no-source no-ops, `last_sent_week` short-circuit even when otherwise due, dispatch-once-per-week).
- **API spec**: `WeeklyDigestController.api.spec.js` — permission checks on all four routes, config PUT/GET round-trip with sanitization, `sources` shape, `preview` 400 when no source is configured.
- **Component test**: `WeeklyDigest.test.jsx` — loading config/sources, saving settings (PUT payload + success notice), preview rendering, send-test notice, last-run summary display.
- Depends on #1071 (PR 3 — admin page); based on that branch.

## Test plan
- [x] `vendor/bin/phpunit` in `fair-audience` — 24 tests passing
- [x] `vendor/bin/phpcs` on all new PHP files — clean
- [x] `npm run test:js` in `fair-audience` — 15 tests passing (3 suites)
- [x] `npm run format` in `fair-audience`
- [x] API spec written against the established Basic-Auth pattern used by existing `.api.spec.js` files; the 4 unauthenticated-request assertions pass locally, the 5 authenticated ones can't be verified in this dev environment (it lacks Basic Auth support — the same pre-existing limitation affects `ParticipantsStats.api.spec.js`)

Refs #916
