### PR TITLE
Reimplement WeeklyEventsProvider::get_week() on EventFeedProvider

### DIFF
--- a/fair-events/src/Services/WeeklyEventsProvider.php
+++ b/fair-events/src/Services/WeeklyEventsProvider.php
@@ -11,16 +11,16 @@ namespace FairEvents\Services;
 
 use FairEvents\Database\EventSourceRepository;
 use FairEvents\Helpers\DateHelper;
-use FairEvents\Helpers\FairEventsApiParser;
-use FairEvents\Helpers\ICalParser;
-use FairEvents\Helpers\QueryHelper;
-use FairEvents\Models\EventDates;
-use FairEvents\Settings\Settings;
 
 defined( 'WPINC' ) || die;
 
 /**
  * Service for aggregating a source's events into a 7-day week structure.
+ *
+ * Reimplemented on top of EventFeedProvider + group_by_day(); the public
+ * return shape is preserved exactly since fair-audience's weekly digest
+ * (WeeklyDigestHooks, WeeklyDigestController, WeeklyDigestRenderer) consumes
+ * it directly.
  */
 class WeeklyEventsProvider {
 
@@ -60,64 +60,30 @@ class WeeklyEventsProvider {
 		$start_datetime = $week_start . ' 00:00:00';
 		$end_datetime   = $week_end . ' 23:59:59';
 
-		// Collect all events.
-		$all_events       = array();
-		$all_category_ids = array();
+		$provider    = new EventFeedProvider();
+		$occurrences = $provider->get_occurrences(
+			$start_datetime,
+			$end_datetime,
+			array(
+				'event_source_slugs' => array( $source_slug ),
+			)
+		);
 
-		foreach ( $source['data_sources'] as $data_source ) {
-			$type = $data_source['source_type'] ?? '';
-
-			if ( 'ical_url' === $type ) {
-				$url = $data_source['config']['url'] ?? '';
-				if ( ! empty( $url ) ) {
-					$this->collect_ical_events( $url, $start_datetime, $end_datetime, $all_events );
-				}
-			} elseif ( 'fair_events_api' === $type ) {
-				$url = $data_source['config']['url'] ?? '';
-				if ( ! empty( $url ) ) {
-					$this->collect_fair_events_api_events( $url, $week_start, $week_end, $start_datetime, $end_datetime, $all_events );
-				}
-			} elseif ( 'categories' === $type ) {
-				$category_ids = $data_source['config']['category_ids'] ?? array();
-				if ( ! empty( $category_ids ) ) {
-					$all_category_ids = array_merge( $all_category_ids, $category_ids );
-				}
-			}
-		}
-
-		$all_category_ids = array_unique( array_map( 'intval', $all_category_ids ) );
-
-		// Local events are always part of a source; categories, when configured,
-		// act only as a filter — mirrors PublicEventsController::get_source_events().
-		$this->collect_local_events( $all_category_ids, $start_datetime, $end_datetime, $all_events );
-		$this->collect_standalone_events( $start_datetime, $end_datetime, $all_events, $all_category_ids );
+		$occurrences_by_date = EventFeedProvider::group_by_day( $occurrences, $start_datetime, $end_datetime );
 
 		// Build 7-day response.
 		$days         = array();
 		$current_date = new \DateTime( $week_start, new \DateTimeZone( wp_timezone_string() ) );
-
-		$tz = new \DateTimeZone( wp_timezone_string() );
+		$tz           = new \DateTimeZone( wp_timezone_string() );
 
 		for ( $i = 0; $i < 7; $i++ ) {
 			$date_string = $current_date->format( 'Y-m-d' );
-			$day_events  = $all_events[ $date_string ] ?? array();
-
-			// Sort by start time.
-			usort(
-				$day_events,
-				function ( $a, $b ) {
-					return strcmp( $a['start_time'] ?? '99:99', $b['start_time'] ?? '99:99' );
-				}
+			$day_events  = array_map(
+				function ( $occurrence ) use ( $tz ) {
+					return $this->format_day_event( $occurrence, $tz );
+				},
+				$occurrences_by_date[ $date_string ] ?? array()
 			);
-
-			// Resolve end_weekday for multi-day events.
-			foreach ( $day_events as &$evt ) {
-				if ( ! empty( $evt['end_date'] ) ) {
-					$end_dt             = new \DateTime( $evt['end_date'], $tz );
-					$evt['end_weekday'] = wp_date( 'l', $end_dt->getTimestamp() );
-				}
-			}
-			unset( $evt );
 
 			$days[] = array(
 				'date'       => $date_string,
@@ -171,201 +137,35 @@ class WeeklyEventsProvider {
 	}
 
 	/**
-	 * Collect iCal events into the events array.
+	 * Map an EventFeedProvider occurrence DTO to the digest's day-event shape.
 	 *
-	 * @param string $url            iCal feed URL.
-	 * @param string $start_datetime Week start datetime.
-	 * @param string $end_datetime   Week end datetime.
-	 * @param array  $all_events     Events grouped by date (modified by reference).
+	 * @param array         $occurrence Occurrence DTO from EventFeedProvider (with
+	 *                                  is_first_day/is_last_day added by group_by_day()).
+	 * @param \DateTimeZone $tz         Site timezone, for resolving end_weekday.
+	 * @return array Day-event shape: title, start_time, end_time, url, all_day,
+	 *               event_id, event_date_id, end_date, end_weekday.
 	 */
-	private function collect_ical_events( $url, $start_datetime, $end_datetime, &$all_events ) {
-		$fetched  = ICalParser::fetch_and_parse( $url );
-		$filtered = ICalParser::filter_events_for_month( $fetched, $start_datetime, $end_datetime );
+	private function format_day_event( $occurrence, $tz ) {
+		$start_date = DateHelper::local_date( $occurrence['start'] );
+		$end_date   = ! empty( $occurrence['end'] ) ? DateHelper::local_date( $occurrence['end'] ) : $start_date;
+		$is_all_day = (bool) $occurrence['all_day'];
 
-		foreach ( $filtered as $event ) {
-			$start_date = DateHelper::local_date( $event['start'] );
-
-			if ( ! isset( $all_events[ $start_date ] ) ) {
-				$all_events[ $start_date ] = array();
-			}
-
-			$end_date = DateHelper::local_date( $event['end'] );
-
-			$all_events[ $start_date ][] = array(
-				'title'         => $event['summary'] ?? '',
-				'start_time'    => $event['all_day'] ? '' : DateHelper::local_time( $event['start'] ),
-				'end_time'      => $event['all_day'] ? '' : DateHelper::local_time( $event['end'] ),
-				'url'           => $event['url'] ?? '',
-				'all_day'       => (bool) $event['all_day'],
-				'event_id'      => null,
-				'event_date_id' => null,
-				'end_date'      => $end_date !== $start_date ? $end_date : null,
-			);
+		$end_weekday = null;
+		if ( $end_date !== $start_date ) {
+			$end_dt      = new \DateTime( $end_date, $tz );
+			$end_weekday = wp_date( 'l', $end_dt->getTimestamp() );
 		}
-	}
 
-	/**
-	 * Collect events from a Fair Events API endpoint.
-	 *
-	 * @param string $url            Fair Events API URL.
-	 * @param string $week_start     Week start date (Y-m-d).
-	 * @param string $week_end       Week end date (Y-m-d).
-	 * @param string $start_datetime Week start datetime.
-	 * @param string $end_datetime   Week end datetime.
-	 * @param array  $all_events     Events grouped by date (modified by reference).
-	 */
-	private function collect_fair_events_api_events( $url, $week_start, $week_end, $start_datetime, $end_datetime, &$all_events ) {
-		$fetched  = FairEventsApiParser::fetch_and_parse( $url, $week_start, $week_end );
-		$filtered = FairEventsApiParser::filter_events_for_month( $fetched, $start_datetime, $end_datetime );
-
-		foreach ( $filtered as $event ) {
-			$start_date = DateHelper::local_date( $event['start'] );
-
-			if ( ! isset( $all_events[ $start_date ] ) ) {
-				$all_events[ $start_date ] = array();
-			}
-
-			$end_date = DateHelper::local_date( $event['end'] );
-
-			$all_events[ $start_date ][] = array(
-				'title'         => $event['summary'] ?? '',
-				'start_time'    => $event['all_day'] ? '' : DateHelper::local_time( $event['start'] ),
-				'end_time'      => $event['all_day'] ? '' : DateHelper::local_time( $event['end'] ),
-				'url'           => $event['url'] ?? '',
-				'all_day'       => (bool) $event['all_day'],
-				'event_id'      => null,
-				'event_date_id' => null,
-				'end_date'      => $end_date !== $start_date ? $end_date : null,
-			);
-		}
-	}
-
-	/**
-	 * Collect WordPress post events, optionally filtered by categories.
-	 *
-	 * @param array  $category_ids   Category term IDs to filter by. Empty means no filter.
-	 * @param string $start_datetime Week start datetime.
-	 * @param string $end_datetime   Week end datetime.
-	 * @param array  $all_events     Events grouped by date (modified by reference).
-	 */
-	private function collect_local_events( $category_ids, $start_datetime, $end_datetime, &$all_events ) {
-		$query_args = array(
-			'post_type'              => Settings::get_enabled_post_types(),
-			'posts_per_page'         => -1,
-			'post_status'            => 'publish',
-			'fair_events_date_query' => array(
-				'start_before' => $end_datetime,
-				'end_after'    => $start_datetime,
-			),
-			'fair_events_order'      => 'ASC',
+		return array(
+			'title'         => $occurrence['title'],
+			'start_time'    => $is_all_day ? '' : DateHelper::local_time( $occurrence['start'] ),
+			'end_time'      => ( $is_all_day || empty( $occurrence['end'] ) ) ? '' : DateHelper::local_time( $occurrence['end'] ),
+			'url'           => $occurrence['url'],
+			'all_day'       => $is_all_day,
+			'event_id'      => $occurrence['event_id'],
+			'event_date_id' => $occurrence['event_date_id'],
+			'end_date'      => $end_date !== $start_date ? $end_date : null,
+			'end_weekday'   => $end_weekday,
 		);
-
-		if ( ! empty( $category_ids ) ) {
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-			$query_args['tax_query'] = array(
-				array(
-					'taxonomy'         => 'category',
-					'field'            => 'term_id',
-					'terms'            => $category_ids,
-					'include_children' => false,
-				),
-			);
-		}
-
-		add_filter( 'posts_join', array( QueryHelper::class, 'join_dates_table' ), 10, 2 );
-		add_filter( 'posts_where', array( QueryHelper::class, 'filter_by_dates' ), 10, 2 );
-		add_filter( 'posts_orderby', array( QueryHelper::class, 'order_by_dates' ), 10, 2 );
-
-		$query = new \WP_Query( $query_args );
-
-		remove_filter( 'posts_join', array( QueryHelper::class, 'join_dates_table' ), 10 );
-		remove_filter( 'posts_where', array( QueryHelper::class, 'filter_by_dates' ), 10 );
-		remove_filter( 'posts_orderby', array( QueryHelper::class, 'order_by_dates' ), 10 );
-
-		$processed = array();
-
-		if ( $query->have_posts() ) {
-			while ( $query->have_posts() ) {
-				$query->the_post();
-				$event_id = get_the_ID();
-
-				if ( isset( $processed[ $event_id ] ) ) {
-					continue;
-				}
-				$processed[ $event_id ] = true;
-
-				$occurrences = EventDates::get_all_by_event_id( $event_id );
-
-				foreach ( $occurrences as $event_dates ) {
-					$start_date = DateHelper::local_date( $event_dates->start_datetime );
-
-					if ( ! isset( $all_events[ $start_date ] ) ) {
-						$all_events[ $start_date ] = array();
-					}
-
-					$is_all_day = (bool) $event_dates->all_day;
-					$start_time = $is_all_day ? '' : DateHelper::local_time( $event_dates->start_datetime );
-					$end_time   = '';
-					if ( ! $is_all_day && $event_dates->end_datetime ) {
-						$end_time = DateHelper::local_time( $event_dates->end_datetime );
-					}
-
-					$end_date = $event_dates->end_datetime ? DateHelper::local_date( $event_dates->end_datetime ) : null;
-
-					$all_events[ $start_date ][] = array(
-						'title'         => get_the_title( $event_id ),
-						'start_time'    => $start_time,
-						'end_time'      => $end_time,
-						'url'           => get_permalink( $event_id ),
-						'all_day'       => $is_all_day,
-						'event_id'      => $event_id,
-						'event_date_id' => (int) $event_dates->id,
-						'end_date'      => $end_date !== $start_date ? $end_date : null,
-					);
-				}
-			}
-		}
-
-		wp_reset_postdata();
-	}
-
-	/**
-	 * Collect standalone events (external/unlinked).
-	 *
-	 * @param string $start_datetime Week start datetime.
-	 * @param string $end_datetime   Week end datetime.
-	 * @param array  $all_events     Events grouped by date (modified by reference).
-	 * @param array  $category_ids   Optional category term IDs to filter by.
-	 */
-	private function collect_standalone_events( $start_datetime, $end_datetime, &$all_events, $category_ids = array() ) {
-		$standalone = EventDates::get_standalone_for_date_range( $start_datetime, $end_datetime, $category_ids );
-
-		foreach ( $standalone as $event_dates ) {
-			$start_date = DateHelper::local_date( $event_dates->start_datetime );
-
-			if ( ! isset( $all_events[ $start_date ] ) ) {
-				$all_events[ $start_date ] = array();
-			}
-
-			$is_all_day = (bool) $event_dates->all_day;
-			$start_time = $is_all_day ? '' : DateHelper::local_time( $event_dates->start_datetime );
-			$end_time   = '';
-			if ( ! $is_all_day && $event_dates->end_datetime ) {
-				$end_time = DateHelper::local_time( $event_dates->end_datetime );
-			}
-
-			$end_date = $event_dates->end_datetime ? DateHelper::local_date( $event_dates->end_datetime ) : null;
-
-			$all_events[ $start_date ][] = array(
-				'title'         => $event_dates->get_display_title(),
-				'start_time'    => $start_time,
-				'end_time'      => $end_time,
-				'url'           => $event_dates->get_display_url(),
-				'all_day'       => $is_all_day,
-				'event_id'      => null,
-				'event_date_id' => (int) $event_dates->id,
-				'end_date'      => $end_date !== $start_date ? $end_date : null,
-			);
-		}
 	}
 }


### PR DESCRIPTION
## Summary

- Layer 3e of the #1093 refactor: reimplement `WeeklyEventsProvider::get_week()` on top of `EventFeedProvider::get_occurrences()` + `EventFeedProvider::group_by_day()`, folding the last of the six copies of the occurrence-assembly pipeline into the shared provider.
- The public return shape is preserved exactly (`{source, week, days[].events[].{title,start_time,end_time,url,all_day,event_id,event_date_id,end_date,end_weekday}}`) — fair-audience consumes it directly in `WeeklyDigestHooks.php`, `WeeklyDigestController.php`, and `WeeklyDigestRenderer.php`, none of which needed changes.
- `parse_iso_week()` is untouched (still used by `fair-events-experimental`).

Refs #1093

## Test plan

- [x] `npm run test:php` in `fair-events` (45 tests) and `fair-audience` (25 tests) — all pass.
- [x] `vendor/bin/phpcs` clean on the changed file.
- [x] WP-CLI `eval-file` manual check: created an event source, a post-linked single-day event, and a multi-day standalone event, then called `get_week()` and verified the 7-day shape, field presence, and values (title, start/end time, url, event_id, event_date_id, end_date, end_weekday) for both event types — passed.
