### PR TITLE
Save typed ticket prices when no prices were stored

### DIFF
--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -746,7 +746,12 @@ export default function EventTickets({
 		ticketTypes.forEach((type, tIndex) => {
 			salePeriods.forEach((period, pIndex) => {
 				const val = getPrice(type, period);
-				if (!val.enabled) return;
+				// The `enabled` flag is only user-controllable via the
+				// "Available" checkbox, which renders only in multiple-periods
+				// mode. In single-period mode there is no way to flip it, so a
+				// typed price/capacity must always save — otherwise price-less
+				// cells (seeded enabled: false) silently drop their input.
+				if (effectiveMultiple && !val.enabled) return;
 				if (val.price === '' && val.capacity === '') return;
 				pricesArray.push({
 					ticket_type_index: tIndex,

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -797,3 +797,116 @@ describe('EventTickets — single pricing period by default (#1138)', () => {
 		expect(screen.getByText('Day of event')).toBeInTheDocument();
 	});
 });
+
+describe('EventTickets — pricing an event with no stored prices (#1175)', () => {
+	// A ticket type + sale period saved without any price. In single-period
+	// mode the pricing cell is seeded enabled:false and there is no "Available"
+	// checkbox to flip it, so a typed price must still reach the save payload.
+	const initialDataUnpriced = {
+		...initialDataWithTicketType,
+		sale_periods: [
+			{
+				id: 701,
+				name: '',
+				sale_start: '2026-01-01',
+				sale_end: '2026-02-01',
+			},
+		],
+		prices: [],
+	};
+
+	// Same data, but multiple-periods mode is on so the "Available" checkbox
+	// renders and its unchecked state must still exclude the cell.
+	const initialDataUnpricedMulti = {
+		...initialDataUnpriced,
+		settings: { multiple_pricing_periods: true },
+	};
+
+	// The per-cell Price input is the only spinbutton carrying step="0.01"
+	// (Total capacity / ticket-type capacity inputs have no step).
+	const getPriceInput = () =>
+		screen
+			.getAllByRole('spinbutton')
+			.find((el) => el.getAttribute('step') === '0.01');
+
+	async function saveAndCapturePayload(onSaveRef) {
+		let savedPayload = null;
+		apiFetch.mockImplementation(({ method, data }) => {
+			if (method === 'PUT') {
+				savedPayload = data;
+				return Promise.resolve({
+					...initialDataUnpriced,
+					prices: [],
+				});
+			}
+			return new Promise(() => {});
+		});
+
+		expect(onSaveRef.current).not.toBeNull();
+		await act(async () => {
+			await onSaveRef.current();
+		});
+		return savedPayload;
+	}
+
+	it('single-period mode: a typed price is included in the save payload', async () => {
+		const { onSaveRef } = renderTickets({
+			initialData: initialDataUnpriced,
+		});
+
+		// Single-period mode renders no "Available" checkbox.
+		expect(screen.queryByText('Available')).not.toBeInTheDocument();
+
+		const priceInput = getPriceInput();
+		expect(priceInput).toBeTruthy();
+		fireEvent.change(priceInput, { target: { value: '15' } });
+
+		const savedPayload = await saveAndCapturePayload(onSaveRef);
+
+		expect(savedPayload).not.toBeNull();
+		expect(savedPayload.prices).toHaveLength(1);
+		expect(savedPayload.prices[0]).toMatchObject({
+			ticket_type_index: 0,
+			sale_period_index: 0,
+			price: 15,
+		});
+	});
+
+	it('multiple-periods mode: an unchecked cell stays excluded from the save payload', async () => {
+		const { onSaveRef } = renderTickets({
+			initialData: initialDataUnpricedMulti,
+		});
+
+		// The checkbox renders unchecked and hides the price input.
+		const available = screen.getByRole('checkbox', { name: 'Available' });
+		expect(available).not.toBeChecked();
+		expect(getPriceInput()).toBeUndefined();
+
+		const savedPayload = await saveAndCapturePayload(onSaveRef);
+
+		expect(savedPayload).not.toBeNull();
+		expect(savedPayload.prices).toHaveLength(0);
+	});
+
+	it('multiple-periods mode: checking Available then typing a price includes the cell', async () => {
+		const { onSaveRef } = renderTickets({
+			initialData: initialDataUnpricedMulti,
+		});
+
+		fireEvent.click(screen.getByRole('checkbox', { name: 'Available' }));
+
+		const priceInput = getPriceInput();
+		expect(priceInput).toBeTruthy();
+		fireEvent.change(priceInput, { target: { value: '9' } });
+
+		const savedPayload = await saveAndCapturePayload(onSaveRef);
+
+		expect(savedPayload).not.toBeNull();
+		expect(savedPayload.prices).toHaveLength(1);
+		expect(savedPayload.prices[0]).toMatchObject({
+			ticket_type_index: 0,
+			sale_period_index: 0,
+			price: 9,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug on the Manage Event **Tickets** tab. For an event whose ticket types and sale period were saved without any prices, typing a price and clicking **Save tickets** reported success but silently discarded the price — leaving the event permanently unpriceable. Closes #1175.

Each pricing cell carries an "Available" flag that gates the save, but the checkbox controlling it renders only in multiple-periods mode. In the default single-period mode there was no way to flip a cell (seeded unavailable when it loads with no stored price) back to available, so its typed price was dropped on every save.

The fix enforces the availability filter only when the checkbox is actually shown (multiple-periods mode). In single-period mode a typed price/capacity now always saves; deliberately unchecked cells in multiple-periods mode stay excluded, exactly as before.

## Notes

- Client-side only — the REST controller and DB schema were already correct; the `enabled` flag is purely a UI concept.
- The `enabled: false` initialization on load is intentionally left unchanged: forcing it true would flip the visible "Available" checkbox default in multiple-periods mode. Gating the save filter is the narrower fix.
- Events already stuck in this state become priceable again with no manual data repair.

## Test plan

- [x] `npx jest EventTickets` — 40/40 pass, including 3 new tests for #1175.
- [x] New regression test fails on pre-fix code and passes with the fix (verified via stash).
- [x] Multiple-periods exclusion behaviour still covered (unchecked cell stays out of the payload).
- [ ] Manual: on an event with ticket types + one sale period + no stored prices, type a price → Save → reload → price persists and the public signup flow offers it.
