### PR TITLE
Fail closed when payments unavailable for paid tickets

### DIFF
--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -225,6 +225,18 @@ class GetTicketsController extends WP_REST_Controller {
 			}
 		}
 
+		// Fail closed: a priced ticket must never be saved when payment can't
+		// be collected. Rejecting up front avoids the orphaned pending_payment
+		// row left by the connector-unconfigured case and the silent
+		// free-confirmation the old connector-absent fallback produced.
+		if ( $amount > 0 && $this->payments_unavailable() ) {
+			return new WP_Error(
+				'payment_unavailable',
+				__( 'Paid tickets are not available because online payments are not configured.', 'fair-events' ),
+				array( 'status' => 503 )
+			);
+		}
+
 		$this->increment_rate_limit();
 
 		// Persist the signup row.
@@ -265,18 +277,9 @@ class GetTicketsController extends WP_REST_Controller {
 			);
 		}
 
-		// Paid path — fall back to confirmed if payment connector is absent.
-		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
-			\FairEvents\Models\EventSignup::update_status( $signup_id, 'confirmed' );
-			$this->fire_signup_created( $signup_id, $event_date_id, $name, $email, $ticket_selection, null );
-			return rest_ensure_response(
-				array(
-					'status'  => 'confirmed',
-					'message' => __( 'You have successfully registered!', 'fair-events' ),
-				)
-			);
-		}
-
+		// Paid path — payments were confirmed available before the signup row
+		// was saved (see the fail-closed guard above), so a transaction can be
+		// created here without a free-fallback.
 		$currency    = get_option( 'fair_payment_currency', 'EUR' );
 		$description = sprintf(
 			/* translators: %d: event date ID */
@@ -492,6 +495,16 @@ class GetTicketsController extends WP_REST_Controller {
 		$count        = count( $occurrences );
 		$total_amount = $unit_price * $count;
 
+		// Fail closed before any row is written: reject a priced multi-instance
+		// signup when payment can't be collected, mirroring create_signup().
+		if ( $total_amount > 0 && $this->payments_unavailable() ) {
+			return new WP_Error(
+				'payment_unavailable',
+				__( 'Paid tickets are not available because online payments are not configured.', 'fair-events' ),
+				array( 'status' => 503 )
+			);
+		}
+
 		// Persist one signup row per chosen occurrence (quantity fixed at 1;
 		// instance count is the only multiplier for this scope).
 		$signup_ids = array();
@@ -543,20 +556,9 @@ class GetTicketsController extends WP_REST_Controller {
 			);
 		}
 
-		// Paid path — fall back to confirmed if payment connector is absent.
-		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
-			foreach ( $signup_ids as $index => $signup_id ) {
-				\FairEvents\Models\EventSignup::update_status( $signup_id, 'confirmed' );
-				$this->fire_signup_created( $signup_id, $occurrence_ids[ $index ], $name, $email, $ticket_selection, null );
-			}
-			return rest_ensure_response(
-				array(
-					'status'  => 'confirmed',
-					'message' => __( 'You have successfully registered!', 'fair-events' ),
-				)
-			);
-		}
-
+		// Paid path — payments were confirmed available before any signup row
+		// was saved (see the fail-closed guard above), so a shared transaction
+		// can be created here without a free-fallback.
 		$currency    = get_option( 'fair_payment_currency', 'EUR' );
 		$description = sprintf(
 			/* translators: %d: event date ID */
@@ -634,6 +636,22 @@ class GetTicketsController extends WP_REST_Controller {
 				'currency'       => $currency,
 			)
 		);
+	}
+
+	/**
+	 * Whether online payments can be collected right now.
+	 *
+	 * True when the payments connector is missing entirely, or installed but
+	 * not configured (no Mollie key / OAuth). Priced signups are rejected up
+	 * front in that case instead of being saved and then failing at payment
+	 * time, so no orphaned pending_payment rows are created and no priced
+	 * ticket is ever confirmed for free.
+	 *
+	 * @return bool
+	 */
+	private function payments_unavailable() {
+		return ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class )
+			|| ! \FairPaymentsConnector\API\TransactionAPI::is_configured();
 	}
 
 	/**

--- a/fair-events/src/API/__tests__/GetTicketsPaymentUnavailable.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsPaymentUnavailable.api.spec.js
@@ -1,0 +1,266 @@
+/**
+ * Playwright API tests for the get-tickets fallback endpoint's fail-closed
+ * behaviour when online payments can't be collected (#1177).
+ *
+ * This endpoint only serves signups when fair-audience is NOT active
+ * (fair-events/src/blocks/event-signup/render.php defers to the Event Signup
+ * block otherwise), so these tests skip gracefully when fair-audience is
+ * active in the test environment.
+ *
+ * Like fair-audience's EventSignupSlidingScale spec, this assumes the dev
+ * stack has no payment connector configured: a priced signup must be rejected
+ * up front with 503 payment_unavailable, creating no signup (and therefore no
+ * transaction) row, so a paid ticket is never confirmed for free and no
+ * orphaned pending_payment row is left behind. A free (price-0) signup on the
+ * same event must still confirm.
+ *
+ * Covers every priced path the ticket calls out: single instance, whole
+ * series, and multiple instances.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}-${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+test.describe('GetTicketsController — payments unavailable (fail closed)', () => {
+	let api;
+	let fairAudienceActive = false;
+	let eventPostId;
+	let masterEventDateId;
+	let occurrenceIds;
+	let singleTypeId;
+	let seriesTypeId;
+	let multiTypeId;
+
+	// Count signup rows for an event date via the admin GET route, so a
+	// rejection can be proven to have written nothing.
+	async function countSignups(eventDateId) {
+		const res = await api.get('/wp-json/fair-events/v1/get-tickets', {
+			headers: adminHeaders,
+			params: { event_date: eventDateId },
+		});
+		expect(res.ok()).toBeTruthy();
+		return (await res.json()).length;
+	}
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+		if (fairAudienceActive) {
+			return;
+		}
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Get-tickets payments-unavailable test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2035-05-01 10:00:00',
+				end_datetime: '2035-05-01 12:00:00',
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		masterEventDateId = (await edRes.json()).id;
+
+		const occRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
+			{ headers: adminHeaders }
+		);
+		expect(occRes.ok()).toBeTruthy();
+		occurrenceIds = (await occRes.json()).map((o) => o.id).sort();
+		expect(occurrenceIds.length).toBe(3);
+
+		// Three priced ticket types — one per purchase path — plus an
+		// always-on sale period so each price resolves server-side.
+		const baseType = {
+			capacity: null,
+			invitation_only: false,
+			minimum_activities: 0,
+			disable_at: null,
+			group_ids: [],
+		};
+		const ticketsRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							...baseType,
+							name: 'Single session',
+							recurrence_scope: 'single_instance',
+						},
+						{
+							...baseType,
+							name: 'Series pass',
+							recurrence_scope: 'whole_series',
+						},
+						{
+							...baseType,
+							name: 'Pick your sessions',
+							recurrence_scope: 'multiple_instances',
+							minimum_instances: 2,
+						},
+					],
+					sale_periods: [
+						{
+							name: 'Always on',
+							sale_start: '2020-01-01 00:00:00',
+							sale_end: '2099-01-01 00:00:00',
+						},
+					],
+					prices: [
+						{
+							ticket_type_index: 0,
+							sale_period_index: 0,
+							price: 20,
+						},
+						{
+							ticket_type_index: 1,
+							sale_period_index: 0,
+							price: 30,
+						},
+						{
+							ticket_type_index: 2,
+							sale_period_index: 0,
+							price: 10,
+						},
+					],
+					settings: {},
+				},
+			}
+		);
+		expect(ticketsRes.ok()).toBeTruthy();
+		const types = (await ticketsRes.json()).ticket_types || [];
+		singleTypeId = types.find(
+			(t) => t.recurrence_scope === 'single_instance'
+		)?.id;
+		seriesTypeId = types.find(
+			(t) => t.recurrence_scope === 'whole_series'
+		)?.id;
+		multiTypeId = types.find(
+			(t) => t.recurrence_scope === 'multiple_instances'
+		)?.id;
+		expect(singleTypeId).toBeTruthy();
+		expect(seriesTypeId).toBeTruthy();
+		expect(multiTypeId).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (fairAudienceActive) {
+			return;
+		}
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+		await api.dispose();
+	});
+
+	test('a paid single-instance signup is rejected 503 and writes nothing', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const before = await countSignups(masterEventDateId);
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: masterEventDateId,
+				name: 'Single Tester',
+				email: uniqueEmail('single'),
+				ticket_type_id: singleTypeId,
+				quantity: 1,
+			},
+		});
+		expect(res.status()).toBe(503);
+		expect((await res.json()).code).toBe('payment_unavailable');
+		expect(await countSignups(masterEventDateId)).toBe(before);
+	});
+
+	test('a paid whole-series signup is rejected 503 and writes nothing', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const before = await countSignups(masterEventDateId);
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: masterEventDateId,
+				name: 'Series Tester',
+				email: uniqueEmail('series'),
+				ticket_type_id: seriesTypeId,
+				quantity: 1,
+			},
+		});
+		expect(res.status()).toBe(503);
+		expect((await res.json()).code).toBe('payment_unavailable');
+		expect(await countSignups(masterEventDateId)).toBe(before);
+	});
+
+	test('a paid multiple-instances signup is rejected 503 and writes nothing', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const chosen = [occurrenceIds[0], occurrenceIds[1]];
+		const before = await Promise.all(chosen.map(countSignups));
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: masterEventDateId,
+				name: 'Multi Tester',
+				email: uniqueEmail('multi'),
+				ticket_type_id: multiTypeId,
+				event_date_ids: chosen,
+			},
+		});
+		expect(res.status()).toBe(503);
+		expect((await res.json()).code).toBe('payment_unavailable');
+		const after = await Promise.all(chosen.map(countSignups));
+		expect(after).toEqual(before);
+	});
+
+	test('a free signup on the same event still confirms', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		// No ticket type → amount 0 → free path, unaffected by the guard.
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: masterEventDateId,
+				name: 'Free Tester',
+				email: uniqueEmail('free'),
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		expect((await res.json()).status).toBe('confirmed');
+	});
+});

--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -328,14 +328,20 @@ class AdminPages {
 				$localized_data
 			);
 
+			// `connectorActive` is always present so the tickets screen can tell
+			// "connector plugin missing" apart from "installed but unconfigured"
+			// — the JS shows a different warning for each. `paymentConfigured`
+			// and `settingsUrl` only exist when the connector is active.
+			$connector_active        = class_exists( '\FairPaymentsConnector\Payment\MolliePaymentHandler' );
 			$payments_connector_data = array(
-				'currency' => get_option( 'fair_payment_currency', 'EUR' ),
+				'currency'        => get_option( 'fair_payment_currency', 'EUR' ),
+				'connectorActive' => $connector_active,
 			);
 
 			// Reuse the connector's own "configured" definition rather than
 			// re-reading its options here, so the notice matches the
 			// top-of-page admin notice in fair-payments-connector.
-			if ( class_exists( '\FairPaymentsConnector\Payment\MolliePaymentHandler' ) ) {
+			if ( $connector_active ) {
 				$payments_connector_data['paymentConfigured'] = \FairPaymentsConnector\Payment\MolliePaymentHandler::is_configured();
 				$payments_connector_data['settingsUrl']       = admin_url( 'admin.php?page=fair-payments-connector-settings' );
 			}

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -88,8 +88,30 @@ export default function EventTickets({
 	// period is ever hidden.
 	const effectiveMultiple =
 		salePeriods.length > 1 || settings.multiple_pricing_periods;
-	const paymentNotConfigured =
-		window.fairPaymentsConnector?.paymentConfigured === false;
+	// Payments are unavailable when the connector plugin is missing
+	// (connectorActive !== true) or installed but not yet configured
+	// (paymentConfigured === false). The two cases show different warnings.
+	const connectorActive =
+		window.fairPaymentsConnector?.connectorActive === true;
+	const paymentConfigured =
+		window.fairPaymentsConnector?.paymentConfigured === true;
+	const paymentsUnavailable = !connectorActive || !paymentConfigured;
+	// Any price > 0 across every source makes at least one ticket purchasable,
+	// so the "payments not set up" warning is relevant. Free ticketing (all
+	// prices 0) works without payments, so it must not trigger the warning.
+	const hasPurchasablePrice =
+		Object.values(prices).some(
+			(cell) =>
+				cell && cell.enabled !== false && parseFloat(cell.price) > 0
+		) ||
+		options.some((o) => {
+			if (parseFloat(o.price) > 0) return true;
+			if (parseFloat(o.discounted_price) > 0) return true;
+			return Object.values(o.period_prices_map || {}).some(
+				(v) => parseFloat(v) > 0
+			);
+		});
+	const showPaymentsWarning = paymentsUnavailable && hasPurchasablePrice;
 	const hasInvitationTickets = ticketTypes.some((t) => t.invitation_only);
 	const hasGroups = groups.length > 0;
 	const groupNameById = Object.fromEntries(groups.map((g) => [g.id, g.name]));
@@ -866,23 +888,31 @@ export default function EventTickets({
 				</Notice>
 			)}
 
-			{paymentNotConfigured && hasAdvancedTickets && (
-				<Notice
-					status="warning"
-					isDismissible={false}
-					actions={[
-						{
-							label: __('Set up Mollie', 'fair-events'),
-							url: window.fairPaymentsConnector.settingsUrl,
-						},
-					]}
-				>
-					{__(
-						"Prices are set, but payments aren't configured.",
-						'fair-events'
-					)}
-				</Notice>
-			)}
+			{showPaymentsWarning &&
+				(connectorActive ? (
+					<Notice
+						status="warning"
+						isDismissible={false}
+						actions={[
+							{
+								label: __('Set up Mollie', 'fair-events'),
+								url: window.fairPaymentsConnector.settingsUrl,
+							},
+						]}
+					>
+						{__(
+							"Paid tickets won't be sold until Mollie payments are configured.",
+							'fair-events'
+						)}
+					</Notice>
+				) : (
+					<Notice status="warning" isDismissible={false}>
+						{__(
+							'Paid tickets need the Fair Payments Connector plugin. Install and activate it to sell tickets.',
+							'fair-events'
+						)}
+					</Notice>
+				))}
 
 			<HStack spacing={2} justify="space-between">
 				<Button

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -553,28 +553,66 @@ describe('EventTickets — save button and dirty tracking (#987)', () => {
 	});
 });
 
-describe('EventTickets — payment-not-configured notice (#988)', () => {
+describe('EventTickets — payments-unavailable notice (#988, #1177)', () => {
 	const originalFairPaymentsConnector = window.fairPaymentsConnector;
+
+	// A ticket type carrying a price > 0 through the prices map, so
+	// hasPurchasablePrice is true and the warning is relevant.
+	const initialDataWithPaidTicket = {
+		...emptyInitialData,
+		ticket_types: [initialDataWithTicketType.ticket_types[0]],
+		sale_periods: [
+			{ id: 10, name: '', sale_start: '', sale_end: '', sort_order: 0 },
+		],
+		prices: [
+			{
+				ticket_type_id: 1,
+				sale_period_id: 10,
+				price: 15,
+				capacity: null,
+			},
+		],
+	};
+
+	// Only an add-on carries a price; no ticket-type price at all.
+	const initialDataWithPaidAddon = {
+		...emptyInitialData,
+		ticket_types: [initialDataWithTicketType.ticket_types[0]],
+		options: [
+			{
+				name: 'Dinner',
+				short_name: '',
+				price: 20,
+				discounted_price: null,
+				capacity: null,
+				collaborator_ids: [],
+				period_prices: [],
+				sort_order: 0,
+			},
+		],
+	};
+
+	const mollieRegex =
+		/Paid tickets won't be sold until Mollie payments are configured/i;
+	const missingPluginRegex =
+		/Paid tickets need the Fair Payments Connector plugin/i;
 
 	afterEach(() => {
 		window.fairPaymentsConnector = originalFairPaymentsConnector;
 	});
 
-	it('shows the notice when payments are unconfigured and tickets exist', () => {
+	it('shows the Mollie notice when the connector is active but unconfigured and a price > 0', () => {
 		window.fairPaymentsConnector = {
+			connectorActive: true,
 			paymentConfigured: false,
 			settingsUrl:
 				'http://example.test/wp-admin/admin.php?page=fair-payments-connector-settings',
 		};
 		const { container } = renderTickets({
-			initialData: initialDataWithTicketType,
+			initialData: initialDataWithPaidTicket,
 		});
 
-		expect(
-			within(container).getByText(
-				/Prices are set, but payments aren't configured/i
-			)
-		).toBeInTheDocument();
+		expect(within(container).getByText(mollieRegex)).toBeInTheDocument();
 		const link = within(container).getByRole('link', {
 			name: 'Set up Mollie',
 		});
@@ -584,48 +622,74 @@ describe('EventTickets — payment-not-configured notice (#988)', () => {
 		);
 	});
 
-	it('does not show the notice when there are no tickets yet', () => {
-		window.fairPaymentsConnector = {
-			paymentConfigured: false,
-			settingsUrl:
-				'http://example.test/wp-admin/admin.php?page=fair-payments-connector-settings',
-		};
-		const { container } = renderTickets({ initialData: emptyInitialData });
-
-		expect(
-			within(container).queryByText(
-				/Prices are set, but payments aren't configured/i
-			)
-		).not.toBeInTheDocument();
-	});
-
-	it('does not show the notice when payments are configured', () => {
-		window.fairPaymentsConnector = {
-			paymentConfigured: true,
-			settingsUrl:
-				'http://example.test/wp-admin/admin.php?page=fair-payments-connector-settings',
-		};
+	it('shows the missing-plugin notice when the connector is inactive and a price > 0', () => {
+		window.fairPaymentsConnector = { currency: 'EUR' };
 		const { container } = renderTickets({
-			initialData: initialDataWithTicketType,
+			initialData: initialDataWithPaidTicket,
 		});
 
 		expect(
-			within(container).queryByText(
-				/Prices are set, but payments aren't configured/i
-			)
+			within(container).getByText(missingPluginRegex)
+		).toBeInTheDocument();
+		// No settings link when the plugin isn't installed.
+		expect(
+			within(container).queryByRole('link', { name: 'Set up Mollie' })
 		).not.toBeInTheDocument();
 	});
 
-	it('does not show the notice when paymentConfigured is absent (connector inactive)', () => {
+	it('shows the notice for add-on-only pricing', () => {
+		window.fairPaymentsConnector = { currency: 'EUR' };
+		const { container } = renderTickets({
+			initialData: initialDataWithPaidAddon,
+		});
+
+		expect(
+			within(container).getByText(missingPluginRegex)
+		).toBeInTheDocument();
+	});
+
+	it('does not show any notice when every price is 0', () => {
 		window.fairPaymentsConnector = { currency: 'EUR' };
 		const { container } = renderTickets({
 			initialData: initialDataWithTicketType,
 		});
 
 		expect(
-			within(container).queryByText(
-				/Prices are set, but payments aren't configured/i
-			)
+			within(container).queryByText(mollieRegex)
+		).not.toBeInTheDocument();
+		expect(
+			within(container).queryByText(missingPluginRegex)
+		).not.toBeInTheDocument();
+	});
+
+	it('does not show any notice when there are no tickets yet', () => {
+		window.fairPaymentsConnector = { connectorActive: false };
+		const { container } = renderTickets({ initialData: emptyInitialData });
+
+		expect(
+			within(container).queryByText(mollieRegex)
+		).not.toBeInTheDocument();
+		expect(
+			within(container).queryByText(missingPluginRegex)
+		).not.toBeInTheDocument();
+	});
+
+	it('does not show any notice when payments are configured', () => {
+		window.fairPaymentsConnector = {
+			connectorActive: true,
+			paymentConfigured: true,
+			settingsUrl:
+				'http://example.test/wp-admin/admin.php?page=fair-payments-connector-settings',
+		};
+		const { container } = renderTickets({
+			initialData: initialDataWithPaidTicket,
+		});
+
+		expect(
+			within(container).queryByText(mollieRegex)
+		).not.toBeInTheDocument();
+		expect(
+			within(container).queryByText(missingPluginRegex)
 		).not.toBeInTheDocument();
 	});
 });

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -229,6 +229,33 @@ foreach ( $ticket_types as $ticket_type ) {
 	}
 }
 
+// Fail closed on the visitor form too: when online payments can't be
+// collected (connector missing, or installed but unconfigured), a ticket type
+// priced above 0 is not purchasable — the endpoint would reject it. Disable
+// those options so a priced ticket is never presented as buyable; when every
+// configured type is paid, hide the form and show a single message instead of
+// a list of dead options (per the ticket's open-question recommendation).
+$payments_unavailable = ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class )
+	|| ! \FairPaymentsConnector\API\TransactionAPI::is_configured();
+
+$has_paid_type = false;
+$has_free_type = false;
+foreach ( $ticket_types as $ticket_type ) {
+	$tt_price = $price_by_type_id[ (int) $ticket_type->id ] ?? null;
+	if ( null !== $tt_price && $tt_price > 0 ) {
+		$has_paid_type = true;
+	} else {
+		$has_free_type = true;
+	}
+}
+// Nothing is purchasable when payments are down and every configured ticket
+// type carries a price. Registering with no ticket type, or a free type, still
+// works — so the form is only hidden when a free path doesn't exist.
+$all_purchases_blocked = $payments_unavailable
+	&& ! empty( $ticket_types )
+	&& $has_paid_type
+	&& ! $has_free_type;
+
 // Generate unique form ID.
 $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 ?>
@@ -248,7 +275,11 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 	</div>
 <?php endif; ?>
 
-<?php if ( 'confirmed' !== $callback_status ) : ?>
+<?php if ( 'confirmed' !== $callback_status && $all_purchases_blocked ) : ?>
+	<div class="message-container message-error" role="alert">
+		<?php esc_html_e( 'Ticket sales are temporarily unavailable. Please check back later.', 'fair-events' ); ?>
+	</div>
+<?php elseif ( 'confirmed' !== $callback_status ) : ?>
 	<form
 		id="<?php echo esc_attr( $form_id ); ?>"
 		class="fair-events-get-tickets-form"
@@ -312,13 +343,17 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 					<option value=""><?php esc_html_e( 'Select a ticket type…', 'fair-events' ); ?></option>
 					<?php foreach ( $ticket_types as $ticket_type ) : ?>
 						<?php
-						$type_id    = (int) $ticket_type->id;
-						$type_price = $price_by_type_id[ $type_id ] ?? null;
-						$label      = esc_html( $ticket_type->name );
+						$type_id          = (int) $ticket_type->id;
+						$type_price       = $price_by_type_id[ $type_id ] ?? null;
+						$type_unavailable = $payments_unavailable && null !== $type_price && $type_price > 0;
+						$label            = esc_html( $ticket_type->name );
 						if ( null !== $type_price ) {
 							$label .= ' — ' . esc_html( $currency_symbol . number_format( $type_price, 2 ) );
 						} elseif ( null === $active_sale_period ) {
 							$label .= ' — ' . esc_html__( 'No active sale period', 'fair-events' );
+						}
+						if ( $type_unavailable ) {
+							$label .= ' — ' . esc_html__( 'ticket sales temporarily unavailable', 'fair-events' );
 						}
 						?>
 						<option
@@ -326,6 +361,7 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 							data-ticket-price="<?php echo esc_attr( null !== $type_price ? number_format( $type_price, 2, '.', '' ) : '' ); ?>"
 							data-recurrence-scope="<?php echo esc_attr( $ticket_type->recurrence_scope ); ?>"
 							data-min-instances="<?php echo esc_attr( (string) $ticket_type->minimum_instances ); ?>"
+							<?php echo $type_unavailable ? 'disabled' : ''; ?>
 						>
 							<?php echo esc_html( $label ); ?>
 						</option>


### PR DESCRIPTION
## Summary

When paid ticket prices are set but online payments aren't available — the
payments-connector plugin is missing, or installed but Mollie isn't configured —
the **fair-events base signup path** (used when fair-audience is inactive) both
misled organizers and mishandled visitors. This makes it warn correctly in admin
and fail closed at the point of sale.

Fixes three bugs on that path:

1. **No warning when the connector plugin isn't installed** — the tickets screen
   only knew the "installed but unconfigured" case, so a site without the
   connector got zero feedback while every paid signup was silently confirmed
   **for free**.
2. **The warning fired on the wrong condition** — as soon as any ticket type or
   sale period existed, even at price 0, with inaccurate "Prices are set" copy.
3. **Visitors hit a dead end when the connector was installed but unconfigured**
   — a signup + transaction were created, then payment initiation failed,
   leaving an orphaned `pending_payment` row.

Closes #1177

## Changes

- **Admin signal** (`AdminPages.php`): localize an always-present
  `connectorActive` boolean so the tickets screen can distinguish "plugin
  missing" from "installed but unconfigured".
- **Admin warning** (`EventTickets.js`): gate the notice on `paymentsUnavailable
  && hasPurchasablePrice`, where `hasPurchasablePrice` considers **all** price
  sources (ticket-type/period prices, add-on price, discounted add-on price,
  per-period add-on prices). Two variants — connector active but unconfigured →
  "Set up Mollie" with the settings link; connector inactive → "Paid tickets
  need the Fair Payments Connector plugin". Never blocks Save.
- **Endpoint fail-closed** (`GetTicketsController.php`): reject every priced path
  (single instance, whole series, multiple instances) with `503
  payment_unavailable` **before** writing any signup or transaction row, using
  the connector's own `TransactionAPI::is_configured()`. Removes the two
  free-fallback branches.
- **Visitor form** (base `event-signup/render.php`): disable paid ticket options
  when payments are down (free / price-0 types keep working), and hide the form
  with a single "temporarily unavailable" message when **every** configured type
  is paid.

**fair-audience is intentionally unchanged.** Its signup controller already
returns `503 payment_unavailable` before creating any record on every paid path,
and its Event Signup block already disables the signup button with a notice when
a paid event's connector isn't ready (commit `338911dc`, June 2026). Extending
that coarse gate to per-ticket-type granularity was scoped out of this PR.

## Testing

- **Component (Jest/RTL)** — rewrote the `EventTickets` notice tests: Mollie
  warning (active + unconfigured + price > 0) with settings link,
  missing-plugin warning (inactive + price > 0) without link, add-on-only
  pricing, and no-notice cases (all prices 0, no tickets, payments configured).
  Full fair-events JS suite: **114 passing**.
- **API (Playwright)** — new `GetTicketsPaymentUnavailable.api.spec.js` asserts
  the single-instance, whole-series and multiple-instance paid paths return 503
  and write zero rows, and that a free signup still confirms. Like the existing
  `GetTickets*` specs it skips when fair-audience is active, and follows the same
  "dev stack has no connector configured" convention as fair-audience's
  `EventSignupSlidingScale` spec.
- **Live verification** — because the `get-tickets` route only registers when
  fair-audience is inactive (so the api spec skips on the default stack), I
  exercised `create_signup()` directly against the running stack (connector
  present, `is_configured()` false) via a throwaway WP-CLI `eval-file` script:
  a paid submit returned `503 payment_unavailable` with **0 rows before / 0
  after**, and a free submit confirmed. `phpcs` clean on changed lines;
  `npm run build` run for fair-events.
