### PR TITLE
Restyle the All Participants page with native layout components

### DIFF
--- a/.changeset/restyle-all-participants.md
+++ b/.changeset/restyle-all-participants.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": patch
+---
+
+Restyle the All Participants page with native WordPress components: stat tiles sit in an equal-width responsive grid with hover feedback and an accent highlight on the tile matching the active filter (aria-pressed), the tiles/notices/table share consistent VStack spacing, the events popover uses ItemGroup, and the page's inline styles move to a `style.css` built to `style-index.css` (AdminHooks now enqueues per-page stylesheets when present).

--- a/fair-audience/src/Admin/AdminHooks.php
+++ b/fair-audience/src/Admin/AdminHooks.php
@@ -314,6 +314,16 @@ class AdminHooks {
 			);
 
 			wp_enqueue_style( 'wp-components' );
+
+			$style_file = $plugin_dir . "build/admin/{$page_name}/style-index.css";
+			if ( file_exists( $style_file ) ) {
+				wp_enqueue_style(
+					"fair-audience-{$page_name}",
+					plugin_dir_url( dirname( __DIR__ ) ) . "build/admin/{$page_name}/style-index.css",
+					array( 'wp-components' ),
+					$asset_data['version']
+				);
+			}
 		}
 	}
 }

--- a/fair-audience/src/Admin/all-participants/AllParticipants.js
+++ b/fair-audience/src/Admin/all-participants/AllParticipants.js
@@ -5,12 +5,14 @@ import {
 	Button,
 	Card,
 	CardBody,
-	Flex,
-	FlexItem,
 	Spinner,
 	Popover,
 	Notice,
 	Snackbar,
+	__experimentalGrid as Grid,
+	__experimentalVStack as VStack,
+	__experimentalItemGroup as ItemGroup,
+	__experimentalItem as Item,
 	__experimentalText as Text,
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
@@ -232,21 +234,15 @@ export default function AllParticipants() {
 						item.email.toLowerCase() !==
 							item.wp_user.email.toLowerCase();
 					return (
-						<span
-							style={{
-								display: 'flex',
-								alignItems: 'center',
-								gap: '4px',
-							}}
-						>
+						<span className="fair-audience-wp-user">
 							{item.wp_user.display_name}
 							{hasEmailMismatch && (
 								<span
+									className="fair-audience-wp-user__mismatch"
 									title={__(
 										'Email addresses do not match',
 										'fair-audience'
 									)}
-									style={{ color: '#d63638' }}
 								>
 									<Icon icon={caution} size={16} />
 								</span>
@@ -260,7 +256,7 @@ export default function AllParticipants() {
 				id: 'events_signed_up',
 				label: __('Events Signed Up', 'fair-audience'),
 				render: ({ item }) => (
-					<div style={{ textAlign: 'right' }}>
+					<div className="fair-audience-count-cell">
 						{item.events_signed_up > 0 ? (
 							<Button
 								variant="link"
@@ -286,7 +282,7 @@ export default function AllParticipants() {
 				id: 'events_collaborated',
 				label: __('Events Collaborated', 'fair-audience'),
 				render: ({ item }) => (
-					<div style={{ textAlign: 'right' }}>
+					<div className="fair-audience-count-cell">
 						{item.events_collaborated > 0 ? (
 							<Button
 								variant="link"
@@ -582,6 +578,26 @@ export default function AllParticipants() {
 		setView((v) => ({ ...v, filters, page: 1 }));
 	}, []);
 
+	// The tile whose filters exactly match the current view filters, so the
+	// active scope is visible in the tile row ("Audience total" when
+	// unfiltered).
+	const activeTileId = useMemo(() => {
+		const current = view.filters || [];
+		const active = statTiles.find(
+			(tile) =>
+				tile.filters.length === current.length &&
+				tile.filters.every((tileFilter) =>
+					current.some(
+						(viewFilter) =>
+							viewFilter.field === tileFilter.field &&
+							viewFilter.operator === tileFilter.operator &&
+							viewFilter.value === tileFilter.value
+					)
+				)
+		);
+		return active ? active.id : null;
+	}, [statTiles, view.filters]);
+
 	const resendResultTitle = useMemo(() => {
 		if (!resendResult) {
 			return '';
@@ -613,63 +629,82 @@ export default function AllParticipants() {
 			</button>
 			<hr className="wp-header-end" />
 
-			<Flex wrap>
-				{statTiles.map((tile) => (
-					<FlexItem key={tile.id} style={{ minWidth: '160px' }}>
-						<Card>
-							<CardBody
-								as="button"
-								type="button"
-								onClick={() => filterByTile(tile.filters)}
-								style={{
-									cursor: 'pointer',
-									textAlign: 'left',
-									width: '100%',
-									border: 'none',
-									background: 'none',
-								}}
-							>
-								<Text size={24} weight={600} as="div">
-									{stats ? tile.value : '—'}
-								</Text>
-								<Text as="div">{tile.label}</Text>
-							</CardBody>
-						</Card>
-					</FlexItem>
-				))}
-			</Flex>
-
-			{errorMessage && (
-				<Notice
-					status="error"
-					isDismissible={true}
-					onRemove={() => setErrorMessage(null)}
+			<VStack
+				spacing={4}
+				className="fair-audience-all-participants__content"
+			>
+				<Grid
+					templateColumns="repeat(auto-fit, minmax(180px, 1fr))"
+					gap={3}
 				>
-					{errorMessage}
-				</Notice>
-			)}
+					{statTiles.map((tile) => {
+						const isActive = activeTileId === tile.id;
+						return (
+							<Card
+								key={tile.id}
+								size="small"
+								className={
+									isActive
+										? 'fair-audience-stat-tile is-active'
+										: 'fair-audience-stat-tile'
+								}
+							>
+								<CardBody
+									as="button"
+									type="button"
+									className="fair-audience-stat-tile__button"
+									aria-pressed={isActive}
+									onClick={() => filterByTile(tile.filters)}
+								>
+									<Text
+										size={24}
+										weight={600}
+										as="div"
+										className="fair-audience-stat-tile__value"
+									>
+										{stats ? tile.value : '—'}
+									</Text>
+									<Text as="div" variant="muted">
+										{tile.label}
+									</Text>
+								</CardBody>
+							</Card>
+						);
+					})}
+				</Grid>
 
-			<EmailSendResultNotice
-				result={resendResult}
-				title={resendResultTitle}
-				onDismiss={() => setResendResult(null)}
-			/>
+				{errorMessage && (
+					<Notice
+						status="error"
+						isDismissible={true}
+						onRemove={() => setErrorMessage(null)}
+					>
+						{errorMessage}
+					</Notice>
+				)}
 
-			<Card>
-				<CardBody style={{ overflowX: 'auto' }}>
-					<DataViews
-						data={participants}
-						fields={fields}
-						view={view}
-						onChangeView={setView}
-						actions={actions}
-						paginationInfo={paginationInfo}
-						defaultLayouts={DEFAULT_LAYOUTS}
-						isLoading={isLoading}
-						getItemId={(item) => item.id}
-					/>
-				</CardBody>
-			</Card>
+				<EmailSendResultNotice
+					result={resendResult}
+					title={resendResultTitle}
+					onDismiss={() => setResendResult(null)}
+				/>
+
+				<Card>
+					<CardBody className="fair-audience-all-participants__table">
+						<DataViews
+							data={participants}
+							fields={fields}
+							view={view}
+							onChangeView={setView}
+							actions={actions}
+							paginationInfo={paginationInfo}
+							defaultLayouts={DEFAULT_LAYOUTS}
+							isLoading={isLoading}
+							getItemId={(item) => item.id}
+						/>
+					</CardBody>
+				</Card>
+			</VStack>
 
 			{eventsPopover && (
 				<Popover
@@ -677,42 +712,25 @@ export default function AllParticipants() {
 					onClose={() => setEventsPopover(null)}
 					placement="bottom-start"
 				>
-					<div
-						style={{
-							padding: '12px',
-							minWidth: '200px',
-							maxWidth: '300px',
-						}}
-					>
+					<div className="fair-audience-events-popover">
 						{popoverLoading ? (
 							<Spinner />
 						) : popoverEvents.length === 0 ? (
-							<p style={{ margin: 0 }}>
+							<Text as="p">
 								{__('No events found.', 'fair-audience')}
-							</p>
+							</Text>
 						) : (
-							<ul
-								style={{
-									margin: 0,
-									padding: 0,
-									listStyle: 'none',
-								}}
-							>
+							<ItemGroup size="small">
 								{popoverEvents.map((event) => (
-									<li
+									<Item
 										key={event.event_id}
-										style={{
-											padding: '4px 0',
-										}}
+										as="a"
+										href={`${window.fairAudienceAllParticipantsData?.participantsUrl}${event.event_date_id}`}
 									>
-										<a
-											href={`${window.fairAudienceAllParticipantsData?.participantsUrl}${event.event_date_id}`}
-										>
-											{event.title}
-										</a>
-									</li>
+										{event.title}
+									</Item>
 								))}
-							</ul>
+							</ItemGroup>
 						)}
 					</div>
 				</Popover>
@@ -741,14 +759,7 @@ export default function AllParticipants() {
 			</ConfirmDialog>
 
 			{snackbar && (
-				<div
-					style={{
-						position: 'fixed',
-						bottom: '16px',
-						left: '16px',
-						zIndex: 100000,
-					}}
-				>
+				<div className="fair-audience-all-participants__snackbar">
 					<Snackbar onRemove={() => setSnackbar(null)}>
 						{snackbar}
 					</Snackbar>

--- a/fair-audience/src/Admin/all-participants/index.js
+++ b/fair-audience/src/Admin/all-participants/index.js
@@ -1,5 +1,6 @@
 import { createRoot } from '@wordpress/element';
 import AllParticipants from './AllParticipants.js';
+import './style.css';
 
 const rootElement = document.getElementById(
 	'fair-audience-all-participants-root'

--- a/fair-audience/src/Admin/all-participants/style.css
+++ b/fair-audience/src/Admin/all-participants/style.css
@@ -1,0 +1,65 @@
+/* All Participants admin page. */
+
+.fair-audience-all-participants__content {
+	margin-top: 16px;
+}
+
+/* Clickable stat tiles above the participants table. */
+.fair-audience-stat-tile__button {
+	display: block;
+	width: 100%;
+	margin: 0;
+	border: none;
+	border-radius: 2px;
+	background: none;
+	text-align: left;
+	cursor: pointer;
+}
+
+.fair-audience-stat-tile__button:hover,
+.fair-audience-stat-tile__button:focus-visible {
+	background: #f6f7f7;
+}
+
+.fair-audience-stat-tile.is-active {
+	box-shadow: inset 0 0 0 1.5px var(--wp-admin-theme-color);
+}
+
+.fair-audience-stat-tile.is-active .fair-audience-stat-tile__value {
+	color: var(--wp-admin-theme-color);
+}
+
+.fair-audience-all-participants__table {
+	overflow-x: auto;
+}
+
+.fair-audience-events-popover {
+	min-width: 220px;
+	max-width: 320px;
+	padding: 8px;
+}
+
+.fair-audience-events-popover p {
+	margin: 4px 8px;
+}
+
+.fair-audience-wp-user {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.fair-audience-wp-user__mismatch {
+	color: #d63638;
+}
+
+.fair-audience-count-cell {
+	text-align: right;
+}
+
+.fair-audience-all-participants__snackbar {
+	position: fixed;
+	bottom: 16px;
+	left: 16px;
+	z-index: 100000;
+}


### PR DESCRIPTION
## Summary

- Replace the `Flex` row of stat tiles with an equal-width responsive `Grid` (`repeat(auto-fit, minmax(180px, 1fr))`); tiles get hover/focus feedback, `aria-pressed`, and an admin-accent highlight on the tile whose filters match the current view ("Audience total" when unfiltered).
- Wrap tiles, notices, and the table card in a `VStack spacing={4}` for consistent vertical rhythm.
- Render the events popover with native `ItemGroup`/`Item` links instead of a hand-styled `<ul>`.
- Move all inline `style={{…}}` on the page into `src/Admin/all-participants/style.css` (same pattern as fair-events' calendar page); `AdminHooks::enqueue_page_script()` now enqueues `build/admin/{page}/style-index.css` whenever it exists, so any fair-audience admin page can add a stylesheet.

## Test plan

- `npm run test:js` in fair-audience: 15/15 pass, including the existing stat-tile tests (#1054).
- `npm run build` emits `style-index.css`; verified live at 1440px and 800px viewports — tiles wrap, active-tile highlight follows clicks, table filters accordingly, browser console clean.
- `vendor/bin/phpcs` on AdminHooks.php reports only pre-existing findings on untouched lines.