### PR TITLE
Resolve base signup pricing without the experimental plugin

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -913,11 +913,8 @@ class EventSignupController extends WP_REST_Controller {
 		}
 
 		// Recompute the per-instance price server-side; never trust a client amount.
-		$unit_price = 0.0;
-		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$resolved   = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_for_ticket_type( $ticket_type->id, $participant->id );
-			$unit_price = null !== $resolved ? (float) $resolved : 0.0;
-		}
+		$resolved     = \FairAudience\Services\SignupPriceResolver::resolve_price_for_ticket_type( $ticket_type->id, $participant->id );
+		$unit_price   = null !== $resolved ? (float) $resolved : 0.0;
 		$count        = count( $pending_occurrences );
 		$total_amount = $unit_price * $count;
 
@@ -1894,16 +1891,17 @@ class EventSignupController extends WP_REST_Controller {
 	 */
 	private function maybe_start_paid_signup( $event_id, $event_date_id, $participant, $existing, $user_id, $ticket_type_id = null, $option_items = array(), $invitation_token = '', $chosen_amount = null ) {
 		$final_price = null;
-		if ( $event_date_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+		if ( $event_date_id ) {
 			if ( $ticket_type_id ) {
-				$final_price = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_for_ticket_type( $ticket_type_id, $participant->id );
-			} elseif ( \FairEventsExperimental\Services\EventSignupPricing::resolve_sliding_scale( $event_date_id ) ) {
+				$final_price = \FairAudience\Services\SignupPriceResolver::resolve_price_for_ticket_type( $ticket_type_id, $participant->id );
+			} elseif ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class )
+				&& \FairEventsExperimental\Services\EventSignupPricing::resolve_sliding_scale( $event_date_id ) ) {
 				// Sliding scale replaces the fixed base-price path; group discounts
 				// (resolve_price()) do not stack on a buyer-chosen amount. Never
 				// trust the client value — always re-clamp against stored [min, max].
 				$final_price = \FairEventsExperimental\Services\EventSignupPricing::clamp_chosen_amount( $event_date_id, $chosen_amount );
 			} else {
-				$final_price = \FairEventsExperimental\Services\EventSignupPricing::resolve_price( $event_date_id, $participant->id );
+				$final_price = \FairAudience\Services\SignupPriceResolver::resolve_price( $event_date_id, $participant->id );
 			}
 		}
 
@@ -1933,8 +1931,7 @@ class EventSignupController extends WP_REST_Controller {
 		// Determine whether a price is configured for this event regardless of
 		// how the resolution turned out (discount-to-zero, service unavailable, etc.).
 		$has_paid_price_configured = $event_date_id
-			&& class_exists( \FairEventsExperimental\Services\EventSignupPricing::class )
-			&& \FairEventsExperimental\Services\EventSignupPricing::has_paid_price_configured(
+			&& \FairAudience\Services\SignupPriceResolver::has_paid_price_configured(
 				(int) $event_date_id,
 				$ticket_type_id
 			);
@@ -2149,11 +2146,8 @@ class EventSignupController extends WP_REST_Controller {
 			}
 		}
 
-		$series_price = 0.0;
-		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$resolved     = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_for_ticket_type( $ticket_type->id, $participant->id );
-			$series_price = null !== $resolved ? (float) $resolved : 0.0;
-		}
+		$resolved     = \FairAudience\Services\SignupPriceResolver::resolve_price_for_ticket_type( $ticket_type->id, $participant->id );
+		$series_price = null !== $resolved ? (float) $resolved : 0.0;
 
 		$ledger = new EventParticipantTransactionRepository();
 
@@ -2912,8 +2906,7 @@ class EventSignupController extends WP_REST_Controller {
 					$resume_url = add_query_arg( 'resume', $resume_token, $token_url );
 
 					$is_paid = $event_date_id
-						&& class_exists( \FairEventsExperimental\Services\EventSignupPricing::class )
-						&& \FairEventsExperimental\Services\EventSignupPricing::has_paid_price_configured(
+						&& \FairAudience\Services\SignupPriceResolver::has_paid_price_configured(
 							(int) $event_date_id,
 							$ticket_type_id ? (int) $ticket_type_id : null
 						);

--- a/fair-audience/src/API/__tests__/EventSignupBasePricing.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupBasePricing.api.spec.js
@@ -1,0 +1,210 @@
+/**
+ * Playwright API tests for base signup pricing without the experimental
+ * plugin (#1180): with only fair-events + fair-audience active, the signup
+ * flow must resolve prices through FairEvents\Services\SignupPricing /
+ * TicketPricing (via FairAudience\Services\SignupPriceResolver) instead of
+ * silently collapsing to free.
+ *
+ * Like EventSignupSlidingScale's and GetTicketsPaymentUnavailable's specs,
+ * this assumes the dev stack has no payment connector configured: any event
+ * with a positive price must be rejected with 503 payment_unavailable,
+ * never confirmed for free. A free (price-0) ticket type on the same event
+ * must still confirm, proving the guard isn't over-blocking.
+ *
+ * These assertions hold in both plugin configurations (base-only and with
+ * fair-events-experimental active) — the resolver falls back correctly
+ * either way — so the spec runs unconditionally rather than skipping based
+ * on experimental plugin state.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+async function createEventWithDates(api, title) {
+	const res = await api.post('/wp-json/wp/v2/fair_event', {
+		headers: authHeaders,
+		data: { title, status: 'publish' },
+	});
+	expect(res.ok()).toBeTruthy();
+	const eventId = (await res.json()).id;
+
+	const eventsRes = await api.get('/wp-json/fair-audience/v1/events', {
+		headers: authHeaders,
+		params: { per_page: 100 },
+	});
+	expect(eventsRes.ok()).toBeTruthy();
+	const match = (await eventsRes.json()).find((e) => e.event_id === eventId);
+	expect(match, 'event-date row for test event').toBeTruthy();
+	return { eventId, eventDateId: match.event_date_id };
+}
+
+async function deleteEvent(api, eventId) {
+	if (!eventId) return;
+	await api.delete(`/wp-json/wp/v2/fair_event/${eventId}`, {
+		headers: authHeaders,
+		params: { force: 'true' },
+	});
+}
+
+test.describe('Base signup pricing — simple per-date price', () => {
+	let api;
+	let event;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+		event = await createEventWithDates(
+			api,
+			`Base Pricing Simple Test ${Date.now()}`
+		);
+
+		const configRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${event.eventDateId}/tickets`,
+			{
+				headers: authHeaders,
+				data: {
+					signup_price: 12.5,
+					settings: {},
+				},
+			}
+		);
+		expect(configRes.ok(), await configRes.text()).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		await deleteEvent(api, event?.eventId);
+		await api.dispose();
+	});
+
+	test('a priced simple signup is rejected 503 and writes nothing (never falls through free)', async () => {
+		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
+			headers: authHeaders,
+			data: {
+				event_id: event.eventId,
+				event_date_id: event.eventDateId,
+			},
+		});
+		expect(res.status()).toBe(503);
+		expect((await res.json()).code).toBe('payment_unavailable');
+
+		const statusRes = await api.get(
+			'/wp-json/fair-audience/v1/event-signup/status',
+			{
+				headers: authHeaders,
+				params: {
+					event_id: event.eventId,
+					event_date_id: event.eventDateId,
+				},
+			}
+		);
+		expect(statusRes.ok()).toBeTruthy();
+		expect((await statusRes.json()).is_signed_up).toBe(false);
+	});
+});
+
+test.describe('Base signup pricing — ticket-type price', () => {
+	let api;
+	let event;
+	let paidTypeId;
+	let freeTypeId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+		event = await createEventWithDates(
+			api,
+			`Base Pricing Ticket Type Test ${Date.now()}`
+		);
+
+		const ticketsRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${event.eventDateId}/tickets`,
+			{
+				headers: authHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'Paid tier',
+							capacity: null,
+							sort_order: 0,
+							recurrence_scope: 'single_instance',
+						},
+						{
+							name: 'Free tier',
+							capacity: null,
+							sort_order: 1,
+							recurrence_scope: 'single_instance',
+						},
+					],
+					sale_periods: [
+						{
+							name: 'Always on',
+							sale_start: '2020-01-01 00:00:00',
+							sale_end: '2099-01-01 00:00:00',
+						},
+					],
+					prices: [
+						{
+							ticket_type_index: 0,
+							sale_period_index: 0,
+							price: 18,
+						},
+					],
+					settings: {},
+				},
+			}
+		);
+		expect(ticketsRes.ok(), await ticketsRes.text()).toBeTruthy();
+		const types = (await ticketsRes.json()).ticket_types || [];
+		paidTypeId = types.find((t) => t.name === 'Paid tier')?.id;
+		freeTypeId = types.find((t) => t.name === 'Free tier')?.id;
+		expect(paidTypeId).toBeTruthy();
+		expect(freeTypeId).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		await deleteEvent(api, event?.eventId);
+		await api.dispose();
+	});
+
+	test('a priced ticket-type signup is rejected 503 and writes nothing', async () => {
+		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
+			headers: authHeaders,
+			data: {
+				event_id: event.eventId,
+				event_date_id: event.eventDateId,
+				ticket_type_id: paidTypeId,
+				email: uniqueEmail('base-pricing-paid'),
+			},
+		});
+		expect(res.status()).toBe(503);
+		expect((await res.json()).code).toBe('payment_unavailable');
+	});
+
+	test('a ticket type with no price row (0) still confirms', async () => {
+		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
+			headers: authHeaders,
+			data: {
+				event_id: event.eventId,
+				event_date_id: event.eventDateId,
+				ticket_type_id: freeTypeId,
+			},
+		});
+		expect(res.ok(), await res.text()).toBeTruthy();
+		expect((await res.json()).status).toMatch(
+			/^(signed_up|already_signed_up)$/
+		);
+	});
+});

--- a/fair-audience/src/Services/SignupPriceResolver.php
+++ b/fair-audience/src/Services/SignupPriceResolver.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Signup Price Resolver
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Single seam fair-audience's signup flow uses to reach base pricing:
+ * prefers the full-featured `FairEventsExperimental\Services\EventSignupPricing`
+ * when the experimental plugin is active, and otherwise falls back to the
+ * base resolution that lives in fair-events proper
+ * (`FairEvents\Services\SignupPricing` / `TicketPricing`).
+ *
+ * Experimental-only pricing (group discounts, sliding scale, invitation
+ * prices, activity options) stays behind its own `class_exists` guards at
+ * each call site — those already degrade to null/no-op, never to free, so
+ * they don't need a facade.
+ */
+class SignupPriceResolver {
+
+	/**
+	 * Resolve the effective price for a specific ticket type.
+	 *
+	 * @param int      $ticket_type_id Ticket type ID.
+	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
+	 * @return float|null Final price, or null when not purchasable right now.
+	 */
+	public static function resolve_price_for_ticket_type( $ticket_type_id, $participant_id = null ) {
+		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			return \FairEventsExperimental\Services\EventSignupPricing::resolve_price_for_ticket_type( $ticket_type_id, $participant_id );
+		}
+
+		if ( class_exists( \FairEvents\Services\TicketPricing::class ) ) {
+			return \FairEvents\Services\TicketPricing::resolve_unit_price( $ticket_type_id );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve the plain per-date signup price.
+	 *
+	 * @param int      $event_date_id  Event date ID.
+	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
+	 * @return float|null Final price, or null when no price is configured.
+	 */
+	public static function resolve_price( $event_date_id, $participant_id = null ) {
+		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			return \FairEventsExperimental\Services\EventSignupPricing::resolve_price( $event_date_id, $participant_id );
+		}
+
+		if ( class_exists( \FairEvents\Services\SignupPricing::class ) ) {
+			return \FairEvents\Services\SignupPricing::resolve_base_signup_price( $event_date_id );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check whether a positive price is configured for an event date or
+	 * ticket type, ignoring discount rules and sale-period timing. Used by
+	 * the fail-closed "payment unavailable" guard so a paid event never
+	 * completes signup for free.
+	 *
+	 * @param int      $event_date_id  Event date ID.
+	 * @param int|null $ticket_type_id Ticket type ID, or null for event-date pricing.
+	 * @return bool True when a price > 0 is configured.
+	 */
+	public static function has_paid_price_configured( $event_date_id, $ticket_type_id = null ) {
+		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			return \FairEventsExperimental\Services\EventSignupPricing::has_paid_price_configured( $event_date_id, $ticket_type_id );
+		}
+
+		if ( class_exists( \FairEvents\Services\SignupPricing::class ) ) {
+			return \FairEvents\Services\SignupPricing::has_paid_price_configured( $event_date_id, $ticket_type_id );
+		}
+
+		return false;
+	}
+}

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -439,13 +439,10 @@ if ( $pricing_event_date_id && class_exists( \FairEvents\Models\TicketType::clas
 			}
 		}
 
-		$tt_price = null;
-		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$tt_price = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_for_ticket_type(
-				$tt->id,
-				$participant ? (int) $participant->id : null
-			);
-		}
+		$tt_price = \FairAudience\Services\SignupPriceResolver::resolve_price_for_ticket_type(
+			$tt->id,
+			$participant ? (int) $participant->id : null
+		);
 		if ( null === $tt_price ) {
 			continue;
 		}
@@ -634,8 +631,8 @@ if ( $has_ticket_types ) {
 	if ( null === $signup_price ) {
 		$signup_price = $ticket_types_for_display[0]['price'];
 	}
-} elseif ( $pricing_event_date_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-	$signup_price = \FairEventsExperimental\Services\EventSignupPricing::resolve_price(
+} elseif ( $pricing_event_date_id ) {
+	$signup_price = \FairAudience\Services\SignupPriceResolver::resolve_price(
 		(int) $pricing_event_date_id,
 		$participant ? (int) $participant->id : null
 	);
@@ -688,10 +685,10 @@ if ( null !== $signup_price ) {
 		if ( $signup_price > 0 ) {
 			// Resolved price is positive — connector required.
 			$payment_unavailable = true;
-		} elseif ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+		} else {
 			// Resolved price is zero but event may carry a paid base price
 			// (e.g. 100%-discounted or pricing-service glitch).
-			$payment_unavailable = \FairEventsExperimental\Services\EventSignupPricing::has_paid_price_configured(
+			$payment_unavailable = \FairAudience\Services\SignupPriceResolver::has_paid_price_configured(
 				(int) $pricing_event_date_id
 			);
 		}

--- a/fair-events-experimental/src/Services/EventSignupPricing.php
+++ b/fair-events-experimental/src/Services/EventSignupPricing.php
@@ -11,6 +11,7 @@ use FairEvents\Models\EventDates;
 use FairEvents\Models\EventDateSetting;
 use FairEventsExperimental\Models\GroupPricingRule;
 use FairEvents\Models\TicketType;
+use FairEvents\Services\SignupPricing;
 use FairEvents\Services\TicketPricing;
 use FairEventsExperimental\Models\TicketOptionCollaborator;
 
@@ -33,35 +34,20 @@ class EventSignupPricing {
 	 * @return float|null Final price, or null when no price is configured.
 	 */
 	public static function resolve_price( $event_date_id, $participant_id = null ) {
-		$event_date = EventDates::get_by_id( $event_date_id );
+		// Base price (including generated-occurrence → master inheritance,
+		// already resolved by EventDates::hydrate()) lives in fair-events so
+		// the base plugin combo doesn't need this experimental service.
+		$base_price = SignupPricing::resolve_base_signup_price( $event_date_id );
 
-		if ( ! $event_date ) {
+		if ( null === $base_price ) {
 			return null;
 		}
-
-		// Generated occurrences do not store signup_price — inherit from master.
-		$pricing_event_date_id = $event_date_id;
-		if ( null === $event_date->signup_price
-			&& 'generated' === $event_date->occurrence_type
-			&& $event_date->master_id ) {
-			$master = EventDates::get_by_id( $event_date->master_id );
-			if ( $master && null !== $master->signup_price ) {
-				$event_date            = $master;
-				$pricing_event_date_id = $master->id;
-			}
-		}
-
-		if ( null === $event_date->signup_price ) {
-			return null;
-		}
-
-		$base_price = (float) $event_date->signup_price;
 
 		if ( empty( $participant_id ) ) {
 			return $base_price;
 		}
 
-		$rules = GroupPricingRule::get_all_by_event_date_id( $pricing_event_date_id );
+		$rules = GroupPricingRule::get_all_by_event_date_id( $event_date_id );
 		if ( empty( $rules ) ) {
 			return $base_price;
 		}
@@ -248,27 +234,7 @@ class EventSignupPricing {
 	 * @return bool True when a price > 0 is configured.
 	 */
 	public static function has_paid_price_configured( int $event_date_id, ?int $ticket_type_id = null ): bool {
-		if ( $ticket_type_id ) {
-			$price = TicketPricing::resolve_unit_price( $ticket_type_id );
-			return null !== $price && $price > 0;
-		}
-
-		$event_date = EventDates::get_by_id( $event_date_id );
-		if ( ! $event_date ) {
-			return false;
-		}
-
-		// Generated occurrences inherit signup_price from master.
-		if ( null === $event_date->signup_price
-			&& 'generated' === $event_date->occurrence_type
-			&& $event_date->master_id ) {
-			$master = EventDates::get_by_id( $event_date->master_id );
-			if ( $master ) {
-				$event_date = $master;
-			}
-		}
-
-		return null !== $event_date->signup_price && (float) $event_date->signup_price > 0;
+		return SignupPricing::has_paid_price_configured( $event_date_id, $ticket_type_id );
 	}
 
 	/**

--- a/fair-events/__tests__/Services/SignupPricingTest.php
+++ b/fair-events/__tests__/Services/SignupPricingTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * SignupPricing pure-logic tests
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Services\SignupPricing;
+
+/**
+ * Validates the pure "is this a paid price" check used by
+ * has_paid_price_configured(). DB-backed lookups (EventDates::get_by_id(),
+ * TicketPricing::resolve_unit_price()) are exercised via API integration
+ * tests, not here.
+ */
+class SignupPricingTest extends TestCase {
+
+	/**
+	 * No price configured at all.
+	 */
+	public function test_null_price_is_not_positive() {
+		$this->assertFalse( SignupPricing::is_price_positive( null ) );
+	}
+
+	/**
+	 * A price of exactly zero is a genuinely free event, not paid.
+	 */
+	public function test_zero_price_is_not_positive() {
+		$this->assertFalse( SignupPricing::is_price_positive( 0 ) );
+		$this->assertFalse( SignupPricing::is_price_positive( 0.0 ) );
+	}
+
+	/**
+	 * Negative prices (shouldn't normally occur) are not treated as paid.
+	 */
+	public function test_negative_price_is_not_positive() {
+		$this->assertFalse( SignupPricing::is_price_positive( -5.0 ) );
+	}
+
+	/**
+	 * Any positive amount, including numeric strings from the DB, counts as paid.
+	 */
+	public function test_positive_price_is_positive() {
+		$this->assertTrue( SignupPricing::is_price_positive( 10.5 ) );
+		$this->assertTrue( SignupPricing::is_price_positive( '10.5' ) );
+	}
+}

--- a/fair-events/src/Services/SignupPricing.php
+++ b/fair-events/src/Services/SignupPricing.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Base Signup Pricing Service
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Services;
+
+use FairEvents\Models\EventDates;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Canonical home for base (non-experimental) signup pricing: the plain
+ * per-date signup price and the "is this event actually paid" fail-closed
+ * check. Group discounts, sliding scale, and invitation pricing stay in
+ * FairEventsExperimental\Services\EventSignupPricing, which delegates its
+ * base portions here so the two copies can't drift.
+ *
+ * Master → generated-occurrence inheritance for signup_price is already
+ * resolved by EventDates::hydrate() (see EventDates::resolve_instance()),
+ * so callers here always see the effective price without re-implementing
+ * that lookup.
+ */
+class SignupPricing {
+
+	/**
+	 * Resolve the plain per-date signup price, with no discounts applied.
+	 *
+	 * @param int $event_date_id Event date ID.
+	 * @return float|null Signup price, or null when none is configured.
+	 */
+	public static function resolve_base_signup_price( int $event_date_id ): ?float {
+		$event_date = EventDates::get_by_id( $event_date_id );
+
+		if ( ! $event_date || null === $event_date->signup_price ) {
+			return null;
+		}
+
+		return (float) $event_date->signup_price;
+	}
+
+	/**
+	 * Check whether a positive price is configured for an event date or ticket
+	 * type, ignoring discount rules and sale-period timing.
+	 *
+	 * Used to determine if payment is *intended* even when the resolved price
+	 * comes back as zero (e.g. because a discount rule brings it to zero).
+	 *
+	 * @param int      $event_date_id  Event date ID.
+	 * @param int|null $ticket_type_id Ticket type ID, or null for event-date pricing.
+	 * @return bool True when a price > 0 is configured.
+	 */
+	public static function has_paid_price_configured( int $event_date_id, ?int $ticket_type_id = null ): bool {
+		if ( $ticket_type_id ) {
+			return self::is_price_positive( TicketPricing::resolve_unit_price( $ticket_type_id ) );
+		}
+
+		$event_date = EventDates::get_by_id( $event_date_id );
+
+		if ( ! $event_date ) {
+			return false;
+		}
+
+		return self::is_price_positive( $event_date->signup_price );
+	}
+
+	/**
+	 * Pure "is this a positive price" check, split out for unit testing
+	 * without a database.
+	 *
+	 * @param mixed $price Price value (may be null, int, float, or numeric string).
+	 * @return bool True when the price is a positive number.
+	 */
+	public static function is_price_positive( $price ): bool {
+		return null !== $price && (float) $price > 0;
+	}
+}


### PR DESCRIPTION
## Summary

With only `fair-events` + `fair-audience` active, the entire event-signup pricing path reached prices only through `FairEventsExperimental\Services\EventSignupPricing`. Every `class_exists()` guard around it was false, so pricing silently collapsed: ticket tiers disappeared from the signup block, the simple per-date signup price stopped showing, and the fail-closed "payment unavailable" guard was itself disabled — letting a paid event complete signup for free.

- Add `FairEvents\Services\SignupPricing` — the canonical base home for the plain per-date signup price and the "is this event actually paid" check, alongside the existing `TicketPricing::resolve_unit_price()`. Master → generated-occurrence inheritance for `signup_price` turned out to already be handled transparently by `EventDates::hydrate()`, so this service doesn't need to re-implement it.
- `FairEventsExperimental\Services\EventSignupPricing::resolve_price()` and `::has_paid_price_configured()` now delegate their base portions to `SignupPricing`, so the two copies can't drift. Group discounts, sliding scale, and invitation pricing stay experimental-only, unchanged.
- Add `FairAudience\Services\SignupPriceResolver` — the single seam fair-audience's signup call sites use: prefers the experimental service when active, falls back to the base fair-events resolution otherwise.
- Rewire the three base call sites (`render.php` ticket-tier price / simple price / fail-closed check, and `EventSignupController.php`'s ticket-type price / simple price / fail-closed check, used at signup creation and the resume-registration email) through the resolver, dropping the now-unnecessary `class_exists` guards around them.

Net effect with the experimental plugin off: ticket tiers render at their configured prices, the simple signup price shows and is charged, and a paid event with no payments connector configured now fails closed (503, no signup written) instead of completing for free.

## Verification

- `fair-events` PHPUnit: added `SignupPricingTest` for the pure "is this a positive price" logic; full suite passes (73 tests).
- `fair-events-experimental` PHPUnit: full suite passes (one pre-existing unrelated failure in `VenueTest`, confirmed present on `main` before this change).
- `phpcs`: clean on all new/changed files.
- Manual verification via WP-CLI `eval-file` against a real DB, run twice — once with `fair-events-experimental` inactive, once active — confirming identical results for: simple signup price resolution, `has_paid_price_configured` (priced / free / unconfigured event), and ticket-type price resolution via `TicketPricing`.
- Added `EventSignupBasePricing.api.spec.js` covering the money-critical path (a priced simple signup and a priced ticket-type signup both reject 503 `payment_unavailable` and write nothing; a free ticket type still confirms). Not run end-to-end here — the local dev stack's Basic Auth requires a WP Application Password, which requires HTTPS that isn't set up in this checkout; this is a pre-existing environment gap unrelated to this change.

Closes #1180

## Test plan

- [ ] `npm run test:php` in `fair-events` and `fair-events-experimental`
- [ ] `npm run test:api` in `fair-audience` (requires an authenticated dev stack)
- [ ] Manually verify in a browser: deactivate `fair-events-experimental`, confirm ticket tiers/simple price show correctly on an Event Signup block and a paid event without a connector shows the disabled/notice state instead of a free signup button
