### PR TITLE
Hide date dropdown for whole-series ticket passes

### DIFF
--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -206,6 +206,18 @@ const SCROLL_RESTORE_KEY = 'fairAudienceOccurrenceScrollY';
 	}
 
 	/**
+	 * Whether the selected ticket type is a 'whole_series' scope pass.
+	 * @param {HTMLElement} block The block element
+	 * @return {boolean} True when the pass covers every occurrence in the series.
+	 */
+	function isWholeSeriesSelected(block) {
+		const selected = getSelectedTicketType(block);
+		return (
+			!!selected && selected.dataset.recurrenceScope === 'whole_series'
+		);
+	}
+
+	/**
 	 * Number of checked occurrence checkboxes in the multi-instance picker.
 	 * @param {HTMLElement} block The block element
 	 * @return {number} Count of checked event_date_ids[] checkboxes.
@@ -228,33 +240,45 @@ const SCROLL_RESTORE_KEY = 'fairAudienceOccurrenceScrollY';
 	}
 
 	/**
-	 * Show the multi-occurrence checkbox picker (hiding the single-occurrence
-	 * dropdown) when a 'multiple_instances' ticket type is selected, and vice
-	 * versa. Clears stale checkbox state when switching away so a leftover
-	 * selection can't leak into a later submission for a different scope.
+	 * Sync the two occurrence pickers to the selected ticket type's scope:
+	 * - 'multiple_instances' shows the checkbox picker and hides the single
+	 *   date dropdown;
+	 * - 'whole_series' hides both, since the pass covers every occurrence and
+	 *   the date choice is irrelevant;
+	 * - 'single_instance' (the default) shows the date dropdown only.
+	 *
+	 * Clears stale checkbox state when switching away from multiple_instances
+	 * so a leftover selection can't leak into a later submission for a
+	 * different scope. The date dropdown is handled independently of the
+	 * instance picker so it still gets hidden for a whole_series pass on
+	 * events that have no multiple_instances type (and thus no instance
+	 * picker rendered).
 	 * @param {HTMLElement} block The block element
 	 */
 	function updateInstancePickerVisibility(block) {
+		const multipleInstances = isMultipleInstancesSelected(block);
+		const wholeSeries = isWholeSeriesSelected(block);
+
 		const instancePicker = block.querySelector(
 			'.fair-audience-instance-picker'
 		);
-		if (!instancePicker) {
-			return;
+		if (instancePicker) {
+			instancePicker.style.display = multipleInstances ? '' : 'none';
+			if (!multipleInstances) {
+				instancePicker
+					.querySelectorAll('input[type="checkbox"]')
+					.forEach(function (cb) {
+						cb.checked = false;
+					});
+			}
 		}
+
 		const occurrencePicker = block.querySelector(
 			'.fair-audience-occurrence-picker'
 		);
-		const active = isMultipleInstancesSelected(block);
-		instancePicker.style.display = active ? '' : 'none';
 		if (occurrencePicker) {
-			occurrencePicker.style.display = active ? 'none' : '';
-		}
-		if (!active) {
-			instancePicker
-				.querySelectorAll('input[type="checkbox"]')
-				.forEach(function (cb) {
-					cb.checked = false;
-				});
+			occurrencePicker.style.display =
+				multipleInstances || wholeSeries ? 'none' : '';
 		}
 	}
 


### PR DESCRIPTION
## Summary

`Refs #1169`

Follow-up to the admin-side scope fix (`7e6680c7`, #1158). That restored the three ticket-type **scopes** in the manage-event admin, but the frontend signup still showed a stale "Choose a date" dropdown when a **whole-series** ticket was picked — visible in #1169 as the date selector staying on screen with "Ciclo entero" selected.

## Root cause

In `fair-audience/src/blocks/event-signup/frontend.js`, `updateInstancePickerVisibility()`:

1. Only toggled the single-occurrence dropdown between `single_instance` and `multiple_instances`; a `whole_series` selection fell through to the "show the dropdown" branch.
2. **Bailed out early** (`if (!instancePicker) return;`) whenever no `multiple_instances` instance picker was rendered. An event with just `single_instance` + `whole_series` types — the class-schedule case in the screenshot — has no instance picker, so the dropdown was never touched at all.

## Fix

Handle the occurrence dropdown independently of the instance picker, and hide it for a `whole_series` selection too:

- `multiple_instances` → checkbox picker shown, date dropdown hidden
- `whole_series` → both hidden (the pass covers every occurrence; the date is irrelevant)
- `single_instance` (default) → date dropdown only

The submitted `event_date_id` still comes from the block wrapper (`data-event-date-id`), so the backend applies the whole-series pass on the master unchanged — this is a pure UI-visibility fix.

## Testing

- `npm run build` in `fair-audience` ✅
- `npm run test:js` in `fair-audience` — 25 passed ✅
- Frontend `viewScript` (self-executing IIFE) has no unit-test harness here, matching the repo convention.

⚠️ **Needs a rebuild + redeploy to verify visually on the live site** — please re-check that "Ciclo entero" hides the date dropdown while "Clase suelta" still shows it.
