### PR TITLE
Stamp weekly digest last-sent-week when the slot already passed

### DIFF
--- a/fair-audience/__tests__/Hooks/WeeklyDigestHooksTest.php
+++ b/fair-audience/__tests__/Hooks/WeeklyDigestHooksTest.php
@@ -172,4 +172,23 @@ class WeeklyDigestHooksTest extends TestCase {
 		WeeklyDigestHooks::run_due();
 		$this->assertArrayNotHasKey( 'fair_audience_weekly_digest_last_run_result', $GLOBALS['_fair_test_options'] );
 	}
+
+	/**
+	 * Due_moment() resolves to the configured day/time within now's ISO week.
+	 */
+	public function test_due_moment_resolves_configured_slot_in_current_week() {
+		// 2026-07-06 is the Monday of ISO week 2026-W28.
+		$now = new DateTime( '2026-07-08 12:00:00', new DateTimeZone( 'UTC' ) );
+		$due = WeeklyDigestHooks::due_moment( $now, 1, '08:00' );
+
+		$this->assertSame( '2026-07-06 08:00:00', $due->format( 'Y-m-d H:i:s' ) );
+	}
+
+	/**
+	 * Iso_week() formats as "<ISO year>-W<ISO week>", zero-padded.
+	 */
+	public function test_iso_week_formats_year_and_week() {
+		$now = new DateTime( '2026-07-08 12:00:00', new DateTimeZone( 'UTC' ) );
+		$this->assertSame( '2026-W28', WeeklyDigestHooks::iso_week( $now ) );
+	}
 }

--- a/fair-audience/src/API/WeeklyDigestController.php
+++ b/fair-audience/src/API/WeeklyDigestController.php
@@ -7,6 +7,7 @@
 
 namespace FairAudience\API;
 
+use FairAudience\Hooks\WeeklyDigestHooks;
 use FairAudience\Services\EmailService;
 use FairAudience\Services\WeeklyDigestRenderer;
 use WP_REST_Controller;
@@ -124,8 +125,32 @@ class WeeklyDigestController extends WP_REST_Controller {
 				'config'          => $config,
 				'last_sent_week'  => get_option( 'fair_audience_weekly_digest_last_sent_week', '' ),
 				'last_run_result' => get_option( 'fair_audience_weekly_digest_last_run_result', array() ),
+				'next_send'       => $this->next_send( $config ),
 			)
 		);
+	}
+
+	/**
+	 * The next moment the digest is scheduled to go out, honoring the
+	 * at-most-once-per-ISO-week guard the same way the cron tick does.
+	 *
+	 * @param array $config Current digest config.
+	 * @return string ISO 8601 datetime, or '' when the digest is disabled.
+	 */
+	private function next_send( array $config ) {
+		if ( empty( $config['enabled'] ) ) {
+			return '';
+		}
+
+		$now  = new \DateTime( 'now', wp_timezone() );
+		$due  = WeeklyDigestHooks::due_moment( $now, (int) $config['day_of_week'], $config['time_of_day'] );
+		$sent = get_option( 'fair_audience_weekly_digest_last_sent_week', '' );
+
+		if ( WeeklyDigestHooks::iso_week( $now ) === $sent ) {
+			$due->modify( '+1 week' );
+		}
+
+		return $due->format( DATE_ATOM );
 	}
 
 	/**
@@ -138,6 +163,12 @@ class WeeklyDigestController extends WP_REST_Controller {
 		$config = WeeklyDigestRenderer::sanitize_config( $request->get_params() );
 
 		update_option( 'fair_audience_weekly_digest', $config );
+
+		$now = new \DateTime( 'now', wp_timezone() );
+		$due = WeeklyDigestHooks::due_moment( $now, (int) $config['day_of_week'], $config['time_of_day'] );
+		if ( $now >= $due ) {
+			update_option( 'fair_audience_weekly_digest_last_sent_week', WeeklyDigestHooks::iso_week( $now ) );
+		}
 
 		return rest_ensure_response( array( 'config' => $config ) );
 	}

--- a/fair-audience/src/API/__tests__/WeeklyDigestController.api.spec.js
+++ b/fair-audience/src/API/__tests__/WeeklyDigestController.api.spec.js
@@ -20,6 +20,16 @@ const authHeaders = {
 		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
 };
 
+/**
+ * ISO day of week (1=Monday..7=Sunday) for a JS Date.
+ *
+ * @param {Date} date A date.
+ * @return {number} ISO day of week.
+ */
+function isoDayOfWeek(date) {
+	return ((date.getDay() + 6) % 7) + 1;
+}
+
 test.describe('WeeklyDigestController — /weekly-digest', () => {
 	let api;
 	let originalConfig;
@@ -201,6 +211,59 @@ test.describe('WeeklyDigestController — /weekly-digest', () => {
 				})
 			);
 		}
+	});
+
+	test('PUT with a slot later this week leaves last_sent_week unchanged', async () => {
+		const now = new Date();
+		const beforeRes = await api.get(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{ headers: authHeaders }
+		);
+		const { last_sent_week: beforeWeek } = await beforeRes.json();
+
+		const putRes = await api.put(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{
+				headers: authHeaders,
+				data: {
+					enabled: true,
+					day_of_week: isoDayOfWeek(now),
+					time_of_day: '23:59',
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+
+		const getRes = await api.get(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{ headers: authHeaders }
+		);
+		const getBody = await getRes.json();
+		expect(getBody.last_sent_week).toBe(beforeWeek);
+	});
+
+	test('PUT with a slot earlier this week stamps last_sent_week for the current ISO week', async () => {
+		const now = new Date();
+
+		const putRes = await api.put(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{
+				headers: authHeaders,
+				data: {
+					enabled: true,
+					day_of_week: isoDayOfWeek(now),
+					time_of_day: '00:00',
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+
+		const getRes = await api.get(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{ headers: authHeaders }
+		);
+		const getBody = await getRes.json();
+		expect(getBody.last_sent_week).toMatch(/^\d{4}-W\d{2}$/);
 	});
 
 	test('preview without a configured source returns 400', async () => {

--- a/fair-audience/src/Admin/weekly-digest/WeeklyDigest.js
+++ b/fair-audience/src/Admin/weekly-digest/WeeklyDigest.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import {
 	Button,
@@ -53,6 +54,7 @@ export default function WeeklyDigest() {
 	const [config, setConfig] = useState(null);
 	const [lastSentWeek, setLastSentWeek] = useState('');
 	const [lastRunResult, setLastRunResult] = useState(null);
+	const [nextSend, setNextSend] = useState('');
 	const [sources, setSources] = useState([]);
 	const [preview, setPreview] = useState(null);
 	const introRef = useRef(null);
@@ -64,6 +66,7 @@ export default function WeeklyDigest() {
 				setConfig(digest.config);
 				setLastSentWeek(digest.last_sent_week);
 				setLastRunResult(digest.last_run_result);
+				setNextSend(digest.next_send);
 				setSources(sourceList);
 			})
 			.catch((err) => {
@@ -97,6 +100,11 @@ export default function WeeklyDigest() {
 		saveDigestConfig(updatedConfig)
 			.then((response) => {
 				setConfig(response.config);
+				return getDigestConfig();
+			})
+			.then((digest) => {
+				setLastSentWeek(digest.last_sent_week);
+				setNextSend(digest.next_send);
 				setNotice({
 					status: 'success',
 					message: __(
@@ -324,6 +332,15 @@ export default function WeeklyDigest() {
 								lastSentWeek || __('n/a', 'fair-audience'),
 								lastRunResult?.status ||
 									__('unknown', 'fair-audience')
+							)}
+						</p>
+					)}
+					{config.enabled && nextSend && (
+						<p>
+							{sprintf(
+								/* translators: %s: date and time the next digest is scheduled to send */
+								__('Next digest: %s', 'fair-audience'),
+								dateI18n('l, F j H:i', nextSend)
 							)}
 						</p>
 					)}

--- a/fair-audience/src/Admin/weekly-digest/__tests__/WeeklyDigest.test.jsx
+++ b/fair-audience/src/Admin/weekly-digest/__tests__/WeeklyDigest.test.jsx
@@ -32,6 +32,7 @@ function mockApiFetch({
 	config = CONFIG,
 	lastSentWeek = '',
 	lastRunResult = {},
+	nextSend = '',
 	sources = SOURCES,
 } = {}) {
 	apiFetch.mockImplementation(({ path, method }) => {
@@ -43,6 +44,7 @@ function mockApiFetch({
 				config,
 				last_sent_week: lastSentWeek,
 				last_run_result: lastRunResult,
+				next_send: nextSend,
 			});
 		}
 		if (path === '/fair-audience/v1/weekly-digest' && method === 'PUT') {
@@ -177,6 +179,28 @@ describe('WeeklyDigest — last run summary', () => {
 		expect(
 			await screen.findByText('Last sent for week 2026-W27 — sent')
 		).toBeInTheDocument();
+	});
+
+	it('shows the next scheduled send when the digest is enabled', async () => {
+		mockApiFetch({
+			config: { ...CONFIG, enabled: true },
+			nextSend: '2026-07-20T08:00:00+02:00',
+		});
+		render(<WeeklyDigest />);
+
+		expect(await screen.findByText(/^Next digest:/)).toBeInTheDocument();
+	});
+
+	it('hides the next-send line when the digest is disabled', async () => {
+		mockApiFetch({
+			config: { ...CONFIG, enabled: false },
+			nextSend: '2026-07-20T08:00:00+02:00',
+		});
+		render(<WeeklyDigest />);
+
+		await screen.findByRole('button', { name: 'Save settings' });
+
+		expect(screen.queryByText(/^Next digest:/)).not.toBeInTheDocument();
 	});
 });
 

--- a/fair-audience/src/Admin/weekly-digest/weekly-digest-api.js
+++ b/fair-audience/src/Admin/weekly-digest/weekly-digest-api.js
@@ -6,7 +6,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Load the weekly digest config plus last-run info.
  *
- * @return {Promise<Object>} Promise resolving to `{ config, last_sent_week, last_run_result }`.
+ * @return {Promise<Object>} Promise resolving to `{ config, last_sent_week, last_run_result, next_send }`.
  */
 export function getDigestConfig() {
 	return apiFetch({ path: '/fair-audience/v1/weekly-digest' });

--- a/fair-audience/src/Hooks/WeeklyDigestHooks.php
+++ b/fair-audience/src/Hooks/WeeklyDigestHooks.php
@@ -73,7 +73,7 @@ class WeeklyDigestHooks {
 		}
 
 		$now              = new \DateTime( 'now', wp_timezone() );
-		$current_iso_week = $now->format( 'o' ) . '-W' . $now->format( 'W' );
+		$current_iso_week = self::iso_week( $now );
 
 		if ( get_option( 'fair_audience_weekly_digest_last_sent_week', '' ) === $current_iso_week ) {
 			return;
@@ -99,13 +99,35 @@ class WeeklyDigestHooks {
 	 * @return bool
 	 */
 	private static function is_due( \DateTime $now, $day_of_week, $time_of_day ) {
+		return $now >= self::due_moment( $now, $day_of_week, $time_of_day );
+	}
+
+	/**
+	 * The exact moment this week's configured day/time falls on.
+	 *
+	 * @param \DateTime $now         Current time in site timezone.
+	 * @param int       $day_of_week ISO day of week (1=Monday..7=Sunday).
+	 * @param string    $time_of_day 'HH:MM'.
+	 * @return \DateTime
+	 */
+	public static function due_moment( \DateTime $now, $day_of_week, $time_of_day ) {
 		list( $hour, $minute ) = array_map( 'intval', explode( ':', $time_of_day ) );
 
 		$due = clone $now;
 		$due->setISODate( (int) $now->format( 'o' ), (int) $now->format( 'W' ), $day_of_week );
 		$due->setTime( $hour, $minute, 0 );
 
-		return $now >= $due;
+		return $due;
+	}
+
+	/**
+	 * ISO year-week identifier for the given moment, e.g. "2026-W29".
+	 *
+	 * @param \DateTime $now A moment in time.
+	 * @return string
+	 */
+	public static function iso_week( \DateTime $now ) {
+		return $now->format( 'o' ) . '-W' . $now->format( 'W' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `WeeklyDigestHooks::is_due()` returns `$now >= $due`, open-ended within the ISO week (deliberate — a briefly-down cron still catches up). But on first enable, `fair_audience_weekly_digest_last_sent_week` is empty, so the next 5-minute tick dispatches for a slot that already passed *before the config existed*.
- Extracted a shared `due_moment()`/`iso_week()` pair on `WeeklyDigestHooks` used by both the cron tick and the controller.
- `WeeklyDigestController::update_config()` now stamps `last_sent_week` at save time whenever the newly-saved day/time slot has already passed this ISO week, so the first real send lands on the next occurrence instead of immediately.
- `get_config()` now also returns a `next_send` estimate, surfaced in the settings page's "Last run" card.

## Test plan

- [x] `vendor/bin/phpunit` (fair-audience) — `WeeklyDigestHooksTest`, including new `due_moment()`/`iso_week()` cases
- [x] `npx jest` (fair-audience) — full suite, including new WeeklyDigest component cases for the next-send line
- [x] `vendor/bin/phpcs` clean on changed PHP files
- [x] `npm run build` in fair-audience
- [ ] New Playwright API cases for the stamping behavior added to `WeeklyDigestController.api.spec.js` (not run here — needs a live `wp-env`/docker WP instance)

Closes #1086
