### PR TITLE
Fix manual series dropping when master date is edited

### DIFF
--- a/fair-events/e2e/manual-series-master-date-edit.spec.js
+++ b/fair-events/e2e/manual-series-master-date-edit.spec.js
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test';
+
+const WP_ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const WP_ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * Regression for #979: editing an irregular (manual) series' master event
+ * only through its own start_datetime — the "Event Details" start-date field,
+ * not the "Edit series" modal — used to fall into the rrule-regenerate path
+ * in EventDatesController::update_item(), which treated the manual master's
+ * null rrule as "series ended" and wiped every hand-picked date.
+ */
+
+async function apiFetch(page, options) {
+	const result = await page.evaluate(async (opts) => {
+		try {
+			// eslint-disable-next-line no-undef
+			const res = await wp.apiFetch(opts);
+			return { ok: true, data: res };
+		} catch (err) {
+			return {
+				ok: false,
+				error: {
+					message: err && err.message,
+					code: err && err.code,
+					data: err && err.data,
+				},
+			};
+		}
+	}, options);
+	if (!result.ok) {
+		throw new Error(
+			`apiFetch ${options.method || 'GET'} ${
+				options.path
+			} failed: ${JSON.stringify(result.error)}`
+		);
+	}
+	return result.data;
+}
+
+async function login(page) {
+	await page.goto('/wp-admin');
+	if (page.url().includes('wp-login.php')) {
+		await page.fill('#user_login', WP_ADMIN_USER);
+		await page.fill('#user_pass', WP_ADMIN_PASS);
+		await page.click('#wp-submit');
+	}
+	await page.waitForSelector('#wpadminbar');
+}
+
+test.describe('Manual (irregular) series survives editing the master date', () => {
+	test('PUT with only start_datetime keeps recurrence_mode=manual and the other dates', async ({
+		page,
+	}) => {
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+		const master = await apiFetch(page, {
+			path: '/fair-events/v1/event-dates',
+			method: 'POST',
+			data: {
+				title: 'Manual series master-date-edit regression',
+				start_datetime: '2026-08-01 18:00:00',
+				end_datetime: '2026-08-01 20:00:00',
+				all_day: false,
+			},
+		});
+
+		try {
+			await apiFetch(page, {
+				path: `/fair-events/v1/event-dates/${master.id}`,
+				method: 'PUT',
+				data: {
+					recurrence_mode: 'manual',
+					manual_dates: ['2026-08-01', '2026-08-15', '2026-09-01'],
+				},
+			});
+
+			const afterCreate = await apiFetch(page, {
+				path: `/fair-events/v1/event-dates/${master.id}`,
+			});
+			expect(afterCreate.recurrence_mode).toBe('manual');
+			expect(afterCreate.generated_occurrences).toHaveLength(2);
+
+			// Edit only the master's own start/end time — what the Event
+			// Details start-date field sends — with no rrule/manual_dates.
+			await apiFetch(page, {
+				path: `/fair-events/v1/event-dates/${master.id}`,
+				method: 'PUT',
+				data: {
+					start_datetime: '2026-08-01 19:00:00',
+					end_datetime: '2026-08-01 21:00:00',
+				},
+			});
+
+			const afterEdit = await apiFetch(page, {
+				path: `/fair-events/v1/event-dates/${master.id}`,
+			});
+
+			expect(afterEdit.recurrence_mode).toBe('manual');
+			expect(afterEdit.occurrence_type).toBe('master');
+			expect(afterEdit.start_datetime).toBe('2026-08-01 19:00:00');
+			expect(afterEdit.generated_occurrences).toHaveLength(2);
+
+			const dates = afterEdit.generated_occurrences
+				.map((occ) => occ.start_datetime)
+				.sort();
+			expect(dates).toEqual([
+				'2026-08-15 19:00:00',
+				'2026-09-01 19:00:00',
+			]);
+		} finally {
+			await apiFetch(page, {
+				path: `/fair-events/v1/event-dates/${master.id}`,
+				method: 'DELETE',
+			}).catch(() => {});
+		}
+	});
+});

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -971,7 +971,25 @@ class EventDatesController extends WP_REST_Controller {
 
 			$dates_changed_on_recurring = $dates_changed && ( $existing->occurrence_type === 'master' || $rrule_changed );
 
-			if ( $rrule_changed || $dates_changed_on_recurring ) {
+			if ( 'manual' === $existing->recurrence_mode && ! $rrule_changed && $dates_changed_on_recurring ) {
+				// A manual (hand-picked-dates) master's own start/end changed via a
+				// plain field edit (e.g. the Event Details start-date field), not via
+				// the recurrence_mode/manual_dates params handled below. Reflow the
+				// shared time-of-day + duration across the existing hand-picked dates
+				// instead of falling into the rrule-regenerate branch below, which
+				// would treat the manual master's null rrule as "series ended" and
+				// wipe the whole series (#979).
+				$existing_dates = array_merge(
+					array( ( new \DateTime( $update_data['start_datetime'] ?? $existing->start_datetime ) )->format( 'Y-m-d' ) ),
+					array_map(
+						static function ( $child ) {
+							return ( new \DateTime( $child->start_datetime ) )->format( 'Y-m-d' );
+						},
+						EventDates::get_generated_by_master_id( $id, true )
+					)
+				);
+				RecurrenceService::set_manual_occurrences( $id, $existing_dates );
+			} elseif ( $rrule_changed || $dates_changed_on_recurring ) {
 				$effective_rrule = $update_data['rrule'] ?? $existing->rrule;
 
 				// Classify the impact before applying, for informational purposes —


### PR DESCRIPTION
## Summary

- Confirmed the reported bug in #979: editing only a manual (irregular) series master's start/end datetime — the field the "Event Details" form sends, not the "Edit series" modal — dropped the entire series. `EventDatesController::update_item()` treated any master date/time change as reason to fall into the rrule-regenerate branch, and a manual master has no rrule, so it was read as "series ended" and wiped every hand-picked date back to a single occurrence.
- Fixed by reflowing the shared time-of-day + duration across the existing hand-picked dates via `RecurrenceService::set_manual_occurrences()` when the master itself is `recurrence_mode: 'manual'`, instead of falling through to the rrule regenerate path.
- Reproduced locally via `wp eval-file` against a real DB before and after the fix, then added an e2e regression test.

## Test plan
- [x] Reproduced the bug against a live WordPress instance via WP-CLI `eval-file` (manual series wiped to a single occurrence by a start_datetime-only PUT)
- [x] Added `e2e/manual-series-master-date-edit.spec.js`; confirmed it fails on `main` and passes with the fix
- [x] `vendor/bin/phpunit` (fair-events) — 62 tests pass
- [x] `vendor/bin/phpcs` on the changed file — no new errors (2 pre-existing unrelated findings)
- [x] `npx playwright test src/API/__tests__/EventDatesController.api.spec.js` — same pre-existing failures on `main` and on this branch (unrelated env/auth issue), no new failures

Refs #979
