### PR TITLE
Fix week block to honor all start_of_week days, not just Monday

### DIFF
--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -152,10 +152,8 @@ $first_day_of_month_ts = strtotime( "{$current_year}-{$current_month}-01" );
 $days_in_month         = (int) gmdate( 't', $first_day_of_month_ts );
 $first_weekday         = (int) gmdate( 'w', $first_day_of_month_ts ); // 0=Sunday, 6=Saturday
 
-// Adjust for Monday start (startOfWeek attribute)
-if ( 1 === $start_of_week ) {
-	$first_weekday = ( 0 === $first_weekday ) ? 6 : $first_weekday - 1;
-}
+// Adjust so day 0 in the grid matches the configured start_of_week (0-6).
+$first_weekday = ( $first_weekday - $start_of_week + 7 ) % 7;
 
 $leading_blanks  = $first_weekday;
 $total_cells     = $leading_blanks + $days_in_month;

--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -53,8 +53,11 @@ if ( ! function_exists( 'fair_events_get_week_boundaries' ) ) {
 	function fair_events_get_week_boundaries( $year, $week, $start_of_week ) {
 		$date = new DateTime();
 		$date->setISODate( $year, $week );
-		if ( 0 === $start_of_week ) {
-			$date->modify( '-1 day' );
+		// setISODate() lands on the Monday (weekday 1). Step back to whichever
+		// weekday start_of_week configures (0 = Sunday .. 6 = Saturday).
+		$days_back = ( 1 - $start_of_week + 7 ) % 7;
+		if ( $days_back > 0 ) {
+			$date->modify( "-{$days_back} days" );
 		}
 		$week_start = $date->format( 'Y-m-d' );
 		$date->modify( '+6 days' );


### PR DESCRIPTION
## Summary

- `fair_events_get_week_boundaries()` (events-week block) relied on `DateTime::setISODate()`, which always resolves to the ISO Monday, and only special-cased `start_of_week === 0` (Sunday). Any other start day (Tue–Sat, unlocked by the recent core `start_of_week` migration) silently fell back to Monday. Generalized the offset to a modulo calculation covering all 7 possible values.
- The calendar block had the same Monday-only special case in its leading-blank-days calculation, while its weekday-label row already used a general `% 7` formula. Applied the same fix there so both blocks are consistent for every start day.

Refs #1069

## Test plan

- [x] Verified the offset formula by hand for `start_of_week = 0..6`
- [x] `vendor/bin/phpcs` clean on changed lines (pre-existing unrelated warnings elsewhere in both files untouched)
- [x] `npm run format` — no unrelated changes
- No JS/CSS changed, so no `npm run build` needed
- No existing automated test exercises week-start-day boundary logic; none needed updating
