### PR TITLE
Simplify ticket setup to a single sale period by default

### DIFF
--- a/fair-events-experimental/src/Admin/manage-event/EventTickets.js
+++ b/fair-events-experimental/src/Admin/manage-event/EventTickets.js
@@ -38,8 +38,6 @@ export default function EventTickets({
 	const [salePeriods, setSalePeriods] = useState([]);
 	const [prices, setPrices] = useState({});
 	const [settings, setSettings] = useState({
-		continues_pricing_period: true,
-		unlimited_tickets_in_price_period: true,
 		show_ticket_type_capacity: false,
 		multiple_pricing_periods: false,
 		show_seats_per_ticket: false,
@@ -685,17 +683,15 @@ export default function EventTickets({
 		const updated = [...salePeriods];
 		updated[index] = { ...updated[index], [field]: value };
 
-		if (settings.continues_pricing_period) {
-			if (field === 'sale_end') {
-				const next = index + 1;
-				if (next < updated.length) {
-					updated[next] = { ...updated[next], sale_start: value };
-				}
-			} else if (field === 'sale_start') {
-				const prev = index - 1;
-				if (prev >= 0) {
-					updated[prev] = { ...updated[prev], sale_end: value };
-				}
+		if (field === 'sale_end') {
+			const next = index + 1;
+			if (next < updated.length) {
+				updated[next] = { ...updated[next], sale_start: value };
+			}
+		} else if (field === 'sale_start') {
+			const prev = index - 1;
+			if (prev >= 0) {
+				updated[prev] = { ...updated[prev], sale_end: value };
 			}
 		}
 
@@ -720,9 +716,6 @@ export default function EventTickets({
 	};
 
 	const getEffectiveSalePeriods = () => {
-		if (!settings.continues_pricing_period) {
-			return salePeriods;
-		}
 		return salePeriods.map((p, i) => {
 			const updated = { ...p };
 			if (i > 0) {
@@ -972,10 +965,6 @@ export default function EventTickets({
 																		cell.price
 																  )
 																: '—'}
-															{!settings.unlimited_tickets_in_price_period &&
-																cell.capacity !==
-																	'' &&
-																` (${cell.capacity})`}
 														</td>
 													);
 												}
@@ -1074,8 +1063,6 @@ export default function EventTickets({
 												<tbody>
 													{salePeriods.map(
 														(period, pIndex) => {
-															const isContinuous =
-																settings.continues_pricing_period;
 															const isFirst =
 																pIndex === 0;
 															const isLast =
@@ -1083,7 +1070,6 @@ export default function EventTickets({
 																salePeriods.length -
 																	1;
 															const fromValue =
-																isContinuous &&
 																!isFirst
 																	? salePeriods[
 																			pIndex -
@@ -1094,7 +1080,6 @@ export default function EventTickets({
 																	: period.sale_start ||
 																	  '';
 															const untilValue =
-																isContinuous &&
 																isLast
 																	? period.sale_end ||
 																	  endDatetime
@@ -1489,8 +1474,6 @@ export default function EventTickets({
 													)}
 													{salePeriods.map(
 														(period, pIndex) => {
-															const isContinuous =
-																settings.continues_pricing_period;
 															const isFirst =
 																pIndex === 0;
 															const isLast =
@@ -1498,7 +1481,6 @@ export default function EventTickets({
 																salePeriods.length -
 																	1;
 															const fromValue =
-																isContinuous &&
 																!isFirst
 																	? salePeriods[
 																			pIndex -
@@ -1509,7 +1491,6 @@ export default function EventTickets({
 																	: period.sale_start ||
 																	  '';
 															const untilValue =
-																isContinuous &&
 																isLast
 																	? period.sale_end ||
 																	  endDatetime
@@ -1873,43 +1854,6 @@ export default function EventTickets({
 																								}
 																							/>
 																						</HStack>
-																						{!settings.unlimited_tickets_in_price_period && (
-																							<HStack
-																								alignment="center"
-																								spacing={
-																									2
-																								}
-																							>
-																								<span
-																									style={{
-																										whiteSpace:
-																											'nowrap',
-																									}}
-																								>
-																									{__(
-																										'Cap',
-																										'fair-events-experimental'
-																									)}
-																								</span>
-																								<TextControl
-																									type="number"
-																									min="0"
-																									value={
-																										cell.capacity
-																									}
-																									onChange={(
-																										v
-																									) =>
-																										updatePrice(
-																											type,
-																											period,
-																											'capacity',
-																											v
-																										)
-																									}
-																								/>
-																							</HStack>
-																						)}
 																					</>
 																				)}
 																			</VStack>
@@ -2419,35 +2363,6 @@ export default function EventTickets({
 						initialOpen={false}
 					>
 						<VStack spacing={4}>
-							<CheckboxControl
-								label={__(
-									'Continues pricing period',
-									'fair-events-experimental'
-								)}
-								checked={settings.continues_pricing_period}
-								onChange={(value) =>
-									setSettings((prev) => ({
-										...prev,
-										continues_pricing_period: value,
-									}))
-								}
-							/>
-							<CheckboxControl
-								label={__(
-									'Unlimited tickets in pricing period',
-									'fair-events-experimental'
-								)}
-								checked={
-									settings.unlimited_tickets_in_price_period
-								}
-								onChange={(value) =>
-									setSettings((prev) => ({
-										...prev,
-										unlimited_tickets_in_price_period:
-											value,
-									}))
-								}
-							/>
 							<CheckboxControl
 								label={__(
 									'Per-ticket-type capacity',

--- a/fair-events/src/API/__tests__/TicketsController.api.spec.js
+++ b/fair-events/src/API/__tests__/TicketsController.api.spec.js
@@ -279,3 +279,119 @@ test.describe('TicketsController — disabled flag and delete guard', () => {
 		);
 	});
 });
+
+test.describe('TicketsController — retired pricing-period settings (#1138)', () => {
+	let api;
+	let eventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Retired-settings test ${Date.now()}`,
+				start_datetime: '2030-08-01 10:00:00',
+				end_datetime: '2030-08-01 12:00:00',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		eventDateId = (await edRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (eventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+	});
+
+	test('saving settings that include the retired keys drops them on load', async () => {
+		const putRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [],
+					sale_periods: [],
+					prices: [],
+					settings: {
+						continues_pricing_period: false,
+						unlimited_tickets_in_price_period: false,
+						show_ticket_type_capacity: true,
+					},
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+
+		const getRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{ headers: adminHeaders }
+		);
+		expect(getRes.ok()).toBeTruthy();
+		const body = await getRes.json();
+		expect(body.settings).not.toHaveProperty('continues_pricing_period');
+		expect(body.settings).not.toHaveProperty(
+			'unlimited_tickets_in_price_period'
+		);
+		// A setting that is still current is unaffected.
+		expect(body.settings.show_ticket_type_capacity).toBe(true);
+	});
+
+	test('importing an export that includes the retired fields succeeds and drops them', async () => {
+		const importRes = await api.post(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets/import`,
+			{
+				headers: adminHeaders,
+				data: {
+					version: 1,
+					type: 'fair-events-tickets',
+					capacity: null,
+					settings: {
+						continues_pricing_period: true,
+						unlimited_tickets_in_price_period: false,
+						multiple_pricing_periods: false,
+					},
+					ticket_types: [
+						{
+							name: 'General',
+							capacity: null,
+							invitation_only: false,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'single_instance',
+							minimum_instances: 0,
+							group_ids: [],
+						},
+					],
+					sale_periods: [
+						{
+							name: '',
+							sale_start: '2030-01-01 00:00:00',
+							sale_end: '2030-08-02 00:00:00',
+						},
+					],
+					prices: [
+						{
+							ticket_type_index: 0,
+							sale_period_index: 0,
+							price: 10,
+							capacity: 5,
+						},
+					],
+					options: [],
+				},
+			}
+		);
+		expect(importRes.ok()).toBeTruthy();
+		const body = await importRes.json();
+		expect(body.settings).not.toHaveProperty('continues_pricing_period');
+		expect(body.settings).not.toHaveProperty(
+			'unlimited_tickets_in_price_period'
+		);
+		expect(body.ticket_types?.[0]?.name).toBe('General');
+	});
+});

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -13,6 +13,7 @@ import {
 	CardBody,
 	Button,
 	CheckboxControl,
+	__experimentalConfirmDialog as ConfirmDialog,
 	DropdownMenu,
 	FormTokenField,
 	MenuGroup,
@@ -51,8 +52,6 @@ export default function EventTickets({
 	const [salePeriods, setSalePeriods] = useState([]);
 	const [prices, setPrices] = useState({});
 	const [settings, setSettings] = useState({
-		continues_pricing_period: true,
-		unlimited_tickets_in_price_period: true,
 		show_ticket_type_capacity: false,
 		multiple_pricing_periods: false,
 		activity_collaborator_discount: false,
@@ -71,6 +70,7 @@ export default function EventTickets({
 	const [showScopeModal, setShowScopeModal] = useState(false);
 	const [pendingScope, setPendingScope] = useState('single_instance');
 	const [participants, setParticipants] = useState([]);
+	const [mergePeriodsDialogOpen, setMergePeriodsDialogOpen] = useState(false);
 	const fileInputRef = useRef(null);
 
 	// Dirty-state tracking (#987): snapshot the save payload right after it's
@@ -83,6 +83,11 @@ export default function EventTickets({
 		window.fairEventsManageEventData?.manageInvitationsUrl || '';
 
 	const hasAdvancedTickets = ticketTypes.length > 0 || salePeriods.length > 0;
+	// An event loaded with more than one stored sale period always renders in
+	// multiple-periods mode, regardless of the stored toggle, so no configured
+	// period is ever hidden.
+	const effectiveMultiple =
+		salePeriods.length > 1 || settings.multiple_pricing_periods;
 	const paymentNotConfigured =
 		window.fairPaymentsConnector?.paymentConfigured === false;
 	const hasInvitationTickets = ticketTypes.some((t) => t.invitation_only);
@@ -441,18 +446,17 @@ export default function EventTickets({
 		const afterEventEnd = endDatetime
 			? dayAfterDate(endDatetime)
 			: dayAfterDate(eventFirstDay);
+		// A single sale window covering today through the day after the event
+		// ends. For an event already in the past (today would be after the
+		// window's own end), default to the event's own dates instead of an
+		// inverted range.
+		const saleStart = today > afterEventEnd ? eventFirstDay : today;
 		setSalePeriods([
 			{
 				name: '',
-				sale_start: today,
-				sale_end: eventFirstDay,
-				sort_order: 0,
-			},
-			{
-				name: '',
-				sale_start: eventFirstDay,
+				sale_start: saleStart,
 				sale_end: afterEventEnd,
-				sort_order: 1,
+				sort_order: 0,
 			},
 		]);
 	};
@@ -589,21 +593,107 @@ export default function EventTickets({
 		const updated = [...salePeriods];
 		updated[index] = { ...updated[index], [field]: value };
 
-		if (settings.continues_pricing_period) {
-			if (field === 'sale_end') {
-				const next = index + 1;
-				if (next < updated.length) {
-					updated[next] = { ...updated[next], sale_start: value };
-				}
-			} else if (field === 'sale_start') {
-				const prev = index - 1;
-				if (prev >= 0) {
-					updated[prev] = { ...updated[prev], sale_end: value };
-				}
+		// Sale periods always chain: each period's start is implied by the
+		// previous period's end, so gaps/overlaps are impossible by construction.
+		if (field === 'sale_end') {
+			const next = index + 1;
+			if (next < updated.length) {
+				updated[next] = { ...updated[next], sale_start: value };
+			}
+		} else if (field === 'sale_start') {
+			const prev = index - 1;
+			if (prev >= 0) {
+				updated[prev] = { ...updated[prev], sale_end: value };
 			}
 		}
 
 		setSalePeriods(updated);
+	};
+
+	// "Multiple pricing periods" toggled on: split the single sale window at
+	// the event's first day into two named, prefilled, editable periods,
+	// migrating the existing single-period prices to the first one.
+	// Toggled off with several periods defined: ask for confirmation before
+	// merging back into one window (mergeToSinglePeriod does the merge).
+	const handleToggleMultiplePeriods = (value) => {
+		if (value) {
+			if (salePeriods.length <= 1) {
+				const base = salePeriods[0];
+				const eventFirstDay = startDatetime
+					? startDatetime.split(' ')[0].split('T')[0]
+					: getSiteToday();
+				const windowStart = base?.sale_start || getSiteToday();
+				const windowEnd =
+					base?.sale_end ||
+					(endDatetime ? dayAfterDate(endDatetime) : '');
+				if (base) {
+					const newPrices = { ...prices };
+					ticketTypes.forEach((type) => {
+						const oldKey = getPriceKey(type, base);
+						if (prices[oldKey] !== undefined) {
+							const typeKey =
+								type.id || `new-${ticketTypes.indexOf(type)}`;
+							newPrices[`${typeKey}-new-0`] = prices[oldKey];
+						}
+					});
+					setPrices(newPrices);
+				}
+				setSalePeriods([
+					{
+						name: __('Advance ticket', 'fair-events'),
+						sale_start: windowStart,
+						sale_end: eventFirstDay,
+						sort_order: 0,
+					},
+					{
+						name: __('Day of event', 'fair-events'),
+						sale_start: eventFirstDay,
+						sale_end: windowEnd,
+						sort_order: 1,
+					},
+				]);
+			}
+			setSettings((prev) => ({
+				...prev,
+				multiple_pricing_periods: true,
+			}));
+		} else if (salePeriods.length > 1) {
+			setMergePeriodsDialogOpen(true);
+		} else {
+			setSettings((prev) => ({
+				...prev,
+				multiple_pricing_periods: false,
+			}));
+		}
+	};
+
+	const mergeToSinglePeriod = () => {
+		const first = salePeriods[0];
+		const last = salePeriods[salePeriods.length - 1];
+		if (first) {
+			const newPrices = {};
+			ticketTypes.forEach((type) => {
+				const oldKey = getPriceKey(type, first);
+				if (prices[oldKey] !== undefined) {
+					const typeKey =
+						type.id || `new-${ticketTypes.indexOf(type)}`;
+					newPrices[`${typeKey}-new-0`] = prices[oldKey];
+				}
+			});
+			setPrices(newPrices);
+			setSalePeriods([
+				{
+					name: '',
+					sale_start: first.sale_start,
+					sale_end:
+						last.sale_end ||
+						(endDatetime ? dayAfterDate(endDatetime) : ''),
+					sort_order: 0,
+				},
+			]);
+		}
+		setSettings((prev) => ({ ...prev, multiple_pricing_periods: false }));
+		setMergePeriodsDialogOpen(false);
 	};
 
 	const getPriceKey = (type, period) => {
@@ -631,15 +721,10 @@ export default function EventTickets({
 	const getEffectiveSalePeriods = () => {
 		const periods = salePeriods.map((p, i) => {
 			const updated = { ...p };
-			if (settings.continues_pricing_period && i > 0) {
+			if (i > 0) {
 				updated.sale_start = salePeriods[i - 1].sale_end || '';
 			}
-			if (
-				settings.continues_pricing_period &&
-				i === salePeriods.length - 1 &&
-				endDatetime &&
-				!p.sale_end
-			) {
+			if (i === salePeriods.length - 1 && endDatetime && !p.sale_end) {
 				updated.sale_end = dayAfterDate(endDatetime);
 			}
 			updated.sale_start = appendTime(updated.sale_start);
@@ -932,7 +1017,7 @@ export default function EventTickets({
 										</div>
 									</HStack>
 								)}
-								{settings.multiple_pricing_periods ? (
+								{effectiveMultiple ? (
 									<VStack spacing={3}>
 										<div style={{ overflowX: 'auto' }}>
 											<table className="wp-list-table widefat striped">
@@ -962,8 +1047,6 @@ export default function EventTickets({
 												<tbody>
 													{salePeriods.map(
 														(period, pIndex) => {
-															const isContinuous =
-																settings.continues_pricing_period;
 															const isFirst =
 																pIndex === 0;
 															const isLast =
@@ -971,7 +1054,6 @@ export default function EventTickets({
 																salePeriods.length -
 																	1;
 															const fromValue =
-																isContinuous &&
 																!isFirst
 																	? salePeriods[
 																			pIndex -
@@ -982,7 +1064,6 @@ export default function EventTickets({
 																	: period.sale_start ||
 																	  '';
 															const untilValue =
-																isContinuous &&
 																isLast
 																	? period.sale_end ||
 																	  endDatetime
@@ -1265,8 +1346,6 @@ export default function EventTickets({
 												)}
 												{salePeriods.map(
 													(period, pIndex) => {
-														const isContinuous =
-															settings.continues_pricing_period;
 														const isFirst =
 															pIndex === 0;
 														const isLast =
@@ -1274,7 +1353,6 @@ export default function EventTickets({
 															salePeriods.length -
 																1;
 														const fromValue =
-															isContinuous &&
 															!isFirst
 																? salePeriods[
 																		pIndex -
@@ -1284,7 +1362,6 @@ export default function EventTickets({
 																: period.sale_start ||
 																  '';
 														const untilValue =
-															isContinuous &&
 															isLast
 																? period.sale_end ||
 																  (endDatetime
@@ -1310,20 +1387,14 @@ export default function EventTickets({
 																	dateTooltip
 																}
 															>
-																{settings.multiple_pricing_periods
+																{effectiveMultiple
 																	? period.name ||
 																	  __(
 																			'(unnamed)',
 																			'fair-events'
 																	  )
-																	: pIndex ===
-																	  0
-																	? __(
-																			'Advance ticket',
-																			'fair-events'
-																	  )
 																	: __(
-																			'Day of event',
+																			'Price',
 																			'fair-events'
 																	  )}
 															</th>
@@ -1656,104 +1727,68 @@ export default function EventTickets({
 																			1
 																		}
 																	>
-																		<CheckboxControl
-																			__nextHasNoMarginBottom
-																			label={__(
-																				'Available',
-																				'fair-events'
-																			)}
-																			checked={
-																				cell.enabled !==
-																				false
-																			}
-																			onChange={(
-																				v
-																			) =>
-																				updatePrice(
-																					type,
-																					period,
-																					'enabled',
-																					v
-																				)
-																			}
-																		/>
-																		{cell.enabled !==
-																			false && (
-																			<>
-																				<HStack
-																					alignment="center"
-																					spacing={
-																						2
-																					}
-																				>
-																					<span
-																						style={{
-																							whiteSpace:
-																								'nowrap',
-																						}}
-																					>
-																						{__(
-																							'Price',
-																							'fair-events'
-																						)}
-																					</span>
-																					<TextControl
-																						type="number"
-																						step="0.01"
-																						min="0"
-																						value={
-																							cell.price
-																						}
-																						onChange={(
-																							v
-																						) =>
-																							updatePrice(
-																								type,
-																								period,
-																								'price',
-																								v
-																							)
-																						}
-																					/>
-																				</HStack>
-																				{!settings.unlimited_tickets_in_price_period && (
-																					<HStack
-																						alignment="center"
-																						spacing={
-																							2
-																						}
-																					>
-																						<span
-																							style={{
-																								whiteSpace:
-																									'nowrap',
-																							}}
-																						>
-																							{__(
-																								'Cap',
-																								'fair-events'
-																							)}
-																						</span>
-																						<TextControl
-																							type="number"
-																							min="0"
-																							value={
-																								cell.capacity
-																							}
-																							onChange={(
-																								v
-																							) =>
-																								updatePrice(
-																									type,
-																									period,
-																									'capacity',
-																									v
-																								)
-																							}
-																						/>
-																					</HStack>
+																		{effectiveMultiple && (
+																			<CheckboxControl
+																				__nextHasNoMarginBottom
+																				label={__(
+																					'Available',
+																					'fair-events'
 																				)}
-																			</>
+																				checked={
+																					cell.enabled !==
+																					false
+																				}
+																				onChange={(
+																					v
+																				) =>
+																					updatePrice(
+																						type,
+																						period,
+																						'enabled',
+																						v
+																					)
+																				}
+																			/>
+																		)}
+																		{(!effectiveMultiple ||
+																			cell.enabled !==
+																				false) && (
+																			<HStack
+																				alignment="center"
+																				spacing={
+																					2
+																				}
+																			>
+																				<span
+																					style={{
+																						whiteSpace:
+																							'nowrap',
+																					}}
+																				>
+																					{__(
+																						'Price',
+																						'fair-events'
+																					)}
+																				</span>
+																				<TextControl
+																					type="number"
+																					step="0.01"
+																					min="0"
+																					value={
+																						cell.price
+																					}
+																					onChange={(
+																						v
+																					) =>
+																						updatePrice(
+																							type,
+																							period,
+																							'price',
+																							v
+																						)
+																					}
+																				/>
+																			</HStack>
 																		)}
 																	</VStack>
 																</td>
@@ -2286,43 +2321,6 @@ export default function EventTickets({
 						<VStack spacing={4}>
 							<CheckboxControl
 								label={__(
-									'Chain sale periods together',
-									'fair-events'
-								)}
-								help={__(
-									'Each period starts when the previous one ends, so there are no gaps.',
-									'fair-events'
-								)}
-								checked={settings.continues_pricing_period}
-								onChange={(value) =>
-									setSettings((prev) => ({
-										...prev,
-										continues_pricing_period: value,
-									}))
-								}
-							/>
-							<CheckboxControl
-								label={__(
-									'No ticket limit per sale period',
-									'fair-events'
-								)}
-								help={__(
-									'Allow selling tickets without a per-period cap during any sale period.',
-									'fair-events'
-								)}
-								checked={
-									settings.unlimited_tickets_in_price_period
-								}
-								onChange={(value) =>
-									setSettings((prev) => ({
-										...prev,
-										unlimited_tickets_in_price_period:
-											value,
-									}))
-								}
-							/>
-							<CheckboxControl
-								label={__(
 									'Per-ticket-type capacity',
 									'fair-events'
 								)}
@@ -2347,13 +2345,8 @@ export default function EventTickets({
 									'Enable time-based pricing with multiple sale periods (e.g. early bird, regular, late). When off, a single flat price applies for the whole sale window.',
 									'fair-events'
 								)}
-								checked={settings.multiple_pricing_periods}
-								onChange={(value) =>
-									setSettings((prev) => ({
-										...prev,
-										multiple_pricing_periods: value,
-									}))
-								}
+								checked={effectiveMultiple}
+								onChange={handleToggleMultiplePeriods}
 							/>
 							<CheckboxControl
 								label={__(
@@ -2432,6 +2425,22 @@ export default function EventTickets({
 					</PanelBody>
 				</Panel>
 			</Card>
+			<ConfirmDialog
+				isOpen={mergePeriodsDialogOpen}
+				onConfirm={mergeToSinglePeriod}
+				onCancel={() => setMergePeriodsDialogOpen(false)}
+				confirmButtonText={__('Merge periods', 'fair-events')}
+				cancelButtonText={__('Cancel', 'fair-events')}
+			>
+				{sprintf(
+					/* translators: %d: number of sale periods being merged */
+					__(
+						'Merge to one sale window? Prices for the other %d periods will be discarded.',
+						'fair-events'
+					),
+					Math.max(salePeriods.length - 1, 0)
+				)}
+			</ConfirmDialog>
 			{showScopeModal && (
 				<Modal
 					title={__('Choose ticket scope', 'fair-events')}

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -663,3 +663,137 @@ describe('EventTickets — editable table renders without expanding a panel (#98
 		expect(screen.getByDisplayValue('General')).toBeInTheDocument();
 	});
 });
+
+describe('EventTickets — single pricing period by default (#1138)', () => {
+	const originalManageEventData = window.fairEventsManageEventData;
+
+	afterEach(() => {
+		window.fairEventsManageEventData = originalManageEventData;
+	});
+
+	const initialDataWithOnePeriod = {
+		...initialDataWithTicketType,
+		sale_periods: [
+			{
+				id: 501,
+				name: '',
+				sale_start: '2026-01-01',
+				sale_end: '2026-02-01',
+			},
+		],
+		prices: [
+			{
+				ticket_type_id: 1,
+				sale_period_id: 501,
+				price: '12',
+			},
+		],
+	};
+
+	const initialDataWithTwoPeriods = {
+		...initialDataWithTicketType,
+		sale_periods: [
+			{
+				id: 601,
+				name: 'Advance ticket',
+				sale_start: '2026-01-01',
+				sale_end: '2026-01-15',
+			},
+			{
+				id: 602,
+				name: 'Day of event',
+				sale_start: '2026-01-15',
+				sale_end: '2026-02-01',
+			},
+		],
+		prices: [
+			{ ticket_type_id: 1, sale_period_id: 601, price: '20' },
+			{ ticket_type_id: 1, sale_period_id: 602, price: '5' },
+		],
+		settings: { multiple_pricing_periods: false },
+	};
+
+	it('adding the first ticket type seeds exactly one sale period and shows a single Price column with no Available checkbox', () => {
+		window.fairEventsManageEventData = { siteToday: '2026-07-15' };
+		renderTickets({
+			initialData: emptyInitialData,
+			startDatetime: '2026-08-01 10:00:00',
+			endDatetime: '2026-08-01 12:00:00',
+		});
+
+		fireEvent.click(
+			screen.getByRole('button', { name: '+ Add Ticket Type' })
+		);
+
+		expect(
+			screen.getAllByRole('columnheader', { name: 'Price' })
+		).toHaveLength(1);
+		expect(screen.queryByText('Available')).not.toBeInTheDocument();
+	});
+
+	it('a seeded sale window for a past-dated event is never inverted', () => {
+		window.fairEventsManageEventData = { siteToday: '2026-07-15' };
+		renderTickets({
+			initialData: emptyInitialData,
+			startDatetime: '2020-01-01 10:00:00',
+			endDatetime: '2020-01-01 12:00:00',
+		});
+
+		fireEvent.click(
+			screen.getByRole('button', { name: '+ Add Ticket Type' })
+		);
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		const fromInput = screen.getByLabelText('From');
+		const untilInput = screen.getByLabelText('Until');
+		expect(fromInput.value <= untilInput.value).toBe(true);
+		expect(fromInput.value).toBe('2020-01-01');
+	});
+
+	it('turning on "Multiple pricing periods" splits the window into Advance ticket / Day of event and migrates the price', () => {
+		renderTickets({
+			initialData: initialDataWithOnePeriod,
+			startDatetime: '2026-01-10 10:00:00',
+			endDatetime: '2026-02-01 12:00:00',
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		fireEvent.click(
+			screen.getByRole('checkbox', {
+				name: /Multiple pricing periods/i,
+			})
+		);
+
+		expect(screen.getByText('Advance ticket')).toBeInTheDocument();
+		expect(screen.getByText('Day of event')).toBeInTheDocument();
+		expect(screen.getByDisplayValue('12')).toBeInTheDocument();
+	});
+
+	it('turning off "Multiple pricing periods" with several periods asks for confirmation before merging', () => {
+		renderTickets({ initialData: initialDataWithTwoPeriods });
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		fireEvent.click(
+			screen.getByRole('checkbox', {
+				name: /Multiple pricing periods/i,
+			})
+		);
+
+		expect(
+			screen.getByText(/Merge to one sale window/i)
+		).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Merge periods' }));
+
+		expect(screen.queryByText('Advance ticket')).not.toBeInTheDocument();
+		expect(screen.queryByText('Day of event')).not.toBeInTheDocument();
+		expect(screen.getByDisplayValue('20')).toBeInTheDocument();
+	});
+
+	it('an event loaded with two stored periods renders in multi-period mode regardless of the stored toggle', () => {
+		renderTickets({ initialData: initialDataWithTwoPeriods });
+
+		expect(screen.getByText('Advance ticket')).toBeInTheDocument();
+		expect(screen.getByText('Day of event')).toBeInTheDocument();
+	});
+});

--- a/fair-events/src/Models/EventDateSetting.php
+++ b/fair-events/src/Models/EventDateSetting.php
@@ -66,8 +66,6 @@ class EventDateSetting {
 	 * Settings at their default value do not need a DB row.
 	 */
 	const DEFAULTS = array(
-		'continues_pricing_period'            => '1',
-		'unlimited_tickets_in_price_period'   => '1',
 		'show_ticket_type_capacity'           => '0',
 		'multiple_pricing_periods'            => '0',
 		'activity_collaborator_discount'      => '0',

--- a/fair-events/src/Services/TicketPricing.php
+++ b/fair-events/src/Services/TicketPricing.php
@@ -7,7 +7,6 @@
 
 namespace FairEvents\Services;
 
-use FairEvents\Models\EventDateSetting;
 use FairEvents\Models\TicketPrice;
 use FairEvents\Models\TicketSalePeriod;
 use FairEvents\Models\TicketType;
@@ -28,9 +27,8 @@ class TicketPricing {
 	 * timezone: sale_start is the first day on sale (00:00:00 site time) and
 	 * sale_end is the first day no longer on sale (00:00:00 site time).
 	 *
-	 * When no period matches and the per-event-date `continues_pricing_period`
-	 * setting is on, falls back to the last period whose start is already in
-	 * the past.
+	 * Sale periods always chain: when no period matches, falls back to the
+	 * last period whose start is already in the past.
 	 *
 	 * @param int $event_date_id Event date ID.
 	 * @return TicketSalePeriod|null Active period or null.
@@ -39,10 +37,7 @@ class TicketPricing {
 		$now          = current_time( 'mysql' );
 		$sale_periods = TicketSalePeriod::get_all_by_event_date_id( $event_date_id );
 
-		$continues = class_exists( EventDateSetting::class )
-			&& '1' === EventDateSetting::get( $event_date_id, 'continues_pricing_period' );
-
-		return self::pick_active_period( $sale_periods, $now, $continues );
+		return self::pick_active_period( $sale_periods, $now, true );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Ticket setup now seeds exactly **one** sale period by default (instead of always seeding two, "Advance ticket" and "Day of event", even when Multiple pricing periods was off). Single-period mode shows one plain "Price" column with no "Available" checkbox.
- Sale periods always chain (each period's start is implied by the previous period's end) — the "Chain sale periods together" option is gone, along with "No ticket limit per sale period" and its per-cell Cap input, since nothing enforced per-period caps at signup anyway.
- Turning "Multiple pricing periods" on splits the single window at the event's first day into editable "Advance ticket" / "Day of event" periods, migrating the existing price to the first one.
- Turning it off with several periods defined asks for confirmation (`ConfirmDialog`) before merging back to one window, keeping the first period's prices.
- An event loaded with more than one stored sale period always renders in multi-period mode, regardless of its stored toggle, so no configured period is hidden.
- Backend: `TicketPricing::resolve_active_sale_period` always chains now; the two retired settings (`continues_pricing_period`, `unlimited_tickets_in_price_period`) are dropped from `EventDateSetting::DEFAULTS`, so they're ignored on read and no longer written — older events aren't affected.
- Mirrored the checkbox/Cap-input removal in the `fair-events-experimental` copy (used only by the Duplicate wizard) so it stops writing the retired settings, without touching its distinct simple/advanced/sliding-scale model.

Closes #1138

## Test plan

- [x] `npm run test:js` in `fair-events` — 106 tests pass, including 5 new component tests covering: single seeded period + single Price column with no Available checkbox, past-dated seed not inverted, toggle-on split + price migration, toggle-off confirmation + merge, and multi-mode rendering for events loaded with 2 stored periods.
- [x] `vendor/bin/phpunit __tests__/Services/TicketPricingTest.php` — 8 tests pass.
- [x] `vendor/bin/phpcs` clean on the changed PHP files.
- [x] `npm run build` in `fair-events` and `fair-events-experimental`.
- [ ] New Playwright API tests added to `TicketsController.api.spec.js` (save/load round-trip drops retired settings; import with retired fields succeeds and drops them) — not run here, requires a live WP instance (`npm run test:api`).
