### PR TITLE
Hide legacy fair-audience/event-signup from block inserter

### DIFF
--- a/fair-audience/src/blocks/event-signup/block.json
+++ b/fair-audience/src/blocks/event-signup/block.json
@@ -3,15 +3,16 @@
 	"apiVersion": 3,
 	"name": "fair-audience/event-signup",
 	"version": "1.0.0",
-	"title": "Event Signup",
+	"title": "Event Signup (legacy)",
 	"category": "widgets",
 	"icon": "groups",
-	"description": "Allow audience members to sign up for events",
+	"description": "Legacy signup block. Superseded by Event Signup (fair-events) — transform instances without custom questions to fair-events/event-signup.",
 	"keywords": ["event", "signup", "register", "rsvp", "audience"],
 	"textdomain": "fair-audience",
 	"supports": {
 		"html": false,
 		"align": ["wide", "full"],
+		"inserter": false,
 		"spacing": {
 			"padding": true,
 			"margin": ["top", "bottom"]

--- a/fair-audience/src/blocks/event-signup/editor.js
+++ b/fair-audience/src/blocks/event-signup/editor.js
@@ -1,7 +1,7 @@
 import './style.css';
 import './editor.css';
 
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockType, createBlock } from '@wordpress/blocks';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
@@ -13,8 +13,11 @@ import {
 	TextControl,
 	TextareaControl,
 	ToggleControl,
+	Notice,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+const UNIFIED_NAME = 'fair-events/event-signup';
 
 // Custom question blocks that can be nested inside the signup form. Mirrors the
 // Fair Form block's set (see fair-form/editor.js) so organizers collect the same
@@ -37,6 +40,22 @@ const ALLOWED_BLOCKS = [
 ];
 
 registerBlockType('fair-audience/event-signup', {
+	transforms: {
+		to: [
+			{
+				type: 'block',
+				blocks: [UNIFIED_NAME],
+				// Instances with custom questions would silently lose them —
+				// only offer the transform when there's nothing to drop.
+				isMatch: (attributes, block) =>
+					!block.innerBlocks || block.innerBlocks.length === 0,
+				transform: (attributes) =>
+					createBlock(UNIFIED_NAME, {
+						submitButtonText: attributes.signupButtonText,
+					}),
+			},
+		],
+	},
 	edit: ({ attributes, setAttributes }) => {
 		const {
 			signupButtonText,
@@ -171,6 +190,12 @@ registerBlockType('fair-audience/event-signup', {
 				</InspectorControls>
 
 				<div {...blockProps}>
+					<Notice status="info" isDismissible={false}>
+						{__(
+							'This block has moved to Event Signup (fair-events). Transform it to the new block.',
+							'fair-audience'
+						)}
+					</Notice>
 					<div className="fair-audience-event-signup-editor-header">
 						<span className="fair-audience-event-signup-editor-label">
 							{__('Event Signup', 'fair-audience')}

--- a/fair-events/src/blocks/event-signup/editor.js
+++ b/fair-events/src/blocks/event-signup/editor.js
@@ -5,23 +5,17 @@
  * get-tickets form; when fair-audience is active the render delegates to its
  * participant-aware flow.
  *
- * This bundle also re-registers the legacy fair-audience/event-signup block to
- * hide it from the inserter and add a transform to this block (the sibling
- * legacy fair-events/get-tickets block handles its own transform).
+ * The legacy fair-audience/event-signup and fair-events/get-tickets blocks
+ * hide themselves from the inserter and register their own transforms to
+ * this block.
  *
  * @package FairEvents
  */
 
-import {
-	registerBlockType,
-	unregisterBlockType,
-	getBlockType,
-	createBlock,
-} from '@wordpress/blocks';
+import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import domReady from '@wordpress/dom-ready';
 import ServerSideRender from '@wordpress/server-side-render';
 import metadata from './block.json';
 import './editor.css';
@@ -56,67 +50,4 @@ registerBlockType(metadata.name, {
 			</>
 		);
 	},
-});
-
-/**
- * Re-register the legacy fair-audience/event-signup block (owned by another
- * plugin) to hide it from the inserter and add a transform to the unified
- * block, mirroring the calendar-button precedent. Only runs when fair-audience
- * is active (otherwise the block isn't registered and this no-ops).
- *
- * @return {boolean} True once handled (or block absent for good).
- */
-function migrateLegacyEventSignup() {
-	const legacyName = 'fair-audience/event-signup';
-	const blockType = getBlockType(legacyName);
-
-	if (!blockType) {
-		// Not registered yet (or fair-audience inactive) — retry a few times.
-		return false;
-	}
-
-	const { name, ...settings } = blockType;
-
-	const existingTo = settings.transforms?.to || [];
-	const alreadyMigrated = existingTo.some(
-		(t) => t.__fairEventsUnifiedTransform === true
-	);
-	if (alreadyMigrated) {
-		return true;
-	}
-
-	const toUnified = {
-		type: 'block',
-		blocks: [UNIFIED_NAME],
-		__fairEventsUnifiedTransform: true,
-		transform: (attrs) =>
-			createBlock(UNIFIED_NAME, {
-				submitButtonText: attrs.signupButtonText,
-			}),
-	};
-
-	unregisterBlockType(legacyName);
-	registerBlockType(legacyName, {
-		...settings,
-		supports: {
-			...settings.supports,
-			inserter: false,
-		},
-		transforms: {
-			...settings.transforms,
-			to: [...existingTo, toUnified],
-		},
-	});
-
-	return true;
-}
-
-domReady(() => {
-	if (!migrateLegacyEventSignup()) {
-		setTimeout(() => {
-			if (!migrateLegacyEventSignup()) {
-				setTimeout(migrateLegacyEventSignup, 500);
-			}
-		}, 100);
-	}
 });


### PR DESCRIPTION
## Summary

- Implements PR 5 from the #1083 discussion (https://github.com/marcin-wosinek/fair-event-plugins/issues/1083#issuecomment-4979945067): the legacy `fair-audience/event-signup` block now deprecates itself in its own `block.json` (`supports.inserter: false`, retitled "Event Signup (legacy)"), instead of relying on the client-side re-registration hack in `fair-events`' editor bundle.
- Removes `migrateLegacyEventSignup()` and the `domReady` retry logic from `fair-events/src/blocks/event-signup/editor.js` — the legacy block owns its own inserter visibility and transform now, matching the `fair-events/get-tickets` precedent.
- Adds a non-dismissible notice to the legacy block's edit UI pointing at the unified block, and registers a guarded `to` transform (`signupButtonText → submitButtonText`) that only offers itself when the instance has no nested custom-question blocks, so those aren't silently dropped.

Refs #1083

## Test plan

- [x] `npm run format` (fair-audience, fair-events)
- [x] `npm run build` (fair-audience, fair-events) — translation catalogs regenerated as part of the build
- [x] `npm run test:js` passes in both fair-audience and fair-events
- [ ] Manual editor check with both plugins active (needs a running WP env): neither legacy block name should appear in the inserter; an existing legacy instance with questions shows the notice and offers no transform; one without questions offers the transform and carries over the button text
- [ ] E2E user-flow suite (`get-tickets-purchase.spec.js`, `resume-signup-recognised-email.spec.js`, `conditional-signup-fields.spec.js`) — not run in this environment
