### PR TITLE
Add subscribe link to events-calendar block

### DIFF
--- a/fair-events/e2e/events-calendar-subscribe.spec.js
+++ b/fair-events/e2e/events-calendar-subscribe.spec.js
@@ -1,0 +1,163 @@
+import { test, expect } from '@playwright/test';
+
+const WP_ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const WP_ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * Verifies the events-calendar "Subscribe to calendar" link (#1124):
+ * a webcal:// link pointing at the public ICS feed, reflecting the block's
+ * category filter, plus a copyable plain-URL fallback.
+ */
+
+async function apiFetch(page, options) {
+	const result = await page.evaluate(async (opts) => {
+		try {
+			// eslint-disable-next-line no-undef
+			const res = await wp.apiFetch(opts);
+			return { ok: true, data: res };
+		} catch (err) {
+			return {
+				ok: false,
+				error: {
+					message: err && err.message,
+					code: err && err.code,
+					data: err && err.data,
+					raw: JSON.stringify(err),
+				},
+			};
+		}
+	}, options);
+	if (!result.ok) {
+		throw new Error(
+			`apiFetch ${options.method || 'GET'} ${
+				options.path
+			} failed: ${JSON.stringify(result.error)}`
+		);
+	}
+	return result.data;
+}
+
+async function login(page) {
+	await page.goto('/wp-admin');
+	if (page.url().includes('wp-login.php')) {
+		await page.fill('#user_login', WP_ADMIN_USER);
+		await page.fill('#user_pass', WP_ADMIN_PASS);
+		await page.click('#wp-submit');
+	}
+	await page.waitForSelector('#wpadminbar');
+}
+
+test.describe('Events Calendar — Subscribe link', () => {
+	test('shows a webcal:// link to the ICS feed and a copyable fallback', async ({
+		page,
+		context,
+	}) => {
+		test.setTimeout(60_000);
+
+		await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+		await page.setViewportSize({ width: 1200, height: 900 });
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+		const priorPages = await apiFetch(page, {
+			path: '/wp/v2/pages?search=Subscribe%20Calendar&per_page=20',
+		});
+		for (const p of priorPages) {
+			await apiFetch(page, {
+				path: `/wp/v2/pages/${p.id}?force=true`,
+				method: 'DELETE',
+			}).catch(() => {});
+		}
+
+		const calendarPage = await apiFetch(page, {
+			path: '/wp/v2/pages',
+			method: 'POST',
+			data: {
+				title: 'Subscribe Calendar',
+				status: 'publish',
+				content: '<!-- wp:fair-events/events-calendar /-->',
+			},
+		});
+
+		await page.goto(calendarPage.link || `/?page_id=${calendarPage.id}`);
+
+		const link = page.locator('.fair-events-subscribe-link');
+		await expect(link).toBeVisible();
+
+		const href = await link.getAttribute('href');
+		expect(href).toMatch(/^webcal:\/\//);
+		expect(href).toContain('/fair-events/v1/calendar.ics');
+
+		const button = page.locator('.fair-events-subscribe-copy-btn');
+		await expect(button).toHaveText('Copy feed URL');
+
+		await button.click();
+		await expect(button).toHaveText('✓');
+
+		const clipboardText = await page.evaluate(() =>
+			navigator.clipboard.readText()
+		);
+		expect(clipboardText).toMatch(/^https:\/\//);
+		expect(clipboardText).toContain('/fair-events/v1/calendar.ics');
+
+		await expect(button).toHaveText('Copy feed URL', { timeout: 3000 });
+
+		// Cleanup.
+		await apiFetch(page, {
+			path: `/wp/v2/pages/${calendarPage.id}?force=true`,
+			method: 'DELETE',
+		}).catch(() => {});
+	});
+
+	test('reflects the category filter in the feed URL', async ({ page }) => {
+		test.setTimeout(60_000);
+
+		await page.setViewportSize({ width: 1200, height: 900 });
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+		const categories = await apiFetch(page, {
+			path: '/wp/v2/categories?per_page=1&exclude=1',
+		});
+		test.skip(
+			categories.length === 0,
+			'No non-default category available for this test'
+		);
+		const category = categories[0];
+
+		const priorPages = await apiFetch(page, {
+			path: '/wp/v2/pages?search=Subscribe%20Calendar%20Filtered&per_page=20',
+		});
+		for (const p of priorPages) {
+			await apiFetch(page, {
+				path: `/wp/v2/pages/${p.id}?force=true`,
+				method: 'DELETE',
+			}).catch(() => {});
+		}
+
+		const calendarPage = await apiFetch(page, {
+			path: '/wp/v2/pages',
+			method: 'POST',
+			data: {
+				title: 'Subscribe Calendar Filtered',
+				status: 'publish',
+				content: `<!-- wp:fair-events/events-calendar {"categories":[${category.id}]} /-->`,
+			},
+		});
+
+		await page.goto(calendarPage.link || `/?page_id=${calendarPage.id}`);
+
+		const link = page.locator('.fair-events-subscribe-link');
+		const href = await link.getAttribute('href');
+		expect(href).toContain(`categories=${category.slug}`);
+
+		// Cleanup.
+		await apiFetch(page, {
+			path: `/wp/v2/pages/${calendarPage.id}?force=true`,
+			method: 'DELETE',
+		}).catch(() => {});
+	});
+});

--- a/fair-events/src/blocks/events-calendar/block.json
+++ b/fair-events/src/blocks/events-calendar/block.json
@@ -51,15 +51,21 @@
 			"items": {
 				"type": "string"
 			}
+		},
+		"showSubscribe": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {
 		"html": false,
 		"anchor": true,
-		"align": ["wide", "full"]
+		"align": ["wide", "full"],
+		"interactivity": true
 	},
 	"editorScript": "file:./editor.js",
 	"editorStyle": "file:./editor.css",
 	"style": "file:./style-editor.css",
+	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/fair-events/src/blocks/events-calendar/components/EditComponent.js
+++ b/fair-events/src/blocks/events-calendar/components/EditComponent.js
@@ -30,6 +30,7 @@ const EditComponent = ({ attributes, setAttributes }) => {
 		backgroundColor,
 		textColor,
 		eventSources,
+		showSubscribe,
 	} = attributes;
 
 	const blockProps = useBlockProps();
@@ -112,6 +113,18 @@ const EditComponent = ({ attributes, setAttributes }) => {
 						}
 						help={__(
 							'Display draft events in the calendar',
+							'fair-events'
+						)}
+					/>
+
+					<ToggleControl
+						label={__('Show Subscribe Link', 'fair-events')}
+						checked={showSubscribe}
+						onChange={(value) =>
+							setAttributes({ showSubscribe: value })
+						}
+						help={__(
+							'Displays a link to subscribe to this calendar in an external calendar app',
 							'fair-events'
 						)}
 					/>

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -16,6 +16,43 @@ use FairEvents\Services\EventFeedProvider;
 use FairEvents\Settings\Settings;
 
 /**
+ * Build the subscription feed URLs (webcal:// and plain https://) for the
+ * configured category filter.
+ *
+ * Deliberately reflects only the category filter, not the current
+ * month/year — a subscription is an ongoing feed, so freezing it to one
+ * month is wrong; the feed's own bounded window (-1mo / +12mo) is what a
+ * subscriber wants. The block's eventSources and showDrafts filters have no
+ * feed equivalent (the feed is public and source-agnostic), so a
+ * source-filtered calendar still links the all-sources feed.
+ *
+ * @param int[] $categories Category term IDs.
+ * @return array{webcal: string, https: string} Feed URLs.
+ */
+if ( ! function_exists( 'fair_events_build_subscribe_urls' ) ) {
+	function fair_events_build_subscribe_urls( array $categories ) {
+		$feed_url = rest_url( 'fair-events/v1/calendar.ics' );
+
+		$slugs = array();
+		foreach ( $categories as $category_id ) {
+			$term = get_term( $category_id, 'category' );
+			if ( $term && ! is_wp_error( $term ) ) {
+				$slugs[] = $term->slug;
+			}
+		}
+
+		if ( ! empty( $slugs ) ) {
+			$feed_url = add_query_arg( 'categories', implode( ',', $slugs ), $feed_url );
+		}
+
+		return array(
+			'webcal' => preg_replace( '#^https?://#', 'webcal://', $feed_url ),
+			'https'  => $feed_url,
+		);
+	}
+}
+
+/**
  * Convert color value to CSS value
  *
  * Converts either a hex color or a WordPress color preset name to a CSS value.
@@ -125,6 +162,7 @@ $show_drafts     = $attributes['showDrafts'] ?? false;
 $bg_color        = $attributes['backgroundColor'] ?? 'primary';
 $text_color      = $attributes['textColor'] ?? '#ffffff';
 $event_sources   = $attributes['eventSources'] ?? array();
+$show_subscribe  = $attributes['showSubscribe'] ?? true;
 
 // Convert WordPress event colors to CSS values (used for post-linked/standalone events)
 $bg_color_value   = fair_events_convert_color_to_css( $bg_color );
@@ -214,6 +252,9 @@ for ( $i = 0; $i < 7; $i++ ) {
 
 // Get current date for today highlighting
 $today = current_time( 'Y-m-d' );
+
+// Subscription feed links (webcal:// + copyable https:// fallback).
+$subscribe_urls = fair_events_build_subscribe_urls( is_array( $categories ) ? $categories : array() );
 
 ?>
 <div <?php echo wp_kses_post( get_block_wrapper_attributes( array( 'class' => 'wp-block-fair-events-events-calendar' ) ) ); ?>>
@@ -355,6 +396,38 @@ $today = current_time( 'Y-m-d' );
 			?>
 		</div>
 	</div>
+
+	<?php if ( $show_subscribe ) : ?>
+	<div class="fair-events-subscribe">
+		<a href="<?php echo esc_url( $subscribe_urls['webcal'] ); ?>" class="fair-events-subscribe-link">
+			<?php esc_html_e( 'Subscribe to calendar', 'fair-events' ); ?>
+		</a>
+		<p class="fair-events-subscribe-note">
+			<?php esc_html_e( 'Subscribed calendars refresh on your calendar app\'s own schedule (often hours, not instant).', 'fair-events' ); ?>
+		</p>
+		<div class="fair-events-subscribe-copy"
+			data-wp-interactive="fair-events/calendar-subscribe"
+			<?php
+			echo wp_interactivity_data_wp_context( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- self-escaping (JSON-encodes and esc_attr()'s internally).
+				array(
+					'copied'      => false,
+					'feedUrl'     => $subscribe_urls['https'],
+					'copyLabel'   => __( 'Copy feed URL', 'fair-events' ),
+					'copiedLabel' => '✓',
+				)
+			);
+			?>
+		>
+			<button
+				class="fair-events-subscribe-copy-btn"
+				type="button"
+				data-wp-on--click="actions.copy"
+				data-wp-text="state.label"
+			></button>
+		</div>
+	</div>
+	<?php endif; ?>
+
 	<?php if ( class_exists( \FairAudience\Services\Branding::class ) ) : ?>
 		<?php echo wp_kses_post( \FairAudience\Services\Branding::block_html() ); ?>
 	<?php endif; ?>

--- a/fair-events/src/blocks/events-calendar/style.scss
+++ b/fair-events/src/blocks/events-calendar/style.scss
@@ -57,7 +57,10 @@
 
 	.calendar-header {
 		display: grid;
-		grid-template-columns: repeat(7, 1fr); // Equal width cells that grow to fill space
+		grid-template-columns: repeat(
+			7,
+			1fr
+		); // Equal width cells that grow to fill space
 		background: #f0f0f0;
 		border-bottom: 1px solid #ddd;
 	}
@@ -78,7 +81,10 @@
 
 	.calendar-body {
 		display: grid;
-		grid-template-columns: repeat(7, 1fr); // Equal width cells that grow to fill space
+		grid-template-columns: repeat(
+			7,
+			1fr
+		); // Equal width cells that grow to fill space
 		background: #fff;
 	}
 
@@ -154,7 +160,10 @@
 			a {
 				display: block;
 				padding: 0.25rem 0.375rem;
-				background: var(--event-bg-color, #2271b1); // Full button by default
+				background: var(
+					--event-bg-color,
+					#2271b1
+				); // Full button by default
 				color: var(--event-text-color, #fff);
 				text-decoration: none;
 				border-radius: 3px;
@@ -178,8 +187,14 @@
 			// Draft events: outlined style
 			&.is-draft a {
 				background: transparent;
-				color: var(--event-bg-color, #2271b1); // Text uses background color
-				border-color: var(--event-bg-color, #2271b1); // Border uses background color
+				color: var(
+					--event-bg-color,
+					#2271b1
+				); // Text uses background color
+				border-color: var(
+					--event-bg-color,
+					#2271b1
+				); // Border uses background color
 
 				&:hover {
 					background: var(--event-bg-color, #2271b1);
@@ -194,8 +209,8 @@
 					display: block;
 					padding: 0.25rem 0.375rem;
 					background: var(--event-bg-color, #4caf50);
-          color: var(--event-text-color, #fff);
-          border-radius: 3px;
+					color: var(--event-text-color, #fff);
+					border-radius: 3px;
 					overflow: hidden;
 					text-overflow: ellipsis;
 					white-space: nowrap;
@@ -221,6 +236,51 @@
 					}
 				}
 			}
+		}
+	}
+
+	.fair-events-subscribe {
+		margin-top: 0.75rem;
+		text-align: right;
+	}
+
+	.fair-events-subscribe-link {
+		display: inline-block;
+		padding: 0.375rem 0.875rem;
+		background: transparent;
+		border: 1px solid currentColor;
+		border-radius: 4px;
+		text-decoration: none;
+		font-size: 0.8125rem;
+		color: #1e1e1e;
+		opacity: 0.7;
+
+		&:hover {
+			opacity: 1;
+		}
+	}
+
+	.fair-events-subscribe-note {
+		margin: 0.375rem 0 0;
+		font-size: 0.75rem;
+		color: #757575;
+	}
+
+	.fair-events-subscribe-copy {
+		margin-top: 0.375rem;
+	}
+
+	.fair-events-subscribe-copy-btn {
+		padding: 0.375rem 0.875rem;
+		background: transparent;
+		border: 1px solid currentColor;
+		border-radius: 4px;
+		cursor: pointer;
+		font-size: 0.8125rem;
+		opacity: 0.7;
+
+		&:hover {
+			opacity: 1;
 		}
 	}
 
@@ -325,7 +385,7 @@
 
 					// Show full date (e.g., "15 January")
 					&::after {
-						content: ' ' attr(data-month-name);
+						content: " " attr(data-month-name);
 						font-weight: 400;
 						font-size: 0.875rem;
 						color: #666;

--- a/fair-events/src/blocks/events-calendar/view.js
+++ b/fair-events/src/blocks/events-calendar/view.js
@@ -1,0 +1,75 @@
+/**
+ * Events Calendar View - Interactivity API store
+ *
+ * Handles the "Copy link" button click for the subscribe fallback URL.
+ */
+
+import { store, getContext } from '@wordpress/interactivity';
+
+/**
+ * Copy text to the clipboard via the throwaway-textarea + execCommand
+ * trick, for browsers/contexts (plain HTTP, non-localhost) where the
+ * modern Clipboard API isn't available.
+ *
+ * @param {string} text Text to copy.
+ * @return {boolean} Whether the copy succeeded.
+ */
+function fallbackCopy(text) {
+	const textarea = document.createElement('textarea');
+	textarea.value = text;
+	textarea.style.position = 'fixed';
+	textarea.style.opacity = '0';
+	document.body.appendChild(textarea);
+	textarea.focus();
+	textarea.select();
+
+	let success = false;
+	try {
+		success = document.execCommand('copy');
+	} finally {
+		document.body.removeChild(textarea);
+	}
+
+	return success;
+}
+
+store('fair-events/calendar-subscribe', {
+	state: {
+		get label() {
+			const context = getContext();
+			return context.copied ? context.copiedLabel : context.copyLabel;
+		},
+	},
+	actions: {
+		*copy() {
+			const context = getContext();
+			const feedUrl = context.feedUrl;
+
+			if (!feedUrl) {
+				return;
+			}
+
+			let success = false;
+
+			if (navigator.clipboard) {
+				try {
+					yield navigator.clipboard.writeText(feedUrl);
+					success = true;
+				} catch (e) {
+					success = fallbackCopy(feedUrl);
+				}
+			} else {
+				success = fallbackCopy(feedUrl);
+			}
+
+			if (!success) {
+				return;
+			}
+
+			context.copied = true;
+			setTimeout(() => {
+				context.copied = false;
+			}, 2000);
+		},
+	},
+});


### PR DESCRIPTION
## Summary

- Add a "Subscribe to calendar" link to the `events-calendar` block's footer, using the `webcal://` scheme so calendar apps (Google, Apple, Outlook) subscribe to the auto-updating feed from #1059 instead of downloading a static file.
- The link reflects the block's category filter (converted from term IDs to slugs); date/month filters are deliberately not reflected since a subscription should stay an ongoing feed, not freeze to one month.
- A short note sets expectations that subscribed calendars refresh on the app's own schedule, not instantly.
- A copyable plain `https://` URL fallback is available (Interactivity API store `fair-events/calendar-subscribe`, mirroring the `events-week` copy-summary pattern) for cases where `webcal://` isn't handled.
- Gated behind a new `showSubscribe` block attribute (default `true`), toggleable via a new InspectorControls setting.

Closes #1124

## Notes

- The block's `eventSources` and `showDrafts` filters have no feed equivalent (the feed is public and source-agnostic), so a source-filtered calendar view still links the all-sources feed — noted in a code comment.

## Test plan

- [x] `npm run build` (fair-events)
- [x] `npm run format` (fair-events)
- [x] `npm run test:js` — 101 tests passing
- [x] `vendor/bin/phpcs` on changed PHP file — no new errors introduced (pre-existing findings in the file untouched)
- [ ] `npm run test:e2e` — new `events-calendar-subscribe.spec.js` added; requires a running WP instance to execute
- [ ] Manual: subscribe via the link in Google Calendar and confirm a read-only, auto-updating calendar is added
