### PR TITLE
Lead the base signup form with a ticket radio group

### DIFF
--- a/e2e/user-flows/get-tickets-cancel-and-restart.spec.js
+++ b/e2e/user-flows/get-tickets-cancel-and-restart.spec.js
@@ -51,8 +51,10 @@ test.describe('get-tickets block (fair-audience inactive): abandon and restart',
 		await form.locator('input[name="name"]').fill(`Abandoned ${stamp}`);
 		await form.locator('input[name="email"]').fill(abandonedEmail);
 		await form
-			.locator('select[name="ticket_type_id"]')
-			.selectOption(String(event.ticketTypeId));
+			.locator(
+				`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
+			)
+			.check();
 
 		// Submit → redirected through the Mollie double to the callback URL,
 		// which only polls; the buyer never lands on a confirmed state because
@@ -80,8 +82,10 @@ test.describe('get-tickets block (fair-audience inactive): abandon and restart',
 		await form.locator('input[name="name"]').fill(`Fresh Buyer ${stamp}`);
 		await form.locator('input[name="email"]').fill(buyerEmail);
 		await form
-			.locator('select[name="ticket_type_id"]')
-			.selectOption(String(event.ticketTypeId));
+			.locator(
+				`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
+			)
+			.check();
 		await form.locator('button[type="submit"]').click();
 		await expect(page.locator('.message-processing')).toBeVisible({
 			timeout: 30000,

--- a/e2e/user-flows/get-tickets-form-layout.spec.js
+++ b/e2e/user-flows/get-tickets-form-layout.spec.js
@@ -1,0 +1,99 @@
+/**
+ * E2E: base Event Signup form layout (fair-events alone, no other Fair
+ * Event plugin active) — the ticket-type radio group precedes name/email
+ * with the first available type preselected, and the occurrence picker sits
+ * directly beneath the ticket section (#1187).
+ *
+ * fair-audience, fair-audience-experimental, and fair-events-experimental
+ * are all deactivated for this describe block so the base
+ * fair-events/event-signup render path (render.php's own markup, not the
+ * fair-audience delegation) is what's under test — mirroring the "fair-events
+ * only" combination in e2e/screenshots/event-signup-combinations.spec.js.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+import { wpCli } from '../support/wp-cli.js';
+
+test.describe('Event Signup form layout (fair-events alone)', () => {
+	test.beforeAll(() => {
+		wpCli(
+			'plugin deactivate fair-audience fair-audience-experimental fair-events-experimental'
+		);
+	});
+
+	test.afterAll(() => {
+		wpCli(
+			'plugin activate fair-audience fair-audience-experimental fair-events-experimental'
+		);
+	});
+
+	test('ticket type radio group renders before name/email, first available type preselected', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('paid', { block: 'get-tickets' });
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		// A plain <select> must be gone from the ticket section.
+		await expect(form.locator('select[name="ticket_type_id"]')).toHaveCount(
+			0
+		);
+
+		const fieldset = form.locator('.fair-events-ticket-fieldset');
+		await expect(fieldset).toBeVisible();
+		await expect(fieldset.locator('legend')).toHaveText(
+			'Choose ticket type'
+		);
+
+		const ticketRadio = form.locator(
+			`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
+		);
+		await expect(ticketRadio).toBeChecked();
+
+		// DOM order: the ticket fieldset markup precedes both the name and
+		// email fields.
+		const html = await form.innerHTML();
+		const fieldsetIndex = html.indexOf('fair-events-ticket-fieldset');
+		const nameIndex = html.indexOf('name="name"');
+		const emailIndex = html.indexOf('name="email"');
+		expect(fieldsetIndex).toBeGreaterThan(-1);
+		expect(fieldsetIndex).toBeLessThan(nameIndex);
+		expect(fieldsetIndex).toBeLessThan(emailIndex);
+	});
+
+	test('occurrence picker sits directly after the ticket section, ahead of name/email', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('three-ticket-scopes');
+		const multiInstanceTypeId = event.extraTypeIds[1];
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		const html = await form.innerHTML();
+		const fieldsetIndex = html.indexOf('fair-events-ticket-fieldset');
+		const pickerIndex = html.indexOf('fair-events-instance-picker');
+		const nameIndex = html.indexOf('name="name"');
+		expect(pickerIndex).toBeGreaterThan(-1);
+		expect(pickerIndex).toBeGreaterThan(fieldsetIndex);
+		expect(pickerIndex).toBeLessThan(nameIndex);
+
+		// Hidden until the multiple_instances ticket type is selected.
+		const instancePicker = form.locator('.fair-events-instance-picker');
+		await expect(instancePicker).toBeHidden();
+
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${multiInstanceTypeId}"]`
+			)
+			.check();
+		await expect(instancePicker).toBeVisible();
+	});
+});

--- a/e2e/user-flows/get-tickets-purchase.spec.js
+++ b/e2e/user-flows/get-tickets-purchase.spec.js
@@ -62,8 +62,10 @@ test.describe('get-tickets block purchase (fair-audience inactive)', () => {
 		await form.locator('input[name="name"]').fill(buyerName);
 		await form.locator('input[name="email"]').fill(email);
 		await form
-			.locator('select[name="ticket_type_id"]')
-			.selectOption(String(event.ticketTypeId));
+			.locator(
+				`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
+			)
+			.check();
 
 		// Submit → payment_required with a checkout_url that (via the Mollie
 		// double) is the callback URL itself, so the browser lands straight on
@@ -137,8 +139,10 @@ test.describe('get-tickets block purchase (fair-audience inactive)', () => {
 			.fill(`E2E GetTickets Free ${stamp}`);
 		await form.locator('input[name="email"]').fill(email);
 		await form
-			.locator('select[name="ticket_type_id"]')
-			.selectOption(String(event.ticketTypeId));
+			.locator(
+				`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
+			)
+			.check();
 
 		await form.locator('button[type="submit"]').click();
 

--- a/fair-events/src/blocks/event-signup/frontend.css
+++ b/fair-events/src/blocks/event-signup/frontend.css
@@ -76,3 +76,33 @@
 	font-size: 0.9em;
 	color: #555;
 }
+
+.fair-events-get-tickets-form .fair-events-ticket-fieldset {
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	padding: 12px 16px 16px;
+	margin: 0;
+}
+
+.fair-events-get-tickets-form .fair-events-ticket-fieldset legend {
+	padding: 0 4px;
+}
+
+.fair-events-get-tickets-form .fair-events-ticket-option {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-weight: normal;
+	margin-bottom: 8px;
+}
+
+.fair-events-get-tickets-form .fair-events-ticket-option:last-child {
+	margin-bottom: 0;
+}
+
+.fair-events-get-tickets-form .fair-events-quantity-newsletter-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+	align-items: flex-end;
+}

--- a/fair-events/src/blocks/event-signup/frontend.js
+++ b/fair-events/src/blocks/event-signup/frontend.js
@@ -75,14 +75,14 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 			submitForm(form, data);
 		});
 
-		const ticketTypeField = form.querySelector(
-			'select[name="ticket_type_id"]'
+		const ticketTypeFields = form.querySelectorAll(
+			'input[name="ticket_type_id"]'
 		);
-		if (ticketTypeField) {
-			ticketTypeField.addEventListener('change', function () {
+		ticketTypeFields.forEach(function (field) {
+			field.addEventListener('change', function () {
 				updateInstancePicker(form);
 			});
-		}
+		});
 
 		const instancePicker = form.querySelector(
 			'.fair-events-instance-picker'
@@ -101,16 +101,12 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 	}
 
 	/**
-	 * Selected <option> of the ticket type <select>, if any.
+	 * Checked ticket type radio input, if any.
 	 * @param {HTMLFormElement} form The get-tickets form.
-	 * @return {HTMLOptionElement|null} The selected option element.
+	 * @return {HTMLInputElement|null} The checked radio input element.
 	 */
 	function getSelectedTicketTypeOption(form) {
-		const select = form.querySelector('select[name="ticket_type_id"]');
-		if (!select || !select.value) {
-			return null;
-		}
-		return select.options[select.selectedIndex] || null;
+		return form.querySelector('input[name="ticket_type_id"]:checked');
 	}
 
 	/**
@@ -318,7 +314,7 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 		}
 
 		const ticketTypeField = form.querySelector(
-			'select[name="ticket_type_id"]'
+			'input[name="ticket_type_id"]:checked'
 		);
 		if (ticketTypeField && ticketTypeField.value) {
 			data.ticket_type_id = parseInt(ticketTypeField.value, 10);

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -297,6 +297,84 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 		do_action( 'fair_events_signup_render_before_form', $context );
 		?>
 
+		<?php if ( ! empty( $ticket_types ) ) : ?>
+			<?php
+			$first_enabled_type_id = null;
+			foreach ( $ticket_types as $ticket_type ) {
+				$type_id    = (int) $ticket_type->id;
+				$type_price = $price_by_type_id[ $type_id ] ?? null;
+				if ( ! ( $payments_unavailable && null !== $type_price && $type_price > 0 ) ) {
+					$first_enabled_type_id = $type_id;
+					break;
+				}
+			}
+			?>
+			<div class="form-row">
+				<fieldset class="fair-events-ticket-fieldset">
+					<legend class="form-label"><?php esc_html_e( 'Choose ticket type', 'fair-events' ); ?></legend>
+					<?php foreach ( $ticket_types as $ticket_type ) : ?>
+						<?php
+						$type_id          = (int) $ticket_type->id;
+						$type_price       = $price_by_type_id[ $type_id ] ?? null;
+						$type_unavailable = $payments_unavailable && null !== $type_price && $type_price > 0;
+						$label            = esc_html( $ticket_type->name );
+						if ( null !== $type_price ) {
+							$label .= ' — ' . esc_html( $currency_symbol . number_format( $type_price, 2 ) );
+						} elseif ( null === $active_sale_period ) {
+							$label .= ' — ' . esc_html__( 'No active sale period', 'fair-events' );
+						}
+						if ( $type_unavailable ) {
+							$label .= ' — ' . esc_html__( 'ticket sales temporarily unavailable', 'fair-events' );
+						}
+						$radio_id = $form_id . '-ticket-type-' . $type_id;
+						?>
+						<label class="fair-events-ticket-option" for="<?php echo esc_attr( $radio_id ); ?>">
+							<input
+								type="radio"
+								id="<?php echo esc_attr( $radio_id ); ?>"
+								name="ticket_type_id"
+								value="<?php echo esc_attr( $type_id ); ?>"
+								data-ticket-price="<?php echo esc_attr( null !== $type_price ? number_format( $type_price, 2, '.', '' ) : '' ); ?>"
+								data-recurrence-scope="<?php echo esc_attr( $ticket_type->recurrence_scope ); ?>"
+								data-min-instances="<?php echo esc_attr( (string) $ticket_type->minimum_instances ); ?>"
+								<?php echo $type_unavailable ? 'disabled' : ''; ?>
+								<?php echo $type_id === $first_enabled_type_id ? 'checked' : ''; ?>
+							/>
+							<?php echo esc_html( $label ); ?>
+						</label>
+					<?php endforeach; ?>
+				</fieldset>
+			</div>
+		<?php endif; ?>
+
+		<?php if ( $has_instance_picker ) : ?>
+			<div class="form-row fair-events-instance-picker" style="display: none;">
+				<span class="form-label"><?php esc_html_e( 'Choose occurrences', 'fair-events' ); ?></span>
+				<?php foreach ( $occurrences_for_picker as $occ_row ) : ?>
+					<?php
+					$occ_label   = \FairEvents\Helpers\DateRangeFormatter::format(
+						$occ_row['start_datetime'],
+						$occ_row['end_datetime'],
+						$occ_row['all_day']
+					);
+					$checkbox_id = $form_id . '-inst-' . (int) $occ_row['id'];
+					?>
+					<label class="fair-events-instance-option" for="<?php echo esc_attr( $checkbox_id ); ?>">
+						<input
+							type="checkbox"
+							name="event_date_ids[]"
+							id="<?php echo esc_attr( $checkbox_id ); ?>"
+							value="<?php echo (int) $occ_row['id']; ?>"
+							class="form-checkbox"
+						/>
+						<?php echo esc_html( $occ_label ); ?>
+					</label>
+				<?php endforeach; ?>
+				<p class="fair-events-instance-picker-hint"></p>
+				<p class="fair-events-instance-picker-total"></p>
+			</div>
+		<?php endif; ?>
+
 		<div class="form-row">
 			<label for="<?php echo esc_attr( $form_id ); ?>-name" class="form-label">
 				<?php esc_html_e( 'Your Name', 'fair-events' ); ?>
@@ -330,99 +408,33 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 			/>
 		</div>
 
-		<?php if ( ! empty( $ticket_types ) ) : ?>
-			<div class="form-row">
-				<label for="<?php echo esc_attr( $form_id ); ?>-ticket-type" class="form-label">
-					<?php esc_html_e( 'Ticket Type', 'fair-events' ); ?>
+		<div class="fair-events-quantity-newsletter-row">
+			<div class="form-row fair-events-quantity-row">
+				<label for="<?php echo esc_attr( $form_id ); ?>-quantity" class="form-label">
+					<?php esc_html_e( 'Quantity', 'fair-events' ); ?>
 				</label>
-				<select
-					id="<?php echo esc_attr( $form_id ); ?>-ticket-type"
-					name="ticket_type_id"
-					class="form-input"
-				>
-					<option value=""><?php esc_html_e( 'Select a ticket type…', 'fair-events' ); ?></option>
-					<?php foreach ( $ticket_types as $ticket_type ) : ?>
-						<?php
-						$type_id          = (int) $ticket_type->id;
-						$type_price       = $price_by_type_id[ $type_id ] ?? null;
-						$type_unavailable = $payments_unavailable && null !== $type_price && $type_price > 0;
-						$label            = esc_html( $ticket_type->name );
-						if ( null !== $type_price ) {
-							$label .= ' — ' . esc_html( $currency_symbol . number_format( $type_price, 2 ) );
-						} elseif ( null === $active_sale_period ) {
-							$label .= ' — ' . esc_html__( 'No active sale period', 'fair-events' );
-						}
-						if ( $type_unavailable ) {
-							$label .= ' — ' . esc_html__( 'ticket sales temporarily unavailable', 'fair-events' );
-						}
-						?>
-						<option
-							value="<?php echo esc_attr( $type_id ); ?>"
-							data-ticket-price="<?php echo esc_attr( null !== $type_price ? number_format( $type_price, 2, '.', '' ) : '' ); ?>"
-							data-recurrence-scope="<?php echo esc_attr( $ticket_type->recurrence_scope ); ?>"
-							data-min-instances="<?php echo esc_attr( (string) $ticket_type->minimum_instances ); ?>"
-							<?php echo $type_unavailable ? 'disabled' : ''; ?>
-						>
-							<?php echo esc_html( $label ); ?>
-						</option>
-					<?php endforeach; ?>
-				</select>
-			</div>
-		<?php endif; ?>
-
-		<?php if ( $has_instance_picker ) : ?>
-			<div class="form-row fair-events-instance-picker" style="display: none;">
-				<span class="form-label"><?php esc_html_e( 'Choose occurrences', 'fair-events' ); ?></span>
-				<?php foreach ( $occurrences_for_picker as $occ_row ) : ?>
-					<?php
-					$occ_label   = \FairEvents\Helpers\DateRangeFormatter::format(
-						$occ_row['start_datetime'],
-						$occ_row['end_datetime'],
-						$occ_row['all_day']
-					);
-					$checkbox_id = $form_id . '-inst-' . (int) $occ_row['id'];
-					?>
-					<label class="fair-events-instance-option" for="<?php echo esc_attr( $checkbox_id ); ?>">
-						<input
-							type="checkbox"
-							name="event_date_ids[]"
-							id="<?php echo esc_attr( $checkbox_id ); ?>"
-							value="<?php echo (int) $occ_row['id']; ?>"
-							class="form-checkbox"
-						/>
-						<?php echo esc_html( $occ_label ); ?>
-					</label>
-				<?php endforeach; ?>
-				<p class="fair-events-instance-picker-hint"></p>
-				<p class="fair-events-instance-picker-total"></p>
-			</div>
-		<?php endif; ?>
-
-		<div class="form-row fair-events-quantity-row">
-			<label for="<?php echo esc_attr( $form_id ); ?>-quantity" class="form-label">
-				<?php esc_html_e( 'Quantity', 'fair-events' ); ?>
-			</label>
-			<input
-				type="number"
-				id="<?php echo esc_attr( $form_id ); ?>-quantity"
-				name="quantity"
-				class="form-input"
-				value="1"
-				min="1"
-				max="10"
-			/>
-		</div>
-
-		<div class="form-row">
-			<label class="form-checkbox-label">
 				<input
-					type="checkbox"
-					name="mailing_opt_in"
+					type="number"
+					id="<?php echo esc_attr( $form_id ); ?>-quantity"
+					name="quantity"
+					class="form-input"
 					value="1"
-					class="form-checkbox"
+					min="1"
+					max="10"
 				/>
-				<?php esc_html_e( 'Keep me informed about future events', 'fair-events' ); ?>
-			</label>
+			</div>
+
+			<div class="form-row">
+				<label class="form-checkbox-label">
+					<input
+						type="checkbox"
+						name="mailing_opt_in"
+						value="1"
+						class="form-checkbox"
+					/>
+					<?php esc_html_e( 'Keep me informed about future events', 'fair-events' ); ?>
+				</label>
+			</div>
 		</div>
 
 		<?php if ( '' !== trim( $content ) ) : ?>


### PR DESCRIPTION
## Summary

- Replace the base Event Signup form's `<select>` ticket picker with a `<fieldset>` radio group, preselecting the first available ticket type so the form is submittable and price-aware immediately.
- Reorder the base form: ticket radio list → occurrence picker → name/email → quantity + newsletter → nested content → submit.
- Update `frontend.js` to read the checked `input[name="ticket_type_id"]` radio instead of the `<select>`'s value.
- Add fieldset/radio and quantity+newsletter row styling to `frontend.css`.
- Update the `get-tickets-purchase` and `get-tickets-cancel-and-restart` e2e specs to `.check()` the ticket radio instead of `.selectOption()` on the removed `<select>`.

Only the base (fair-audience-inactive) render path is touched — the participant-aware fair-audience flow already used a radio group and is unaffected.

Refs #1187 (implements https://github.com/marcin-wosinek/fair-event-plugins/issues/1187#issuecomment-5010654642)

## Test plan

- [x] `npm run test:js` (fair-events) — 15 suites / 114 tests pass
- [x] `vendor/bin/phpcs fair-events/src/blocks/event-signup/render.php` — clean
- [x] `npm run build` (fair-events) — succeeds
- [x] e2e: `get-tickets-purchase.spec.js`, `get-tickets-cancel-and-restart.spec.js`, `multi-instance-purchase.spec.js`, `ticket-purchase-confirmation.spec.js`, `event-signup-combinations.spec.js` screenshots — all pass (9/9), including free & paid purchase, abandon/restart, and multi-occurrence purchase through the new radio layout
- [x] Verified the `signup-fair-events-only.png` screenshot shows the ticket radio group preselected and positioned above name/email
