### PR TITLE
Add screenshot e2e for Event Signup across plugin combos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ test-results/
 */playwright-report/
 */test-results/
 */tests/screenshots/*.png
+e2e/screenshots/output/
 */.env
 
 # Local deploy config (real values); template `.deploy/example.env` is committed

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -17,6 +17,9 @@ e2e/
 │   └── wp-cli.js                         # wpCli / runScript / resetCapturedMail / loginAsAdmin
 ├── user-flows/                           # functional specs
 │   └── ticket-purchase-confirmation.spec.js
+├── screenshots/                          # visual-review captures (no behavioural assertions)
+│   ├── event-signup-combinations.spec.js
+│   └── output/                           # gitignored PNGs
 └── mu-plugins/                           # mounted into wp-env only (see .wp-env.json)
     ├── fair-e2e-support.php              # auto-loaded mu-plugin (mail capture + Mollie test creds + loads the double)
     ├── lib/
@@ -123,9 +126,15 @@ Each prints a single `MARKER:{json}` line (`E2E_SEED`, `E2E_STATE`,
     `multiple_instances` ticket type priced per instance (default `10.00`;
     override `{"price":N}`), `minimum_instances` default `2` (override
     `{"minimumInstances":N}`).
+  - `three-ticket-scopes` — a 3-occurrence weekly series **pinned to a fixed
+    absolute date** (not `+7 days`, so screenshots stay stable across runs)
+    carrying one ticket type per recurrence scope: `single_instance`,
+    `whole_series`, `multiple_instances`. Always renders the unified
+    `fair-events/event-signup` block regardless of the `block` override. Used
+    by `screenshots/event-signup-combinations.spec.js`.
 
   Emits the event permalink + ids: `flavour`, `eventId`, `eventDateId`,
-  `salePeriodId`, `ticketTypeId`, `optionIds`, `occurrenceIds`,
+  `salePeriodId`, `ticketTypeId`, `extraTypeIds`, `optionIds`, `occurrenceIds`,
   `minimumInstances`, `price`.
 - **`cleanup-event.php <eventId> <eventDateId>`** — deletes a seeded event and
   everything off it (signed-up participants + their option rows, the

--- a/e2e/mu-plugins/lib/event-factory.php
+++ b/e2e/mu-plugins/lib/event-factory.php
@@ -73,6 +73,31 @@ if ( ! function_exists( 'fair_e2e_create_event' ) ) {
 	}
 
 	/**
+	 * Add a single occurrence at a fixed absolute datetime (two hours long), for
+	 * flavours whose screenshots must stay stable across runs instead of
+	 * drifting with fair_e2e_add_date()'s '+7 days'.
+	 *
+	 * @param int    $event_id Event post ID.
+	 * @param string $start    Start datetime, 'Y-m-d H:i:s' (UTC).
+	 * @return int Event date ID.
+	 */
+	function fair_e2e_add_date_at( $event_id, $start ) {
+		$event_date_id = EventDates::save_occurrence(
+			$event_id,
+			$start,
+			gmdate( 'Y-m-d H:i:s', strtotime( $start . ' +2 hours' ) ),
+			false,
+			'single'
+		);
+
+		if ( ! $event_date_id ) {
+			WP_CLI::error( 'Failed to create event date.' );
+		}
+
+		return (int) $event_date_id;
+	}
+
+	/**
 	 * Turn an event's single occurrence into a weekly recurring series (master +
 	 * generated occurrences), all linked to the event post like production
 	 * recurring events — as opposed to the standalone event-dates created via
@@ -166,6 +191,33 @@ if ( ! function_exists( 'fair_e2e_create_event' ) ) {
 
 		if ( ! $ticket_type_id ) {
 			WP_CLI::error( 'Failed to create multiple_instances ticket type.' );
+		}
+
+		return (int) $ticket_type_id;
+	}
+
+	/**
+	 * Add a 'whole_series' ticket type (covers every occurrence of the series,
+	 * priced once) on the series master.
+	 *
+	 * @param int    $master_event_date_id The series master's event_date_id.
+	 * @param string $name                 Ticket type name.
+	 * @return int Ticket type ID.
+	 */
+	function fair_e2e_add_whole_series_ticket_type( $master_event_date_id, $name ) {
+		$ticket_type_id = TicketType::create(
+			$master_event_date_id,
+			$name,
+			null, // capacity.
+			0, // sort_order.
+			false, // invitation_only.
+			0, // minimum_activities.
+			null, // disable_at.
+			'whole_series'
+		);
+
+		if ( ! $ticket_type_id ) {
+			WP_CLI::error( 'Failed to create whole_series ticket type.' );
 		}
 
 		return (int) $ticket_type_id;

--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -14,6 +14,12 @@
  *                        ticket type priced per instance (default 10.00; override
  *                        {"price":N}), minimum_instances default 2 (override
  *                        {"minimumInstances":N}).
+ *   three-ticket-scopes  a 3-occurrence weekly series (fixed base date, for
+ *                        stable screenshots) carrying one ticket type of each
+ *                        recurrence scope: single_instance, whole_series, and
+ *                        multiple_instances (default prices 15/40/10; override
+ *                        {"price":N} sets the single_instance price). Always
+ *                        renders the unified fair-events/event-signup block.
  *
  * Examples:
  *   wp eval-file .../seed-event.php paid
@@ -48,6 +54,7 @@ $minimum_instances = isset( $overrides['minimumInstances'] ) ? (int) $overrides[
 $ticket_type_id    = 0;
 $option_ids        = array();
 $occurrence_ids    = array();
+$extra_type_ids    = array();
 $is_paid           = true;
 
 // Which purchase block the event page carries. Default: fair-audience
@@ -57,7 +64,11 @@ $is_paid           = true;
 // unified fair-events/event-signup block with a nested fair-form question,
 // delegated through fair-audience's participant-aware flow (#1160).
 $block_content = '<!-- wp:fair-audience/event-signup /-->';
-if ( isset( $overrides['block'] ) && 'get-tickets' === $overrides['block'] ) {
+if ( 'three-ticket-scopes' === $flavour ) {
+	// Always the unified block — this flavour exists to screenshot it across
+	// plugin combinations, so the block override is not honoured here.
+	$block_content = '<!-- wp:fair-events/event-signup /-->';
+} elseif ( isset( $overrides['block'] ) && 'get-tickets' === $overrides['block'] ) {
 	$block_content = '<!-- wp:fair-events/get-tickets /-->';
 } elseif ( isset( $overrides['block'] ) && 'unified-with-question' === $overrides['block'] ) {
 	$block_content = implode(
@@ -70,8 +81,14 @@ if ( isset( $overrides['block'] ) && 'get-tickets' === $overrides['block'] ) {
 	);
 }
 
-$event_id       = fair_e2e_create_event( 'E2E ' . $flavour . ' Event ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ), $block_content );
-$event_date_id  = fair_e2e_add_date( $event_id );
+$event_id = fair_e2e_create_event( 'E2E ' . $flavour . ' Event ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ), $block_content );
+
+// three-ticket-scopes pins its occurrence to a fixed absolute date (rather than
+// fair_e2e_add_date()'s '+7 days') so the rendered dates/prices are stable and
+// reviewable as regressions across runs.
+$event_date_id  = 'three-ticket-scopes' === $flavour
+	? fair_e2e_add_date_at( $event_id, '2027-01-15 18:00:00' )
+	: fair_e2e_add_date( $event_id );
 $sale_period_id = fair_e2e_add_sale_period( $event_date_id );
 
 switch ( $flavour ) {
@@ -115,8 +132,23 @@ switch ( $flavour ) {
 		fair_e2e_add_price( $ticket_type_id, $sale_period_id, $price, null );
 		break;
 
+	case 'three-ticket-scopes':
+		$price = isset( $overrides['price'] ) ? (float) $overrides['price'] : 15.00;
+		// Turns the single occurrence already created above into the series
+		// master (same event_date_id/sale_period_id) plus 2 generated siblings.
+		$occurrence_ids = fair_e2e_add_series( $event_id, 3 );
+		$single_type_id = fair_e2e_add_ticket_type( $event_date_id, 'Single Session', null );
+		$whole_type_id  = fair_e2e_add_whole_series_ticket_type( $event_date_id, 'Full Series Pass' );
+		$multi_type_id  = fair_e2e_add_multi_instance_ticket_type( $event_date_id, 'Pick your sessions', $minimum_instances );
+		fair_e2e_add_price( $single_type_id, $sale_period_id, $price, null );
+		fair_e2e_add_price( $whole_type_id, $sale_period_id, 40.00, null );
+		fair_e2e_add_price( $multi_type_id, $sale_period_id, 10.00, null );
+		$ticket_type_id = $single_type_id;
+		$extra_type_ids = array( $whole_type_id, $multi_type_id );
+		break;
+
 	default:
-		WP_CLI::error( "Unknown flavour '{$flavour}'. Use one of: free, paid, paid-with-options, capacity-1, multiple-instances." );
+		WP_CLI::error( "Unknown flavour '{$flavour}'. Use one of: free, paid, paid-with-options, capacity-1, multiple-instances, three-ticket-scopes." );
 }
 
 echo 'E2E_SEED:' . wp_json_encode(
@@ -127,6 +159,7 @@ echo 'E2E_SEED:' . wp_json_encode(
 		'eventDateId'      => (int) $event_date_id,
 		'salePeriodId'     => (int) $sale_period_id,
 		'ticketTypeId'     => (int) $ticket_type_id,
+		'extraTypeIds'     => array_map( 'intval', $extra_type_ids ),
 		'optionIds'        => array_map( 'intval', $option_ids ),
 		'occurrenceIds'    => array_map( 'intval', $occurrence_ids ),
 		'minimumInstances' => (int) $minimum_instances,

--- a/e2e/screenshots/event-signup-combinations.spec.js
+++ b/e2e/screenshots/event-signup-combinations.spec.js
@@ -1,0 +1,139 @@
+/**
+ * Screenshot e2e: the unified fair-events/event-signup block across three
+ * plugin combinations, for manual visual review (#1185).
+ *
+ * The SAME `wp:fair-events/event-signup` block is placed on the page in every
+ * combination — only the active-plugin set changes. The block is designed to
+ * be usable always: with fair-audience inactive it renders its own anonymous
+ * get-tickets form; with fair-audience active it delegates to
+ * fair-audience/event-signup for the participant-aware flow (see
+ * fair-events/src/blocks/event-signup/render.php). fair-audience-experimental
+ * is deactivated in all three combos (it's active by default in
+ * .wp-env.json). fair-payments-connector, fair-form, and fair-platform are
+ * infrastructure and stay untouched throughout.
+ *
+ * Each combo seeds the same 'three-ticket-scopes' event (a 3-occurrence
+ * recurring series with one ticket type per recurrence scope: single_instance,
+ * whole_series, multiple_instances) at a fixed future date, so the three
+ * screenshots are directly comparable and stable across runs.
+ *
+ * No behavioural assertions beyond "the render-gate selector is visible" —
+ * pass = page renders + screenshot captured. Plugin toggling follows the
+ * established in-instance pattern from user-flows/get-tickets-purchase.spec.js;
+ * the single-worker serial Playwright run guarantees no cross-spec bleed.
+ */
+
+import path from 'node:path';
+import { test, expect } from '../support/fixtures.js';
+import { wpCli } from '../support/wp-cli.js';
+
+const OUTPUT_DIR = path.join(process.cwd(), 'e2e/screenshots/output');
+
+/** Reactivate the full default .wp-env.json plugin set. */
+function restoreDefaultPlugins() {
+	wpCli(
+		'plugin activate fair-audience fair-audience-experimental fair-events-experimental'
+	);
+}
+
+test.describe('Event Signup screenshots: fair-events only', () => {
+	test.beforeAll(() => {
+		wpCli(
+			'plugin deactivate fair-audience fair-audience-experimental fair-events-experimental'
+		);
+	});
+
+	test.afterAll(() => {
+		restoreDefaultPlugins();
+	});
+
+	test('renders the anonymous get-tickets form', async ({
+		page,
+		seedEvent,
+	}, testInfo) => {
+		const event = seedEvent('three-ticket-scopes');
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		const screenshotPath = path.join(
+			OUTPUT_DIR,
+			'signup-fair-events-only.png'
+		);
+		await page.screenshot({ path: screenshotPath });
+		await testInfo.attach('signup-fair-events-only', {
+			path: screenshotPath,
+			contentType: 'image/png',
+		});
+	});
+});
+
+test.describe('Event Signup screenshots: fair-events + fair-audience', () => {
+	test.beforeAll(() => {
+		wpCli(
+			'plugin deactivate fair-audience-experimental fair-events-experimental'
+		);
+		wpCli('plugin activate fair-audience');
+	});
+
+	test.afterAll(() => {
+		restoreDefaultPlugins();
+	});
+
+	test('renders the participant-aware signup flow', async ({
+		page,
+		seedEvent,
+	}, testInfo) => {
+		const event = seedEvent('three-ticket-scopes');
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-audience-event-signup');
+		await expect(form).toBeVisible();
+
+		const screenshotPath = path.join(
+			OUTPUT_DIR,
+			'signup-fair-events-audience.png'
+		);
+		await page.screenshot({ path: screenshotPath });
+		await testInfo.attach('signup-fair-events-audience', {
+			path: screenshotPath,
+			contentType: 'image/png',
+		});
+	});
+});
+
+test.describe('Event Signup screenshots: fair-events + fair-audience + fair-events-experimental', () => {
+	test.beforeAll(() => {
+		wpCli('plugin deactivate fair-audience-experimental');
+		wpCli('plugin activate fair-audience fair-events-experimental');
+	});
+
+	test.afterAll(() => {
+		restoreDefaultPlugins();
+	});
+
+	test('renders the participant-aware signup flow with the experimental layer active', async ({
+		page,
+		seedEvent,
+	}, testInfo) => {
+		const event = seedEvent('three-ticket-scopes');
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-audience-event-signup');
+		await expect(form).toBeVisible();
+
+		const screenshotPath = path.join(
+			OUTPUT_DIR,
+			'signup-fair-events-audience-experimental.png'
+		);
+		await page.screenshot({ path: screenshotPath });
+		await testInfo.attach('signup-fair-events-audience-experimental', {
+			path: screenshotPath,
+			contentType: 'image/png',
+		});
+	});
+});

--- a/e2e/support/fixtures.js
+++ b/e2e/support/fixtures.js
@@ -32,7 +32,8 @@ export const test = base.extend({
 		 * Seed a fresh event in the given flavour and return its parsed
 		 * E2E_SEED payload (pageUrl + ids).
 		 *
-		 * @param {string} flavour   Preset: free | paid | paid-with-options | capacity-1.
+		 * @param {string} flavour   Preset: free | paid | paid-with-options | capacity-1 |
+		 *                           multiple-instances | three-ticket-scopes.
 		 * @param {object} overrides Optional JSON overrides (e.g. { price, options }).
 		 * @return {object} Parsed E2E_SEED payload.
 		 */


### PR DESCRIPTION
## Summary

- Adds a `three-ticket-scopes` seed flavour (repo-root `e2e/mu-plugins/`) — a
  3-occurrence weekly series pinned to a fixed absolute date, carrying one
  ticket type per recurrence scope (`single_instance`, `whole_series`,
  `multiple_instances`), always placed with the unified
  `fair-events/event-signup` block.
- Adds `e2e/screenshots/event-signup-combinations.spec.js`: three `describe`
  blocks toggle the active-plugin set in-instance (fair-events only /
  + fair-audience / + fair-audience + fair-events-experimental,
  fair-audience-experimental off throughout) and screenshot the same seeded
  event page, saved to `e2e/screenshots/output/` (gitignored) and attached to
  the Playwright report.
- No behavioural assertions beyond the render-gate selector being visible —
  pass = page renders + screenshot captured, per the ticket.

**Harness-isolation note:** the ticket's risk section floated "separate spec
runs, each against its own harness configuration." `wp-env` boots one fixed
plugin set per instance, so that isn't a clean fit and isn't wired anywhere in
the repo. This PR uses the same in-instance plugin-toggling pattern already
established in `e2e/user-flows/get-tickets-purchase.spec.js` — each combo sets
its exact active-plugin set in `beforeAll` and restores the default set in
`afterAll`; the single-worker serial Playwright run guarantees no cross-spec
bleed.

Closes #1185

## Test plan

- [x] `php -l` on the changed PHP files
- [x] `vendor/bin/phpcs` clean on the changed PHP files (one pre-existing
      warning, unrelated to this change)
- [x] `npx wp-scripts format` / `node --check` on the changed/new JS
- [ ] `npm run test:e2e:setup && npm run test:e2e -- event-signup-combinations`
      — **not run**; this environment has no Docker daemon available, so the
      wp-env harness this spec depends on could not be booted here. Please run
      this locally before merging.
