### PR TITLE
Render nested blocks in the unified signup form

### DIFF
--- a/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
+++ b/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
@@ -29,9 +29,12 @@ jest.mock('@wordpress/data', () => {
 // useBlockProps/useInnerBlocksProps need the editor's block context, which
 // jsdom doesn't provide; stub them to plain markers so we can assert on the
 // questions region without a full editor.
+const mockUseInnerBlocksProps = jest.fn(() => ({
+	'data-testid': 'inner-blocks',
+}));
 jest.mock('@wordpress/block-editor', () => ({
 	useBlockProps: () => ({}),
-	useInnerBlocksProps: () => ({ 'data-testid': 'inner-blocks' }),
+	useInnerBlocksProps: (...args) => mockUseInnerBlocksProps(...args),
 	InspectorControls: ({ children }) => children,
 	InnerBlocks: Object.assign(() => null, {
 		Content: () => null,
@@ -66,19 +69,39 @@ describe('Event Signup EditComponent', () => {
 		);
 	};
 
-	it('shows the custom-questions region when fair-form is active', () => {
-		renderEdit(true);
+	it('always shows the form content region, fair-form active or not', () => {
+		const { unmount } = renderEdit(true);
 
 		expect(screen.getByTestId('ssr')).toBeInTheDocument();
 		expect(screen.getByTestId('inner-blocks')).toBeInTheDocument();
-		expect(screen.getByText('Custom questions')).toBeInTheDocument();
-	});
+		expect(screen.getByText('Form content')).toBeInTheDocument();
+		unmount();
 
-	it('hides the custom-questions region when fair-form is inactive', () => {
 		renderEdit(false);
 
 		expect(screen.getByTestId('ssr')).toBeInTheDocument();
-		expect(screen.queryByTestId('inner-blocks')).toBeNull();
-		expect(screen.queryByText('Custom questions')).toBeNull();
+		expect(screen.getByTestId('inner-blocks')).toBeInTheDocument();
+		expect(screen.getByText('Form content')).toBeInTheDocument();
+	});
+
+	it('only offers the fair-form question blocks once fair-form is active', () => {
+		const { unmount } = renderEdit(false);
+		const [, inactiveOptions] = mockUseInnerBlocksProps.mock.calls.at(-1);
+		expect(inactiveOptions.allowedBlocks).toEqual([
+			'core/heading',
+			'core/paragraph',
+			'core/list',
+		]);
+		unmount();
+
+		renderEdit(true);
+		const [, activeOptions] = mockUseInnerBlocksProps.mock.calls.at(-1);
+		expect(activeOptions.allowedBlocks).toEqual(
+			expect.arrayContaining([
+				'core/heading',
+				'fair-audience/fair-form-short-text',
+				'fair-audience/fair-form-conditional',
+			])
+		);
 	});
 });

--- a/fair-events/src/blocks/event-signup/editor.js
+++ b/fair-events/src/blocks/event-signup/editor.js
@@ -28,14 +28,14 @@ import './editor.css';
 
 const UNIFIED_NAME = 'fair-events/event-signup';
 
-// Custom question blocks that can be nested inside the signup form. Mirrors
-// the legacy fair-audience/event-signup block's set, minus the file-upload
-// question: the unified form is submittable by anonymous visitors and
-// uploads stay out until there is a vetted path.
-const ALLOWED_BLOCKS = [
-	'core/heading',
-	'core/paragraph',
-	'core/list',
+// Blocks always allowed in the form content area, regardless of fair-form.
+const BASE_ALLOWED_BLOCKS = ['core/heading', 'core/paragraph', 'core/list'];
+
+// Custom question blocks that can additionally be nested once fair-form is
+// active. Mirrors the legacy fair-audience/event-signup block's set, minus
+// the file-upload question: the unified form is submittable by anonymous
+// visitors and uploads stay out until there is a vetted path.
+const FAIR_FORM_ALLOWED_BLOCKS = [
 	'fair-audience/fair-form-short-text',
 	'fair-audience/fair-form-long-text',
 	'fair-audience/fair-form-phone',
@@ -62,10 +62,14 @@ registerBlockType(metadata.name, {
 			[]
 		);
 
+		const allowedBlocks = isFairFormActive
+			? [...BASE_ALLOWED_BLOCKS, ...FAIR_FORM_ALLOWED_BLOCKS]
+			: BASE_ALLOWED_BLOCKS;
+
 		const innerBlocksProps = useInnerBlocksProps(
 			{ className: 'fair-events-event-signup-questions' },
 			{
-				allowedBlocks: ALLOWED_BLOCKS,
+				allowedBlocks,
 				renderAppender: InnerBlocks.ButtonBlockAppender,
 			}
 		);
@@ -89,14 +93,10 @@ registerBlockType(metadata.name, {
 						block={UNIFIED_NAME}
 						attributes={attributes}
 					/>
-					{isFairFormActive && (
-						<>
-							<div className="fair-events-event-signup-questions-label">
-								{__('Custom questions', 'fair-events')}
-							</div>
-							<div {...innerBlocksProps} />
-						</>
-					)}
+					<div className="fair-events-event-signup-questions-label">
+						{__('Form content', 'fair-events')}
+					</div>
+					<div {...innerBlocksProps} />
 				</div>
 			</>
 		);

--- a/fair-events/src/blocks/event-signup/frontend.js
+++ b/fair-events/src/blocks/event-signup/frontend.js
@@ -12,6 +12,8 @@ import {
 	handlePaymentCallback,
 	computeTicketTotal,
 	formatPrice,
+	collectQuestionAnswers,
+	validateQuestions,
 } from 'fair-events-shared';
 import './frontend.css';
 
@@ -288,6 +290,12 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 			}
 		}
 
+		const questionError = validateQuestions(form);
+		if (questionError) {
+			showMessage(messageContainer, questionError, 'error', CSS_PREFIX);
+			return false;
+		}
+
 		return true;
 	}
 
@@ -339,6 +347,8 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 
 		const honeypotField = form.querySelector('input[name="_honeypot"]');
 		data._honeypot = honeypotField ? honeypotField.value : '';
+
+		data.questionnaire_answers = collectQuestionAnswers(form);
 
 		return data;
 	}

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -425,6 +425,12 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 			</label>
 		</div>
 
+		<?php if ( '' !== trim( $content ) ) : ?>
+			<div class="fair-events-event-signup-questions">
+				<?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner blocks content is already escaped by WordPress. ?>
+			</div>
+		<?php endif; ?>
+
 		<!-- Honeypot field (hidden from users, should remain empty) -->
 		<input
 			type="text"


### PR DESCRIPTION
## Summary

Layer 1 of the "nested blocks silently dropped" fix, scoped to `fair-events` only (no fair-audience delegation behaviour change yet):

- `render.php` now echoes `$content` inside the `<form>`, wrapped in `.fair-events-event-signup-questions`, between the mailing opt-in row and the submit button — mirroring the legacy fair-audience placement. Previously nested blocks (headings, paragraphs, questions) were silently dropped on any site without fair-audience.
- `editor.js` always renders the InnerBlocks area (relabeled "Form content"), instead of hiding it entirely when fair-form is inactive. `core/heading`, `core/paragraph`, and `core/list` are always allowed; the `fair-audience/fair-form-*` question blocks are additionally offered once fair-form is active.
- `frontend.js` imports `validateQuestions` / `collectQuestionAnswers` from `fair-events-shared`, validates questions before submit, and adds `questionnaire_answers` to the POST payload (JSON only — no file-upload question on this block, so no `FormData` path needed). The endpoint doesn't read this field yet (Layer 2); sending it early is harmless.
- Updated `editor.test.jsx` for the new gating: the form-content area is always present, and the allowed-blocks list only grows to include fair-form question blocks when fair-form is active.

Refs #1181

## Test plan

- [x] `npm run test:js` (fair-events) — 15 suites / 114 tests pass
- [x] `npm run format` — no formatting diffs beyond the intended files
- [x] `vendor/bin/phpcs` clean on `render.php`
- [x] `npm run build` (fair-events) — compiles cleanly
