### PR TITLE
Lock the master date in the irregular series editor

### DIFF
--- a/fair-events/src/Admin/manage-event/SeriesModal.js
+++ b/fair-events/src/Admin/manage-event/SeriesModal.js
@@ -53,22 +53,20 @@ function dateOnly(datetime) {
 }
 
 /**
- * Seed the manual-dates list from whatever the modal already knows about the
- * series: an existing manual series' own occurrences, or (lossless rule →
- * manual seeding) an existing rule series' generated occurrences, or just the
- * event's own start date for a brand-new series.
+ * Seed the extra (non-master) manual dates from whatever the modal already
+ * knows about the series: an existing manual series' generated occurrences,
+ * or (lossless rule → manual seeding) an existing rule series' generated
+ * occurrences. The master's own date is tracked separately and never appears
+ * in this list — see the `masterDate` prop of the "Irregular series" tab.
  *
- * @param {string}      startDatetime       Master row's start_datetime.
+ * @param {string}           masterDateStr        Master row's own date (Y-m-d).
  * @param {Array|undefined} generatedOccurrences Existing generated children, if any.
- * @return {string[]} Sorted, deduplicated Y-m-d dates.
+ * @return {string[]} Sorted, deduplicated Y-m-d dates, excluding the master's own date.
  */
-function seedManualDates(startDatetime, generatedOccurrences) {
-	const dates = [
-		dateOnly(startDatetime),
-		...(generatedOccurrences || []).map((occ) =>
-			dateOnly(occ.start_datetime)
-		),
-	].filter(Boolean);
+function seedManualDates(masterDateStr, generatedOccurrences) {
+	const dates = (generatedOccurrences || [])
+		.map((occ) => dateOnly(occ.start_datetime))
+		.filter((d) => Boolean(d) && d !== masterDateStr);
 
 	return [...new Set(dates)].sort();
 }
@@ -106,8 +104,12 @@ export default function SeriesModal({
 			? { enabled: true, ...parseRRule(initialRrule) }
 			: { ...DEFAULT_RECURRENCE }
 	);
+	// The master's own date is fixed — it's edited from the Event Details
+	// form, not from this modal. Only the extra occurrence dates are
+	// editable here.
+	const masterDateStr = dateOnly(startDatetime);
 	const [manualDates, setManualDates] = useState(() =>
-		seedManualDates(startDatetime, generatedOccurrences)
+		seedManualDates(masterDateStr, generatedOccurrences)
 	);
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState(null);
@@ -120,9 +122,10 @@ export default function SeriesModal({
 	);
 
 	const filledManualDates = manualDates.filter(Boolean);
-	const uniqueManualDates = new Set(filledManualDates);
+	const allManualDates = [masterDateStr, ...filledManualDates];
+	const uniqueManualDates = new Set(allManualDates);
 	const hasDuplicateManualDates =
-		uniqueManualDates.size !== filledManualDates.length;
+		uniqueManualDates.size !== allManualDates.length;
 
 	const updateManualDate = (index, value) => {
 		setManualDates((prev) => prev.map((d, i) => (i === index ? value : d)));
@@ -146,7 +149,7 @@ export default function SeriesModal({
 			const data = isManualTab
 				? {
 						recurrence_mode: 'manual',
-						manual_dates: filledManualDates,
+						manual_dates: allManualDates,
 				  }
 				: { rrule };
 
@@ -204,7 +207,7 @@ export default function SeriesModal({
 	const confirmDisabled = saving
 		? true
 		: isManualTab
-		? filledManualDates.length === 0 || hasDuplicateManualDates
+		? hasDuplicateManualDates
 		: preview.totalCount === 0;
 
 	const tabs = [
@@ -314,13 +317,28 @@ export default function SeriesModal({
 							)}
 
 							<VStack spacing={2}>
+								<HStack alignment="center">
+									<TextControl
+										type="date"
+										label={__('Master date', 'fair-events')}
+										hideLabelFromVision
+										value={masterDateStr}
+										disabled
+									/>
+									<span style={{ color: '#757575' }}>
+										{__(
+											'Master date — edit it from Event Details',
+											'fair-events'
+										)}
+									</span>
+								</HStack>
 								{manualDates.map((date, index) => (
 									// eslint-disable-next-line react/no-array-index-key
 									<HStack key={index} alignment="center">
 										<TextControl
 											type="date"
 											label={sprintf(
-												/* translators: %d: 1-based row number in the manual date list */
+												/* translators: %d: 1-based row number in the extra-dates list */
 												__('Date %d', 'fair-events'),
 												index + 1
 											)}
@@ -336,7 +354,6 @@ export default function SeriesModal({
 											onClick={() =>
 												removeManualDateRow(index)
 											}
-											disabled={manualDates.length === 1}
 										>
 											{__('Remove', 'fair-events')}
 										</Button>

--- a/fair-events/src/Admin/manage-event/__tests__/SeriesModal.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/SeriesModal.test.jsx
@@ -6,10 +6,11 @@
  *
  * Covers:
  *   - Seeding the date list from existing generated occurrences.
- *   - Add / remove date rows.
+ *   - The master's own date row is fixed (disabled, no Remove button) —
+ *     only the extra occurrence rows are editable/removable.
  *   - Duplicate-day rejection (visible Notice, confirm disabled).
- *   - Confirm sends { recurrence_mode: 'manual', manual_dates } on the
- *     Irregular tab instead of { rrule }.
+ *   - Confirm sends { recurrence_mode: 'manual', manual_dates } (master date
+ *     + extras) on the Irregular tab instead of { rrule }.
  */
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -72,7 +73,7 @@ it('seeds the date list from existing generated occurrences when editing a manua
 	]);
 });
 
-it('adds and removes date rows', async () => {
+it('adds and removes date rows, and keeps the master date fixed', async () => {
 	await renderModal({
 		eventDateId: 1,
 		initialRrule: null,
@@ -86,13 +87,20 @@ it('adds and removes date rows', async () => {
 
 	openIrregularTab();
 
-	expect(screen.getAllByDisplayValue('2026-07-01')).toHaveLength(1);
+	// The master's own date row is disabled and has no Remove button.
+	const masterInput = screen.getByDisplayValue('2026-07-01');
+	expect(masterInput).toBeDisabled();
+	expect(
+		screen.queryByRole('button', { name: 'Remove' })
+	).not.toBeInTheDocument();
 
 	fireEvent.click(screen.getByRole('button', { name: 'Add date' }));
-	expect(screen.getAllByRole('button', { name: 'Remove' })).toHaveLength(2);
-
-	fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[1]);
 	expect(screen.getAllByRole('button', { name: 'Remove' })).toHaveLength(1);
+
+	fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[0]);
+	expect(
+		screen.queryByRole('button', { name: 'Remove' })
+	).not.toBeInTheDocument();
 });
 
 it('shows a Notice and disables confirm when two rows share the same date', async () => {


### PR DESCRIPTION
## Summary
- The "Irregular series" editor listed the master occurrence's own date as just another editable/removable row. Editing or removing it let a different date become the earliest date, which `RecurrenceService::set_manual_occurrences()` promotes to master server-side, so the recurrence calendar widget ended up highlighting the wrong date as the series master.
- The master's date is now rendered as a fixed, disabled row in the modal — only the extra occurrence dates are add/edit/removable there. Confirm always submits `[masterDate, ...extraDates]` as `manual_dates`.
- To move the master's own date, use the Event Details start-date field instead.

## Test plan
- [x] `npx jest src/Admin/manage-event` (80 tests, all pass)
- [x] `npm run format`
- [ ] Manual check in wp-admin: open "Edit series" on a manual/irregular series master, confirm the master's date row is disabled, add/remove extra dates, save, and verify the calendar still highlights the original master date in blue
