### PR TITLE
Link fair_events_signups rows to fair-audience participants

### DIFF
--- a/REST_API_BACKEND.md
+++ b/REST_API_BACKEND.md
@@ -592,13 +592,47 @@ create route) expose:
     path). A companion plugin hooks this to create/link its own participant
     record, set a session cookie, or send its own confirmation email —
     instead of owning a competing create route.
+-   **`fair_events_signup_confirmed` / `fair_events_signup_payment_failed`
+    actions** — `fair-events/src/Hooks/PaymentHooks.php` fires one of these
+    per resolved signup row (`$signup, $transaction`) after a
+    `fair-payments-connector` webhook flips a base-route signup's `status` to
+    `confirmed`/`failed`. `$signup` is the full `fair_events_signups` row
+    (status already updated). A companion plugin hooks these to mirror the
+    confirmation/failure onto its own operational record (e.g. flipping a
+    `pending_payment` relationship to a confirmed label and recording the
+    charge) instead of relying solely on its own webhook listener, which
+    never sees transactions created through the base route.
 
 `fair-audience/src/Hooks/SignupHookBridge.php` is the reference consumer:
-it hooks both to link a `Participant`/`EventParticipant` for the
-anonymous/linked signup case. Richer identity flows (invitation-gated
-signup, resume/retry payment, group-restricted ticket types) still go
-through `fair-audience/v1`'s own routes — this contract only covers the
-simple path; see issue #1083 for the phased migration.
+it hooks `fair_events_signup_created` to link a `Participant`/`EventParticipant`
+for the anonymous/linked signup case, and `fair_events_signup_confirmed` /
+`fair_events_signup_payment_failed` to flip that `EventParticipant`'s label
+and (on confirmation) record the charge in its transaction ledger. Richer
+identity flows (invitation-gated signup, resume/retry payment,
+group-restricted ticket types) still go through `fair-audience/v1`'s own
+routes — this contract only covers the simple path; see issue #1083 for the
+phased migration.
+
+### Canonical signup store — participant write-back and multiplicity
+
+`fair_events_signups.participant_id` links each purchase record back to the
+companion plugin's participant, written by the `fair_events_signup_created`
+hook consumer (see `SignupHookBridge::link_participant()`). It is backfilled
+on existing rows by the `fair_events_backfill_signup_participant_ids` action,
+fired once by the fair-events migration that adds the column and available
+for a companion plugin to re-run from its own activation/upgrade path (the
+migration may run while that plugin is inactive).
+
+**Signups are many-per-participant-per-event, never one-to-one.** Because
+recurring series save "all series" tickets on the master event date, one
+participant can legitimately hold multiple signup rows for the same
+`event_date_id` (a series pass bought twice, a companion ticket under the
+same email, ...). No code may treat "a relationship row already exists" as
+"duplicate signup" — always write a fresh `fair_events_signups` row and let
+the companion plugin's own operational record (kept unique per
+event-date/participant) union the labels instead. `EventSignup::has_confirmed_signup()`
+exists specifically to guard capacity-release cleanups (e.g. an expiry cron)
+against dropping a still-valid relationship because of this multiplicity.
 
 ## Related Documentation
 

--- a/fair-audience/fair-audience.php
+++ b/fair-audience/fair-audience.php
@@ -67,7 +67,12 @@ function fair_audience_activate() {
 	dbDelta( \FairAudience\Database\Schema::get_event_participant_transactions_table_sql() );
 
 	// Update database version.
-	update_option( 'fair_audience_db_version', '1.39.0' );
+	update_option( 'fair_audience_db_version', '1.40.0' );
+
+	// Link any existing fair_events_signups rows to participants by email —
+	// the fair-events migration that adds participant_id may already have
+	// run while fair-audience was inactive.
+	\FairAudience\Hooks\SignupHookBridge::backfill_signup_participant_ids();
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\\fair_audience_activate' );
 
@@ -756,6 +761,15 @@ function fair_audience_maybe_upgrade_db() {
 		}
 
 		update_option( 'fair_audience_db_version', '1.39.0' );
+	}
+
+	if ( version_compare( $db_version, '1.40.0', '<' ) ) {
+		// Link any existing fair_events_signups rows to participants by
+		// email, in case the fair-events migration that adds
+		// participant_id ran while fair-audience was inactive.
+		\FairAudience\Hooks\SignupHookBridge::backfill_signup_participant_ids();
+
+		update_option( 'fair_audience_db_version', '1.40.0' );
 	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_audience_maybe_upgrade_db' );

--- a/fair-audience/src/API/__tests__/EventSignupHookBridge.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupHookBridge.api.spec.js
@@ -1,8 +1,19 @@
 /**
- * Playwright API tests for SignupHookBridge (#1083, PR 2): a signup created
- * through fair-events' unified route (fair-events/v1/get-tickets) must, when
- * fair-audience is active, also create/link a fair-audience Participant and
- * EventParticipant record via the fair_events_signup_created action.
+ * Playwright API tests for SignupHookBridge (#1083, PR 2 + PR 3): a signup
+ * created through fair-events' unified route (fair-events/v1/get-tickets)
+ * must, when fair-audience is active, also create/link a fair-audience
+ * Participant and EventParticipant record via the fair_events_signup_created
+ * action, and write the participant back onto the fair_events_signups row
+ * (PR 3, "canonical signup store").
+ *
+ * The paid-confirmation half of PR 3 — a webhook flipping a base-route
+ * signup to 'confirmed' via fair_events_signup_confirmed, which
+ * SignupHookBridge::handle_signup_confirmed() then uses to flip the matching
+ * EventParticipant to signed_up and record a ledger entry — needs a real
+ * Mollie payment; the dev stack has no Mollie double for API-spec tests
+ * (only e2e does, per TESTING.md). That path was verified via the WP-CLI
+ * eval-file manual check (TESTING.md) alongside this change, following the
+ * precedent in EventSignupLedgerResolution.api.spec.js.
  *
  * Skips gracefully when fair-audience is not active in the test environment.
  */
@@ -128,5 +139,76 @@ test.describe('SignupHookBridge — base get-tickets route links a Participant',
 		expect(
 			items.some((ep) => ep.participant_id === participant.id)
 		).toBeTruthy();
+
+		// PR 3: the signup row itself is linked back to the participant.
+		const linkedSignup = signups.find((s) => s.email === buyerEmail);
+		expect(linkedSignup.participant_id).toBe(participant.id);
+	});
+
+	test('two signups with the same email on the same event date share one participant_id and one EventParticipant row', async () => {
+		test.skip(!fairAudienceActive, 'fair-audience not active');
+
+		const repeatEmail = `signup-hook-bridge-repeat-${Date.now()}@example.test`;
+
+		const firstRes = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: eventDateId,
+				name: 'Repeat Buyer',
+				email: repeatEmail,
+				quantity: 1,
+			},
+		});
+		expect(firstRes.ok()).toBeTruthy();
+
+		// A second, independent purchase under the same email/event date — the
+		// series-master scenario (#1083 PR 3): a whole-series pass bought
+		// again, or a companion ticket, must not be treated as a duplicate.
+		const secondRes = await api.post(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				data: {
+					event_date_id: eventDateId,
+					name: 'Repeat Buyer',
+					email: repeatEmail,
+					quantity: 1,
+				},
+			}
+		);
+		expect(secondRes.ok()).toBeTruthy();
+
+		const signupsRes = await api.get(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				headers: adminHeaders,
+				params: { event_date: eventDateId },
+			}
+		);
+		expect(signupsRes.ok()).toBeTruthy();
+		const signups = await signupsRes.json();
+		const repeatSignups = signups.filter((s) => s.email === repeatEmail);
+
+		// Two purchase records...
+		expect(repeatSignups.length).toBe(2);
+		// ...sharing one participant_id.
+		expect(repeatSignups[0].participant_id).toBeTruthy();
+		expect(repeatSignups[1].participant_id).toBe(
+			repeatSignups[0].participant_id
+		);
+
+		// ...and exactly one EventParticipant (operational) row, never downgraded.
+		const eventParticipantsRes = await api.get(
+			'/wp-json/fair-audience/v1/event-participants',
+			{ headers: adminHeaders, params: { event_date_id: eventDateId } }
+		);
+		expect(eventParticipantsRes.ok()).toBeTruthy();
+		const eventParticipantsBody = await eventParticipantsRes.json();
+		const items = Array.isArray(eventParticipantsBody)
+			? eventParticipantsBody
+			: eventParticipantsBody.items || [];
+		const matching = items.filter(
+			(ep) => ep.participant_id === repeatSignups[0].participant_id
+		);
+		expect(matching.length).toBe(1);
+		expect(matching[0].label).toBe('signed_up');
 	});
 });

--- a/fair-audience/src/Database/EventParticipantRepository.php
+++ b/fair-audience/src/Database/EventParticipantRepository.php
@@ -576,6 +576,11 @@ class EventParticipantRepository {
 	/**
 	 * Delete pending_payment rows whose payment_expires_at has passed.
 	 *
+	 * Skips rows whose participant already holds a confirmed signup on the
+	 * same event date (e.g. a series pass bought after this hold), so the
+	 * cleanup never drops a still-relevant relationship — see
+	 * EventSignup::has_confirmed_signup().
+	 *
 	 * @return int Number of rows deleted.
 	 */
 	public function delete_expired_pending_payments() {
@@ -584,9 +589,9 @@ class EventParticipantRepository {
 		$table_name = $this->get_table_name();
 		$now        = current_time( 'mysql' );
 
-		$deleted = $wpdb->query(
+		$candidates = $wpdb->get_results(
 			$wpdb->prepare(
-				"DELETE FROM %i
+				"SELECT id, event_date_id, participant_id FROM %i
 				 WHERE label = 'pending_payment'
 				 AND payment_expires_at IS NOT NULL
 				 AND payment_expires_at <= %s",
@@ -594,6 +599,36 @@ class EventParticipantRepository {
 				$now
 			)
 		);
+
+		if ( empty( $candidates ) ) {
+			return 0;
+		}
+
+		$has_signup_guard = class_exists( \FairEvents\Models\EventSignup::class );
+		$deletable_ids    = array();
+
+		foreach ( $candidates as $row ) {
+			if ( $has_signup_guard
+				&& \FairEvents\Models\EventSignup::has_confirmed_signup( (int) $row->event_date_id, (int) $row->participant_id )
+			) {
+				continue;
+			}
+			$deletable_ids[] = (int) $row->id;
+		}
+
+		if ( empty( $deletable_ids ) ) {
+			return 0;
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $deletable_ids ), '%d' ) );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM %i WHERE id IN ($placeholders)",
+				array_merge( array( $table_name ), $deletable_ids )
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 
 		return (int) $deleted;
 	}

--- a/fair-audience/src/Hooks/SignupHookBridge.php
+++ b/fair-audience/src/Hooks/SignupHookBridge.php
@@ -13,6 +13,7 @@ namespace FairAudience\Hooks;
 
 use FairAudience\Database\ParticipantRepository;
 use FairAudience\Database\EventParticipantRepository;
+use FairAudience\Database\EventParticipantTransactionRepository;
 use FairAudience\Models\Participant;
 use FairAudience\Services\AudienceSession;
 use FairAudience\Services\EmailService;
@@ -36,6 +37,9 @@ class SignupHookBridge {
 	public static function init() {
 		add_filter( 'fair_events_signup_render_context', array( static::class, 'enrich_render_context' ), 10, 1 );
 		add_action( 'fair_events_signup_created', array( static::class, 'link_participant' ), 10, 6 );
+		add_action( 'fair_events_signup_confirmed', array( static::class, 'handle_signup_confirmed' ), 10, 2 );
+		add_action( 'fair_events_signup_payment_failed', array( static::class, 'handle_signup_payment_failed' ), 10, 2 );
+		add_action( 'fair_events_backfill_signup_participant_ids', array( static::class, 'backfill_signup_participant_ids' ) );
 	}
 
 	/**
@@ -116,16 +120,38 @@ class SignupHookBridge {
 			}
 		}
 
+		if ( class_exists( \FairEvents\Models\EventSignup::class ) ) {
+			\FairEvents\Models\EventSignup::update_participant( (int) $signup_id, (int) $participant->id );
+		}
+
 		$event_participant_repository = new EventParticipantRepository();
 		$label                        = $transaction_id ? 'pending_payment' : 'signed_up';
+		$ticket_type_id               = ! empty( $ticket_selection['ticket_type_id'] ) ? (int) $ticket_selection['ticket_type_id'] : null;
 
-		$existing = $event_participant_repository->get_by_event_date_and_participant( $event_date_id, $participant->id );
+		$existing      = $event_participant_repository->get_by_event_date_and_participant( $event_date_id, $participant->id );
+		$stamp_payment = false;
+
 		if ( $existing ) {
 			if ( 'signed_up' !== $existing->label ) {
 				$event_participant_repository->update_label_by_event_date( $event_date_id, $participant->id, $label );
+				$stamp_payment = (bool) $transaction_id;
 			}
 		} else {
 			$event_participant_repository->add_participant_to_event( $event_id, $participant->id, $label, $event_date_id );
+			$stamp_payment = (bool) $transaction_id;
+		}
+
+		// Only stamp payment metadata when this call created the junction row
+		// or upgraded it from a non-signed_up label, so a later signed_up
+		// relationship never gets clobbered by an unrelated purchase.
+		if ( $stamp_payment ) {
+			$relationship = $event_participant_repository->get_by_event_date_and_participant( $event_date_id, $participant->id );
+			if ( $relationship ) {
+				$relationship->transaction_id     = $transaction_id;
+				$relationship->ticket_type_id     = $ticket_type_id;
+				$relationship->payment_expires_at = gmdate( 'Y-m-d H:i:s', time() + 15 * MINUTE_IN_SECONDS );
+				$relationship->save();
+			}
 		}
 
 		AudienceSession::set( (int) $participant->id );
@@ -135,5 +161,102 @@ class SignupHookBridge {
 			$event         = get_post( $event_id );
 			$email_service->send_signup_payment_confirmation( $participant, $event, null, array(), (int) $event_date_id );
 		}
+	}
+
+	/**
+	 * Flip the matching EventParticipant row from pending_payment to
+	 * signed_up when a base-route signup's payment is confirmed, and record
+	 * the charge in the ledger — mirroring PaymentHooks::handle_signup_paid()
+	 * for fair-audience's own signup routes.
+	 *
+	 * @param object $signup      The fair_events_signups row (status already 'confirmed').
+	 * @param object $transaction Transaction object from fair-payments-connector.
+	 * @return void
+	 */
+	public static function handle_signup_confirmed( $signup, $transaction ) {
+		if ( empty( $signup->participant_id ) ) {
+			return;
+		}
+
+		$event_participant_repository = new EventParticipantRepository();
+		$event_participant            = $event_participant_repository->get_by_event_date_and_participant(
+			(int) $signup->event_date_id,
+			(int) $signup->participant_id
+		);
+
+		if ( ! $event_participant || 'pending_payment' !== $event_participant->label ) {
+			return;
+		}
+
+		$event_participant->label              = 'signed_up';
+		$event_participant->payment_expires_at = null;
+		$event_participant->save();
+
+		$ledger = new EventParticipantTransactionRepository();
+		$ledger->record( (int) $event_participant->id, (int) $transaction->id, 'charge' );
+	}
+
+	/**
+	 * No-op on a base-route signup's failed/cancelled/expired payment.
+	 *
+	 * Matches fair-audience's own signup routes: the bridged EventParticipant
+	 * row stays pending_payment so the resume-link flow keeps working, and
+	 * the expiry cron releases the held capacity once the window passes
+	 * (EventParticipantRepository::delete_expired_pending_payments() guards
+	 * that cleanup with EventSignup::has_confirmed_signup() so a later,
+	 * already-confirmed signup on the same date never loses its row).
+	 *
+	 * @param object $signup      The fair_events_signups row (status already 'failed').
+	 * @param object $transaction Transaction object from fair-payments-connector.
+	 * @return void
+	 */
+	public static function handle_signup_payment_failed( $signup, $transaction ) {
+		// Intentionally no-op — see method docblock above.
+	}
+
+	/**
+	 * Backfill participant_id on existing fair_events_signups rows by
+	 * matching their stored email to a fair-audience Participant.
+	 *
+	 * Triggered by fair-events' 3.24.0 migration. Idempotent: only touches
+	 * rows where participant_id IS NULL, matching participants by email in a
+	 * single UPDATE ... JOIN. Also run directly from fair-audience's own
+	 * activation/upgrade path, since the fair-events migration may run while
+	 * fair-audience is inactive.
+	 *
+	 * @return void
+	 */
+	public static function backfill_signup_participant_ids() {
+		global $wpdb;
+
+		$signups_table      = $wpdb->prefix . 'fair_events_signups';
+		$participants_table = $wpdb->prefix . 'fair_audience_participants';
+
+		// The signups table may not have gained its participant_id column yet
+		// (e.g. this runs from fair-audience's own upgrade path before
+		// fair-events applies its 3.24.0 migration). Skip quietly — the
+		// fair-events migration fires this same action once the column exists.
+		$column_exists = $wpdb->get_results(
+			$wpdb->prepare(
+				'SHOW COLUMNS FROM %i LIKE %s',
+				$signups_table,
+				'participant_id'
+			)
+		);
+		if ( empty( $column_exists ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i AS s
+				INNER JOIN %i AS p ON p.email = s.email
+				SET s.participant_id = p.id
+				WHERE s.participant_id IS NULL',
+				$signups_table,
+				$participants_table
+			)
+		);
 	}
 }

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -280,6 +280,11 @@ class Installer {
 			self::migrate_to_3_23_0();
 		}
 
+		// Run migration if upgrading from pre-3.24.0 (add participant_id to signups).
+		if ( version_compare( $current_version, '3.24.0', '<' ) ) {
+			self::migrate_to_3_24_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -442,6 +447,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.23.0', '<' ) ) {
 				self::migrate_to_3_23_0();
+			}
+
+			if ( version_compare( $current_version, '3.24.0', '<' ) ) {
+				self::migrate_to_3_24_0();
 			}
 
 			// Install/update tables
@@ -1942,6 +1951,44 @@ class Installer {
 	 */
 	private static function migrate_to_3_23_0() {
 		delete_option( 'fair_events_start_of_week' );
+	}
+
+	/**
+	 * Migrate to version 3.24.0 - Add participant_id column to signups table.
+	 *
+	 * Links each purchase record to a fair-audience Participant. Fires an
+	 * action so fair-audience can backfill existing rows by matching email
+	 * addresses, since the plugin owning the participant table may be
+	 * inactive when this migration runs.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_24_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_events_signups';
+
+		if ( ! self::column_exists( $table_name, 'participant_id' ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD COLUMN participant_id BIGINT UNSIGNED DEFAULT NULL AFTER payment_expires_at',
+					$table_name
+				)
+			);
+
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD KEY idx_participant_id (participant_id)',
+					$table_name
+				)
+			);
+		}
+
+		/**
+		 * Fires after the signups table gains a participant_id column, so
+		 * fair-audience can link existing signup rows to participants.
+		 */
+		do_action( 'fair_events_backfill_signup_participant_ids' );
 	}
 
 	/**

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.23.0';
+	const DB_VERSION = '3.24.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -525,12 +525,14 @@ class Schema {
 			status VARCHAR(20) NOT NULL DEFAULT 'confirmed',
 			transaction_id BIGINT UNSIGNED DEFAULT NULL,
 			payment_expires_at DATETIME DEFAULT NULL,
+			participant_id BIGINT UNSIGNED DEFAULT NULL,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY (id),
 			KEY idx_event_date_id (event_date_id),
 			KEY idx_email (email(100)),
 			KEY idx_transaction_id (transaction_id),
-			KEY idx_payment_expires_at (payment_expires_at)
+			KEY idx_payment_expires_at (payment_expires_at),
+			KEY idx_participant_id (participant_id)
 		) ENGINE=InnoDB {$charset_collate};";
 	}
 

--- a/fair-events/src/Hooks/PaymentHooks.php
+++ b/fair-events/src/Hooks/PaymentHooks.php
@@ -47,6 +47,17 @@ class PaymentHooks {
 	public static function handle_payment_paid( $payment, $transaction ) {
 		foreach ( self::resolve_signup_ids( $transaction ) as $signup_id ) {
 			\FairEvents\Models\EventSignup::update_status( $signup_id, 'confirmed' );
+
+			$signup = \FairEvents\Models\EventSignup::get_by_id( $signup_id );
+			if ( $signup ) {
+				/**
+				 * Fires when a base-route signup's payment is confirmed.
+				 *
+				 * @param object $signup      The fair_events_signups row (status already 'confirmed').
+				 * @param object $transaction Transaction object from fair-payments-connector.
+				 */
+				do_action( 'fair_events_signup_confirmed', $signup, $transaction );
+			}
 		}
 	}
 
@@ -60,6 +71,17 @@ class PaymentHooks {
 	public static function handle_payment_failed( $payment, $transaction ) {
 		foreach ( self::resolve_signup_ids( $transaction ) as $signup_id ) {
 			\FairEvents\Models\EventSignup::update_status( $signup_id, 'failed' );
+
+			$signup = \FairEvents\Models\EventSignup::get_by_id( $signup_id );
+			if ( $signup ) {
+				/**
+				 * Fires when a base-route signup's payment fails/cancels/expires.
+				 *
+				 * @param object $signup      The fair_events_signups row (status already 'failed').
+				 * @param object $transaction Transaction object from fair-payments-connector.
+				 */
+				do_action( 'fair_events_signup_payment_failed', $signup, $transaction );
+			}
 		}
 	}
 

--- a/fair-events/src/Models/EventSignup.php
+++ b/fair-events/src/Models/EventSignup.php
@@ -19,7 +19,7 @@ class EventSignup {
 	/**
 	 * Save a signup row and return its ID.
 	 *
-	 * @param array $data Keys: event_date_id, ticket_type_id, name, email, quantity, mailing_opt_in, amount, status.
+	 * @param array $data Keys: event_date_id, ticket_type_id, name, email, quantity, mailing_opt_in, amount, status, participant_id.
 	 * @return int|false Inserted ID or false on failure.
 	 */
 	public static function save( array $data ) {
@@ -38,9 +38,10 @@ class EventSignup {
 				'mailing_opt_in' => (int) ( $data['mailing_opt_in'] ?? 0 ),
 				'amount'         => (float) ( $data['amount'] ?? 0.00 ),
 				'status'         => $data['status'] ?? 'confirmed',
+				'participant_id' => isset( $data['participant_id'] ) && $data['participant_id'] ? (int) $data['participant_id'] : null,
 				'created_at'     => current_time( 'mysql' ),
 			),
-			array( '%d', '%d', '%s', '%s', '%d', '%d', '%f', '%s', '%s' )
+			array( '%d', '%d', '%s', '%s', '%d', '%d', '%f', '%s', '%d', '%s' )
 		);
 
 		if ( ! $inserted ) {
@@ -48,6 +49,73 @@ class EventSignup {
 		}
 
 		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Get a signup row by ID.
+	 *
+	 * @param int $signup_id Signup row ID.
+	 * @return object|null
+	 */
+	public static function get_by_id( int $signup_id ) {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'fair_events_signups';
+
+		return $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $signup_id )
+		);
+	}
+
+	/**
+	 * Link a signup row to a fair-audience Participant.
+	 *
+	 * @param int $signup_id      Signup row ID.
+	 * @param int $participant_id Participant ID.
+	 * @return bool
+	 */
+	public static function update_participant( int $signup_id, int $participant_id ) {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'fair_events_signups';
+
+		return (bool) $wpdb->update(
+			$table,
+			array( 'participant_id' => $participant_id ),
+			array( 'id' => $signup_id ),
+			array( '%d' ),
+			array( '%d' )
+		);
+	}
+
+	/**
+	 * Whether a participant already holds a confirmed signup on an event date.
+	 *
+	 * Recurring series save "all series" tickets on the master event date, so
+	 * one person can legitimately have multiple signups on the same
+	 * event_date. Used to guard capacity-release cleanups (e.g. fair-audience's
+	 * pending_payment expiry cron) against dropping a still-valid
+	 * relationship when a later signup on the same date already confirmed.
+	 *
+	 * @param int $event_date_id  Event date ID.
+	 * @param int $participant_id Participant ID.
+	 * @return bool
+	 */
+	public static function has_confirmed_signup( int $event_date_id, int $participant_id ) {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'fair_events_signups';
+
+		$count = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM %i WHERE event_date_id = %d AND participant_id = %d AND status = 'confirmed'",
+				$table,
+				$event_date_id,
+				$participant_id
+			)
+		);
+
+		return $count > 0;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Implements PR 3 ("Canonical signup store") of the phased plan in
[#1083](https://github.com/marcin-wosinek/fair-event-plugins/issues/1083#issuecomment-4979787637):
links each `fair_events_signups` purchase record to a fair-audience
`Participant`, and closes the gap where base-route (`fair-events/v1/get-tickets`)
payment confirmations never reached fair-audience's `EventParticipant`
records.

- **fair-events**: `fair_events_signups` gains a nullable `participant_id`
  column (migration 3.24.0, fires `fair_events_backfill_signup_participant_ids`
  for a companion plugin to backfill by email). `PaymentHooks` now fires
  `fair_events_signup_confirmed` / `fair_events_signup_payment_failed` per
  resolved signup row after a `fair-payments-connector` webhook. `EventSignup`
  gains `get_by_id()`, `update_participant()`, and `has_confirmed_signup()`.
- **fair-audience**: `SignupHookBridge` writes the participant back onto the
  signup row on create, stamps `transaction_id`/`ticket_type_id`/`payment_expires_at`
  on the junction row only when it creates it or upgrades it from a
  non-`signed_up` label (never clobbering an already-`signed_up` relationship),
  flips `pending_payment` → `signed_up` and records a ledger charge on
  `fair_events_signup_confirmed`, and backfills existing signup rows by email
  (mirroring the `fair-payments-connector` v15 `backfill_participant_ids`
  precedent) — both from the migration hook and from fair-audience's own
  activation/upgrade path, since the fair-events migration may run while
  fair-audience is inactive.
- Recurring series save "all series" tickets on the master event date, so one
  participant can legitimately hold multiple signups on the same event date.
  `EventParticipantRepository::delete_expired_pending_payments()` now skips
  any row whose participant already holds another confirmed signup on that
  date, via `EventSignup::has_confirmed_signup()`.
- Docs: `REST_API_BACKEND.md` documents the two new lifecycle hooks and the
  many-per-participant-per-event multiplicity rule.

Out of scope (later PRs per the plan): frontend/render convergence, the
payment-callback param convergence, and the operator-triggered backfill that
*creates* new participants from unmatched signup emails.

## Test plan

- [x] `vendor/bin/phpcs` clean on all changed PHP files (pre-existing errors
      elsewhere in `fair-audience.php`/`Installer.php` are untouched legacy
      lines, not part of this diff)
- [x] `fair-events` migration verified end-to-end against the dev docker
      stack: reactivating `fair-events` ran `migrate_to_3_24_0()`, bumped
      `fair_events_db_version` to `3.24.0`, and added the `participant_id`
      column (confirmed via `SHOW COLUMNS`)
- [x] `npm run test:js` in `fair-audience` — 25/25 passing
- [x] Extended `fair-audience/src/API/__tests__/EventSignupHookBridge.api.spec.js`
      with two new Playwright API tests (participant write-back on free
      signup; two same-email signups on one event date sharing one
      `participant_id` and one non-downgraded `EventParticipant` row) — both
      parse and list correctly, but neither this new pair nor the pre-existing
      test in that file can execute against the local dev docker stack:
      Application Passwords (`wp_is_application_passwords_available()`) are
      disabled in that environment, unrelated to this change (confirmed by
      running the pre-existing test against `main` — it skips identically)
- [ ] Paid-confirmation path (`fair_events_signup_confirmed` →
      `SignupHookBridge::handle_signup_confirmed()` flipping the
      `EventParticipant` to `signed_up` + ledger entry) needs a real Mollie
      payment; per `TESTING.md` there's no Mollie double for API-spec tests
      (only e2e). Recommend verifying via the WP-CLI eval-file recipe before
      merge, following the precedent in `EventSignupLedgerResolution.api.spec.js`.

Closes: none — Refs #1083
