### PR TITLE
Reflect selected occurrence in OG/Twitter/JSON-LD meta and admin bar

### DIFF
--- a/fair-events/src/Hooks/AdminBarHooks.php
+++ b/fair-events/src/Hooks/AdminBarHooks.php
@@ -7,7 +7,7 @@
 
 namespace FairEvents\Hooks;
 
-use FairEvents\Models\EventDates;
+use FairEvents\Helpers\SelectedOccurrence;
 use FairEvents\Settings\Settings;
 
 defined( 'WPINC' ) || die;
@@ -48,7 +48,7 @@ class AdminBarHooks {
 			return;
 		}
 
-		$event_date = EventDates::get_by_event_id( $post_id );
+		$event_date = SelectedOccurrence::resolve( $post_id );
 		if ( ! $event_date ) {
 			return;
 		}

--- a/fair-events/src/Hooks/OpenGraphHooks.php
+++ b/fair-events/src/Hooks/OpenGraphHooks.php
@@ -13,7 +13,7 @@ namespace FairEvents\Hooks;
 
 use FairEvents\Helpers\DateHelper;
 use FairEvents\Helpers\EventSchema;
-use FairEvents\Models\EventDates;
+use FairEvents\Helpers\SelectedOccurrence;
 use FairEvents\Settings\Settings;
 
 defined( 'WPINC' ) || die;
@@ -147,7 +147,7 @@ class OpenGraphHooks {
 			return null;
 		}
 
-		$event_date = EventDates::get_by_event_id( $post_id );
+		$event_date = SelectedOccurrence::resolve( $post_id );
 		if ( ! $event_date ) {
 			return null;
 		}


### PR DESCRIPTION
## Summary

- `OpenGraphHooks::get_event_context()` fetched the master `EventDates` row directly, so a shared `?event_date=<id>` link's OG tags, Twitter card, and JSON-LD `Event` always previewed the master date/time/venue instead of the selected occurrence. Now routes through `SelectedOccurrence::resolve( $post_id )`, the same series-validated helper the event-info/event-dates blocks and calendar button already use — this fixes `og:title`, `event:start_time`/`end_time`, `event:location`, the Twitter card, and JSON-LD `startDate` all at once, with the existing tamper-safe fallback to the master/next-upcoming occurrence.
- `AdminBarHooks::add_manage_event_node()` had the same issue — the "Manage Event" admin-bar link always opened the master occurrence. Same fix applied so it opens the selected occurrence.

Closes #659

### Audit of remaining per-event-page surfaces (AC #3)

Confirmed no other surface needs the same fix:

| Surface | Status |
|---|---|
| `event-info`, `event-dates` blocks | Already use `SelectedOccurrence::resolve()` |
| `CalendarButtonHooks` | Already uses `resolve()` |
| `fair-audience/event-signup` block | Already pivots picker + pricing to the URL-selected occurrence |
| `fair-events/get-tickets` block | Already honors `?event_date=` via its own inline resolution / defers to fair-audience's signup block |
| `fair-audience/signups-list` block | Already uses `resolve()` |
| `audience-signup`, `event-interest` blocks | **Intentionally out of scope** — these register interest in the event as a whole, not a specific occurrence |
| `events-list`, `events-calendar`, `weekly-schedule` | Out of scope — these list *many* events |

## Test plan

- [x] `vendor/bin/phpcs` clean on changed files
- [x] `npm run format` — no unrelated changes
- [x] `npm run test:php` (PHPUnit) — 62 tests, 102 assertions, all passing (`SelectedOccurrence` behavior, including tamper/fallback handling, already covered by `__tests__/Helpers/SelectedOccurrenceTest.php`)
- No JS/CSS changed, so no `npm run build` needed
- Live manual verification (WP-CLI `eval-file`: loading `<head>` with `?event_date=<child-id>` and checking the admin-bar link) was **not** performed — this checkout's `docker compose` ports conflict with another already-running Fair Events environment. The logic swap is otherwise identical to the pattern already exercised by `event-info`/`event-dates`/`CalendarButtonHooks`, and is covered by existing `SelectedOccurrence` unit tests.
