### PR TITLE
Add EventFeedProvider: single pipeline for occurrence assembly

### DIFF
--- a/fair-events/__tests__/Services/EventFeedProviderTest.php
+++ b/fair-events/__tests__/Services/EventFeedProviderTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * EventFeedProvider::group_by_day() unit tests
+ *
+ * Pure-logic tests only — get_occurrences() requires a live WordPress
+ * environment (get_post(), wp_get_post_terms(), wpdb) and is covered by the
+ * WP-CLI eval-file manual check instead (see TESTING.md).
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Services\EventFeedProvider;
+
+/**
+ * Tests for EventFeedProvider::group_by_day()
+ */
+class EventFeedProviderTest extends TestCase {
+
+	/**
+	 * Build a minimal occurrence DTO for a single-day event.
+	 *
+	 * @param string $uid   Occurrence uid.
+	 * @param string $start Naive 'Y-m-d H:i:s' start.
+	 * @param string $end   Naive 'Y-m-d H:i:s' end.
+	 * @return array Occurrence DTO.
+	 */
+	private function make_occurrence( $uid, $start, $end ) {
+		return array(
+			'uid'   => $uid,
+			'start' => $start,
+			'end'   => $end,
+		);
+	}
+
+	/**
+	 * A single-day occurrence lands in exactly one bucket, marked as both
+	 * first and last day.
+	 */
+	public function test_single_day_occurrence_lands_in_one_bucket() {
+		$occurrences = array(
+			$this->make_occurrence( 'a', '2026-03-10 09:00:00', '2026-03-10 11:00:00' ),
+		);
+
+		$by_day = EventFeedProvider::group_by_day( $occurrences, '2026-03-01 00:00:00', '2026-03-31 23:59:59' );
+
+		$this->assertArrayHasKey( '2026-03-10', $by_day );
+		$this->assertCount( 1, $by_day['2026-03-10'] );
+		$this->assertTrue( $by_day['2026-03-10'][0]['is_first_day'] );
+		$this->assertTrue( $by_day['2026-03-10'][0]['is_last_day'] );
+	}
+
+	/**
+	 * A multi-day occurrence is expanded into a bucket per spanned day, with
+	 * is_first_day/is_last_day set only on the boundary days.
+	 */
+	public function test_multi_day_occurrence_expands_across_buckets() {
+		$occurrences = array(
+			$this->make_occurrence( 'a', '2026-03-10 09:00:00', '2026-03-12 17:00:00' ),
+		);
+
+		$by_day = EventFeedProvider::group_by_day( $occurrences, '2026-03-01 00:00:00', '2026-03-31 23:59:59' );
+
+		$this->assertSame( array( '2026-03-10', '2026-03-11', '2026-03-12' ), array_keys( $by_day ) );
+
+		$this->assertTrue( $by_day['2026-03-10'][0]['is_first_day'] );
+		$this->assertFalse( $by_day['2026-03-10'][0]['is_last_day'] );
+
+		$this->assertFalse( $by_day['2026-03-11'][0]['is_first_day'] );
+		$this->assertFalse( $by_day['2026-03-11'][0]['is_last_day'] );
+
+		$this->assertFalse( $by_day['2026-03-12'][0]['is_first_day'] );
+		$this->assertTrue( $by_day['2026-03-12'][0]['is_last_day'] );
+	}
+
+	/**
+	 * A multi-day occurrence is clipped to the requested range, not expanded
+	 * past it.
+	 */
+	public function test_multi_day_occurrence_is_clipped_to_range() {
+		$occurrences = array(
+			$this->make_occurrence( 'a', '2026-02-27 09:00:00', '2026-03-02 17:00:00' ),
+		);
+
+		$by_day = EventFeedProvider::group_by_day( $occurrences, '2026-03-01 00:00:00', '2026-03-31 23:59:59' );
+
+		$this->assertSame( array( '2026-03-01', '2026-03-02' ), array_keys( $by_day ) );
+
+		// Clipped days still carry the DTO's true first/last-day markers.
+		$this->assertFalse( $by_day['2026-03-01'][0]['is_first_day'] );
+		$this->assertTrue( $by_day['2026-03-02'][0]['is_last_day'] );
+	}
+
+	/**
+	 * Occurrences on the same day are sorted by start time.
+	 */
+	public function test_same_day_occurrences_sorted_by_start_time() {
+		$occurrences = array(
+			$this->make_occurrence( 'late', '2026-03-10 18:00:00', '2026-03-10 19:00:00' ),
+			$this->make_occurrence( 'early', '2026-03-10 09:00:00', '2026-03-10 10:00:00' ),
+		);
+
+		$by_day = EventFeedProvider::group_by_day( $occurrences, '2026-03-01 00:00:00', '2026-03-31 23:59:59' );
+
+		$this->assertSame( array( 'early', 'late' ), array_column( $by_day['2026-03-10'], 'uid' ) );
+	}
+
+	/**
+	 * An occurrence with no end falls back to a single-day bucket at start.
+	 */
+	public function test_occurrence_with_no_end_defaults_to_start_day() {
+		$occurrence = $this->make_occurrence( 'a', '2026-03-10 09:00:00', '' );
+
+		$by_day = EventFeedProvider::group_by_day( array( $occurrence ), '2026-03-01 00:00:00', '2026-03-31 23:59:59' );
+
+		$this->assertSame( array( '2026-03-10' ), array_keys( $by_day ) );
+	}
+}

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -1145,6 +1145,28 @@ class EventDates {
 	}
 
 	/**
+	 * Get category term IDs for a standalone event date from the junction table
+	 *
+	 * @param int $event_date_id Event date ID.
+	 * @return int[] Array of term IDs.
+	 */
+	public static function get_category_ids( $event_date_id ) {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_event_date_categories';
+
+		$term_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				'SELECT term_id FROM %i WHERE event_date_id = %d',
+				$table_name,
+				$event_date_id
+			)
+		);
+
+		return array_map( 'intval', $term_ids );
+	}
+
+	/**
 	 * Get all linked post IDs for an event date from the junction table
 	 *
 	 * @param int $event_date_id Event date ID.

--- a/fair-events/src/Services/EventFeedProvider.php
+++ b/fair-events/src/Services/EventFeedProvider.php
@@ -1,0 +1,420 @@
+<?php
+/**
+ * Event Feed Provider
+ *
+ * Single pipeline for assembling occurrence DTOs for a date range, merging
+ * the local (post-linked + standalone) and external (iCal/Fair Events API)
+ * streams. See https://github.com/marcin-wosinek/fair-event-plugins/issues/1093.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Services;
+
+use FairEvents\Database\EventSourceRepository;
+use FairEvents\Helpers\DateHelper;
+use FairEvents\Helpers\FairEventsApiParser;
+use FairEvents\Helpers\ICalParser;
+use FairEvents\Models\EventDates;
+use FairEvents\Settings\Settings;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Assembles normalized occurrence DTOs for a date range.
+ *
+ * DTO shape: uid, event_date_id, event_id, occurrence_type, title,
+ * description, start, end, all_day, url, categories, source
+ * ('post'|'standalone'|'ical'|'api'), is_draft, source_color.
+ *
+ * `start`/`end` are naive site-local 'Y-m-d H:i:s' strings — the same form
+ * every other internal consumer (EventDates, WeeklyEventsProvider, blocks)
+ * already uses. Callers that need ISO 8601 (the public REST feed) convert
+ * at their own boundary via DateHelper::local_to_iso8601().
+ */
+class EventFeedProvider {
+
+	/**
+	 * Get normalized occurrence DTOs for a date range, sorted by start.
+	 *
+	 * @param string $start   Range start, naive 'Y-m-d H:i:s' site-local.
+	 * @param string $end     Range end, naive 'Y-m-d H:i:s' site-local.
+	 * @param array  $filters {
+	 *     Optional filters.
+	 *
+	 *     @type int[]  $categories           Category term IDs (OR'd with any
+	 *                                        category-type data sources on the
+	 *                                        given event sources).
+	 *     @type string[] $event_source_slugs Event source slugs whose iCal/API
+	 *                                        streams and category filters are
+	 *                                        merged in.
+	 *     @type bool   $include_drafts       Include draft posts.
+	 *     @type bool   $include_all_statuses Include posts of any status
+	 *                                        (supersedes include_drafts).
+	 * }
+	 * @return array[] Flat array of occurrence DTOs, sorted by 'start' ASC.
+	 */
+	public function get_occurrences( $start, $end, $filters = array() ) {
+		$filters = array_merge(
+			array(
+				'categories'           => array(),
+				'event_source_slugs'   => array(),
+				'include_drafts'       => false,
+				'include_all_statuses' => false,
+			),
+			$filters
+		);
+
+		list( $external_occurrences, $source_category_ids ) = $this->get_external_stream(
+			$start,
+			$end,
+			$filters['event_source_slugs']
+		);
+
+		$category_ids = array_values(
+			array_unique(
+				array_map( 'intval', array_merge( $filters['categories'], $source_category_ids ) )
+			)
+		);
+
+		$local_occurrences = $this->get_local_stream(
+			$start,
+			$end,
+			$category_ids,
+			$filters['include_drafts'],
+			$filters['include_all_statuses']
+		);
+
+		$occurrences = array_merge( $local_occurrences, $external_occurrences );
+
+		usort(
+			$occurrences,
+			function ( $a, $b ) {
+				return strcmp( $a['start'], $b['start'] );
+			}
+		);
+
+		return $occurrences;
+	}
+
+	/**
+	 * Expand a flat occurrence list into per-day buckets over a range,
+	 * marking first/last day for multi-day spans and sorting each day by
+	 * start time. Used by day-grid consumers (calendar/week blocks); REST
+	 * and list consumers use the flat list from get_occurrences() directly.
+	 *
+	 * @param array[] $occurrences  Flat DTO list, as returned by get_occurrences().
+	 * @param string  $range_start  Range start, naive 'Y-m-d H:i:s' or 'Y-m-d'.
+	 * @param string  $range_end    Range end, naive 'Y-m-d H:i:s' or 'Y-m-d'.
+	 * @return array<string, array[]> Map of 'Y-m-d' => DTOs (each with
+	 *                                'is_first_day'/'is_last_day' added),
+	 *                                sorted by start time within each day.
+	 */
+	public static function group_by_day( array $occurrences, $range_start, $range_end ) {
+		$range_start_date = DateHelper::local_date( $range_start );
+		$range_end_date   = DateHelper::local_date( $range_end );
+
+		$by_day = array();
+
+		foreach ( $occurrences as $occurrence ) {
+			$start_date = DateHelper::local_date( $occurrence['start'] );
+			$end_date   = ! empty( $occurrence['end'] ) ? DateHelper::local_date( $occurrence['end'] ) : $start_date;
+
+			$loop_date = max( $start_date, $range_start_date );
+			$last_date = min( $end_date, $range_end_date );
+
+			while ( $loop_date <= $last_date ) {
+				if ( ! isset( $by_day[ $loop_date ] ) ) {
+					$by_day[ $loop_date ] = array();
+				}
+
+				$by_day[ $loop_date ][] = array_merge(
+					$occurrence,
+					array(
+						'is_first_day' => $loop_date === $start_date,
+						'is_last_day'  => $loop_date === $end_date,
+					)
+				);
+
+				$loop_date = DateHelper::next_date( $loop_date );
+			}
+		}
+
+		foreach ( $by_day as &$day_occurrences ) {
+			usort(
+				$day_occurrences,
+				function ( $a, $b ) {
+					return strcmp( $a['start'], $b['start'] );
+				}
+			);
+		}
+		unset( $day_occurrences );
+
+		return $by_day;
+	}
+
+	/**
+	 * Local stream: post-linked and standalone rows from the fair_event_dates
+	 * table, filtered by enabled post types, post status, and categories.
+	 *
+	 * @param string $start                 Range start, naive site-local.
+	 * @param string $end                   Range end, naive site-local.
+	 * @param int[]  $category_ids          Category term IDs to filter by (empty = no filter).
+	 * @param bool   $include_drafts        Include draft posts.
+	 * @param bool   $include_all_statuses  Include posts of any status.
+	 * @return array[] Occurrence DTOs.
+	 */
+	private function get_local_stream( $start, $end, $category_ids, $include_drafts, $include_all_statuses ) {
+		$rows               = EventDates::get_for_date_range( $start, $end );
+		$enabled_post_types = Settings::get_enabled_post_types();
+		$site_host          = wp_parse_url( get_site_url(), PHP_URL_HOST );
+
+		$occurrences = array();
+
+		foreach ( $rows as $row ) {
+			$resolved_event_id = $row->get_resolved_event_id();
+
+			if ( $resolved_event_id ) {
+				$occurrence = $this->format_post_occurrence(
+					$row,
+					$resolved_event_id,
+					$enabled_post_types,
+					$include_drafts,
+					$include_all_statuses,
+					$category_ids,
+					$site_host
+				);
+			} else {
+				$occurrence = $this->format_standalone_occurrence( $row, $category_ids, $site_host );
+			}
+
+			if ( null !== $occurrence ) {
+				$occurrences[] = $occurrence;
+			}
+		}
+
+		return $occurrences;
+	}
+
+	/**
+	 * Build a DTO for a post-linked row, or null if it's filtered out.
+	 *
+	 * @param EventDates $row                   Event date row.
+	 * @param int        $event_id              Resolved linked post ID.
+	 * @param string[]   $enabled_post_types    Post types eligible for the feed.
+	 * @param bool       $include_drafts        Include draft posts.
+	 * @param bool       $include_all_statuses  Include posts of any status.
+	 * @param int[]      $category_ids          Category term IDs to filter by.
+	 * @param string     $site_host             Host for uid construction.
+	 * @return array|null Occurrence DTO, or null if filtered out.
+	 */
+	private function format_post_occurrence( EventDates $row, $event_id, $enabled_post_types, $include_drafts, $include_all_statuses, $category_ids, $site_host ) {
+		$post = get_post( $event_id );
+
+		if ( ! $post || ! in_array( $post->post_type, $enabled_post_types, true ) ) {
+			return null;
+		}
+
+		$is_draft = 'publish' !== $post->post_status;
+
+		if ( $is_draft && ! $include_drafts && ! $include_all_statuses ) {
+			return null;
+		}
+
+		$post_category_ids = wp_get_post_terms( $event_id, 'category', array( 'fields' => 'ids' ) );
+		if ( is_wp_error( $post_category_ids ) ) {
+			$post_category_ids = array();
+		}
+
+		if ( ! empty( $category_ids ) && empty( array_intersect( $post_category_ids, $category_ids ) ) ) {
+			return null;
+		}
+
+		$description = '';
+		if ( has_excerpt( $event_id ) ) {
+			$description = get_the_excerpt( $event_id );
+		} elseif ( $post->post_content ) {
+			$description = wp_trim_words( wp_strip_all_tags( $post->post_content ), 30 );
+		}
+
+		return array(
+			'uid'             => 'fair_event_' . $event_id . '_' . $row->id . '@' . $site_host,
+			'event_date_id'   => (int) $row->id,
+			'event_id'        => (int) $event_id,
+			'occurrence_type' => $row->occurrence_type,
+			'title'           => $row->get_display_title(),
+			'description'     => $description,
+			'start'           => $row->start_datetime,
+			'end'             => $row->end_datetime ? $row->end_datetime : $row->start_datetime,
+			'all_day'         => (bool) $row->all_day,
+			'url'             => $row->get_display_url(),
+			'categories'      => $this->get_category_objects( $post_category_ids ),
+			'source'          => 'post',
+			'is_draft'        => $is_draft,
+			'source_color'    => null,
+		);
+	}
+
+	/**
+	 * Build a DTO for a standalone row, or null if it's filtered out.
+	 *
+	 * @param EventDates $row          Event date row.
+	 * @param int[]      $category_ids Category term IDs to filter by.
+	 * @param string     $site_host    Host for uid construction.
+	 * @return array|null Occurrence DTO, or null if filtered out.
+	 */
+	private function format_standalone_occurrence( EventDates $row, $category_ids, $site_host ) {
+		$row_category_ids = EventDates::get_category_ids( $row->id );
+
+		if ( ! empty( $category_ids ) && empty( array_intersect( $row_category_ids, $category_ids ) ) ) {
+			return null;
+		}
+
+		return array(
+			'uid'             => 'standalone_' . $row->id . '@' . $site_host,
+			'event_date_id'   => (int) $row->id,
+			'event_id'        => null,
+			'occurrence_type' => $row->occurrence_type,
+			'title'           => $row->get_display_title(),
+			'description'     => '',
+			'start'           => $row->start_datetime,
+			'end'             => $row->end_datetime ? $row->end_datetime : $row->start_datetime,
+			'all_day'         => (bool) $row->all_day,
+			'url'             => $row->get_display_url(),
+			'categories'      => $this->get_category_objects( $row_category_ids ),
+			'source'          => 'standalone',
+			'is_draft'        => false,
+			'source_color'    => null,
+		);
+	}
+
+	/**
+	 * Resolve term IDs to {id, name, slug} objects, dropping any that no
+	 * longer exist.
+	 *
+	 * @param int[] $term_ids Category term IDs.
+	 * @return array[] Array of ['id','name','slug'].
+	 */
+	private function get_category_objects( $term_ids ) {
+		$categories = array();
+
+		foreach ( $term_ids as $term_id ) {
+			$term = get_term( (int) $term_id, 'category' );
+			if ( $term && ! is_wp_error( $term ) ) {
+				$categories[] = array(
+					'id'   => $term->term_id,
+					'name' => $term->name,
+					'slug' => $term->slug,
+				);
+			}
+		}
+
+		return $categories;
+	}
+
+	/**
+	 * External stream: iCal/Fair Events API events from the given event
+	 * sources' data sources, plus any category filter contributed by their
+	 * 'categories' data sources (merged into the local stream's filter by
+	 * the caller — local events are always included; categories, when
+	 * configured, only narrow them, mirroring the pre-#1093 behavior).
+	 *
+	 * @param string   $start               Range start, naive site-local.
+	 * @param string   $end                 Range end, naive site-local.
+	 * @param string[] $event_source_slugs  Event source slugs.
+	 * @return array{0: array[], 1: int[]} [occurrence DTOs, merged category term IDs].
+	 */
+	private function get_external_stream( $start, $end, $event_source_slugs ) {
+		$occurrences  = array();
+		$category_ids = array();
+
+		if ( empty( $event_source_slugs ) ) {
+			return array( $occurrences, $category_ids );
+		}
+
+		$repository = new EventSourceRepository();
+
+		foreach ( $event_source_slugs as $slug ) {
+			if ( ! is_string( $slug ) ) {
+				continue;
+			}
+
+			$source = $repository->get_by_slug( $slug );
+
+			if ( ! $source || ! $source['enabled'] ) {
+				continue;
+			}
+
+			foreach ( $source['data_sources'] as $data_source ) {
+				$type = $data_source['source_type'] ?? '';
+
+				if ( 'ical_url' === $type ) {
+					$url = $data_source['config']['url'] ?? '';
+					if ( empty( $url ) ) {
+						continue;
+					}
+
+					$color    = $data_source['config']['color'] ?? '#4caf50';
+					$fetched  = ICalParser::fetch_and_parse( $url );
+					$filtered = ICalParser::filter_events_for_month( $fetched, $start, $end );
+
+					foreach ( $filtered as $event ) {
+						$occurrences[] = $this->format_external_occurrence( $event, 'ical', $color );
+					}
+				} elseif ( 'fair_events_api' === $type ) {
+					$url = $data_source['config']['url'] ?? '';
+					if ( empty( $url ) ) {
+						continue;
+					}
+
+					$color     = $data_source['config']['color'] ?? '#4caf50';
+					$api_start = DateHelper::local_date( $start );
+					$api_end   = DateHelper::local_date( $end );
+					$fetched   = FairEventsApiParser::fetch_and_parse( $url, $api_start, $api_end );
+					$filtered  = FairEventsApiParser::filter_events_for_month( $fetched, $start, $end );
+
+					foreach ( $filtered as $event ) {
+						$occurrences[] = $this->format_external_occurrence( $event, 'api', $color );
+					}
+				} elseif ( 'categories' === $type ) {
+					$ids = $data_source['config']['category_ids'] ?? array();
+					if ( ! empty( $ids ) ) {
+						$category_ids = array_merge( $category_ids, $ids );
+					}
+				}
+			}
+		}
+
+		return array( $occurrences, array_unique( array_map( 'intval', $category_ids ) ) );
+	}
+
+	/**
+	 * Build a DTO for an external (iCal/API) event.
+	 *
+	 * @param array  $event  Event data from ICalParser or FairEventsApiParser.
+	 * @param string $source 'ical' or 'api'.
+	 * @param string $color  Source color (hex).
+	 * @return array Occurrence DTO.
+	 */
+	private function format_external_occurrence( array $event, $source, $color ) {
+		$start = $event['start'] ?? '';
+		$end   = ! empty( $event['end'] ) ? $event['end'] : $start;
+
+		return array(
+			'uid'             => $event['uid'] ?? md5( $start . ( $event['summary'] ?? '' ) ),
+			'event_date_id'   => null,
+			'event_id'        => null,
+			'occurrence_type' => 'external',
+			'title'           => $event['summary'] ?? '',
+			'description'     => $event['description'] ?? '',
+			'start'           => $start,
+			'end'             => $end,
+			'all_day'         => (bool) ( $event['all_day'] ?? false ),
+			'url'             => $event['url'] ?? '',
+			'categories'      => array(),
+			'source'          => $source,
+			'is_draft'        => false,
+			'source_color'    => $color,
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Layer 2 of the #1093 refactor (base: main, which already includes #1094 / Layer 1). Adds a single service, `FairEvents\Services\EventFeedProvider`, that owns the "occurrences for a date range" pipeline. Nothing consumes it yet — that's the remaining PRs in this stack (`PublicEventsController`, then each block, then `WeeklyEventsProvider`).

- **`get_occurrences( $start, $end, $filters )`** merges two streams and returns a flat, sorted list of normalized occurrence DTOs:
  - **Local stream**: `EventDates::get_for_date_range()` (already returns post-linked and standalone rows in one query with inheritance resolved), filtered in PHP by enabled post types + post status (`get_resolved_event_id()`/`get_post()`) and categories (`wp_get_post_terms()` for post-linked, the junction table for standalone).
  - **External stream**: iCal/Fair Events API events from the given event sources' data sources; a source's `categories` data source contributes to the *local* stream's category filter rather than filtering the external stream itself — this mirrors the existing `WeeklyEventsProvider`/`PublicEventsController::get_source_events()` semantics ("local events are always included; categories, when configured, act only as a filter", from c87cb01b).
  - Every title/URL comes from the Layer 1 resolver (`get_display_title()`/`get_display_url()`) — the provider never builds a link itself.
- **`group_by_day( $occurrences, $range_start, $range_end )`** (static): expands multi-day spans into per-day buckets with `is_first_day`/`is_last_day`, clipped to the range, sorted by start time per day. For grid consumers (calendar/week blocks); REST and list consumers will use the flat list directly.
- Added `EventDates::get_category_ids()` — the standalone-event counterpart to the existing `get_linked_post_ids()`, so the provider doesn't duplicate the junction-table query that used to live inline in `PublicEventsController::get_standalone_event_categories()`.

### DTO shape

```
uid, event_date_id, event_id, occurrence_type, title, description,
start, end, all_day, url, categories, source ('post'|'standalone'|'ical'|'api'),
is_draft, source_color
```

`start`/`end` are naive site-local `'Y-m-d H:i:s'` strings, matching every other internal consumer (`EventDates`, `WeeklyEventsProvider`, the blocks). The public REST feed (next PR) converts to ISO 8601 at its own boundary via `DateHelper::local_to_iso8601()`, same as it does today from raw DB rows — the DTO itself doesn't bake in the REST-specific format.

## Test plan

- [x] `vendor/bin/phpunit` — 45/45 passing, including 5 new `group_by_day()` cases (single-day, multi-day expansion, range clipping, same-day sort order, missing-end fallback).
- [x] `vendor/bin/phpcs` clean on changed files (pre-existing unrelated errors in `EventDates.php` left untouched).
- [x] `npm run format` — no diff beyond the intended files.
- [ ] **Not yet covered**: `get_occurrences()` itself needs a live WordPress environment (`get_post()`, `wp_get_post_terms()`, `wpdb`) and isn't called by anything in this PR, so there's nothing to exercise end-to-end yet. Its integration coverage (WP-CLI `eval-file` check per TESTING.md, plus the REST API spec parity assertions) lands with the first consumer migration in the next PR, where it's actually wired in.

Refs #1093

Part of the stack implementing https://github.com/marcin-wosinek/fair-event-plugins/issues/1093#issuecomment-4954961391. Builds on #1094 (merged). Next: `PublicEventsController` on the provider.
