### PR TITLE
Accept nested question blocks in unified Event Signup block

### DIFF
--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -53,9 +53,21 @@ $is_paid           = true;
 // Which purchase block the event page carries. Default: fair-audience
 // event-signup. Override {"block":"get-tickets"} for specs that exercise the
 // fair-events standalone purchase path (with fair-audience deactivated).
+// Override {"block":"unified-with-question"} for specs that exercise the
+// unified fair-events/event-signup block with a nested fair-form question,
+// delegated through fair-audience's participant-aware flow (#1160).
 $block_content = '<!-- wp:fair-audience/event-signup /-->';
 if ( isset( $overrides['block'] ) && 'get-tickets' === $overrides['block'] ) {
 	$block_content = '<!-- wp:fair-events/get-tickets /-->';
+} elseif ( isset( $overrides['block'] ) && 'unified-with-question' === $overrides['block'] ) {
+	$block_content = implode(
+		"\n",
+		array(
+			'<!-- wp:fair-events/event-signup -->',
+			'<!-- wp:fair-audience/fair-form-short-text {"questionKey":"dietary","questionText":"Dietary needs"} /-->',
+			'<!-- /wp:fair-events/event-signup -->',
+		)
+	);
 }
 
 $event_id       = fair_e2e_create_event( 'E2E ' . $flavour . ' Event ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ), $block_content );

--- a/e2e/user-flows/unified-signup-nested-question.spec.js
+++ b/e2e/user-flows/unified-signup-nested-question.spec.js
@@ -1,0 +1,46 @@
+/**
+ * E2E: signup with a custom question nested in the unified Event Signup
+ * block, delegated through fair-audience's participant-aware flow (#1160).
+ *
+ * The unified fair-events/event-signup block now accepts nested fair-form
+ * question blocks and forwards them, unchanged, to the legacy
+ * fair-audience/event-signup render when fair-audience is active. This drives
+ * a real free signup through the browser with a nested short-text question to
+ * prove the question renders on the unified block and the signup completes.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+
+test.describe('unified event-signup block: nested custom question', () => {
+	test('a free signup with a custom question completes', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('free', { block: 'unified-with-question' });
+		const stamp = Date.now();
+		const email = `unified.question.${stamp}@example.test`;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-audience-signup-register');
+		await expect(form).toBeVisible();
+
+		// The nested fair-form question, forwarded through the delegated
+		// render, appears alongside the name/email fields.
+		const question = form.locator('[data-question-key="dietary"]');
+		await expect(question).toBeVisible();
+		await expect(question).toContainText('Dietary needs');
+
+		await form.locator('input[name="signup_name"]').fill('Unified Visitor');
+		await form.locator('input[name="signup_email"]').fill(email);
+		await question.locator('input[type="text"]').fill('No nuts');
+
+		await form.locator('.fair-audience-signup-submit-button').click();
+
+		await expect(
+			page.getByText('You are signed up for this event', {
+				exact: false,
+			})
+		).toBeVisible();
+	});
+});

--- a/fair-audience/src/blocks/event-signup/editor.js
+++ b/fair-audience/src/blocks/event-signup/editor.js
@@ -39,20 +39,34 @@ const ALLOWED_BLOCKS = [
 	'fair-audience/fair-form-conditional',
 ];
 
+// The file-upload question can nest inside a conditional block, so this
+// scans the whole inner-block tree rather than just the top level.
+function hasFileUploadQuestion(blocks) {
+	return (blocks || []).some(
+		(block) =>
+			block.name === 'fair-audience/fair-form-file-upload' ||
+			hasFileUploadQuestion(block.innerBlocks)
+	);
+}
+
 registerBlockType('fair-audience/event-signup', {
 	transforms: {
 		to: [
 			{
 				type: 'block',
 				blocks: [UNIFIED_NAME],
-				// Instances with custom questions would silently lose them —
-				// only offer the transform when there's nothing to drop.
+				// A nested file-upload question would silently lose upload
+				// handling on the unified block (no vetted anonymous-upload
+				// path yet) — withhold the transform in that case. Other
+				// questions survive the transform via innerBlocks below.
 				isMatch: (attributes, block) =>
-					!block.innerBlocks || block.innerBlocks.length === 0,
-				transform: (attributes) =>
-					createBlock(UNIFIED_NAME, {
-						submitButtonText: attributes.signupButtonText,
-					}),
+					!hasFileUploadQuestion(block.innerBlocks),
+				transform: (attributes, innerBlocks) =>
+					createBlock(
+						UNIFIED_NAME,
+						{ submitButtonText: attributes.signupButtonText },
+						innerBlocks
+					),
 			},
 		],
 	},

--- a/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
+++ b/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+// ServerSideRender hits the REST API for a live render; stub it to a marker
+// so we can render the block in isolation.
+jest.mock(
+	'@wordpress/server-side-render',
+	() => () => <div data-testid="ssr" />,
+	{ virtual: true }
+);
+
+const mockUseSelect = jest.fn();
+jest.mock('@wordpress/data', () => {
+	const stub = () => stub;
+	return new Proxy(
+		{ useSelect: (...args) => mockUseSelect(...args) },
+		{
+			get(target, prop) {
+				if (prop in target) return target[prop];
+				return stub;
+			},
+		}
+	);
+});
+
+// useBlockProps/useInnerBlocksProps need the editor's block context, which
+// jsdom doesn't provide; stub them to plain markers so we can assert on the
+// questions region without a full editor.
+jest.mock('@wordpress/block-editor', () => ({
+	useBlockProps: () => ({}),
+	useInnerBlocksProps: () => ({ 'data-testid': 'inner-blocks' }),
+	InspectorControls: ({ children }) => children,
+	InnerBlocks: Object.assign(() => null, {
+		Content: () => null,
+		ButtonBlockAppender: () => null,
+	}),
+}));
+
+// Capture the block settings passed to registerBlockType so the edit
+// function can be rendered directly, without a live block registry.
+let capturedSettings;
+jest.mock('@wordpress/blocks', () => ({
+	registerBlockType: (name, settings) => {
+		capturedSettings = settings;
+	},
+}));
+
+describe('Event Signup EditComponent', () => {
+	let Edit;
+
+	beforeAll(() => {
+		require('../editor.js');
+		Edit = capturedSettings.edit;
+	});
+
+	const renderEdit = (isFairFormActive) => {
+		mockUseSelect.mockReturnValue(isFairFormActive);
+		return render(
+			<Edit
+				attributes={{ submitButtonText: 'Get Tickets' }}
+				setAttributes={() => {}}
+			/>
+		);
+	};
+
+	it('shows the custom-questions region when fair-form is active', () => {
+		renderEdit(true);
+
+		expect(screen.getByTestId('ssr')).toBeInTheDocument();
+		expect(screen.getByTestId('inner-blocks')).toBeInTheDocument();
+		expect(screen.getByText('Custom questions')).toBeInTheDocument();
+	});
+
+	it('hides the custom-questions region when fair-form is inactive', () => {
+		renderEdit(false);
+
+		expect(screen.getByTestId('ssr')).toBeInTheDocument();
+		expect(screen.queryByTestId('inner-blocks')).toBeNull();
+		expect(screen.queryByText('Custom questions')).toBeNull();
+	});
+});

--- a/fair-events/src/blocks/event-signup/editor.css
+++ b/fair-events/src/blocks/event-signup/editor.css
@@ -7,3 +7,19 @@
 		cursor: default;
 	}
 }
+
+.fair-events-event-signup-questions-label {
+	font-weight: 600;
+	font-size: 13px;
+	color: #1e1e1e;
+	margin-top: 12px;
+	margin-bottom: 4px;
+}
+
+.fair-events-event-signup-questions {
+	min-height: 40px;
+	margin: 4px 0 16px;
+	padding: 8px;
+	border: 1px dashed #ccc;
+	border-radius: 4px;
+}

--- a/fair-events/src/blocks/event-signup/editor.js
+++ b/fair-events/src/blocks/event-signup/editor.js
@@ -13,8 +13,14 @@
  */
 
 import { registerBlockType } from '@wordpress/blocks';
-import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls,
+	InnerBlocks,
+} from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import ServerSideRender from '@wordpress/server-side-render';
 import metadata from './block.json';
@@ -22,10 +28,47 @@ import './editor.css';
 
 const UNIFIED_NAME = 'fair-events/event-signup';
 
+// Custom question blocks that can be nested inside the signup form. Mirrors
+// the legacy fair-audience/event-signup block's set, minus the file-upload
+// question: the unified form is submittable by anonymous visitors and
+// uploads stay out until there is a vetted path.
+const ALLOWED_BLOCKS = [
+	'core/heading',
+	'core/paragraph',
+	'core/list',
+	'fair-audience/fair-form-short-text',
+	'fair-audience/fair-form-long-text',
+	'fair-audience/fair-form-phone',
+	'fair-audience/fair-form-select-one',
+	'fair-audience/fair-form-radio',
+	'fair-audience/fair-form-multiselect',
+	'fair-audience/fair-form-consent',
+	'fair-audience/fair-form-conditional',
+];
+
 registerBlockType(metadata.name, {
 	...metadata,
 	edit: function Edit({ attributes, setAttributes }) {
 		const blockProps = useBlockProps();
+
+		// The fair-form question set is only registered when fair-form is
+		// active. Without it, offer no question blocks — there is no
+		// fair-events-owned default question set.
+		const isFairFormActive = useSelect(
+			(select) =>
+				!!select('core/blocks').getBlockType(
+					'fair-audience/fair-form-short-text'
+				),
+			[]
+		);
+
+		const innerBlocksProps = useInnerBlocksProps(
+			{ className: 'fair-events-event-signup-questions' },
+			{
+				allowedBlocks: ALLOWED_BLOCKS,
+				renderAppender: InnerBlocks.ButtonBlockAppender,
+			}
+		);
 
 		return (
 			<>
@@ -46,8 +89,29 @@ registerBlockType(metadata.name, {
 						block={UNIFIED_NAME}
 						attributes={attributes}
 					/>
+					{isFairFormActive && (
+						<>
+							<div className="fair-events-event-signup-questions-label">
+								{__('Custom questions', 'fair-events')}
+							</div>
+							<div {...innerBlocksProps} />
+						</>
+					)}
 				</div>
 			</>
 		);
 	},
+	save: () => {
+		// Dynamic block (rendered via render.php), but the nested question
+		// blocks must be serialized so render.php receives them as $content.
+		return <InnerBlocks.Content />;
+	},
+	deprecated: [
+		{
+			// Previously a pure dynamic block with no saved markup. Existing
+			// instances have no inner blocks, so migrating them to the
+			// InnerBlocks.Content save is a no-op that avoids block recovery.
+			save: () => null,
+		},
+	],
 });

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -17,16 +17,16 @@ defined( 'WPINC' ) || die;
 
 // When fair-audience is active it owns the participant-aware signup flow.
 // Delegate to its block via render_block() so its richer render runs unchanged
-// and its view script/styles enqueue, then stop.
+// and its view script/styles enqueue, then stop. Nested question blocks are
+// forwarded so the delegated render receives them as $content, exactly as on
+// the legacy fair-audience block.
 if ( class_exists( \FairAudience\API\EventSignupController::class ) ) {
-	echo render_block( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render_block() returns trusted, already-escaped block markup.
-		array(
-			'blockName' => 'fair-audience/event-signup',
-			'attrs'     => array(
-				'signupButtonText' => $attributes['submitButtonText'] ?? '',
-			),
-		)
+	$delegated_block              = $block->parsed_block;
+	$delegated_block['blockName'] = 'fair-audience/event-signup';
+	$delegated_block['attrs']     = array(
+		'signupButtonText' => $attributes['submitButtonText'] ?? '',
 	);
+	echo render_block( $delegated_block ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render_block() returns trusted, already-escaped block markup.
 	return;
 }
 


### PR DESCRIPTION
## Summary

- The unified `fair-events/event-signup` block gains a "Custom questions" InnerBlocks region, gated on fair-form being active, offering the same fair-form question set as the legacy block minus file-upload (no vetted anonymous-upload path yet).
- Adds `save`/`deprecated` so the block moves from unsaved to serialized content without triggering block-recovery on existing instances (mirrors the legacy block's own migration).
- The delegated render (fair-audience active) now forwards the parsed inner blocks so nested questions render, validate, and store exactly as they do today on the legacy block. The base (anonymous) flow is unchanged — it keeps ignoring `$content`, so the anonymous signup route still accepts no answer payloads.
- The legacy `fair-audience/event-signup` transform now carries `innerBlocks` through to the unified block, and is withheld only when a file-upload question is nested anywhere in the tree (including inside a conditional), instead of whenever any question is present at all.

Closes #1160

## Test plan

- [x] `npm run test:js` (fair-events, fair-audience) — all pass, including new `fair-events/src/blocks/event-signup/__tests__/editor.test.jsx` covering the questions region appearing/disappearing based on fair-form availability.
- [x] `vendor/bin/phpcs` clean on changed PHP.
- [x] `npm run build` in fair-events and fair-audience.
- [x] WP-CLI `eval-file` manual check: rendering the unified block with a nested question while fair-audience is active outputs the question markup — confirms the delegation forwards inner blocks end-to-end.
- [x] `npm run test:e2e` — new spec `e2e/user-flows/unified-signup-nested-question.spec.js` (free signup with a nested custom question completes) plus the full existing signup-related suite (`conditional-signup-fields`, `get-tickets-purchase`, `resume-signup-recognised-email`, `signup-cancel-and-restart`, `signups-list-permission`) — all pass.
- [ ] API spec — not added. `EventSignupController.php`'s `questionnaire_answers` handling is unchanged by this PR (this ticket only changes how questions reach the delegated render, not how they're validated/stored), so the existing fair-audience API specs already cover that path.
