### PR TITLE
Fill in JSON-LD offers, location, and eventStatus fields

### DIFF
--- a/fair-events/e2e/opengraph-jsonld.spec.js
+++ b/fair-events/e2e/opengraph-jsonld.spec.js
@@ -1,0 +1,211 @@
+import { test, expect } from '@playwright/test';
+
+const WP_ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const WP_ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * Verifies the Schema.org Event JSON-LD emitted on wp_head for singular
+ * event posts: a `location` node is always present, and `offers` reflects
+ * ticket types + active sale-period prices when present.
+ */
+
+async function apiFetch(page, options) {
+	const result = await page.evaluate(async (opts) => {
+		try {
+			// eslint-disable-next-line no-undef
+			const res = await wp.apiFetch(opts);
+			return { ok: true, data: res };
+		} catch (err) {
+			return {
+				ok: false,
+				error: {
+					message: err && err.message,
+					code: err && err.code,
+					data: err && err.data,
+					raw: JSON.stringify(err),
+				},
+			};
+		}
+	}, options);
+	if (!result.ok) {
+		throw new Error(
+			`apiFetch ${options.method || 'GET'} ${
+				options.path
+			} failed: ${JSON.stringify(result.error)}`
+		);
+	}
+	return result.data;
+}
+
+async function login(page) {
+	await page.goto('/wp-admin');
+	if (page.url().includes('wp-login.php')) {
+		await page.fill('#user_login', WP_ADMIN_USER);
+		await page.fill('#user_pass', WP_ADMIN_PASS);
+		await page.click('#wp-submit');
+	}
+	await page.waitForSelector('#wpadminbar');
+}
+
+async function getJsonLd(page, url) {
+	await page.goto(url);
+	const raw = await page
+		.locator('script[type="application/ld+json"]')
+		.first()
+		.textContent();
+	return JSON.parse(raw);
+}
+
+test.describe('Fair Events JSON-LD structured data', () => {
+	test('emits location and offers for an event with a venue and ticket types', async ({
+		page,
+	}) => {
+		test.setTimeout(120_000);
+
+		await page.setViewportSize({ width: 1200, height: 900 });
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+		await apiFetch(page, {
+			path: '/wp/v2/settings',
+			method: 'POST',
+			data: {
+				fair_events_register_post_type: true,
+				fair_events_enabled_post_types: ['fair_event'],
+			},
+		});
+
+		const now = new Date();
+		const start = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+		const iso = (d) => d.toISOString().slice(0, 19).replace('T', ' ');
+
+		const eventDate = await apiFetch(page, {
+			path: '/fair-events/v1/event-dates',
+			method: 'POST',
+			data: {
+				title: 'JSON-LD Test Event With Tickets',
+				start_datetime: iso(start),
+				end_datetime: iso(
+					new Date(start.getTime() + 2 * 60 * 60 * 1000)
+				),
+				all_day: false,
+			},
+		});
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}`,
+			method: 'PUT',
+			data: { address: '123 Test Street, Testville' },
+		});
+
+		const post = await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}/create-post`,
+			method: 'POST',
+			data: { post_status: 'publish' },
+		});
+		const postId = post.event_id || post.post_id;
+
+		// Active sale period covering "now" plus a public ticket type priced in it.
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}/tickets`,
+			method: 'PUT',
+			data: {
+				ticket_types: [{ name: 'General Admission' }],
+				sale_periods: [
+					{
+						name: 'Main sale',
+						sale_start: iso(
+							new Date(now.getTime() - 24 * 60 * 60 * 1000)
+						),
+						sale_end: iso(
+							new Date(now.getTime() + 24 * 60 * 60 * 1000)
+						),
+					},
+				],
+				prices: [
+					{
+						ticket_type_index: 0,
+						sale_period_index: 0,
+						price: 15,
+					},
+				],
+			},
+		});
+
+		const permalink = post.link || `/?p=${postId}`;
+		const data = await getJsonLd(page, permalink);
+
+		expect(data['@type']).toBe('Event');
+		expect(data.location).toBeTruthy();
+		expect(data.location.address.name).toBe('123 Test Street, Testville');
+		expect(data.eventAttendanceMode).toBe(
+			'https://schema.org/OfflineEventAttendanceMode'
+		);
+		expect(data.offers).toHaveLength(1);
+		expect(data.offers[0].price).toBe('15');
+		expect(data.offers[0].priceCurrency).toBeTruthy();
+
+		// Cleanup.
+		await apiFetch(page, {
+			path: `/wp/v2/fair_event/${postId}?force=true`,
+			method: 'DELETE',
+		}).catch(() => {});
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}`,
+			method: 'DELETE',
+		}).catch(() => {});
+	});
+
+	test('still emits a valid location with no offers for an event without ticket types', async ({
+		page,
+	}) => {
+		test.setTimeout(120_000);
+
+		await page.setViewportSize({ width: 1200, height: 900 });
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+		const now = new Date();
+		const start = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+		const iso = (d) => d.toISOString().slice(0, 19).replace('T', ' ');
+
+		const eventDate = await apiFetch(page, {
+			path: '/fair-events/v1/event-dates',
+			method: 'POST',
+			data: {
+				title: 'JSON-LD Test Event Without Tickets',
+				start_datetime: iso(start),
+				end_datetime: iso(
+					new Date(start.getTime() + 2 * 60 * 60 * 1000)
+				),
+				all_day: false,
+			},
+		});
+
+		const post = await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}/create-post`,
+			method: 'POST',
+			data: { post_status: 'publish' },
+		});
+		const postId = post.event_id || post.post_id;
+
+		const permalink = post.link || `/?p=${postId}`;
+		const data = await getJsonLd(page, permalink);
+
+		expect(data['@type']).toBe('Event');
+		expect(data.location).toBeTruthy();
+		expect(data.location['@type']).toBe('Place');
+		expect(data.offers).toBeUndefined();
+
+		// Cleanup.
+		await apiFetch(page, {
+			path: `/wp/v2/fair_event/${postId}?force=true`,
+			method: 'DELETE',
+		}).catch(() => {});
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}`,
+			method: 'DELETE',
+		}).catch(() => {});
+	});
+});

--- a/fair-events/src/Hooks/OpenGraphHooks.php
+++ b/fair-events/src/Hooks/OpenGraphHooks.php
@@ -36,24 +36,14 @@ class OpenGraphHooks {
 	 * @return void
 	 */
 	public function output_og_tags() {
-		if ( ! is_singular() ) {
+		$context = $this->get_event_context();
+		if ( ! $context ) {
 			return;
 		}
 
-		$post_id       = get_the_ID();
-		$post_type     = get_post_type( $post_id );
-		$enabled_types = Settings::get_enabled_post_types();
-
-		if ( ! in_array( $post_type, $enabled_types, true ) ) {
-			return;
-		}
-
-		$event_date = EventDates::get_by_event_id( $post_id );
-		if ( ! $event_date ) {
-			return;
-		}
-
-		$post = get_post( $post_id );
+		$post_id    = $context['post_id'];
+		$event_date = $context['event_date'];
+		$post       = get_post( $post_id );
 
 		// Standard OG tags.
 		$this->output_meta_tag( 'og:title', $this->get_title( $post, $event_date ) );
@@ -67,18 +57,20 @@ class OpenGraphHooks {
 			$this->output_meta_tag( 'og:image', $image_url );
 		}
 
-		// Event-specific tags.
+		// Event-specific tags — only emitted together, and only when there is a
+		// start date, so we never print half-valid event markup (matches the
+		// JSON-LD guard below).
 		if ( ! empty( $event_date->start_datetime ) ) {
 			$this->output_meta_tag( 'event:start_time', $this->format_iso8601( $event_date->start_datetime ) );
-		}
 
-		if ( ! empty( $event_date->end_datetime ) ) {
-			$this->output_meta_tag( 'event:end_time', $this->format_iso8601( $event_date->end_datetime ) );
-		}
+			if ( ! empty( $event_date->end_datetime ) ) {
+				$this->output_meta_tag( 'event:end_time', $this->format_iso8601( $event_date->end_datetime ) );
+			}
 
-		$location = $this->get_location( $event_date, $post_id );
-		if ( $location ) {
-			$this->output_meta_tag( 'event:location', $location );
+			$location = $this->get_location( $event_date, $post_id );
+			if ( $location ) {
+				$this->output_meta_tag( 'event:location', $location );
+			}
 		}
 	}
 
@@ -88,25 +80,15 @@ class OpenGraphHooks {
 	 * @return void
 	 */
 	public function output_twitter_tags() {
-		if ( ! is_singular() ) {
+		$context = $this->get_event_context();
+		if ( ! $context ) {
 			return;
 		}
 
-		$post_id       = get_the_ID();
-		$post_type     = get_post_type( $post_id );
-		$enabled_types = Settings::get_enabled_post_types();
-
-		if ( ! in_array( $post_type, $enabled_types, true ) ) {
-			return;
-		}
-
-		$event_date = EventDates::get_by_event_id( $post_id );
-		if ( ! $event_date ) {
-			return;
-		}
-
-		$post      = get_post( $post_id );
-		$image_url = $this->get_image_url( $post_id );
+		$post_id    = $context['post_id'];
+		$event_date = $context['event_date'];
+		$post       = get_post( $post_id );
+		$image_url  = $this->get_image_url( $post_id );
 
 		$this->output_name_meta_tag( 'twitter:card', $image_url ? 'summary_large_image' : 'summary' );
 		$this->output_name_meta_tag( 'twitter:title', $this->get_title( $post, $event_date ) );
@@ -123,23 +105,16 @@ class OpenGraphHooks {
 	 * @return void
 	 */
 	public function output_jsonld() {
-		if ( ! is_singular() ) {
+		$context = $this->get_event_context();
+		if ( ! $context ) {
 			return;
 		}
 
-		$post_id       = get_the_ID();
-		$post_type     = get_post_type( $post_id );
-		$enabled_types = Settings::get_enabled_post_types();
+		$post_id    = $context['post_id'];
+		$event_date = $context['event_date'];
 
-		if ( ! in_array( $post_type, $enabled_types, true ) ) {
-			return;
-		}
-
-		$event_date = EventDates::get_by_event_id( $post_id );
-		if ( ! $event_date ) {
-			return;
-		}
-
+		// Never emit half-valid event markup: without a start date there is no
+		// event to describe (matches the OG event:* guard above).
 		if ( empty( $event_date->start_datetime ) ) {
 			return;
 		}
@@ -152,7 +127,9 @@ class OpenGraphHooks {
 			'name'        => $this->get_title( $post, $event_date ),
 			'startDate'   => $this->format_iso8601( $event_date->start_datetime ),
 			'url'         => get_permalink( $post_id ),
-			'eventStatus' => 'https://schema.org/EventScheduled',
+			'eventStatus' => 'cancelled' === $event_date->status
+				? 'https://schema.org/EventCancelled'
+				: 'https://schema.org/EventScheduled',
 		);
 
 		if ( ! empty( $event_date->end_datetime ) ) {
@@ -169,9 +146,13 @@ class OpenGraphHooks {
 			$data['image'] = $image_url;
 		}
 
-		$location = $this->get_jsonld_location( $event_date, $post_id );
-		if ( $location ) {
-			$data['location'] = $location;
+		$location_data               = $this->get_jsonld_location( $event_date, $post_id );
+		$data['location']            = $location_data['location'];
+		$data['eventAttendanceMode'] = $location_data['attendance_mode'];
+
+		$offers = $this->get_jsonld_offers( $event_date, $post_id );
+		if ( ! empty( $offers ) ) {
+			$data['offers'] = $offers;
 		}
 
 		$data['organizer'] = array(
@@ -186,13 +167,49 @@ class OpenGraphHooks {
 	}
 
 	/**
-	 * Build Schema.org location object for JSON-LD
+	 * Build the shared preamble used by all three wp_head hooks: confirms the
+	 * current request is a singular, enabled-post-type page linked to an
+	 * event date, so OG, Twitter, and JSON-LD all make the same decision.
+	 *
+	 * @return array{post_id: int, event_date: EventDates}|null Context array, or null if this page has no event.
+	 */
+	private function get_event_context() {
+		if ( ! is_singular() ) {
+			return null;
+		}
+
+		$post_id       = get_the_ID();
+		$post_type     = get_post_type( $post_id );
+		$enabled_types = Settings::get_enabled_post_types();
+
+		if ( ! in_array( $post_type, $enabled_types, true ) ) {
+			return null;
+		}
+
+		$event_date = EventDates::get_by_event_id( $post_id );
+		if ( ! $event_date ) {
+			return null;
+		}
+
+		return array(
+			'post_id'    => $post_id,
+			'event_date' => $event_date,
+		);
+	}
+
+	/**
+	 * Build Schema.org location object for JSON-LD, guaranteeing a valid
+	 * `location` node (never null) and reporting the attendance mode.
 	 *
 	 * @param EventDates $event_date Event date object.
 	 * @param int        $post_id    Post ID.
-	 * @return array|null Location data array or null.
+	 * @return array{location: array, attendance_mode: string} Location data and eventAttendanceMode value.
 	 */
 	private function get_jsonld_location( $event_date, $post_id ) {
+		$offline = 'https://schema.org/OfflineEventAttendanceMode';
+		$online  = 'https://schema.org/OnlineEventAttendanceMode';
+
+		// 1. Venue.
 		if ( ! empty( $event_date->venue_id )
 			&& class_exists( \FairEventsExperimental\Models\Venue::class ) ) {
 			$venue = \FairEventsExperimental\Models\Venue::get_by_id( $event_date->venue_id );
@@ -203,7 +220,10 @@ class OpenGraphHooks {
 				);
 
 				if ( ! empty( $venue->address ) ) {
-					$location['address'] = $venue->address;
+					$location['address'] = array(
+						'@type' => 'PostalAddress',
+						'name'  => $venue->address,
+					);
 				}
 
 				if ( ! empty( $venue->latitude ) && ! empty( $venue->longitude ) ) {
@@ -214,21 +234,154 @@ class OpenGraphHooks {
 					);
 				}
 
-				return $location;
+				return array(
+					'location'        => $location,
+					'attendance_mode' => $offline,
+				);
 			}
 		}
 
-		// Fall back to event_location meta.
-		$meta_location = get_post_meta( $post_id, 'event_location', true );
-		if ( ! empty( $meta_location ) ) {
+		// 2. Event date's own free-text address.
+		if ( ! empty( $event_date->address ) ) {
 			return array(
-				'@type'   => 'Place',
-				'name'    => $meta_location,
-				'address' => $meta_location,
+				'location'        => array(
+					'@type'   => 'Place',
+					'name'    => $event_date->address,
+					'address' => array(
+						'@type' => 'PostalAddress',
+						'name'  => $event_date->address,
+					),
+				),
+				'attendance_mode' => $offline,
 			);
 		}
 
-		return null;
+		// 3. Fall back to event_location meta.
+		$meta_location = get_post_meta( $post_id, 'event_location', true );
+		if ( ! empty( $meta_location ) ) {
+			return array(
+				'location'        => array(
+					'@type'   => 'Place',
+					'name'    => $meta_location,
+					'address' => array(
+						'@type' => 'PostalAddress',
+						'name'  => $meta_location,
+					),
+				),
+				'attendance_mode' => $offline,
+			);
+		}
+
+		// 4. Online event: no physical location, but an external link.
+		if ( 'external' === $event_date->link_type && ! empty( $event_date->external_url ) ) {
+			return array(
+				'location'        => array(
+					'@type' => 'VirtualLocation',
+					'url'   => $event_date->external_url,
+				),
+				'attendance_mode' => $online,
+			);
+		}
+
+		// 5. Final fallback so `location` is never absent.
+		return array(
+			'location'        => array(
+				'@type' => 'Place',
+				'name'  => get_bloginfo( 'name' ),
+			),
+			'attendance_mode' => $offline,
+		);
+	}
+
+	/**
+	 * Build Schema.org Offer objects for JSON-LD from the ticketing models.
+	 *
+	 * Everything is behind class_exists() guards since a fair-events-only
+	 * site (without ticketing) must not fatal.
+	 *
+	 * @param EventDates $event_date Event date object.
+	 * @param int        $post_id    Post ID.
+	 * @return array Offer objects (empty when ticketing is unavailable or unpriced).
+	 */
+	private function get_jsonld_offers( $event_date, $post_id ) {
+		if ( ! class_exists( \FairEvents\Models\TicketType::class )
+			|| ! class_exists( \FairEvents\Models\TicketPrice::class )
+			|| ! class_exists( \FairEvents\Models\TicketSalePeriod::class ) ) {
+			return array();
+		}
+
+		// Pivot to the series master for generated occurrences — pricing lives
+		// there, same as get-tickets/render.php.
+		$pricing_event_date_id = $event_date->id;
+		if ( 'generated' === $event_date->occurrence_type && ! empty( $event_date->master_id ) ) {
+			$pricing_event_date_id = (int) $event_date->master_id;
+		}
+
+		$ticket_types = \FairEvents\Models\TicketType::get_all_by_event_date_id( $pricing_event_date_id );
+		if ( empty( $ticket_types ) ) {
+			return array();
+		}
+
+		$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $pricing_event_date_id );
+
+		$now             = current_time( 'mysql' );
+		$active_period   = null;
+		$upcoming_period = null;
+		foreach ( $sale_periods as $period ) {
+			if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
+				$active_period = $period;
+				break;
+			}
+			if ( $period->sale_start > $now && ( ! $upcoming_period || $period->sale_start < $upcoming_period->sale_start ) ) {
+				$upcoming_period = $period;
+			}
+		}
+
+		// Search crawls happen outside the sale window: fall back to the
+		// nearest upcoming period's price so `offers` isn't empty just
+		// because sales haven't opened yet.
+		$selected_period = $active_period ? $active_period : $upcoming_period;
+		if ( ! $selected_period ) {
+			return array();
+		}
+
+		$price_by_type_id = array();
+		foreach ( \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id ) as $price ) {
+			if ( (int) $price->sale_period_id === (int) $selected_period->id ) {
+				$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
+			}
+		}
+
+		$currency   = get_option( 'fair_payment_currency', 'EUR' );
+		$permalink  = get_permalink( $post_id );
+		$valid_from = $active_period ? null : $this->format_iso8601( $selected_period->sale_start );
+
+		$offers = array();
+		foreach ( $ticket_types as $ticket_type ) {
+			if ( $ticket_type->disabled || $ticket_type->invitation_only ) {
+				continue;
+			}
+
+			if ( ! isset( $price_by_type_id[ $ticket_type->id ] ) ) {
+				continue;
+			}
+
+			$offer = array(
+				'@type'         => 'Offer',
+				'price'         => (string) $price_by_type_id[ $ticket_type->id ],
+				'priceCurrency' => $currency,
+				'availability'  => 'https://schema.org/InStock',
+				'url'           => $permalink,
+			);
+
+			if ( $valid_from ) {
+				$offer['validFrom'] = $valid_from;
+			}
+
+			$offers[] = $offer;
+		}
+
+		return $offers;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Extracted the shared `is_singular` / enabled-post-type / `EventDates` preamble into `get_event_context()` so OG, Twitter, and JSON-LD all make the same page-eligibility decision.
- Gated the `event:start_time` / `event:end_time` / `event:location` OG tags behind the same `start_datetime` presence check JSON-LD already uses, so we never emit half-valid event markup.
- `get_jsonld_location()` now always returns a valid `location` node (venue → event date's free-text address → `event_location` meta → `VirtualLocation` for external-link online events → a `Place` named after the site as a last resort), and reports `eventAttendanceMode` alongside it.
- Added `get_jsonld_offers()`: one `Offer` per public (non-disabled, non-invitation-only) ticket type, priced from the active sale period, falling back to the nearest upcoming period (with `validFrom`) when none is active. Everything is behind `class_exists()` guards so a fair-events-only site without ticketing doesn't fatal.
- `eventStatus` now reflects the row's `status` (`cancelled` → `EventCancelled`, otherwise `EventScheduled`) instead of being hardcoded.

Out of scope (noted in the linked comment): sliding-scale/pay-what-you-can `priceSpecification` — no model fields exist to map yet.

Closes #1062

## Test plan

- [x] `vendor/bin/phpcs` clean on `fair-events/src/Hooks/OpenGraphHooks.php`
- [x] New Playwright e2e (`fair-events/e2e/opengraph-jsonld.spec.js`): an event with a venue/address + active-period ticket price emits `location` and a priced `offers[0]`; an event with no ticket types still emits a valid `location` and no `offers` key
- [x] WP-CLI `eval-file` manual check: cancelled event → `eventStatus: EventCancelled`; external-link online event with no physical location → `VirtualLocation` + `OnlineEventAttendanceMode`
- [ ] Manual: run a live URL through Google's [Rich Results Test](https://search.google.com/test/rich-results) (not done in this sandboxed environment — recommend running before merge)
