### PR TITLE
Make the recurrence calendar navigate instead of toggle

### DIFF
--- a/fair-events/src/Admin/manage-event/EditInstancesModal.js
+++ b/fair-events/src/Admin/manage-event/EditInstancesModal.js
@@ -1,0 +1,99 @@
+/**
+ * EditInstancesModal — lists a series' occurrences with explicit
+ * Cancel / Restore actions. This is the only place cancel/restore happens;
+ * the calendar grid is navigation-only.
+ *
+ * @package FairEvents
+ */
+
+import { useMemo } from '@wordpress/element';
+import {
+	Button,
+	Modal,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+// Naive site-local date (no timezone re-conversion — see UI_GUIDELINES.md
+// "Dates and times"). Only the calendar date matters here.
+function formatInstanceDate(dateStr) {
+	return new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
+		weekday: 'long',
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+	});
+}
+
+/**
+ * @param {Object}   props
+ * @param {Array}    props.generatedOccurrences All occurrences (active and cancelled) from the master's `generated_occurrences`.
+ * @param {string}   props.togglingExdate       The date currently being toggled, or null.
+ * @param {Function} props.onToggleExdate       Called with a `Y-m-d` date to cancel/restore it.
+ * @param {Function} props.onClose              Called to dismiss the modal.
+ */
+export default function EditInstancesModal({
+	generatedOccurrences,
+	togglingExdate,
+	onToggleExdate,
+	onClose,
+}) {
+	const occurrences = useMemo(() => {
+		return [...(generatedOccurrences || [])].sort((a, b) =>
+			a.start_datetime.localeCompare(b.start_datetime)
+		);
+	}, [generatedOccurrences]);
+
+	return (
+		<Modal
+			title={__('Edit instances', 'fair-events')}
+			onRequestClose={onClose}
+			className="fair-events-edit-instances-modal"
+		>
+			<VStack spacing={2}>
+				{occurrences.length === 0 && (
+					<p>{__('No occurrences yet.', 'fair-events')}</p>
+				)}
+				{occurrences.map((occ) => {
+					const date = occ.start_datetime.split(' ')[0];
+					const isCancelled = occ.status === 'cancelled';
+					const isToggling = togglingExdate === date;
+
+					return (
+						<HStack key={occ.id} justify="space-between">
+							<span
+								style={{
+									textDecoration: isCancelled
+										? 'line-through'
+										: 'none',
+								}}
+							>
+								{formatInstanceDate(date)}
+								{isCancelled &&
+									` (${__('Cancelled', 'fair-events')})`}
+							</span>
+							<Button
+								variant="tertiary"
+								isDestructive={!isCancelled}
+								isBusy={isToggling}
+								disabled={isToggling}
+								onClick={() => onToggleExdate(date)}
+							>
+								{isCancelled
+									? __('Restore', 'fair-events')
+									: __('Cancel', 'fair-events')}
+							</Button>
+						</HStack>
+					);
+				})}
+			</VStack>
+
+			<HStack justify="flex-end" style={{ marginTop: '24px' }}>
+				<Button variant="tertiary" onClick={onClose}>
+					{__('Close', 'fair-events')}
+				</Button>
+			</HStack>
+		</Modal>
+	);
+}

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -48,6 +48,7 @@ import EventPhotos from './EventPhotos.js';
 import RecurrenceCalendar from './RecurrenceCalendar.js';
 import RecurrenceImpactSummary from './RecurrenceImpactSummary.js';
 import SeriesModal from './SeriesModal.js';
+import EditInstancesModal from './EditInstancesModal.js';
 import EventSignups from './EventSignups.js';
 import EventContextHeader from './EventContextHeader.js';
 
@@ -114,6 +115,7 @@ export default function ManageEventApp() {
 	const [recurrenceImpact, setRecurrenceImpact] = useState(null);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const [seriesModalOpen, setSeriesModalOpen] = useState(false);
+	const [editInstancesModalOpen, setEditInstancesModalOpen] = useState(false);
 	const [endSeriesDialogOpen, setEndSeriesDialogOpen] = useState(false);
 
 	// Dirty-state tracking (#987): snapshot the saved form/ticket state so we
@@ -1067,11 +1069,28 @@ export default function ManageEventApp() {
 													' '
 												)[0]
 											}
-											manageEventUrl={`${manageEventUrl}&event_date_id=${eventDateId}`}
-											onToggleExdate={handleToggleExdate}
-											togglingExdate={togglingExdate}
+											manageEventUrl={manageEventUrl}
+											masterEventDateId={eventDateId}
 											embedded
 										/>
+									)}
+
+								{eventDate.occurrence_type === 'master' &&
+									(eventDate.generated_occurrences?.length >
+										0 ||
+										eventDate.cancelled_dates?.length >
+											0) && (
+										<Button
+											variant="secondary"
+											onClick={() =>
+												setEditInstancesModalOpen(true)
+											}
+										>
+											{__(
+												'Edit instances',
+												'fair-events'
+											)}
+										</Button>
 									)}
 							</VStack>
 						</CardBody>
@@ -1416,6 +1435,15 @@ export default function ManageEventApp() {
 					onClose={() => setSeriesModalOpen(false)}
 					onSaved={handleSeriesSaved}
 					onImpact={handleSeriesImpact}
+				/>
+			)}
+
+			{editInstancesModalOpen && (
+				<EditInstancesModal
+					generatedOccurrences={eventDate.generated_occurrences}
+					togglingExdate={togglingExdate}
+					onToggleExdate={handleToggleExdate}
+					onClose={() => setEditInstancesModalOpen(false)}
 				/>
 			)}
 		</div>

--- a/fair-events/src/Admin/manage-event/RecurrenceCalendar.js
+++ b/fair-events/src/Admin/manage-event/RecurrenceCalendar.js
@@ -1,8 +1,9 @@
 /**
  * Recurrence Calendar Component
  *
- * Simple mini-calendar showing recurring event occurrences
- * with cancel/restore toggle for individual dates.
+ * Simple mini-calendar showing recurring event occurrences. Every occurrence
+ * and the master cell navigate to their manage-event page; cancelling and
+ * restoring occurrences happens in the "Edit instances" modal instead.
  *
  * @package FairEvents
  */
@@ -28,20 +29,17 @@ export default function RecurrenceCalendar({
 	cancelledDates,
 	masterDate,
 	manageEventUrl,
-	onToggleExdate,
-	togglingExdate,
+	masterEventDateId,
 	embedded = false,
 }) {
 	const occurrences = generatedOccurrences || [];
 	const cancelledDatesList = cancelledDates || [];
 
-	// Build lookup maps. generatedOccurrences includes cancelled rows (so the
-	// API can report their id/status too) — only active ones count as
-	// "occurrences" here, cancelled ones are tracked via cancelledSet below.
+	// generatedOccurrences includes cancelled rows too (with id/status), so a
+	// single map covers both active and cancelled cells.
 	const occurrenceByDate = useMemo(() => {
 		const map = {};
 		occurrences.forEach((occ) => {
-			if (occ.status === 'cancelled') return;
 			const date = occ.start_datetime.split(' ')[0];
 			map[date] = occ;
 		});
@@ -158,8 +156,7 @@ export default function RecurrenceCalendar({
 						masterDate={masterDate}
 						todayStr={todayStr}
 						manageEventUrl={manageEventUrl}
-						onToggleExdate={onToggleExdate}
-						togglingExdate={togglingExdate}
+						masterEventDateId={masterEventDateId}
 					/>
 				))}
 			</div>
@@ -243,8 +240,7 @@ function MiniMonth({
 	masterDate,
 	todayStr,
 	manageEventUrl,
-	onToggleExdate,
-	togglingExdate,
+	masterEventDateId,
 }) {
 	const year = monthDate.getFullYear();
 	const month = monthDate.getMonth();
@@ -267,11 +263,18 @@ function MiniMonth({
 	for (let day = 1; day <= daysInMonth; day++) {
 		const date = new Date(year, month, day);
 		const dateStr = formatLocalDate(date);
-		const isOccurrence = dateStr in occurrenceByDate;
-		const isCancelled = cancelledSet.has(dateStr);
+		const occ = occurrenceByDate[dateStr];
+		const isCancelled =
+			occ?.status === 'cancelled' || cancelledSet.has(dateStr);
+		const isOccurrence = !!occ && !isCancelled;
 		const isMaster = dateStr === masterDate;
 		const isToday = dateStr === todayStr;
-		const occ = occurrenceByDate[dateStr];
+		const fullDateLabel = date.toLocaleDateString(undefined, {
+			weekday: 'long',
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric',
+		});
 
 		let bg = 'transparent';
 		let color = '#1e1e1e';
@@ -315,32 +318,11 @@ function MiniMonth({
 			position: 'relative',
 		};
 
-		const isToggleable = (isOccurrence || isCancelled) && !isMaster;
-		const isToggling = togglingExdate === dateStr;
+		const isNavigable = (isOccurrence || isCancelled) && !isMaster;
 
 		const cellContent = (
-			<div
-				key={dateStr}
-				style={cellStyle}
-				onClick={
-					isToggleable && !isToggling
-						? () => onToggleExdate(dateStr)
-						: undefined
-				}
-				role={isToggleable ? 'button' : undefined}
-				tabIndex={isToggleable ? 0 : undefined}
-				onKeyDown={
-					isToggleable && !isToggling
-						? (e) => {
-								if (e.key === 'Enter' || e.key === ' ') {
-									e.preventDefault();
-									onToggleExdate(dateStr);
-								}
-						  }
-						: undefined
-				}
-			>
-				{isToggling ? '…' : day}
+			<div key={dateStr} style={cellStyle}>
+				{day}
 			</div>
 		);
 
@@ -348,29 +330,27 @@ function MiniMonth({
 			cells.push(
 				<Tooltip key={dateStr} text={__('Master event', 'fair-events')}>
 					<a
-						href={`${manageEventUrl}`}
+						href={`${manageEventUrl}&event_date_id=${masterEventDateId}`}
+						aria-label={fullDateLabel}
 						style={{ textDecoration: 'none' }}
 					>
 						{cellContent}
 					</a>
 				</Tooltip>
 			);
-		} else if (isOccurrence) {
+		} else if (isNavigable) {
 			cells.push(
 				<Tooltip
 					key={dateStr}
-					text={__('Click to cancel this occurrence', 'fair-events')}
+					text={__('Open this occurrence', 'fair-events')}
 				>
-					{cellContent}
-				</Tooltip>
-			);
-		} else if (isCancelled) {
-			cells.push(
-				<Tooltip
-					key={dateStr}
-					text={__('Click to restore this occurrence', 'fair-events')}
-				>
-					{cellContent}
+					<a
+						href={`${manageEventUrl}&event_date_id=${occ.id}`}
+						aria-label={fullDateLabel}
+						style={{ textDecoration: 'none' }}
+					>
+						{cellContent}
+					</a>
 				</Tooltip>
 			);
 		} else {

--- a/fair-events/src/Admin/manage-event/__tests__/EditInstancesModal.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EditInstancesModal.test.jsx
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for EditInstancesModal (#981 Part 3).
+ *
+ * Covers:
+ *   - Opens and lists occurrences with their cancel/restore action.
+ *   - Cancel/Restore calls onToggleExdate with the occurrence's date.
+ *   - Close calls onClose.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EditInstancesModal from '../EditInstancesModal.js';
+
+const generatedOccurrences = [
+	{ id: 2, start_datetime: '2026-07-08 18:00:00', status: 'active' },
+	{ id: 3, start_datetime: '2026-07-15 18:00:00', status: 'cancelled' },
+];
+
+// Matches the date formatting in EditInstancesModal.
+function instanceDateLabel(dateStr) {
+	return new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
+		weekday: 'long',
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+	});
+}
+
+it('lists occurrences with Cancel / Restore actions', () => {
+	render(
+		<EditInstancesModal
+			generatedOccurrences={generatedOccurrences}
+			togglingExdate={null}
+			onToggleExdate={() => {}}
+			onClose={() => {}}
+		/>
+	);
+
+	expect(
+		screen.getByText(instanceDateLabel('2026-07-08'), { exact: false })
+	).toBeInTheDocument();
+	expect(
+		screen.getByText(instanceDateLabel('2026-07-15'), { exact: false })
+	).toBeInTheDocument();
+	expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+	expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
+});
+
+it('calls onToggleExdate with the date when Cancel is clicked', () => {
+	const onToggleExdate = jest.fn();
+	render(
+		<EditInstancesModal
+			generatedOccurrences={generatedOccurrences}
+			togglingExdate={null}
+			onToggleExdate={onToggleExdate}
+			onClose={() => {}}
+		/>
+	);
+
+	fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+	expect(onToggleExdate).toHaveBeenCalledWith('2026-07-08');
+});
+
+it('calls onToggleExdate with the date when Restore is clicked', () => {
+	const onToggleExdate = jest.fn();
+	render(
+		<EditInstancesModal
+			generatedOccurrences={generatedOccurrences}
+			togglingExdate={null}
+			onToggleExdate={onToggleExdate}
+			onClose={() => {}}
+		/>
+	);
+
+	fireEvent.click(screen.getByRole('button', { name: 'Restore' }));
+	expect(onToggleExdate).toHaveBeenCalledWith('2026-07-15');
+});
+
+it('calls onClose when Close is clicked', () => {
+	const onClose = jest.fn();
+	render(
+		<EditInstancesModal
+			generatedOccurrences={generatedOccurrences}
+			togglingExdate={null}
+			onToggleExdate={() => {}}
+			onClose={onClose}
+		/>
+	);
+
+	// The WP Modal chrome also renders its own "Close" dismiss button, so
+	// disambiguate by taking the last one (our footer button).
+	const closeButtons = screen.getAllByRole('button', { name: 'Close' });
+	fireEvent.click(closeButtons[closeButtons.length - 1]);
+	expect(onClose).toHaveBeenCalled();
+});

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -301,6 +301,50 @@ describe('context header (#986)', () => {
 	});
 });
 
+describe('edit instances modal (#981 Part 3)', () => {
+	it('opens the Edit instances modal from the Recurrence card', async () => {
+		window.history.replaceState({}, '', '?tab=event-details');
+		apiFetch.mockImplementation((opts) => {
+			if (opts.path && opts.path.includes('/event-dates/')) {
+				return Promise.resolve({
+					...mockEventDate,
+					occurrence_type: 'master',
+					rrule: 'FREQ=WEEKLY',
+					generated_occurrences: [
+						{
+							id: 2,
+							start_datetime: '2026-07-08 18:00:00',
+							status: 'active',
+						},
+						{
+							id: 3,
+							start_datetime: '2026-07-15 18:00:00',
+							status: 'cancelled',
+						},
+					],
+				});
+			}
+			return Promise.resolve([]);
+		});
+
+		render(<ManageEventApp />);
+		await waitFor(() =>
+			expect(
+				screen.getByRole('tab', { name: 'Event Details' })
+			).toBeInTheDocument()
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Edit instances' }));
+
+		expect(
+			screen.getByRole('heading', { name: 'Edit instances' })
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'Restore' })
+		).toBeInTheDocument();
+	});
+});
+
 describe('create-on-the-fly categories (#992)', () => {
 	beforeEach(() => {
 		window.history.replaceState({}, '', '?tab=event-details');

--- a/fair-events/src/Admin/manage-event/__tests__/RecurrenceCalendar.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/RecurrenceCalendar.test.jsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for RecurrenceCalendar (#981 Part 3).
+ *
+ * Covers:
+ *   - Active and cancelled cells render as links with the correct
+ *     `event_date_id` href and a full-date aria-label.
+ *   - The master cell links to itself.
+ *   - The grid no longer toggles on click (no onToggleExdate/togglingExdate
+ *     props exist any more).
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import RecurrenceCalendar from '../RecurrenceCalendar.js';
+
+const generatedOccurrences = [
+	{ id: 2, start_datetime: '2026-07-08 18:00:00', status: 'active' },
+	{ id: 3, start_datetime: '2026-07-15 18:00:00', status: 'cancelled' },
+];
+
+// Matches the aria-label built in RecurrenceCalendar's MiniMonth.
+function fullDateLabel(dateStr) {
+	return new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
+		weekday: 'long',
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+	});
+}
+
+it('renders active occurrences as navigable links with a full-date aria-label', () => {
+	render(
+		<RecurrenceCalendar
+			generatedOccurrences={generatedOccurrences}
+			cancelledDates={['2026-07-15']}
+			masterDate="2026-07-01"
+			manageEventUrl="http://example.com/manage"
+			masterEventDateId={1}
+			embedded
+		/>
+	);
+
+	const activeLink = screen.getByRole('link', {
+		name: fullDateLabel('2026-07-08'),
+	});
+	expect(activeLink).toHaveAttribute(
+		'href',
+		'http://example.com/manage&event_date_id=2'
+	);
+});
+
+it('renders cancelled occurrences as navigable links to their own event_date_id', () => {
+	render(
+		<RecurrenceCalendar
+			generatedOccurrences={generatedOccurrences}
+			cancelledDates={['2026-07-15']}
+			masterDate="2026-07-01"
+			manageEventUrl="http://example.com/manage"
+			masterEventDateId={1}
+			embedded
+		/>
+	);
+
+	const cancelledLink = screen.getByRole('link', {
+		name: fullDateLabel('2026-07-15'),
+	});
+	expect(cancelledLink).toHaveAttribute(
+		'href',
+		'http://example.com/manage&event_date_id=3'
+	);
+});
+
+it('links the master cell to the master event_date_id', () => {
+	render(
+		<RecurrenceCalendar
+			generatedOccurrences={generatedOccurrences}
+			cancelledDates={['2026-07-15']}
+			masterDate="2026-07-01"
+			manageEventUrl="http://example.com/manage"
+			masterEventDateId={1}
+			embedded
+		/>
+	);
+
+	const masterLink = screen.getByRole('link', {
+		name: fullDateLabel('2026-07-01'),
+	});
+	expect(masterLink).toHaveAttribute(
+		'href',
+		'http://example.com/manage&event_date_id=1'
+	);
+});


### PR DESCRIPTION
## Summary

- `RecurrenceCalendar`'s grid cells are now navigation-only: active and cancelled occurrences link to `manageEventUrl&event_date_id={occ.id}` (backend already returns id/status for every generated occurrence, cancelled included), and every navigable cell carries a full-date `aria-label`. The master cell still links to itself.
- Added a new "Edit instances" modal (`EditInstancesModal.js`), opened from a button on the Recurrence card, which lists a series' occurrences with explicit Cancel/Restore actions wired to the existing `toggle-exdate` endpoint. This replaces click-to-toggle on the calendar grid as the only place cancel/restore happens.
- No change to `SeriesModal.js`, shared `recurrence.js`/`RecurrenceControl.js`, `EventEditForm.js`, or the backend — those already satisfy their parts of #981.

Refs #981 (implements the "Part 3" calendar redesign scoped in [this comment](https://github.com/marcin-wosinek/fair-event-plugins/issues/981#issuecomment-4957003130); other parts of the ticket already landed in prior PRs).

## Test plan

- [x] `npm run build` in `fair-events`
- [x] `npm run test:js` in `fair-events` (12 suites, 92 tests passing)
- [x] New tests: `RecurrenceCalendar.test.jsx` (active/cancelled/master links + aria-labels), `EditInstancesModal.test.jsx` (list, Cancel/Restore, Close), plus a modal-wiring test in `ManageEventApp.test.jsx`
