### PR TITLE
Redesign Manage Event header into breadcrumb, meta, chips

### DIFF
--- a/fair-events-shared/src/dateTime.js
+++ b/fair-events-shared/src/dateTime.js
@@ -58,3 +58,16 @@ export function formatSiteLocalDatetime(datetime) {
 	const { formats } = getSettings();
 	return dateI18n(formats.datetime, `${datetime.replace(' ', 'T')}Z`, true);
 }
+
+/**
+ * Same naive-local convention as formatSiteLocalDatetime, but formats only
+ * the time portion (e.g. for showing an end time next to an already-printed
+ * start date).
+ *
+ * @param {string} datetime Naive datetime string, e.g. "2026-09-01 10:00:00".
+ * @return {string} Formatted time in the site's format.
+ */
+export function formatSiteLocalTime(datetime) {
+	const { formats } = getSettings();
+	return dateI18n(formats.time, `${datetime.replace(' ', 'T')}Z`, true);
+}

--- a/fair-events/src/Admin/manage-event/EventContextHeader.js
+++ b/fair-events/src/Admin/manage-event/EventContextHeader.js
@@ -1,44 +1,74 @@
 /**
  * EventContextHeader Component
  *
- * Context block shown directly under the Manage Event H1: occurrence
- * date/time, a series/occurrence badge, public-link status, and (for
- * generated occurrences) an explanation of why the Tickets tab is disabled.
+ * Structured context header shown directly under the Manage Event H1:
+ * breadcrumb, date/time/venue meta line, a chip row (link status, series
+ * badge, categories), and a "View public page" button. For generated
+ * occurrences, also explains why the Tickets tab is disabled.
  *
  * @package FairEvents
  */
 
+import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { formatSiteLocalDatetime } from 'fair-events-shared';
+import { dateI18n, getSettings } from '@wordpress/date';
+import {
+	formatSiteLocalDatetime,
+	formatSiteLocalTime,
+	getEventDisplayTitle,
+} from 'fair-events-shared';
 
 /**
- * @param {Object} props
- * @param {Object} props.eventDate      Event date object from the REST API.
- * @param {string} props.manageEventUrl Base Manage Event admin URL (no event_date_id).
+ * @param {Object}      props
+ * @param {Object}      props.eventDate      Event date object from the REST API.
+ * @param {string}      props.manageEventUrl Base Manage Event admin URL (no event_date_id).
+ * @param {string}      props.calendarUrl    Base Calendar admin URL.
+ * @param {Array}       props.venues         Venues loaded for the site (id, name).
  */
-export default function EventContextHeader({ eventDate, manageEventUrl }) {
+export default function EventContextHeader({
+	eventDate,
+	manageEventUrl,
+	calendarUrl,
+	venues = [],
+}) {
 	if (!eventDate) return null;
 
 	const dateLine = eventDate.start_datetime
 		? formatSiteLocalDatetime(eventDate.start_datetime)
 		: '—';
+	const timeRangeLine = eventDate.end_datetime
+		? `${dateLine} – ${formatSiteLocalTime(eventDate.end_datetime)}`
+		: dateLine;
+
+	const venue = venues.find((v) => v.id === eventDate.venue_id);
+	const venueLine = venue?.name || eventDate.address || null;
 
 	const linkedPosts = eventDate.linked_posts || [];
-	let linkStatus;
+	let linkChip;
 	if (eventDate.link_type === 'post' && linkedPosts.length > 0) {
-		linkStatus = sprintf(
-			/* translators: %s: title or URL of the linked post/page */
-			__('Links to: %s', 'fair-events'),
-			linkedPosts[0].title
-		);
+		linkChip = {
+			label: sprintf(
+				/* translators: %s: title of the linked post/page */
+				__('Public page: %s', 'fair-events'),
+				linkedPosts[0].title
+			),
+			className: 'fair-events-context-badge is-linked',
+		};
 	} else if (eventDate.link_type === 'external' && eventDate.external_url) {
-		linkStatus = sprintf(
-			/* translators: %s: title or URL of the linked post/page */
-			__('Links to: %s', 'fair-events'),
-			eventDate.external_url
-		);
+		linkChip = {
+			label: sprintf(
+				/* translators: %s: external URL the event links to */
+				__('External page: %s', 'fair-events'),
+				eventDate.external_url
+			),
+			className: 'fair-events-context-badge',
+		};
 	} else {
-		linkStatus = __('No public page yet', 'fair-events');
+		linkChip = {
+			label: __('No public page yet', 'fair-events'),
+			className: 'fair-events-context-badge',
+		};
 	}
 
 	const isMaster = eventDate.occurrence_type === 'master';
@@ -49,32 +79,81 @@ export default function EventContextHeader({ eventDate, manageEventUrl }) {
 		? `${manageEventUrl}&event_date_id=${eventDate.master.id}`
 		: null;
 
+	const seriesCount = isMaster
+		? 1 + (eventDate.generated_occurrences?.length || 0)
+		: 0;
+
+	const eventTitle = getEventDisplayTitle(eventDate.title);
+
+	let calendarLinkLabel = __('Calendar', 'fair-events');
+	let calendarHref = calendarUrl;
+	if (calendarUrl && eventDate.start_datetime) {
+		const month = eventDate.start_datetime.slice(0, 7);
+		calendarHref = `${calendarUrl}&month=${month}`;
+		const { formats } = getSettings();
+		const monthLabel = dateI18n(
+			formats.month || 'F Y',
+			`${eventDate.start_datetime.replace(' ', 'T')}Z`,
+			true
+		);
+		calendarLinkLabel = sprintf(
+			/* translators: %s: month and year, e.g. "July 2026" */
+			__('Calendar · %s', 'fair-events'),
+			monthLabel
+		);
+	}
+
+	const categories = eventDate.categories || [];
+
 	return (
 		<div
 			className="fair-events-context-header"
-			style={{ margin: '8px 0 16px' }}
+			style={{
+				margin: '8px 0 16px',
+				borderLeft: '3px solid #2271b1',
+				paddingLeft: '12px',
+			}}
 		>
+			<nav aria-label={__('Breadcrumb', 'fair-events')}>
+				{createInterpolateElement(
+					sprintf(
+						/* translators: 1: calendar link label (wrapped in <calendarlink> tags), 2: event title — breadcrumb trail after "Fair Events ›" */
+						__(
+							'Fair Events › <calendarlink>%1$s</calendarlink> › %2$s',
+							'fair-events'
+						),
+						calendarLinkLabel,
+						eventTitle
+					),
+					{
+						calendarlink: calendarHref ? (
+							<a href={calendarHref} />
+						) : (
+							<span />
+						),
+					}
+				)}
+			</nav>
+			<p style={{ margin: '4px 0' }}>
+				{timeRangeLine}
+				{venueLine && ` · ${venueLine}`}
+			</p>
 			<p style={{ margin: '0 0 4px' }}>
-				{dateLine}
-				{isMaster &&
-					(() => {
-						const count =
-							1 + (eventDate.generated_occurrences?.length || 0);
-						return (
-							<span className="fair-events-context-badge">
-								{sprintf(
-									/* translators: %d: number of dates in the recurring series */
-									_n(
-										'Recurring series — %d date',
-										'Recurring series — %d dates',
-										count,
-										'fair-events'
-									),
-									count
-								)}
-							</span>
-						);
-					})()}
+				<span className={linkChip.className}>{linkChip.label}</span>
+				{isMaster && (
+					<span className="fair-events-context-badge">
+						{sprintf(
+							/* translators: %d: number of dates in the recurring series */
+							_n(
+								'Recurring series — %d date',
+								'Recurring series — %d dates',
+								seriesCount,
+								'fair-events'
+							),
+							seriesCount
+						)}
+					</span>
+				)}
 				{isGenerated && (
 					<span className="fair-events-context-badge">
 						{sprintf(
@@ -88,8 +167,27 @@ export default function EventContextHeader({ eventDate, manageEventUrl }) {
 						</a>
 					</span>
 				)}
+				{categories.map((category) => (
+					<span
+						key={category.id}
+						className="fair-events-context-badge"
+					>
+						{category.name}
+					</span>
+				))}
 			</p>
-			<p style={{ margin: '0 0 4px' }}>{linkStatus}</p>
+			{eventDate.display_url && (
+				<p style={{ margin: '0 0 4px' }}>
+					<Button
+						variant="secondary"
+						href={eventDate.display_url}
+						target="_blank"
+						rel="noreferrer"
+					>
+						{__('View public page', 'fair-events')}
+					</Button>
+				</p>
+			)}
 			{isGenerated && (
 				<p style={{ margin: 0 }}>
 					{__('Tickets are managed on the series —', 'fair-events')}{' '}

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -1219,27 +1219,14 @@ export default function ManageEventApp() {
 			<h1>
 				{__('Manage Event', 'fair-events')}
 				{': '}
-				{eventDate.display_url ? (
-					<a
-						href={eventDate.display_url}
-						target="_blank"
-						rel="noreferrer"
-						style={{
-							color: 'inherit',
-							textDecoration: 'none',
-							borderBottom: '1px dotted currentColor',
-						}}
-					>
-						{getEventDisplayTitle(title)}
-					</a>
-				) : (
-					getEventDisplayTitle(title)
-				)}
+				{getEventDisplayTitle(title)}
 			</h1>
 
 			<EventContextHeader
 				eventDate={eventDate}
 				manageEventUrl={manageEventUrl}
+				calendarUrl={calendarUrl}
+				venues={venues}
 			/>
 
 			{error && (
@@ -1282,12 +1269,6 @@ export default function ManageEventApp() {
 					return descriptor ? descriptor.render(ctx) : null;
 				}}
 			</TabPanel>
-
-			<HStack spacing={2} style={{ marginTop: '16px' }}>
-				<Button variant="secondary" href={calendarUrl}>
-					{__('Back to Calendar', 'fair-events')}
-				</Button>
-			</HStack>
 
 			<ConfirmDialog
 				isOpen={deleteDialogOpen}

--- a/fair-events/src/Admin/manage-event/__tests__/EventContextHeader.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventContextHeader.test.jsx
@@ -1,0 +1,226 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for EventContextHeader (#1049).
+ *
+ * Covers:
+ *   - Occurrence variants: single (no series badge), master (recurring-series
+ *     count badge), generated (occurrence badge + "view series" link +
+ *     tickets-on-series note).
+ *   - Link-status variants: post, external, none.
+ *   - Breadcrumb calendar link carries &month=YYYY-MM from start_datetime.
+ *   - "View public page" button present iff display_url is set.
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import EventContextHeader from '../EventContextHeader.js';
+
+const manageEventUrl = '/wp-admin/admin.php?page=fair-events-manage-event';
+const calendarUrl = '/wp-admin/admin.php?page=fair-events-calendar';
+
+const baseEventDate = {
+	id: 1,
+	title: 'Test Event',
+	start_datetime: '2026-07-15 18:00:00',
+	end_datetime: '2026-07-15 20:00:00',
+	venue_id: null,
+	address: null,
+	link_type: 'none',
+	external_url: null,
+	display_url: null,
+	occurrence_type: 'single',
+	categories: [],
+};
+
+it('renders nothing when eventDate is missing', () => {
+	const { container } = render(
+		<EventContextHeader eventDate={null} manageEventUrl={manageEventUrl} />
+	);
+	expect(container).toBeEmptyDOMElement();
+});
+
+it('single occurrence: no series badge, no generated note', () => {
+	render(
+		<EventContextHeader
+			eventDate={baseEventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+		/>
+	);
+	expect(screen.queryByText(/Recurring series/i)).not.toBeInTheDocument();
+	expect(screen.queryByText(/Occurrence of/i)).not.toBeInTheDocument();
+	expect(
+		screen.queryByText(/Tickets are managed on the series/i)
+	).not.toBeInTheDocument();
+});
+
+it('master occurrence: shows recurring-series count badge', () => {
+	const eventDate = {
+		...baseEventDate,
+		occurrence_type: 'master',
+		generated_occurrences: [{ id: 2 }, { id: 3 }],
+	};
+	render(
+		<EventContextHeader
+			eventDate={eventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+		/>
+	);
+	expect(screen.getByText(/Recurring series — 3 dates/i)).toBeInTheDocument();
+});
+
+it('generated occurrence: shows occurrence badge, view-series link, and tickets note', () => {
+	const eventDate = {
+		...baseEventDate,
+		occurrence_type: 'generated',
+		master: {
+			id: 9,
+			title: 'Master Event',
+			start_datetime: '2026-07-01 18:00:00',
+		},
+	};
+	render(
+		<EventContextHeader
+			eventDate={eventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+		/>
+	);
+	expect(
+		screen.getByText(/Occurrence of Master Event on/i)
+	).toBeInTheDocument();
+	const viewSeriesLinks = screen.getAllByRole('link', {
+		name: /view series|open the master event/i,
+	});
+	expect(viewSeriesLinks.length).toBeGreaterThan(0);
+	viewSeriesLinks.forEach((link) => {
+		expect(link).toHaveAttribute(
+			'href',
+			`${manageEventUrl}&event_date_id=9`
+		);
+	});
+	expect(
+		screen.getByText(/Tickets are managed on the series/i)
+	).toBeInTheDocument();
+});
+
+it('link status: post shows the linked post title', () => {
+	const eventDate = {
+		...baseEventDate,
+		link_type: 'post',
+		linked_posts: [{ id: 5, title: 'My Public Page' }],
+	};
+	render(
+		<EventContextHeader
+			eventDate={eventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+		/>
+	);
+	expect(
+		screen.getByText(/Public page: My Public Page/i)
+	).toBeInTheDocument();
+});
+
+it('link status: external shows the external URL', () => {
+	const eventDate = {
+		...baseEventDate,
+		link_type: 'external',
+		external_url: 'https://example.com/event',
+	};
+	render(
+		<EventContextHeader
+			eventDate={eventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+		/>
+	);
+	expect(
+		screen.getByText(/External page: https:\/\/example\.com\/event/i)
+	).toBeInTheDocument();
+});
+
+it('link status: none shows the fallback chip', () => {
+	render(
+		<EventContextHeader
+			eventDate={baseEventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+		/>
+	);
+	expect(screen.getByText(/No public page yet/i)).toBeInTheDocument();
+});
+
+it('breadcrumb calendar link carries &month=YYYY-MM from start_datetime', () => {
+	render(
+		<EventContextHeader
+			eventDate={baseEventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+		/>
+	);
+	const calendarLink = screen.getByRole('link', { name: /Calendar/i });
+	expect(calendarLink).toHaveAttribute(
+		'href',
+		`${calendarUrl}&month=2026-07`
+	);
+});
+
+it('"View public page" button is shown only when display_url is set', () => {
+	const { rerender } = render(
+		<EventContextHeader
+			eventDate={baseEventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+		/>
+	);
+	expect(
+		screen.queryByRole('link', { name: /View public page/i })
+	).not.toBeInTheDocument();
+
+	rerender(
+		<EventContextHeader
+			eventDate={{
+				...baseEventDate,
+				display_url: 'https://example.com/event',
+			}}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+		/>
+	);
+	const button = screen.getByRole('link', { name: /View public page/i });
+	expect(button).toHaveAttribute('href', 'https://example.com/event');
+});
+
+it('resolves the venue name from the venues prop', () => {
+	const eventDate = { ...baseEventDate, venue_id: 7 };
+	render(
+		<EventContextHeader
+			eventDate={eventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+			venues={[{ id: 7, name: 'Community Hall' }]}
+		/>
+	);
+	expect(screen.getByText(/Community Hall/i)).toBeInTheDocument();
+});
+
+it('renders category chips', () => {
+	const eventDate = {
+		...baseEventDate,
+		categories: [
+			{ id: 1, name: 'Workshops', slug: 'workshops' },
+			{ id: 2, name: 'Music', slug: 'music' },
+		],
+	};
+	render(
+		<EventContextHeader
+			eventDate={eventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+		/>
+	);
+	expect(screen.getByText('Workshops')).toBeInTheDocument();
+	expect(screen.getByText('Music')).toBeInTheDocument();
+});

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -223,7 +223,11 @@ describe('context header (#986)', () => {
 
 		expect(
 			screen.getByText(
-				formatSiteLocalDatetime(mockEventDate.start_datetime)
+				new RegExp(
+					formatSiteLocalDatetime(
+						mockEventDate.start_datetime
+					).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+				)
 			)
 		).toBeInTheDocument();
 		expect(screen.queryByText(/Recurring series/)).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Rework `EventContextHeader.js` from an h1 + two bare `<p>` lines into a structured header: breadcrumb (`Fair Events › Calendar · Month YYYY › event title`, deep-linked to the event's month) → date/time/venue meta line → chip row (link status, series/occurrence badge, category chips) → an explicit "View public page" button.
- Remove the bottom "Back to Calendar" button and the dotted-underline disguised title link — both are superseded by the breadcrumb and the new button.
- Add a `formatSiteLocalTime` helper to `fair-events-shared` so the meta line can show a `start – end` time range without re-printing the full date.
- Display-only change — no REST/DB changes.

Closes #1049

## Test plan

- [x] `npm run test:js` in `fair-events` (81 passed, includes new `EventContextHeader.test.jsx`)
- [x] `npm test` in `fair-events-shared` (115 passed)
- [x] `npm run build` + `npm run format` in `fair-events`
- [x] Manually verified in the dev WordPress instance: single event with a linked post (chip + "View public page" button), an event with no public page yet, and confirmed the breadcrumb's calendar link carries `&month=YYYY-MM` and the old "Back to Calendar" button is gone.
