### PR TITLE
Include local events for sources without a categories data source

### DIFF
--- a/fair-events/src/Services/WeeklyEventsProvider.php
+++ b/fair-events/src/Services/WeeklyEventsProvider.php
@@ -80,17 +80,17 @@ class WeeklyEventsProvider {
 			} elseif ( 'categories' === $type ) {
 				$category_ids = $data_source['config']['category_ids'] ?? array();
 				if ( ! empty( $category_ids ) ) {
-					$this->collect_category_events( $category_ids, $start_datetime, $end_datetime, $all_events );
 					$all_category_ids = array_merge( $all_category_ids, $category_ids );
 				}
 			}
 		}
 
-		// Fetch standalone events filtered by collected category IDs.
-		if ( ! empty( $all_category_ids ) ) {
-			$all_category_ids = array_unique( array_map( 'intval', $all_category_ids ) );
-			$this->collect_standalone_events( $start_datetime, $end_datetime, $all_events, $all_category_ids );
-		}
+		$all_category_ids = array_unique( array_map( 'intval', $all_category_ids ) );
+
+		// Local events are always part of a source; categories, when configured,
+		// act only as a filter — mirrors PublicEventsController::get_source_events().
+		$this->collect_local_events( $all_category_ids, $start_datetime, $end_datetime, $all_events );
+		$this->collect_standalone_events( $start_datetime, $end_datetime, $all_events, $all_category_ids );
 
 		// Build 7-day response.
 		$days         = array();
@@ -241,14 +241,14 @@ class WeeklyEventsProvider {
 	}
 
 	/**
-	 * Collect WordPress post events filtered by categories.
+	 * Collect WordPress post events, optionally filtered by categories.
 	 *
-	 * @param array  $category_ids   Category term IDs.
+	 * @param array  $category_ids   Category term IDs to filter by. Empty means no filter.
 	 * @param string $start_datetime Week start datetime.
 	 * @param string $end_datetime   Week end datetime.
 	 * @param array  $all_events     Events grouped by date (modified by reference).
 	 */
-	private function collect_category_events( $category_ids, $start_datetime, $end_datetime, &$all_events ) {
+	private function collect_local_events( $category_ids, $start_datetime, $end_datetime, &$all_events ) {
 		$query_args = array(
 			'post_type'              => Settings::get_enabled_post_types(),
 			'posts_per_page'         => -1,
@@ -258,16 +258,19 @@ class WeeklyEventsProvider {
 				'end_after'    => $start_datetime,
 			),
 			'fair_events_order'      => 'ASC',
+		);
+
+		if ( ! empty( $category_ids ) ) {
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-			'tax_query'              => array(
+			$query_args['tax_query'] = array(
 				array(
 					'taxonomy'         => 'category',
 					'field'            => 'term_id',
 					'terms'            => $category_ids,
 					'include_children' => false,
 				),
-			),
-		);
+			);
+		}
 
 		add_filter( 'posts_join', array( QueryHelper::class, 'join_dates_table' ), 10, 2 );
 		add_filter( 'posts_where', array( QueryHelper::class, 'filter_by_dates' ), 10, 2 );


### PR DESCRIPTION
## Summary

- `WeeklyEventsProvider::get_week()` only collected local (post-linked and standalone) events inside the `'categories' === $type` data-source branch, so a source made up solely of external feeds (`ical_url` / `fair_events_api`) produced a weekly digest missing all of its local events.
- Every other view of a source — the public JSON feed, iCal feed, source-view admin calendar (`PublicEventsController::get_source_events()`), and the events-calendar block — always includes local events, applying category IDs only as an optional filter.
- Fixed `get_week()` to mirror that behavior: local events (post-linked via `collect_local_events()`, renamed from `collect_category_events()`) and standalone events are now collected unconditionally after the data-source loop, with the `tax_query` on `collect_local_events()` applied only when category IDs were actually configured.
- No REST API, JS, or fair-audience changes needed — the digest preview, test-send, and cron send all consume `get_week()` and pick up the fix automatically, as does `fair-events-experimental`'s `WeeklyEventsController`.

Closes #1087

## Test plan

- [x] `vendor/bin/phpcs` clean on the changed file.
- [x] `npm run test:php` in `fair-events` — 28 tests pass.
- [x] Manual WP-CLI `eval-file` check (docker environment) with a source containing only an `ical_url` data source (no `categories`): confirmed a post-linked event and a standalone event both now appear in `get_week()` output.
- [x] Manual WP-CLI `eval-file` check with a `categories` data source configured and a category the post event doesn't have: confirmed the uncategorized post event is still filtered out — no regression to category filtering.
