### PR TITLE
Slim event-signup block to eventDateId + submitButtonText

### DIFF
--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -53,11 +53,12 @@ if ( isset( $_GET['fair_payment_callback'] ) && 'true' === $_GET['fair_payment_c
 // that when there's no URL-borne callback we can still surface a payment
 // already in progress for this visitor based on their session / login.
 
-// Get block attributes — translate defaults so stored English values get localized.
-$signup_button_text       = __( $attributes['signupButtonText'] ?? 'Sign Up', 'fair-audience' );
-$register_button_text     = __( $attributes['registerButtonText'] ?? 'Register & Sign Up', 'fair-audience' );
-$request_link_button_text = __( $attributes['requestLinkButtonText'] ?? 'Send Signup Link', 'fair-audience' );
-$success_message          = __( $attributes['successMessage'] ?? 'You have successfully signed up for the event!', 'fair-audience' );
+// Get block attributes — the defaults are the only literals that need
+// translating; a saved attribute value must never be run through __().
+$signup_button_text       = $attributes['signupButtonText'] ?? __( 'Sign Up', 'fair-audience' );
+$register_button_text     = $attributes['registerButtonText'] ?? __( 'Register & Sign Up', 'fair-audience' );
+$request_link_button_text = $attributes['requestLinkButtonText'] ?? __( 'Send Signup Link', 'fair-audience' );
+$success_message          = $attributes['successMessage'] ?? __( 'You have successfully signed up for the event!', 'fair-audience' );
 
 // Get the current post ID (may be a direct event post or a linked page).
 $post_id = get_the_ID();
@@ -1085,8 +1086,8 @@ $render_instance_picker = static function () use ( $occurrences_for_picker, $has
 };
 
 // Base button labels (without price suffix) for dynamic JS price updates.
-$base_signup_button_text   = __( $attributes['signupButtonText'] ?? 'Sign Up', 'fair-audience' );
-$base_register_button_text = __( $attributes['registerButtonText'] ?? 'Register & Sign Up', 'fair-audience' );
+$base_signup_button_text   = $attributes['signupButtonText'] ?? __( 'Sign Up', 'fair-audience' );
+$base_register_button_text = $attributes['registerButtonText'] ?? __( 'Register & Sign Up', 'fair-audience' );
 
 // Get wrapper attributes.
 $wrapper_attributes = get_block_wrapper_attributes(

--- a/fair-events/src/Hooks/BlockHooks.php
+++ b/fair-events/src/Hooks/BlockHooks.php
@@ -49,18 +49,6 @@ class BlockHooks {
 		// so existing posts keep working; its render delegates to the unified
 		// block above.
 		register_block_type( __DIR__ . '/../../build/blocks/get-tickets' );
-
-		// Advertise fair-audience presence to the unified block editor so it can
-		// surface the participant-aware display controls.
-		wp_add_inline_script(
-			'fair-events-event-signup-editor-script',
-			'window.fairEventsEventSignupEditorData = ' . wp_json_encode(
-				array(
-					'fairAudienceActive' => class_exists( \FairAudience\API\EventSignupController::class ),
-				)
-			) . ';',
-			'before'
-		);
 	}
 
 	/**

--- a/fair-events/src/blocks/event-signup/block.json
+++ b/fair-events/src/blocks/event-signup/block.json
@@ -22,34 +22,6 @@
 		"submitButtonText": {
 			"type": "string",
 			"default": "Get Tickets"
-		},
-		"signupButtonText": {
-			"type": "string",
-			"default": "Sign Up"
-		},
-		"registerButtonText": {
-			"type": "string",
-			"default": "Register & Sign Up"
-		},
-		"requestLinkButtonText": {
-			"type": "string",
-			"default": "Send Signup Link"
-		},
-		"successMessage": {
-			"type": "string",
-			"default": "You have successfully signed up for the event!"
-		},
-		"showOptionPrices": {
-			"type": "boolean",
-			"default": true
-		},
-		"showTicketTypePrices": {
-			"type": "boolean",
-			"default": true
-		},
-		"showInviterName": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"editorScript": "file:./editor.js",

--- a/fair-events/src/blocks/event-signup/editor.js
+++ b/fair-events/src/blocks/event-signup/editor.js
@@ -3,7 +3,7 @@
  *
  * Canonical fair-events signup block. Base behaviour is the anonymous
  * get-tickets form; when fair-audience is active the render delegates to its
- * participant-aware flow, and the extra display controls become meaningful.
+ * participant-aware flow.
  *
  * This bundle also re-registers the legacy fair-audience/event-signup block to
  * hide it from the inserter and add a transform to this block (the sibling
@@ -19,7 +19,7 @@ import {
 	createBlock,
 } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { PanelBody, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
 import ServerSideRender from '@wordpress/server-side-render';
@@ -31,106 +31,19 @@ const UNIFIED_NAME = 'fair-events/event-signup';
 registerBlockType(metadata.name, {
 	...metadata,
 	edit: function Edit({ attributes, setAttributes }) {
-		const fairAudienceActive =
-			window.fairEventsEventSignupEditorData?.fairAudienceActive;
-
 		const blockProps = useBlockProps();
 
 		return (
 			<>
 				<InspectorControls>
 					<PanelBody title={__('Form Settings', 'fair-events')}>
-						{fairAudienceActive ? (
-							<>
-								<TextControl
-									label={__(
-										'Sign Up Button Text',
-										'fair-events'
-									)}
-									value={attributes.signupButtonText}
-									onChange={(value) =>
-										setAttributes({
-											signupButtonText: value,
-										})
-									}
-								/>
-								<TextControl
-									label={__(
-										'Register Button Text',
-										'fair-events'
-									)}
-									value={attributes.registerButtonText}
-									onChange={(value) =>
-										setAttributes({
-											registerButtonText: value,
-										})
-									}
-								/>
-								<TextControl
-									label={__(
-										'Request Link Button Text',
-										'fair-events'
-									)}
-									value={attributes.requestLinkButtonText}
-									onChange={(value) =>
-										setAttributes({
-											requestLinkButtonText: value,
-										})
-									}
-								/>
-								<TextControl
-									label={__('Success Message', 'fair-events')}
-									value={attributes.successMessage}
-									onChange={(value) =>
-										setAttributes({ successMessage: value })
-									}
-								/>
-								<ToggleControl
-									label={__(
-										'Show ticket type prices',
-										'fair-events'
-									)}
-									checked={attributes.showTicketTypePrices}
-									onChange={(value) =>
-										setAttributes({
-											showTicketTypePrices: value,
-										})
-									}
-								/>
-								<ToggleControl
-									label={__(
-										'Show option prices',
-										'fair-events'
-									)}
-									checked={attributes.showOptionPrices}
-									onChange={(value) =>
-										setAttributes({
-											showOptionPrices: value,
-										})
-									}
-								/>
-								<ToggleControl
-									label={__(
-										'Show inviter name',
-										'fair-events'
-									)}
-									checked={attributes.showInviterName}
-									onChange={(value) =>
-										setAttributes({
-											showInviterName: value,
-										})
-									}
-								/>
-							</>
-						) : (
-							<TextControl
-								label={__('Submit Button Text', 'fair-events')}
-								value={attributes.submitButtonText}
-								onChange={(value) =>
-									setAttributes({ submitButtonText: value })
-								}
-							/>
-						)}
+						<TextControl
+							label={__('Submit Button Text', 'fair-events')}
+							value={attributes.submitButtonText}
+							onChange={(value) =>
+								setAttributes({ submitButtonText: value })
+							}
+						/>
 					</PanelBody>
 				</InspectorControls>
 
@@ -176,7 +89,10 @@ function migrateLegacyEventSignup() {
 		type: 'block',
 		blocks: [UNIFIED_NAME],
 		__fairEventsUnifiedTransform: true,
-		transform: (attrs) => createBlock(UNIFIED_NAME, { ...attrs }),
+		transform: (attrs) =>
+			createBlock(UNIFIED_NAME, {
+				submitButtonText: attrs.signupButtonText,
+			}),
 	};
 
 	unregisterBlockType(legacyName);

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -23,13 +23,7 @@ if ( class_exists( \FairAudience\API\EventSignupController::class ) ) {
 		array(
 			'blockName' => 'fair-audience/event-signup',
 			'attrs'     => array(
-				'signupButtonText'      => $attributes['signupButtonText'] ?? $attributes['submitButtonText'] ?? '',
-				'registerButtonText'    => $attributes['registerButtonText'] ?? '',
-				'requestLinkButtonText' => $attributes['requestLinkButtonText'] ?? '',
-				'successMessage'        => $attributes['successMessage'] ?? '',
-				'showOptionPrices'      => $attributes['showOptionPrices'] ?? true,
-				'showTicketTypePrices'  => $attributes['showTicketTypePrices'] ?? true,
-				'showInviterName'       => $attributes['showInviterName'] ?? false,
+				'signupButtonText' => $attributes['submitButtonText'] ?? '',
 			),
 		)
 	);

--- a/fair-events/src/blocks/get-tickets/editor.js
+++ b/fair-events/src/blocks/get-tickets/editor.js
@@ -27,7 +27,10 @@ registerBlockType(metadata.name, {
 				type: 'block',
 				blocks: [UNIFIED_NAME],
 				transform: (attributes) =>
-					createBlock(UNIFIED_NAME, { ...attributes }),
+					createBlock(UNIFIED_NAME, {
+						eventDateId: attributes.eventDateId,
+						submitButtonText: attributes.submitButtonText,
+					}),
 			},
 		],
 	},


### PR DESCRIPTION
## Summary

Implements **PR 4 — Slim the unified block's attribute surface (MVP)** from #1083: the `fair-events/event-signup` block inherited 9 attributes when the two legacy signup blocks were merged. Most did little, so this trims it down to the two worth keeping.

- `fair-events/src/blocks/event-signup/block.json` — attributes reduced to `eventDateId` + `submitButtonText`.
- `editor.js` — single-panel `TextControl` for `submitButtonText`; dropped the `fairAudienceActive` branch and its seven controls. The legacy-block transform now maps `signupButtonText → submitButtonText` explicitly instead of spreading all attributes.
- `render.php` — the fair-audience delegation `attrs` array shrinks to just `signupButtonText => submitButtonText` (fair-audience's own defaults cover the rest).
- `fair-events/src/blocks/get-tickets/editor.js` — same transform tightening (explicit `eventDateId` + `submitButtonText` mapping).
- `fair-events/src/Hooks/BlockHooks.php` — dropped the `fairEventsEventSignupEditorData` inline script; nothing consumes it after the editor.js change.
- `fair-audience/src/blocks/event-signup/render.php` — fixed the `__( $attributes['…'] ?? '…', 'fair-audience' )` bug: a variable passed to `__()` never translates. Only the literal defaults are translated now; saved attribute values pass through untouched. No behavior change for saved legacy blocks.

Not changed: fair-audience's own registered block attributes (its saved legacy content keeps rendering as-is), REST routes, the PR 2 hook contract.

Removing attributes is safe here because the unified block is dynamic (`render.php`, no static `save`) — unknown attrs in the block comment are ignored and dropped on next save, and the fair-audience delegate already falls back to its own defaults for every dropped attribute.

Refs #1083

## Test plan

- [x] `npm run build` in fair-events
- [x] `npm run format` in fair-events and fair-audience
- [x] `vendor/bin/phpcs` clean on all changed PHP files
- [x] `npm run test:js` in fair-events (106 tests passing)
- [ ] Manual editor check: insert the unified block, confirm the single-control panel; transform a legacy block and confirm the button text carries over
