### PR TITLE
Add public ICS calendar feed endpoint

### DIFF
--- a/fair-events/src/API/CalendarFeedController.php
+++ b/fair-events/src/API/CalendarFeedController.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * REST API Controller for the public ICS calendar feed
+ *
+ * Read-only mirror of the public JSON events feed (PublicEventsController),
+ * serialized as iCalendar for subscribing in Google Calendar, Outlook, etc.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\API;
+
+defined( 'WPINC' ) || die;
+
+use FairEvents\Helpers\DateHelper;
+use FairEvents\Services\EventFeedProvider;
+use Sabre\VObject\Component\VCalendar;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+
+/**
+ * Handles the public ICS calendar feed endpoint
+ */
+class CalendarFeedController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-events/v1';
+
+	/**
+	 * Hard cap on the number of events serialized into a single feed, as a
+	 * DoS guard alongside the bounded date range.
+	 *
+	 * @var int
+	 */
+	const MAX_EVENTS = 1000;
+
+	/**
+	 * Register the routes for the calendar feed
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		// GET /fair-events/v1/calendar.ics - Public ICS calendar feed.
+		register_rest_route(
+			$this->namespace,
+			'/calendar\.ics',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_calendar' ),
+					// Genuinely public read-only feed — a subscribe URL for
+					// calendar clients, mirroring the already-public
+					// /events endpoint.
+					'permission_callback' => '__return_true',
+					'args'                => array(
+						'start_date' => array(
+							'description' => __( 'Filter events starting on or after this date (Y-m-d format).', 'fair-events' ),
+							'type'        => 'string',
+							'format'      => 'date',
+						),
+						'end_date'   => array(
+							'description' => __( 'Filter events ending on or before this date (Y-m-d format).', 'fair-events' ),
+							'type'        => 'string',
+							'format'      => 'date',
+						),
+						'categories' => array(
+							'description' => __( 'Filter by category slugs (comma-separated).', 'fair-events' ),
+							'type'        => 'string',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Serve the ICS calendar feed
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return void Sends headers and echoes the ICS body directly.
+	 */
+	public function get_calendar( $request ) {
+		$start_date = $request->get_param( 'start_date' );
+		$end_date   = $request->get_param( 'end_date' );
+		$categories = $request->get_param( 'categories' );
+
+		$provider    = new EventFeedProvider();
+		$occurrences = $provider->get_occurrences(
+			$this->range_start( $start_date ),
+			$this->range_end( $end_date ),
+			array( 'categories' => $this->resolve_category_ids( $categories ) )
+		);
+
+		$occurrences = array_slice( $occurrences, 0, self::MAX_EVENTS );
+
+		$vcalendar = $this->build_vcalendar( $occurrences );
+
+		header( 'Content-Type: text/calendar; charset=utf-8' );
+		header( 'Content-Disposition: inline; filename="calendar.ics"' );
+		echo $vcalendar->serialize(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- ICS body, not HTML.
+		exit;
+	}
+
+	/**
+	 * Build the VCALENDAR component for a set of occurrences.
+	 *
+	 * @param array[] $occurrences Occurrence DTOs from EventFeedProvider.
+	 * @return VCalendar
+	 */
+	private function build_vcalendar( array $occurrences ) {
+		$vcalendar                    = new VCalendar();
+		$vcalendar->{'X-WR-CALNAME'}  = get_bloginfo( 'name' );
+		$vcalendar->{'X-WR-TIMEZONE'} = wp_timezone_string();
+
+		foreach ( $occurrences as $occurrence ) {
+			if ( empty( $occurrence['start'] ) ) {
+				continue;
+			}
+
+			$this->add_vevent( $vcalendar, $occurrence );
+		}
+
+		return $vcalendar;
+	}
+
+	/**
+	 * Add a single VEVENT to the calendar for an occurrence DTO.
+	 *
+	 * @param VCalendar $vcalendar  Calendar to add the event to.
+	 * @param array     $occurrence Occurrence DTO.
+	 * @return void
+	 */
+	private function add_vevent( VCalendar $vcalendar, array $occurrence ) {
+		$now = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+
+		$vevent = $vcalendar->add(
+			'VEVENT',
+			array(
+				'UID'           => $occurrence['uid'],
+				'SUMMARY'       => $occurrence['title'],
+				'DESCRIPTION'   => $occurrence['description'],
+				'DTSTAMP'       => $now,
+				'LAST-MODIFIED' => $now,
+			)
+		);
+
+		if ( ! empty( $occurrence['url'] ) ) {
+			$vevent->add( 'URL', $occurrence['url'] );
+		}
+
+		if ( $occurrence['all_day'] ) {
+			$start_date = DateHelper::local_date( $occurrence['start'] );
+			$end_date   = DateHelper::next_date( DateHelper::local_date( $occurrence['end'] ) );
+
+			$vevent->add( 'DTSTART', $start_date, array( 'VALUE' => 'DATE' ) );
+			$vevent->add( 'DTEND', $end_date, array( 'VALUE' => 'DATE' ) );
+		} else {
+			$vevent->add( 'DTSTART', DateHelper::local_to_ical_utc( $occurrence['start'] ) );
+			$vevent->add( 'DTEND', DateHelper::local_to_ical_utc( $occurrence['end'] ) );
+		}
+	}
+
+	/**
+	 * Convert an optional Y-m-d start_date param into a naive site-local
+	 * range-start datetime, bounded to one month before now when omitted.
+	 *
+	 * @param string|null $start_date Y-m-d date, or null/empty for the bounded default.
+	 * @return string Naive 'Y-m-d H:i:s' site-local datetime.
+	 */
+	private function range_start( $start_date ) {
+		if ( $start_date ) {
+			return $start_date . ' 00:00:00';
+		}
+
+		return wp_date( 'Y-m-d 00:00:00', strtotime( '-1 month', time() ) );
+	}
+
+	/**
+	 * Convert an optional Y-m-d end_date param into a naive site-local
+	 * range-end datetime, bounded to twelve months after now when omitted.
+	 *
+	 * @param string|null $end_date Y-m-d date, or null/empty for the bounded default.
+	 * @return string Naive 'Y-m-d H:i:s' site-local datetime.
+	 */
+	private function range_end( $end_date ) {
+		if ( $end_date ) {
+			return $end_date . ' 23:59:59';
+		}
+
+		return wp_date( 'Y-m-d 23:59:59', strtotime( '+12 months', time() ) );
+	}
+
+	/**
+	 * Resolve a comma-separated list of category slugs into term IDs.
+	 *
+	 * @param string|null $categories Comma-separated category slugs.
+	 * @return int[] Category term IDs.
+	 */
+	private function resolve_category_ids( $categories ) {
+		$category_ids = array();
+
+		if ( empty( $categories ) ) {
+			return $category_ids;
+		}
+
+		$category_slugs = array_map( 'trim', explode( ',', $categories ) );
+		foreach ( $category_slugs as $slug ) {
+			$term = get_term_by( 'slug', $slug, 'category' );
+			if ( $term ) {
+				$category_ids[] = $term->term_id;
+			}
+		}
+
+		return $category_ids;
+	}
+}

--- a/fair-events/src/API/__tests__/CalendarFeedController.api.spec.js
+++ b/fair-events/src/API/__tests__/CalendarFeedController.api.spec.js
@@ -1,0 +1,226 @@
+/**
+ * Playwright API tests for CalendarFeedController's public ICS calendar feed
+ * (#1059).
+ *
+ * The feed reuses EventFeedProvider — the same pipeline PublicEventsController
+ * consumes — and serializes occurrences as iCalendar via sabre/vobject.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('CalendarFeedController — ICS calendar feed', () => {
+	let api;
+	let eventPostId;
+	let timedEventDateId;
+	let standaloneEventDateId;
+	let allDayEventDateId;
+	let categoryId;
+	let otherCategoryId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Calendar feed test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const timedRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Calendar feed timed test ${Date.now()}`,
+				link_type: 'post',
+				start_datetime: '2035-09-01 10:00:00',
+				end_datetime: '2035-09-01 12:00:00',
+			},
+		});
+		expect(timedRes.ok()).toBeTruthy();
+		timedEventDateId = (await timedRes.json()).id;
+
+		// The create endpoint doesn't wire event_id through — a PUT is
+		// needed to actually link the post (see PublicEventsController's
+		// recurring-occurrences test for the same quirk).
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${timedEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { event_id: eventPostId },
+			}
+		);
+		expect(linkRes.ok()).toBeTruthy();
+
+		const categoryRes = await api.post('/wp-json/wp/v2/categories', {
+			headers: adminHeaders,
+			data: { name: `Calendar feed test ${Date.now()}` },
+		});
+		expect(categoryRes.ok()).toBeTruthy();
+		categoryId = (await categoryRes.json()).id;
+
+		const otherCategoryRes = await api.post('/wp-json/wp/v2/categories', {
+			headers: adminHeaders,
+			data: { name: `Calendar feed unused ${Date.now()}` },
+		});
+		expect(otherCategoryRes.ok()).toBeTruthy();
+		otherCategoryId = (await otherCategoryRes.json()).id;
+
+		const standaloneRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Calendar feed standalone test ${Date.now()}`,
+					start_datetime: '2035-09-02 10:00:00',
+					end_datetime: '2035-09-02 12:00:00',
+					link_type: 'external',
+					external_url: 'https://example.com/calendar-feed-test',
+					categories: [categoryId],
+				},
+			}
+		);
+		expect(standaloneRes.ok()).toBeTruthy();
+		standaloneEventDateId = (await standaloneRes.json()).id;
+
+		const allDayRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Calendar feed all-day test ${Date.now()}`,
+					start_datetime: '2035-09-03 00:00:00',
+					end_datetime: '2035-09-03 00:00:00',
+					all_day: true,
+					link_type: 'external',
+					external_url: 'https://example.com/calendar-feed-all-day',
+				},
+			}
+		);
+		expect(allDayRes.ok()).toBeTruthy();
+		allDayEventDateId = (await allDayRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (standaloneEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${standaloneEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (allDayEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${allDayEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (categoryId) {
+			await api.delete(
+				`/wp-json/wp/v2/categories/${categoryId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (otherCategoryId) {
+			await api.delete(
+				`/wp-json/wp/v2/categories/${otherCategoryId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+	});
+
+	test('serves a valid ICS feed with the right headers', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/calendar.ics?start_date=2035-09-01&end_date=2035-09-30'
+		);
+		expect(res.ok()).toBeTruthy();
+		expect(res.headers()['content-type']).toContain('text/calendar');
+		expect(res.headers()['content-disposition']).toContain('calendar.ics');
+
+		const body = await res.text();
+		expect(body).toContain('BEGIN:VCALENDAR');
+		expect(body).toContain('END:VCALENDAR');
+	});
+
+	test('includes a VEVENT per seeded occurrence with correct UID prefixes and URLs', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/calendar.ics?start_date=2035-09-01&end_date=2035-09-30'
+		);
+		expect(res.ok()).toBeTruthy();
+		// Unfold RFC 5545 line folding (CRLF + leading space) before
+		// substring assertions, since sabre wraps long lines (e.g. URLs).
+		const body = (await res.text()).replace(/\r\n /g, '');
+
+		const timedEdRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${timedEventDateId}`,
+			{ headers: adminHeaders }
+		);
+		const timedEventDate = await timedEdRes.json();
+
+		expect(body).toContain(
+			`UID:fair_event_${eventPostId}_${timedEventDateId}@`
+		);
+		expect(body).toContain(`URL;VALUE=URI:${timedEventDate.display_url}`);
+		// Timed event: UTC Z time.
+		expect(body).toMatch(/DTSTART:\d{8}T\d{6}Z/);
+
+		expect(body).toContain(`UID:standalone_${standaloneEventDateId}@`);
+		expect(body).toContain(
+			'URL;VALUE=URI:https://example.com/calendar-feed-test'
+		);
+
+		// All-day event: DATE value, exclusive end (+1 day).
+		expect(body).toContain(`UID:standalone_${allDayEventDateId}@`);
+		expect(body).toMatch(/DTSTART;VALUE=DATE:2035-09-03/);
+		expect(body).toMatch(/DTEND;VALUE=DATE:2035-09-04/);
+	});
+
+	test('categories filter narrows the feed', async () => {
+		const category = await (
+			await api.get(`/wp-json/wp/v2/categories/${categoryId}`, {
+				headers: adminHeaders,
+			})
+		).json();
+
+		const matchingRes = await api.get(
+			`/wp-json/fair-events/v1/calendar.ics?start_date=2035-09-01&end_date=2035-09-30&categories=${category.slug}`
+		);
+		expect(matchingRes.ok()).toBeTruthy();
+		const matchingBody = await matchingRes.text();
+		expect(matchingBody).toContain(
+			`UID:standalone_${standaloneEventDateId}@`
+		);
+
+		const otherCategory = await (
+			await api.get(`/wp-json/wp/v2/categories/${otherCategoryId}`, {
+				headers: adminHeaders,
+			})
+		).json();
+
+		const nonMatchingRes = await api.get(
+			`/wp-json/fair-events/v1/calendar.ics?start_date=2035-09-01&end_date=2035-09-30&categories=${otherCategory.slug}`
+		);
+		expect(nonMatchingRes.ok()).toBeTruthy();
+		const nonMatchingBody = await nonMatchingRes.text();
+		expect(nonMatchingBody).not.toContain(
+			`UID:standalone_${standaloneEventDateId}@`
+		);
+	});
+});

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -151,6 +151,17 @@ class Plugin {
 			}
 		);
 
+		// Calendar feed controller — registers `/fair-events/v1/calendar.ics`,
+		// a public read-only ICS mirror of the /events feed for subscribing
+		// in calendar clients.
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new \FairEvents\API\CalendarFeedController();
+				$controller->register_routes();
+			}
+		);
+
 		if ( Features::is_enabled( 'ticketing' ) ) {
 			add_action(
 				'rest_api_init',


### PR DESCRIPTION
## Summary

- Adds `GET /fair-events/v1/calendar.ics`, a public read-only ICS mirror of the existing `/fair-events/v1/events` JSON feed, so events can be subscribed to in Google Calendar, Outlook, etc.
- Reuses `EventFeedProvider::get_occurrences()` — the same pipeline `PublicEventsController` already consumes — so both feeds share stable UIDs and query logic with no drift.
- Serializes with `sabre/vobject` (already a dependency): timed events as UTC `...Z` times, all-day events as `VALUE=DATE` with an exclusive end date (the inverse of `ICalParser`'s import logic).
- Bounded default date range (`now − 1 month` → `now + 12 months`) plus a hard 1000-event cap when params are omitted, as a DoS guard on the unauthenticated endpoint.
- Registered in `Plugin.php` alongside `PublicEventsController`, unflagged (read-only mirror of an already-public endpoint).

Refs #1059 (comment: https://github.com/marcin-wosinek/fair-event-plugins/issues/1059#issuecomment-4966551463)

## Test plan

- [x] `vendor/bin/phpcs` clean on changed PHP files
- [x] New Playwright API spec `CalendarFeedController.api.spec.js` — feed headers/content-type, VEVENT per occurrence with correct UID prefixes and URLs, all-day exclusive end date, categories filter — all passing against the local WP env
- [x] Manually verified the endpoint returns a valid `BEGIN:VCALENDAR`/`END:VCALENDAR` document with correct headers
