### PR TITLE
Emit Event JSON-LD ItemList on calendar/week blocks

### DIFF
--- a/fair-events/__tests__/Helpers/EventSchemaTest.php
+++ b/fair-events/__tests__/Helpers/EventSchemaTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Tests for EventSchema::item_list_from_occurrences() behaviour.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Helpers\EventSchema;
+
+/**
+ * Unit tests for building a Schema.org ItemList from occurrence DTOs.
+ *
+ * These tests exercise external (ical/api) DTOs only, since the
+ * post/standalone `location` merge calls EventDates::get_by_id() (a real DB
+ * call) — that path is covered by the WP-CLI manual check instead.
+ */
+class EventSchemaTest extends TestCase {
+
+	/**
+	 * Build a minimal external occurrence DTO.
+	 *
+	 * @param array $overrides Property overrides.
+	 * @return array Occurrence DTO.
+	 */
+	private function make_dto( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'uid'             => 'ical-1@example.com',
+				'event_date_id'   => null,
+				'event_id'        => null,
+				'occurrence_type' => 'external',
+				'title'           => 'Test Event',
+				'description'     => 'A test description',
+				'start'           => '2026-07-15 10:00:00',
+				'end'             => '2026-07-15 12:00:00',
+				'all_day'         => false,
+				'url'             => 'https://example.com/event',
+				'categories'      => array(),
+				'source'          => 'ical',
+				'is_draft'        => false,
+				'source_color'    => '#4caf50',
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * An empty occurrence list yields no ItemList.
+	 *
+	 * @return void
+	 */
+	public function test_empty_input_returns_null() {
+		$this->assertNull( EventSchema::item_list_from_occurrences( array() ) );
+	}
+
+	/**
+	 * A single occurrence yields an ItemList with exactly one ListItem.
+	 *
+	 * @return void
+	 */
+	public function test_single_dto_yields_one_list_item() {
+		$item_list = EventSchema::item_list_from_occurrences( array( $this->make_dto() ) );
+
+		$this->assertNotNull( $item_list );
+		$this->assertSame( 'https://schema.org', $item_list['@context'] );
+		$this->assertSame( 'ItemList', $item_list['@type'] );
+		$this->assertCount( 1, $item_list['itemListElement'] );
+		$this->assertSame( 1, $item_list['itemListElement'][0]['position'] );
+	}
+
+	/**
+	 * Multiple occurrences get sequential 1..n positions.
+	 *
+	 * @return void
+	 */
+	public function test_assigns_sequential_positions() {
+		$occurrences = array(
+			$this->make_dto( array( 'uid' => 'a' ) ),
+			$this->make_dto( array( 'uid' => 'b' ) ),
+			$this->make_dto( array( 'uid' => 'c' ) ),
+		);
+
+		$item_list = EventSchema::item_list_from_occurrences( $occurrences );
+
+		$positions = array_column( $item_list['itemListElement'], 'position' );
+		$this->assertSame( array( 1, 2, 3 ), $positions );
+	}
+
+	/**
+	 * External (ical/api) DTOs become thin Events: no `location`, since
+	 * there is no EventDates row to derive it from.
+	 *
+	 * @return void
+	 */
+	public function test_external_dtos_are_thin_items() {
+		$item_list = EventSchema::item_list_from_occurrences( array( $this->make_dto() ) );
+
+		$event = $item_list['itemListElement'][0]['item'];
+
+		$this->assertSame( 'Event', $event['@type'] );
+		$this->assertSame( 'Test Event', $event['name'] );
+		$this->assertSame( 'https://example.com/event', $event['url'] );
+		$this->assertArrayHasKey( 'startDate', $event );
+		$this->assertArrayHasKey( 'endDate', $event );
+		$this->assertArrayHasKey( 'description', $event );
+		$this->assertArrayNotHasKey( 'location', $event );
+		$this->assertArrayNotHasKey( 'offers', $event );
+		$this->assertArrayNotHasKey( 'organizer', $event );
+		$this->assertArrayNotHasKey( 'eventStatus', $event );
+	}
+
+	/**
+	 * A DTO with no start is dropped rather than producing a half-valid Event.
+	 *
+	 * @return void
+	 */
+	public function test_dto_without_start_is_dropped() {
+		$occurrences = array(
+			$this->make_dto( array( 'uid' => 'a' ) ),
+			$this->make_dto(
+				array(
+					'uid'   => 'b',
+					'start' => '',
+				)
+			),
+		);
+
+		$item_list = EventSchema::item_list_from_occurrences( $occurrences );
+
+		$this->assertCount( 1, $item_list['itemListElement'] );
+	}
+}

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -66,6 +66,17 @@ if ( ! function_exists( 'get_the_title' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_timezone' ) ) {
+	/**
+	 * Stub of WordPress wp_timezone() — always UTC for deterministic tests.
+	 *
+	 * @return \DateTimeZone UTC timezone.
+	 */
+	function wp_timezone() {
+		return new \DateTimeZone( 'UTC' );
+	}
+}
+
 if ( ! function_exists( 'add_query_arg' ) ) {
 	/**
 	 * Minimal stub of WordPress add_query_arg() for a single key/value pair.

--- a/fair-events/src/Helpers/EventSchema.php
+++ b/fair-events/src/Helpers/EventSchema.php
@@ -1,0 +1,394 @@
+<?php
+/**
+ * Schema.org Event JSON-LD shaping
+ *
+ * Pure, static helpers for building Schema.org `Event` structures — shared
+ * between the single-event JSON-LD emitted on wp_head (OpenGraphHooks) and
+ * the `ItemList` JSON-LD emitted by the calendar/week blocks, so both stay
+ * in sync with a single source of truth.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Helpers;
+
+use FairEvents\Models\EventDates;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Builds Schema.org Event/ItemList JSON-LD structures.
+ */
+class EventSchema {
+
+	/**
+	 * Build the full Schema.org Event object for a single event page.
+	 *
+	 * @param EventDates $event_date Event date object.
+	 * @param int        $post_id    Linked post ID.
+	 * @return array|null Event object (without `@context`), or null when there is no start date.
+	 */
+	public static function event_to_jsonld( EventDates $event_date, $post_id ) {
+		if ( empty( $event_date->start_datetime ) ) {
+			return null;
+		}
+
+		$post = get_post( $post_id );
+
+		$data = array(
+			'@type'       => 'Event',
+			'name'        => self::get_title( $post, $event_date ),
+			'startDate'   => DateHelper::local_to_iso8601( $event_date->start_datetime ),
+			'url'         => get_permalink( $post_id ),
+			'eventStatus' => 'cancelled' === $event_date->status
+				? 'https://schema.org/EventCancelled'
+				: 'https://schema.org/EventScheduled',
+		);
+
+		if ( ! empty( $event_date->end_datetime ) ) {
+			$data['endDate'] = DateHelper::local_to_iso8601( $event_date->end_datetime );
+		}
+
+		$description = self::get_description( $post );
+		if ( $description ) {
+			$data['description'] = $description;
+		}
+
+		$image_url = self::get_image_url( $post_id );
+		if ( $image_url ) {
+			$data['image'] = $image_url;
+		}
+
+		$location_data               = self::get_jsonld_location( $event_date, $post_id );
+		$data['location']            = $location_data['location'];
+		$data['eventAttendanceMode'] = $location_data['attendance_mode'];
+
+		$offers = self::get_jsonld_offers( $event_date, $post_id );
+		if ( ! empty( $offers ) ) {
+			$data['offers'] = $offers;
+		}
+
+		$data['organizer'] = array(
+			'@type' => 'Organization',
+			'name'  => get_bloginfo( 'name' ),
+			'url'   => home_url(),
+		);
+
+		return $data;
+	}
+
+	/**
+	 * Build a lean Schema.org Event object from an EventFeedProvider occurrence
+	 * DTO, for use inside an `ItemList`.
+	 *
+	 * Carries `name`, `startDate`, `endDate`, `url`, `description`, and —
+	 * for post/standalone occurrences only — `location`. Does not include
+	 * `offers`/`organizer`/`image`/`eventStatus`; those stay single-page-only.
+	 *
+	 * @param array $dto Occurrence DTO, as returned by EventFeedProvider::get_occurrences().
+	 * @return array|null Event object, or null when the DTO has no start.
+	 */
+	public static function occurrence_to_jsonld( array $dto ) {
+		if ( empty( $dto['start'] ) ) {
+			return null;
+		}
+
+		$event = array(
+			'@type'     => 'Event',
+			'name'      => $dto['title'],
+			'startDate' => DateHelper::local_to_iso8601( $dto['start'] ),
+			'url'       => $dto['url'],
+		);
+
+		if ( ! empty( $dto['end'] ) ) {
+			$event['endDate'] = DateHelper::local_to_iso8601( $dto['end'] );
+		}
+
+		if ( ! empty( $dto['description'] ) ) {
+			$event['description'] = $dto['description'];
+		}
+
+		if ( in_array( $dto['source'], array( 'post', 'standalone' ), true ) && ! empty( $dto['event_date_id'] ) ) {
+			$event_date = EventDates::get_by_id( $dto['event_date_id'] );
+			if ( $event_date ) {
+				$location_data     = self::get_jsonld_location( $event_date, $dto['event_id'] );
+				$event['location'] = $location_data['location'];
+			}
+		}
+
+		return $event;
+	}
+
+	/**
+	 * Build a Schema.org `ItemList` of `ListItem` → `Event` entries from a flat
+	 * occurrence list.
+	 *
+	 * @param array[] $occurrences Flat DTO list, as returned by EventFeedProvider::get_occurrences().
+	 * @return array|null ItemList object (with `@context`), or null when there are no valid occurrences.
+	 */
+	public static function item_list_from_occurrences( array $occurrences ) {
+		$list_items = array();
+		$position   = 1;
+
+		foreach ( $occurrences as $occurrence ) {
+			$event = self::occurrence_to_jsonld( $occurrence );
+			if ( null === $event ) {
+				continue;
+			}
+
+			$list_items[] = array(
+				'@type'    => 'ListItem',
+				'position' => $position,
+				'item'     => $event,
+			);
+
+			++$position;
+		}
+
+		if ( empty( $list_items ) ) {
+			return null;
+		}
+
+		return array(
+			'@context'        => 'https://schema.org',
+			'@type'           => 'ItemList',
+			'itemListElement' => $list_items,
+		);
+	}
+
+	/**
+	 * Get the display title for an event.
+	 *
+	 * @param \WP_Post   $post       Post object.
+	 * @param EventDates $event_date Event date object.
+	 * @return string Title string.
+	 */
+	public static function get_title( $post, EventDates $event_date ) {
+		$title = $event_date->get_display_title();
+
+		if ( ! $title ) {
+			$title = $post->post_title;
+		}
+
+		return $title;
+	}
+
+	/**
+	 * Get the description for an event.
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return string Description string.
+	 */
+	public static function get_description( $post ) {
+		$excerpt = get_the_excerpt( $post );
+
+		if ( $excerpt ) {
+			return $excerpt;
+		}
+
+		return wp_trim_words( wp_strip_all_tags( $post->post_content ), 30, '...' );
+	}
+
+	/**
+	 * Get the featured image URL for an event.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string|null Image URL or null.
+	 */
+	public static function get_image_url( $post_id ) {
+		$thumbnail_id = get_post_thumbnail_id( $post_id );
+		if ( ! $thumbnail_id ) {
+			return null;
+		}
+
+		$url = wp_get_attachment_url( $thumbnail_id );
+		return $url ? $url : null;
+	}
+
+	/**
+	 * Build Schema.org location object for JSON-LD, guaranteeing a valid
+	 * `location` node (never null) and reporting the attendance mode.
+	 *
+	 * @param EventDates $event_date Event date object.
+	 * @param int        $post_id    Post ID.
+	 * @return array{location: array, attendance_mode: string} Location data and eventAttendanceMode value.
+	 */
+	public static function get_jsonld_location( EventDates $event_date, $post_id ) {
+		$offline = 'https://schema.org/OfflineEventAttendanceMode';
+		$online  = 'https://schema.org/OnlineEventAttendanceMode';
+
+		// 1. Venue.
+		if ( ! empty( $event_date->venue_id )
+			&& class_exists( \FairEventsExperimental\Models\Venue::class ) ) {
+			$venue = \FairEventsExperimental\Models\Venue::get_by_id( $event_date->venue_id );
+			if ( $venue ) {
+				$location = array(
+					'@type' => 'Place',
+					'name'  => $venue->name,
+				);
+
+				if ( ! empty( $venue->address ) ) {
+					$location['address'] = array(
+						'@type' => 'PostalAddress',
+						'name'  => $venue->address,
+					);
+				}
+
+				if ( ! empty( $venue->latitude ) && ! empty( $venue->longitude ) ) {
+					$location['geo'] = array(
+						'@type'     => 'GeoCoordinates',
+						'latitude'  => $venue->latitude,
+						'longitude' => $venue->longitude,
+					);
+				}
+
+				return array(
+					'location'        => $location,
+					'attendance_mode' => $offline,
+				);
+			}
+		}
+
+		// 2. Event date's own free-text address.
+		if ( ! empty( $event_date->address ) ) {
+			return array(
+				'location'        => array(
+					'@type'   => 'Place',
+					'name'    => $event_date->address,
+					'address' => array(
+						'@type' => 'PostalAddress',
+						'name'  => $event_date->address,
+					),
+				),
+				'attendance_mode' => $offline,
+			);
+		}
+
+		// 3. Fall back to event_location meta.
+		$meta_location = $post_id ? get_post_meta( $post_id, 'event_location', true ) : '';
+		if ( ! empty( $meta_location ) ) {
+			return array(
+				'location'        => array(
+					'@type'   => 'Place',
+					'name'    => $meta_location,
+					'address' => array(
+						'@type' => 'PostalAddress',
+						'name'  => $meta_location,
+					),
+				),
+				'attendance_mode' => $offline,
+			);
+		}
+
+		// 4. Online event: no physical location, but an external link.
+		if ( 'external' === $event_date->link_type && ! empty( $event_date->external_url ) ) {
+			return array(
+				'location'        => array(
+					'@type' => 'VirtualLocation',
+					'url'   => $event_date->external_url,
+				),
+				'attendance_mode' => $online,
+			);
+		}
+
+		// 5. Final fallback so `location` is never absent.
+		return array(
+			'location'        => array(
+				'@type' => 'Place',
+				'name'  => get_bloginfo( 'name' ),
+			),
+			'attendance_mode' => $offline,
+		);
+	}
+
+	/**
+	 * Build Schema.org Offer objects for JSON-LD from the ticketing models.
+	 *
+	 * Everything is behind class_exists() guards since a fair-events-only
+	 * site (without ticketing) must not fatal.
+	 *
+	 * @param EventDates $event_date Event date object.
+	 * @param int        $post_id    Post ID.
+	 * @return array Offer objects (empty when ticketing is unavailable or unpriced).
+	 */
+	public static function get_jsonld_offers( EventDates $event_date, $post_id ) {
+		if ( ! class_exists( \FairEvents\Models\TicketType::class )
+			|| ! class_exists( \FairEvents\Models\TicketPrice::class )
+			|| ! class_exists( \FairEvents\Models\TicketSalePeriod::class ) ) {
+			return array();
+		}
+
+		// Pivot to the series master for generated occurrences — pricing lives
+		// there, same as get-tickets/render.php.
+		$pricing_event_date_id = $event_date->id;
+		if ( 'generated' === $event_date->occurrence_type && ! empty( $event_date->master_id ) ) {
+			$pricing_event_date_id = (int) $event_date->master_id;
+		}
+
+		$ticket_types = \FairEvents\Models\TicketType::get_all_by_event_date_id( $pricing_event_date_id );
+		if ( empty( $ticket_types ) ) {
+			return array();
+		}
+
+		$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $pricing_event_date_id );
+
+		$now             = current_time( 'mysql' );
+		$active_period   = null;
+		$upcoming_period = null;
+		foreach ( $sale_periods as $period ) {
+			if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
+				$active_period = $period;
+				break;
+			}
+			if ( $period->sale_start > $now && ( ! $upcoming_period || $period->sale_start < $upcoming_period->sale_start ) ) {
+				$upcoming_period = $period;
+			}
+		}
+
+		// Search crawls happen outside the sale window: fall back to the
+		// nearest upcoming period's price so `offers` isn't empty just
+		// because sales haven't opened yet.
+		$selected_period = $active_period ? $active_period : $upcoming_period;
+		if ( ! $selected_period ) {
+			return array();
+		}
+
+		$price_by_type_id = array();
+		foreach ( \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id ) as $price ) {
+			if ( (int) $price->sale_period_id === (int) $selected_period->id ) {
+				$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
+			}
+		}
+
+		$currency   = get_option( 'fair_payment_currency', 'EUR' );
+		$permalink  = get_permalink( $post_id );
+		$valid_from = $active_period ? null : DateHelper::local_to_iso8601( $selected_period->sale_start );
+
+		$offers = array();
+		foreach ( $ticket_types as $ticket_type ) {
+			if ( $ticket_type->disabled || $ticket_type->invitation_only ) {
+				continue;
+			}
+
+			if ( ! isset( $price_by_type_id[ $ticket_type->id ] ) ) {
+				continue;
+			}
+
+			$offer = array(
+				'@type'         => 'Offer',
+				'price'         => (string) $price_by_type_id[ $ticket_type->id ],
+				'priceCurrency' => $currency,
+				'availability'  => 'https://schema.org/InStock',
+				'url'           => $permalink,
+			);
+
+			if ( $valid_from ) {
+				$offer['validFrom'] = $valid_from;
+			}
+
+			$offers[] = $offer;
+		}
+
+		return $offers;
+	}
+}

--- a/fair-events/src/Hooks/OpenGraphHooks.php
+++ b/fair-events/src/Hooks/OpenGraphHooks.php
@@ -11,6 +11,8 @@
 
 namespace FairEvents\Hooks;
 
+use FairEvents\Helpers\DateHelper;
+use FairEvents\Helpers\EventSchema;
 use FairEvents\Models\EventDates;
 use FairEvents\Settings\Settings;
 
@@ -46,13 +48,13 @@ class OpenGraphHooks {
 		$post       = get_post( $post_id );
 
 		// Standard OG tags.
-		$this->output_meta_tag( 'og:title', $this->get_title( $post, $event_date ) );
-		$this->output_meta_tag( 'og:description', $this->get_description( $post ) );
+		$this->output_meta_tag( 'og:title', EventSchema::get_title( $post, $event_date ) );
+		$this->output_meta_tag( 'og:description', EventSchema::get_description( $post ) );
 		$this->output_meta_tag( 'og:url', get_permalink( $post_id ) );
 		$this->output_meta_tag( 'og:type', 'event' );
 		$this->output_meta_tag( 'og:site_name', get_bloginfo( 'name' ) );
 
-		$image_url = $this->get_image_url( $post_id );
+		$image_url = EventSchema::get_image_url( $post_id );
 		if ( $image_url ) {
 			$this->output_meta_tag( 'og:image', $image_url );
 		}
@@ -61,10 +63,10 @@ class OpenGraphHooks {
 		// start date, so we never print half-valid event markup (matches the
 		// JSON-LD guard below).
 		if ( ! empty( $event_date->start_datetime ) ) {
-			$this->output_meta_tag( 'event:start_time', $this->format_iso8601( $event_date->start_datetime ) );
+			$this->output_meta_tag( 'event:start_time', DateHelper::local_to_iso8601( $event_date->start_datetime ) );
 
 			if ( ! empty( $event_date->end_datetime ) ) {
-				$this->output_meta_tag( 'event:end_time', $this->format_iso8601( $event_date->end_datetime ) );
+				$this->output_meta_tag( 'event:end_time', DateHelper::local_to_iso8601( $event_date->end_datetime ) );
 			}
 
 			$location = $this->get_location( $event_date, $post_id );
@@ -88,11 +90,11 @@ class OpenGraphHooks {
 		$post_id    = $context['post_id'];
 		$event_date = $context['event_date'];
 		$post       = get_post( $post_id );
-		$image_url  = $this->get_image_url( $post_id );
+		$image_url  = EventSchema::get_image_url( $post_id );
 
 		$this->output_name_meta_tag( 'twitter:card', $image_url ? 'summary_large_image' : 'summary' );
-		$this->output_name_meta_tag( 'twitter:title', $this->get_title( $post, $event_date ) );
-		$this->output_name_meta_tag( 'twitter:description', $this->get_description( $post ) );
+		$this->output_name_meta_tag( 'twitter:title', EventSchema::get_title( $post, $event_date ) );
+		$this->output_name_meta_tag( 'twitter:description', EventSchema::get_description( $post ) );
 
 		if ( $image_url ) {
 			$this->output_name_meta_tag( 'twitter:image', $image_url );
@@ -110,56 +112,15 @@ class OpenGraphHooks {
 			return;
 		}
 
-		$post_id    = $context['post_id'];
-		$event_date = $context['event_date'];
+		$event = EventSchema::event_to_jsonld( $context['event_date'], $context['post_id'] );
 
 		// Never emit half-valid event markup: without a start date there is no
 		// event to describe (matches the OG event:* guard above).
-		if ( empty( $event_date->start_datetime ) ) {
+		if ( null === $event ) {
 			return;
 		}
 
-		$post = get_post( $post_id );
-
-		$data = array(
-			'@context'    => 'https://schema.org',
-			'@type'       => 'Event',
-			'name'        => $this->get_title( $post, $event_date ),
-			'startDate'   => $this->format_iso8601( $event_date->start_datetime ),
-			'url'         => get_permalink( $post_id ),
-			'eventStatus' => 'cancelled' === $event_date->status
-				? 'https://schema.org/EventCancelled'
-				: 'https://schema.org/EventScheduled',
-		);
-
-		if ( ! empty( $event_date->end_datetime ) ) {
-			$data['endDate'] = $this->format_iso8601( $event_date->end_datetime );
-		}
-
-		$description = $this->get_description( $post );
-		if ( $description ) {
-			$data['description'] = $description;
-		}
-
-		$image_url = $this->get_image_url( $post_id );
-		if ( $image_url ) {
-			$data['image'] = $image_url;
-		}
-
-		$location_data               = $this->get_jsonld_location( $event_date, $post_id );
-		$data['location']            = $location_data['location'];
-		$data['eventAttendanceMode'] = $location_data['attendance_mode'];
-
-		$offers = $this->get_jsonld_offers( $event_date, $post_id );
-		if ( ! empty( $offers ) ) {
-			$data['offers'] = $offers;
-		}
-
-		$data['organizer'] = array(
-			'@type' => 'Organization',
-			'name'  => get_bloginfo( 'name' ),
-			'url'   => home_url(),
-		);
+		$data = array_merge( array( '@context' => 'https://schema.org' ), $event );
 
 		echo '<script type="application/ld+json">' . "\n";
 		echo wp_json_encode( $data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT );
@@ -198,242 +159,6 @@ class OpenGraphHooks {
 	}
 
 	/**
-	 * Build Schema.org location object for JSON-LD, guaranteeing a valid
-	 * `location` node (never null) and reporting the attendance mode.
-	 *
-	 * @param EventDates $event_date Event date object.
-	 * @param int        $post_id    Post ID.
-	 * @return array{location: array, attendance_mode: string} Location data and eventAttendanceMode value.
-	 */
-	private function get_jsonld_location( $event_date, $post_id ) {
-		$offline = 'https://schema.org/OfflineEventAttendanceMode';
-		$online  = 'https://schema.org/OnlineEventAttendanceMode';
-
-		// 1. Venue.
-		if ( ! empty( $event_date->venue_id )
-			&& class_exists( \FairEventsExperimental\Models\Venue::class ) ) {
-			$venue = \FairEventsExperimental\Models\Venue::get_by_id( $event_date->venue_id );
-			if ( $venue ) {
-				$location = array(
-					'@type' => 'Place',
-					'name'  => $venue->name,
-				);
-
-				if ( ! empty( $venue->address ) ) {
-					$location['address'] = array(
-						'@type' => 'PostalAddress',
-						'name'  => $venue->address,
-					);
-				}
-
-				if ( ! empty( $venue->latitude ) && ! empty( $venue->longitude ) ) {
-					$location['geo'] = array(
-						'@type'     => 'GeoCoordinates',
-						'latitude'  => $venue->latitude,
-						'longitude' => $venue->longitude,
-					);
-				}
-
-				return array(
-					'location'        => $location,
-					'attendance_mode' => $offline,
-				);
-			}
-		}
-
-		// 2. Event date's own free-text address.
-		if ( ! empty( $event_date->address ) ) {
-			return array(
-				'location'        => array(
-					'@type'   => 'Place',
-					'name'    => $event_date->address,
-					'address' => array(
-						'@type' => 'PostalAddress',
-						'name'  => $event_date->address,
-					),
-				),
-				'attendance_mode' => $offline,
-			);
-		}
-
-		// 3. Fall back to event_location meta.
-		$meta_location = get_post_meta( $post_id, 'event_location', true );
-		if ( ! empty( $meta_location ) ) {
-			return array(
-				'location'        => array(
-					'@type'   => 'Place',
-					'name'    => $meta_location,
-					'address' => array(
-						'@type' => 'PostalAddress',
-						'name'  => $meta_location,
-					),
-				),
-				'attendance_mode' => $offline,
-			);
-		}
-
-		// 4. Online event: no physical location, but an external link.
-		if ( 'external' === $event_date->link_type && ! empty( $event_date->external_url ) ) {
-			return array(
-				'location'        => array(
-					'@type' => 'VirtualLocation',
-					'url'   => $event_date->external_url,
-				),
-				'attendance_mode' => $online,
-			);
-		}
-
-		// 5. Final fallback so `location` is never absent.
-		return array(
-			'location'        => array(
-				'@type' => 'Place',
-				'name'  => get_bloginfo( 'name' ),
-			),
-			'attendance_mode' => $offline,
-		);
-	}
-
-	/**
-	 * Build Schema.org Offer objects for JSON-LD from the ticketing models.
-	 *
-	 * Everything is behind class_exists() guards since a fair-events-only
-	 * site (without ticketing) must not fatal.
-	 *
-	 * @param EventDates $event_date Event date object.
-	 * @param int        $post_id    Post ID.
-	 * @return array Offer objects (empty when ticketing is unavailable or unpriced).
-	 */
-	private function get_jsonld_offers( $event_date, $post_id ) {
-		if ( ! class_exists( \FairEvents\Models\TicketType::class )
-			|| ! class_exists( \FairEvents\Models\TicketPrice::class )
-			|| ! class_exists( \FairEvents\Models\TicketSalePeriod::class ) ) {
-			return array();
-		}
-
-		// Pivot to the series master for generated occurrences — pricing lives
-		// there, same as get-tickets/render.php.
-		$pricing_event_date_id = $event_date->id;
-		if ( 'generated' === $event_date->occurrence_type && ! empty( $event_date->master_id ) ) {
-			$pricing_event_date_id = (int) $event_date->master_id;
-		}
-
-		$ticket_types = \FairEvents\Models\TicketType::get_all_by_event_date_id( $pricing_event_date_id );
-		if ( empty( $ticket_types ) ) {
-			return array();
-		}
-
-		$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $pricing_event_date_id );
-
-		$now             = current_time( 'mysql' );
-		$active_period   = null;
-		$upcoming_period = null;
-		foreach ( $sale_periods as $period ) {
-			if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
-				$active_period = $period;
-				break;
-			}
-			if ( $period->sale_start > $now && ( ! $upcoming_period || $period->sale_start < $upcoming_period->sale_start ) ) {
-				$upcoming_period = $period;
-			}
-		}
-
-		// Search crawls happen outside the sale window: fall back to the
-		// nearest upcoming period's price so `offers` isn't empty just
-		// because sales haven't opened yet.
-		$selected_period = $active_period ? $active_period : $upcoming_period;
-		if ( ! $selected_period ) {
-			return array();
-		}
-
-		$price_by_type_id = array();
-		foreach ( \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id ) as $price ) {
-			if ( (int) $price->sale_period_id === (int) $selected_period->id ) {
-				$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
-			}
-		}
-
-		$currency   = get_option( 'fair_payment_currency', 'EUR' );
-		$permalink  = get_permalink( $post_id );
-		$valid_from = $active_period ? null : $this->format_iso8601( $selected_period->sale_start );
-
-		$offers = array();
-		foreach ( $ticket_types as $ticket_type ) {
-			if ( $ticket_type->disabled || $ticket_type->invitation_only ) {
-				continue;
-			}
-
-			if ( ! isset( $price_by_type_id[ $ticket_type->id ] ) ) {
-				continue;
-			}
-
-			$offer = array(
-				'@type'         => 'Offer',
-				'price'         => (string) $price_by_type_id[ $ticket_type->id ],
-				'priceCurrency' => $currency,
-				'availability'  => 'https://schema.org/InStock',
-				'url'           => $permalink,
-			);
-
-			if ( $valid_from ) {
-				$offer['validFrom'] = $valid_from;
-			}
-
-			$offers[] = $offer;
-		}
-
-		return $offers;
-	}
-
-	/**
-	 * Get the title for OG tag
-	 *
-	 * @param \WP_Post   $post       Post object.
-	 * @param EventDates $event_date Event date object.
-	 * @return string Title string.
-	 */
-	private function get_title( $post, $event_date ) {
-		$title = $event_date->get_display_title();
-
-		if ( ! $title ) {
-			$title = $post->post_title;
-		}
-
-		return $title;
-	}
-
-	/**
-	 * Get the description for OG tag
-	 *
-	 * @param \WP_Post $post Post object.
-	 * @return string Description string.
-	 */
-	private function get_description( $post ) {
-		$excerpt = get_the_excerpt( $post );
-
-		if ( $excerpt ) {
-			return $excerpt;
-		}
-
-		return wp_trim_words( wp_strip_all_tags( $post->post_content ), 30, '...' );
-	}
-
-	/**
-	 * Get the image URL for OG tag
-	 *
-	 * @param int $post_id Post ID.
-	 * @return string|null Image URL or null.
-	 */
-	private function get_image_url( $post_id ) {
-		$thumbnail_id = get_post_thumbnail_id( $post_id );
-		if ( ! $thumbnail_id ) {
-			return null;
-		}
-
-		$url = wp_get_attachment_url( $thumbnail_id );
-		return $url ? $url : null;
-	}
-
-	/**
 	 * Get the location string for OG tag
 	 *
 	 * @param EventDates $event_date Event date object.
@@ -457,22 +182,6 @@ class OpenGraphHooks {
 		$location = get_post_meta( $post_id, 'event_location', true );
 
 		return ! empty( $location ) ? $location : null;
-	}
-
-	/**
-	 * Format a MySQL datetime string as ISO 8601
-	 *
-	 * @param string $datetime MySQL datetime (Y-m-d H:i:s).
-	 * @return string ISO 8601 formatted datetime.
-	 */
-	private function format_iso8601( $datetime ) {
-		$dt = \DateTime::createFromFormat( 'Y-m-d H:i:s', $datetime );
-
-		if ( ! $dt ) {
-			return $datetime;
-		}
-
-		return $dt->format( 'c' );
 	}
 
 	/**

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -11,6 +11,7 @@
 
 defined( 'WPINC' ) || die;
 
+use FairEvents\Helpers\EventSchema;
 use FairEvents\Services\EventFeedProvider;
 use FairEvents\Settings\Settings;
 
@@ -179,6 +180,8 @@ $occurrences = $provider->get_occurrences(
 );
 
 $events_by_date = EventFeedProvider::group_by_day( $occurrences, $query_start, $query_end );
+
+$item_list = EventSchema::item_list_from_occurrences( $occurrences );
 
 // Calculate previous/next month URLs
 $prev_month_timestamp = strtotime( '-1 month', $first_day_of_month_ts );
@@ -358,3 +361,9 @@ $today = current_time( 'Y-m-d' );
 		<?php echo wp_kses_post( \FairAudience\Services\Branding::block_html() ); ?>
 	<?php endif; ?>
 </div>
+<?php if ( null !== $item_list ) : ?>
+	<script type="application/ld+json">
+	<?php echo wp_json_encode( $item_list, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT ); ?>
+
+	</script>
+<?php endif; ?>

--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -17,6 +17,7 @@
 defined( 'WPINC' ) || die;
 
 use FairEvents\Helpers\DateHelper;
+use FairEvents\Helpers\EventSchema;
 use FairEvents\Services\EventFeedProvider;
 use FairEvents\Settings\Settings;
 
@@ -131,6 +132,8 @@ $occurrences = $provider->get_occurrences(
 );
 
 $occurrences_by_date = EventFeedProvider::group_by_day( $occurrences, $week_start, $week_end );
+
+$item_list = EventSchema::item_list_from_occurrences( $occurrences );
 
 // Map each day's occurrence DTOs to the shape the template renders.
 $events_by_date = array();
@@ -311,3 +314,9 @@ if ( $show_copy_summary ) {
 	<?php endif; ?>
 
 </div>
+<?php if ( null !== $item_list ) : ?>
+	<script type="application/ld+json">
+	<?php echo wp_json_encode( $item_list, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT ); ?>
+
+	</script>
+<?php endif; ?>


### PR DESCRIPTION
## Summary

- Adds a static `FairEvents\Helpers\EventSchema` helper that shapes Schema.org
  `Event` objects — used both for the existing single-event page JSON-LD and
  for a new lean `ItemList` JSON-LD emitted by the events-calendar and
  events-week blocks.
- The blocks already build a flat, deduplicated occurrence list via
  `EventFeedProvider::get_occurrences()`; the `ItemList` is built from that
  same list, so multi-day events appear exactly once.
- `OpenGraphHooks::output_jsonld()` now delegates to
  `EventSchema::event_to_jsonld()` instead of keeping a private copy of the
  location/offers/ISO-8601 shaping logic, so the two features can't diverge.
- Retires the private `format_iso8601()` formatter in favor of
  `DateHelper::local_to_iso8601()` (same instant, UTC offset instead of local
  offset — both valid ISO 8601).

Refs #1064

## Test plan

- [x] `vendor/bin/phpunit` (fair-events) — 50/50 passing, including new
      `EventSchemaTest`
- [x] `vendor/bin/phpcs` on changed files — clean (pre-existing findings in
      `render.php` files are unrelated to this change)
- [x] `npm run test:js` — 92/92 passing
- [x] `npx playwright test e2e/opengraph-jsonld.spec.js` — 3/3 passing,
      confirms the `OpenGraphHooks` refactor is behavior-preserving
- [x] WP-CLI `eval-file` manual check: created a standalone event with an
      address, confirmed `EventSchema::item_list_from_occurrences()` returns
      a valid `ItemList` whose entry carries the correct `location` (via
      `EventDates::get_by_id()`) and ISO 8601 `startDate`/`endDate`
- [x] `npm run build` in fair-events so both blocks ship the new JSON-LD from
      `build/`
