### PR TITLE
Replace events-calendar subscribe controls with a dropdown

### DIFF
--- a/fair-events/e2e/events-calendar-subscribe.spec.js
+++ b/fair-events/e2e/events-calendar-subscribe.spec.js
@@ -4,9 +4,10 @@ const WP_ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
 const WP_ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
 
 /**
- * Verifies the events-calendar "Subscribe to calendar" link (#1124):
- * a webcal:// link pointing at the public ICS feed, reflecting the block's
- * category filter, plus a copyable plain-URL fallback.
+ * Verifies the events-calendar "Subscribe to calendar" dropdown (#1154):
+ * a single outline trigger button that opens a dropdown with Google
+ * Calendar, Outlook, Apple Calendar (webcal), and Copy feed URL entries,
+ * all reflecting the block's category filter.
  */
 
 async function apiFetch(page, options) {
@@ -47,8 +48,26 @@ async function login(page) {
 	await page.waitForSelector('#wpadminbar');
 }
 
-test.describe('Events Calendar — Subscribe link', () => {
-	test('shows a webcal:// link to the ICS feed and a copyable fallback', async ({
+async function createCalendarPage(page, title, content) {
+	const priorPages = await apiFetch(page, {
+		path: `/wp/v2/pages?search=${encodeURIComponent(title)}&per_page=20`,
+	});
+	for (const p of priorPages) {
+		await apiFetch(page, {
+			path: `/wp/v2/pages/${p.id}?force=true`,
+			method: 'DELETE',
+		}).catch(() => {});
+	}
+
+	return apiFetch(page, {
+		path: '/wp/v2/pages',
+		method: 'POST',
+		data: { title, status: 'publish', content },
+	});
+}
+
+test.describe('Events Calendar — Subscribe dropdown', () => {
+	test('shows a single trigger that opens a dropdown with all subscription options', async ({
 		page,
 		context,
 	}) => {
@@ -61,48 +80,98 @@ test.describe('Events Calendar — Subscribe link', () => {
 		await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
 		await page.waitForFunction(() => window.wp && window.wp.apiFetch);
 
-		const priorPages = await apiFetch(page, {
-			path: '/wp/v2/pages?search=Subscribe%20Calendar&per_page=20',
-		});
-		for (const p of priorPages) {
-			await apiFetch(page, {
-				path: `/wp/v2/pages/${p.id}?force=true`,
-				method: 'DELETE',
-			}).catch(() => {});
-		}
-
-		const calendarPage = await apiFetch(page, {
-			path: '/wp/v2/pages',
-			method: 'POST',
-			data: {
-				title: 'Subscribe Calendar',
-				status: 'publish',
-				content: '<!-- wp:fair-events/events-calendar /-->',
-			},
-		});
+		const calendarPage = await createCalendarPage(
+			page,
+			'Subscribe Calendar',
+			'<!-- wp:fair-events/events-calendar /-->'
+		);
 
 		await page.goto(calendarPage.link || `/?page_id=${calendarPage.id}`);
 
-		const link = page.locator('.fair-events-subscribe-link');
-		await expect(link).toBeVisible();
+		const trigger = page.locator('.fair-events-subscribe-trigger');
+		await expect(trigger).toBeVisible();
+		await expect(trigger).toHaveText('Subscribe to calendar');
+		await expect(trigger).toHaveAttribute('aria-expanded', 'false');
 
-		const href = await link.getAttribute('href');
-		expect(href).toMatch(/^webcal:\/\//);
-		expect(href).toContain('/fair-events/v1/calendar.ics');
+		// No leftover elements from the old three-element stack: the old
+		// always-visible link is gone, and the note is only inside the
+		// (closed) dropdown panel, not visible on the page.
+		await expect(page.locator('.fair-events-subscribe-link')).toHaveCount(
+			0
+		);
 
-		const button = page.locator('.fair-events-subscribe-copy-btn');
-		await expect(button).toHaveText('Copy feed URL');
+		const panel = page.locator('.fair-events-subscribe-panel');
+		await expect(panel).toBeHidden();
+		await expect(panel.locator('.fair-events-subscribe-note')).toBeHidden();
 
-		await button.click();
-		await expect(button).toHaveText('✓');
+		await trigger.click();
+		await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+		await expect(panel).toBeVisible();
+
+		const entries = panel.locator('.fair-events-subscribe-entry');
+		await expect(entries).toHaveCount(4);
+
+		const googleEntry = panel.getByRole('menuitem', {
+			name: 'Google Calendar',
+		});
+		await expect(googleEntry).toHaveAttribute('target', '_blank');
+		const googleHref = await googleEntry.getAttribute('href');
+		expect(googleHref).toContain('calendar.google.com/calendar/r?cid=');
+		expect(decodeURIComponent(googleHref)).toContain(
+			'/fair-events/v1/calendar.ics'
+		);
+
+		const outlookEntry = panel.getByRole('menuitem', { name: 'Outlook' });
+		await expect(outlookEntry).toHaveAttribute('target', '_blank');
+		const outlookHref = await outlookEntry.getAttribute('href');
+		expect(outlookHref).toContain('outlook.live.com/calendar/0/addfromweb');
+		expect(decodeURIComponent(outlookHref)).toContain(
+			'/fair-events/v1/calendar.ics'
+		);
+
+		const appleEntry = panel.getByRole('menuitem', {
+			name: 'Apple Calendar',
+		});
+		const appleHref = await appleEntry.getAttribute('href');
+		expect(appleHref).toMatch(/^webcal:\/\//);
+		expect(appleHref).toContain('/fair-events/v1/calendar.ics');
+
+		await expect(panel.locator('.fair-events-subscribe-note')).toHaveText(
+			"Subscribed calendars refresh on your calendar app's own schedule (often hours, not instant)."
+		);
+
+		// Copy entry copies the feed URL and shows the confirmation.
+		const copyButton = panel.locator('.fair-events-subscribe-entry-copy');
+		await copyButton.click();
+		await expect(copyButton).toHaveText('✓');
 
 		const clipboardText = await page.evaluate(() =>
 			navigator.clipboard.readText()
 		);
-		expect(clipboardText).toMatch(/^https:\/\//);
+		expect(clipboardText).toMatch(/^https?:\/\//);
 		expect(clipboardText).toContain('/fair-events/v1/calendar.ics');
 
-		await expect(button).toHaveText('Copy feed URL', { timeout: 3000 });
+		await expect(copyButton).toHaveText('Copy feed URL', {
+			timeout: 3000,
+		});
+
+		// Escape closes the dropdown.
+		await page.keyboard.press('Escape');
+		await expect(panel).toBeHidden();
+		await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+		// Outside click closes the dropdown (click the calendar navigation
+		// title — on-page but outside the admin bar and the dropdown).
+		await trigger.click();
+		await expect(panel).toBeVisible();
+		await page.locator('.navigation-title').click();
+		await expect(panel).toBeHidden();
+
+		// Selecting the Apple Calendar entry closes the dropdown.
+		await trigger.click();
+		await expect(panel).toBeVisible();
+		await appleEntry.click();
+		await expect(panel).toBeHidden();
 
 		// Cleanup.
 		await apiFetch(page, {
@@ -111,7 +180,7 @@ test.describe('Events Calendar — Subscribe link', () => {
 		}).catch(() => {});
 	});
 
-	test('reflects the category filter in the feed URL', async ({ page }) => {
+	test('reflects the category filter in the feed URLs', async ({ page }) => {
 		test.setTimeout(60_000);
 
 		await page.setViewportSize({ width: 1200, height: 900 });
@@ -128,31 +197,28 @@ test.describe('Events Calendar — Subscribe link', () => {
 		);
 		const category = categories[0];
 
-		const priorPages = await apiFetch(page, {
-			path: '/wp/v2/pages?search=Subscribe%20Calendar%20Filtered&per_page=20',
-		});
-		for (const p of priorPages) {
-			await apiFetch(page, {
-				path: `/wp/v2/pages/${p.id}?force=true`,
-				method: 'DELETE',
-			}).catch(() => {});
-		}
-
-		const calendarPage = await apiFetch(page, {
-			path: '/wp/v2/pages',
-			method: 'POST',
-			data: {
-				title: 'Subscribe Calendar Filtered',
-				status: 'publish',
-				content: `<!-- wp:fair-events/events-calendar {"categories":[${category.id}]} /-->`,
-			},
-		});
+		const calendarPage = await createCalendarPage(
+			page,
+			'Subscribe Calendar Filtered',
+			`<!-- wp:fair-events/events-calendar {"categories":[${category.id}]} /-->`
+		);
 
 		await page.goto(calendarPage.link || `/?page_id=${calendarPage.id}`);
 
-		const link = page.locator('.fair-events-subscribe-link');
-		const href = await link.getAttribute('href');
-		expect(href).toContain(`categories=${category.slug}`);
+		await page.locator('.fair-events-subscribe-trigger').click();
+		const panel = page.locator('.fair-events-subscribe-panel');
+
+		const googleHref = await panel
+			.getByRole('menuitem', { name: 'Google Calendar' })
+			.getAttribute('href');
+		expect(decodeURIComponent(googleHref)).toContain(
+			`categories=${category.slug}`
+		);
+
+		const appleHref = await panel
+			.getByRole('menuitem', { name: 'Apple Calendar' })
+			.getAttribute('href');
+		expect(appleHref).toContain(`categories=${category.slug}`);
 
 		// Cleanup.
 		await apiFetch(page, {

--- a/fair-events/languages/fair-events-de_DE.po
+++ b/fair-events/languages/fair-events-de_DE.po
@@ -389,13 +389,13 @@ msgstr "Veranstaltungsdauer"
 msgid "Copy"
 msgstr "Kopieren"
 
-#: src/blocks/events-calendar/render.php:264
+#: src/blocks/events-calendar/render.php:317
 #: src/blocks/events-week/render.php:234
 #: src/Admin/calendar/components/CalendarHeader.js:29
 msgid "Previous"
 msgstr "Zurück"
 
-#: src/blocks/events-calendar/render.php:270
+#: src/blocks/events-calendar/render.php:323
 #: src/blocks/events-week/render.php:240
 #: src/Admin/calendar/components/CalendarHeader.js:35
 msgid "Next"
@@ -1364,37 +1364,37 @@ msgstr "Nach Vorkommen-Typ filtern."
 
 #. translators: %d: number of days
 #: src/blocks/event-info/render.php:68
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d days"
 msgstr "Alle %d Tage"
 
 #. translators: %s: day of week
 #: src/blocks/event-info/render.php:75
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every 2 weeks on %s"
 msgstr "Alle 2 Wochen am %s"
 
 #. translators: 1: number of weeks, 2: day of week
 #: src/blocks/event-info/render.php:79
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %1$d weeks on %2$s"
 msgstr "Alle %1$d Wochen am %2$s"
 
 #. translators: %s: day of week
 #: src/blocks/event-info/render.php:82
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %s"
 msgstr "Jeden %s"
 
 #. translators: %d: number of months
 #: src/blocks/event-info/render.php:87
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d months"
 msgstr "Alle %d Monate"
 
 #. translators: %d: number of years
 #: src/blocks/event-info/render.php:94
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d years"
 msgstr "Alle %d Jahre"
 
@@ -1404,7 +1404,7 @@ msgstr "Jährlich"
 
 #. translators: %s: date of next occurrence
 #: src/blocks/event-info/render.php:169
-#, php-format, js-format
+#, php-format,js-format
 msgid "Next: %s"
 msgstr "Nächste: %s"
 
@@ -2033,7 +2033,7 @@ msgstr "Eines der ausgewählten Vorkommen ist für dieses Ticket ungültig."
 #: src/API/GetTicketsController.php:476
 #: src/blocks/event-signup/frontend.js:176
 #: src/blocks/event-signup/frontend.js:262
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d occurrence."
 msgid_plural "Please select at least %d occurrences."
 msgstr[0] "Bitte wählen Sie mindestens %d Vorkommen aus."
@@ -2541,15 +2541,15 @@ msgstr "Manuelle Daten dürfen keine Duplikate enthalten — nur ein Vorkommen p
 msgid "Event Signup: could not resolve an event date for this page."
 msgstr "Event Signup: konnte kein Veranstaltungsdatum für diese Seite auflösen."
 
-#: src/blocks/events-calendar/render.php:403
+#: src/blocks/events-calendar/render.php:477
 msgid "Subscribe to calendar"
 msgstr "Zum Kalender abonnieren"
 
-#: src/blocks/events-calendar/render.php:406
+#: src/blocks/events-calendar/render.php:527
 msgid "Subscribed calendars refresh on your calendar app's own schedule (often hours, not instant)."
 msgstr "Abonnierte Kalender werden nach dem eigenen Zeitplan Ihrer Kalender-App aktualisiert (oft Stunden, nicht sofort)."
 
-#: src/blocks/events-calendar/render.php:415
+#: src/blocks/events-calendar/render.php:462
 msgid "Copy feed URL"
 msgstr "Feed-URL kopieren"
 
@@ -2797,3 +2797,14 @@ msgctxt "block description"
 msgid "Legacy signup block. Superseded by Event Signup — transform existing instances to fair-events/event-signup."
 msgstr "Veralteter Anmeldungsblock. Ersetzt durch Event Signup — transformieren Sie vorhandene Instanzen zu fair-events/event-signup."
 
+#: src/blocks/events-calendar/render.php:494
+msgid "Google Calendar"
+msgstr ""
+
+#: src/blocks/events-calendar/render.php:505
+msgid "Outlook"
+msgstr ""
+
+#: src/blocks/events-calendar/render.php:514
+msgid "Apple Calendar"
+msgstr ""

--- a/fair-events/languages/fair-events-es_ES.po
+++ b/fair-events/languages/fair-events-es_ES.po
@@ -389,13 +389,13 @@ msgstr "Duración del evento"
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/blocks/events-calendar/render.php:264
+#: src/blocks/events-calendar/render.php:317
 #: src/blocks/events-week/render.php:234
 #: src/Admin/calendar/components/CalendarHeader.js:29
 msgid "Previous"
 msgstr "Anterior"
 
-#: src/blocks/events-calendar/render.php:270
+#: src/blocks/events-calendar/render.php:323
 #: src/blocks/events-week/render.php:240
 #: src/Admin/calendar/components/CalendarHeader.js:35
 msgid "Next"
@@ -1364,37 +1364,37 @@ msgstr "Filtrar por tipo de ocurrencia."
 
 #. translators: %d: number of days
 #: src/blocks/event-info/render.php:68
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d days"
 msgstr "Cada %d días"
 
 #. translators: %s: day of week
 #: src/blocks/event-info/render.php:75
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every 2 weeks on %s"
 msgstr "Cada 2 semanas el %s"
 
 #. translators: 1: number of weeks, 2: day of week
 #: src/blocks/event-info/render.php:79
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %1$d weeks on %2$s"
 msgstr "Cada %1$d semanas el %2$s"
 
 #. translators: %s: day of week
 #: src/blocks/event-info/render.php:82
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %s"
 msgstr "Cada %s"
 
 #. translators: %d: number of months
 #: src/blocks/event-info/render.php:87
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d months"
 msgstr "Cada %d meses"
 
 #. translators: %d: number of years
 #: src/blocks/event-info/render.php:94
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d years"
 msgstr "Cada %d años"
 
@@ -1404,7 +1404,7 @@ msgstr "Anualmente"
 
 #. translators: %s: date of next occurrence
 #: src/blocks/event-info/render.php:169
-#, php-format, js-format
+#, php-format,js-format
 msgid "Next: %s"
 msgstr "Siguiente: %s"
 
@@ -2033,7 +2033,7 @@ msgstr "Una de las ocurrencias seleccionadas no es válida para esta entrada."
 #: src/API/GetTicketsController.php:476
 #: src/blocks/event-signup/frontend.js:176
 #: src/blocks/event-signup/frontend.js:262
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d occurrence."
 msgid_plural "Please select at least %d occurrences."
 msgstr[0] "Selecciona al menos %d ocurrencia."
@@ -2541,15 +2541,15 @@ msgstr "Las fechas manuales no deben contener duplicados — solo se admite una 
 msgid "Event Signup: could not resolve an event date for this page."
 msgstr "Registro de evento: no se pudo resolver una fecha de evento para esta página."
 
-#: src/blocks/events-calendar/render.php:403
+#: src/blocks/events-calendar/render.php:477
 msgid "Subscribe to calendar"
 msgstr "Suscribirse al calendario"
 
-#: src/blocks/events-calendar/render.php:406
+#: src/blocks/events-calendar/render.php:527
 msgid "Subscribed calendars refresh on your calendar app's own schedule (often hours, not instant)."
 msgstr "Los calendarios suscritos se actualizan según el horario de tu aplicación de calendario (a menudo horas, no al instante)."
 
-#: src/blocks/events-calendar/render.php:415
+#: src/blocks/events-calendar/render.php:462
 msgid "Copy feed URL"
 msgstr "Copiar URL del feed"
 
@@ -2797,3 +2797,14 @@ msgctxt "block description"
 msgid "Legacy signup block. Superseded by Event Signup — transform existing instances to fair-events/event-signup."
 msgstr "Bloque de registro heredado. Reemplazado por Event Signup — transforma las instancias existentes a fair-events/event-signup."
 
+#: src/blocks/events-calendar/render.php:494
+msgid "Google Calendar"
+msgstr ""
+
+#: src/blocks/events-calendar/render.php:505
+msgid "Outlook"
+msgstr ""
+
+#: src/blocks/events-calendar/render.php:514
+msgid "Apple Calendar"
+msgstr ""

--- a/fair-events/languages/fair-events-fr_FR.po
+++ b/fair-events/languages/fair-events-fr_FR.po
@@ -389,13 +389,13 @@ msgstr "Durée de l'événement"
 msgid "Copy"
 msgstr "Copier"
 
-#: src/blocks/events-calendar/render.php:264
+#: src/blocks/events-calendar/render.php:317
 #: src/blocks/events-week/render.php:234
 #: src/Admin/calendar/components/CalendarHeader.js:29
 msgid "Previous"
 msgstr "Précédent"
 
-#: src/blocks/events-calendar/render.php:270
+#: src/blocks/events-calendar/render.php:323
 #: src/blocks/events-week/render.php:240
 #: src/Admin/calendar/components/CalendarHeader.js:35
 msgid "Next"
@@ -1364,37 +1364,37 @@ msgstr "Filtrer par type d'occurrence."
 
 #. translators: %d: number of days
 #: src/blocks/event-info/render.php:68
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d days"
 msgstr "Tous les %d jours"
 
 #. translators: %s: day of week
 #: src/blocks/event-info/render.php:75
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every 2 weeks on %s"
 msgstr "Tous les 2 semaines le %s"
 
 #. translators: 1: number of weeks, 2: day of week
 #: src/blocks/event-info/render.php:79
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %1$d weeks on %2$s"
 msgstr "Tous les %1$d semaines le %2$s"
 
 #. translators: %s: day of week
 #: src/blocks/event-info/render.php:82
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %s"
 msgstr "Tous les %s"
 
 #. translators: %d: number of months
 #: src/blocks/event-info/render.php:87
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d months"
 msgstr "Tous les %d mois"
 
 #. translators: %d: number of years
 #: src/blocks/event-info/render.php:94
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d years"
 msgstr "Tous les %d ans"
 
@@ -1404,7 +1404,7 @@ msgstr "Annuellement"
 
 #. translators: %s: date of next occurrence
 #: src/blocks/event-info/render.php:169
-#, php-format, js-format
+#, php-format,js-format
 msgid "Next: %s"
 msgstr "Suivant : %s"
 
@@ -2033,7 +2033,7 @@ msgstr "L'une des occurrences sélectionnées n'est pas valide pour ce billet."
 #: src/API/GetTicketsController.php:476
 #: src/blocks/event-signup/frontend.js:176
 #: src/blocks/event-signup/frontend.js:262
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d occurrence."
 msgid_plural "Please select at least %d occurrences."
 msgstr[0] "Veuillez sélectionner au moins %d occurrence."
@@ -2541,15 +2541,15 @@ msgstr "Les dates manuelles ne doivent pas contenir de doublons — une seule oc
 msgid "Event Signup: could not resolve an event date for this page."
 msgstr "Inscription à l'événement : impossible de résoudre une date d'événement pour cette page."
 
-#: src/blocks/events-calendar/render.php:403
+#: src/blocks/events-calendar/render.php:477
 msgid "Subscribe to calendar"
 msgstr "S'abonner au calendrier"
 
-#: src/blocks/events-calendar/render.php:406
+#: src/blocks/events-calendar/render.php:527
 msgid "Subscribed calendars refresh on your calendar app's own schedule (often hours, not instant)."
 msgstr "Les calendriers abonnés se rafraîchissent selon le calendrier de votre application de calendrier (souvent des heures, pas instantané)."
 
-#: src/blocks/events-calendar/render.php:415
+#: src/blocks/events-calendar/render.php:462
 msgid "Copy feed URL"
 msgstr "Copier l'URL du flux"
 
@@ -2797,3 +2797,14 @@ msgctxt "block description"
 msgid "Legacy signup block. Superseded by Event Signup — transform existing instances to fair-events/event-signup."
 msgstr "Bloc d'inscription hérité. Remplacé par Event Signup — transformez les instances existantes en fair-events/event-signup."
 
+#: src/blocks/events-calendar/render.php:494
+msgid "Google Calendar"
+msgstr ""
+
+#: src/blocks/events-calendar/render.php:505
+msgid "Outlook"
+msgstr ""
+
+#: src/blocks/events-calendar/render.php:514
+msgid "Apple Calendar"
+msgstr ""

--- a/fair-events/languages/fair-events-pl_PL.po
+++ b/fair-events/languages/fair-events-pl_PL.po
@@ -389,13 +389,13 @@ msgstr "Czas trwania wydarzenia"
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: src/blocks/events-calendar/render.php:264
+#: src/blocks/events-calendar/render.php:317
 #: src/blocks/events-week/render.php:234
 #: src/Admin/calendar/components/CalendarHeader.js:29
 msgid "Previous"
 msgstr "Poprzedni"
 
-#: src/blocks/events-calendar/render.php:270
+#: src/blocks/events-calendar/render.php:323
 #: src/blocks/events-week/render.php:240
 #: src/Admin/calendar/components/CalendarHeader.js:35
 msgid "Next"
@@ -1365,37 +1365,37 @@ msgstr "Filtruj według typu wystąpienia."
 
 #. translators: %d: number of days
 #: src/blocks/event-info/render.php:68
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d days"
 msgstr "Co %d dni"
 
 #. translators: %s: day of week
 #: src/blocks/event-info/render.php:75
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every 2 weeks on %s"
 msgstr "Co 2 tygodnie w %s"
 
 #. translators: 1: number of weeks, 2: day of week
 #: src/blocks/event-info/render.php:79
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %1$d weeks on %2$s"
 msgstr "Co %1$d tygodni w %2$s"
 
 #. translators: %s: day of week
 #: src/blocks/event-info/render.php:82
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %s"
 msgstr "Co %s"
 
 #. translators: %d: number of months
 #: src/blocks/event-info/render.php:87
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d months"
 msgstr "Co %d miesięcy"
 
 #. translators: %d: number of years
 #: src/blocks/event-info/render.php:94
-#, php-format, js-format
+#, php-format,js-format
 msgid "Every %d years"
 msgstr "Co %d lat"
 
@@ -1405,7 +1405,7 @@ msgstr "Rocznie"
 
 #. translators: %s: date of next occurrence
 #: src/blocks/event-info/render.php:169
-#, php-format, js-format
+#, php-format,js-format
 msgid "Next: %s"
 msgstr "Następnie: %s"
 
@@ -2034,7 +2034,7 @@ msgstr "Jedno z wybranych zdarzeń nie jest ważne dla tego biletu."
 #: src/API/GetTicketsController.php:476
 #: src/blocks/event-signup/frontend.js:176
 #: src/blocks/event-signup/frontend.js:262
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d occurrence."
 msgid_plural "Please select at least %d occurrences."
 msgstr[0] "Proszę wybrać co najmniej %d wystąpienie."
@@ -2547,15 +2547,15 @@ msgstr "Daty ręczne nie mogą zawierać duplikatów — obsługiwane jest tylko
 msgid "Event Signup: could not resolve an event date for this page."
 msgstr "Rejestracja zdarzenia: nie można rozpoznać daty zdarzenia dla tej strony."
 
-#: src/blocks/events-calendar/render.php:403
+#: src/blocks/events-calendar/render.php:477
 msgid "Subscribe to calendar"
 msgstr "Subskrybuj kalendarz"
 
-#: src/blocks/events-calendar/render.php:406
+#: src/blocks/events-calendar/render.php:527
 msgid "Subscribed calendars refresh on your calendar app's own schedule (often hours, not instant)."
 msgstr "Subskrybowane kalendarze odświeżają się zgodnie z harmonogramem Twojej aplikacji kalendarza (często godziny, nie natychmiast)."
 
-#: src/blocks/events-calendar/render.php:415
+#: src/blocks/events-calendar/render.php:462
 msgid "Copy feed URL"
 msgstr "Skopiuj adres URL kanału"
 
@@ -2805,3 +2805,14 @@ msgctxt "block description"
 msgid "Legacy signup block. Superseded by Event Signup — transform existing instances to fair-events/event-signup."
 msgstr "Starszy blok rejestracji. Zastąpiony przez Event Signup — przekształć istniejące instancje na fair-events/event-signup."
 
+#: src/blocks/events-calendar/render.php:494
+msgid "Google Calendar"
+msgstr ""
+
+#: src/blocks/events-calendar/render.php:505
+msgid "Outlook"
+msgstr ""
+
+#: src/blocks/events-calendar/render.php:514
+msgid "Apple Calendar"
+msgstr ""

--- a/fair-events/languages/fair-events.pot
+++ b/fair-events/languages/fair-events.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-15T12:01:43+00:00\n"
+"POT-Creation-Date: 2026-07-16T09:06:41+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fair-events\n"
@@ -601,28 +601,40 @@ msgstr ""
 msgid "Powered by Fair Events"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:264
+#: src/blocks/events-calendar/render.php:317
 #: src/blocks/events-week/render.php:234
 #: src/Admin/calendar/components/CalendarHeader.js:29
 msgid "Previous"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:270
+#: src/blocks/events-calendar/render.php:323
 #: src/blocks/events-week/render.php:240
 #: src/Admin/calendar/components/CalendarHeader.js:35
 msgid "Next"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:403
+#: src/blocks/events-calendar/render.php:462
+msgid "Copy feed URL"
+msgstr ""
+
+#: src/blocks/events-calendar/render.php:477
 msgid "Subscribe to calendar"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:406
-msgid "Subscribed calendars refresh on your calendar app's own schedule (often hours, not instant)."
+#: src/blocks/events-calendar/render.php:494
+msgid "Google Calendar"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:415
-msgid "Copy feed URL"
+#: src/blocks/events-calendar/render.php:505
+msgid "Outlook"
+msgstr ""
+
+#: src/blocks/events-calendar/render.php:514
+msgid "Apple Calendar"
+msgstr ""
+
+#: src/blocks/events-calendar/render.php:527
+msgid "Subscribed calendars refresh on your calendar app's own schedule (often hours, not instant)."
 msgstr ""
 
 #: src/blocks/events-list/render.php:297

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -16,8 +16,9 @@ use FairEvents\Services\EventFeedProvider;
 use FairEvents\Settings\Settings;
 
 /**
- * Build the subscription feed URLs (webcal:// and plain https://) for the
- * configured category filter.
+ * Build the subscription feed URLs (webcal://, plain https://, and the
+ * Google/Outlook subscribe-by-URL deep links) for the configured category
+ * filter.
  *
  * Deliberately reflects only the category filter, not the current
  * month/year — a subscription is an ongoing feed, so freezing it to one
@@ -27,7 +28,7 @@ use FairEvents\Settings\Settings;
  * source-filtered calendar still links the all-sources feed.
  *
  * @param int[] $categories Category term IDs.
- * @return array{webcal: string, https: string} Feed URLs.
+ * @return array{webcal: string, https: string, google: string, outlook: string} Feed URLs.
  */
 if ( ! function_exists( 'fair_events_build_subscribe_urls' ) ) {
 	function fair_events_build_subscribe_urls( array $categories ) {
@@ -45,9 +46,61 @@ if ( ! function_exists( 'fair_events_build_subscribe_urls' ) ) {
 			$feed_url = add_query_arg( 'categories', implode( ',', $slugs ), $feed_url );
 		}
 
+		$webcal_url = preg_replace( '#^https?://#', 'webcal://', $feed_url );
+
 		return array(
-			'webcal' => preg_replace( '#^https?://#', 'webcal://', $feed_url ),
-			'https'  => $feed_url,
+			'webcal'  => $webcal_url,
+			'https'   => $feed_url,
+			'google'  => 'https://calendar.google.com/calendar/r?cid=' . rawurlencode( $webcal_url ),
+			'outlook' => add_query_arg(
+				array(
+					'url'  => rawurlencode( $feed_url ),
+					'name' => rawurlencode( get_bloginfo( 'name' ) ),
+				),
+				'https://outlook.live.com/calendar/0/addfromweb'
+			),
+		);
+	}
+}
+
+/**
+ * Render an inline brand SVG icon for a subscribe dropdown entry.
+ *
+ * Uses the same path data as the Font Awesome icons in the add-to-calendar
+ * button block's dropdown, so the two menus read as one family.
+ *
+ * @param string $provider One of 'google', 'outlook', 'apple', 'copy'.
+ * @return void Outputs HTML directly.
+ */
+if ( ! function_exists( 'fair_events_render_subscribe_icon' ) ) {
+	function fair_events_render_subscribe_icon( $provider ) {
+		$icons = array(
+			'google'  => array(
+				'viewBox' => '0 0 512 512',
+				'path'    => 'M500 261.8C500 403.3 403.1 504 260 504 122.8 504 12 393.2 12 256S122.8 8 260 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9c-88.3-85.2-252.5-21.2-252.5 118.2 0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9l-140.8 0 0-85.3 236.1 0c2.3 12.7 3.9 24.9 3.9 41.4z',
+			),
+			'outlook' => array(
+				'viewBox' => '0 0 448 512',
+				'path'    => 'M0 32l214.6 0 0 214.6-214.6 0 0-214.6zm233.4 0l214.6 0 0 214.6-214.6 0 0-214.6zM0 265.4l214.6 0 0 214.6-214.6 0 0-214.6zm233.4 0l214.6 0 0 214.6-214.6 0 0-214.6z',
+			),
+			'apple'   => array(
+				'viewBox' => '0 0 384 512',
+				'path'    => 'M319.1 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7-55.8 .9-115.1 44.5-115.1 133.2 0 26.2 4.8 53.3 14.4 81.2 12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zM262.5 104.5c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z',
+			),
+			'copy'    => array(
+				'viewBox' => '0 0 576 512',
+				'path'    => 'M419.5 96c-16.6 0-32.7 4.5-46.8 12.7-15.8-16-34.2-29.4-54.5-39.5 28.2-24 64.1-37.2 101.3-37.2 86.4 0 156.5 70 156.5 156.5 0 41.5-16.5 81.3-45.8 110.6l-71.1 71.1c-29.3 29.3-69.1 45.8-110.6 45.8-86.4 0-156.5-70-156.5-156.5 0-1.5 0-3 .1-4.5 .5-17.7 15.2-31.6 32.9-31.1s31.6 15.2 31.1 32.9c0 .9 0 1.8 0 2.6 0 51.1 41.4 92.5 92.5 92.5 24.5 0 48-9.7 65.4-27.1l71.1-71.1c17.3-17.3 27.1-40.9 27.1-65.4 0-51.1-41.4-92.5-92.5-92.5zM275.2 173.3c-1.9-.8-3.8-1.9-5.5-3.1-12.6-6.5-27-10.2-42.1-10.2-24.5 0-48 9.7-65.4 27.1L91.1 258.2c-17.3 17.3-27.1 40.9-27.1 65.4 0 51.1 41.4 92.5 92.5 92.5 16.5 0 32.6-4.4 46.7-12.6 15.8 16 34.2 29.4 54.6 39.5-28.2 23.9-64 37.2-101.3 37.2-86.4 0-156.5-70-156.5-156.5 0-41.5 16.5-81.3 45.8-110.6l71.1-71.1c29.3-29.3 69.1-45.8 110.6-45.8 86.6 0 156.5 70.6 156.5 156.9 0 1.3 0 2.6 0 3.9-.4 17.7-15.1 31.6-32.8 31.2s-31.6-15.1-31.2-32.8c0-.8 0-1.5 0-2.3 0-33.7-18-63.3-44.8-79.6z',
+			),
+		);
+
+		if ( ! isset( $icons[ $provider ] ) ) {
+			return;
+		}
+
+		printf(
+			'<svg class="fair-events-subscribe-icon" viewBox="%1$s" aria-hidden="true" focusable="false"><path fill="currentColor" d="%2$s"></path></svg>',
+			esc_attr( $icons[ $provider ]['viewBox'] ),
+			esc_attr( $icons[ $provider ]['path'] )
 		);
 	}
 }
@@ -398,32 +451,81 @@ $subscribe_urls = fair_events_build_subscribe_urls( is_array( $categories ) ? $c
 	</div>
 
 	<?php if ( $show_subscribe ) : ?>
-	<div class="fair-events-subscribe">
-		<a href="<?php echo esc_url( $subscribe_urls['webcal'] ); ?>" class="fair-events-subscribe-link">
-			<?php esc_html_e( 'Subscribe to calendar', 'fair-events' ); ?>
-		</a>
-		<p class="fair-events-subscribe-note">
-			<?php esc_html_e( 'Subscribed calendars refresh on your calendar app\'s own schedule (often hours, not instant).', 'fair-events' ); ?>
-		</p>
-		<div class="fair-events-subscribe-copy"
-			data-wp-interactive="fair-events/calendar-subscribe"
-			<?php
-			echo wp_interactivity_data_wp_context( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- self-escaping (JSON-encodes and esc_attr()'s internally).
-				array(
-					'copied'      => false,
-					'feedUrl'     => $subscribe_urls['https'],
-					'copyLabel'   => __( 'Copy feed URL', 'fair-events' ),
-					'copiedLabel' => '✓',
-				)
-			);
-			?>
+	<div class="fair-events-subscribe"
+		data-wp-interactive="fair-events/calendar-subscribe"
+		<?php
+		echo wp_interactivity_data_wp_context( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- self-escaping (JSON-encodes and esc_attr()'s internally).
+			array(
+				'isOpen'      => false,
+				'copied'      => false,
+				'feedUrl'     => $subscribe_urls['https'],
+				'copyLabel'   => __( 'Copy feed URL', 'fair-events' ),
+				'copiedLabel' => '✓',
+			)
+		);
+		?>
+		data-wp-on-document--click="actions.handleOutsideClick"
+		data-wp-on-document--keydown="actions.handleKeydown"
+	>
+		<button
+			type="button"
+			class="fair-events-subscribe-trigger wp-block-button__link wp-element-button is-style-outline"
+			aria-haspopup="true"
+			data-wp-on--click="actions.toggle"
+			data-wp-bind--aria-expanded="state.isOpen"
 		>
+			<?php esc_html_e( 'Subscribe to calendar', 'fair-events' ); ?>
+		</button>
+
+		<div class="fair-events-subscribe-panel"
+			role="menu"
+			data-wp-class--is-open="state.isOpen"
+			data-wp-bind--hidden="!state.isOpen"
+		>
+			<a
+				href="<?php echo esc_url( $subscribe_urls['google'] ); ?>"
+				class="fair-events-subscribe-entry"
+				role="menuitem"
+				target="_blank"
+				rel="noopener"
+				data-wp-on--click="actions.close"
+			>
+				<?php fair_events_render_subscribe_icon( 'google' ); ?>
+				<?php esc_html_e( 'Google Calendar', 'fair-events' ); ?>
+			</a>
+			<a
+				href="<?php echo esc_url( $subscribe_urls['outlook'] ); ?>"
+				class="fair-events-subscribe-entry"
+				role="menuitem"
+				target="_blank"
+				rel="noopener"
+				data-wp-on--click="actions.close"
+			>
+				<?php fair_events_render_subscribe_icon( 'outlook' ); ?>
+				<?php esc_html_e( 'Outlook', 'fair-events' ); ?>
+			</a>
+			<a
+				href="<?php echo esc_url( $subscribe_urls['webcal'] ); ?>"
+				class="fair-events-subscribe-entry"
+				role="menuitem"
+				data-wp-on--click="actions.close"
+			>
+				<?php fair_events_render_subscribe_icon( 'apple' ); ?>
+				<?php esc_html_e( 'Apple Calendar', 'fair-events' ); ?>
+			</a>
 			<button
-				class="fair-events-subscribe-copy-btn"
 				type="button"
+				class="fair-events-subscribe-entry fair-events-subscribe-entry-copy"
+				role="menuitem"
 				data-wp-on--click="actions.copy"
-				data-wp-text="state.label"
-			></button>
+			>
+				<?php fair_events_render_subscribe_icon( 'copy' ); ?>
+				<span data-wp-text="state.label"></span>
+			</button>
+
+			<p class="fair-events-subscribe-note">
+				<?php esc_html_e( 'Subscribed calendars refresh on your calendar app\'s own schedule (often hours, not instant).', 'fair-events' ); ?>
+			</p>
 		</div>
 	</div>
 	<?php endif; ?>

--- a/fair-events/src/blocks/events-calendar/style.scss
+++ b/fair-events/src/blocks/events-calendar/style.scss
@@ -240,48 +240,85 @@
 	}
 
 	.fair-events-subscribe {
+		position: relative;
 		margin-top: 0.75rem;
 		text-align: right;
 	}
 
-	.fair-events-subscribe-link {
+	.fair-events-subscribe-trigger {
 		display: inline-block;
-		padding: 0.375rem 0.875rem;
-		background: transparent;
-		border: 1px solid currentColor;
-		border-radius: 4px;
-		text-decoration: none;
-		font-size: 0.8125rem;
-		color: #1e1e1e;
-		opacity: 0.7;
-
-		&:hover {
-			opacity: 1;
-		}
-	}
-
-	.fair-events-subscribe-note {
-		margin: 0.375rem 0 0;
-		font-size: 0.75rem;
-		color: #757575;
-	}
-
-	.fair-events-subscribe-copy {
-		margin-top: 0.375rem;
-	}
-
-	.fair-events-subscribe-copy-btn {
 		padding: 0.375rem 0.875rem;
 		background: transparent;
 		border: 1px solid currentColor;
 		border-radius: 4px;
 		cursor: pointer;
 		font-size: 0.8125rem;
+		color: #1e1e1e;
 		opacity: 0.7;
 
-		&:hover {
+		&:hover,
+		&[aria-expanded="true"] {
 			opacity: 1;
 		}
+	}
+
+	.fair-events-subscribe-panel {
+		position: absolute;
+		right: 0;
+		top: 100%;
+		z-index: 20;
+		margin-top: 0.375rem;
+		min-width: 220px;
+		background: #fff;
+		border: 1px solid #e1e5e9;
+		border-radius: 8px;
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+		text-align: left;
+		opacity: 0;
+		visibility: hidden;
+		transform: translateY(-4px);
+		transition: opacity 0.15s ease, transform 0.15s ease;
+
+		&.is-open {
+			opacity: 1;
+			visibility: visible;
+			transform: translateY(0);
+		}
+	}
+
+	.fair-events-subscribe-entry {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		width: 100%;
+		padding: 0.625rem 0.875rem;
+		background: none;
+		border: none;
+		text-align: left;
+		text-decoration: none;
+		cursor: pointer;
+		font-size: 0.8125rem;
+		color: #1e1e1e;
+
+		&:hover,
+		&:focus {
+			background-color: #f5f5f5;
+		}
+	}
+
+	.fair-events-subscribe-icon {
+		flex-shrink: 0;
+		width: 14px;
+		height: 14px;
+		opacity: 0.8;
+	}
+
+	.fair-events-subscribe-note {
+		margin: 0;
+		padding: 0.5rem 0.875rem 0.75rem;
+		font-size: 0.6875rem;
+		color: #757575;
+		border-top: 1px solid #f0f0f0;
 	}
 
 	// Tablet: Smaller grid

--- a/fair-events/src/blocks/events-calendar/view.js
+++ b/fair-events/src/blocks/events-calendar/view.js
@@ -1,10 +1,11 @@
 /**
  * Events Calendar View - Interactivity API store
  *
- * Handles the "Copy link" button click for the subscribe fallback URL.
+ * Handles the subscribe dropdown: opening/closing, the "Copy link" button
+ * for the subscribe fallback URL, and dismissal via outside click/Escape.
  */
 
-import { store, getContext } from '@wordpress/interactivity';
+import { store, getContext, getElement } from '@wordpress/interactivity';
 
 /**
  * Copy text to the clipboard via the throwaway-textarea + execCommand
@@ -39,8 +40,41 @@ store('fair-events/calendar-subscribe', {
 			const context = getContext();
 			return context.copied ? context.copiedLabel : context.copyLabel;
 		},
+		get isOpen() {
+			const context = getContext();
+			return !!context.isOpen;
+		},
 	},
 	actions: {
+		toggle() {
+			const context = getContext();
+			context.isOpen = !context.isOpen;
+		},
+		close() {
+			const context = getContext();
+			context.isOpen = false;
+		},
+		handleOutsideClick(event) {
+			const context = getContext();
+			if (!context.isOpen) {
+				return;
+			}
+
+			const { ref } = getElement();
+			if (ref.contains(event.target)) {
+				return;
+			}
+
+			context.isOpen = false;
+		},
+		handleKeydown(event) {
+			if (event.key !== 'Escape') {
+				return;
+			}
+
+			const context = getContext();
+			context.isOpen = false;
+		},
 		*copy() {
 			const context = getContext();
 			const feedUrl = context.feedUrl;


### PR DESCRIPTION
## Summary

- Replaces the events-calendar block's three stacked subscribe controls (webcal link, always-visible refresh-delay paragraph, copy button) with a single right-aligned outline "Subscribe to calendar" trigger that opens a dropdown.
- Dropdown offers **Google Calendar**, **Outlook**, **Apple Calendar** (webcal), and **Copy feed URL**, using the same brand icon family as the add-to-calendar button block's provider menu. The refresh-delay note moves inside the dropdown as a muted footer, string unchanged so its translations survive.
- Open/close, outside-click dismissal, and Escape are handled through the block's existing `fair-events/calendar-subscribe` Interactivity API store (extended with `isOpen`/`toggle`/`close`/`handleOutsideClick`/`handleKeydown`) rather than ad-hoc DOM scripting. The trigger exposes `aria-expanded` to assistive technology.
- All entries derive from the same category-filtered feed URL as before, so the category filter is preserved for every subscription method.
- Regenerated translation catalogs (`.pot`/`.po`) for the new provider-entry strings.
- Rewrote `e2e/events-calendar-subscribe.spec.js` to exercise the dropdown: trigger visibility/aria-expanded, all four entries present with correct hrefs/targets, copy confirmation, and closing via Escape, outside click, and entry selection.

Closes #1154

## Test plan

- [x] `npm run build` in `fair-events`
- [x] `npm run format` in `fair-events`
- [x] `vendor/bin/phpcs` on changed PHP — no new violations (all remaining findings pre-exist on `main`)
- [x] `npm run test:js` in `fair-events` — 106/106 passing
- [x] `npx playwright test e2e/events-calendar-subscribe.spec.js` against local WordPress — both tests passing
- [x] Manual `wp eval-file` check confirming rendered markup has the new trigger/entries and no leftover old markup
