### PR TITLE
Replace recurrence checkbox with a Turn-into-a-series modal

### DIFF
--- a/fair-events-shared/src/RecurrenceControl.js
+++ b/fair-events-shared/src/RecurrenceControl.js
@@ -20,22 +20,29 @@ import { RECURRENCE_FREQUENCIES, RECURRENCE_END_TYPES } from './recurrence.js';
  * @param {Object}   props
  * @param {Object}   props.value                Recurrence state: { enabled, frequency, endType, count, until }.
  * @param {Function} props.onChange             Callback receiving the merged recurrence object.
+ * @param {boolean}  [props.hideToggle]         When true, omit the "Repeat this event" checkbox and always show the fields (for hosts like SeriesModal where recurrence is implicitly on).
  * @return {JSX.Element} The RecurrenceControl component.
  */
-export default function RecurrenceControl({ value, onChange }) {
+export default function RecurrenceControl({
+	value,
+	onChange,
+	hideToggle = false,
+}) {
 	const { enabled, frequency, endType, count, until } = value;
 
 	const update = (changes) => onChange({ ...value, ...changes });
 
 	return (
 		<VStack spacing={2}>
-			<CheckboxControl
-				label={__('Repeat this event', 'fair-events')}
-				checked={enabled}
-				onChange={(checked) => update({ enabled: checked })}
-			/>
+			{!hideToggle && (
+				<CheckboxControl
+					label={__('Repeat this event', 'fair-events')}
+					checked={enabled}
+					onChange={(checked) => update({ enabled: checked })}
+				/>
+			)}
 
-			{enabled && (
+			{(hideToggle || enabled) && (
 				<VStack spacing={2}>
 					<SelectControl
 						label={__('Frequency', 'fair-events')}

--- a/fair-events-shared/src/__tests__/recurrence.test.js
+++ b/fair-events-shared/src/__tests__/recurrence.test.js
@@ -1,4 +1,4 @@
-import { parseRRule, buildRRule } from '../recurrence.js';
+import { parseRRule, buildRRule, expandRRulePreview } from '../recurrence.js';
 
 describe('buildRRule', () => {
 	test('returns null when disabled', () => {
@@ -104,5 +104,90 @@ describe('parseRRule', () => {
 		const rrule = 'FREQ=WEEKLY;INTERVAL=2;UNTIL=20270115';
 		const parsed = parseRRule(rrule);
 		expect(buildRRule({ enabled: true, ...parsed })).toBe(rrule);
+	});
+});
+
+describe('expandRRulePreview', () => {
+	test('expands a daily count rule', () => {
+		const result = expandRRulePreview(
+			'FREQ=DAILY;COUNT=3',
+			'2026-09-01 10:00:00',
+			4
+		);
+		expect(result).toEqual({
+			dates: ['2026-09-01', '2026-09-02', '2026-09-03'],
+			totalCount: 3,
+			remainingCount: 0,
+			lastDate: '2026-09-03',
+		});
+	});
+
+	test('expands a weekly count rule and truncates to the limit', () => {
+		const result = expandRRulePreview(
+			'FREQ=WEEKLY;COUNT=6',
+			'2026-09-01 10:00:00',
+			4
+		);
+		expect(result.dates).toEqual([
+			'2026-09-01',
+			'2026-09-08',
+			'2026-09-15',
+			'2026-09-22',
+		]);
+		expect(result.totalCount).toBe(6);
+		expect(result.remainingCount).toBe(2);
+		expect(result.lastDate).toBe('2026-10-06');
+	});
+
+	test('expands a biweekly (INTERVAL=2) rule', () => {
+		const result = expandRRulePreview(
+			'FREQ=WEEKLY;INTERVAL=2;COUNT=3',
+			'2026-09-01 10:00:00',
+			4
+		);
+		expect(result.dates).toEqual([
+			'2026-09-01',
+			'2026-09-15',
+			'2026-09-29',
+		]);
+	});
+
+	test('expands a monthly rule', () => {
+		const result = expandRRulePreview(
+			'FREQ=MONTHLY;COUNT=3',
+			'2026-01-31 10:00:00',
+			4
+		);
+		expect(result.dates).toEqual([
+			'2026-01-31',
+			'2026-03-03',
+			'2026-04-03',
+		]);
+	});
+
+	test('expands a rule ending on UNTIL', () => {
+		const result = expandRRulePreview(
+			'FREQ=WEEKLY;UNTIL=20260922',
+			'2026-09-01 10:00:00',
+			4
+		);
+		expect(result.dates).toEqual([
+			'2026-09-01',
+			'2026-09-08',
+			'2026-09-15',
+			'2026-09-22',
+		]);
+		expect(result.totalCount).toBe(4);
+		expect(result.remainingCount).toBe(0);
+		expect(result.lastDate).toBe('2026-09-22');
+	});
+
+	test('returns an empty preview for a falsy rrule', () => {
+		expect(expandRRulePreview(null, '2026-09-01 10:00:00')).toEqual({
+			dates: [],
+			totalCount: 0,
+			remainingCount: 0,
+			lastDate: null,
+		});
 	});
 });

--- a/fair-events-shared/src/recurrence.js
+++ b/fair-events-shared/src/recurrence.js
@@ -111,3 +111,110 @@ export function buildRRule({ enabled, frequency, endType, count, until }) {
 
 	return ruleParts.join(';');
 }
+
+const MAX_PREVIEW_OCCURRENCES = 100;
+
+function pad2(n) {
+	return String(n).padStart(2, '0');
+}
+
+function toDateStr(date) {
+	return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(
+		date.getDate()
+	)}`;
+}
+
+function parseRawRRule(rrule) {
+	const result = { freq: null, interval: 1, count: null, until: null };
+	if (!rrule) return result;
+
+	rrule.split(';').forEach((part) => {
+		const [key, value] = part.split('=');
+		if (!key || value === undefined) return;
+
+		switch (key.toUpperCase()) {
+			case 'FREQ':
+				result.freq = value.toUpperCase();
+				break;
+			case 'INTERVAL':
+				result.interval = parseInt(value, 10) || 1;
+				break;
+			case 'COUNT':
+				result.count = parseInt(value, 10);
+				break;
+			case 'UNTIL': {
+				const y = value.substring(0, 4);
+				const m = value.substring(4, 6);
+				const d = value.substring(6, 8);
+				// Mirror RecurrenceService::parse_ical_date(): a bare Ymd
+				// UNTIL means end-of-day, else a same-day occurrence with a
+				// later time-of-day would be excluded.
+				result.until = new Date(`${y}-${m}-${d}T23:59:59`);
+				break;
+			}
+		}
+	});
+
+	return result;
+}
+
+function addInterval(date, freq, interval) {
+	const next = new Date(date);
+	switch (freq) {
+		case 'DAILY':
+			next.setDate(next.getDate() + interval);
+			break;
+		case 'WEEKLY':
+			next.setDate(next.getDate() + interval * 7);
+			break;
+		case 'MONTHLY':
+			next.setMonth(next.getMonth() + interval);
+			break;
+	}
+	return next;
+}
+
+/**
+ * Expand an RRULE into a preview of its occurrence dates, for display before
+ * saving. Mirrors `RecurrenceService::generate_occurrences()` in PHP
+ * (daily/weekly/monthly + INTERVAL + COUNT/UNTIL — the only rule vocabulary
+ * this editor supports) but only needs start dates, not full occurrence
+ * objects, and is capped the same way the server caps generation.
+ *
+ * @param {string} rrule         RRULE string.
+ * @param {string} startDatetime Naive "Y-m-d H:i:s" (or "Y-m-d") start of the first occurrence.
+ * @param {number} limit         Number of leading dates to return in full.
+ * @return {{dates: string[], totalCount: number, remainingCount: number, lastDate: string|null}} Preview summary.
+ */
+export function expandRRulePreview(rrule, startDatetime, limit = 4) {
+	const parsed = parseRawRRule(rrule);
+
+	if (!parsed.freq || !startDatetime) {
+		return { dates: [], totalCount: 0, remainingCount: 0, lastDate: null };
+	}
+
+	const start = new Date(startDatetime.replace(' ', 'T'));
+	const maxCount = parsed.count
+		? Math.min(parsed.count, MAX_PREVIEW_OCCURRENCES)
+		: MAX_PREVIEW_OCCURRENCES;
+
+	const allDates = [];
+	let current = start;
+	let count = 0;
+
+	while (count < maxCount) {
+		if (parsed.until && current > parsed.until) {
+			break;
+		}
+		count++;
+		allDates.push(toDateStr(current));
+		current = addInterval(current, parsed.freq, parsed.interval);
+	}
+
+	return {
+		dates: allDates.slice(0, limit),
+		totalCount: allDates.length,
+		remainingCount: Math.max(0, allDates.length - limit),
+		lastDate: allDates.length ? allDates[allDates.length - 1] : null,
+	};
+}

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -869,7 +869,11 @@ class EventDatesController extends WP_REST_Controller {
 			}
 
 			// Regenerate recurrence occurrences when rrule or dates change.
-			$rrule_changed = isset( $update_data['rrule'] );
+			// array_key_exists (not isset): clearing a series sends rrule: ''
+			// which normalizes to a null $update_data['rrule'] above, and
+			// isset() would treat that null as "unchanged" and skip the
+			// regenerate branch, orphaning the generated occurrences.
+			$rrule_changed = array_key_exists( 'rrule', $update_data );
 
 			$new_start     = $update_data['start_datetime'] ?? null;
 			$new_end       = $update_data['end_datetime'] ?? null;

--- a/fair-events/src/API/__tests__/EventDatesController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesController.api.spec.js
@@ -322,6 +322,117 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 	});
 });
 
+test.describe('EventDatesController — ending a series', () => {
+	let api;
+	let masterEventDateId;
+	let eventPostId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterEach(async () => {
+		if (masterEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+				{ headers: adminHeaders }
+			);
+			masterEventDateId = null;
+		}
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+			eventPostId = null;
+		}
+	});
+
+	async function createRecurringEvent(
+		api,
+		rrule,
+		start = '2035-04-01 10:00:00'
+	) {
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: { title: `End series test ${Date.now()}`, status: 'publish' },
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: start,
+				end_datetime: start.replace('10:00:00', '12:00:00'),
+				rrule,
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		const edBody = await edRes.json();
+		masterEventDateId = edBody.id;
+		return edBody;
+	}
+
+	async function getMaster(api, masterId) {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${masterId}`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		return await res.json();
+	}
+
+	test('PUT rrule: "" clears the series and removes generated occurrences', async ({
+		request: req,
+	}) => {
+		const localApi = await req.newContext({ baseURL: BASE_URL });
+		const master = await createRecurringEvent(
+			localApi,
+			'FREQ=WEEKLY;COUNT=3'
+		);
+		expect(master.generated_occurrences.length).toBe(2);
+
+		const putRes = await localApi.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{ headers: adminHeaders, data: { rrule: '' } }
+		);
+		expect(putRes.ok()).toBeTruthy();
+
+		const after = await getMaster(localApi, masterEventDateId);
+		expect(after.rrule).toBeNull();
+		expect(after.occurrence_type).toBe('single');
+		expect(after.recurrence_mode).toBe('none');
+		expect(after.generated_occurrences.length).toBe(0);
+	});
+
+	test('a details PUT that omits rrule leaves an existing series intact', async ({
+		request: req,
+	}) => {
+		const localApi = await req.newContext({ baseURL: BASE_URL });
+		const master = await createRecurringEvent(
+			localApi,
+			'FREQ=WEEKLY;COUNT=3'
+		);
+		expect(master.generated_occurrences.length).toBe(2);
+
+		const putRes = await localApi.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { title: 'Renamed via details save' },
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+
+		const after = await getMaster(localApi, masterEventDateId);
+		expect(after.rrule).toBe('FREQ=WEEKLY;COUNT=3');
+		expect(after.occurrence_type).toBe('master');
+		expect(after.generated_occurrences.length).toBe(2);
+	});
+});
+
 test.describe('EventDatesController — cancel/restore via toggle-exdate', () => {
 	let api;
 	let masterEventDateId;

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -40,16 +40,25 @@ import {
 	formatSiteLocalDatetime,
 	getEventDisplayTitle,
 	parseRRule,
-	buildRRule,
-	RecurrenceControl,
+	RECURRENCE_FREQUENCIES,
 } from 'fair-events-shared';
 import EventFinance from './EventFinance.js';
 import EventTickets from './EventTickets.js';
 import EventPhotos from './EventPhotos.js';
 import RecurrenceCalendar from './RecurrenceCalendar.js';
 import RecurrenceImpactSummary from './RecurrenceImpactSummary.js';
+import SeriesModal from './SeriesModal.js';
 import EventSignups from './EventSignups.js';
 import EventContextHeader from './EventContextHeader.js';
+
+// Naive site-local date (no timezone re-conversion — see UI_GUIDELINES.md
+// "Dates and times"). `dateStr` may be a plain date or a full datetime.
+function formatDateOnly(dateStr) {
+	return new Date(`${dateStr.split(' ')[0]}T00:00:00`).toLocaleDateString(
+		undefined,
+		{ year: 'numeric', month: 'short', day: 'numeric' }
+	);
+}
 
 export default function ManageEventApp() {
 	const eventDateId = window.fairEventsManageEventData?.eventDateId;
@@ -91,15 +100,6 @@ export default function ManageEventApp() {
 	const [availableCategories, setAvailableCategories] = useState([]);
 	const [creatingCategories, setCreatingCategories] = useState([]);
 
-	// Recurrence state
-	const [recurrence, setRecurrence] = useState({
-		enabled: false,
-		frequency: 'weekly',
-		endType: 'count',
-		count: 10,
-		until: '',
-	});
-
 	// Post creation state
 	const [creatingPost, setCreatingPost] = useState(false);
 	const [selectedPostType, setSelectedPostType] = useState(
@@ -113,6 +113,8 @@ export default function ManageEventApp() {
 	const [togglingExdate, setTogglingExdate] = useState(null);
 	const [recurrenceImpact, setRecurrenceImpact] = useState(null);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const [seriesModalOpen, setSeriesModalOpen] = useState(false);
+	const [endSeriesDialogOpen, setEndSeriesDialogOpen] = useState(false);
 
 	// Dirty-state tracking (#987): snapshot the saved form/ticket state so we
 	// can warn before losing edits and mark which tab holds them.
@@ -214,13 +216,6 @@ export default function ManageEventApp() {
 			setEndDate(eDate || '');
 			setEndTime(eTime ? eTime.substring(0, 5) : '');
 		}
-
-		// Populate recurrence from rrule
-		if (data.rrule) {
-			setRecurrence({ enabled: true, ...parseRRule(data.rrule) });
-		} else {
-			setRecurrence((prev) => ({ ...prev, enabled: false }));
-		}
 	};
 
 	// Plain-object snapshot of every Event Details field, used to detect
@@ -238,7 +233,6 @@ export default function ManageEventApp() {
 			linkType,
 			externalUrl,
 			categories: [...categories].sort(),
-			recurrence,
 		});
 
 	// Runs after every render; only commits a new snapshot right after
@@ -368,7 +362,6 @@ export default function ManageEventApp() {
 					address: venuesEnabled ? undefined : address,
 					link_type: linkType,
 					external_url: linkType === 'external' ? externalUrl : null,
-					rrule: buildRRule(recurrence),
 					categories,
 				},
 			});
@@ -437,6 +430,86 @@ export default function ManageEventApp() {
 				: ''
 		);
 	}, [title, eventDate]);
+
+	const handleSeriesSaved = (updated) => {
+		setEventDate(updated);
+		setSeriesModalOpen(false);
+	};
+
+	const handleSeriesImpact = (impact) => setRecurrenceImpact(impact);
+
+	const confirmEndSeries = async () => {
+		try {
+			const updated = await apiFetch({
+				path: `/fair-events/v1/event-dates/${eventDateId}`,
+				method: 'PUT',
+				data: { rrule: '' },
+			});
+			setEventDate(updated);
+			setRecurrenceImpact(
+				updated.recurrence_impact
+					? { impact: updated.recurrence_impact, blocked: false }
+					: null
+			);
+			setSuccess(__('Series ended.', 'fair-events'));
+		} catch (err) {
+			setError(
+				err.message || __('Failed to end the series.', 'fair-events')
+			);
+		} finally {
+			setEndSeriesDialogOpen(false);
+		}
+	};
+
+	const endSeriesConfirmMessage = useMemo(() => {
+		const count = eventDate?.generated_occurrences?.length || 0;
+		return sprintf(
+			/* translators: %d: number of generated dates that will be removed */
+			_n(
+				'End this series? %d generated date will be removed. This cannot be undone.',
+				'End this series? %d generated dates will be removed. This cannot be undone.',
+				count,
+				'fair-events'
+			),
+			count
+		);
+	}, [eventDate]);
+
+	const seriesSummary = useMemo(() => {
+		if (!eventDate?.rrule) return null;
+
+		const parsed = parseRRule(eventDate.rrule);
+		const freqLabel =
+			RECURRENCE_FREQUENCIES.find((f) => f.value === parsed.frequency)
+				?.label || parsed.frequency;
+		const dateCount = (eventDate.generated_occurrences?.length || 0) + 1;
+
+		let endLabel = '';
+		if (parsed.endType === 'until' && parsed.until) {
+			endLabel = formatDateOnly(parsed.until);
+		} else {
+			const occurrences = eventDate.generated_occurrences || [];
+			const last = occurrences[occurrences.length - 1];
+			if (last) {
+				endLabel = formatDateOnly(last.start_datetime);
+			}
+		}
+
+		return endLabel
+			? sprintf(
+					/* translators: 1: frequency label (e.g. Weekly), 2: number of dates, 3: end date */
+					__('Repeats %1$s · %2$d dates · ends %3$s', 'fair-events'),
+					freqLabel,
+					dateCount,
+					endLabel
+			  )
+			: sprintf(
+					/* translators: 1: frequency label (e.g. Weekly), 2: number of dates */
+					__('Repeats %1$s · %2$d dates', 'fair-events'),
+					freqLabel,
+					dateCount
+			  );
+	}, [eventDate]);
 
 	const handleCreatePost = async () => {
 		setCreatingPost(true);
@@ -615,7 +688,7 @@ export default function ManageEventApp() {
 					eventDateId={eventDateId}
 					startDatetime={eventDate.start_datetime}
 					endDatetime={eventDate.end_datetime}
-					isRecurring={recurrence.enabled}
+					isRecurring={!!eventDate?.rrule}
 					onDirtyChange={handleTicketsDirtyChange}
 				/>
 			),
@@ -927,10 +1000,55 @@ export default function ManageEventApp() {
 						</CardHeader>
 						<CardBody>
 							<VStack spacing={4}>
-								<RecurrenceControl
-									value={recurrence}
-									onChange={setRecurrence}
-								/>
+								<HStack alignment="center" wrap>
+									<span>
+										{eventDate.rrule
+											? seriesSummary
+											: __(
+													'This event happens once.',
+													'fair-events'
+											  )}
+									</span>
+									{eventDate.rrule ? (
+										<>
+											<Button
+												variant="secondary"
+												onClick={() =>
+													setSeriesModalOpen(true)
+												}
+											>
+												{__(
+													'Edit series',
+													'fair-events'
+												)}
+											</Button>
+											<Button
+												variant="tertiary"
+												isDestructive
+												onClick={() =>
+													setEndSeriesDialogOpen(true)
+												}
+											>
+												{__(
+													'End series',
+													'fair-events'
+												)}
+											</Button>
+										</>
+									) : (
+										<Button
+											variant="primary"
+											onClick={() =>
+												setSeriesModalOpen(true)
+											}
+										>
+											{__(
+												'Turn into a series',
+												'fair-events'
+											)}
+										</Button>
+									)}
+								</HStack>
 
 								{eventDate.occurrence_type === 'master' &&
 									(eventDate.generated_occurrences?.length >
@@ -1279,6 +1397,27 @@ export default function ManageEventApp() {
 			>
 				{deleteConfirmMessage}
 			</ConfirmDialog>
+
+			<ConfirmDialog
+				isOpen={endSeriesDialogOpen}
+				onConfirm={confirmEndSeries}
+				onCancel={() => setEndSeriesDialogOpen(false)}
+				confirmButtonText={__('End series', 'fair-events')}
+				cancelButtonText={__('Cancel', 'fair-events')}
+			>
+				{endSeriesConfirmMessage}
+			</ConfirmDialog>
+
+			{seriesModalOpen && (
+				<SeriesModal
+					eventDateId={eventDateId}
+					initialRrule={eventDate.rrule}
+					startDatetime={eventDate.start_datetime}
+					onClose={() => setSeriesModalOpen(false)}
+					onSaved={handleSeriesSaved}
+					onImpact={handleSeriesImpact}
+				/>
+			)}
 		</div>
 	);
 }

--- a/fair-events/src/Admin/manage-event/SeriesModal.js
+++ b/fair-events/src/Admin/manage-event/SeriesModal.js
@@ -1,0 +1,232 @@
+/**
+ * SeriesModal — "Turn into a series" / "Edit series" modal.
+ *
+ * Owns the frequency/ends fields and a live schedule preview, and saves
+ * immediately on confirm (recurrence no longer rides along with the details
+ * form's dirty-snapshot / Save flow).
+ *
+ * @package FairEvents
+ */
+
+import { useMemo, useState } from '@wordpress/element';
+import {
+	Button,
+	Modal,
+	Notice,
+	TabPanel,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	buildRRule,
+	expandRRulePreview,
+	parseRRule,
+	RecurrenceControl,
+} from 'fair-events-shared';
+
+const DEFAULT_RECURRENCE = {
+	enabled: true,
+	frequency: 'weekly',
+	endType: 'count',
+	count: 10,
+	until: '',
+};
+
+// Naive site-local date (no timezone re-conversion — see UI_GUIDELINES.md
+// "Dates and times"). Only the calendar date matters for the preview.
+function formatPreviewDate(dateStr) {
+	return new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+	});
+}
+
+/**
+ * @param {Object}        props
+ * @param {number}        props.eventDateId   The event date being edited.
+ * @param {string|null}   props.initialRrule  Stored rrule, or null when creating a new series.
+ * @param {string}        props.startDatetime Naive "Y-m-d H:i:s" start of the first occurrence, for the preview.
+ * @param {Function}      props.onClose       Called to dismiss the modal without saving.
+ * @param {Function}      props.onSaved       Called with the updated event date after a successful save.
+ * @param {Function}      props.onImpact      Called with `{ impact, blocked }` (or null) after save succeeds or fails.
+ */
+export default function SeriesModal({
+	eventDateId,
+	initialRrule,
+	startDatetime,
+	onClose,
+	onSaved,
+	onImpact,
+}) {
+	const isEditing = !!initialRrule;
+
+	const [recurrence, setRecurrence] = useState(() =>
+		initialRrule
+			? { enabled: true, ...parseRRule(initialRrule) }
+			: { ...DEFAULT_RECURRENCE }
+	);
+	const [saving, setSaving] = useState(false);
+	const [error, setError] = useState(null);
+
+	const rrule = buildRRule(recurrence);
+
+	const preview = useMemo(
+		() => expandRRulePreview(rrule, startDatetime, 4),
+		[rrule, startDatetime]
+	);
+
+	const handleConfirm = async () => {
+		setSaving(true);
+		setError(null);
+
+		try {
+			const updated = await apiFetch({
+				path: `/fair-events/v1/event-dates/${eventDateId}`,
+				method: 'PUT',
+				data: { rrule },
+			});
+			onImpact(
+				updated.recurrence_impact
+					? { impact: updated.recurrence_impact, blocked: false }
+					: null
+			);
+			onSaved(updated);
+		} catch (err) {
+			setError(
+				err.message || __('Failed to save the series.', 'fair-events')
+			);
+			onImpact(
+				err.data?.impact
+					? { impact: err.data.impact, blocked: true }
+					: null
+			);
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const confirmLabel = isEditing
+		? sprintf(
+				/* translators: %d: number of dates in the series */
+				__('Update series — %d dates', 'fair-events'),
+				preview.totalCount
+		  )
+		: sprintf(
+				/* translators: %d: number of dates in the series */
+				__('Create series — %d dates', 'fair-events'),
+				preview.totalCount
+		  );
+
+	const tabs = [
+		{
+			name: 'regular',
+			title: __('Regular schedule', 'fair-events'),
+		},
+		{
+			name: 'irregular',
+			title: __('Irregular series', 'fair-events'),
+			disabled: true,
+		},
+	];
+
+	return (
+		<Modal
+			title={
+				isEditing
+					? __('Edit series', 'fair-events')
+					: __('Turn into a series', 'fair-events')
+			}
+			onRequestClose={onClose}
+			className="fair-events-series-modal"
+		>
+			{error && (
+				<Notice status="error" isDismissible={false}>
+					{error}
+				</Notice>
+			)}
+
+			<TabPanel tabs={tabs}>
+				{(tab) =>
+					tab.name === 'regular' ? (
+						<HStack
+							spacing={6}
+							alignment="top"
+							wrap
+							style={{ marginTop: '16px' }}
+						>
+							<VStack spacing={4} style={{ minWidth: '260px' }}>
+								<RecurrenceControl
+									value={recurrence}
+									onChange={setRecurrence}
+									hideToggle
+								/>
+							</VStack>
+
+							<VStack spacing={2} style={{ minWidth: '200px' }}>
+								<strong>
+									{__('Schedule preview', 'fair-events')}
+								</strong>
+								{preview.dates.length === 0 && (
+									<p>
+										{__(
+											'No dates match this schedule yet.',
+											'fair-events'
+										)}
+									</p>
+								)}
+								<ul style={{ margin: 0, paddingLeft: '20px' }}>
+									{preview.dates.map((date) => (
+										<li key={date}>
+											{formatPreviewDate(date)}
+										</li>
+									))}
+								</ul>
+								{preview.remainingCount > 0 && (
+									<p>
+										{sprintf(
+											/* translators: 1: number of remaining dates, 2: last date in the series */
+											__(
+												'… %1$d more, until %2$s',
+												'fair-events'
+											),
+											preview.remainingCount,
+											formatPreviewDate(preview.lastDate)
+										)}
+									</p>
+								)}
+							</VStack>
+						</HStack>
+					) : (
+						<p style={{ marginTop: '16px' }}>
+							{__(
+								'Irregular series (picking arbitrary dates) is coming in a future update.',
+								'fair-events'
+							)}
+						</p>
+					)
+				}
+			</TabPanel>
+
+			<HStack
+				justify="flex-end"
+				spacing={2}
+				style={{ marginTop: '24px' }}
+			>
+				<Button variant="tertiary" onClick={onClose} disabled={saving}>
+					{__('Cancel', 'fair-events')}
+				</Button>
+				<Button
+					variant="primary"
+					onClick={handleConfirm}
+					isBusy={saving}
+					disabled={saving || preview.totalCount === 0}
+				>
+					{confirmLabel}
+				</Button>
+			</HStack>
+		</Modal>
+	);
+}


### PR DESCRIPTION
## Summary

- Replaces the inline "Repeat this event" checkbox in the Recurrence card
  (`ManageEventApp.js`) with a summary row — "This event happens once." or
  "Repeats weekly · N dates · ends …" — plus **Turn into a series** /
  **Edit series** / **End series** actions.
- Adds `SeriesModal.js`: a tabbed modal (Regular schedule now, Irregular
  series stubbed for a follow-up) with a live schedule preview
  (`expandRRulePreview`, new shared helper) and immediate save on confirm —
  recurrence no longer rides along in the Event Details dirty-snapshot /
  "Save event details" flow.
- Fixes a latent bug in `EventDatesController::update_item`: clearing a
  series via `rrule: ''` normalizes to `null` before persisting, and the
  regenerate-occurrences guard used `isset()` on that `null` — so End
  series silently no-opped and left orphaned generated occurrences. Now
  uses `array_key_exists()`.
- Confirms (and tests) that a details save with no `rrule` key never
  touches an existing series.

Closes #1050

## Notes

- The "Irregular series" tab is intentionally a disabled placeholder per
  the ticket — arbitrary-date series are a follow-up.
- Impact display (`RecurrenceImpactSummary`) is still post-save, as the
  ticket's open question recommended; a pre-confirm dry-run PUT is left
  as a follow-up.
- The Playwright API-spec suite (`npm run test:api`) currently fails
  broadly in this environment (`req.newContext is not a function`,
  401s on category/title-validation tests) — confirmed this is pre-existing
  on `main` too, not something this PR introduced. The two new
  end-series/omit-rrule tests follow the same pattern as the existing
  (currently failing) recurrence tests in this file and should pass once
  the environment issue is fixed.

## Test plan

- [x] `npm run test:js` in `fair-events` — 81 passed
- [x] `npm test` in `fair-events-shared` — 121 passed (incl. new
      `expandRRulePreview` cases: daily/weekly/biweekly/monthly ×
      count/until, plus the empty-rrule case)
- [x] `npm run build` in `fair-events`
- [x] `vendor/bin/phpcs` on `EventDatesController.php` — no new findings
      (pre-existing short-ternary/Yoda/prepare-placeholder warnings only,
      confirmed identical on `main`)
- [ ] `npm run test:api` — pre-existing environment failures (see Notes);
      not verified end-to-end against a working WP instance
