### PR TITLE
Convert hand-rolled admin notices to wp_admin_notice()

### DIFF
--- a/fair-audience-experimental/src/Admin/MediaBatchActions.php
+++ b/fair-audience-experimental/src/Admin/MediaBatchActions.php
@@ -294,9 +294,12 @@ class MediaBatchActions {
 					$author_name
 				);
 
-				printf(
-					'<div class="notice notice-success is-dismissible"><p>%s</p></div>',
-					esc_html( $message )
+				wp_admin_notice(
+					esc_html( $message ),
+					array(
+						'type'        => 'success',
+						'dismissible' => true,
+					)
 				);
 			}
 		}

--- a/fair-payments-connector/fair-payments-connector.php
+++ b/fair-payments-connector/fair-payments-connector.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/marcin-wosinek/fair-event-plugins
  * Description: Simple payment block for WordPress
  * Version: 1.5.1
- * Requires at least: 6.2
+ * Requires at least: 6.7
  * Author: Marcin Wosinek
  * Author URI: https://github.com/marcin-wosinek
  * License: GPL-2.0-or-later

--- a/fair-payments-connector/readme.txt
+++ b/fair-payments-connector/readme.txt
@@ -1,7 +1,7 @@
 === Fair Payments Connector ===
 Contributors: marcinwosinek
 Tags: payment, mollie, events, bookkeeping, block
-Requires at least: 6.2
+Requires at least: 6.7
 Tested up to: 7.0
 Stable tag: 1.5.1
 Requires PHP: 7.4

--- a/fair-payments-connector/src/Admin/AdminPages.php
+++ b/fair-payments-connector/src/Admin/AdminPages.php
@@ -172,24 +172,24 @@ class AdminPages {
 			/* translators: %s: link to settings page */
 			$message = __( 'Fair Payment is <strong>not set up</strong> — no payments can be processed yet. <a href="%s">Set up Mollie</a>.', 'fair-payments-connector' );
 		}
-		?>
-		<div class="notice notice-warning">
-			<p>
-				<?php
-				printf(
-					wp_kses(
-						$message,
-						array(
-							'strong' => array(),
-							'a'      => array( 'href' => array() ),
-						)
-					),
-					esc_url( $settings_url )
-				);
-				?>
-			</p>
-		</div>
-		<?php
+		$notice_message = sprintf(
+			wp_kses(
+				$message,
+				array(
+					'strong' => array(),
+					'a'      => array( 'href' => array() ),
+				)
+			),
+			esc_url( $settings_url )
+		);
+
+		wp_admin_notice(
+			$notice_message,
+			array(
+				'type'        => 'warning',
+				'dismissible' => false,
+			)
+		);
 	}
 
 	/**

--- a/fair-payments-connector/src/Admin/MigrationNotice.php
+++ b/fair-payments-connector/src/Admin/MigrationNotice.php
@@ -60,16 +60,21 @@ class MigrationNotice {
 	 */
 	private function render_migration_notice() {
 		$settings_url = admin_url( 'admin.php?page=fair-payments-connector-settings' );
-		?>
-		<div class="notice notice-warning is-dismissible">
-			<p>
-				<strong><?php esc_html_e( 'Fair Payments Connector:', 'fair-payments-connector' ); ?></strong>
-				<?php esc_html_e( 'Please migrate to OAuth authentication.', 'fair-payments-connector' ); ?>
-				<a href="<?php echo esc_url( $settings_url ); ?>" class="button button-small" style="margin-left: 10px;">
-					<?php esc_html_e( 'Connect with Mollie', 'fair-payments-connector' ); ?>
-				</a>
-			</p>
-		</div>
-		<?php
+
+		$message = sprintf(
+			'<strong>%1$s</strong> %2$s <a href="%3$s" class="button button-small" style="margin-left: 10px;">%4$s</a>',
+			esc_html__( 'Fair Payments Connector:', 'fair-payments-connector' ),
+			esc_html__( 'Please migrate to OAuth authentication.', 'fair-payments-connector' ),
+			esc_url( $settings_url ),
+			esc_html__( 'Connect with Mollie', 'fair-payments-connector' )
+		);
+
+		wp_admin_notice(
+			$message,
+			array(
+				'type'        => 'warning',
+				'dismissible' => true,
+			)
+		);
 	}
 }

--- a/fair-platform/src/Admin/settings-page.php
+++ b/fair-platform/src/Admin/settings-page.php
@@ -60,27 +60,28 @@ defined( 'WPINC' ) || die;
 				</tbody>
 			</table>
 
-			<?php if ( ! $mollie_configured ) : ?>
-				<div class="notice notice-error inline">
-					<p>
-						<strong><?php esc_html_e( 'Mollie OAuth is not configured.', 'fair-platform' ); ?></strong>
-					</p>
-					<p><?php esc_html_e( 'Add the following to your wp-config.php:', 'fair-platform' ); ?></p>
-					<pre>define('MOLLIE_CLIENT_ID', 'app_xxxxxxxxxxxxx');
-define('MOLLIE_CLIENT_SECRET', 'xxxxxxxxxxxxx');</pre>
-					<p>
-						<?php
-						echo wp_kses_post(
-							sprintf(
-								/* translators: %s: README.md URL */
-								__( 'See <a href="%s" target="_blank">README.md</a> for setup instructions.', 'fair-platform' ),
-								'https://github.com/marcinwosinek/fair-event-plugins/blob/main/fair-platform/README.md'
-							)
-						);
-						?>
-					</p>
-				</div>
-			<?php endif; ?>
+			<?php
+			if ( ! $mollie_configured ) :
+				$notice_message  = '<p><strong>' . esc_html__( 'Mollie OAuth is not configured.', 'fair-platform' ) . '</strong></p>';
+				$notice_message .= '<p>' . esc_html__( 'Add the following to your wp-config.php:', 'fair-platform' ) . '</p>';
+				$notice_message .= "<pre>define('MOLLIE_CLIENT_ID', 'app_xxxxxxxxxxxxx');\ndefine('MOLLIE_CLIENT_SECRET', 'xxxxxxxxxxxxx');</pre>";
+				$notice_message .= '<p>' . sprintf(
+					/* translators: %s: README.md URL */
+					__( 'See <a href="%s" target="_blank">README.md</a> for setup instructions.', 'fair-platform' ),
+					'https://github.com/marcinwosinek/fair-event-plugins/blob/main/fair-platform/README.md'
+				) . '</p>';
+
+				wp_admin_notice(
+					$notice_message,
+					array(
+						'type'               => 'error',
+						'dismissible'        => false,
+						'additional_classes' => array( 'inline' ),
+						'paragraph_wrap'     => false,
+					)
+				);
+			endif;
+			?>
 		</div>
 
 		<!-- Test Connection -->
@@ -104,7 +105,13 @@ define('MOLLIE_CLIENT_SECRET', 'xxxxxxxxxxxxx');</pre>
 				// Handle test OAuth request.
 				if ( isset( $_POST['action'] ) && 'test_oauth' === $_POST['action'] ) {
 					if ( ! isset( $_POST['fair_platform_nonce'] ) || ! wp_verify_nonce( $_POST['fair_platform_nonce'], 'fair_platform_test_oauth' ) ) {
-						echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid nonce.', 'fair-platform' ) . '</p></div>';
+						wp_admin_notice(
+							esc_html__( 'Invalid nonce.', 'fair-platform' ),
+							array(
+								'type'        => 'error',
+								'dismissible' => false,
+							)
+						);
 					} else {
 						$test_url = add_query_arg(
 							array(
@@ -116,9 +123,13 @@ define('MOLLIE_CLIENT_SECRET', 'xxxxxxxxxxxxx');</pre>
 							home_url( '/oauth/authorize' )
 						);
 
-						echo '<div class="notice notice-info"><p>';
-						echo esc_html__( 'Redirecting to Mollie OAuth...', 'fair-platform' );
-						echo '</p></div>';
+						wp_admin_notice(
+							esc_html__( 'Redirecting to Mollie OAuth...', 'fair-platform' ),
+							array(
+								'type'        => 'info',
+								'dismissible' => false,
+							)
+						);
 						echo '<script>window.location.href = ' . wp_json_encode( $test_url ) . ';</script>';
 					}
 				}
@@ -126,28 +137,47 @@ define('MOLLIE_CLIENT_SECRET', 'xxxxxxxxxxxxx');</pre>
 				// Show test result.
 				if ( isset( $_GET['test'] ) && 'complete' === $_GET['test'] ) {
 					if ( isset( $_GET['mollie_access_token'] ) ) {
-						echo '<div class="notice notice-success"><p>';
-						echo '<strong>' . esc_html__( 'OAuth test successful!', 'fair-platform' ) . '</strong><br>';
-						echo esc_html__( 'Access token received:', 'fair-platform' ) . ' ';
-						echo '<code>' . esc_html( substr( sanitize_text_field( $_GET['mollie_access_token'] ), 0, 20 ) . '...' ) . '</code>';
-						echo '</p></div>';
+						$notice_message  = '<strong>' . esc_html__( 'OAuth test successful!', 'fair-platform' ) . '</strong><br>';
+						$notice_message .= esc_html__( 'Access token received:', 'fair-platform' ) . ' ';
+						$notice_message .= '<code>' . esc_html( substr( sanitize_text_field( $_GET['mollie_access_token'] ), 0, 20 ) . '...' ) . '</code>';
+
+						wp_admin_notice(
+							$notice_message,
+							array(
+								'type'        => 'success',
+								'dismissible' => false,
+							)
+						);
 					} elseif ( isset( $_GET['error'] ) ) {
-						echo '<div class="notice notice-error"><p>';
-						echo '<strong>' . esc_html__( 'OAuth test failed:', 'fair-platform' ) . '</strong><br>';
-						echo esc_html( sanitize_text_field( $_GET['error'] ) );
+						$notice_message  = '<strong>' . esc_html__( 'OAuth test failed:', 'fair-platform' ) . '</strong><br>';
+						$notice_message .= esc_html( sanitize_text_field( $_GET['error'] ) );
 						if ( isset( $_GET['error_description'] ) ) {
-							echo '<br>' . esc_html( sanitize_text_field( $_GET['error_description'] ) );
+							$notice_message .= '<br>' . esc_html( sanitize_text_field( $_GET['error_description'] ) );
 						}
-						echo '</p></div>';
+
+						wp_admin_notice(
+							$notice_message,
+							array(
+								'type'        => 'error',
+								'dismissible' => false,
+							)
+						);
 					}
 				}
 				?>
 
-			<?php else : ?>
-				<div class="notice notice-warning inline">
-					<p><?php esc_html_e( 'Configure Mollie credentials first to test the connection.', 'fair-platform' ); ?></p>
-				</div>
-			<?php endif; ?>
+				<?php
+			else :
+				wp_admin_notice(
+					esc_html__( 'Configure Mollie credentials first to test the connection.', 'fair-platform' ),
+					array(
+						'type'               => 'warning',
+						'dismissible'        => false,
+						'additional_classes' => array( 'inline' ),
+					)
+				);
+			endif;
+			?>
 		</div>
 
 		<!-- Recent OAuth Activity -->

--- a/fair-platform/src/Core/Plugin.php
+++ b/fair-platform/src/Core/Plugin.php
@@ -1436,19 +1436,22 @@ class Plugin {
 	 * @return void
 	 */
 	public function missing_instagram_credentials_notice() {
-		?>
-		<div class="notice notice-warning">
-			<p>
-				<strong><?php esc_html_e( 'Fair Platform:', 'fair-platform' ); ?></strong>
-				<?php
-				esc_html_e(
-					'Instagram OAuth credentials not configured. Please add INSTAGRAM_APP_ID and INSTAGRAM_APP_SECRET to wp-config.php for Instagram integration.',
-					'fair-platform'
-				);
-				?>
-			</p>
-		</div>
-		<?php
+		$message = sprintf(
+			'<strong>%1$s</strong> %2$s',
+			esc_html__( 'Fair Platform:', 'fair-platform' ),
+			esc_html__(
+				'Instagram OAuth credentials not configured. Please add INSTAGRAM_APP_ID and INSTAGRAM_APP_SECRET to wp-config.php for Instagram integration.',
+				'fair-platform'
+			)
+		);
+
+		wp_admin_notice(
+			$message,
+			array(
+				'type'        => 'warning',
+				'dismissible' => false,
+			)
+		);
 	}
 
 	/**
@@ -1457,19 +1460,22 @@ class Plugin {
 	 * @return void
 	 */
 	public function missing_credentials_notice() {
-		?>
-		<div class="notice notice-error">
-			<p>
-				<strong><?php esc_html_e( 'Fair Platform:', 'fair-platform' ); ?></strong>
-				<?php
-				esc_html_e(
-					'Mollie OAuth credentials not configured. Please add MOLLIE_CLIENT_ID and MOLLIE_CLIENT_SECRET to wp-config.php',
-					'fair-platform'
-				);
-				?>
-			</p>
-		</div>
-		<?php
+		$message = sprintf(
+			'<strong>%1$s</strong> %2$s',
+			esc_html__( 'Fair Platform:', 'fair-platform' ),
+			esc_html__(
+				'Mollie OAuth credentials not configured. Please add MOLLIE_CLIENT_ID and MOLLIE_CLIENT_SECRET to wp-config.php',
+				'fair-platform'
+			)
+		);
+
+		wp_admin_notice(
+			$message,
+			array(
+				'type'        => 'error',
+				'dismissible' => false,
+			)
+		);
 	}
 
 	/**
@@ -1478,19 +1484,22 @@ class Plugin {
 	 * @return void
 	 */
 	public function missing_library_notice() {
-		?>
-		<div class="notice notice-error">
-			<p>
-				<strong><?php esc_html_e( 'Fair Platform:', 'fair-platform' ); ?></strong>
-				<?php
-				esc_html_e(
-					'Mollie PHP library not installed. Please run: composer require mollie/mollie-api-php',
-					'fair-platform'
-				);
-				?>
-			</p>
-		</div>
-		<?php
+		$message = sprintf(
+			'<strong>%1$s</strong> %2$s',
+			esc_html__( 'Fair Platform:', 'fair-platform' ),
+			esc_html__(
+				'Mollie PHP library not installed. Please run: composer require mollie/mollie-api-php',
+				'fair-platform'
+			)
+		);
+
+		wp_admin_notice(
+			$message,
+			array(
+				'type'        => 'error',
+				'dismissible' => false,
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Converts the 12 hand-rolled `<div class="notice notice-*">` blocks in `fair-audience-experimental`, `fair-payments-connector`, and `fair-platform` to the core `wp_admin_notice()` helper (WP 6.4+), so notice classes/escaping run through one code path.
- Bumps `fair-payments-connector`'s `Requires at least` from 6.2 to 6.7, matching its siblings, since `wp_admin_notice()` needs 6.4+.
- Corrects the ticket's call-site list: the fair-audience notice actually lives in `fair-audience-experimental/src/Admin/MediaBatchActions.php` (not `fair-audience`), so that plugin is included in scope for this one notice.

Refs #878

## Notes

- `fair-platform/src/Admin/settings-page.php` stays a PHP template; only the notice rendering changed, not the broader "don't use PHP templates" refactor (out of scope per the ticket).
- `wp_admin_notice()` does not escape `$message`; every message body kept its existing `esc_html__`/`wp_kses`/`esc_url` escaping before being handed to the helper, which then runs the final markup through `wp_kses_post()` as a second layer.

## Test plan

- [x] `vendor/bin/phpcs` on all changed files — no new errors introduced (verified against pre-change error counts for each file).
- [ ] Manual wp-admin check per notice type (error/warning/info/success), confirming colors, dismiss button (MigrationNotice, MediaBatchActions), and `inline` placement (settings-page.php lines 64 & 147) are unchanged.
