### PR TITLE
Fix blank fair-form Answers Overview admin page

### DIFF
--- a/.changeset/fix-answers-overview-blank-page.md
+++ b/.changeset/fix-answers-overview-blank-page.md
@@ -1,0 +1,5 @@
+---
+"fair-form": patch
+---
+
+Fix the Answers Overview admin page rendering blank. It imported `ToggleGroupControl`/`ToggleGroupControlOption` from `@wordpress/components` under their stable names, which some WordPress versions only expose under the experimental aliases, crashing the whole React tree. The DataViews table also needed its columns listed explicitly via `view.fields`, which is required in the installed `@wordpress/dataviews` version.

--- a/e2e/fair-form-admin-menu.spec.js
+++ b/e2e/fair-form-admin-menu.spec.js
@@ -1,0 +1,109 @@
+/**
+ * Fair Form admin pages — mount smoke (#1077).
+ *
+ * fair-form's admin pages had zero e2e coverage, so PR #1076 (blank Answers
+ * Overview page — `__experimentalToggleGroupControl` didn't exist, and
+ * DataViews needs `view.fields`) shipped without CI catching it: the crash
+ * was a runtime-only React error, invisible to `npm run build` and `phpcs`.
+ * Mirrors fair-events-admin-menu.spec.js and
+ * fair-payments-connector-admin-menu.spec.js — every admin page must mount
+ * something into its React root, not just render an empty `<div>`.
+ *
+ * The Answers Overview check goes further: it seeds one real submission and
+ * asserts its row renders with real data, since "root has children" alone
+ * would not have caught the missing `view.fields` regression (DataViews can
+ * mount with a table that has zero visible columns).
+ *
+ * Run: `npm run test:e2e -- fair-form-admin-menu`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin, runScript } from './support/wp-cli.js';
+
+/** Visible Fair Form admin pages and their React root element ids. */
+const VISIBLE_PAGES = [
+	{ slug: 'fair-form', root: 'fair-form-answers-overview-root' },
+	{
+		slug: 'fair-form-form-answers',
+		root: 'fair-form-form-answers-root',
+	},
+];
+
+/**
+ * Hidden pages (empty parent slug — not in the visible menu, so navigate
+ * directly instead of asserting a menu link).
+ */
+const HIDDEN_PAGES = [
+	{
+		slug: 'fair-form-questionnaire-responses',
+		root: 'fair-form-questionnaire-responses-root',
+	},
+	{
+		slug: 'fair-form-submission-detail',
+		root: 'fair-form-submission-detail-root',
+	},
+];
+
+test.describe('Fair Form admin menu', () => {
+	test('top-level menu is present with Answers Overview and All Answers', async ({
+		page,
+	}) => {
+		await loginAsAdmin(page);
+		await page.goto('/wp-admin/');
+
+		const menu = page.locator('#toplevel_page_fair-form');
+		await expect(menu).toBeVisible();
+
+		for (const { slug } of VISIBLE_PAGES) {
+			await expect(
+				menu.locator(`a[href*="page=${slug}"]`).first(),
+				`menu link for ${slug} missing`
+			).toBeAttached();
+		}
+	});
+
+	test('every page mounts its React root', async ({ page }) => {
+		await loginAsAdmin(page);
+
+		for (const { slug, root } of [...VISIBLE_PAGES, ...HIDDEN_PAGES]) {
+			await page.goto(`/wp-admin/admin.php?page=${slug}`);
+			await expect(
+				page.locator(`#${root}`),
+				`${slug}: React root element missing`
+			).toBeAttached();
+			await expect(
+				page.locator(`#${root} > *`).first(),
+				`${slug}: root is empty — admin bundle did not load`
+			).toBeAttached({ timeout: 15000 });
+		}
+	});
+
+	test.describe('Answers Overview with seeded data', () => {
+		let seed;
+
+		test.beforeAll(() => {
+			seed = runScript('seed-fair-form-answer.php', 'E2E_FAIR_FORM_SEED');
+		});
+
+		test.afterAll(() => {
+			runScript(
+				'cleanup-fair-form-answer.php',
+				'E2E_FAIR_FORM_CLEANUP',
+				`${seed.postId} ${seed.submissionId} ${seed.answerId}`
+			);
+		});
+
+		test('renders the seeded submission row, not just an empty table', async ({
+			page,
+		}) => {
+			await loginAsAdmin(page);
+			await page.goto('/wp-admin/admin.php?page=fair-form');
+
+			await expect(
+				page.getByRole('cell', { name: seed.postTitle }),
+				'seeded page title missing from the grouped-by-page table — a ' +
+					'root with children is not enough, the row must carry real data'
+			).toBeVisible({ timeout: 15000 });
+		});
+	});
+});

--- a/e2e/mu-plugins/scripts/cleanup-fair-form-answer.php
+++ b/e2e/mu-plugins/scripts/cleanup-fair-form-answer.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Tear down E2E-seeded data for the fair-form admin-menu mount-smoke suite (#1077).
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/cleanup-fair-form-answer.php \
+ *     <postId> <submissionId> <answerId>
+ *
+ * Prints a single `E2E_FAIR_FORM_CLEANUP:{json}` line with row counts.
+ *
+ * @package FairFormE2E
+ */
+
+global $wpdb;
+
+$page_id       = isset( $args[0] ) ? (int) $args[0] : 0;
+$submission_id = isset( $args[1] ) ? (int) $args[1] : 0;
+$answer_id     = isset( $args[2] ) ? (int) $args[2] : 0;
+
+if ( ! $page_id || ! $submission_id || ! $answer_id ) {
+	WP_CLI::error( 'Usage: cleanup-fair-form-answer.php <postId> <submissionId> <answerId>' );
+}
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off teardown script.
+
+$answers_table     = $wpdb->prefix . 'fair_audience_questionnaire_answers';
+$submissions_table = $wpdb->prefix . 'fair_audience_questionnaire_submissions';
+
+$deleted                = array();
+$deleted['answers']     = (int) $wpdb->delete( $answers_table, array( 'id' => $answer_id ), array( '%d' ) );
+$deleted['submissions'] = (int) $wpdb->delete( $submissions_table, array( 'id' => $submission_id ), array( '%d' ) );
+$deleted['post']        = wp_delete_post( $page_id, true ) ? 1 : 0;
+
+// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+echo 'E2E_FAIR_FORM_CLEANUP:' . wp_json_encode( $deleted ) . "\n";

--- a/e2e/mu-plugins/scripts/seed-fair-form-answer.php
+++ b/e2e/mu-plugins/scripts/seed-fair-form-answer.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Seed a questionnaire submission + answer for the fair-form admin-menu
+ * mount-smoke suite (#1077).
+ *
+ * The Answers Overview page groups by page/event/form and would silently
+ * render an empty table if the DataViews `fields` config regressed (#1076) —
+ * an empty root still "mounts", so this suite needs at least one real row to
+ * prove the label/count actually render, not just that a root has children.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-fair-form-answer.php
+ *
+ * Prints a single `E2E_FAIR_FORM_SEED:{json}` line the spec parses.
+ *
+ * @package FairFormE2E
+ */
+
+use FairForm\Models\QuestionnaireSubmission;
+use FairForm\Models\QuestionnaireAnswer;
+
+$post_title = 'E2E Fair Form Page ' . gmdate( 'YmdHis' );
+
+$page_id = wp_insert_post(
+	array(
+		'post_type'   => 'page',
+		'post_status' => 'publish',
+		'post_title'  => $post_title,
+	),
+	true
+);
+
+if ( is_wp_error( $page_id ) ) {
+	WP_CLI::error( 'Failed to create page: ' . $page_id->get_error_message() );
+}
+
+$submission = new QuestionnaireSubmission(
+	array(
+		'post_id'    => $page_id,
+		'title'      => 'E2E Submission',
+		'form_id'    => 'e2e-form',
+		'form_title' => 'E2E Form',
+	)
+);
+
+if ( ! $submission->save() ) {
+	WP_CLI::error( 'Failed to create questionnaire submission.' );
+}
+
+$answer = new QuestionnaireAnswer(
+	array(
+		'submission_id' => $submission->id,
+		'question_key'  => 'e2e_question',
+		'question_text' => 'How did you hear about us?',
+		'question_type' => 'short_text',
+		'answer_value'  => 'E2E Answer Value',
+		'display_order' => 0,
+	)
+);
+
+if ( ! $answer->save() ) {
+	WP_CLI::error( 'Failed to create questionnaire answer.' );
+}
+
+echo 'E2E_FAIR_FORM_SEED:' . wp_json_encode(
+	array(
+		'postId'       => (int) $page_id,
+		'postTitle'    => $post_title,
+		'submissionId' => (int) $submission->id,
+		'answerId'     => (int) $answer->id,
+	)
+) . "\n";

--- a/fair-form/src/Admin/answers-overview/AnswersOverview.js
+++ b/fair-form/src/Admin/answers-overview/AnswersOverview.js
@@ -4,8 +4,8 @@ import apiFetch from '@wordpress/api-fetch';
 import {
 	Card,
 	CardBody,
-	ToggleGroupControl,
-	ToggleGroupControlOption,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 
@@ -19,6 +19,7 @@ const DEFAULT_VIEW = {
 	},
 	search: '',
 	filters: [],
+	fields: ['label', 'count'],
 };
 
 const DEFAULT_LAYOUTS = {


### PR DESCRIPTION
## Summary
- `AnswersOverview.js` imported `ToggleGroupControl`/`ToggleGroupControlOption` under their stable names from `@wordpress/components`, but this WordPress version only exposes them under the `__experimental*` aliases — the undefined import crashed the whole React tree with no visible error, leaving the admin page blank.
- Once that render crash was fixed, the `DataViews` table showed no columns/rows because the installed `@wordpress/dataviews` version requires `view.fields` to explicitly list which fields to display.

## Test plan
- [x] Rebuilt (`npm run build`) and verified via a headless browser session against local WordPress that `/wp-admin/admin.php?page=fair-form` now renders the "Group by" toggle and a table with real submission data
- [x] Confirmed the REST call to `/fair-form/v1/questionnaire-responses/grouped` now fires and returns data