### PR TITLE
Add signup hook contract between fair-events and fair-audience

### DIFF
--- a/REST_API_BACKEND.md
+++ b/REST_API_BACKEND.md
@@ -557,6 +557,49 @@ Every REST controller gets a Playwright API spec in `src/API/__tests__/`
 
 ---
 
+## Cross-Plugin Extension Hooks
+
+When a companion plugin (e.g. `fair-audience`) needs to enrich or react to a
+base plugin's REST create path — instead of registering a competing route
+that duplicates validation, pricing, and payment logic — expose the seam as a
+filter (for shaping data before it's used) and/or an action (for reacting
+after a write completes). This keeps the base route the single source of
+truth and lets experimental features stay additive.
+
+### Example: `fair-events` unified signup
+
+`fair-events/src/blocks/event-signup/render.php` (base render, used when no
+companion plugin renders a richer flow) and
+`fair-events/src/API/GetTicketsController.php` (the `fair-events/v1/get-tickets`
+create route) expose:
+
+-   **`fair_events_signup_render_context` filter** — the base render builds a
+    context array (`event_date_id`, `ticket_types`, `price_by_type_id`,
+    `active_sale_period`, `occurrences_for_picker`, `currency_symbol`,
+    `callback_status`/`callback_tx_id`/`callback_token`, `prefill_name`,
+    `prefill_email`, `submit_button_text`) and runs it through this filter
+    before rendering, so a companion plugin can inject viewer identity,
+    session pre-fill, or participant-filtered ticket types/prices without a
+    parallel template. Two render-slot actions,
+    `fair_events_signup_render_before_form` and
+    `fair_events_signup_render_after_form` (both passed the same context),
+    let a companion plugin contribute UI fragments (e.g. a resume/retry card)
+    directly inside the `<form>`.
+-   **`fair_events_signup_created` action** — fires
+    `( $signup_id, $event_date_id, $name, $email, $ticket_selection, $transaction_id )`
+    after a signup row is persisted through the base create path (once per
+    row for multi-occurrence signups; `$transaction_id` is `null` on the free
+    path). A companion plugin hooks this to create/link its own participant
+    record, set a session cookie, or send its own confirmation email —
+    instead of owning a competing create route.
+
+`fair-audience/src/Hooks/SignupHookBridge.php` is the reference consumer:
+it hooks both to link a `Participant`/`EventParticipant` for the
+anonymous/linked signup case. Richer identity flows (invitation-gated
+signup, resume/retry payment, group-restricted ticket types) still go
+through `fair-audience/v1`'s own routes — this contract only covers the
+simple path; see issue #1083 for the phased migration.
+
 ## Related Documentation
 
 -   [REST_API_USAGE.md](./REST_API_USAGE.md) - Frontend implementation guide

--- a/fair-audience/src/API/__tests__/EventSignupHookBridge.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupHookBridge.api.spec.js
@@ -1,0 +1,132 @@
+/**
+ * Playwright API tests for SignupHookBridge (#1083, PR 2): a signup created
+ * through fair-events' unified route (fair-events/v1/get-tickets) must, when
+ * fair-audience is active, also create/link a fair-audience Participant and
+ * EventParticipant record via the fair_events_signup_created action.
+ *
+ * Skips gracefully when fair-audience is not active in the test environment.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('SignupHookBridge — base get-tickets route links a Participant', () => {
+	let api;
+	let fairAudienceActive = false;
+	let eventPostId;
+	let eventDateId;
+	const buyerEmail = `signup-hook-bridge-${Date.now()}@example.test`;
+	const buyerName = 'Signup Hook Bridge Tester';
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+		if (!fairAudienceActive) {
+			return;
+		}
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Signup hook bridge test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2035-07-01 10:00:00',
+				end_datetime: '2035-07-01 12:00:00',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		eventDateId = (await edRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (fairAudienceActive && eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+		await api.dispose();
+	});
+
+	test('a free signup through the base route creates a linked Participant and EventParticipant', async () => {
+		test.skip(!fairAudienceActive, 'fair-audience not active');
+
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: eventDateId,
+				name: buyerName,
+				email: buyerEmail,
+				quantity: 1,
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		expect(body.status).toBe('confirmed');
+
+		// The fair_events_signups row exists (base plugin's own record).
+		const signupsRes = await api.get(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				headers: adminHeaders,
+				params: { event_date: eventDateId },
+			}
+		);
+		expect(signupsRes.ok()).toBeTruthy();
+		const signups = await signupsRes.json();
+		expect(signups.some((s) => s.email === buyerEmail)).toBeTruthy();
+
+		// SignupHookBridge linked a fair-audience Participant by email.
+		const participantsRes = await api.get(
+			'/wp-json/fair-audience/v1/participants',
+			{ headers: adminHeaders, params: { search: buyerEmail } }
+		);
+		expect(participantsRes.ok()).toBeTruthy();
+		const participantsBody = await participantsRes.json();
+		const participant = participantsBody.find(
+			(p) => p.email === buyerEmail
+		);
+		expect(participant).toBeTruthy();
+
+		// ...and an EventParticipant row ties that participant to this event date.
+		const eventParticipantsRes = await api.get(
+			'/wp-json/fair-audience/v1/event-participants',
+			{ headers: adminHeaders, params: { event_date_id: eventDateId } }
+		);
+		expect(eventParticipantsRes.ok()).toBeTruthy();
+		const eventParticipants = await eventParticipantsRes.json();
+		const items = Array.isArray(eventParticipants)
+			? eventParticipants
+			: eventParticipants.items || [];
+		expect(
+			items.some((ep) => ep.participant_id === participant.id)
+		).toBeTruthy();
+	});
+});

--- a/fair-audience/src/Core/Plugin.php
+++ b/fair-audience/src/Core/Plugin.php
@@ -92,6 +92,10 @@ class Plugin {
 		// Initialize the weekly events digest cron.
 		\FairAudience\Hooks\WeeklyDigestHooks::init();
 
+		// Extend fair-events' unified signup block/route for the simple
+		// anonymous/linked case via the fair_events_signup_* hook contract.
+		\FairAudience\Hooks\SignupHookBridge::init();
+
 		// Initialize blocks.
 		$block_hooks = new \FairAudience\Hooks\BlockHooks();
 	}

--- a/fair-audience/src/Hooks/SignupHookBridge.php
+++ b/fair-audience/src/Hooks/SignupHookBridge.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Signup Hook Bridge
+ *
+ * Extends fair-events' unified event-signup block/route (fair-events/v1/get-tickets)
+ * for the simple anonymous/linked case, instead of owning a competing create route.
+ * See fair-events/REST_API_BACKEND.md for the documented hook contract.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Hooks;
+
+use FairAudience\Database\ParticipantRepository;
+use FairAudience\Database\EventParticipantRepository;
+use FairAudience\Models\Participant;
+use FairAudience\Services\AudienceSession;
+use FairAudience\Services\EmailService;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Bridges the base fair-events signup render/create path to fair-audience's
+ * participant records for the simple (anonymous/linked, non-invitation,
+ * non-group-restricted) signup case. The identity routes (/status, /resume,
+ * /request-link, /register, /retry-payment, /add-activities) stay on
+ * fair-audience/v1 and are unaffected by this bridge.
+ */
+class SignupHookBridge {
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_filter( 'fair_events_signup_render_context', array( static::class, 'enrich_render_context' ), 10, 1 );
+		add_action( 'fair_events_signup_created', array( static::class, 'link_participant' ), 10, 6 );
+	}
+
+	/**
+	 * Inject the signed-in/known viewer's name and email into the base
+	 * form's pre-fill so returning participants don't retype them.
+	 *
+	 * @param array $context Render context from fair-events' base render.
+	 * @return array Filtered context.
+	 */
+	public static function enrich_render_context( $context ) {
+		$participant_repository = new ParticipantRepository();
+		$participant            = null;
+
+		$participant_id = AudienceSession::get_participant_id();
+		if ( $participant_id ) {
+			$participant = $participant_repository->get_by_id( $participant_id );
+		} elseif ( get_current_user_id() ) {
+			$participant = $participant_repository->get_by_user_id( get_current_user_id() );
+		}
+
+		if ( $participant ) {
+			$context['prefill_name']  = trim( $participant->name . ' ' . $participant->surname );
+			$context['prefill_email'] = (string) $participant->email;
+		}
+
+		return $context;
+	}
+
+	/**
+	 * Create or link the Participant + EventParticipant records for a signup
+	 * created through the base fair-events/v1/get-tickets route, set the
+	 * session cookie, and send the confirmation email — mirroring the simple
+	 * path of EventSignupController::create_signup() without duplicating its
+	 * invitation/group/sliding-scale/questionnaire handling.
+	 *
+	 * @param int      $signup_id        The fair_events_signups row just created.
+	 * @param int      $event_date_id    Event-date ID the signup targets.
+	 * @param string   $name             Buyer name.
+	 * @param string   $email            Buyer email.
+	 * @param array    $ticket_selection Ticket selection ('ticket_type_id', 'quantity', 'event_date_ids').
+	 * @param int|null $transaction_id   fair-payments-connector transaction ID, or null on the free path.
+	 * @return void
+	 */
+	public static function link_participant( $signup_id, $event_date_id, $name, $email, $ticket_selection, $transaction_id ) {
+		if ( empty( $email ) || ! is_email( $email ) ) {
+			return;
+		}
+
+		if ( ! class_exists( \FairEvents\Models\EventDates::class ) ) {
+			return;
+		}
+
+		$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+		if ( ! $event_date ) {
+			return;
+		}
+
+		$event_id = $event_date->get_resolved_event_id();
+		if ( ! $event_id ) {
+			return;
+		}
+
+		$participant_repository = new ParticipantRepository();
+		$participant            = $participant_repository->get_by_email( $email );
+
+		if ( ! $participant ) {
+			$participant = new Participant();
+			$participant->populate(
+				array(
+					'name'          => $name,
+					'email'         => $email,
+					'email_profile' => 'minimal',
+					'status'        => 'confirmed',
+				)
+			);
+			if ( ! $participant->save() ) {
+				return;
+			}
+		}
+
+		$event_participant_repository = new EventParticipantRepository();
+		$label                        = $transaction_id ? 'pending_payment' : 'signed_up';
+
+		$existing = $event_participant_repository->get_by_event_date_and_participant( $event_date_id, $participant->id );
+		if ( $existing ) {
+			if ( 'signed_up' !== $existing->label ) {
+				$event_participant_repository->update_label_by_event_date( $event_date_id, $participant->id, $label );
+			}
+		} else {
+			$event_participant_repository->add_participant_to_event( $event_id, $participant->id, $label, $event_date_id );
+		}
+
+		AudienceSession::set( (int) $participant->id );
+
+		if ( ! $transaction_id ) {
+			$email_service = new EmailService();
+			$event         = get_post( $event_id );
+			$email_service->send_signup_payment_confirmation( $participant, $event, null, array(), (int) $event_date_id );
+		}
+	}
+}

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -249,8 +249,14 @@ class GetTicketsController extends WP_REST_Controller {
 			);
 		}
 
+		$ticket_selection = array(
+			'ticket_type_id' => $ticket_type_id ? $ticket_type_id : null,
+			'quantity'       => $quantity,
+		);
+
 		// Free path.
 		if ( $amount <= 0 ) {
+			$this->fire_signup_created( $signup_id, $event_date_id, $name, $email, $ticket_selection, null );
 			return rest_ensure_response(
 				array(
 					'status'  => 'confirmed',
@@ -262,6 +268,7 @@ class GetTicketsController extends WP_REST_Controller {
 		// Paid path — fall back to confirmed if payment connector is absent.
 		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
 			\FairEvents\Models\EventSignup::update_status( $signup_id, 'confirmed' );
+			$this->fire_signup_created( $signup_id, $event_date_id, $name, $email, $ticket_selection, null );
 			return rest_ensure_response(
 				array(
 					'status'  => 'confirmed',
@@ -307,6 +314,8 @@ class GetTicketsController extends WP_REST_Controller {
 
 		\FairEvents\Models\EventSignup::update_transaction( $signup_id, (int) $transaction_id );
 
+		$this->fire_signup_created( $signup_id, $event_date_id, $name, $email, $ticket_selection, (int) $transaction_id );
+
 		// Load the freshly created transaction so its access token can be attached
 		// to the redirect URL, mirroring PaymentEndpoint::create_payment. The token
 		// gates the shared /payments/{id}/status endpoint this now polls.
@@ -339,6 +348,35 @@ class GetTicketsController extends WP_REST_Controller {
 				'currency'       => $currency,
 			)
 		);
+	}
+
+	/**
+	 * Fire the sanctioned extension point for plugins (e.g. fair-audience)
+	 * that want to attach viewer identity / participant records to a signup
+	 * created through the base route, instead of owning a competing create
+	 * route. See REST_API_BACKEND.md for the documented contract.
+	 *
+	 * @param int      $signup_id        The fair_events_signups row just created.
+	 * @param int      $event_date_id    Event-date ID the signup targets.
+	 * @param string   $name             Buyer name.
+	 * @param string   $email            Buyer email.
+	 * @param array    $ticket_selection Ticket selection: 'ticket_type_id', 'quantity',
+	 *                                   and — for 'multiple_instances' types — 'event_date_ids'.
+	 * @param int|null $transaction_id   fair-payments-connector transaction ID, or null on the free path.
+	 * @return void
+	 */
+	private function fire_signup_created( $signup_id, $event_date_id, $name, $email, $ticket_selection, $transaction_id ) {
+		/**
+		 * Fires after a signup row is persisted through the base create path.
+		 *
+		 * @param int      $signup_id        The fair_events_signups row just created.
+		 * @param int      $event_date_id    Event-date ID the signup targets.
+		 * @param string   $name             Buyer name.
+		 * @param string   $email            Buyer email.
+		 * @param array    $ticket_selection Ticket selection details.
+		 * @param int|null $transaction_id   fair-payments-connector transaction ID, or null on the free path.
+		 */
+		do_action( 'fair_events_signup_created', $signup_id, $event_date_id, $name, $email, $ticket_selection, $transaction_id );
 	}
 
 	/**
@@ -480,8 +518,23 @@ class GetTicketsController extends WP_REST_Controller {
 			$signup_ids[] = (int) $signup_id;
 		}
 
+		$occurrence_ids   = array_map(
+			function ( $occ ) {
+				return (int) $occ->id;
+			},
+			$occurrences
+		);
+		$ticket_selection = array(
+			'ticket_type_id' => (int) $ticket_type->id,
+			'quantity'       => 1,
+			'event_date_ids' => $occurrence_ids,
+		);
+
 		// Free path.
 		if ( $total_amount <= 0 ) {
+			foreach ( $signup_ids as $index => $signup_id ) {
+				$this->fire_signup_created( $signup_id, $occurrence_ids[ $index ], $name, $email, $ticket_selection, null );
+			}
 			return rest_ensure_response(
 				array(
 					'status'  => 'confirmed',
@@ -492,8 +545,9 @@ class GetTicketsController extends WP_REST_Controller {
 
 		// Paid path — fall back to confirmed if payment connector is absent.
 		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
-			foreach ( $signup_ids as $signup_id ) {
+			foreach ( $signup_ids as $index => $signup_id ) {
 				\FairEvents\Models\EventSignup::update_status( $signup_id, 'confirmed' );
+				$this->fire_signup_created( $signup_id, $occurrence_ids[ $index ], $name, $email, $ticket_selection, null );
 			}
 			return rest_ensure_response(
 				array(
@@ -546,8 +600,9 @@ class GetTicketsController extends WP_REST_Controller {
 			return $transaction_id;
 		}
 
-		foreach ( $signup_ids as $signup_id ) {
+		foreach ( $signup_ids as $index => $signup_id ) {
 			\FairEvents\Models\EventSignup::update_transaction( $signup_id, (int) $transaction_id );
+			$this->fire_signup_created( $signup_id, $occurrence_ids[ $index ], $name, $email, $ticket_selection, (int) $transaction_id );
 		}
 
 		$transaction = \FairPaymentsConnector\Models\Transaction::get_by_id( $transaction_id );

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -180,6 +180,61 @@ if ( class_exists( \FairEvents\Models\TicketSalePeriod::class ) && class_exists(
 $currency_symbol = 'EUR' === get_option( 'fair_payment_currency', 'EUR' ) ? '€' : get_option( 'fair_payment_currency', 'EUR' );
 $powered_by      = (bool) get_option( 'fair_events_powered_by_branding', false );
 
+/**
+ * Extension point for plugins (e.g. fair-audience) that want to enrich the
+ * base signup form without owning a competing render — resolved viewer
+ * identity, session pre-fill, or group/participant-filtered ticket types and
+ * prices can all be layered on by filtering this context array. See
+ * REST_API_BACKEND.md for the documented shape and consumers.
+ *
+ * @param array    $context    Render context (event_date_id, ticket_types, price_by_type_id,
+ *                              active_sale_period, occurrences_for_picker, currency_symbol,
+ *                              callback_status, callback_tx_id, callback_token, prefill_name,
+ *                              prefill_email, submit_button_text).
+ * @param array    $attributes Block attributes.
+ * @param WP_Block $block      Block instance.
+ */
+$context = apply_filters(
+	'fair_events_signup_render_context',
+	array(
+		'event_date_id'          => $event_date_id,
+		'ticket_types'           => $ticket_types,
+		'price_by_type_id'       => $price_by_type_id,
+		'active_sale_period'     => $active_sale_period,
+		'occurrences_for_picker' => $occurrences_for_picker,
+		'currency_symbol'        => $currency_symbol,
+		'callback_status'        => $callback_status,
+		'callback_tx_id'         => $callback_tx_id,
+		'callback_token'         => $callback_token,
+		'prefill_name'           => '',
+		'prefill_email'          => '',
+		'submit_button_text'     => $submit_button_text,
+	),
+	$attributes,
+	$block
+);
+
+$event_date_id          = (int) $context['event_date_id'];
+$ticket_types           = $context['ticket_types'];
+$price_by_type_id       = $context['price_by_type_id'];
+$active_sale_period     = $context['active_sale_period'];
+$occurrences_for_picker = $context['occurrences_for_picker'];
+$has_instance_picker    = ! empty( $occurrences_for_picker );
+$currency_symbol        = $context['currency_symbol'];
+$callback_status        = $context['callback_status'];
+$prefill_name           = $context['prefill_name'];
+$prefill_email          = $context['prefill_email'];
+$submit_button_text     = $context['submit_button_text'];
+
+// Recompute the multiple_instances flag from the (possibly filtered) ticket types.
+$has_multiple_instances_type = false;
+foreach ( $ticket_types as $ticket_type ) {
+	if ( $ticket_type->is_multiple_instances() ) {
+		$has_multiple_instances_type = true;
+		break;
+	}
+}
+
 // Generate unique form ID.
 $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 ?>
@@ -204,7 +259,19 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 		id="<?php echo esc_attr( $form_id ); ?>"
 		class="fair-events-get-tickets-form"
 		data-event-date-id="<?php echo esc_attr( $event_date_id ); ?>"
+		data-fair-audience-active="<?php echo esc_attr( class_exists( \FairAudience\API\EventSignupController::class ) ? '1' : '0' ); ?>"
 	>
+		<?php
+		/**
+		 * Fires just inside the signup <form>, before the name/email fields.
+		 * fair-audience uses this to contribute identity fragments (resume
+		 * card, register-with-token prompt) without a parallel template.
+		 *
+		 * @param array $context Render context, see fair_events_signup_render_context.
+		 */
+		do_action( 'fair_events_signup_render_before_form', $context );
+		?>
+
 		<div class="form-row">
 			<label for="<?php echo esc_attr( $form_id ); ?>-name" class="form-label">
 				<?php esc_html_e( 'Your Name', 'fair-events' ); ?>
@@ -215,6 +282,7 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 				id="<?php echo esc_attr( $form_id ); ?>-name"
 				name="name"
 				class="form-input"
+				value="<?php echo esc_attr( $prefill_name ); ?>"
 				required
 				maxlength="255"
 				autocomplete="name"
@@ -231,6 +299,7 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 				id="<?php echo esc_attr( $form_id ); ?>-email"
 				name="email"
 				class="form-input"
+				value="<?php echo esc_attr( $prefill_email ); ?>"
 				required
 				autocomplete="email"
 			/>
@@ -341,6 +410,18 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 				<?php echo esc_html( $submit_button_text ); ?>
 			</button>
 		</div>
+
+		<?php
+		/**
+		 * Fires just inside the signup <form>, after the submit button.
+		 * fair-audience uses this to contribute identity fragments
+		 * (request-link prompt, retry-payment card) without a parallel
+		 * template.
+		 *
+		 * @param array $context Render context, see fair_events_signup_render_context.
+		 */
+		do_action( 'fair_events_signup_render_after_form', $context );
+		?>
 	</form>
 
 	<div class="message-container" role="alert" aria-live="polite"></div>


### PR DESCRIPTION
## Summary

PR 2 of the sequential plan in #1083: replaces the coarse whole-render
delegation from PR 1 (#1135) with the two sanctioned extension points from
the issue, so fair-audience *extends* the base signup render/create path
instead of owning a competing one for the simple case.

- **`fair_events_signup_render_context` filter** (`fair-events/src/blocks/event-signup/render.php`)
  — the base render builds a context array (event date, ticket types + prices,
  occurrence list, currency, callback state, name/email pre-fill) and passes
  it through this filter before rendering. Two render-slot actions,
  `fair_events_signup_render_before_form` / `_after_form`, let a companion
  plugin contribute UI fragments inside the `<form>` without a parallel
  template.
- **`fair_events_signup_created` action** (`fair-events/src/API/GetTicketsController.php`)
  — fires `(signup_id, event_date_id, name, email, ticket_selection, transaction_id)`
  after a signup row is persisted through the base `fair-events/v1/get-tickets`
  route (once per row for multi-occurrence signups).
- **`fair-audience/src/Hooks/SignupHookBridge.php`** is the reference
  consumer: hooks the filter to pre-fill a known participant's name/email,
  and hooks the action to create/link a `Participant` + `EventParticipant`
  row and set the session cookie for the anonymous/linked case.

### Scope

Per the issue's PR 2 scope note, only the *simple* path moves onto the hooks.
fair-audience's identity routes (`/status`, `/resume`, `/request-link`,
`/register`, `/retry-payment`, `/add-activities`) stay on `fair-audience/v1`,
untouched. The block's whole-render delegation to `fair-audience/event-signup`
for the richer flow (invitation gating, sliding scale, resume/retry cards,
questionnaires, group-restricted ticket types) is also untouched — migrating
that onto render slots is the "Frontend/render convergence" bullet under
PR 3+ in the issue, not this PR. This PR's deliverable is the hook contract
itself plus a working, tested seam for the case it's scoped to.

Documented in [REST_API_BACKEND.md](../blob/main/REST_API_BACKEND.md#cross-plugin-extension-hooks)
under a new "Cross-Plugin Extension Hooks" section.

## Test plan

- [x] `vendor/bin/phpcs` on changed PHP files — no new errors (3 pre-existing
      short-ternary errors in `GetTicketsController.php` are unchanged from
      main).
- [x] `php -l` on all changed PHP files.
- [x] `npm run format` in `fair-events` and `fair-audience` (root pre-commit
      hook also ran `format:php` across the repo — no fixable errors).
- [x] `npx jest` in `fair-events` (101 tests) and `fair-audience` (25 tests)
      — all pass.
- [x] Added `fair-audience/src/API/__tests__/EventSignupHookBridge.api.spec.js`,
      a new Playwright API spec covering the deliverable: a signup created
      through the unified `fair-events/v1/get-tickets` route with fair-audience
      active produces both the `fair_events_signups` row and a linked
      `Participant`/`EventParticipant` record.
- [ ] Could not run the new Playwright spec (or the full `test:api` suite)
      against a live WordPress instance — this worktree's `docker compose up`
      conflicts on port 3306 with another environment already running
      elsewhere on this machine. Syntax-checked with `node --check`; logic
      was cross-checked against sibling controllers'
      request/response shapes (`ParticipantsController`,
      `EventParticipantsController`). Recommend running `npm run test:api`
      against a live environment before merge.

Refs #1083
