### PR TITLE
Require confirmed status for marketing email consent gate

### DIFF
--- a/fair-audience/__tests__/Services/RecipientResolverTest.php
+++ b/fair-audience/__tests__/Services/RecipientResolverTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * RecipientResolver::can_receive_email() tests
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairAudience\Services\RecipientResolver;
+use FairAudience\Services\EmailType;
+use FairAudience\Models\Participant;
+
+/**
+ * Validates the marketing-consent gate that decides whether a participant
+ * receives a marketing email. A pending double-opt-in subscriber must not
+ * be treated as consented until they confirm.
+ */
+class RecipientResolverTest extends TestCase {
+
+	/**
+	 * Build a participant with the given email_profile/status.
+	 *
+	 * @param string $email_profile 'minimal' | 'marketing' | 'declined'.
+	 * @param string $status        'pending' | 'confirmed'.
+	 * @return Participant
+	 */
+	private function participant( $email_profile, $status ) {
+		$participant                = new Participant();
+		$participant->email_profile = $email_profile;
+		$participant->status        = $status;
+		return $participant;
+	}
+
+	/**
+	 * MINIMAL emails are always allowed regardless of profile/status.
+	 */
+	public function test_minimal_email_always_allowed() {
+		$resolver = new RecipientResolver();
+		$this->assertTrue(
+			$resolver->can_receive_email( $this->participant( 'marketing', 'pending' ), EmailType::MINIMAL )
+		);
+		$this->assertTrue(
+			$resolver->can_receive_email( $this->participant( 'declined', 'confirmed' ), EmailType::MINIMAL )
+		);
+	}
+
+	/**
+	 * A confirmed marketing subscriber receives marketing email.
+	 */
+	public function test_marketing_confirmed_can_receive_marketing() {
+		$resolver = new RecipientResolver();
+		$this->assertTrue(
+			$resolver->can_receive_email( $this->participant( 'marketing', 'confirmed' ), EmailType::MARKETING )
+		);
+	}
+
+	/**
+	 * A pending marketing subscriber (double opt-in not yet confirmed) must
+	 * not receive marketing email.
+	 */
+	public function test_marketing_pending_cannot_receive_marketing() {
+		$resolver = new RecipientResolver();
+		$this->assertFalse(
+			$resolver->can_receive_email( $this->participant( 'marketing', 'pending' ), EmailType::MARKETING )
+		);
+	}
+
+	/**
+	 * A minimal-profile participant never receives marketing email.
+	 */
+	public function test_minimal_profile_cannot_receive_marketing() {
+		$resolver = new RecipientResolver();
+		$this->assertFalse(
+			$resolver->can_receive_email( $this->participant( 'minimal', 'confirmed' ), EmailType::MARKETING )
+		);
+	}
+
+	/**
+	 * A declined participant never receives marketing email.
+	 */
+	public function test_declined_cannot_receive_marketing() {
+		$resolver = new RecipientResolver();
+		$this->assertFalse(
+			$resolver->can_receive_email( $this->participant( 'declined', 'confirmed' ), EmailType::MARKETING )
+		);
+	}
+}

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -141,6 +141,19 @@ class EmailService {
 	}
 
 	/**
+	 * Human-readable reason a participant was skipped for a marketing send.
+	 *
+	 * @param Participant $participant The skipped participant.
+	 * @return string Skip reason.
+	 */
+	private function marketing_skip_reason( Participant $participant ): string {
+		if ( 'marketing' === $participant->email_profile && 'pending' === $participant->status ) {
+			return __( 'Participant has not yet confirmed their marketing subscription.', 'fair-audience' );
+		}
+		return __( 'Participant opted out of marketing emails.', 'fair-audience' );
+	}
+
+	/**
 	 * Check if a participant has a valid email address.
 	 *
 	 * @param Participant $participant The participant to check.
@@ -1539,7 +1552,7 @@ class EmailService {
 				$results['skipped'][] = array(
 					'name'   => $participant->name,
 					'email'  => $participant->email,
-					'reason' => __( 'Participant opted out of marketing emails.', 'fair-audience' ),
+					'reason' => $this->marketing_skip_reason( $participant ),
 				);
 				continue;
 			}
@@ -1613,7 +1626,7 @@ class EmailService {
 				$results['skipped'][] = array(
 					'name'   => $participant->name,
 					'email'  => $participant->email,
-					'reason' => __( 'Participant opted out of marketing emails.', 'fair-audience' ),
+					'reason' => $this->marketing_skip_reason( $participant ),
 				);
 				continue;
 			}
@@ -3130,7 +3143,7 @@ class EmailService {
 				$results['skipped'][] = array(
 					'name'   => $participant->name,
 					'email'  => $participant->email,
-					'reason' => __( 'Participant opted out of marketing emails.', 'fair-audience' ),
+					'reason' => $this->marketing_skip_reason( $participant ),
 				);
 				continue;
 			}

--- a/fair-audience/src/Services/RecipientResolver.php
+++ b/fair-audience/src/Services/RecipientResolver.php
@@ -248,7 +248,8 @@ class RecipientResolver {
 			return true;
 		}
 
-		return 'marketing' === $participant->email_profile;
+		return 'marketing' === $participant->email_profile
+			&& 'confirmed' === $participant->status;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `RecipientResolver::can_receive_email()` treated `email_profile === 'marketing'` as sufficient consent to send, ignoring the `status` (`pending` | `confirmed`) column. A double-opt-in subscriber who never clicked the confirmation link was still mailed on every marketing send path (custom mail, event invitations, scheduled/current-events mailings), since they all resolve recipients through this one gate.
- The fix requires `status === 'confirmed'` in addition to `email_profile === 'marketing'`. MINIMAL emails are unaffected.
- Skipped-recipient results (`EmailService`) now distinguish "not yet confirmed" from "opted out" in the `reason` string, since the two used to share the same "opted out of marketing emails" copy.

Closes #1106

## Test plan

- [x] Added `fair-audience/__tests__/Services/RecipientResolverTest.php` (PHPUnit) covering the pending-vs-confirmed matrix: MINIMAL always allowed, marketing+confirmed allowed, marketing+pending blocked, minimal-profile blocked, declined blocked.
- [x] `vendor/bin/phpunit __tests__/Services/RecipientResolverTest.php` — 5/5 pass.
- [x] `vendor/bin/phpcs` clean on all changed files.
- [x] `php -l` on `EmailService.php`.
