### PR TITLE
Show ticket scope selector for irregular (manual) series

### DIFF
--- a/fair-events/src/API/__tests__/GetTicketsIrregularSeries.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsIrregularSeries.api.spec.js
@@ -1,0 +1,174 @@
+/**
+ * Playwright API tests for whole-series ticket coverage on an irregular
+ * (manually-built) series — recurrence_mode='manual', no rrule (#1158).
+ *
+ * This endpoint only serves signups when fair-audience is NOT active
+ * (fair-events/src/blocks/get-tickets/render.php defers to the Event Signup
+ * block otherwise), so these tests skip gracefully when fair-audience is
+ * active in the test environment.
+ *
+ * Covers:
+ *   - a whole_series ticket type on a manual-mode master is accepted when
+ *     purchasing a non-first (generated) occurrence.
+ *   - the signup persists against the child occurrence, priced from the
+ *     master, confirming series resolution works the same way it does for
+ *     rrule-based series (#983) even though this series has no rrule.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('GetTicketsController — irregular (manual) series whole_series scope', () => {
+	let api;
+	let fairAudienceActive = false;
+	let eventPostId;
+	let masterEventDateId;
+	let occurrenceIds;
+	let childEventDateId;
+	let ticketTypeId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+		if (fairAudienceActive) {
+			return;
+		}
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Get-tickets irregular series test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2035-07-01 10:00:00',
+				end_datetime: '2035-07-01 12:00:00',
+				recurrence_mode: 'manual',
+				manual_dates: ['2035-07-01', '2035-07-10', '2035-07-20'],
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		masterEventDateId = (await edRes.json()).id;
+
+		const occRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
+			{ headers: adminHeaders }
+		);
+		expect(occRes.ok()).toBeTruthy();
+		occurrenceIds = (await occRes.json()).map((o) => o.id).sort();
+		expect(occurrenceIds.length).toBe(3);
+		// A non-first occurrence — the case exercised for whole-series coverage.
+		childEventDateId = occurrenceIds[1];
+
+		const ticketsRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'Season pass',
+							capacity: null,
+							invitation_only: false,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'whole_series',
+							group_ids: [],
+						},
+					],
+					sale_periods: [
+						{
+							name: 'Always on',
+							sale_start: '2020-01-01 00:00:00',
+							sale_end: '2099-01-01 00:00:00',
+						},
+					],
+					prices: [
+						{
+							ticket_type_index: 0,
+							sale_period_index: 0,
+							price: 25,
+						},
+					],
+					settings: {},
+				},
+			}
+		);
+		expect(ticketsRes.ok()).toBeTruthy();
+		const ticketsBody = await ticketsRes.json();
+		ticketTypeId = ticketsBody.ticket_types?.[0]?.id;
+		expect(ticketTypeId).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (fairAudienceActive) {
+			return;
+		}
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+		await api.dispose();
+	});
+
+	test('whole_series ticket type on a manual master is accepted for a generated occurrence', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: childEventDateId,
+				name: 'Irregular Series Tester',
+				email: `irregular-series-${Date.now()}@example.test`,
+				ticket_type_id: ticketTypeId,
+				quantity: 1,
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+	});
+
+	test('the signup persists against the child occurrence, priced from the master', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const signupsRes = await api.get(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				headers: adminHeaders,
+				params: { event_date: childEventDateId },
+			}
+		);
+		expect(signupsRes.ok()).toBeTruthy();
+		const signups = await signupsRes.json();
+		const signup = signups.find((s) => s.ticket_type_id === ticketTypeId);
+		expect(signup).toBeTruthy();
+		expect(parseFloat(signup.amount)).toBe(25);
+		expect(signup.status).toBe('pending_payment');
+	});
+});

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -41,7 +41,7 @@ export default function EventTickets({
 	onDataRef,
 	startDatetime,
 	endDatetime: endDatetimeProp,
-	isRecurring,
+	isSeries,
 	onDirtyChange,
 }) {
 	const [capacity, setCapacity] = useState('');
@@ -379,7 +379,7 @@ export default function EventTickets({
 	};
 
 	const openAddTicketModal = () => {
-		if (isRecurring) {
+		if (isSeries) {
 			setPendingScope('single_instance');
 			setShowScopeModal(true);
 		} else {
@@ -1336,7 +1336,7 @@ export default function EventTickets({
 														)}
 													</th>
 												)}
-												{isRecurring && (
+												{isSeries && (
 													<th>
 														{__(
 															'Scope',
@@ -1605,7 +1605,7 @@ export default function EventTickets({
 															/>
 														</td>
 													)}
-													{isRecurring && (
+													{isSeries && (
 														<td>
 															{type.has_sales ? (
 																<span>

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -708,7 +708,7 @@ export default function ManageEventApp() {
 					eventDateId={eventDateId}
 					startDatetime={eventDate.start_datetime}
 					endDatetime={eventDate.end_datetime}
-					isRecurring={!!eventDate?.rrule}
+					isSeries={isSeries}
 					onDirtyChange={handleTicketsDirtyChange}
 				/>
 			),

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -4,7 +4,7 @@
  * Component tests for the recurrence-scope selector in EventTickets (#663, #935).
  *
  * Exercises:
- *   - Scope column is visible only when isRecurring={true}.
+ *   - Scope column is visible only when isSeries={true}.
  *   - "+ Add Ticket Type" on a recurring event opens a scope-choice modal.
  *   - A new ticket type is seeded with the scope chosen in the modal.
  *   - Scope cell is read-only text when has_sales is true.
@@ -128,9 +128,9 @@ describe('EventTickets — empty state (no advanced tickets)', () => {
 });
 
 describe('EventTickets — recurrence scope selector', () => {
-	it('shows Scope column when isRecurring is true', () => {
+	it('shows Scope column when isSeries is true', () => {
 		renderTickets({
-			isRecurring: true,
+			isSeries: true,
 			initialData: initialDataWithTicketType,
 		});
 		expect(screen.getByText('Scope')).toBeInTheDocument();
@@ -139,22 +139,22 @@ describe('EventTickets — recurrence scope selector', () => {
 		expect(console).toHaveWarned();
 	});
 
-	it('does not show Scope column when isRecurring is false', () => {
+	it('does not show Scope column when isSeries is false', () => {
 		renderTickets({
-			isRecurring: false,
+			isSeries: false,
 			initialData: initialDataWithTicketType,
 		});
 		expect(screen.queryByText('Scope')).not.toBeInTheDocument();
 	});
 
-	it('does not show Scope column when isRecurring is omitted', () => {
+	it('does not show Scope column when isSeries is omitted', () => {
 		renderTickets({ initialData: initialDataWithTicketType });
 		expect(screen.queryByText('Scope')).not.toBeInTheDocument();
 	});
 
 	it('new ticket type is seeded with recurrence_scope single_instance', () => {
 		renderTickets({
-			isRecurring: true,
+			isSeries: true,
 			// Start with a ticket type so hasAdvancedTickets = true and the
 			// "+ Add Ticket Type" button is visible in the table footer.
 			initialData: initialDataWithTicketType,
@@ -186,7 +186,7 @@ describe('EventTickets — recurrence scope selector', () => {
 
 	it('changing scope selector to whole_series updates the combobox value', () => {
 		renderTickets({
-			isRecurring: true,
+			isSeries: true,
 			initialData: initialDataWithTicketType,
 		});
 
@@ -204,7 +204,7 @@ describe('EventTickets — recurrence scope selector', () => {
 
 	it('save payload includes updated recurrence_scope', async () => {
 		const { onSaveRef } = renderTickets({
-			isRecurring: true,
+			isSeries: true,
 			initialData: initialDataWithTicketType,
 		});
 
@@ -244,7 +244,7 @@ describe('EventTickets — recurrence scope selector', () => {
 describe('EventTickets — multiple_instances scope (#930)', () => {
 	it('offers multiple_instances as a scope option', () => {
 		renderTickets({
-			isRecurring: true,
+			isSeries: true,
 			initialData: initialDataWithTicketType,
 		});
 
@@ -267,7 +267,7 @@ describe('EventTickets — multiple_instances scope (#930)', () => {
 
 	it('shows a "Minimum instances" input once multiple_instances is selected', () => {
 		renderTickets({
-			isRecurring: true,
+			isSeries: true,
 			initialData: initialDataWithTicketType,
 		});
 
@@ -291,7 +291,7 @@ describe('EventTickets — multiple_instances scope (#930)', () => {
 
 	it('save payload includes the entered minimum_instances', async () => {
 		const { onSaveRef } = renderTickets({
-			isRecurring: true,
+			isSeries: true,
 			initialData: initialDataWithTicketType,
 		});
 
@@ -335,7 +335,7 @@ describe('EventTickets — multiple_instances scope (#930)', () => {
 describe('EventTickets — scope-choice modal', () => {
 	it('opens a modal when "+ Add Ticket Type" is clicked on a recurring event', () => {
 		renderTickets({
-			isRecurring: true,
+			isSeries: true,
 			initialData: initialDataWithTicketType,
 		});
 
@@ -350,7 +350,7 @@ describe('EventTickets — scope-choice modal', () => {
 
 	it('does not open a modal on a non-recurring event', () => {
 		renderTickets({
-			isRecurring: false,
+			isSeries: false,
 			initialData: initialDataWithTicketType,
 		});
 
@@ -365,7 +365,7 @@ describe('EventTickets — scope-choice modal', () => {
 
 	it('adds a whole_series ticket when that option is chosen in the modal', () => {
 		renderTickets({
-			isRecurring: true,
+			isSeries: true,
 			initialData: initialDataWithTicketType,
 		});
 
@@ -410,7 +410,7 @@ const initialDataWithSoldTicketType = {
 describe('EventTickets — scope lock when has_sales', () => {
 	it('renders scope as read-only text when has_sales is true', () => {
 		renderTickets({
-			isRecurring: true,
+			isSeries: true,
 			initialData: initialDataWithSoldTicketType,
 		});
 
@@ -427,7 +427,7 @@ describe('EventTickets — scope lock when has_sales', () => {
 
 	it('renders scope as SelectControl when has_sales is false', () => {
 		renderTickets({
-			isRecurring: true,
+			isSeries: true,
 			initialData: initialDataWithTicketType,
 		});
 

--- a/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/ManageEventApp.test.jsx
@@ -17,6 +17,12 @@ import ManageEventApp from '../ManageEventApp.js';
 
 jest.mock('@wordpress/api-fetch');
 
+jest.mock('../EventTickets.js', () => {
+	return function MockEventTickets({ isSeries }) {
+		return <div>isSeries: {String(isSeries)}</div>;
+	};
+});
+
 const mockEventDate = {
 	id: 1,
 	title: 'Test Event',
@@ -185,6 +191,33 @@ it('keeps Tickets and Finance tabs enabled for post-linked events', async () => 
 	expect(screen.getByRole('tab', { name: 'Finance' })).not.toHaveAttribute(
 		'aria-disabled',
 		'true'
+	);
+});
+
+it('passes isSeries=true to EventTickets for an irregular (manual) series (#1158)', async () => {
+	window.history.replaceState({}, '', '?tab=tickets');
+	window.fairEventsManageEventData = {
+		eventDateId: '1',
+		calendarUrl: 'http://example.com/calendar',
+		manageEventUrl: 'http://example.com/manage',
+		enabledPostTypes: [],
+		enabledFeatures: { ticketing: true },
+		paymentEntriesUrl: 'http://example.com/entries',
+	};
+	apiFetch.mockImplementation((opts) => {
+		if (opts.path && opts.path.includes('/event-dates/')) {
+			return Promise.resolve({
+				...mockEventDate,
+				rrule: null,
+				recurrence_mode: 'manual',
+			});
+		}
+		return Promise.resolve([]);
+	});
+
+	render(<ManageEventApp />);
+	await waitFor(() =>
+		expect(screen.getByText('isSeries: true')).toBeInTheDocument()
 	);
 });
 


### PR DESCRIPTION
## Summary

- `EventTickets` gated the whole-series/multiple-instances scope UI (scope modal, Scope column, per-row selector) on a narrow `isRecurring={!!eventDate?.rrule}` prop, so manually-built (irregular) series — `recurrence_mode: 'manual'`, no `rrule` — never saw the scope chooser at all.
- Backend series resolution already works purely off `occurrence_type`/`master_id`, not the rrule, so irregular series work end-to-end once the admin surfaces the scopes.
- Renamed the prop to `isSeries` and pass `ManageEventApp`'s existing `isSeries` check (`rrule` OR manual mode) instead of the rrule-only condition.

Closes #1158

## Test plan

- [x] `npx jest src/Admin/manage-event` — 86 tests pass, including a new `ManageEventApp` test asserting `isSeries=true` propagates to `EventTickets` for a `recurrence_mode: 'manual'` event, and updated `EventTickets` scope-selector tests (renamed prop).
- [x] Added `GetTicketsIrregularSeries.api.spec.js`, a sibling of `GetTicketsRecurringMaster.api.spec.js`, covering a `whole_series` ticket type on a manual-mode master resolving correctly for a generated occurrence. Could not execute locally — the dev Docker environment's Apache isn't passing the `Authorization` header through to PHP, so REST Basic Auth 401s for *any* API spec here, including the pre-existing `GetTicketsRecurringMaster` spec (verified un-related to this change).
