### PR TITLE
Add outro text to the weekly digest email

### DIFF
--- a/fair-audience/__tests__/Services/WeeklyDigestRendererTest.php
+++ b/fair-audience/__tests__/Services/WeeklyDigestRendererTest.php
@@ -236,4 +236,17 @@ class WeeklyDigestRendererTest extends TestCase {
 		$html = WeeklyDigestRenderer::render( $week, '<p>Hello!</p>' );
 		$this->assertStringContainsString( '<p>Hello!</p>', $html );
 	}
+
+	/**
+	 * Outro HTML is appended below the day listing.
+	 */
+	public function test_render_appends_outro_html() {
+		$week = $this->week( array() );
+		$html = WeeklyDigestRenderer::render( $week, '', '<p>See you there!</p>' );
+		$this->assertStringContainsString( '<p>See you there!</p>', $html );
+		$this->assertGreaterThan(
+			strpos( $html, 'No events scheduled this week.' ),
+			strpos( $html, 'See you there!' )
+		);
+	}
 }

--- a/fair-audience/src/API/WeeklyDigestController.php
+++ b/fair-audience/src/API/WeeklyDigestController.php
@@ -185,7 +185,7 @@ class WeeklyDigestController extends WP_REST_Controller {
 		return rest_ensure_response(
 			array(
 				'subject' => WeeklyDigestRenderer::render_subject( $config['subject'], $week ),
-				'html'    => WeeklyDigestRenderer::render( $week, $config['intro'] ),
+				'html'    => WeeklyDigestRenderer::render( $week, $config['intro'], $config['outro'] ),
 				'week'    => $week['week'],
 				'empty'   => WeeklyDigestRenderer::is_week_empty( $week ),
 			)
@@ -206,7 +206,7 @@ class WeeklyDigestController extends WP_REST_Controller {
 
 		$config  = get_option( 'fair_audience_weekly_digest', WeeklyDigestRenderer::default_config() );
 		$subject = WeeklyDigestRenderer::render_subject( $config['subject'], $week );
-		$html    = WeeklyDigestRenderer::render( $week, $config['intro'] );
+		$html    = WeeklyDigestRenderer::render( $week, $config['intro'], $config['outro'] );
 
 		$current_user = wp_get_current_user();
 
@@ -278,6 +278,7 @@ class WeeklyDigestController extends WP_REST_Controller {
 			'skip_empty'  => array( 'type' => 'boolean' ),
 			'subject'     => array( 'type' => 'string' ),
 			'intro'       => array( 'type' => 'string' ),
+			'outro'       => array( 'type' => 'string' ),
 		);
 	}
 }

--- a/fair-audience/src/Admin/weekly-digest/WeeklyDigest.js
+++ b/fair-audience/src/Admin/weekly-digest/WeeklyDigest.js
@@ -268,6 +268,16 @@ export default function WeeklyDigest() {
 						onChange={(value) => updateField('intro', value)}
 					/>
 
+					<TextareaControl
+						label={__('Outro text', 'fair-audience')}
+						help={__(
+							'Optional text shown below the list of events.',
+							'fair-audience'
+						)}
+						value={config.outro}
+						onChange={(value) => updateField('outro', value)}
+					/>
+
 					<Button
 						variant="primary"
 						onClick={handleSave}

--- a/fair-audience/src/Admin/weekly-digest/__tests__/WeeklyDigest.test.jsx
+++ b/fair-audience/src/Admin/weekly-digest/__tests__/WeeklyDigest.test.jsx
@@ -20,6 +20,7 @@ const CONFIG = {
 	skip_empty: true,
 	subject: 'This week’s events: {week_start} – {week_end}',
 	intro: '',
+	outro: '',
 };
 
 const SOURCES = [

--- a/fair-audience/src/Hooks/WeeklyDigestHooks.php
+++ b/fair-audience/src/Hooks/WeeklyDigestHooks.php
@@ -131,7 +131,7 @@ class WeeklyDigestHooks {
 			}
 
 			$subject = WeeklyDigestRenderer::render_subject( $config['subject'], $week );
-			$html    = WeeklyDigestRenderer::render( $week, $config['intro'] );
+			$html    = WeeklyDigestRenderer::render( $week, $config['intro'], $config['outro'] );
 
 			$email_service = new EmailService();
 			$results       = $email_service->send_bulk_custom_mail_to_all( $subject, $html, true );

--- a/fair-audience/src/Services/WeeklyDigestRenderer.php
+++ b/fair-audience/src/Services/WeeklyDigestRenderer.php
@@ -34,6 +34,7 @@ class WeeklyDigestRenderer {
 			'skip_empty'  => true,
 			'subject'     => __( 'This week’s events: {week_start} – {week_end}', 'fair-audience' ),
 			'intro'       => '',
+			'outro'       => '',
 		);
 	}
 
@@ -74,6 +75,7 @@ class WeeklyDigestRenderer {
 			'skip_empty'  => isset( $value['skip_empty'] ) ? ! empty( $value['skip_empty'] ) : $defaults['skip_empty'],
 			'subject'     => isset( $value['subject'] ) ? sanitize_text_field( $value['subject'] ) : $defaults['subject'],
 			'intro'       => isset( $value['intro'] ) ? wp_kses_post( $value['intro'] ) : $defaults['intro'],
+			'outro'       => isset( $value['outro'] ) ? wp_kses_post( $value['outro'] ) : $defaults['outro'],
 		);
 	}
 
@@ -131,9 +133,10 @@ class WeeklyDigestRenderer {
 	 *
 	 * @param array  $week  Week data from WeeklyEventsProvider::get_week().
 	 * @param string $intro Optional intro HTML (already sanitized).
+	 * @param string $outro Optional outro HTML (already sanitized).
 	 * @return string Inner HTML content.
 	 */
-	public static function render( array $week, $intro = '' ) {
+	public static function render( array $week, $intro = '', $outro = '' ) {
 		$html = '';
 
 		if ( ! empty( $intro ) ) {
@@ -175,6 +178,10 @@ class WeeklyDigestRenderer {
 
 		if ( '' === $html ) {
 			$html = '<p>' . esc_html__( 'No events scheduled this week.', 'fair-audience' ) . '</p>';
+		}
+
+		if ( ! empty( $outro ) ) {
+			$html .= '<div style="margin: 20px 0 0 0;">' . wp_kses_post( $outro ) . '</div>';
 		}
 
 		return $html;


### PR DESCRIPTION
Mirrors the existing intro field: a new admin textarea, sanitized
option, and rendering support in preview, test-send, and the cron
dispatch path.
