### PR TITLE
Use date param for event-signup occurrence picker

### DIFF
--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -140,7 +140,7 @@ const SCROLL_RESTORE_KEY = 'fairAudienceOccurrenceScrollY';
 
 	/**
 	 * Wire the recurrence occurrence picker. Changing the select navigates
-	 * the page to the same URL with ?event_date=<id>, so sibling event
+	 * the page to the same URL with ?event_date=<Y-m-d>, so sibling event
 	 * blocks (event-info, event-dates, calendar-button) re-render for the
 	 * picked occurrence and the dropdown's own state is preserved via the
 	 * server-rendered default selection.
@@ -152,23 +152,23 @@ const SCROLL_RESTORE_KEY = 'fairAudienceOccurrenceScrollY';
 		);
 		if (!select) return;
 		select.addEventListener('change', function () {
-			navigateToOccurrence(this.value);
+			const option = this.options[this.selectedIndex];
+			navigateToOccurrence(option ? option.dataset.eventDate : '');
 		});
 	}
 
 	/**
-	 * Navigate the current page to the same URL with ?event_date=<id> set,
+	 * Navigate the current page to the same URL with ?event_date=<Y-m-d> set,
 	 * preserving any other query params (e.g. fair_payment_callback). The
 	 * scroll position is stashed first and restored on the reloaded page
 	 * (see restoreScrollPosition()) so picking a date doesn't jump the
 	 * viewer back to the top of the page.
-	 * @param {string} eventDateId Selected occurrence id
+	 * @param {string} eventDate Selected occurrence date (Y-m-d)
 	 */
-	function navigateToOccurrence(eventDateId) {
-		const id = parseInt(eventDateId, 10);
-		if (!id) return;
+	function navigateToOccurrence(eventDate) {
+		if (!eventDate) return;
 		const url = new URL(window.location.href);
-		url.searchParams.set('event_date', String(id));
+		url.searchParams.set('event_date', eventDate);
 		sessionStorage.setItem(SCROLL_RESTORE_KEY, String(window.scrollY));
 		window.location.assign(url.toString());
 	}

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -100,6 +100,7 @@ if ( $event_dates_obj
 	foreach ( $upcoming as $occ ) {
 		$occurrences_for_picker[] = array(
 			'id'             => (int) $occ->id,
+			'date'           => \FairEvents\Helpers\OccurrenceDateParam::format( $occ ),
 			'start_datetime' => $occ->start_datetime,
 			'end_datetime'   => $occ->end_datetime,
 			'all_day'        => (bool) $occ->all_day,
@@ -330,20 +331,34 @@ $callback_is_open = $has_callback_state
 
 // When the picker is shown, re-pivot the wrapper-level event_date_id and
 // is_signed_up to the occurrence the user is most likely to act on next:
-// the URL-selected occurrence (?event_date=<id>) when it matches one of
-// the upcoming rows, otherwise the first not-yet-signed-up upcoming
-// occurrence, or the first one if they're already signed up for everything.
+// the URL-selected occurrence (?event_date=<Y-m-d>, with a legacy numeric
+// id still resolving for old links) when it matches one of the upcoming
+// rows, otherwise the first not-yet-signed-up upcoming occurrence, or the
+// first one if they're already signed up for everything.
 $has_occurrence_picker = count( $occurrences_for_picker ) > 1;
 if ( $has_occurrence_picker ) {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$url_selected_id = isset( $_GET['event_date'] ) ? absint( wp_unslash( $_GET['event_date'] ) ) : 0;
+	$raw_event_date_param = isset( $_GET['event_date'] ) ? sanitize_text_field( wp_unslash( $_GET['event_date'] ) ) : '';
 
 	$default_idx = null;
-	if ( $url_selected_id > 0 ) {
-		foreach ( $occurrences_for_picker as $idx => $occ_row ) {
-			if ( (int) $occ_row['id'] === $url_selected_id ) {
-				$default_idx = $idx;
-				break;
+	if ( '' !== $raw_event_date_param ) {
+		if ( \FairEvents\Helpers\OccurrenceDateParam::is_legacy_id( $raw_event_date_param ) ) {
+			$url_selected_id = absint( $raw_event_date_param );
+			foreach ( $occurrences_for_picker as $idx => $occ_row ) {
+				if ( (int) $occ_row['id'] === $url_selected_id ) {
+					$default_idx = $idx;
+					break;
+				}
+			}
+		} else {
+			$url_selected_date = \FairEvents\Helpers\OccurrenceDateParam::parse( $raw_event_date_param );
+			if ( null !== $url_selected_date ) {
+				foreach ( $occurrences_for_picker as $idx => $occ_row ) {
+					if ( $occ_row['date'] === $url_selected_date ) {
+						$default_idx = $idx;
+						break;
+					}
+				}
 			}
 		}
 	}
@@ -936,10 +951,11 @@ $render_add_activities = static function () use ( $addable_options, $has_addable
  * Render the upcoming-occurrence picker for recurring events.
  *
  * The picker is a no-op when fewer than two upcoming occurrences exist.
- * Renders a <select> dropdown. Each option carries data-event-date-id and
- * data-signed-up so the frontend JS can re-target the submit and toggle
- * between "Sign up" / "Cancel signup" as the user changes the selection,
- * and so the dropdown can sync the selection into the page URL.
+ * Renders a <select> dropdown. Each option carries data-event-date-id,
+ * data-event-date (the public Y-m-d param) and data-signed-up so the
+ * frontend JS can re-target the submit, toggle between "Sign up" /
+ * "Cancel signup" as the user changes the selection, and sync the
+ * selection into the page URL as a readable date.
  */
 $render_occurrence_picker = static function () use ( $occurrences_for_picker, $has_occurrence_picker, $form_id, $state ) {
 	if ( ! $has_occurrence_picker ) {
@@ -964,7 +980,7 @@ $render_occurrence_picker = static function () use ( $occurrences_for_picker, $h
 				$label .= ' — ' . __( 'signed up', 'fair-audience' );
 			}
 		}
-		echo '<option value="' . (int) $occ_row['id'] . '" data-event-date-id="' . (int) $occ_row['id'] . '" data-signed-up="' . ( $occ_row['signed_up'] ? 'true' : 'false' ) . '"';
+		echo '<option value="' . (int) $occ_row['id'] . '" data-event-date-id="' . (int) $occ_row['id'] . '" data-event-date="' . esc_attr( $occ_row['date'] ) . '" data-signed-up="' . ( $occ_row['signed_up'] ? 'true' : 'false' ) . '"';
 		if ( ! empty( $occ_row['is_default'] ) ) {
 			echo ' selected';
 		}


### PR DESCRIPTION
## Summary
- The recurring-event occurrence picker in fair-audience's Event Signup
  block still read/wrote `?event_date=<id>`, an opaque internal id that's
  meaningless to humans and breaks when occurrences are regenerated.
- Switches both the read side (`render.php`) and write side (`frontend.js`)
  to the same `Y-m-d` date contract fair-events already uses elsewhere
  (#1119), via the shared `OccurrenceDateParam` helper. Legacy numeric ids
  still resolve for old links.

## Notes
- This block is what actually renders on a recurring-event page when
  fair-audience is active — the fair-events `get-tickets` block defers to
  it in that case — so this closes the gap left by #1119, which only
  updated `get-tickets`'s own rendering path.
- Internal REST/API usage (`event_date_id` submitted to the signup
  endpoint) is unchanged — out of scope, not part of the public URL
  contract.

## Test plan
- [x] `vendor/bin/phpcs` clean on changed lines (pre-existing warnings in
      the file are unrelated to this change)
- [x] `npm run build` / `npm run format` in fair-audience
- [ ] Manual: on a recurring event page, changing the occurrence dropdown
      updates the URL to `?event_date=2026-07-29` instead of
      `?event_date=<id>`, and old bookmarked numeric-id links still resolve
