### PR TITLE
Switch recurring event links to date-based event_date param

### DIFF
--- a/fair-events/__tests__/Helpers/OccurrenceDateParamTest.php
+++ b/fair-events/__tests__/Helpers/OccurrenceDateParamTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests for OccurrenceDateParam.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Helpers\OccurrenceDateParam;
+use FairEvents\Models\EventDates;
+
+/**
+ * Unit tests for the public `event_date` URL param format/parse/legacy logic.
+ */
+class OccurrenceDateParamTest extends TestCase {
+
+	/**
+	 * Format() derives Y-m-d from a row's start_datetime.
+	 *
+	 * @return void
+	 */
+	public function test_format_returns_y_m_d_from_start_datetime() {
+		$row                 = new EventDates();
+		$row->start_datetime = '2026-06-29 18:30:00';
+
+		$this->assertSame( '2026-06-29', OccurrenceDateParam::format( $row ) );
+	}
+
+	/**
+	 * Parse() accepts a strictly valid Y-m-d date.
+	 *
+	 * @return void
+	 */
+	public function test_parse_accepts_valid_date() {
+		$this->assertSame( '2026-06-29', OccurrenceDateParam::parse( '2026-06-29' ) );
+	}
+
+	/**
+	 * Parse() rejects the legacy dotted format.
+	 *
+	 * @return void
+	 */
+	public function test_parse_rejects_dotted_format() {
+		$this->assertNull( OccurrenceDateParam::parse( '2026.06.29' ) );
+	}
+
+	/**
+	 * Parse() rejects an out-of-range date instead of silently rolling it over.
+	 *
+	 * @return void
+	 */
+	public function test_parse_rejects_out_of_range_date() {
+		$this->assertNull( OccurrenceDateParam::parse( '2026-13-40' ) );
+	}
+
+	/**
+	 * Parse() rejects garbage and empty input.
+	 *
+	 * @return void
+	 */
+	public function test_parse_rejects_garbage_and_empty() {
+		$this->assertNull( OccurrenceDateParam::parse( 'not-a-date' ) );
+		$this->assertNull( OccurrenceDateParam::parse( '' ) );
+	}
+
+	/**
+	 * Is_legacy_id() distinguishes all-digit ids from dashed dates.
+	 *
+	 * @return void
+	 */
+	public function test_is_legacy_id_distinguishes_ids_from_dates() {
+		$this->assertTrue( OccurrenceDateParam::is_legacy_id( '16' ) );
+		$this->assertFalse( OccurrenceDateParam::is_legacy_id( '2026-06-29' ) );
+	}
+}

--- a/fair-events/__tests__/Helpers/SelectedOccurrenceTest.php
+++ b/fair-events/__tests__/Helpers/SelectedOccurrenceTest.php
@@ -173,6 +173,61 @@ class SelectedOccurrenceTest extends TestCase {
 	}
 
 	/**
+	 * When an occurrence exists today, pick_default_pivot() prefers it over
+	 * any upcoming occurrence.
+	 *
+	 * @return void
+	 */
+	public function test_pick_default_pivot_prefers_today_over_upcoming() {
+		$today    = $this->make_row( array( 'id' => 7 ) );
+		$upcoming = $this->make_row( array( 'id' => 8 ) );
+
+		$result = $this->invoke_pick_default_pivot( $today, array( $upcoming ) );
+
+		$this->assertSame( 7, $result->id );
+	}
+
+	/**
+	 * With no occurrence today, pick_default_pivot() falls back to the
+	 * closest upcoming occurrence.
+	 *
+	 * @return void
+	 */
+	public function test_pick_default_pivot_falls_back_to_upcoming() {
+		$upcoming = $this->make_row( array( 'id' => 8 ) );
+
+		$result = $this->invoke_pick_default_pivot( null, array( $upcoming ) );
+
+		$this->assertSame( 8, $result->id );
+	}
+
+	/**
+	 * With neither today nor an upcoming occurrence, pick_default_pivot()
+	 * returns null so the caller falls back to the master row.
+	 *
+	 * @return void
+	 */
+	public function test_pick_default_pivot_returns_null_when_none_available() {
+		$result = $this->invoke_pick_default_pivot( null, array() );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Invoke the private pick_default_pivot() via reflection.
+	 *
+	 * @param EventDates|null $today    Today's occurrence, if any.
+	 * @param EventDates[]    $upcoming Upcoming occurrences.
+	 * @return EventDates|null
+	 */
+	private function invoke_pick_default_pivot( ?EventDates $today, array $upcoming ) {
+		$reflection = new \ReflectionClass( SelectedOccurrence::class );
+		$method     = $reflection->getMethod( 'pick_default_pivot' );
+
+		return $method->invoke( null, $today, $upcoming );
+	}
+
+	/**
 	 * Invoke SelectedOccurrence::resolve() with a pre-built master row and a
 	 * list of upcoming occurrences injected via the static override mechanism.
 	 *

--- a/fair-events/__tests__/Models/EventDatesTest.php
+++ b/fair-events/__tests__/Models/EventDatesTest.php
@@ -30,7 +30,7 @@ class EventDatesTest extends TestCase {
 	/**
 	 * Generated occurrence with event_id = NULL and link_type = 'post'
 	 * resolves the link via the master's event_id (issue #1090), with
-	 * `?event_date={id}` appended since it's a generated occurrence.
+	 * `?event_date={Y-m-d}` appended since it's a generated occurrence.
 	 */
 	public function test_post_link_resolves_via_master_for_generated_occurrence() {
 		$master            = new EventDates();
@@ -46,8 +46,9 @@ class EventDatesTest extends TestCase {
 		$occurrence->master_id       = 1;
 		$occurrence->occurrence_type = 'generated';
 		$occurrence->link_type       = 'post';
+		$occurrence->start_datetime  = '2026-06-29 18:30:00';
 
-		$this->assertSame( 'https://example.com/?p=42&event_date=2', $occurrence->get_display_url() );
+		$this->assertSame( 'https://example.com/?p=42&event_date=2026-06-29', $occurrence->get_display_url() );
 	}
 
 	/**

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -77,6 +77,60 @@ if ( ! function_exists( 'wp_timezone' ) ) {
 	}
 }
 
+if ( ! function_exists( 'absint' ) ) {
+	/**
+	 * Stub of WordPress absint().
+	 *
+	 * @param mixed $value Value to cast.
+	 * @return int Non-negative integer.
+	 */
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+	/**
+	 * Stub of WordPress wp_unslash() — a no-op for test input (no magic quotes).
+	 *
+	 * @param mixed $value Value to unslash.
+	 * @return mixed Unmodified value.
+	 */
+	function wp_unslash( $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	/**
+	 * Stub of WordPress sanitize_text_field() — trims whitespace only.
+	 *
+	 * @param string $value Value to sanitize.
+	 * @return string Trimmed value.
+	 */
+	function sanitize_text_field( $value ) {
+		return trim( (string) $value );
+	}
+}
+
+if ( ! function_exists( 'current_time' ) ) {
+	/**
+	 * Stub of WordPress current_time() — tests override via $GLOBALS['_fair_test_now'].
+	 *
+	 * @param string $type Format type, e.g. 'mysql' or a date() format string.
+	 * @return string Formatted current (or overridden) time.
+	 */
+	function current_time( $type ) {
+		$now = isset( $GLOBALS['_fair_test_now'] ) ? $GLOBALS['_fair_test_now'] : time();
+
+		if ( 'mysql' === $type ) {
+			return gmdate( 'Y-m-d H:i:s', $now );
+		}
+
+		return gmdate( $type, $now );
+	}
+}
+
 if ( ! function_exists( 'add_query_arg' ) ) {
 	/**
 	 * Minimal stub of WordPress add_query_arg() for a single key/value pair.

--- a/fair-events/src/Helpers/OccurrenceDateParam.php
+++ b/fair-events/src/Helpers/OccurrenceDateParam.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Parse and format the public `event_date` URL param.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Helpers;
+
+use FairEvents\Models\EventDates;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * The public `?event_date=` URL param identifies a recurring occurrence by
+ * its calendar date (`Y-m-d`), not its opaque internal id, so links stay
+ * readable and survive occurrence regeneration. This helper is the single
+ * place that formats a row into that param and parses it back.
+ */
+class OccurrenceDateParam {
+
+	/**
+	 * Format an event-date row's start date for use as the public URL param.
+	 *
+	 * @param EventDates $row Event date row.
+	 * @return string Date in `Y-m-d` format.
+	 */
+	public static function format( EventDates $row ): string {
+		return gmdate( 'Y-m-d', strtotime( $row->start_datetime ) );
+	}
+
+	/**
+	 * Parse a URL param into a strict `Y-m-d` SQL date, or null if invalid.
+	 *
+	 * Round-trips through DateTime so out-of-range dates like `2026-13-40`
+	 * (which PHP would otherwise silently roll over) are rejected.
+	 *
+	 * @param string $param Raw URL param value.
+	 * @return string|null `Y-m-d` date, or null if not a valid date.
+	 */
+	public static function parse( string $param ): ?string {
+		$date = \DateTime::createFromFormat( 'Y-m-d', $param );
+
+		if ( ! $date || $date->format( 'Y-m-d' ) !== $param ) {
+			return null;
+		}
+
+		return $date->format( 'Y-m-d' );
+	}
+
+	/**
+	 * Whether a raw URL param looks like a legacy numeric event-date id.
+	 *
+	 * A date param always contains dashes, so an all-digits string is
+	 * unambiguously the old id-based format.
+	 *
+	 * @param string $param Raw URL param value.
+	 * @return bool True if the param is all digits.
+	 */
+	public static function is_legacy_id( string $param ): bool {
+		return (bool) preg_match( '/^\d+$/', $param );
+	}
+}

--- a/fair-events/src/Helpers/SelectedOccurrence.php
+++ b/fair-events/src/Helpers/SelectedOccurrence.php
@@ -12,10 +12,11 @@ use FairEvents\Models\EventDates;
 defined( 'WPINC' ) || die;
 
 /**
- * When a recurring event page is loaded with `?event_date=<id>`, sibling
+ * When a recurring event page is loaded with `?event_date=<date>`, sibling
  * blocks (event-info, event-dates, calendar-button) should render data for
  * that specific occurrence instead of the master row. This helper validates
- * the URL-provided id and falls back to the default row otherwise.
+ * the URL-provided date (or, for legacy links, the numeric id) and falls
+ * back to the default row otherwise.
  */
 class SelectedOccurrence {
 
@@ -39,38 +40,74 @@ class SelectedOccurrence {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$candidate_id = isset( $_GET['event_date'] ) ? absint( wp_unslash( $_GET['event_date'] ) ) : 0;
+		$raw_param = isset( $_GET['event_date'] ) ? sanitize_text_field( wp_unslash( $_GET['event_date'] ) ) : '';
 
-		if ( $candidate_id > 0 ) {
-			if ( $candidate_id === (int) $default->id ) {
-				return $default;
-			}
+		if ( '' !== $raw_param ) {
+			$date = OccurrenceDateParam::parse( $raw_param );
 
-			$candidate = EventDates::get_by_id( $candidate_id );
-			// Only accept candidates that belong to the same series as the
-			// default row, i.e. generated children whose master_id points
-			// to it. Prevents URL tampering from rendering an unrelated
-			// event on this post's page. Invalid candidate IDs fall
-			// through to the no-param default below.
-			if ( $candidate && (int) $candidate->master_id === (int) $default->id ) {
-				return self::with_master_venue_fallback( $candidate, $default );
+			if ( null !== $date ) {
+				$candidate = EventDates::get_by_master_id_and_date( (int) $default->id, $date );
+				// A date not in this series returns null and falls through
+				// to the no-param default below — the same anti-tampering
+				// guarantee the legacy id check gives.
+				if ( $candidate ) {
+					return self::with_master_venue_fallback( $candidate, $default );
+				}
+			} elseif ( OccurrenceDateParam::is_legacy_id( $raw_param ) ) {
+				// Legacy fallback: old `?event_date=<id>` links keep resolving.
+				$candidate_id = absint( $raw_param );
+
+				if ( $candidate_id === (int) $default->id ) {
+					return $default;
+				}
+
+				$candidate = EventDates::get_by_id( $candidate_id );
+				// Only accept candidates that belong to the same series as
+				// the default row, i.e. generated children whose master_id
+				// points to it. Prevents URL tampering from rendering an
+				// unrelated event on this post's page.
+				if ( $candidate && (int) $candidate->master_id === (int) $default->id ) {
+					return self::with_master_venue_fallback( $candidate, $default );
+				}
 			}
 		}
 
-		// No (valid) URL param: for recurring series, pivot to the closest
-		// upcoming occurrence (the master itself if its own date is still in
-		// the future, otherwise the next generated child) so all blocks on
-		// the page describe the next-in-sequence date instead of the
-		// abstract master row. Falls back to the master if no future
-		// occurrences exist (e.g. series has fully ended).
+		// No (valid) URL param: for recurring series, prefer today's
+		// occurrence if one exists, otherwise pivot to the closest upcoming
+		// occurrence (the master itself if its own date is still in the
+		// future, otherwise the next generated child) so all blocks on the
+		// page describe the relevant date instead of the abstract master
+		// row. Falls back to the master if no matching occurrences exist
+		// (e.g. series has fully ended).
 		if ( 'master' === $default->occurrence_type ) {
-			$upcoming = EventDates::get_upcoming_by_master_id( (int) $default->id );
-			if ( ! empty( $upcoming ) ) {
-				return self::with_master_venue_fallback( $upcoming[0], $default );
+			$today    = EventDates::get_by_master_id_and_date( (int) $default->id, current_time( 'Y-m-d' ) );
+			$upcoming = $today ? array() : EventDates::get_upcoming_by_master_id( (int) $default->id );
+			$pivot    = self::pick_default_pivot( $today, $upcoming );
+
+			if ( $pivot ) {
+				return self::with_master_venue_fallback( $pivot, $default );
 			}
 		}
 
 		return $default;
+	}
+
+	/**
+	 * Choose which occurrence to pivot to when no URL param is present.
+	 *
+	 * Order: today's occurrence, then the closest upcoming one, else none
+	 * (caller falls back to the master row itself).
+	 *
+	 * @param EventDates|null $today    Today's occurrence in the series, if any.
+	 * @param EventDates[]    $upcoming Upcoming occurrences, ordered ascending.
+	 * @return EventDates|null
+	 */
+	private static function pick_default_pivot( ?EventDates $today, array $upcoming ): ?EventDates {
+		if ( $today ) {
+			return $today;
+		}
+
+		return $upcoming[0] ?? null;
 	}
 
 	/**

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -615,7 +615,7 @@ class EventDates {
 	 * for post-linked events (falling back to the master's linked post for
 	 * generated occurrences), or the permalink of a post linked via the
 	 * junction table (recurring instances linked from the post editor), if
-	 * any. Generated occurrences additionally get `?event_date={id}`
+	 * any. Generated occurrences additionally get `?event_date={Y-m-d}`
 	 * appended so the page can resolve which sibling occurrence to show
 	 * (see SelectedOccurrence); master/single rows link straight to the
 	 * plain permalink since it already resolves unambiguously.
@@ -637,7 +637,7 @@ class EventDates {
 	}
 
 	/**
-	 * Append `?event_date={id}` to a URL for generated occurrences only.
+	 * Append `?event_date={Y-m-d}` to a URL for generated occurrences only.
 	 *
 	 * @param string|false $url Permalink to decorate.
 	 * @return string|null Decorated URL, or null if $url was falsy.
@@ -651,7 +651,7 @@ class EventDates {
 			return $url;
 		}
 
-		return add_query_arg( 'event_date', (int) $this->id, $url );
+		return add_query_arg( 'event_date', \FairEvents\Helpers\OccurrenceDateParam::format( $this ), $url );
 	}
 
 	/**
@@ -1296,6 +1296,39 @@ class EventDates {
 		}
 
 		return $dates;
+	}
+
+	/**
+	 * Get the occurrence in a series that falls on a given calendar date
+	 *
+	 * Looks up the master row itself plus every generated child, taking the
+	 * earliest start_datetime on that date if more than one occurrence
+	 * shares it (rare).
+	 *
+	 * @param int    $master_id Master event date ID.
+	 * @param string $date      Date in `Y-m-d` format.
+	 * @return EventDates|null Matching occurrence, or null if none.
+	 */
+	public static function get_by_master_id_and_date( $master_id, $date ) {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_event_dates';
+
+		$result = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM %i WHERE (id = %d OR master_id = %d) AND status = 'active' AND DATE(start_datetime) = %s ORDER BY start_datetime ASC LIMIT 1",
+				$table_name,
+				$master_id,
+				$master_id,
+				$date
+			)
+		);
+
+		if ( ! $result ) {
+			return null;
+		}
+
+		return self::hydrate( $result );
 	}
 
 	/**

--- a/fair-events/src/blocks/get-tickets/render.php
+++ b/fair-events/src/blocks/get-tickets/render.php
@@ -21,9 +21,35 @@ if ( class_exists( \FairAudience\API\EventSignupController::class ) ) {
 
 $submit_button_text = $attributes['submitButtonText'] ?? __( 'Get Tickets', 'fair-events' );
 
-// Resolve event_date_id: query string → block attribute → current post's event date.
+// Resolve event_date_id: query string (date, scoped to this post's series;
+// legacy numeric id kept for old links) → block attribute → current post's
+// event date.
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$event_date_id = isset( $_GET['event_date'] ) ? absint( $_GET['event_date'] ) : (int) ( $attributes['eventDateId'] ?? 0 );
+$raw_event_date_param = isset( $_GET['event_date'] ) ? sanitize_text_field( wp_unslash( $_GET['event_date'] ) ) : '';
+$event_date_id        = 0;
+
+if ( '' !== $raw_event_date_param && class_exists( \FairEvents\Models\EventDates::class ) ) {
+	if ( \FairEvents\Helpers\OccurrenceDateParam::is_legacy_id( $raw_event_date_param ) ) {
+		$event_date_id = absint( $raw_event_date_param );
+	} else {
+		$date = \FairEvents\Helpers\OccurrenceDateParam::parse( $raw_event_date_param );
+		if ( null !== $date ) {
+			// get_by_event_id() only matches rows with their own event_id set
+			// (master/single occurrences), so this is always the series master.
+			$post_event_date = \FairEvents\Models\EventDates::get_by_event_id( get_the_ID() );
+			if ( $post_event_date ) {
+				$matched = \FairEvents\Models\EventDates::get_by_master_id_and_date( (int) $post_event_date->id, $date );
+				if ( $matched ) {
+					$event_date_id = (int) $matched->id;
+				}
+			}
+		}
+	}
+}
+
+if ( ! $event_date_id ) {
+	$event_date_id = (int) ( $attributes['eventDateId'] ?? 0 );
+}
 
 if ( ! $event_date_id && class_exists( \FairEvents\Models\EventDates::class ) ) {
 	$post_event_date = \FairEvents\Models\EventDates::get_by_event_id( get_the_ID() );


### PR DESCRIPTION
## Summary

Recurring event pages selected an occurrence via `?event_date=<id>`, an
opaque internal id that's meaningless to humans and breaks when
occurrences are regenerated. This switches the public URL contract to a
`Y-m-d` date, and fixes the no-param default to prefer today's occurrence
over always pivoting to the next upcoming one.

- New `FairEvents\Helpers\OccurrenceDateParam` helper: `format()`,
  `parse()` (strict `Y-m-d` validation), `is_legacy_id()`.
- New `EventDates::get_by_master_id_and_date()` model method.
- `SelectedOccurrence::resolve()` now accepts a date param (validated
  against the series), keeps a legacy fallback for old numeric-id links,
  and checks for today's occurrence before pivoting to "next upcoming".
- `EventDates::with_occurrence_arg()` (the single URL-emitter behind
  `get_display_url()`, used by the calendar/week blocks and the public
  events API) now emits `event_date={Y-m-d}` instead of the numeric id.
- `get-tickets/render.php` resolves the date param against the post's
  series to the numeric id it needs internally, with legacy id support
  kept and its existing block-attribute/current-post fallbacks unchanged.
- `GetTicketsController`'s REST param and `EventSignups.js` are unchanged
  (out of scope — internal, not the public URL contract).

Closes #955

## Test plan

- [x] `vendor/bin/phpunit` (fair-events) — 60 tests pass, including new
      `OccurrenceDateParamTest` and today-vs-upcoming pivot tests in
      `SelectedOccurrenceTest`.
- [x] `vendor/bin/phpcs` clean on all changed files (pre-existing
      unrelated warnings in `EventDates.php` / `get-tickets/render.php`
      confirmed present before this change too).
- [x] Manual WP-CLI `eval-file` check against a real recurring series:
      display URL emits `event_date=<today's Y-m-d>`, no-param resolves to
      today's occurrence, explicit date resolves to that occurrence,
      legacy numeric id still resolves, and an out-of-series date falls
      through to the today/upcoming default.
