### PR TITLE
Calendar: visible Add event button and event-pill legend

### DIFF
--- a/fair-events/src/Admin/calendar/CalendarApp.js
+++ b/fair-events/src/Admin/calendar/CalendarApp.js
@@ -17,6 +17,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { formatLocalDate, calculateLeadingDays } from 'fair-events-shared';
 import CalendarHeader from './components/CalendarHeader.js';
 import CalendarGrid from './components/CalendarGrid.js';
+import CalendarLegend from './components/CalendarLegend.js';
 import QuickEventModal from './components/QuickEventModal.js';
 
 function getInitialDate() {
@@ -140,6 +141,18 @@ export default function CalendarApp() {
 		setModalDate(date);
 	};
 
+	const handleHeaderAddEvent = () => {
+		const today = new Date();
+		const sameMonth =
+			today.getFullYear() === currentDate.getFullYear() &&
+			today.getMonth() === currentDate.getMonth();
+		handleAddEvent(
+			sameMonth
+				? today
+				: new Date(currentDate.getFullYear(), currentDate.getMonth(), 1)
+		);
+	};
+
 	const handleModalClose = () => {
 		setModalDate(null);
 	};
@@ -194,6 +207,7 @@ export default function CalendarApp() {
 						onPrevMonth={handlePrevMonth}
 						onNextMonth={handleNextMonth}
 						onToday={handleToday}
+						onAddEvent={handleHeaderAddEvent}
 					/>
 				</CardHeader>
 				<CardBody className="fair-events-calendar-card-body">
@@ -202,14 +216,18 @@ export default function CalendarApp() {
 							<Spinner />
 						</div>
 					) : (
-						<CalendarGrid
-							currentDate={currentDate}
-							events={events}
-							onAddEvent={handleAddEvent}
-							manageEventUrl={
-								window.fairEventsCalendarData?.manageEventUrl
-							}
-						/>
+						<>
+							<CalendarGrid
+								currentDate={currentDate}
+								events={events}
+								onAddEvent={handleAddEvent}
+								manageEventUrl={
+									window.fairEventsCalendarData
+										?.manageEventUrl
+								}
+							/>
+							<CalendarLegend />
+						</>
 					)}
 				</CardBody>
 			</Card>

--- a/fair-events/src/Admin/calendar/components/CalendarHeader.js
+++ b/fair-events/src/Admin/calendar/components/CalendarHeader.js
@@ -14,6 +14,7 @@ export default function CalendarHeader({
 	onPrevMonth,
 	onNextMonth,
 	onToday,
+	onAddEvent,
 }) {
 	const monthYear = currentDate.toLocaleDateString(undefined, {
 		month: 'long',
@@ -32,6 +33,9 @@ export default function CalendarHeader({
 				</Button>
 				<Button variant="secondary" onClick={onNextMonth}>
 					{__('Next', 'fair-events')}
+				</Button>
+				<Button variant="primary" onClick={onAddEvent}>
+					{__('Add event', 'fair-events')}
 				</Button>
 			</div>
 		</>

--- a/fair-events/src/Admin/calendar/components/CalendarLegend.js
+++ b/fair-events/src/Admin/calendar/components/CalendarLegend.js
@@ -1,0 +1,29 @@
+/**
+ * Calendar Legend Component
+ *
+ * Explains the four event-pill icon/color variants shown on the grid.
+ *
+ * @package FairEvents
+ */
+
+import { getLinkTypeVariants } from './linkTypes.js';
+
+export default function CalendarLegend() {
+	return (
+		<div className="fair-events-calendar-legend">
+			{getLinkTypeVariants().map(({ type, icon, label }) => (
+				<span
+					key={type}
+					className={`fair-events-calendar-event-row link-type-${type}`}
+				>
+					<span className="fair-events-calendar-event">
+						<span
+							className={`dashicons ${icon} fair-events-calendar-event-icon`}
+						/>
+						{label}
+					</span>
+				</span>
+			))}
+		</div>
+	);
+}

--- a/fair-events/src/Admin/calendar/components/DayCell.js
+++ b/fair-events/src/Admin/calendar/components/DayCell.js
@@ -9,6 +9,7 @@
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { getEventDisplayTitle } from 'fair-events-shared';
+import { getLinkTypeIcon } from './linkTypes.js';
 
 const MAX_VISIBLE_EVENTS = 3;
 
@@ -144,14 +145,7 @@ export default function DayCell({
 					{visibleEvents.map((event, index) => {
 						const eventPostId = getEventPostId(event.uid);
 						const linkType = getEventLinkType(event);
-						const linkTypeIcon =
-							linkType === 'post'
-								? 'dashicons-admin-post'
-								: linkType === 'instance'
-								? 'dashicons-update'
-								: linkType === 'external'
-								? 'dashicons-admin-links'
-								: 'dashicons-editor-unlink';
+						const linkTypeIcon = getLinkTypeIcon(linkType);
 						const categoryNames =
 							event.categories?.map((c) => c.name) || [];
 						const displayTitle = getEventDisplayTitle(event.title);

--- a/fair-events/src/Admin/calendar/components/__tests__/CalendarHeader.test.jsx
+++ b/fair-events/src/Admin/calendar/components/__tests__/CalendarHeader.test.jsx
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for CalendarHeader's "Add event" button (#1052).
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CalendarHeader from '../CalendarHeader.js';
+
+const currentDate = new Date(2026, 6, 1);
+
+it('renders Previous, Today, Next, and Add event buttons', () => {
+	render(
+		<CalendarHeader
+			currentDate={currentDate}
+			onPrevMonth={() => {}}
+			onNextMonth={() => {}}
+			onToday={() => {}}
+			onAddEvent={() => {}}
+		/>
+	);
+	expect(
+		screen.getByRole('button', { name: 'Previous' })
+	).toBeInTheDocument();
+	expect(screen.getByRole('button', { name: 'Today' })).toBeInTheDocument();
+	expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+	expect(
+		screen.getByRole('button', { name: 'Add event' })
+	).toBeInTheDocument();
+});
+
+it('calls onAddEvent when the Add event button is clicked', () => {
+	const onAddEvent = jest.fn();
+	render(
+		<CalendarHeader
+			currentDate={currentDate}
+			onPrevMonth={() => {}}
+			onNextMonth={() => {}}
+			onToday={() => {}}
+			onAddEvent={onAddEvent}
+		/>
+	);
+	fireEvent.click(screen.getByRole('button', { name: 'Add event' }));
+	expect(onAddEvent).toHaveBeenCalledTimes(1);
+});

--- a/fair-events/src/Admin/calendar/components/__tests__/CalendarLegend.test.jsx
+++ b/fair-events/src/Admin/calendar/components/__tests__/CalendarLegend.test.jsx
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for CalendarLegend (#1052).
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import CalendarLegend from '../CalendarLegend.js';
+
+it('renders all four link-type variants with their labels and classes', () => {
+	const { container } = render(<CalendarLegend />);
+
+	expect(screen.getByText('Public page')).toBeInTheDocument();
+	expect(screen.getByText('Series occurrence')).toBeInTheDocument();
+	expect(screen.getByText('External page')).toBeInTheDocument();
+	expect(screen.getByText('No public page yet')).toBeInTheDocument();
+
+	expect(
+		container.querySelector('.link-type-post .dashicons-admin-post')
+	).toBeInTheDocument();
+	expect(
+		container.querySelector('.link-type-instance .dashicons-update')
+	).toBeInTheDocument();
+	expect(
+		container.querySelector('.link-type-external .dashicons-admin-links')
+	).toBeInTheDocument();
+	expect(
+		container.querySelector('.link-type-unlinked .dashicons-editor-unlink')
+	).toBeInTheDocument();
+});

--- a/fair-events/src/Admin/calendar/components/linkTypes.js
+++ b/fair-events/src/Admin/calendar/components/linkTypes.js
@@ -1,0 +1,62 @@
+/**
+ * Event Link Type Metadata
+ *
+ * Shared source of truth for the four link-type variants shown as event
+ * pills on the calendar grid (DayCell) and explained in the legend
+ * (CalendarLegend).
+ *
+ * @package FairEvents
+ */
+
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Get the dashicon class for a link type.
+ *
+ * @param {string} linkType 'post', 'instance', 'external', or 'unlinked'.
+ * @return {string} Dashicon class name.
+ */
+export function getLinkTypeIcon(linkType) {
+	switch (linkType) {
+		case 'instance':
+			return 'dashicons-update';
+		case 'external':
+			return 'dashicons-admin-links';
+		case 'unlinked':
+			return 'dashicons-editor-unlink';
+		case 'post':
+		default:
+			return 'dashicons-admin-post';
+	}
+}
+
+/**
+ * Get the list of link-type variants with their icon and user-facing label,
+ * in the order they should appear in the legend.
+ *
+ * @return {Array<{type: string, icon: string, label: string}>} Variants.
+ */
+export function getLinkTypeVariants() {
+	return [
+		{
+			type: 'post',
+			icon: getLinkTypeIcon('post'),
+			label: __('Public page', 'fair-events'),
+		},
+		{
+			type: 'instance',
+			icon: getLinkTypeIcon('instance'),
+			label: __('Series occurrence', 'fair-events'),
+		},
+		{
+			type: 'external',
+			icon: getLinkTypeIcon('external'),
+			label: __('External page', 'fair-events'),
+		},
+		{
+			type: 'unlinked',
+			icon: getLinkTypeIcon('unlinked'),
+			label: __('No public page yet', 'fair-events'),
+		},
+	];
+}

--- a/fair-events/src/Admin/calendar/style.css
+++ b/fair-events/src/Admin/calendar/style.css
@@ -274,6 +274,19 @@ a.fair-events-calendar-event:visited {
 	padding: 2px 6px;
 }
 
+/* Legend */
+.fair-events-calendar-legend {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	padding: 12px;
+	border-top: 1px solid #c3c4c7;
+}
+
+.fair-events-calendar-legend .fair-events-calendar-event {
+	cursor: default;
+}
+
 /* Responsive */
 @media screen and (max-width: 782px) {
 	.fair-events-calendar-day {


### PR DESCRIPTION
## Summary
- Add a primary "Add event" button to the calendar header, always visible (not hover-gated), so first-time and touch users have a discoverable way to create events beyond the per-day hover "+"
- Add a legend row under the calendar grid explaining the four event-pill icon/color variants (public page, series occurrence, external page, no public page yet)
- Extract the link-type icon/label mapping into a shared `linkTypes.js` used by both `DayCell` and the new `CalendarLegend`, so the grid and legend can't drift apart

Refs #1052

## Test plan
- [x] `npm run test:js` in fair-events (84 tests passing, including new `CalendarHeader.test.jsx` and `CalendarLegend.test.jsx`)
- [x] `npm run build` in fair-events
- [x] `npm run format` clean
