### PR TITLE
Add irregular (hand-picked date) recurring series

### DIFF
--- a/fair-events/__tests__/Services/RecurrenceServiceTest.php
+++ b/fair-events/__tests__/Services/RecurrenceServiceTest.php
@@ -118,4 +118,52 @@ class RecurrenceServiceTest extends TestCase {
 		$this->assertContains( '2035-03-01', $starts );
 		$this->assertContains( '2035-03-15', $starts );
 	}
+
+	// -----------------------------------------------------------------------
+	// build_manual_occurrences — pure, no DB
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Dates are sorted ascending regardless of input order, each taking the
+	 * reference row's time-of-day and duration.
+	 */
+	public function test_build_manual_occurrences_sorts_and_applies_time_and_duration() {
+		$occurrences = RecurrenceService::build_manual_occurrences(
+			'2035-03-01 10:00:00',
+			'2035-03-01 12:00:00',
+			array( '2035-03-15', '2035-03-01', '2035-03-08' )
+		);
+
+		$this->assertCount( 3, $occurrences );
+		$this->assertSame( '2035-03-01T10:00:00', $occurrences[0]['start'] );
+		$this->assertSame( '2035-03-01T12:00:00', $occurrences[0]['end'] );
+		$this->assertSame( '2035-03-08T10:00:00', $occurrences[1]['start'] );
+		$this->assertSame( '2035-03-15T10:00:00', $occurrences[2]['start'] );
+	}
+
+	/**
+	 * Duplicate dates are collapsed to a single occurrence.
+	 */
+	public function test_build_manual_occurrences_deduplicates() {
+		$occurrences = RecurrenceService::build_manual_occurrences(
+			'2035-03-01 10:00:00',
+			'2035-03-01 12:00:00',
+			array( '2035-03-01', '2035-03-01' )
+		);
+
+		$this->assertCount( 1, $occurrences );
+	}
+
+	/**
+	 * An empty date list produces no occurrences (caller falls back / no-ops).
+	 */
+	public function test_build_manual_occurrences_empty_list() {
+		$occurrences = RecurrenceService::build_manual_occurrences(
+			'2035-03-01 10:00:00',
+			'2035-03-01 12:00:00',
+			array()
+		);
+
+		$this->assertSame( array(), $occurrences );
+	}
 }

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -304,66 +304,82 @@ class EventDatesController extends WP_REST_Controller {
 	 */
 	private function get_create_update_args() {
 		return array(
-			'title'          => array(
+			'title'           => array(
 				'description'       => __( 'Event title.', 'fair-events' ),
 				'type'              => 'string',
 				'required'          => true,
 				'sanitize_callback' => 'sanitize_text_field',
 			),
-			'start_datetime' => array(
+			'start_datetime'  => array(
 				'description'       => __( 'Start date/time (Y-m-d H:i:s format).', 'fair-events' ),
 				'type'              => 'string',
 				'required'          => true,
 				'sanitize_callback' => 'sanitize_text_field',
 			),
-			'end_datetime'   => array(
+			'end_datetime'    => array(
 				'description'       => __( 'End date/time (Y-m-d H:i:s format).', 'fair-events' ),
 				'type'              => 'string',
 				'required'          => false,
 				'sanitize_callback' => 'sanitize_text_field',
 			),
-			'all_day'        => array(
+			'all_day'         => array(
 				'description' => __( 'Whether this is an all-day event.', 'fair-events' ),
 				'type'        => 'boolean',
 				'required'    => false,
 				'default'     => false,
 			),
-			'venue_id'       => array(
+			'venue_id'        => array(
 				'description' => __( 'Venue ID.', 'fair-events' ),
 				'type'        => array( 'integer', 'null' ),
 				'required'    => false,
 			),
-			'address'        => array(
+			'address'         => array(
 				'description'       => __( 'Free-text address (used when Venues feature is disabled).', 'fair-events' ),
 				'type'              => array( 'string', 'null' ),
 				'required'          => false,
 				'sanitize_callback' => 'sanitize_textarea_field',
 			),
-			'link_type'      => array(
+			'link_type'       => array(
 				'description' => __( 'Link type (post, external, none).', 'fair-events' ),
 				'type'        => 'string',
 				'required'    => false,
 				'default'     => 'none',
 				'enum'        => array( 'post', 'external', 'none' ),
 			),
-			'external_url'   => array(
+			'external_url'    => array(
 				'description'       => __( 'External URL for the event.', 'fair-events' ),
 				'type'              => 'string',
 				'required'          => false,
 				'sanitize_callback' => 'esc_url_raw',
 			),
-			'event_id'       => array(
+			'event_id'        => array(
 				'description' => __( 'Linked post ID.', 'fair-events' ),
 				'type'        => array( 'integer', 'null' ),
 				'required'    => false,
 			),
-			'rrule'          => array(
+			'rrule'           => array(
 				'description'       => __( 'Recurrence rule in RRULE format.', 'fair-events' ),
 				'type'              => array( 'string', 'null' ),
 				'required'          => false,
 				'sanitize_callback' => 'sanitize_text_field',
 			),
-			'categories'     => array(
+			'recurrence_mode' => array(
+				'description' => __( 'Recurrence shape: none (single date), rule (RRULE-based), or manual (hand-picked dates).', 'fair-events' ),
+				'type'        => 'string',
+				'required'    => false,
+				'enum'        => array( 'none', 'rule', 'manual' ),
+			),
+			'manual_dates'    => array(
+				'description'       => __( 'Hand-picked occurrence dates (Y-m-d) for a manual-mode series. The earliest date becomes the master.', 'fair-events' ),
+				'type'              => 'array',
+				'required'          => false,
+				'items'             => array(
+					'type'   => 'string',
+					'format' => 'date',
+				),
+				'validate_callback' => array( $this, 'validate_manual_dates' ),
+			),
+			'categories'      => array(
 				'description' => __( 'Category term IDs.', 'fair-events' ),
 				'type'        => 'array',
 				'required'    => false,
@@ -385,6 +401,71 @@ class EventDatesController extends WP_REST_Controller {
 		$args['start_datetime']['required'] = false;
 
 		return $args;
+	}
+
+	/**
+	 * Validate the `manual_dates` param for a manual-mode series.
+	 *
+	 * Rejects malformed/non-calendar dates, duplicate days (a manual series
+	 * supports one occurrence per day, same as reconcile_occurrences()'
+	 * anchor keying), and lists longer than RecurrenceService::MAX_OCCURRENCES.
+	 *
+	 * @param mixed           $value   Raw param value.
+	 * @param WP_REST_Request $request Full request object.
+	 * @param string          $param   Param name.
+	 * @return true|WP_Error True if valid, WP_Error otherwise.
+	 */
+	public function validate_manual_dates( $value, $request, $param ) {
+		if ( ! is_array( $value ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				__( 'manual_dates must be an array of Y-m-d dates.', 'fair-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( count( $value ) > RecurrenceService::MAX_OCCURRENCES ) {
+			return new WP_Error(
+				'rest_too_many_manual_dates',
+				sprintf(
+					/* translators: %d: maximum allowed occurrence count. */
+					__( 'A series can have at most %d dates.', 'fair-events' ),
+					RecurrenceService::MAX_OCCURRENCES
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		$seen = array();
+		foreach ( $value as $date ) {
+			if ( ! is_string( $date ) || ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
+				return new WP_Error(
+					'rest_invalid_manual_date',
+					__( 'Each manual date must be in Y-m-d format.', 'fair-events' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			$parsed = \DateTime::createFromFormat( 'Y-m-d', $date );
+			if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $date ) {
+				return new WP_Error(
+					'rest_invalid_manual_date',
+					__( 'Each manual date must be a valid calendar date.', 'fair-events' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			if ( isset( $seen[ $date ] ) ) {
+				return new WP_Error(
+					'rest_duplicate_manual_date',
+					__( 'Manual dates must not contain duplicates — only one occurrence per day is supported.', 'fair-events' ),
+					array( 'status' => 400 )
+				);
+			}
+			$seen[ $date ] = true;
+		}
+
+		return true;
 	}
 
 	/**
@@ -449,13 +530,21 @@ class EventDatesController extends WP_REST_Controller {
 			RecurrenceService::regenerate_standalone_occurrences( $id, $rrule );
 		}
 
+		// Set a hand-picked (manual) occurrence list, if provided.
+		$recurrence_mode = $request->get_param( 'recurrence_mode' );
+		$manual_dates    = $request->get_param( 'manual_dates' );
+		$is_manual       = 'manual' === $recurrence_mode && ! empty( $manual_dates );
+		if ( $is_manual ) {
+			RecurrenceService::set_manual_occurrences( $id, $manual_dates );
+		}
+
 		// Set categories for standalone event date.
 		$categories = $request->get_param( 'categories' );
 		if ( is_array( $categories ) ) {
 			$this->set_standalone_categories( $id, $categories );
 
 			// Propagate categories to generated occurrences.
-			if ( ! empty( $rrule ) ) {
+			if ( ! empty( $rrule ) || $is_manual ) {
 				$generated = EventDates::get_generated_by_master_id( $id, true );
 				foreach ( $generated as $occ ) {
 					$this->set_standalone_categories( $occ->id, $categories );
@@ -943,6 +1032,35 @@ class EventDatesController extends WP_REST_Controller {
 					$this->set_standalone_categories( $id, $cat_ids );
 				}
 			}
+		}
+
+		// Set a hand-picked (manual) occurrence list. Not folded into the
+		// $update_data block above since recurrence_mode/manual_dates can be
+		// sent without any other field changing, and the manual path reads
+		// the master's (already-updated) start_datetime/end_datetime itself
+		// rather than needing them threaded through here.
+		$recurrence_mode = $request->get_param( 'recurrence_mode' );
+		$manual_dates    = $request->get_param( 'manual_dates' );
+		if ( 'manual' === $recurrence_mode && is_array( $manual_dates ) ) {
+			$manual_master_id = ( 'generated' === $existing->occurrence_type && $existing->master_id )
+				? $existing->master_id
+				: $id;
+			$manual_master    = EventDates::get_by_id( $manual_master_id );
+
+			// Classify the impact before applying, for informational purposes
+			// only — reconcile_occurrences() soft-cancels stale rows, so
+			// there's no destructive-change guard to gate this on.
+			$manual_occurrences = RecurrenceService::build_manual_occurrences(
+				$manual_master->start_datetime,
+				$manual_master->end_datetime,
+				$manual_dates
+			);
+			$recurrence_impact  = RecurrenceService::classify_change(
+				$manual_master_id,
+				array_slice( $manual_occurrences, 1 )
+			);
+
+			RecurrenceService::set_manual_occurrences( $manual_master_id, $manual_dates );
 		}
 
 		// Handle categories parameter.

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -477,7 +477,25 @@ export default function ManageEventApp() {
 		);
 	}, [eventDate]);
 
+	const isSeries =
+		!!eventDate?.rrule || eventDate?.recurrence_mode === 'manual';
+
 	const seriesSummary = useMemo(() => {
+		if (eventDate?.recurrence_mode === 'manual') {
+			const dateCount =
+				(eventDate.generated_occurrences?.length || 0) + 1;
+			return sprintf(
+				/* translators: %d: number of dates in the series */
+				_n(
+					'Irregular series · %d date',
+					'Irregular series · %d dates',
+					dateCount,
+					'fair-events'
+				),
+				dateCount
+			);
+		}
+
 		if (!eventDate?.rrule) return null;
 
 		const parsed = parseRRule(eventDate.rrule);
@@ -1004,14 +1022,14 @@ export default function ManageEventApp() {
 							<VStack spacing={4}>
 								<HStack alignment="center" wrap>
 									<span>
-										{eventDate.rrule
+										{isSeries
 											? seriesSummary
 											: __(
 													'This event happens once.',
 													'fair-events'
 											  )}
 									</span>
-									{eventDate.rrule ? (
+									{isSeries ? (
 										<>
 											<Button
 												variant="secondary"
@@ -1431,7 +1449,9 @@ export default function ManageEventApp() {
 				<SeriesModal
 					eventDateId={eventDateId}
 					initialRrule={eventDate.rrule}
+					initialRecurrenceMode={eventDate.recurrence_mode}
 					startDatetime={eventDate.start_datetime}
+					generatedOccurrences={eventDate.generated_occurrences}
 					onClose={() => setSeriesModalOpen(false)}
 					onSaved={handleSeriesSaved}
 					onImpact={handleSeriesImpact}

--- a/fair-events/src/Admin/manage-event/SeriesModal.js
+++ b/fair-events/src/Admin/manage-event/SeriesModal.js
@@ -3,7 +3,8 @@
  *
  * Owns the frequency/ends fields and a live schedule preview, and saves
  * immediately on confirm (recurrence no longer rides along with the details
- * form's dirty-snapshot / Save flow).
+ * form's dirty-snapshot / Save flow). Also owns the "Irregular series"
+ * hand-picked-dates editor.
  *
  * @package FairEvents
  */
@@ -14,6 +15,7 @@ import {
 	Modal,
 	Notice,
 	TabPanel,
+	TextControl,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -44,29 +46,68 @@ function formatPreviewDate(dateStr) {
 	});
 }
 
+// Naive site-local Y-m-d slice — mirrors formatPreviewDate's no-reconversion
+// rule (UI_GUIDELINES.md "Dates and times").
+function dateOnly(datetime) {
+	return datetime ? datetime.slice(0, 10) : '';
+}
+
+/**
+ * Seed the manual-dates list from whatever the modal already knows about the
+ * series: an existing manual series' own occurrences, or (lossless rule →
+ * manual seeding) an existing rule series' generated occurrences, or just the
+ * event's own start date for a brand-new series.
+ *
+ * @param {string}      startDatetime       Master row's start_datetime.
+ * @param {Array|undefined} generatedOccurrences Existing generated children, if any.
+ * @return {string[]} Sorted, deduplicated Y-m-d dates.
+ */
+function seedManualDates(startDatetime, generatedOccurrences) {
+	const dates = [
+		dateOnly(startDatetime),
+		...(generatedOccurrences || []).map((occ) =>
+			dateOnly(occ.start_datetime)
+		),
+	].filter(Boolean);
+
+	return [...new Set(dates)].sort();
+}
+
 /**
  * @param {Object}        props
- * @param {number}        props.eventDateId   The event date being edited.
- * @param {string|null}   props.initialRrule  Stored rrule, or null when creating a new series.
- * @param {string}        props.startDatetime Naive "Y-m-d H:i:s" start of the first occurrence, for the preview.
- * @param {Function}      props.onClose       Called to dismiss the modal without saving.
- * @param {Function}      props.onSaved       Called with the updated event date after a successful save.
- * @param {Function}      props.onImpact      Called with `{ impact, blocked }` (or null) after save succeeds or fails.
+ * @param {number}        props.eventDateId            The event date being edited.
+ * @param {string|null}   props.initialRrule           Stored rrule, or null when creating a new series.
+ * @param {string|null}   props.initialRecurrenceMode  Stored recurrence_mode ('none'|'rule'|'manual'), or null.
+ * @param {string}        props.startDatetime          Naive "Y-m-d H:i:s" start of the first occurrence, for the preview.
+ * @param {Array}         [props.generatedOccurrences] Existing generated children, used to seed the manual-dates editor.
+ * @param {Function}      props.onClose                Called to dismiss the modal without saving.
+ * @param {Function}      props.onSaved                Called with the updated event date after a successful save.
+ * @param {Function}      props.onImpact               Called with `{ impact, blocked }` (or null) after save succeeds or fails.
  */
 export default function SeriesModal({
 	eventDateId,
 	initialRrule,
+	initialRecurrenceMode,
 	startDatetime,
+	generatedOccurrences,
 	onClose,
 	onSaved,
 	onImpact,
 }) {
-	const isEditing = !!initialRrule;
+	const isEditing = !!initialRrule || 'manual' === initialRecurrenceMode;
+	const isInitiallyManual = 'manual' === initialRecurrenceMode;
+
+	const [activeTab, setActiveTab] = useState(
+		isInitiallyManual ? 'irregular' : 'regular'
+	);
 
 	const [recurrence, setRecurrence] = useState(() =>
 		initialRrule
 			? { enabled: true, ...parseRRule(initialRrule) }
 			: { ...DEFAULT_RECURRENCE }
+	);
+	const [manualDates, setManualDates] = useState(() =>
+		seedManualDates(startDatetime, generatedOccurrences)
 	);
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState(null);
@@ -78,15 +119,41 @@ export default function SeriesModal({
 		[rrule, startDatetime]
 	);
 
+	const filledManualDates = manualDates.filter(Boolean);
+	const uniqueManualDates = new Set(filledManualDates);
+	const hasDuplicateManualDates =
+		uniqueManualDates.size !== filledManualDates.length;
+
+	const updateManualDate = (index, value) => {
+		setManualDates((prev) => prev.map((d, i) => (i === index ? value : d)));
+	};
+
+	const addManualDateRow = () => {
+		setManualDates((prev) => [...prev, '']);
+	};
+
+	const removeManualDateRow = (index) => {
+		setManualDates((prev) => prev.filter((_, i) => i !== index));
+	};
+
+	const isManualTab = 'irregular' === activeTab;
+
 	const handleConfirm = async () => {
 		setSaving(true);
 		setError(null);
 
 		try {
+			const data = isManualTab
+				? {
+						recurrence_mode: 'manual',
+						manual_dates: filledManualDates,
+				  }
+				: { rrule };
+
 			const updated = await apiFetch({
 				path: `/fair-events/v1/event-dates/${eventDateId}`,
 				method: 'PUT',
-				data: { rrule },
+				data,
 			});
 			onImpact(
 				updated.recurrence_impact
@@ -108,7 +175,21 @@ export default function SeriesModal({
 		}
 	};
 
-	const confirmLabel = isEditing
+	const manualDateCount = uniqueManualDates.size;
+
+	const confirmLabel = isManualTab
+		? isEditing
+			? sprintf(
+					/* translators: %d: number of dates in the series */
+					__('Update series — %d dates', 'fair-events'),
+					manualDateCount
+			  )
+			: sprintf(
+					/* translators: %d: number of dates in the series */
+					__('Create series — %d dates', 'fair-events'),
+					manualDateCount
+			  )
+		: isEditing
 		? sprintf(
 				/* translators: %d: number of dates in the series */
 				__('Update series — %d dates', 'fair-events'),
@@ -120,6 +201,12 @@ export default function SeriesModal({
 				preview.totalCount
 		  );
 
+	const confirmDisabled = saving
+		? true
+		: isManualTab
+		? filledManualDates.length === 0 || hasDuplicateManualDates
+		: preview.totalCount === 0;
+
 	const tabs = [
 		{
 			name: 'regular',
@@ -128,7 +215,6 @@ export default function SeriesModal({
 		{
 			name: 'irregular',
 			title: __('Irregular series', 'fair-events'),
-			disabled: true,
 		},
 	];
 
@@ -148,7 +234,11 @@ export default function SeriesModal({
 				</Notice>
 			)}
 
-			<TabPanel tabs={tabs}>
+			<TabPanel
+				tabs={tabs}
+				initialTabName={activeTab}
+				onSelect={setActiveTab}
+			>
 				{(tab) =>
 					tab.name === 'regular' ? (
 						<HStack
@@ -200,12 +290,67 @@ export default function SeriesModal({
 							</VStack>
 						</HStack>
 					) : (
-						<p style={{ marginTop: '16px' }}>
-							{__(
-								'Irregular series (picking arbitrary dates) is coming in a future update.',
-								'fair-events'
+						<VStack spacing={3} style={{ marginTop: '16px' }}>
+							<p>
+								{__(
+									'Pick the exact dates this event happens on.',
+									'fair-events'
+								)}
+							</p>
+							<p style={{ color: '#757575' }}>
+								{__(
+									'One session per day. All dates share the event’s start time and length.',
+									'fair-events'
+								)}
+							</p>
+
+							{hasDuplicateManualDates && (
+								<Notice status="error" isDismissible={false}>
+									{__(
+										'Each date can only be used once — remove the duplicate before saving.',
+										'fair-events'
+									)}
+								</Notice>
 							)}
-						</p>
+
+							<VStack spacing={2}>
+								{manualDates.map((date, index) => (
+									// eslint-disable-next-line react/no-array-index-key
+									<HStack key={index} alignment="center">
+										<TextControl
+											type="date"
+											label={sprintf(
+												/* translators: %d: 1-based row number in the manual date list */
+												__('Date %d', 'fair-events'),
+												index + 1
+											)}
+											hideLabelFromVision
+											value={date}
+											onChange={(value) =>
+												updateManualDate(index, value)
+											}
+										/>
+										<Button
+											variant="tertiary"
+											isDestructive
+											onClick={() =>
+												removeManualDateRow(index)
+											}
+											disabled={manualDates.length === 1}
+										>
+											{__('Remove', 'fair-events')}
+										</Button>
+									</HStack>
+								))}
+							</VStack>
+
+							<Button
+								variant="secondary"
+								onClick={addManualDateRow}
+							>
+								{__('Add date', 'fair-events')}
+							</Button>
+						</VStack>
 					)
 				}
 			</TabPanel>
@@ -222,7 +367,7 @@ export default function SeriesModal({
 					variant="primary"
 					onClick={handleConfirm}
 					isBusy={saving}
-					disabled={saving || preview.totalCount === 0}
+					disabled={confirmDisabled}
 				>
 					{confirmLabel}
 				</Button>

--- a/fair-events/src/Admin/manage-event/__tests__/SeriesModal.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/SeriesModal.test.jsx
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for the "Irregular series" hand-picked-dates editor in SeriesModal
+ * (#979).
+ *
+ * Covers:
+ *   - Seeding the date list from existing generated occurrences.
+ *   - Add / remove date rows.
+ *   - Duplicate-day rejection (visible Notice, confirm disabled).
+ *   - Confirm sends { recurrence_mode: 'manual', manual_dates } on the
+ *     Irregular tab instead of { rrule }.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import SeriesModal from '../SeriesModal.js';
+
+jest.mock('@wordpress/api-fetch');
+
+beforeEach(() => {
+	// The Regular schedule tab renders RecurrenceControl, which uses
+	// @wordpress/components' deprecated 36px default SelectControl/
+	// NumberControl size, and TabPanel (ariakit) commits its tab ids in a
+	// post-mount effect — both emit console noise unrelated to what these
+	// tests exercise. Matches the suppression convention in
+	// ManageEventApp.test.jsx.
+	jest.spyOn(console, 'warn').mockImplementation(() => {});
+	jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+});
+
+// TabPanel (ariakit) sets up its tab ids in an effect after mount; flushing a
+// tick via waitFor keeps that update wrapped in act() before we interact.
+async function renderModal(props) {
+	const utils = render(<SeriesModal {...props} />);
+	await waitFor(() =>
+		expect(
+			screen.getByRole('tab', { name: 'Regular schedule' })
+		).toBeInTheDocument()
+	);
+	return utils;
+}
+
+function openIrregularTab() {
+	fireEvent.click(screen.getByRole('tab', { name: 'Irregular series' }));
+}
+
+it('seeds the date list from existing generated occurrences when editing a manual series', async () => {
+	await renderModal({
+		eventDateId: 1,
+		initialRrule: null,
+		initialRecurrenceMode: 'manual',
+		startDatetime: '2026-07-01 18:00:00',
+		generatedOccurrences: [
+			{ id: 2, start_datetime: '2026-07-08 18:00:00' },
+			{ id: 3, start_datetime: '2026-07-20 18:00:00' },
+		],
+		onClose: () => {},
+		onSaved: () => {},
+		onImpact: () => {},
+	});
+
+	const dateInputs = screen.getAllByDisplayValue(/2026-07-/);
+	expect(dateInputs.map((el) => el.value)).toEqual([
+		'2026-07-01',
+		'2026-07-08',
+		'2026-07-20',
+	]);
+});
+
+it('adds and removes date rows', async () => {
+	await renderModal({
+		eventDateId: 1,
+		initialRrule: null,
+		initialRecurrenceMode: null,
+		startDatetime: '2026-07-01 18:00:00',
+		generatedOccurrences: [],
+		onClose: () => {},
+		onSaved: () => {},
+		onImpact: () => {},
+	});
+
+	openIrregularTab();
+
+	expect(screen.getAllByDisplayValue('2026-07-01')).toHaveLength(1);
+
+	fireEvent.click(screen.getByRole('button', { name: 'Add date' }));
+	expect(screen.getAllByRole('button', { name: 'Remove' })).toHaveLength(2);
+
+	fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[1]);
+	expect(screen.getAllByRole('button', { name: 'Remove' })).toHaveLength(1);
+});
+
+it('shows a Notice and disables confirm when two rows share the same date', async () => {
+	await renderModal({
+		eventDateId: 1,
+		initialRrule: null,
+		initialRecurrenceMode: 'manual',
+		startDatetime: '2026-07-01 18:00:00',
+		generatedOccurrences: [
+			{ id: 2, start_datetime: '2026-07-08 18:00:00' },
+		],
+		onClose: () => {},
+		onSaved: () => {},
+		onImpact: () => {},
+	});
+
+	const [firstDate, secondDate] = screen.getAllByDisplayValue(/2026-07-/);
+	fireEvent.change(secondDate, { target: { value: firstDate.value } });
+
+	// The WP a11y-speak live region duplicates Notice text for screen readers,
+	// so there are two matches — assert at least one is present.
+	expect(
+		screen.getAllByText(/Each date can only be used once/).length
+	).toBeGreaterThan(0);
+
+	const confirmButton = screen.getByRole('button', {
+		name: /Update series/,
+	});
+	expect(confirmButton).toBeDisabled();
+});
+
+it('sends recurrence_mode + manual_dates on confirm from the Irregular tab', async () => {
+	apiFetch.mockResolvedValue({
+		recurrence_mode: 'manual',
+		generated_occurrences: [],
+	});
+
+	const onSaved = jest.fn();
+
+	await renderModal({
+		eventDateId: 7,
+		initialRrule: null,
+		initialRecurrenceMode: null,
+		startDatetime: '2026-07-01 18:00:00',
+		generatedOccurrences: [],
+		onClose: () => {},
+		onSaved,
+		onImpact: () => {},
+	});
+
+	openIrregularTab();
+	fireEvent.click(screen.getByRole('button', { name: 'Add date' }));
+	const [, secondDate] = screen.getAllByDisplayValue(/2026-07-01|^$/);
+	fireEvent.change(secondDate, { target: { value: '2026-07-15' } });
+
+	fireEvent.click(screen.getByRole('button', { name: /Create series/ }));
+
+	await waitFor(() => expect(onSaved).toHaveBeenCalled());
+
+	expect(apiFetch).toHaveBeenCalledWith(
+		expect.objectContaining({
+			path: '/fair-events/v1/event-dates/7',
+			method: 'PUT',
+			data: {
+				recurrence_mode: 'manual',
+				manual_dates: ['2026-07-01', '2026-07-15'],
+			},
+		})
+	);
+});

--- a/fair-events/src/Services/RecurrenceService.php
+++ b/fair-events/src/Services/RecurrenceService.php
@@ -346,6 +346,96 @@ class RecurrenceService {
 	}
 
 	/**
+	 * Build the {start,end} occurrence set for a hand-picked list of dates.
+	 *
+	 * Pure — no DB access. Each date takes the reference row's time-of-day
+	 * and duration (mirrors the RRULE path's duration handling in
+	 * generate_occurrences()). Dates are deduplicated and sorted ascending
+	 * so the first is always the earliest.
+	 *
+	 * @param string   $reference_start Reference start datetime (Y-m-d H:i:s) —
+	 *                                  supplies time-of-day and duration.
+	 * @param string   $reference_end   Reference end datetime (Y-m-d H:i:s).
+	 * @param string[] $dates           Occurrence dates (Y-m-d), any order, may contain duplicates.
+	 * @return array Array of occurrences with 'start' and 'end' keys, sorted ascending.
+	 */
+	public static function build_manual_occurrences( $reference_start, $reference_end, array $dates ) {
+		$dates = array_values( array_unique( $dates ) );
+		sort( $dates );
+
+		if ( empty( $dates ) ) {
+			return array();
+		}
+
+		$start    = new \DateTime( $reference_start );
+		$end      = new \DateTime( $reference_end );
+		$duration = $start->diff( $end );
+		$time     = $start->format( 'H:i:s' );
+
+		$occurrences = array();
+		foreach ( $dates as $date ) {
+			$occ_start     = new \DateTime( $date . ' ' . $time );
+			$occ_end       = ( clone $occ_start )->add( $duration );
+			$occurrences[] = array(
+				'start' => $occ_start->format( 'Y-m-d\TH:i:s' ),
+				'end'   => $occ_end->format( 'Y-m-d\TH:i:s' ),
+			);
+		}
+
+		return $occurrences;
+	}
+
+	/**
+	 * Set a series to a hand-picked (manual) list of occurrence dates.
+	 *
+	 * Uses reconcile_occurrences() so existing row IDs are preserved when
+	 * dates shift, same as the RRULE paths above. The earliest date becomes
+	 * the master; when only one date remains, the series collapses to a
+	 * plain 'none' single occurrence rather than a one-item manual series.
+	 *
+	 * @param int      $master_id Master (or single) event date row ID.
+	 * @param string[] $dates     Occurrence dates (Y-m-d).
+	 * @return int Number of occurrences set (master + surviving children).
+	 */
+	public static function set_manual_occurrences( $master_id, array $dates ) {
+		$master = EventDates::get_by_id( $master_id );
+
+		if ( ! $master ) {
+			return 0;
+		}
+
+		$occurrences = self::build_manual_occurrences( $master->start_datetime, $master->end_datetime, $dates );
+
+		if ( empty( $occurrences ) ) {
+			return 0;
+		}
+
+		$is_single = 1 === count( $occurrences );
+		$first     = $occurrences[0];
+
+		EventDates::update_by_id(
+			$master_id,
+			array(
+				'occurrence_type'   => $is_single ? 'single' : 'master',
+				'rrule'             => null,
+				'recurrence_mode'   => $is_single ? 'none' : 'manual',
+				'start_datetime'    => $first['start'],
+				'end_datetime'      => $first['end'],
+				'recurrence_anchor' => ( new \DateTime( $first['start'] ) )->format( 'Y-m-d' ),
+			)
+		);
+
+		// Inheritable fields are NOT propagated here — see regenerate_event_occurrences().
+		$generated = array_slice( $occurrences, 1 );
+		return 1 + self::reconcile_occurrences(
+			$master_id,
+			$generated,
+			$master->all_day,
+			array( 'event_id' => $master->event_id )
+		);
+	}
+
+	/**
 	 * Reconcile generated occurrences for a series against the desired set.
 	 *
 	 * Matches desired occurrences to existing generated rows (active or


### PR DESCRIPTION
## Summary

Recurring events only supported rule-based schedules (weekly, monthly,
etc.), which can't model an irregular series like a festival's specific
dates or an ad-hoc class calendar. This adds a **manual** recurrence
mode: pick exact calendar dates, each occurrence inheriting the event's
time-of-day and duration.

- `RecurrenceService::build_manual_occurrences()` (pure) + `set_manual_occurrences()`:
  sorts/dedupes the date list, the earliest date becomes the master, and
  the rest reuse the existing `reconcile_occurrences()` so surviving row
  ids (and their ticket types/signups) are preserved across edits.
  Dropping to a single date collapses the series back to a plain
  `'none'` single occurrence.
- `EventDatesController`: extends `get_create_update_args()` with
  `recurrence_mode` (`none`/`rule`/`manual`) and `manual_dates` (`Y-m-d`
  array, validated for format/duplicates/max length), wires the manual
  path into `create_item()`/`update_item()` alongside the existing rrule
  path, and returns the same informational `recurrence_impact` payload
  (no destructive-change guard, per #996).
- `SeriesModal.js`: enables the previously-disabled "Irregular series"
  tab with an add/remove date-row editor, seeded losslessly from an
  existing series' generated occurrences (works for both a rule series
  being converted and an existing manual series being edited). Rejects
  duplicate days client-side with a visible `Notice` and a disabled
  confirm button — input is never silently dropped.
- `ManageEventApp.js`: the recurrence card now also treats
  `recurrence_mode === 'manual'` as a series (Edit/End buttons, an
  "Irregular series · N dates" summary); the existing `RecurrenceCalendar`
  render condition already covers it unchanged.

Closes #979

## Test plan

- [x] `vendor/bin/phpunit` (fair-events) — 53 tests pass, including new
      `build_manual_occurrences()` unit tests (sort/dedupe/empty).
- [x] `npm run test:js` (fair-events) — 96 tests pass, including a new
      `SeriesModal.test.jsx` covering seeding, add/remove rows,
      duplicate-day rejection, and the manual-mode PUT payload.
- [x] `vendor/bin/phpcs` clean on all changed files (pre-existing
      unrelated warnings in `EventDatesController.php` confirmed present
      before this change too).
- [x] `npm run build` — production assets rebuilt.
- [x] Manual WP-CLI `eval-file` checks against a real DB:
      `set_manual_occurrences()` add/edit-in-place (id preserved)/soft-cancel
      on removal/master-date-shift when the first date is dropped/collapse
      to single when one date remains; and the REST `create`/`update` flow
      (manual create, duplicate-date 400, update returning
      `recurrence_impact`).
