### PR TITLE
Use core start_of_week instead of custom setting

### DIFF
--- a/fair-events/src/Admin/settings/GeneralTab.js
+++ b/fair-events/src/Admin/settings/GeneralTab.js
@@ -8,7 +8,6 @@ import {
 	TextControl,
 	CheckboxControl,
 	ToggleControl,
-	RadioControl,
 	ExternalLink,
 	Card,
 	CardHeader,
@@ -38,7 +37,6 @@ export default function GeneralTab({ onNotice }) {
 	const [registerPostType, setRegisterPostType] = useState(true);
 	const [availablePostTypes, setAvailablePostTypes] = useState([]);
 	const [poweredByBranding, setPoweredByBranding] = useState(false);
-	const [startOfWeek, setStartOfWeek] = useState(1);
 	const [isLoading, setIsLoading] = useState(true);
 	const [isSaving, setIsSaving] = useState(false);
 
@@ -50,7 +48,6 @@ export default function GeneralTab({ onNotice }) {
 				setEnabledPostTypes(settings.enabledPostTypes);
 				setRegisterPostType(settings.registerPostType);
 				setPoweredByBranding(settings.poweredByBranding);
-				setStartOfWeek(settings.startOfWeek);
 
 				// Filter to get content post types that make sense for events.
 				// Exclude system types that shouldn't have event data.
@@ -117,7 +114,6 @@ export default function GeneralTab({ onNotice }) {
 			fair_events_register_post_type: registerPostType,
 			fair_events_enabled_post_types: otherPostTypes,
 			fair_events_powered_by_branding: poweredByBranding,
-			fair_events_start_of_week: startOfWeek,
 		})
 			.then(() => {
 				return loadGeneralSettings();
@@ -127,7 +123,6 @@ export default function GeneralTab({ onNotice }) {
 				setEnabledPostTypes(settings.enabledPostTypes);
 				setRegisterPostType(settings.registerPostType);
 				setPoweredByBranding(settings.poweredByBranding);
-				setStartOfWeek(settings.startOfWeek);
 				onNotice({
 					status: 'success',
 					message: __('Settings saved successfully.', 'fair-events'),
@@ -294,36 +289,12 @@ export default function GeneralTab({ onNotice }) {
 							)}
 							disabled={isSaving}
 						/>
-					</CardBody>
-				</Card>
-
-				<Card>
-					<CardHeader>
-						<h2>{__('Calendar Display', 'fair-events')}</h2>
-					</CardHeader>
-					<CardBody>
-						<RadioControl
-							label={__('Start of Week', 'fair-events')}
-							help={__(
-								'First day of the week shown in the Events Calendar and Events Week View blocks.',
+						<p className="description">
+							{__(
+								'The Events Calendar and Events Week View blocks follow the "Week Starts On" setting under Settings → General.',
 								'fair-events'
 							)}
-							selected={startOfWeek}
-							options={[
-								{
-									label: __('Monday', 'fair-events'),
-									value: 1,
-								},
-								{
-									label: __('Sunday', 'fair-events'),
-									value: 0,
-								},
-							]}
-							onChange={(value) =>
-								setStartOfWeek(parseInt(value, 10))
-							}
-							disabled={isSaving}
-						/>
+						</p>
 					</CardBody>
 				</Card>
 

--- a/fair-events/src/Admin/settings/settings-api.js
+++ b/fair-events/src/Admin/settings/settings-api.js
@@ -16,7 +16,6 @@ export function loadGeneralSettings() {
 			registerPostType: settings.fair_events_register_post_type ?? true,
 			poweredByBranding:
 				settings.fair_events_powered_by_branding ?? false,
-			startOfWeek: settings.fair_events_start_of_week ?? 1,
 		};
 	});
 }

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -275,6 +275,11 @@ class Installer {
 			self::migrate_to_3_22_0();
 		}
 
+		// Run migration if upgrading from pre-3.23.0 (drop orphaned start-of-week option).
+		if ( version_compare( $current_version, '3.23.0', '<' ) ) {
+			self::migrate_to_3_23_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -433,6 +438,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.22.0', '<' ) ) {
 				self::migrate_to_3_22_0();
+			}
+
+			if ( version_compare( $current_version, '3.23.0', '<' ) ) {
+				self::migrate_to_3_23_0();
 			}
 
 			// Install/update tables
@@ -1921,6 +1930,18 @@ class Installer {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Migrate to version 3.23.0 - Drop the orphaned start-of-week option.
+	 *
+	 * Calendar/week-view blocks now read WordPress core's `start_of_week`
+	 * option directly instead of the plugin's own copy.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_23_0() {
+		delete_option( 'fair_events_start_of_week' );
 	}
 
 	/**

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.22.0';
+	const DB_VERSION = '3.23.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table

--- a/fair-events/src/Settings/Settings.php
+++ b/fair-events/src/Settings/Settings.php
@@ -118,19 +118,6 @@ class Settings {
 				'default'           => false,
 			)
 		);
-
-		// Global start-of-week for calendar/week-view blocks. 1 = Monday (default), 0 = Sunday.
-		register_setting(
-			'fair_events_settings',
-			'fair_events_start_of_week',
-			array(
-				'type'              => 'integer',
-				'description'       => __( 'First day of the week shown in calendar and week-view blocks', 'fair-events' ),
-				'sanitize_callback' => array( $this, 'sanitize_start_of_week' ),
-				'show_in_rest'      => true,
-				'default'           => 1,
-			)
-		);
 	}
 
 	/**
@@ -145,21 +132,12 @@ class Settings {
 	/**
 	 * Get the global start-of-week setting for calendar/week-view blocks.
 	 *
-	 * @return int 1 for Monday, 0 for Sunday.
+	 * Reads WordPress core's Settings → General → "Week Starts On" option.
+	 *
+	 * @return int 0-6 (0 = Sunday).
 	 */
 	public static function get_start_of_week() {
-		return (int) get_option( 'fair_events_start_of_week', 1 );
-	}
-
-	/**
-	 * Sanitize start_of_week value (must be 0 or 1).
-	 *
-	 * @param mixed $value Incoming value.
-	 * @return int 0 or 1.
-	 */
-	public function sanitize_start_of_week( $value ) {
-		$int = (int) $value;
-		return ( 0 === $int ) ? 0 : 1;
+		return (int) get_option( 'start_of_week', 1 );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Fair Events had its own `fair_events_start_of_week` option (radio, Mon/Sun only). Reads WordPress core's `start_of_week` (Settings → General) instead, which unlocks all 7 possible start days.
- `Settings::get_start_of_week()` becomes a thin wrapper over `get_option( 'start_of_week', 1 )`; the `register_setting`/`sanitize_start_of_week` for the old option are removed. The `events-calendar`/`events-week` block renderers already derive weekday order via `% 7`, so they need no changes.
- Removed the "Calendar Display" card from the General settings tab and replaced it with a help note pointing to Settings → General.
- Added a `3.23.0` DB migration that deletes the orphaned `fair_events_start_of_week` option.

Closes #1069

## Test plan

- [x] `npm run test:js` in fair-events — 92 passed
- [x] `npm run build` in fair-events
- [x] `vendor/bin/phpcs` on changed PHP files — clean (pre-existing unrelated warnings in the same files are unchanged)
- [x] `grep -rn "fair_events_start_of_week"` in fair-events/src returns only the migration's `delete_option` call
- [ ] Manual WP-CLI render check (Sunday/Saturday start) — not run; local WordPress environment's port 3306 was already in use by another running project
