### PR TITLE
Support simple HTML in weekly digest intro/outro

### DIFF
--- a/fair-audience/src/API/__tests__/WeeklyDigestController.api.spec.js
+++ b/fair-audience/src/API/__tests__/WeeklyDigestController.api.spec.js
@@ -154,6 +154,37 @@ test.describe('WeeklyDigestController — /weekly-digest', () => {
 		expect(body.config.week_scope).toBe('current');
 	});
 
+	test('PUT sanitizes intro/outro: keeps simple HTML, strips <script>', async () => {
+		const putRes = await api.put(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{
+				headers: authHeaders,
+				data: {
+					intro: '<p>Hello <strong>there</strong> <a href="https://example.com">link</a></p><script>alert(1)</script>',
+					outro: '<script>alert(2)</script><p>Bye</p>',
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+		const putBody = await putRes.json();
+		expect(putBody.config.intro).toContain('<strong>there</strong>');
+		expect(putBody.config.intro).toContain(
+			'<a href="https://example.com">link</a>'
+		);
+		expect(putBody.config.intro).not.toContain('<script>');
+		expect(putBody.config.outro).not.toContain('<script>');
+		expect(putBody.config.outro).toContain('<p>Bye</p>');
+
+		const getRes = await api.get(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{ headers: authHeaders }
+		);
+		expect(getRes.ok()).toBeTruthy();
+		const getBody = await getRes.json();
+		expect(getBody.config.intro).toContain('<strong>there</strong>');
+		expect(getBody.config.outro).toContain('<p>Bye</p>');
+	});
+
 	test('GET /weekly-digest/sources returns a list of { slug, name }', async () => {
 		const res = await api.get(
 			'/wp-json/fair-audience/v1/weekly-digest/sources',

--- a/fair-audience/src/Admin/AdminHooks.php
+++ b/fair-audience/src/Admin/AdminHooks.php
@@ -289,6 +289,7 @@ class AdminHooks {
 
 		// Weekly Digest page.
 		if ( 'fair-audience_page_fair-audience-weekly-digest' === $hook ) {
+			wp_enqueue_editor();
 			$this->enqueue_page_script( 'weekly-digest', $plugin_dir );
 		}
 	}

--- a/fair-audience/src/Admin/weekly-digest/QuicktagsTextarea.js
+++ b/fair-audience/src/Admin/weekly-digest/QuicktagsTextarea.js
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	forwardRef,
+	useEffect,
+	useImperativeHandle,
+	useRef,
+} from '@wordpress/element';
+
+/**
+ * Uncontrolled textarea with a Quicktags (Text-mode) toolbar.
+ *
+ * Quicktags mutates the textarea DOM directly, which conflicts with a React
+ * controlled value, so the field is seeded once on mount and callers read
+ * its current value via `ref.current.getValue()` at save time.
+ *
+ * @param {Object}   props
+ * @param {string}   props.id           Stable id for the wp.editor instance.
+ * @param {string}   props.label        Field label.
+ * @param {string}   [props.help]       Optional help text.
+ * @param {string}   props.defaultValue Initial textarea content.
+ * @param {boolean}  [props.disabled]   Disable the textarea.
+ * @param {Object}   ref                Forwarded ref exposing `getValue()`.
+ * @return {JSX.Element} The quicktags-enabled textarea field.
+ */
+const QuicktagsTextarea = forwardRef(function QuicktagsTextarea(
+	{ id, label, help, defaultValue, disabled },
+	ref
+) {
+	const textareaRef = useRef(null);
+
+	useImperativeHandle(ref, () => ({
+		getValue: () => textareaRef.current?.value ?? '',
+	}));
+
+	useEffect(() => {
+		if (window.wp && window.wp.editor) {
+			window.wp.editor.initialize(id, {
+				quicktags: true,
+				tinymce: false,
+				mediaButtons: false,
+			});
+		}
+
+		return () => {
+			if (window.wp && window.wp.editor) {
+				window.wp.editor.remove(id);
+			}
+		};
+	}, [id]);
+
+	return (
+		<div style={{ marginBottom: '16px' }}>
+			<label
+				htmlFor={id}
+				style={{
+					display: 'block',
+					marginBottom: '8px',
+					fontWeight: '600',
+				}}
+			>
+				{label}
+			</label>
+			<textarea
+				ref={textareaRef}
+				id={id}
+				rows={6}
+				style={{ width: '100%' }}
+				defaultValue={defaultValue}
+				disabled={disabled}
+			/>
+			{help && (
+				<p
+					style={{
+						color: '#757575',
+						fontSize: '13px',
+						marginTop: '4px',
+					}}
+				>
+					{help}
+				</p>
+			)}
+		</div>
+	);
+});
+
+export default QuicktagsTextarea;

--- a/fair-audience/src/Admin/weekly-digest/WeeklyDigest.js
+++ b/fair-audience/src/Admin/weekly-digest/WeeklyDigest.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import {
 	Button,
 	Card,
@@ -13,7 +13,6 @@ import {
 	ToggleControl,
 	SelectControl,
 	TextControl,
-	TextareaControl,
 } from '@wordpress/components';
 
 /**
@@ -26,6 +25,7 @@ import {
 	previewDigest,
 	sendTestDigest,
 } from './weekly-digest-api.js';
+import QuicktagsTextarea from './QuicktagsTextarea.js';
 
 const WEEKDAY_LABELS = [
 	__('Monday', 'fair-audience'),
@@ -55,6 +55,8 @@ export default function WeeklyDigest() {
 	const [lastRunResult, setLastRunResult] = useState(null);
 	const [sources, setSources] = useState([]);
 	const [preview, setPreview] = useState(null);
+	const introRef = useRef(null);
+	const outroRef = useRef(null);
 
 	useEffect(() => {
 		Promise.all([getDigestConfig(), getDigestSources()])
@@ -83,7 +85,16 @@ export default function WeeklyDigest() {
 
 	const handleSave = () => {
 		setSaving(true);
-		saveDigestConfig(config)
+		const updatedConfig = {
+			...config,
+			intro: introRef.current
+				? introRef.current.getValue()
+				: config.intro,
+			outro: outroRef.current
+				? outroRef.current.getValue()
+				: config.outro,
+		};
+		saveDigestConfig(updatedConfig)
 			.then((response) => {
 				setConfig(response.config);
 				setNotice({
@@ -258,24 +269,26 @@ export default function WeeklyDigest() {
 						onChange={(value) => updateField('subject', value)}
 					/>
 
-					<TextareaControl
+					<QuicktagsTextarea
+						ref={introRef}
+						id="fair-audience-digest-intro"
 						label={__('Intro text', 'fair-audience')}
 						help={__(
-							'Optional text shown above the list of events.',
+							'Optional HTML shown above the list of events.',
 							'fair-audience'
 						)}
-						value={config.intro}
-						onChange={(value) => updateField('intro', value)}
+						defaultValue={config.intro}
 					/>
 
-					<TextareaControl
+					<QuicktagsTextarea
+						ref={outroRef}
+						id="fair-audience-digest-outro"
 						label={__('Outro text', 'fair-audience')}
 						help={__(
-							'Optional text shown below the list of events.',
+							'Optional HTML shown below the list of events.',
 							'fair-audience'
 						)}
-						value={config.outro}
-						onChange={(value) => updateField('outro', value)}
+						defaultValue={config.outro}
 					/>
 
 					<Button

--- a/fair-audience/src/Admin/weekly-digest/__tests__/WeeklyDigest.test.jsx
+++ b/fair-audience/src/Admin/weekly-digest/__tests__/WeeklyDigest.test.jsx
@@ -66,9 +66,19 @@ function mockApiFetch({
 	});
 }
 
+beforeEach(() => {
+	window.wp = {
+		editor: {
+			initialize: jest.fn(),
+			remove: jest.fn(),
+		},
+	};
+});
+
 afterEach(() => {
 	jest.restoreAllMocks();
 	jest.clearAllMocks();
+	delete window.wp;
 });
 
 describe('WeeklyDigest — loading', () => {
@@ -167,5 +177,63 @@ describe('WeeklyDigest — last run summary', () => {
 		expect(
 			await screen.findByText('Last sent for week 2026-W27 — sent')
 		).toBeInTheDocument();
+	});
+});
+
+describe('WeeklyDigest — quicktags editors', () => {
+	it('initializes and removes the quicktags editor for intro and outro', async () => {
+		mockApiFetch();
+		const { unmount } = render(<WeeklyDigest />);
+
+		await screen.findByRole('button', { name: 'Save settings' });
+
+		expect(window.wp.editor.initialize).toHaveBeenCalledWith(
+			'fair-audience-digest-intro',
+			expect.objectContaining({ quicktags: true, tinymce: false })
+		);
+		expect(window.wp.editor.initialize).toHaveBeenCalledWith(
+			'fair-audience-digest-outro',
+			expect.objectContaining({ quicktags: true, tinymce: false })
+		);
+
+		unmount();
+
+		expect(window.wp.editor.remove).toHaveBeenCalledWith(
+			'fair-audience-digest-intro'
+		);
+		expect(window.wp.editor.remove).toHaveBeenCalledWith(
+			'fair-audience-digest-outro'
+		);
+	});
+
+	it('sends the current intro/outro textarea HTML when saving', async () => {
+		mockApiFetch();
+		render(<WeeklyDigest />);
+
+		await screen.findByRole('button', { name: 'Save settings' });
+
+		fireEvent.change(
+			document.getElementById('fair-audience-digest-intro'),
+			{ target: { value: '<p>Hello <strong>there</strong></p>' } }
+		);
+		fireEvent.change(
+			document.getElementById('fair-audience-digest-outro'),
+			{ target: { value: '<p>Bye</p>' } }
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
+
+		await waitFor(() =>
+			expect(apiFetch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: '/fair-audience/v1/weekly-digest',
+					method: 'PUT',
+					data: expect.objectContaining({
+						intro: '<p>Hello <strong>there</strong></p>',
+						outro: '<p>Bye</p>',
+					}),
+				})
+			)
+		);
 	});
 });

--- a/fair-audience/src/Services/WeeklyDigestRenderer.php
+++ b/fair-audience/src/Services/WeeklyDigestRenderer.php
@@ -140,7 +140,7 @@ class WeeklyDigestRenderer {
 		$html = '';
 
 		if ( ! empty( $intro ) ) {
-			$html .= '<div style="margin: 0 0 20px 0;">' . wp_kses_post( $intro ) . '</div>';
+			$html .= '<div style="margin: 0 0 20px 0;">' . wp_kses_post( wpautop( $intro ) ) . '</div>';
 		}
 
 		foreach ( $week['days'] as $day ) {
@@ -181,7 +181,7 @@ class WeeklyDigestRenderer {
 		}
 
 		if ( ! empty( $outro ) ) {
-			$html .= '<div style="margin: 20px 0 0 0;">' . wp_kses_post( $outro ) . '</div>';
+			$html .= '<div style="margin: 20px 0 0 0;">' . wp_kses_post( wpautop( $outro ) ) . '</div>';
 		}
 
 		return $html;


### PR DESCRIPTION
## Summary

- Replace the Weekly Digest's intro/outro `TextareaControl`s with Quicktags
  editors (`b`, `i`, `link`, `ul`/`ol`/`li`, close tags) so admins can author
  simple HTML with tag buttons instead of hand-writing markup.
- Apply `wpautop()` to intro/outro in `WeeklyDigestRenderer::render()` so
  multi-paragraph plain text no longer collapses into one line.
- Enqueue the classic editor scripts (`wp_enqueue_editor()`) on the Weekly
  Digest admin page.

Closes #1085

## Notes

- `QuicktagsTextarea` is an uncontrolled field local to
  `src/Admin/weekly-digest/`, mirroring the init/remove lifecycle used by
  `fair-audience-experimental`'s `CustomMail.js`. `handleSave` reads its
  current value via a ref at save time, matching that page's "read content
  at save time" pattern.
- Sanitization is unchanged: `WeeklyDigestController` still routes through
  `WeeklyDigestRenderer::sanitize_config()` (`wp_kses_post`) on save, and
  render-time output stays wrapped in `wp_kses_post` too.

## Test plan

- [x] `npx jest src/Admin/weekly-digest` — 7/7 passing, including new tests
      that mock `window.wp.editor` and assert `initialize`/`remove` are
      called for both fields, and that the saved payload carries the
      textarea's current HTML.
- [x] `WeeklyDigestController.api.spec.js` extended with a case that PUTs
      `<strong>`/`<a href>` HTML and a `<script>` tag, and asserts the tags
      round-trip while `<script>` is stripped (not run against a live WP
      instance in this session — no `docker compose` environment available).
- [x] `npm run build` in `fair-audience`
- [x] `npm run format` in `fair-audience` (repo-wide format pass, no logic
      changes)
- [ ] `vendor/bin/phpcs` — clean on the two changed PHP files; pre-existing
      unrelated errors remain in `AdminHooks.php` (verified present on `main`
      before this branch)
- [ ] Manual check: Intro/outro fields show the Quicktags toolbar; saving
      persists HTML; reload shows it back in the editor; multi-paragraph
      intro renders as separate paragraphs in Preview and the sent email
