### PR TITLE
Enrich Quick Add Event modal (categories, linking, recurrence)

### DIFF
--- a/fair-events/src/API/__tests__/EventDatesController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesController.api.spec.js
@@ -157,6 +157,74 @@ test.describe('EventDatesController — standalone category copy on first link',
 	});
 });
 
+test.describe('EventDatesController — create_item with categories + rrule (quick add)', () => {
+	let api;
+	let categoryId;
+	let masterEventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const catRes = await api.post('/wp-json/wp/v2/categories', {
+			headers: adminHeaders,
+			data: { name: `Quick Add Cat ${Date.now()}` },
+		});
+		expect(catRes.ok()).toBeTruthy();
+		categoryId = (await catRes.json()).id;
+	});
+
+	test.afterEach(async () => {
+		if (masterEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+				{ headers: adminHeaders }
+			);
+			masterEventDateId = null;
+		}
+	});
+
+	test.afterAll(async () => {
+		if (categoryId) {
+			await api.delete(
+				`/wp-json/wp/v2/categories/${categoryId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+	});
+
+	test('a standalone create with categories + rrule generates occurrences that all carry the categories', async () => {
+		const res = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Quick add ${Date.now()}`,
+				start_datetime: '2036-01-01 10:00:00',
+				end_datetime: '2036-01-01 12:00:00',
+				link_type: 'none',
+				categories: [categoryId],
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		masterEventDateId = body.id;
+
+		expect(body.occurrence_type).toBe('master');
+		expect(body.rrule).toBe('FREQ=WEEKLY;COUNT=3');
+		expect(body.generated_occurrences.length).toBe(2);
+		expect(body.categories.map((c) => c.id)).toContain(categoryId);
+
+		for (const occ of body.generated_occurrences) {
+			const occRes = await api.get(
+				`/wp-json/fair-events/v1/event-dates/${occ.id}`,
+				{ headers: adminHeaders }
+			);
+			expect(occRes.ok()).toBeTruthy();
+			const occBody = await occRes.json();
+			expect(occBody.categories.map((c) => c.id)).toContain(categoryId);
+		}
+	});
+});
+
 test.describe('EventDatesController — recurrence reconciliation', () => {
 	let api;
 	let masterEventDateId;

--- a/fair-events/src/Admin/calendar/components/QuickEventModal.js
+++ b/fair-events/src/Admin/calendar/components/QuickEventModal.js
@@ -12,13 +12,20 @@ import {
 	TextControl,
 	CheckboxControl,
 	SelectControl,
+	RadioControl,
+	FormTokenField,
+	PanelBody,
 	Button,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { formatLocalDate } from 'fair-events-shared';
+import {
+	formatLocalDate,
+	RecurrenceControl,
+	buildRRule,
+} from 'fair-events-shared';
 
 export default function QuickEventModal({ date, onClose, onSuccess }) {
 	const dateStr = formatLocalDate(date);
@@ -34,13 +41,56 @@ export default function QuickEventModal({ date, onClose, onSuccess }) {
 	const [isSaving, setIsSaving] = useState(false);
 	const [error, setError] = useState(null);
 
+	// Categories.
+	const [categories, setCategories] = useState([]);
+	const [availableCategories, setAvailableCategories] = useState([]);
+
+	// Link type: 'none' | 'external' | 'post'.
+	const [linkType, setLinkType] = useState('none');
+	const [externalUrl, setExternalUrl] = useState('');
+	const [searchResults, setSearchResults] = useState([]);
+	const [linkPostId, setLinkPostId] = useState('');
+
+	// Recurrence.
+	const [recurrence, setRecurrence] = useState({
+		enabled: false,
+		frequency: 'weekly',
+		endType: 'count',
+		count: 10,
+		until: '',
+	});
+
 	useEffect(() => {
 		apiFetch({ path: '/fair-events/v1/venues' })
 			.then((data) => setVenues(data))
 			.catch(() => {
 				// Venues are optional, ignore errors.
 			});
+
+		apiFetch({ path: '/fair-events/v1/sources/categories' })
+			.then((data) => setAvailableCategories(data))
+			.catch(() => {
+				// Categories are optional, ignore errors.
+			});
 	}, []);
+
+	const handleSearchPosts = async (searchTerm) => {
+		if (!searchTerm || searchTerm.length < 2) {
+			setSearchResults([]);
+			return;
+		}
+
+		try {
+			const results = await apiFetch({
+				path: `/wp/v2/search?search=${encodeURIComponent(
+					searchTerm
+				)}&type=post&subtype=any&per_page=10`,
+			});
+			setSearchResults(results);
+		} catch {
+			// Ignore search errors.
+		}
+	};
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
@@ -71,9 +121,36 @@ export default function QuickEventModal({ date, onClose, onSuccess }) {
 					end_datetime: endDatetime,
 					all_day: allDay,
 					venue_id: venueId ? parseInt(venueId, 10) : undefined,
-					link_type: 'none',
+					link_type: linkType === 'post' ? 'none' : linkType,
+					external_url:
+						linkType === 'external' ? externalUrl : undefined,
+					categories,
+					rrule: buildRRule(recurrence),
 				},
 			});
+
+			if (linkType === 'post' && linkPostId) {
+				try {
+					await apiFetch({
+						path: `/fair-events/v1/event-dates/${eventDate.id}/link-post`,
+						method: 'POST',
+						data: {
+							post_id: parseInt(linkPostId, 10),
+						},
+					});
+				} catch (linkErr) {
+					onSuccess(eventDate);
+					setError(
+						linkErr.message ||
+							__(
+								'Event created, but linking the post failed.',
+								'fair-events'
+							)
+					);
+					setIsSaving(false);
+					return;
+				}
+			}
 
 			onSuccess(eventDate);
 		} catch (err) {
@@ -94,7 +171,7 @@ export default function QuickEventModal({ date, onClose, onSuccess }) {
 		<Modal
 			title={__('Quick Add Event', 'fair-events')}
 			onRequestClose={onClose}
-			style={{ maxWidth: '500px', width: '100%' }}
+			style={{ maxWidth: '600px', width: '100%' }}
 		>
 			<form onSubmit={handleSubmit}>
 				<VStack spacing={4}>
@@ -178,6 +255,123 @@ export default function QuickEventModal({ date, onClose, onSuccess }) {
 						options={venueOptions}
 						onChange={setVenueId}
 					/>
+
+					<PanelBody
+						title={__('More options', 'fair-events')}
+						initialOpen={false}
+					>
+						<VStack spacing={4}>
+							<FormTokenField
+								label={__('Categories', 'fair-events')}
+								value={categories
+									.map((id) => {
+										const cat = availableCategories.find(
+											(c) => c.id === id
+										);
+										return cat ? cat.name : '';
+									})
+									.filter(Boolean)}
+								suggestions={availableCategories.map(
+									(c) => c.name
+								)}
+								onChange={(tokens) => {
+									const ids = tokens
+										.map((token) => {
+											const cat =
+												availableCategories.find(
+													(c) => c.name === token
+												);
+											return cat ? cat.id : null;
+										})
+										.filter((id) => id !== null);
+									setCategories(ids);
+								}}
+							/>
+
+							<RadioControl
+								label={__('Link to', 'fair-events')}
+								selected={linkType}
+								options={[
+									{
+										label: __(
+											'Nowhere — show details only',
+											'fair-events'
+										),
+										value: 'none',
+									},
+									{
+										label: __(
+											'An external website',
+											'fair-events'
+										),
+										value: 'external',
+									},
+									{
+										label: __(
+											'A page on this site',
+											'fair-events'
+										),
+										value: 'post',
+									},
+								]}
+								onChange={setLinkType}
+							/>
+
+							{linkType === 'external' && (
+								<TextControl
+									label={__('External URL', 'fair-events')}
+									type="url"
+									value={externalUrl}
+									onChange={setExternalUrl}
+									placeholder="https://"
+								/>
+							)}
+
+							{linkType === 'post' && (
+								<VStack spacing={2}>
+									<TextControl
+										label={__(
+											'Search posts by title',
+											'fair-events'
+										)}
+										onChange={handleSearchPosts}
+										placeholder={__(
+											'Start typing to search...',
+											'fair-events'
+										)}
+									/>
+									{searchResults.length > 0 && (
+										<SelectControl
+											label={__(
+												'Select a post',
+												'fair-events'
+											)}
+											value={linkPostId}
+											options={[
+												{
+													label: __(
+														'Select...',
+														'fair-events'
+													),
+													value: '',
+												},
+												...searchResults.map((r) => ({
+													label: r.title,
+													value: String(r.id),
+												})),
+											]}
+											onChange={setLinkPostId}
+										/>
+									)}
+								</VStack>
+							)}
+
+							<RecurrenceControl
+								value={recurrence}
+								onChange={setRecurrence}
+							/>
+						</VStack>
+					</PanelBody>
 
 					<HStack justify="flex-end" spacing={2}>
 						<Button

--- a/fair-events/src/Admin/calendar/components/__tests__/QuickEventModal.test.jsx
+++ b/fair-events/src/Admin/calendar/components/__tests__/QuickEventModal.test.jsx
@@ -1,0 +1,179 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for QuickEventModal (#976).
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import QuickEventModal from '../QuickEventModal.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const availableCategories = [
+	{ id: 1, name: 'Music' },
+	{ id: 2, name: 'Sports' },
+];
+
+const createdEventDate = { id: 99, title: 'Test Event' };
+
+beforeEach(() => {
+	apiFetch.mockImplementation(({ path, method }) => {
+		if (path === '/fair-events/v1/venues') {
+			return Promise.resolve([]);
+		}
+		if (path === '/fair-events/v1/sources/categories') {
+			return Promise.resolve(availableCategories);
+		}
+		if (path.startsWith('/wp/v2/search')) {
+			return Promise.resolve([{ id: 7, title: 'About Us' }]);
+		}
+		if (path === '/fair-events/v1/event-dates' && method === 'POST') {
+			return Promise.resolve(createdEventDate);
+		}
+		if (path.endsWith('/link-post') && method === 'POST') {
+			return Promise.resolve(createdEventDate);
+		}
+		return Promise.resolve({});
+	});
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+const renderModal = async (props = {}) => {
+	const onClose = jest.fn();
+	const onSuccess = jest.fn();
+	render(
+		<QuickEventModal
+			date={new Date('2026-06-10T00:00:00')}
+			onClose={onClose}
+			onSuccess={onSuccess}
+			{...props}
+		/>
+	);
+	// Let the venues/categories useEffect fetches resolve before interacting.
+	await waitFor(() =>
+		expect(apiFetch).toHaveBeenCalledWith({
+			path: '/fair-events/v1/sources/categories',
+		})
+	);
+	return { onClose, onSuccess };
+};
+
+const fillTitle = (title = 'Test Event') => {
+	fireEvent.change(screen.getByLabelText('Title'), {
+		target: { value: title },
+	});
+};
+
+const openMoreOptions = () => {
+	fireEvent.click(screen.getByRole('button', { name: 'More options' }));
+};
+
+describe('QuickEventModal', () => {
+	it('hides advanced fields behind "More options" by default', async () => {
+		await renderModal();
+		expect(screen.queryByText('Categories')).not.toBeInTheDocument();
+		expect(screen.queryByText('Link to')).not.toBeInTheDocument();
+		expect(screen.queryByText('Repeat this event')).not.toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'More options' })
+		).toBeInTheDocument();
+
+		// The always-visible Venue SelectControl emits a 40px-default-size notice.
+		expect(console).toHaveWarned();
+	});
+
+	it('sends selected category IDs on create', async () => {
+		const { onSuccess } = await renderModal();
+		fillTitle();
+		openMoreOptions();
+
+		const categoryField = await screen.findByLabelText('Categories');
+		fireEvent.change(categoryField, { target: { value: 'Music' } });
+		fireEvent.keyDown(categoryField, { key: 'Enter', code: 'Enter' });
+
+		fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+
+		await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+
+		const createCall = apiFetch.mock.calls.find(
+			([opts]) =>
+				opts.path === '/fair-events/v1/event-dates' &&
+				opts.method === 'POST'
+		);
+		expect(createCall[0].data.categories).toEqual([1]);
+
+		// FormTokenField/SelectControl emit an expected 40px-default-size notice.
+		expect(console).toHaveWarned();
+	});
+
+	it('sends link_type external with the URL', async () => {
+		const { onSuccess } = await renderModal();
+		fillTitle();
+		openMoreOptions();
+
+		fireEvent.click(screen.getByLabelText('An external website'));
+		fireEvent.change(screen.getByLabelText('External URL'), {
+			target: { value: 'https://example.com' },
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+
+		await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+
+		const createCall = apiFetch.mock.calls.find(
+			([opts]) =>
+				opts.path === '/fair-events/v1/event-dates' &&
+				opts.method === 'POST'
+		);
+		expect(createCall[0].data.link_type).toBe('external');
+		expect(createCall[0].data.external_url).toBe('https://example.com');
+	});
+
+	it('chains a link-post call when linking an existing post', async () => {
+		const { onSuccess } = await renderModal();
+		fillTitle();
+		openMoreOptions();
+
+		fireEvent.click(screen.getByLabelText('A page on this site'));
+		fireEvent.change(screen.getByLabelText('Search posts by title'), {
+			target: { value: 'about' },
+		});
+
+		const postSelect = await screen.findByLabelText('Select a post');
+		fireEvent.change(postSelect, { target: { value: '7' } });
+
+		fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+
+		await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+
+		const linkCall = apiFetch.mock.calls.find(([opts]) =>
+			opts.path?.endsWith('/link-post')
+		);
+		expect(linkCall[0].data.post_id).toBe(7);
+	});
+
+	it('sends a non-empty rrule when recurrence is enabled', async () => {
+		const { onSuccess } = await renderModal();
+		fillTitle();
+		openMoreOptions();
+
+		fireEvent.click(screen.getByLabelText('Repeat this event'));
+
+		fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+
+		await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+
+		const createCall = apiFetch.mock.calls.find(
+			([opts]) =>
+				opts.path === '/fair-events/v1/event-dates' &&
+				opts.method === 'POST'
+		);
+		expect(createCall[0].data.rrule).toBeTruthy();
+
+		expect(console).toHaveWarned();
+	});
+});


### PR DESCRIPTION
## Summary

- The calendar "Quick Add Event" modal only captured title/all-day/start-end/venue and hardcoded `link_type: 'none'`, even though `EventDatesController::create_item` already accepts `categories`, `rrule`, `link_type`, and `external_url`.
- The modal now reuses the existing category picker (`FormTokenField` + `/fair-events/v1/sources/categories`), the shared `RecurrenceControl`/`buildRRule` from `fair-events-shared`, and the post-search pattern from `ManageEventApp` to let an organizer assign categories, link a URL or existing post, and make the event recurring — all in one step.
- These new fields sit behind a collapsed "More options" `PanelBody` so the default quick-add path stays title/time/venue only.
- Linking an existing post on create chains a `POST .../link-post` call after the create response returns its new ID, since `create_item` doesn't read `event_id` — this reuses the same junction-table code path the manage-event screen already relies on. If the create succeeds but the link call fails, the event is still surfaced via `onSuccess` and the modal reports the partial failure rather than silently dropping it.
- No backend changes — `create_item` already persisted `categories` and `rrule`; a new API spec test (`EventDatesController.api.spec.js`) confirms a single create with both produces a `master` with generated occurrences that all carry the categories.

Closes #976

## Test plan

- [x] `npm run build` in `fair-events`
- [x] `npm run format` in `fair-events`
- [x] `npm run test:js` (new `QuickEventModal.test.jsx` + full suite) — 101/101 passing
- [ ] `npm run test:api` — could not verify locally; the dev WordPress instance's `admin`/`password` Basic Auth credentials return 401 for *all* `.api.spec.js` tests (pre-existing, reproduced on `main` before this branch's changes), not specific to the new test added here
