### PR TITLE
Complete EventDates resolver: title fallback, resolved event id, canonical URL form

### DIFF
--- a/fair-events/__tests__/Models/EventDatesTest.php
+++ b/fair-events/__tests__/Models/EventDatesTest.php
@@ -29,7 +29,8 @@ class EventDatesTest extends TestCase {
 
 	/**
 	 * Generated occurrence with event_id = NULL and link_type = 'post'
-	 * resolves the link via the master's event_id (issue #1090).
+	 * resolves the link via the master's event_id (issue #1090), with
+	 * `?event_date={id}` appended since it's a generated occurrence.
 	 */
 	public function test_post_link_resolves_via_master_for_generated_occurrence() {
 		$master            = new EventDates();
@@ -46,7 +47,7 @@ class EventDatesTest extends TestCase {
 		$occurrence->occurrence_type = 'generated';
 		$occurrence->link_type       = 'post';
 
-		$this->assertSame( 'https://example.com/?p=42', $occurrence->get_display_url() );
+		$this->assertSame( 'https://example.com/?p=42&event_date=2', $occurrence->get_display_url() );
 	}
 
 	/**
@@ -93,5 +94,134 @@ class EventDatesTest extends TestCase {
 		$external->external_url = 'https://example.org/event';
 
 		$this->assertSame( 'https://example.org/event', $external->get_display_url() );
+	}
+
+	/**
+	 * A single row with its own event_id doesn't get `?event_date=` appended
+	 * — the plain permalink already resolves unambiguously.
+	 */
+	public function test_post_link_omits_occurrence_arg_for_single_row() {
+		$occurrence                  = new EventDates();
+		$occurrence->id              = 5;
+		$occurrence->event_id        = 99;
+		$occurrence->master_id       = null;
+		$occurrence->occurrence_type = 'single';
+		$occurrence->link_type       = 'post';
+
+		$this->assertSame( 'https://example.com/?p=99', $occurrence->get_display_url() );
+	}
+
+	/**
+	 * The master row of a series doesn't get `?event_date=` appended either.
+	 */
+	public function test_post_link_omits_occurrence_arg_for_master_row() {
+		$master                  = new EventDates();
+		$master->id              = 1;
+		$master->event_id        = 42;
+		$master->occurrence_type = 'master';
+		$master->link_type       = 'post';
+
+		$this->assertSame( 'https://example.com/?p=42', $master->get_display_url() );
+	}
+
+	/**
+	 * Display title resolves the #1090 shape (link_type='post',
+	 * event_id NULL) via the master's event_id, same as get_display_url().
+	 */
+	public function test_display_title_resolves_via_master_for_generated_occurrence() {
+		$master            = new EventDates();
+		$master->id        = 1;
+		$master->event_id  = 42;
+		$master->link_type = 'post';
+
+		$this->seed_master_cache( $master );
+
+		$occurrence                  = new EventDates();
+		$occurrence->id              = 2;
+		$occurrence->event_id        = null;
+		$occurrence->master_id       = 1;
+		$occurrence->occurrence_type = 'generated';
+		$occurrence->link_type       = 'post';
+
+		$this->assertSame( 'Post 42', $occurrence->get_display_title() );
+	}
+
+	/**
+	 * Display title returns null when the master has no linked post.
+	 */
+	public function test_display_title_returns_null_when_master_has_no_event_id() {
+		$master            = new EventDates();
+		$master->id        = 1;
+		$master->event_id  = null;
+		$master->link_type = 'post';
+
+		$this->seed_master_cache( $master );
+
+		$occurrence                  = new EventDates();
+		$occurrence->id              = 2;
+		$occurrence->event_id        = null;
+		$occurrence->master_id       = 1;
+		$occurrence->occurrence_type = 'generated';
+		$occurrence->link_type       = 'post';
+
+		$this->assertNull( $occurrence->get_display_title() );
+	}
+
+	/**
+	 * Display title uses the stored title for non-post link types.
+	 */
+	public function test_display_title_uses_stored_title_for_external() {
+		$external               = new EventDates();
+		$external->link_type    = 'external';
+		$external->title        = 'External Meetup';
+		$external->external_url = 'https://example.org/event';
+
+		$this->assertSame( 'External Meetup', $external->get_display_title() );
+	}
+
+	/**
+	 * Resolved event id returns the row's own event_id when present.
+	 */
+	public function test_resolved_event_id_uses_own_event_id() {
+		$occurrence            = new EventDates();
+		$occurrence->id        = 5;
+		$occurrence->event_id  = 99;
+		$occurrence->master_id = null;
+
+		$this->assertSame( 99, $occurrence->get_resolved_event_id() );
+	}
+
+	/**
+	 * Resolved event id falls back to the master's event_id for a
+	 * generated occurrence with no event_id of its own.
+	 */
+	public function test_resolved_event_id_falls_back_to_master() {
+		$master           = new EventDates();
+		$master->id       = 1;
+		$master->event_id = 42;
+
+		$this->seed_master_cache( $master );
+
+		$occurrence                  = new EventDates();
+		$occurrence->id              = 2;
+		$occurrence->event_id        = null;
+		$occurrence->master_id       = 1;
+		$occurrence->occurrence_type = 'generated';
+
+		$this->assertSame( 42, $occurrence->get_resolved_event_id() );
+	}
+
+	/**
+	 * Resolved event id returns null for a standalone row with no
+	 * event_id and no master.
+	 */
+	public function test_resolved_event_id_returns_null_when_unlinked() {
+		$occurrence                  = new EventDates();
+		$occurrence->id              = 5;
+		$occurrence->event_id        = null;
+		$occurrence->master_id       = null;
+		$occurrence->occurrence_type = 'single';
+
+		$this->assertNull( $occurrence->get_resolved_event_id() );
 	}
 }

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -53,3 +53,30 @@ if ( ! function_exists( 'get_permalink' ) ) {
 		return 'https://example.com/?p=' . (int) $post_id;
 	}
 }
+
+if ( ! function_exists( 'get_the_title' ) ) {
+	/**
+	 * Stub of WordPress get_the_title() — deterministic title from a post ID.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Fake title.
+	 */
+	function get_the_title( $post_id ) {
+		return 'Post ' . (int) $post_id;
+	}
+}
+
+if ( ! function_exists( 'add_query_arg' ) ) {
+	/**
+	 * Minimal stub of WordPress add_query_arg() for a single key/value pair.
+	 *
+	 * @param string $key   Query arg name.
+	 * @param mixed  $value Query arg value.
+	 * @param string $url   URL to append to.
+	 * @return string Decorated URL.
+	 */
+	function add_query_arg( $key, $value, $url ) {
+		$separator = ( false === strpos( $url, '?' ) ) ? '?' : '&';
+		return $url . $separator . rawurlencode( $key ) . '=' . rawurlencode( $value );
+	}
+}

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -570,7 +570,9 @@ class EventDates {
 	 * Get display title for an event date
 	 *
 	 * Returns the stored title for external/unlinked events,
-	 * or the post title for post-linked events.
+	 * or the post title for post-linked events, falling back to the master's
+	 * linked post for generated occurrences with no event_id of their own
+	 * (see get_master_event_id()).
 	 *
 	 * @return string|null The display title, or null if no title available.
 	 */
@@ -581,20 +583,41 @@ class EventDates {
 		}
 
 		// For post-linked events, get the post title.
+		$event_id = $this->get_resolved_event_id();
+
+		return $event_id ? get_the_title( $event_id ) : null;
+	}
+
+	/**
+	 * Get the resolved linked post ID for this occurrence
+	 *
+	 * Generated occurrences don't inherit `event_id` from the master (see
+	 * resolve_instance()), so consumers that need the linked post (uid
+	 * construction, categories, description, draft detection) should call
+	 * this instead of reading `event_id` directly.
+	 *
+	 * @return int|null Own event_id, the master's event_id for generated
+	 *                   post-linked occurrences, or null if unlinked.
+	 */
+	public function get_resolved_event_id() {
 		if ( $this->event_id ) {
-			return get_the_title( $this->event_id );
+			return $this->event_id;
 		}
 
-		return null;
+		return $this->get_master_event_id();
 	}
 
 	/**
 	 * Get display URL for an event date
 	 *
-	 * Returns the external URL for external events,
-	 * the post permalink for post-linked events,
-	 * or the permalink of a post linked via the junction table
-	 * (recurring instances linked from the post editor), if any.
+	 * Returns the external URL for external events, or the post permalink
+	 * for post-linked events (falling back to the master's linked post for
+	 * generated occurrences), or the permalink of a post linked via the
+	 * junction table (recurring instances linked from the post editor), if
+	 * any. Generated occurrences additionally get `?event_date={id}`
+	 * appended so the page can resolve which sibling occurrence to show
+	 * (see SelectedOccurrence); master/single rows link straight to the
+	 * plain permalink since it already resolves unambiguously.
 	 *
 	 * @return string|null The display URL, or null if no link.
 	 */
@@ -603,16 +626,31 @@ class EventDates {
 			case 'external':
 				return $this->external_url;
 			case 'post':
-				if ( $this->event_id ) {
-					return get_permalink( $this->event_id );
-				}
-				$master_event_id = $this->get_master_event_id();
-				return $master_event_id ? get_permalink( $master_event_id ) : null;
+				$event_id = $this->get_resolved_event_id();
+				return $event_id ? $this->with_occurrence_arg( get_permalink( $event_id ) ) : null;
 			case 'none':
 			default:
 				$linked_post_id = $this->get_primary_linked_post_id();
-				return $linked_post_id ? get_permalink( $linked_post_id ) : null;
+				return $linked_post_id ? $this->with_occurrence_arg( get_permalink( $linked_post_id ) ) : null;
 		}
+	}
+
+	/**
+	 * Append `?event_date={id}` to a URL for generated occurrences only.
+	 *
+	 * @param string|false $url Permalink to decorate.
+	 * @return string|null Decorated URL, or null if $url was falsy.
+	 */
+	private function with_occurrence_arg( $url ) {
+		if ( ! $url ) {
+			return null;
+		}
+
+		if ( 'generated' !== $this->occurrence_type ) {
+			return $url;
+		}
+
+		return add_query_arg( 'event_date', (int) $this->id, $url );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Layer 1 of the #1093 refactor: complete `EventDates`' link/title resolver so it's correct and consistent for every occurrence shape, before the new `EventFeedProvider` (a later PR) and its consumers are built on top of it.

- `get_display_title()` gained the same master-row fallback `get_display_url()` gained in #1092: a generated occurrence with `event_id IS NULL` and `link_type='post'` (the #1090 shape) now resolves its title via the master, instead of returning `null`.
- Added `get_resolved_event_id()` (public): the row's own `event_id`, falling back to the master's `event_id` for generated post-linked occurrences. Centralizes a lookup that would otherwise be re-derived by the provider (and today by several consumers) for uid construction, categories, description, and draft detection.
- Canonical URL form: `get_display_url()` now appends `?event_date={id}` **only for `generated` occurrences** — `master` and `single` rows link to the plain permalink, which already resolves unambiguously. This is a deliberate behavior change (see Regression notes) that makes the REST feed, admin calendar, and blocks agree on the same URL for the same occurrence, per the plan in the linked comment.

## Regression notes

- REST feed stops appending `?event_date=` for `single` events and master rows (was previously a no-op difference).
- Calendar/week blocks (once migrated to the resolver in a later PR) will stop appending `?event_date=` to the master occurrence of a series.

## Test plan

- [x] `vendor/bin/phpunit __tests__/Models/EventDatesTest.php` — 12/12 passing (added cases for title fallback, `get_resolved_event_id()`, and the generated-vs-master/single URL-form split; added minimal `add_query_arg()`/`get_the_title()` stubs to the test bootstrap).
- [x] `vendor/bin/phpcs` clean on changed files (pre-existing unrelated errors in `EventDates.php` left untouched).
- [x] `npm run format` — no diff beyond the intended files.

Refs #1093

This is the first of a stack of PRs implementing the plan in https://github.com/marcin-wosinek/fair-event-plugins/issues/1093#issuecomment-4954961391; later PRs (new `EventFeedProvider` service, then each consumer migration) will build on this branch.
