### PR TITLE
Resolve links for generated occurrences of post-linked events

### DIFF
--- a/fair-events/__tests__/Models/EventDatesTest.php
+++ b/fair-events/__tests__/Models/EventDatesTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * EventDates::get_display_url() unit tests
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Models;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Models\EventDates;
+use ReflectionProperty;
+
+/**
+ * Tests for EventDates::get_display_url()
+ */
+class EventDatesTest extends TestCase {
+
+	/**
+	 * Seed EventDates::$master_cache with a master row, bypassing the DB.
+	 *
+	 * @param EventDates $master Master row to cache under its own id.
+	 * @return void
+	 */
+	private function seed_master_cache( EventDates $master ) {
+		$cache_property = new ReflectionProperty( EventDates::class, 'master_cache' );
+		$cache_property->setValue( null, array( $master->id => $master ) );
+	}
+
+	/**
+	 * Generated occurrence with event_id = NULL and link_type = 'post'
+	 * resolves the link via the master's event_id (issue #1090).
+	 */
+	public function test_post_link_resolves_via_master_for_generated_occurrence() {
+		$master            = new EventDates();
+		$master->id        = 1;
+		$master->event_id  = 42;
+		$master->link_type = 'post';
+
+		$this->seed_master_cache( $master );
+
+		$occurrence                  = new EventDates();
+		$occurrence->id              = 2;
+		$occurrence->event_id        = null;
+		$occurrence->master_id       = 1;
+		$occurrence->occurrence_type = 'generated';
+		$occurrence->link_type       = 'post';
+
+		$this->assertSame( 'https://example.com/?p=42', $occurrence->get_display_url() );
+	}
+
+	/**
+	 * A generated occurrence whose master has no linked post returns null.
+	 */
+	public function test_post_link_returns_null_when_master_has_no_event_id() {
+		$master            = new EventDates();
+		$master->id        = 1;
+		$master->event_id  = null;
+		$master->link_type = 'post';
+
+		$this->seed_master_cache( $master );
+
+		$occurrence                  = new EventDates();
+		$occurrence->id              = 2;
+		$occurrence->event_id        = null;
+		$occurrence->master_id       = 1;
+		$occurrence->occurrence_type = 'generated';
+		$occurrence->link_type       = 'post';
+
+		$this->assertNull( $occurrence->get_display_url() );
+	}
+
+	/**
+	 * A single (non-generated) row with its own event_id ignores the master lookup.
+	 */
+	public function test_post_link_uses_own_event_id_when_present() {
+		$occurrence                  = new EventDates();
+		$occurrence->id              = 5;
+		$occurrence->event_id        = 99;
+		$occurrence->master_id       = null;
+		$occurrence->occurrence_type = 'single';
+		$occurrence->link_type       = 'post';
+
+		$this->assertSame( 'https://example.com/?p=99', $occurrence->get_display_url() );
+	}
+
+	/**
+	 * External link type is unaffected by the master-resolution fix.
+	 */
+	public function test_external_link_type_unchanged() {
+		$external               = new EventDates();
+		$external->link_type    = 'external';
+		$external->external_url = 'https://example.org/event';
+
+		$this->assertSame( 'https://example.org/event', $external->get_display_url() );
+	}
+}

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -41,3 +41,15 @@ if ( ! function_exists( 'get_option' ) ) {
 		return array_key_exists( $name, $options ) ? $options[ $name ] : $default_value;
 	}
 }
+
+if ( ! function_exists( 'get_permalink' ) ) {
+	/**
+	 * Stub of WordPress get_permalink() — deterministic URL from a post ID.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Fake permalink.
+	 */
+	function get_permalink( $post_id ) {
+		return 'https://example.com/?p=' . (int) $post_id;
+	}
+}

--- a/fair-events/src/API/PublicEventsController.php
+++ b/fair-events/src/API/PublicEventsController.php
@@ -370,7 +370,8 @@ class PublicEventsController extends WP_REST_Controller {
 				{$wpdb->posts}.post_title,
 				{$wpdb->posts}.post_content,
 				{$wpdb->posts}.post_excerpt,
-				{$wpdb->posts}.post_status
+				{$wpdb->posts}.post_status,
+				NULL as master_event_id
 			FROM {$dates_table}
 			INNER JOIN {$wpdb->posts} ON {$dates_table}.event_id = {$wpdb->posts}.ID
 			WHERE {$post_where_clause})
@@ -388,7 +389,8 @@ class PublicEventsController extends WP_REST_Controller {
 				NULL as post_title,
 				NULL as post_content,
 				NULL as post_excerpt,
-				NULL as post_status
+				NULL as post_status,
+				master_dates.event_id as master_event_id
 			FROM {$dates_table}
 			LEFT JOIN {$dates_table} master_dates ON {$dates_table}.master_id = master_dates.id
 			WHERE {$standalone_where_clause})
@@ -419,7 +421,21 @@ class PublicEventsController extends WP_REST_Controller {
 	private function format_occurrence( $row ) {
 		$start_datetime = $row->start_datetime;
 		$end_datetime   = $row->end_datetime ?: $start_datetime;
-		$is_standalone  = empty( $row->event_id ) || ( isset( $row->post_status ) && 'publish' !== $row->post_status );
+
+		// Generated occurrences of a post-linked recurring event don't carry
+		// their own event_id (see EventDates::resolve_instance()); resolve
+		// through the master's event_id so they behave like post-linked rows.
+		$resolved_event_id   = $row->event_id;
+		$resolved_via_master = false;
+		$master_post         = null;
+		if ( empty( $resolved_event_id ) && isset( $row->link_type ) && 'post' === $row->link_type && ! empty( $row->master_event_id ) ) {
+			$resolved_event_id   = $row->master_event_id;
+			$resolved_via_master = true;
+			$master_post         = get_post( $resolved_event_id );
+		}
+
+		$post_status   = $resolved_via_master ? ( $master_post ? $master_post->post_status : null ) : $row->post_status;
+		$is_standalone = empty( $resolved_event_id ) || ( isset( $post_status ) && 'publish' !== $post_status );
 
 		// Determine if all-day event.
 		$all_day = (bool) $row->all_day;
@@ -433,7 +449,13 @@ class PublicEventsController extends WP_REST_Controller {
 		// Get excerpt or truncated content.
 		$description = '';
 		if ( ! $is_standalone ) {
-			if ( ! empty( $row->post_excerpt ) ) {
+			if ( $resolved_via_master ) {
+				if ( has_excerpt( $resolved_event_id ) ) {
+					$description = get_the_excerpt( $resolved_event_id );
+				} elseif ( $master_post && $master_post->post_content ) {
+					$description = wp_trim_words( wp_strip_all_tags( $master_post->post_content ), 30 );
+				}
+			} elseif ( ! empty( $row->post_excerpt ) ) {
 				$description = $row->post_excerpt;
 			} elseif ( ! empty( $row->post_content ) ) {
 				$description = wp_trim_words( wp_strip_all_tags( $row->post_content ), 30 );
@@ -452,15 +474,15 @@ class PublicEventsController extends WP_REST_Controller {
 				$url = $row->external_url;
 			}
 		} else {
-			$uid   = 'fair_event_' . $row->event_id . '_' . $row->occurrence_id . '@' . $site_host;
-			$title = $row->post_title;
-			$url   = add_query_arg( 'event_date', (int) $row->occurrence_id, get_permalink( $row->event_id ) );
+			$uid   = 'fair_event_' . $resolved_event_id . '_' . $row->occurrence_id . '@' . $site_host;
+			$title = $resolved_via_master ? get_the_title( $resolved_event_id ) : $row->post_title;
+			$url   = add_query_arg( 'event_date', (int) $row->occurrence_id, get_permalink( $resolved_event_id ) );
 		}
 
 		// Get categories.
 		$categories = array();
-		if ( ! $is_standalone && $row->event_id ) {
-			$terms = wp_get_post_terms( $row->event_id, 'category' );
+		if ( ! $is_standalone && $resolved_event_id ) {
+			$terms = wp_get_post_terms( $resolved_event_id, 'category' );
 			if ( ! is_wp_error( $terms ) ) {
 				foreach ( $terms as $term ) {
 					$categories[] = array(

--- a/fair-events/src/API/__tests__/PublicEventsController.api.spec.js
+++ b/fair-events/src/API/__tests__/PublicEventsController.api.spec.js
@@ -1,0 +1,89 @@
+/**
+ * Playwright API tests for PublicEventsController's handling of generated
+ * occurrences on a post-linked recurring event (#1090).
+ *
+ * Generated occurrence rows don't inherit `event_id` from their master, so
+ * the public events feed used to leave `url: ""` for every occurrence after
+ * the first. These tests assert the feed resolves the link through the
+ * master's linked post instead.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('PublicEventsController — recurring post-linked occurrences', () => {
+	let api;
+	let eventPostId;
+	let occurrenceIds;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Public feed recurring post-link test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2035-07-01 10:00:00',
+				end_datetime: '2035-07-01 12:00:00',
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+
+		const occRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
+			{ headers: adminHeaders }
+		);
+		expect(occRes.ok()).toBeTruthy();
+		const occurrences = await occRes.json();
+		expect(occurrences.length).toBe(3);
+		occurrenceIds = occurrences.map((o) => o.id).sort((a, b) => a - b);
+	});
+
+	test.afterAll(async () => {
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+	});
+
+	test('generated occurrences get a non-empty, resolvable url', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/events?start_date=2035-07-01&end_date=2035-07-31&per_page=500'
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const eventsForOccurrences = occurrenceIds.map((occurrenceId) =>
+			body.events.find((e) => e.event_date_id === occurrenceId)
+		);
+
+		for (const event of eventsForOccurrences) {
+			expect(event).toBeTruthy();
+			expect(event.url).toBeTruthy();
+			expect(event.url).toContain(`event_date=${event.event_date_id}`);
+			expect(event.uid.startsWith('fair_event_')).toBe(true);
+		}
+	});
+});

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -603,12 +603,40 @@ class EventDates {
 			case 'external':
 				return $this->external_url;
 			case 'post':
-				return $this->event_id ? get_permalink( $this->event_id ) : null;
+				if ( $this->event_id ) {
+					return get_permalink( $this->event_id );
+				}
+				$master_event_id = $this->get_master_event_id();
+				return $master_event_id ? get_permalink( $master_event_id ) : null;
 			case 'none':
 			default:
 				$linked_post_id = $this->get_primary_linked_post_id();
 				return $linked_post_id ? get_permalink( $linked_post_id ) : null;
 		}
+	}
+
+	/**
+	 * Get the linked post ID for a generated occurrence's master row
+	 *
+	 * Generated occurrences don't inherit `event_id` from the master (see
+	 * resolve_instance()), so a `link_type = 'post'` occurrence with no
+	 * `event_id` of its own needs to look up the master's `event_id` directly.
+	 *
+	 * @return int|null Master's event_id, or null if not a generated occurrence
+	 *                   or the master has no linked post.
+	 */
+	private function get_master_event_id() {
+		if ( 'generated' !== $this->occurrence_type || ! $this->master_id ) {
+			return null;
+		}
+
+		if ( ! isset( self::$master_cache[ $this->master_id ] ) ) {
+			self::$master_cache[ $this->master_id ] = self::get_by_id( $this->master_id );
+		}
+
+		$master = self::$master_cache[ $this->master_id ];
+
+		return $master ? $master->event_id : null;
 	}
 
 	/**

--- a/fair-events/src/blocks/events-list/render.php
+++ b/fair-events/src/blocks/events-list/render.php
@@ -373,6 +373,8 @@ if ( ! empty( $event_source_slugs ) && is_array( $event_source_slugs ) ) {
 				$standalone      = $event_data['event_date'];
 				if ( 'external' === $standalone->link_type ) {
 					$event_classes[] = 'is-external';
+				} elseif ( $standalone->get_display_url() ) {
+					$event_classes[] = 'is-linked-post';
 				} else {
 					$event_classes[] = 'is-unlinked';
 				}


### PR DESCRIPTION
## Summary

- Generated occurrence rows of a recurring event inherit `link_type` from
  their master but not `event_id`, so `EventDates::get_display_url()` and
  `PublicEventsController`'s public feed returned no link for every
  occurrence after the first (`url: ""`, no "open" icon in the admin
  calendar).
- `get_display_url()`'s `'post'` case now falls back to the master's
  `event_id` when the occurrence's own is empty (mirroring the existing
  `'none'` case's `master_id ? master_id : id` pattern). All admin-facing
  callers (calendar, list, week blocks, `EventDatesController`) go through
  this method, so the fix propagates automatically.
- `PublicEventsController`'s standalone-branch query now also selects the
  master's `event_id`; `format_occurrence()` resolves through it so a
  post-linked generated occurrence gets a proper `fair_event_…` uid and a
  non-empty `url` instead of falling into the standalone branch.
- `events-list/render.php`'s CSS class logic (`is-linked-post` vs.
  `is-unlinked`) now checks the resolved display URL instead of assuming
  "no link" for anything but external links.

Closes #1090

## Test plan

- [x] `vendor/bin/phpunit` — new `EventDatesTest` covers
      `get_display_url()` resolving via the master for a generated
      occurrence, returning `null` when the master has no linked post, and
      using its own `event_id` when present (32 tests pass).
- [x] `vendor/bin/phpcs` — no new errors on changed files (verified
      before/after error counts match on pre-existing files).
- [x] Manual WP-CLI `eval-file` check against a live WordPress instance:
      created a post-linked recurring event with a generated child
      occurrence (`event_id = NULL`, `link_type` inherited), confirmed
      `get_display_url()` resolves the master's permalink and the public
      `/wp-json/fair-events/v1/events` feed returns a `fair_event_…` uid
      with a non-empty `url` for the child.
- [x] Added `PublicEventsController.api.spec.js` covering the same
      scenario via the REST API (blocked from running locally by the dev
      Docker stack lacking Application Passwords/Basic Auth — verified
      the underlying behavior via the `eval-file` check instead).
