### PR TITLE
Emit event schema dates and iCal times in the site's timezone

### DIFF
--- a/fair-events/__tests__/Helpers/DateHelperTest.php
+++ b/fair-events/__tests__/Helpers/DateHelperTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Tests for DateHelper's timezone-aware formatting.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Helpers\DateHelper;
+
+/**
+ * Unit tests for local_to_iso8601() and local_to_datetime().
+ */
+class DateHelperTest extends TestCase {
+
+	/**
+	 * Reset the timezone stub after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['_fair_test_timezone'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A summer date on a named DST zone emits the summer offset.
+	 *
+	 * @return void
+	 */
+	public function test_local_to_iso8601_summer_offset() {
+		$GLOBALS['_fair_test_timezone'] = 'Europe/Madrid';
+
+		$iso = DateHelper::local_to_iso8601( '2025-06-15 18:15:00' );
+
+		$this->assertSame( '2025-06-15T18:15:00+02:00', $iso );
+	}
+
+	/**
+	 * A winter date on a named DST zone emits the winter offset.
+	 *
+	 * @return void
+	 */
+	public function test_local_to_iso8601_winter_offset() {
+		$GLOBALS['_fair_test_timezone'] = 'Europe/Madrid';
+
+		$iso = DateHelper::local_to_iso8601( '2025-01-15 18:15:00' );
+
+		$this->assertSame( '2025-01-15T18:15:00+01:00', $iso );
+	}
+
+	/**
+	 * A fixed-offset site timezone emits that fixed offset, no DST math.
+	 *
+	 * @return void
+	 */
+	public function test_local_to_iso8601_fixed_offset() {
+		$GLOBALS['_fair_test_timezone'] = '+05:00';
+
+		$iso = DateHelper::local_to_iso8601( '2025-06-15 18:15:00' );
+
+		$this->assertSame( '2025-06-15T18:15:00+05:00', $iso );
+	}
+
+	/**
+	 * An invalid datetime string yields an empty string, not a fatal error.
+	 *
+	 * @return void
+	 */
+	public function test_local_to_iso8601_invalid_datetime() {
+		$this->assertSame( '', DateHelper::local_to_iso8601( 'not-a-date' ) );
+	}
+
+	/**
+	 * Local_to_datetime() returns a DateTime carrying the site timezone.
+	 *
+	 * @return void
+	 */
+	public function test_local_to_datetime_carries_site_timezone() {
+		$GLOBALS['_fair_test_timezone'] = 'Europe/Madrid';
+
+		$dt = DateHelper::local_to_datetime( '2025-06-15 18:15:00' );
+
+		$this->assertInstanceOf( \DateTime::class, $dt );
+		$this->assertSame( 'Europe/Madrid', $dt->getTimezone()->getName() );
+		$this->assertSame( '2025-06-15 18:15:00', $dt->format( 'Y-m-d H:i:s' ) );
+	}
+
+	/**
+	 * Local_to_datetime() returns false on an invalid datetime string.
+	 *
+	 * @return void
+	 */
+	public function test_local_to_datetime_invalid_datetime() {
+		$this->assertFalse( DateHelper::local_to_datetime( 'not-a-date' ) );
+	}
+}

--- a/fair-events/__tests__/Helpers/EventSchemaTest.php
+++ b/fair-events/__tests__/Helpers/EventSchemaTest.php
@@ -113,6 +113,23 @@ class EventSchemaTest extends TestCase {
 	}
 
 	/**
+	 * StartDate/endDate carry the site's local offset, not a hardcoded UTC one.
+	 *
+	 * @return void
+	 */
+	public function test_dates_use_site_local_offset() {
+		$GLOBALS['_fair_test_timezone'] = 'Europe/Madrid';
+
+		$item_list = EventSchema::item_list_from_occurrences( array( $this->make_dto() ) );
+		$event     = $item_list['itemListElement'][0]['item'];
+
+		unset( $GLOBALS['_fair_test_timezone'] );
+
+		$this->assertStringEndsWith( '+02:00', $event['startDate'] );
+		$this->assertStringEndsWith( '+02:00', $event['endDate'] );
+	}
+
+	/**
 	 * A DTO with no start is dropped rather than producing a half-valid Event.
 	 *
 	 * @return void

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -68,12 +68,15 @@ if ( ! function_exists( 'get_the_title' ) ) {
 
 if ( ! function_exists( 'wp_timezone' ) ) {
 	/**
-	 * Stub of WordPress wp_timezone() — always UTC for deterministic tests.
+	 * Stub of WordPress wp_timezone() — UTC by default, overridable via
+	 * $GLOBALS['_fair_test_timezone'] for timezone-sensitive tests.
 	 *
-	 * @return \DateTimeZone UTC timezone.
+	 * @return \DateTimeZone Site timezone.
 	 */
 	function wp_timezone() {
-		return new \DateTimeZone( 'UTC' );
+		$timezone = isset( $GLOBALS['_fair_test_timezone'] ) ? $GLOBALS['_fair_test_timezone'] : 'UTC';
+
+		return new \DateTimeZone( $timezone );
 	}
 }
 

--- a/fair-events/src/API/CalendarFeedController.php
+++ b/fair-events/src/API/CalendarFeedController.php
@@ -117,25 +117,136 @@ class CalendarFeedController extends WP_REST_Controller {
 		$vcalendar->{'X-WR-CALNAME'}  = get_bloginfo( 'name' );
 		$vcalendar->{'X-WR-TIMEZONE'} = wp_timezone_string();
 
+		$tz = wp_timezone();
+
+		if ( $this->is_named_timezone( $tz ) ) {
+			$this->add_vtimezone( $vcalendar, $tz, $occurrences );
+		}
+
 		foreach ( $occurrences as $occurrence ) {
 			if ( empty( $occurrence['start'] ) ) {
 				continue;
 			}
 
-			$this->add_vevent( $vcalendar, $occurrence );
+			$this->add_vevent( $vcalendar, $occurrence, $tz );
 		}
 
 		return $vcalendar;
 	}
 
 	/**
-	 * Add a single VEVENT to the calendar for an occurrence DTO.
+	 * Whether a site timezone is a named IANA zone (e.g. 'Europe/Madrid')
+	 * rather than a fixed UTC offset (e.g. '+05:00').
 	 *
-	 * @param VCalendar $vcalendar  Calendar to add the event to.
-	 * @param array     $occurrence Occurrence DTO.
+	 * @param \DateTimeZone $tz Site timezone.
+	 * @return bool
+	 */
+	private function is_named_timezone( \DateTimeZone $tz ) {
+		return (bool) preg_match( '/^[A-Za-z]/', $tz->getName() );
+	}
+
+	/**
+	 * Add a VTIMEZONE component describing the site's named zone across the
+	 * feed's date range, so DTSTART/DTEND TZID references resolve for
+	 * clients that don't already know the IANA zone.
+	 *
+	 * @param VCalendar     $vcalendar   Calendar to add the component to.
+	 * @param \DateTimeZone $tz          Site timezone.
+	 * @param array[]       $occurrences Occurrence DTOs from EventFeedProvider.
 	 * @return void
 	 */
-	private function add_vevent( VCalendar $vcalendar, array $occurrence ) {
+	private function add_vtimezone( VCalendar $vcalendar, \DateTimeZone $tz, array $occurrences ) {
+		$timestamps = array();
+
+		foreach ( $occurrences as $occurrence ) {
+			foreach ( array( 'start', 'end' ) as $key ) {
+				if ( empty( $occurrence[ $key ] ) ) {
+					continue;
+				}
+
+				$ts = DateHelper::local_to_timestamp( $occurrence[ $key ] );
+
+				if ( false !== $ts ) {
+					$timestamps[] = $ts;
+				}
+			}
+		}
+
+		if ( empty( $timestamps ) ) {
+			return;
+		}
+
+		// Look a year further back than the range start to reliably capture
+		// the offset already active at that point.
+		$range_start = min( $timestamps ) - YEAR_IN_SECONDS;
+		$range_end   = max( $timestamps );
+
+		$transitions = $tz->getTransitions( $range_start, $range_end );
+
+		if ( empty( $transitions ) ) {
+			return;
+		}
+
+		$vtimezone = $vcalendar->add( 'VTIMEZONE', array( 'TZID' => $tz->getName() ) );
+
+		$previous_offset = $transitions[0]['offset'];
+
+		foreach ( $transitions as $index => $transition ) {
+			if ( 0 === $index ) {
+				// The first entry is the state already active at range start, not a transition.
+				continue;
+			}
+
+			$sub = $vtimezone->add( $transition['isdst'] ? 'DAYLIGHT' : 'STANDARD' );
+			$sub->add( 'DTSTART', gmdate( 'Ymd\THis', $transition['ts'] + $transition['offset'] ) );
+			$sub->add( 'TZOFFSETFROM', $this->format_utc_offset( $previous_offset ) );
+			$sub->add( 'TZOFFSETTO', $this->format_utc_offset( $transition['offset'] ) );
+
+			if ( ! empty( $transition['abbr'] ) ) {
+				$sub->add( 'TZNAME', $transition['abbr'] );
+			}
+
+			$previous_offset = $transition['offset'];
+		}
+
+		// A zone without DST transitions in range yields no STANDARD/DAYLIGHT
+		// sub-component above, but RFC 5545 requires at least one.
+		if ( 0 === count( $vtimezone->select( 'STANDARD' ) ) + count( $vtimezone->select( 'DAYLIGHT' ) ) ) {
+			$sub = $vtimezone->add( $transitions[0]['isdst'] ? 'DAYLIGHT' : 'STANDARD' );
+			$sub->add( 'DTSTART', '19700101T000000' );
+			$sub->add( 'TZOFFSETFROM', $this->format_utc_offset( $transitions[0]['offset'] ) );
+			$sub->add( 'TZOFFSETTO', $this->format_utc_offset( $transitions[0]['offset'] ) );
+
+			if ( ! empty( $transitions[0]['abbr'] ) ) {
+				$sub->add( 'TZNAME', $transitions[0]['abbr'] );
+			}
+		}
+	}
+
+	/**
+	 * Format a UTC offset in seconds as an iCal TZOFFSETFROM/TO value.
+	 *
+	 * @param int $seconds Offset in seconds (can be negative).
+	 * @return string Offset formatted as '+HHMM' or '-HHMM'.
+	 */
+	private function format_utc_offset( $seconds ) {
+		$sign    = $seconds < 0 ? '-' : '+';
+		$seconds = abs( $seconds );
+		$hours   = floor( $seconds / HOUR_IN_SECONDS );
+		$minutes = floor( ( $seconds % HOUR_IN_SECONDS ) / MINUTE_IN_SECONDS );
+
+		return sprintf( '%s%02d%02d', $sign, $hours, $minutes );
+	}
+
+	/**
+	 * Add a single VEVENT to the calendar for an occurrence DTO.
+	 *
+	 * @param VCalendar     $vcalendar  Calendar to add the event to.
+	 * @param array         $occurrence Occurrence DTO.
+	 * @param \DateTimeZone $tz         Site timezone.
+	 * @return void
+	 */
+	private function add_vevent( VCalendar $vcalendar, array $occurrence, \DateTimeZone $tz ) {
 		$now = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
 
 		$vevent = $vcalendar->add(
@@ -159,6 +270,9 @@ class CalendarFeedController extends WP_REST_Controller {
 
 			$vevent->add( 'DTSTART', $start_date, array( 'VALUE' => 'DATE' ) );
 			$vevent->add( 'DTEND', $end_date, array( 'VALUE' => 'DATE' ) );
+		} elseif ( $this->is_named_timezone( $tz ) ) {
+			$vevent->add( 'DTSTART', DateHelper::local_to_datetime( $occurrence['start'] ) );
+			$vevent->add( 'DTEND', DateHelper::local_to_datetime( $occurrence['end'] ) );
 		} else {
 			$vevent->add( 'DTSTART', DateHelper::local_to_ical_utc( $occurrence['start'] ) );
 			$vevent->add( 'DTEND', DateHelper::local_to_ical_utc( $occurrence['end'] ) );

--- a/fair-events/src/API/__tests__/CalendarFeedController.api.spec.js
+++ b/fair-events/src/API/__tests__/CalendarFeedController.api.spec.js
@@ -178,8 +178,24 @@ test.describe('CalendarFeedController — ICS calendar feed', () => {
 			`UID:fair_event_${eventPostId}_${timedEventDateId}@`
 		);
 		expect(body).toContain(`URL;VALUE=URI:${timedEventDate.display_url}`);
-		// Timed event: UTC Z time.
-		expect(body).toMatch(/DTSTART:\d{8}T\d{6}Z/);
+
+		// Timed event: local site timezone. A named IANA zone emits
+		// DTSTART;TZID=<zone>:<local time> plus a VTIMEZONE block; a
+		// fixed-offset zone (e.g. the default UTC test env) keeps the
+		// UTC `Z` form, since iCal has no inline-offset form.
+		const settingsRes = await api.get('/wp-json/wp/v2/settings', {
+			headers: adminHeaders,
+		});
+		const { timezone } = await settingsRes.json();
+		const isNamedZone = /^[A-Za-z]/.test(timezone);
+
+		if (isNamedZone) {
+			expect(body).toMatch(/DTSTART;TZID=[^:]+:\d{8}T\d{6}/);
+			expect(body).toContain('BEGIN:VTIMEZONE');
+			expect(body).toContain(`TZID:${timezone}`);
+		} else {
+			expect(body).toMatch(/DTSTART:\d{8}T\d{6}Z/);
+		}
 
 		expect(body).toContain(`UID:standalone_${standaloneEventDateId}@`);
 		expect(body).toContain(

--- a/fair-events/src/Helpers/DateHelper.php
+++ b/fair-events/src/Helpers/DateHelper.php
@@ -36,19 +36,29 @@ class DateHelper {
 	}
 
 	/**
-	 * Convert a site-local naive datetime to an ISO 8601 UTC string.
+	 * Convert a site-local naive datetime to an ISO 8601 string in the site's timezone.
 	 *
 	 * @param string $datetime Naive 'Y-m-d H:i:s' in site-local time.
-	 * @return string ISO 8601 UTC string (e.g. '2025-06-15T17:30:00+00:00'), or empty string on failure.
+	 * @return string ISO 8601 string with the site's offset (e.g. '2025-06-15T18:15:00+02:00'), or empty string on failure.
 	 */
 	public static function local_to_iso8601( $datetime ) {
-		$ts = self::local_to_timestamp( $datetime );
+		$dt = self::local_to_datetime( $datetime );
 
-		if ( false === $ts ) {
+		if ( false === $dt ) {
 			return '';
 		}
 
-		return gmdate( 'c', $ts );
+		return $dt->format( 'c' );
+	}
+
+	/**
+	 * Convert a site-local naive datetime to a timezone-aware DateTime in the site's timezone.
+	 *
+	 * @param string $datetime Naive 'Y-m-d H:i:s' in site-local time.
+	 * @return \DateTime|false Site-timezone-aware DateTime, or false on failure.
+	 */
+	public static function local_to_datetime( $datetime ) {
+		return date_create( $datetime, wp_timezone() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `DateHelper::local_to_iso8601()` now formats in `wp_timezone()` instead of `gmdate('c')`, so JSON-LD (single-event, calendar/week list, offer `validFrom`), OpenGraph tags, and the public JSON feed all carry the site's DST-aware local offset instead of `+00:00`.
- Added `DateHelper::local_to_datetime()`, a timezone-aware `DateTime` in the site's zone.
- `CalendarFeedController` now emits local wall-clock `DTSTART`/`DTEND` with `TZID` plus a generated `VTIMEZONE` block for named IANA site timezones. Fixed-offset sites (no IANA name to reference) keep the existing UTC `Z` form, since iCal has no inline-offset representation.
- The represented instant is unchanged everywhere — only the timezone it's expressed in.

## Test plan

- [x] `vendor/bin/phpunit` — full suite green (69 tests), including new `DateHelperTest` (summer/winter/fixed-offset offsets) and an added `EventSchemaTest` assertion for the local offset.
- [x] `vendor/bin/phpcs` — clean on all changed PHP files.
- [x] Manual `wp eval-file` check against a live WP with `timezone_string=Europe/Madrid`: JSON-LD dates emit `+02:00`/`+01:00` correctly across DST, and the built `VCALENDAR` emits `DTSTART;TZID=Europe/Madrid:20250615T181500` plus a `VTIMEZONE` block with correct `STANDARD`/`DAYLIGHT` transitions.
- [x] `CalendarFeedController.api.spec.js` updated to assert TZID+VTIMEZONE for a named zone or UTC `Z` for a fixed-offset zone, based on the site's actual configured timezone — could not run against this local Docker env (pre-existing Basic Auth failures unrelated to this change, reproduced on unrelated specs like `EventDatesController.api.spec.js`).

Closes #1149
