### PR TITLE
Fix broken form-response links on Audience tab and events list

### DIFF
--- a/fair-audience/src/Admin/events-list/EventsList.js
+++ b/fair-audience/src/Admin/events-list/EventsList.js
@@ -121,7 +121,7 @@ export default function EventsList() {
 				id: 'questionnaire-responses',
 				label: __('Questionnaire Responses', 'fair-audience'),
 				callback: ([item]) => {
-					window.location.href = `admin.php?page=fair-audience-questionnaire-responses&event_date_id=${item.event_date_id}`;
+					window.location.href = `admin.php?page=fair-form-questionnaire-responses&event_date_id=${item.event_date_id}`;
 				},
 			},
 		],

--- a/fair-audience/src/Admin/manage-event-audience-tab/EventAudience.js
+++ b/fair-audience/src/Admin/manage-event-audience-tab/EventAudience.js
@@ -179,7 +179,7 @@ export default function EventAudience({
 			return;
 		}
 		apiFetch({
-			path: `/fair-audience/v1/questionnaire-responses/forms-summary?event_date_id=${eventDateId}`,
+			path: `/fair-form/v1/questionnaire-responses/forms-summary?event_date_id=${eventDateId}`,
 		})
 			.then((data) => {
 				setFormsSummary(Array.isArray(data) ? data : []);
@@ -1794,7 +1794,7 @@ export default function EventAudience({
 											<td>
 												<Button
 													variant="link"
-													href={`admin.php?page=fair-audience-questionnaire-responses&event_date_id=${eventDateId}${
+													href={`admin.php?page=fair-form-questionnaire-responses&event_date_id=${eventDateId}${
 														form.post_id
 															? `&post_id=${form.post_id}`
 															: `&title=${encodeURIComponent(


### PR DESCRIPTION
The Forms card on manage-event Audience tab fetched
/fair-audience/v1/questionnaire-responses/forms-summary, but that
route only exists under fair-form/v1, so the request always 404'd
and silently rendered "No form submissions yet." Also fixed two
"View Responses" links pointing at the nonexistent admin page slug
fair-audience-questionnaire-responses instead of the real
fair-form-questionnaire-responses page.
