### PR TITLE
Accept and store questionnaire answers on anonymous signups

### DIFF
--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -63,17 +63,17 @@ class GetTicketsController extends WP_REST_Controller {
 					'callback'            => array( $this, 'create_signup' ),
 					'permission_callback' => '__return_true',
 					'args'                => array(
-						'event_date_id'  => array(
+						'event_date_id'         => array(
 							'type'              => 'integer',
 							'required'          => true,
 							'sanitize_callback' => 'absint',
 						),
-						'name'           => array(
+						'name'                  => array(
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => 'sanitize_text_field',
 						),
-						'email'          => array(
+						'email'                 => array(
 							'type'              => 'string',
 							'required'          => true,
 							'sanitize_callback' => 'sanitize_email',
@@ -81,19 +81,19 @@ class GetTicketsController extends WP_REST_Controller {
 								return is_email( $value );
 							},
 						),
-						'ticket_type_id' => array(
+						'ticket_type_id'        => array(
 							'type'              => 'integer',
 							'required'          => false,
 							'default'           => 0,
 							'sanitize_callback' => 'absint',
 						),
-						'quantity'       => array(
+						'quantity'              => array(
 							'type'              => 'integer',
 							'required'          => false,
 							'default'           => 1,
 							'sanitize_callback' => 'absint',
 						),
-						'mailing_opt_in' => array(
+						'mailing_opt_in'        => array(
 							'type'              => 'boolean',
 							'required'          => false,
 							'default'           => false,
@@ -102,7 +102,7 @@ class GetTicketsController extends WP_REST_Controller {
 						// Chosen occurrence IDs for 'multiple_instances' ticket types.
 						// Capped so a crafted request can't force an unbounded number
 						// of line items / DB rows per submission.
-						'event_date_ids' => array(
+						'event_date_ids'        => array(
 							'type'              => 'array',
 							'items'             => array( 'type' => 'integer' ),
 							'required'          => false,
@@ -110,10 +110,20 @@ class GetTicketsController extends WP_REST_Controller {
 								return ! is_array( $value ) || count( $value ) <= 50;
 							},
 						),
-						'_honeypot'      => array(
+						'_honeypot'             => array(
 							'type'     => 'string',
 							'required' => false,
 							'default'  => '',
+						),
+						// No 'type' declared: QuestionnaireService::parse_answers()
+						// handles both a decoded array and a raw JSON string.
+						// Capped at 50 answers, mirroring the event_date_ids cap above.
+						'questionnaire_answers' => array(
+							'required'          => false,
+							'default'           => array(),
+							'validate_callback' => function ( $value ) {
+								return ! is_array( $value ) || count( $value ) <= 50;
+							},
 						),
 					),
 				),
@@ -166,6 +176,11 @@ class GetTicketsController extends WP_REST_Controller {
 		$quantity       = max( 1, min( 100, (int) $request->get_param( 'quantity' ) ) );
 		$mailing_opt_in = (bool) $request->get_param( 'mailing_opt_in' );
 
+		$questionnaire_answers = $this->prepare_questionnaire_answers( $request );
+		if ( is_wp_error( $questionnaire_answers ) ) {
+			return $questionnaire_answers;
+		}
+
 		// Validate event date exists.
 		if ( ! class_exists( \FairEvents\Models\EventDates::class ) ) {
 			return new WP_Error(
@@ -215,7 +230,7 @@ class GetTicketsController extends WP_REST_Controller {
 			// path that creates one signup row per chosen occurrence.
 			if ( $ticket_type->is_multiple_instances() ) {
 				$this->increment_rate_limit();
-				return $this->create_multi_instance_signup( $request, $ticket_type, $event_date_id, $name, $email, $mailing_opt_in );
+				return $this->create_multi_instance_signup( $request, $ticket_type, $event_date_id, $name, $email, $mailing_opt_in, $questionnaire_answers );
 			}
 
 			// Resolve price from the active sale period (server-side; client amount is ignored).
@@ -269,6 +284,7 @@ class GetTicketsController extends WP_REST_Controller {
 		// Free path.
 		if ( $amount <= 0 ) {
 			$this->fire_signup_created( $signup_id, $event_date_id, $name, $email, $ticket_selection, null );
+			$this->persist_questionnaire_answers( $signup_id, $event_date_id, $questionnaire_answers );
 			return rest_ensure_response(
 				array(
 					'status'  => 'confirmed',
@@ -318,6 +334,7 @@ class GetTicketsController extends WP_REST_Controller {
 		\FairEvents\Models\EventSignup::update_transaction( $signup_id, (int) $transaction_id );
 
 		$this->fire_signup_created( $signup_id, $event_date_id, $name, $email, $ticket_selection, (int) $transaction_id );
+		$this->persist_questionnaire_answers( $signup_id, $event_date_id, $questionnaire_answers );
 
 		// Load the freshly created transaction so its access token can be attached
 		// to the redirect URL, mirroring PaymentEndpoint::create_payment. The token
@@ -383,6 +400,67 @@ class GetTicketsController extends WP_REST_Controller {
 	}
 
 	/**
+	 * Parse and sanitize the custom question answers from a get-tickets
+	 * request, mirroring fair-audience's EventSignupController. Validation
+	 * runs before any signup mutation so bad input (e.g. a malformed phone
+	 * number) is rejected with a 400 without creating a signup row.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array|WP_Error Sanitized answers, or WP_Error on invalid input.
+	 */
+	private function prepare_questionnaire_answers( $request ) {
+		if ( ! class_exists( \FairForm\Services\QuestionnaireService::class ) ) {
+			return array();
+		}
+		$service = new \FairForm\Services\QuestionnaireService();
+		$answers = $service->parse_answers( $request->get_param( 'questionnaire_answers' ) );
+		return $service->sanitize_answers( $answers );
+	}
+
+	/**
+	 * Persist sanitized custom-question answers for a signup, called right
+	 * after fire_signup_created() so the participant_id fair-audience's
+	 * SignupHookBridge::link_participant() may have just set on the row is
+	 * picked up; the submission stores null (anonymous) when fair-audience
+	 * is inactive or the bridge left it unset. Nothing is persisted for
+	 * signups without custom questions, avoiding empty submissions.
+	 *
+	 * @param int   $signup_id     The fair_events_signups row just created.
+	 * @param int   $event_date_id Event-date ID the signup targets.
+	 * @param array $answers       Sanitized answers from prepare_questionnaire_answers().
+	 * @return void
+	 */
+	private function persist_questionnaire_answers( $signup_id, $event_date_id, $answers ) {
+		if ( empty( $answers ) ) {
+			return;
+		}
+		if ( ! class_exists( \FairForm\Services\QuestionnaireService::class ) ) {
+			return;
+		}
+
+		$signup         = \FairEvents\Models\EventSignup::get_by_id( $signup_id );
+		$participant_id = $signup && $signup->participant_id ? (int) $signup->participant_id : null;
+
+		$event_id = 0;
+		if ( class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+			if ( $event_date && ! empty( $event_date->event_id ) ) {
+				$event_id = (int) $event_date->event_id;
+			}
+		}
+
+		$service = new \FairForm\Services\QuestionnaireService();
+		$service->save_answers(
+			$participant_id,
+			$answers,
+			$event_date_id,
+			$event_id,
+			__( 'Event Signup', 'fair-events' ),
+			true
+		);
+	}
+
+	/**
 	 * Resolve the page the buyer should return to after checkout.
 	 *
 	 * This runs inside a REST request, which carries no post context —
@@ -430,9 +508,10 @@ class GetTicketsController extends WP_REST_Controller {
 	 * @param string                        $name           Buyer name.
 	 * @param string                        $email          Buyer email.
 	 * @param bool                          $mailing_opt_in Whether the buyer opted into mailings.
+	 * @param array                         $questionnaire_answers Sanitized custom-question answers, shared across every occurrence row.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private function create_multi_instance_signup( $request, $ticket_type, $series_page_id, $name, $email, $mailing_opt_in ) {
+	private function create_multi_instance_signup( $request, $ticket_type, $series_page_id, $name, $email, $mailing_opt_in, $questionnaire_answers = array() ) {
 		$raw_ids = $request->get_param( 'event_date_ids' ) ?? array();
 		$raw_ids = array_slice( array_values( array_unique( array_map( 'absint', (array) $raw_ids ) ) ), 0, 50 );
 		$raw_ids = array_filter( $raw_ids );
@@ -547,6 +626,7 @@ class GetTicketsController extends WP_REST_Controller {
 		if ( $total_amount <= 0 ) {
 			foreach ( $signup_ids as $index => $signup_id ) {
 				$this->fire_signup_created( $signup_id, $occurrence_ids[ $index ], $name, $email, $ticket_selection, null );
+				$this->persist_questionnaire_answers( $signup_id, $occurrence_ids[ $index ], $questionnaire_answers );
 			}
 			return rest_ensure_response(
 				array(
@@ -605,6 +685,7 @@ class GetTicketsController extends WP_REST_Controller {
 		foreach ( $signup_ids as $index => $signup_id ) {
 			\FairEvents\Models\EventSignup::update_transaction( $signup_id, (int) $transaction_id );
 			$this->fire_signup_created( $signup_id, $occurrence_ids[ $index ], $name, $email, $ticket_selection, (int) $transaction_id );
+			$this->persist_questionnaire_answers( $signup_id, $occurrence_ids[ $index ], $questionnaire_answers );
 		}
 
 		$transaction = \FairPaymentsConnector\Models\Transaction::get_by_id( $transaction_id );

--- a/fair-events/src/API/__tests__/GetTicketsQuestionnaire.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsQuestionnaire.api.spec.js
@@ -1,0 +1,240 @@
+/**
+ * Playwright API tests for GetTicketsController accepting and persisting
+ * custom-question `questionnaire_answers` on the anonymous signup route
+ * (#1181, Layer 2). Answers are parsed/sanitized/persisted via fair-form's
+ * QuestionnaireService, mirroring fair-audience's EventSignupController.
+ *
+ * Skips gracefully when fair-form is not active in the test environment
+ * (answers are ignored, not rejected, when fair-form is inactive — covered
+ * by the last test below, which runs regardless).
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}-${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+const nameQuestion = (value) => ({
+	question_key: 'favorite_color',
+	question_text: 'Favorite color?',
+	question_type: 'short_text',
+	answer_value: value,
+	display_order: 0,
+});
+
+const phoneQuestion = (value) => ({
+	question_key: 'phone',
+	question_text: 'Phone number?',
+	question_type: 'phone',
+	answer_value: value,
+	display_order: 1,
+});
+
+test.describe('GetTicketsController — questionnaire_answers', () => {
+	let api;
+	let fairFormActive = false;
+	let fairAudienceActive = false;
+	let eventPostId;
+	let eventDateId;
+
+	async function countSignups(eventDateIdToCount) {
+		const res = await api.get('/wp-json/fair-events/v1/get-tickets', {
+			headers: adminHeaders,
+			params: { event_date: eventDateIdToCount },
+		});
+		expect(res.ok()).toBeTruthy();
+		return (await res.json()).length;
+	}
+
+	async function findSubmission(email) {
+		const res = await api.get(
+			'/wp-json/fair-form/v1/questionnaire-responses',
+			{
+				headers: adminHeaders,
+				params: { event_date_id: eventDateId, title: 'Event Signup' },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const submissions = await res.json();
+		return submissions.find((s) =>
+			s.answers.some((a) => a.answer_value === email)
+		);
+	}
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairFormActive = plugins.some(
+				(p) => p.plugin?.includes('fair-form') && p.status === 'active'
+			);
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Get-tickets questionnaire test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2035-06-01 10:00:00',
+				end_datetime: '2035-06-01 12:00:00',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		eventDateId = (await edRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+		await api.dispose();
+	});
+
+	test('answers are stored with participant_id 0 (anonymous) when fair-audience is inactive', async () => {
+		test.skip(!fairFormActive, 'fair-form not active');
+		test.skip(fairAudienceActive, 'fair-audience active — see linked test');
+
+		const email = uniqueEmail('anon');
+		// Use its own event date so the submission lookup by email is unambiguous.
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				event_id: eventPostId,
+				start_datetime: '2035-06-02 10:00:00',
+				end_datetime: '2035-06-02 12:00:00',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		const anonEventDateId = (await edRes.json()).id;
+
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: anonEventDateId,
+				name: 'Anon Tester',
+				email,
+				quantity: 1,
+				questionnaire_answers: [nameQuestion(email)],
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		expect((await res.json()).status).toBe('confirmed');
+
+		const responsesRes = await api.get(
+			'/wp-json/fair-form/v1/questionnaire-responses',
+			{
+				headers: adminHeaders,
+				params: {
+					event_date_id: anonEventDateId,
+					title: 'Event Signup',
+				},
+			}
+		);
+		expect(responsesRes.ok()).toBeTruthy();
+		const submissions = await responsesRes.json();
+		expect(submissions.length).toBe(1);
+		expect(submissions[0].participant_id).toBe(0);
+		expect(
+			submissions[0].answers.some((a) => a.answer_value === email)
+		).toBeTruthy();
+	});
+
+	test('answers are linked to the fair-audience participant when fair-audience is active', async () => {
+		test.skip(!fairFormActive, 'fair-form not active');
+		test.skip(!fairAudienceActive, 'fair-audience not active');
+
+		const email = uniqueEmail('linked');
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: eventDateId,
+				name: 'Linked Tester',
+				email,
+				quantity: 1,
+				questionnaire_answers: [nameQuestion(email)],
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		expect((await res.json()).status).toBe('confirmed');
+
+		const participantsRes = await api.get(
+			'/wp-json/fair-audience/v1/participants',
+			{ headers: adminHeaders, params: { search: email } }
+		);
+		expect(participantsRes.ok()).toBeTruthy();
+		const participant = (await participantsRes.json()).find(
+			(p) => p.email === email
+		);
+		expect(participant).toBeTruthy();
+
+		const submission = await findSubmission(email);
+		expect(submission).toBeTruthy();
+		expect(submission.participant_id).toBe(participant.id);
+	});
+
+	test('invalid answers are rejected with no signup created', async () => {
+		test.skip(!fairFormActive, 'fair-form not active');
+
+		const before = await countSignups(eventDateId);
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: eventDateId,
+				name: 'Invalid Tester',
+				email: uniqueEmail('invalid'),
+				quantity: 1,
+				questionnaire_answers: [phoneQuestion('not-a-phone-number')],
+			},
+		});
+		expect(res.status()).toBe(400);
+		expect((await res.json()).code).toBe('invalid_phone');
+		expect(await countSignups(eventDateId)).toBe(before);
+	});
+
+	test('answers are ignored gracefully when fair-form is inactive', async () => {
+		test.skip(fairFormActive, 'fair-form active — see stored-answer tests');
+
+		const email = uniqueEmail('noform');
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: eventDateId,
+				name: 'No Form Tester',
+				email,
+				quantity: 1,
+				questionnaire_answers: [nameQuestion(email)],
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		expect((await res.json()).status).toBe('confirmed');
+	});
+});


### PR DESCRIPTION
## Summary

- `GetTicketsController` now accepts a `questionnaire_answers` param (capped at 50, matching `event_date_ids`), parses/sanitizes it via `FairForm\Services\QuestionnaireService` (guarded by `class_exists`, silently ignored when fair-form is inactive), and rejects invalid input with a `WP_Error` before any signup mutation.
- Sanitized answers are persisted right after `fire_signup_created()` — for the free path, paid path, and each occurrence of a `multiple_instances` signup — by re-reading the signup row so a `participant_id` set in the meantime by fair-audience's `SignupHookBridge::link_participant()` is picked up; otherwise the submission is anonymous (`participant_id` null).
- Adds `GetTicketsQuestionnaire.api.spec.js` covering: anonymous storage, invalid-answer rejection with no signup row written, answers ignored gracefully when fair-form is inactive, and (skip-gated, matching `EventSignupHookBridge.api.spec.js`) participant linking when fair-audience is active.

Verified end-to-end via the WP-CLI `eval-file` manual-check recipe (TESTING.md) against the dev stack: anonymous storage, invalid-phone rejection with no extra signup row, and fair-form-inactive graceful ignoring all confirmed. The fair-audience-active participant-linking path could not be exercised live — `fair-events/src/Core/Plugin.php` only registers `GetTicketsController`'s routes `when fair-audience's EventSignupController is absent`, so the base route 404s whenever fair-audience is active in this environment; this is a pre-existing condition (also affecting `EventSignupHookBridge.api.spec.js`), unrelated to this change and out of scope for Layer 2.

Closes #1181

## Test plan

- [x] `npm run format` (fair-events)
- [x] `vendor/bin/phpcs` on changed PHP — clean (3 pre-existing short-ternary warnings elsewhere in the file, untouched by this diff)
- [x] Manual WP-CLI `eval-file` verification: anonymous storage, invalid-phone 400 rejection, fair-form-inactive graceful ignore
- [ ] `npm run test:api` — could not run live; the local dev stack has Application Passwords disabled (non-HTTPS), which breaks Basic Auth for every existing `*.api.spec.js` file identically, not just this one
