### PR TITLE
Defer ticket sale-period defaults; resolve window lazily

### DIFF
--- a/fair-events/__tests__/Services/TicketPricingTest.php
+++ b/fair-events/__tests__/Services/TicketPricingTest.php
@@ -99,4 +99,76 @@ class TicketPricingTest extends TestCase {
 		// started yet — the fallback only ever considers the last period.
 		$this->assertNull( TicketPricing::pick_active_period( array( $earlier, $later ), '2026-01-16 00:00:00', true ) );
 	}
+
+	/**
+	 * An unset sale_end substitutes the computed default.
+	 */
+	public function test_apply_default_window_substitutes_unset_end() {
+		$period   = $this->period( '2026-01-01 00:00:00', null );
+		$resolved = TicketPricing::apply_default_window( array( $period ), '2026-03-01 00:00:00' );
+		$this->assertSame( '2026-03-01 00:00:00', $resolved[0]->sale_end );
+		// The original period object is untouched — apply_default_window clones.
+		$this->assertNull( $period->sale_end );
+	}
+
+	/**
+	 * An unset sale_start becomes open (always already started).
+	 */
+	public function test_apply_default_window_unset_start_is_open() {
+		$period   = $this->period( '', '2026-06-01 00:00:00' );
+		$resolved = TicketPricing::apply_default_window( array( $period ), null );
+		$this->assertSame( TicketPricing::OPEN_START_SENTINEL, $resolved[0]->sale_start );
+	}
+
+	/**
+	 * Explicit sale_start/sale_end values are left untouched.
+	 */
+	public function test_apply_default_window_leaves_explicit_values_untouched() {
+		$period   = $this->period( '2026-01-01 00:00:00', '2026-02-01 00:00:00' );
+		$resolved = TicketPricing::apply_default_window( array( $period ), '2026-09-01 00:00:00' );
+		$this->assertSame( '2026-01-01 00:00:00', $resolved[0]->sale_start );
+		$this->assertSame( '2026-02-01 00:00:00', $resolved[0]->sale_end );
+	}
+
+	/**
+	 * With no default end available (e.g. the event/series has no occurrences),
+	 * an unset sale_end is left unset rather than substituting a bogus value.
+	 */
+	public function test_apply_default_window_without_default_end_leaves_end_unset() {
+		$period   = $this->period( '2026-01-01 00:00:00', null );
+		$resolved = TicketPricing::apply_default_window( array( $period ), null );
+		$this->assertNull( $resolved[0]->sale_end );
+	}
+
+	/**
+	 * Compute_default_sale_end() returns the day after the last occurrence at
+	 * midnight site time, regardless of the occurrence's own time-of-day.
+	 */
+	public function test_compute_default_sale_end_is_day_after_at_midnight() {
+		$this->assertSame(
+			'2026-06-16 00:00:00',
+			TicketPricing::compute_default_sale_end( '2026-06-15 18:30:00' )
+		);
+	}
+
+	/**
+	 * With no occurrence to anchor to, there is no default.
+	 */
+	public function test_compute_default_sale_end_null_input_returns_null() {
+		$this->assertNull( TicketPricing::compute_default_sale_end( null ) );
+	}
+
+	/**
+	 * End-to-end: an unset window resolves through pick_active_period() as
+	 * purchasable up through the day after the last occurrence — never
+	 * "closed" just because nothing was ever stored.
+	 */
+	public function test_unset_window_resolves_purchasable_through_default_end() {
+		$period      = $this->period( null, null );
+		$default_end = TicketPricing::compute_default_sale_end( '2026-06-15 18:30:00' );
+		$resolved    = TicketPricing::apply_default_window( array( $period ), $default_end );
+		$this->assertSame( $resolved[0], TicketPricing::pick_active_period( $resolved, '2026-06-15 12:00:00', true ) );
+		// The final day (day after the occurrence) is no longer on sale — half-open range.
+		$this->assertNull( TicketPricing::pick_active_period( $resolved, '2026-06-16 00:00:00', false ) );
+	}
 }

--- a/fair-events/src/API/TicketsController.php
+++ b/fair-events/src/API/TicketsController.php
@@ -367,8 +367,8 @@ class TicketsController extends WP_REST_Controller {
 			: array();
 		foreach ( $incoming_periods as $index => $item ) {
 			$name       = isset( $item['name'] ) ? sanitize_text_field( $item['name'] ) : null;
-			$sale_start = sanitize_text_field( $item['sale_start'] ?? '' );
-			$sale_end   = sanitize_text_field( $item['sale_end'] ?? '' );
+			$sale_start = ! empty( $item['sale_start'] ) ? sanitize_text_field( $item['sale_start'] ) : null;
+			$sale_end   = ! empty( $item['sale_end'] ) ? sanitize_text_field( $item['sale_end'] ) : null;
 
 			$new_id = TicketSalePeriod::create( $event_date_id, $name, $sale_start, $sale_end, $index );
 			if ( $new_id ) {
@@ -596,8 +596,8 @@ class TicketsController extends WP_REST_Controller {
 		$id_map = array();
 		foreach ( $incoming as $index => $item ) {
 			$name       = isset( $item['name'] ) ? sanitize_text_field( $item['name'] ) : null;
-			$sale_start = sanitize_text_field( $item['sale_start'] ?? '' );
-			$sale_end   = sanitize_text_field( $item['sale_end'] ?? '' );
+			$sale_start = ! empty( $item['sale_start'] ) ? sanitize_text_field( $item['sale_start'] ) : null;
+			$sale_end   = ! empty( $item['sale_end'] ) ? sanitize_text_field( $item['sale_end'] ) : null;
 			$sort_order = $index;
 
 			if ( ! empty( $item['id'] ) && in_array( (int) $item['id'], $existing_ids, true ) ) {

--- a/fair-events/src/API/__tests__/GetTicketsUnsetSalePeriod.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsUnsetSalePeriod.api.spec.js
@@ -1,0 +1,209 @@
+/**
+ * Playwright API tests for lazy default sale-period resolution (#1189).
+ *
+ * When a ticket type's sale period is left unset (no sale_start/sale_end
+ * stored), on-sale evaluation must resolve a default lazily — open start,
+ * end at the day after the last occurrence — rather than treating the
+ * unset window as closed.
+ *
+ * This endpoint only serves signups when fair-audience is NOT active
+ * (fair-events/src/blocks/get-tickets/render.php defers to the Event Signup
+ * block otherwise), so these tests skip gracefully when fair-audience is
+ * active in the test environment.
+ *
+ * Covers:
+ *   - single, non-recurring event with an unset window is purchasable.
+ *   - recurring event with an unset window is purchasable through the
+ *     day after its last (generated) occurrence.
+ *   - a series entirely in the past with an unset window is still
+ *     purchasable (the existing continues-fallback semantics), never an
+ *     inverted/empty range.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+/**
+ * Creates an event date (optionally recurring) with a single ticket type
+ * and an unset sale period (no sale_start/sale_end), and a price attached.
+ */
+async function createEventWithUnsetWindow(
+	api,
+	{ startDatetime, endDatetime, rrule }
+) {
+	const data = {
+		title: `Unset sale-period test ${Date.now()}-${Math.random()}`,
+		start_datetime: startDatetime,
+		end_datetime: endDatetime,
+	};
+	if (rrule) data.rrule = rrule;
+
+	const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+		headers: adminHeaders,
+		data,
+	});
+	expect(edRes.ok()).toBeTruthy();
+	const eventDateId = (await edRes.json()).id;
+
+	const ticketsRes = await api.put(
+		`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+		{
+			headers: adminHeaders,
+			data: {
+				ticket_types: [
+					{
+						name: 'General admission',
+						capacity: null,
+						invitation_only: false,
+						minimum_activities: 0,
+						disable_at: null,
+						recurrence_scope: 'single_instance',
+						group_ids: [],
+					},
+				],
+				// Unset window: no sale_start/sale_end stored at all.
+				sale_periods: [
+					{
+						name: '',
+						sale_start: '',
+						sale_end: '',
+					},
+				],
+				prices: [
+					{
+						ticket_type_index: 0,
+						sale_period_index: 0,
+						price: 9,
+					},
+				],
+				settings: {},
+			},
+		}
+	);
+	expect(ticketsRes.ok()).toBeTruthy();
+	const body = await ticketsRes.json();
+	const ticketTypeId = body.ticket_types?.[0]?.id;
+	expect(ticketTypeId).toBeTruthy();
+	// The stored window really is unset — no eager persistence of a computed date.
+	expect(body.sale_periods?.[0]?.sale_start).toBeFalsy();
+	expect(body.sale_periods?.[0]?.sale_end).toBeFalsy();
+
+	return { eventDateId, ticketTypeId };
+}
+
+async function purchase(api, eventDateId, ticketTypeId) {
+	return api.post('/wp-json/fair-events/v1/get-tickets', {
+		data: {
+			event_date_id: eventDateId,
+			name: 'Unset Window Tester',
+			email: `unset-window-${Date.now()}-${Math.random()}@example.test`,
+			ticket_type_id: ticketTypeId,
+			quantity: 1,
+		},
+	});
+}
+
+test.describe('GetTicketsController — lazy default sale-period resolution', () => {
+	let api;
+	let fairAudienceActive = false;
+	const createdEventDateIds = [];
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+	});
+
+	test.afterAll(async () => {
+		for (const id of createdEventDateIds) {
+			await api.delete(`/wp-json/fair-events/v1/event-dates/${id}`, {
+				headers: adminHeaders,
+			});
+		}
+		await api.dispose();
+	});
+
+	test('single, non-recurring event with an unset window is purchasable', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const { eventDateId, ticketTypeId } = await createEventWithUnsetWindow(
+			api,
+			{
+				// Ends tomorrow, so "today" is well inside the default window
+				// (open start → day after the event).
+				startDatetime: tomorrow(1, '10:00:00'),
+				endDatetime: tomorrow(1, '12:00:00'),
+			}
+		);
+		createdEventDateIds.push(eventDateId);
+
+		const res = await purchase(api, eventDateId, ticketTypeId);
+		expect(res.ok()).toBeTruthy();
+	});
+
+	test('recurring event with an unset window is purchasable through the day after its last occurrence', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const { eventDateId, ticketTypeId } = await createEventWithUnsetWindow(
+			api,
+			{
+				startDatetime: tomorrow(1, '10:00:00'),
+				endDatetime: tomorrow(1, '12:00:00'),
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			}
+		);
+		createdEventDateIds.push(eventDateId);
+
+		// Purchasing against the master row resolves the default from the
+		// series' last (generated) occurrence, not the master's own end.
+		const res = await purchase(api, eventDateId, ticketTypeId);
+		expect(res.ok()).toBeTruthy();
+	});
+
+	test('a series entirely in the past with an unset window is still purchasable, never inverted', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const { eventDateId, ticketTypeId } = await createEventWithUnsetWindow(
+			api,
+			{
+				startDatetime: '2020-01-01 10:00:00',
+				endDatetime: '2020-01-01 12:00:00',
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			}
+		);
+		createdEventDateIds.push(eventDateId);
+
+		const res = await purchase(api, eventDateId, ticketTypeId);
+		expect(res.ok()).toBeTruthy();
+	});
+});
+
+/**
+ * Formats a datetime `daysAhead` days from now, in 'Y-m-d HH:MM:SS' form.
+ */
+function tomorrow(daysAhead, time) {
+	const d = new Date();
+	d.setDate(d.getDate() + daysAhead);
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const day = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${day} ${time}`;
+}

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -41,6 +41,7 @@ export default function EventTickets({
 	onDataRef,
 	startDatetime,
 	endDatetime: endDatetimeProp,
+	lastOccurrenceDatetime,
 	isSeries,
 	onDirtyChange,
 }) {
@@ -438,6 +439,14 @@ export default function EventTickets({
 		return d.toISOString().slice(0, 10);
 	};
 
+	// The day after the event/series' last occurrence — the lazily-resolved
+	// default sale end when the window is left unset. Falls back to the
+	// single event's own end when there's no series data (e.g. still loading).
+	const defaultSaleEnd = () => {
+		const anchor = lastOccurrenceDatetime || endDatetime;
+		return anchor ? dayAfterDate(anchor.split(' ')[0].split('T')[0]) : '';
+	};
+
 	const formatSaleDateLabel = (dateStr) => {
 		if (!dateStr) return __('—', 'fair-events');
 		const dateOnly = dateStr.split(' ')[0].split('T')[0];
@@ -460,24 +469,16 @@ export default function EventTickets({
 		return diff > 0 ? diff : null;
 	};
 
+	// Seeds a single default sale period row so prices have somewhere to
+	// attach, but leaves sale_start/sale_end unset: the effective window is
+	// resolved lazily (open start, day-after-last-occurrence end) rather than
+	// frozen into storage at creation time. See getEffectiveSalePeriods().
 	const seedDefaultSalePeriods = () => {
-		const today = getSiteToday();
-		const eventFirstDay = startDatetime
-			? startDatetime.split(' ')[0].split('T')[0]
-			: today;
-		const afterEventEnd = endDatetime
-			? dayAfterDate(endDatetime)
-			: dayAfterDate(eventFirstDay);
-		// A single sale window covering today through the day after the event
-		// ends. For an event already in the past (today would be after the
-		// window's own end), default to the event's own dates instead of an
-		// inverted range.
-		const saleStart = today > afterEventEnd ? eventFirstDay : today;
 		setSalePeriods([
 			{
 				name: '',
-				sale_start: saleStart,
-				sale_end: afterEventEnd,
+				sale_start: '',
+				sale_end: '',
 				sort_order: 0,
 			},
 		]);
@@ -645,9 +646,7 @@ export default function EventTickets({
 					? startDatetime.split(' ')[0].split('T')[0]
 					: getSiteToday();
 				const windowStart = base?.sale_start || getSiteToday();
-				const windowEnd =
-					base?.sale_end ||
-					(endDatetime ? dayAfterDate(endDatetime) : '');
+				const windowEnd = base?.sale_end || defaultSaleEnd();
 				if (base) {
 					const newPrices = { ...prices };
 					ticketTypes.forEach((type) => {
@@ -707,9 +706,7 @@ export default function EventTickets({
 				{
 					name: '',
 					sale_start: first.sale_start,
-					sale_end:
-						last.sale_end ||
-						(endDatetime ? dayAfterDate(endDatetime) : ''),
+					sale_end: last.sale_end || defaultSaleEnd(),
 					sort_order: 0,
 				},
 			]);
@@ -740,14 +737,14 @@ export default function EventTickets({
 			? dateStr + ' 00:00:00'
 			: dateStr;
 
+	// An unset sale_start/sale_end is sent through as empty so the backend
+	// stores NULL — the effective window is then resolved lazily server-side
+	// (open start, day-after-last-occurrence end) rather than frozen here.
 	const getEffectiveSalePeriods = () => {
 		const periods = salePeriods.map((p, i) => {
 			const updated = { ...p };
 			if (i > 0) {
 				updated.sale_start = salePeriods[i - 1].sale_end || '';
-			}
-			if (i === salePeriods.length - 1 && endDatetime && !p.sale_end) {
-				updated.sale_end = dayAfterDate(endDatetime);
 			}
 			updated.sale_start = appendTime(updated.sale_start);
 			updated.sale_end = appendTime(updated.sale_end);
@@ -1031,12 +1028,13 @@ export default function EventTickets({
 													];
 												const end =
 													last.sale_end ||
-													(endDatetime
-														? dayAfterDate(
-																endDatetime
-														  )
-														: '');
-												return end
+													defaultSaleEnd();
+												if (!end)
+													return __(
+														'—',
+														'fair-events'
+													);
+												return last.sale_end
 													? sprintf(
 															/* translators: %s: formatted date */
 															__(
@@ -1047,7 +1045,16 @@ export default function EventTickets({
 																end
 															)
 													  )
-													: __('—', 'fair-events');
+													: sprintf(
+															/* translators: %s: formatted date */
+															__(
+																'until %s (default)',
+																'fair-events'
+															),
+															formatSaleDateLabel(
+																end
+															)
+													  );
 											})()}
 										</div>
 									</HStack>
@@ -1243,11 +1250,7 @@ export default function EventTickets({
 												type="date"
 												value={
 													salePeriods[0].sale_end ||
-													(endDatetime
-														? dayAfterDate(
-																endDatetime
-														  )
-														: '') ||
+													defaultSaleEnd() ||
 													''
 												}
 												onChange={(v) =>
@@ -1399,11 +1402,7 @@ export default function EventTickets({
 														const untilValue =
 															isLast
 																? period.sale_end ||
-																  (endDatetime
-																		? dayAfterDate(
-																				endDatetime
-																		  )
-																		: '')
+																  defaultSaleEnd()
 																: period.sale_end ||
 																  '';
 														const dateTooltip = `${

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -480,6 +480,21 @@ export default function ManageEventApp() {
 	const isSeries =
 		!!eventDate?.rrule || eventDate?.recurrence_mode === 'manual';
 
+	// The latest end_datetime across the event and its generated occurrences —
+	// the anchor for the ticket editor's lazily-resolved default sale end
+	// (day after the last occurrence). Recomputed from eventDate so it tracks
+	// series edits (add/remove/extend occurrences) automatically.
+	const lastOccurrenceDatetime = useMemo(() => {
+		if (!eventDate) return null;
+		const ends = [
+			eventDate.end_datetime,
+			...(eventDate.generated_occurrences || []).map(
+				(o) => o.end_datetime
+			),
+		].filter(Boolean);
+		return ends.length ? ends.sort()[ends.length - 1] : null;
+	}, [eventDate]);
+
 	const seriesSummary = useMemo(() => {
 		if (eventDate?.recurrence_mode === 'manual') {
 			const dateCount =
@@ -708,6 +723,7 @@ export default function ManageEventApp() {
 					eventDateId={eventDateId}
 					startDatetime={eventDate.start_datetime}
 					endDatetime={eventDate.end_datetime}
+					lastOccurrenceDatetime={lastOccurrenceDatetime}
 					isSeries={isSeries}
 					onDirtyChange={handleTicketsDirtyChange}
 				/>

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -795,7 +795,7 @@ describe('EventTickets — single pricing period by default (#1138)', () => {
 		expect(screen.queryByText('Available')).not.toBeInTheDocument();
 	});
 
-	it('a seeded sale window for a past-dated event is never inverted', () => {
+	it('adding a ticket type leaves the sale window unset (#1189) — no concrete dates are seeded', () => {
 		window.fairEventsManageEventData = { siteToday: '2026-07-15' };
 		renderTickets({
 			initialData: emptyInitialData,
@@ -808,10 +808,9 @@ describe('EventTickets — single pricing period by default (#1138)', () => {
 		);
 		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
 
-		const fromInput = screen.getByLabelText('From');
-		const untilInput = screen.getByLabelText('Until');
-		expect(fromInput.value <= untilInput.value).toBe(true);
-		expect(fromInput.value).toBe('2020-01-01');
+		// Nothing is frozen into the "From" field — the window stays unset
+		// until the organiser explicitly picks a date.
+		expect(screen.getByLabelText('From').value).toBe('');
 	});
 
 	it('turning on "Multiple pricing periods" splits the window into Advance ticket / Day of event and migrates the price', () => {
@@ -859,6 +858,73 @@ describe('EventTickets — single pricing period by default (#1138)', () => {
 
 		expect(screen.getByText('Advance ticket')).toBeInTheDocument();
 		expect(screen.getByText('Day of event')).toBeInTheDocument();
+	});
+});
+
+describe('EventTickets — unset sale window shows the resolved default (#1189)', () => {
+	const initialDataWithUnsetPeriod = {
+		...initialDataWithTicketType,
+		sale_periods: [{ id: 701, name: '', sale_start: '', sale_end: '' }],
+		prices: [{ ticket_type_id: 1, sale_period_id: 701, price: '12' }],
+	};
+
+	it('a single event with an unset window shows the day after the event as the default, marked as a default', () => {
+		renderTickets({
+			initialData: initialDataWithUnsetPeriod,
+			startDatetime: '2026-08-01 10:00:00',
+			endDatetime: '2026-08-01 12:00:00',
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		// formatSaleDateLabel() renders a locale-formatted weekday/day/month —
+		// assert on the "(default)" marker and August, not an exact ISO string.
+		expect(
+			screen.getByText(/until .*August.*\(default\)/)
+		).toBeInTheDocument();
+	});
+
+	it("a series with an unset window resolves the default from the last occurrence, not the master's own end", () => {
+		renderTickets({
+			initialData: initialDataWithUnsetPeriod,
+			startDatetime: '2026-08-01 10:00:00',
+			endDatetime: '2026-08-01 12:00:00',
+			lastOccurrenceDatetime: '2026-08-22 12:00:00',
+			isSeries: true,
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		expect(
+			screen.getByText(/until .*August.*\(default\)/)
+		).toBeInTheDocument();
+	});
+
+	it('an explicit sale_end suppresses the "(default)" marker', () => {
+		renderTickets({
+			initialData: {
+				...initialDataWithTicketType,
+				sale_periods: [
+					{
+						id: 702,
+						name: '',
+						sale_start: '2026-08-01',
+						sale_end: '2026-09-01',
+					},
+				],
+				prices: [
+					{ ticket_type_id: 1, sale_period_id: 702, price: '12' },
+				],
+			},
+			startDatetime: '2026-08-01 10:00:00',
+			endDatetime: '2026-08-01 12:00:00',
+			lastOccurrenceDatetime: '2026-08-22 12:00:00',
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		expect(screen.getByText(/until .*September/)).toBeInTheDocument();
+		expect(screen.queryByText(/\(default\)/)).not.toBeInTheDocument();
 	});
 });
 

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -285,6 +285,11 @@ class Installer {
 			self::migrate_to_3_24_0();
 		}
 
+		// Run migration if upgrading from pre-3.25.0 (allow NULL sale_start/sale_end).
+		if ( version_compare( $current_version, '3.25.0', '<' ) ) {
+			self::migrate_to_3_25_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -451,6 +456,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.24.0', '<' ) ) {
 				self::migrate_to_3_24_0();
+			}
+
+			if ( version_compare( $current_version, '3.25.0', '<' ) ) {
+				self::migrate_to_3_25_0();
 			}
 
 			// Install/update tables
@@ -1989,6 +1998,37 @@ class Installer {
 		 * fair-audience can link existing signup rows to participants.
 		 */
 		do_action( 'fair_events_backfill_signup_participant_ids' );
+	}
+
+	/**
+	 * Migrate to version 3.25.0 - Allow NULL sale_start/sale_end on ticket
+	 * sale periods.
+	 *
+	 * Widens the columns so an "unset" window can be stored as a true NULL
+	 * instead of an eagerly-computed date, letting on-sale evaluation resolve
+	 * a lazy default at read time. Additive only — existing rows keep their
+	 * stored values.
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_25_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_events_ticket_sale_periods';
+
+		$wpdb->query(
+			$wpdb->prepare(
+				'ALTER TABLE %i MODIFY COLUMN sale_start DATETIME DEFAULT NULL',
+				$table_name
+			)
+		);
+
+		$wpdb->query(
+			$wpdb->prepare(
+				'ALTER TABLE %i MODIFY COLUMN sale_end DATETIME DEFAULT NULL',
+				$table_name
+			)
+		);
 	}
 
 	/**

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.24.0';
+	const DB_VERSION = '3.25.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -285,8 +285,8 @@ class Schema {
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 			event_date_id BIGINT UNSIGNED NOT NULL,
 			name VARCHAR(255) DEFAULT NULL,
-			sale_start DATETIME NOT NULL,
-			sale_end DATETIME NOT NULL,
+			sale_start DATETIME DEFAULT NULL,
+			sale_end DATETIME DEFAULT NULL,
 			sort_order INT UNSIGNED NOT NULL DEFAULT 0,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -1409,4 +1409,32 @@ class EventDates {
 
 		return self::hydrate( $result );
 	}
+
+	/**
+	 * Get the latest end_datetime across an event date row and its active
+	 * generated occurrences.
+	 *
+	 * Used to resolve the lazy default ticket sale-period end (day after the
+	 * last occurrence) for a single event as well as recurring series: a
+	 * single/master row with no generated children just returns its own end.
+	 *
+	 * @param int $event_date_id Event date ID (master or single row).
+	 * @return string|null Latest end_datetime ('Y-m-d H:i:s'), or null if the row doesn't exist.
+	 */
+	public static function get_last_occurrence_end( $event_date_id ) {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_event_dates';
+
+		return $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT MAX(end_datetime) FROM %i
+				WHERE id = %d
+				OR ( master_id = %d AND status = 'active' )",
+				$table_name,
+				$event_date_id,
+				$event_date_id
+			)
+		);
+	}
 }

--- a/fair-events/src/Models/TicketSalePeriod.php
+++ b/fair-events/src/Models/TicketSalePeriod.php
@@ -144,8 +144,8 @@ class TicketSalePeriod {
 	 *
 	 * @param int         $event_date_id Event date ID.
 	 * @param string|null $name          Name.
-	 * @param string      $sale_start    Sale start datetime.
-	 * @param string      $sale_end      Sale end datetime.
+	 * @param string|null $sale_start    Sale start datetime, or null/empty for unset (resolved lazily).
+	 * @param string|null $sale_end      Sale end datetime, or null/empty for unset (resolved lazily).
 	 * @param int         $sort_order    Sort order.
 	 * @return int|false The sale period ID on success, false on failure.
 	 */
@@ -159,8 +159,8 @@ class TicketSalePeriod {
 			array(
 				'event_date_id' => $event_date_id,
 				'name'          => $name,
-				'sale_start'    => $sale_start,
-				'sale_end'      => $sale_end,
+				'sale_start'    => '' !== $sale_start && null !== $sale_start ? $sale_start : null,
+				'sale_end'      => '' !== $sale_end && null !== $sale_end ? $sale_end : null,
 				'sort_order'    => $sort_order,
 			),
 			array( '%d', '%s', '%s', '%s', '%d' )
@@ -193,13 +193,13 @@ class TicketSalePeriod {
 			$update_format[]     = '%s';
 		}
 
-		if ( isset( $data['sale_start'] ) ) {
-			$update_data['sale_start'] = $data['sale_start'];
+		if ( array_key_exists( 'sale_start', $data ) ) {
+			$update_data['sale_start'] = '' !== $data['sale_start'] && null !== $data['sale_start'] ? $data['sale_start'] : null;
 			$update_format[]           = '%s';
 		}
 
-		if ( isset( $data['sale_end'] ) ) {
-			$update_data['sale_end'] = $data['sale_end'];
+		if ( array_key_exists( 'sale_end', $data ) ) {
+			$update_data['sale_end'] = '' !== $data['sale_end'] && null !== $data['sale_end'] ? $data['sale_end'] : null;
 			$update_format[]         = '%s';
 		}
 

--- a/fair-events/src/Services/TicketPricing.php
+++ b/fair-events/src/Services/TicketPricing.php
@@ -7,6 +7,7 @@
 
 namespace FairEvents\Services;
 
+use FairEvents\Models\EventDates;
 use FairEvents\Models\TicketPrice;
 use FairEvents\Models\TicketSalePeriod;
 use FairEvents\Models\TicketType;
@@ -21,11 +22,23 @@ defined( 'WPINC' ) || die;
 class TicketPricing {
 
 	/**
+	 * Sentinel used as the effective sale_start for a period whose start is
+	 * unset, so it always compares as "already started" against any real
+	 * datetime string without special-casing the comparison in pick_active_period().
+	 */
+	const OPEN_START_SENTINEL = '0000-01-01 00:00:00';
+
+	/**
 	 * Resolve the currently active sale period for an event date.
 	 *
 	 * Periods use a half-open day range [sale_start, sale_end) in the site
 	 * timezone: sale_start is the first day on sale (00:00:00 site time) and
 	 * sale_end is the first day no longer on sale (00:00:00 site time).
+	 *
+	 * A period with an unset sale_start/sale_end is not "closed" — it
+	 * resolves lazily: an open start (always on sale) and/or an end of the
+	 * day after the event/series' last occurrence, computed fresh on every
+	 * call so it automatically tracks series changes.
 	 *
 	 * Sale periods always chain: when no period matches, falls back to the
 	 * last period whose start is already in the past.
@@ -37,7 +50,64 @@ class TicketPricing {
 		$now          = current_time( 'mysql' );
 		$sale_periods = TicketSalePeriod::get_all_by_event_date_id( $event_date_id );
 
+		$default_end  = self::compute_default_sale_end( EventDates::get_last_occurrence_end( $event_date_id ) );
+		$sale_periods = self::apply_default_window( $sale_periods, $default_end );
+
 		return self::pick_active_period( $sale_periods, $now, true );
+	}
+
+	/**
+	 * Compute the lazy default sale_end: the day after the last occurrence,
+	 * at 00:00:00 site time, preserving the half-open [start, end) range so
+	 * the final day stays purchasable.
+	 *
+	 * @param string|null $last_occurrence_end Latest end_datetime across the event/series ('Y-m-d H:i:s'), or null.
+	 * @return string|null Default sale_end ('Y-m-d H:i:s'), or null when there's no occurrence to anchor to.
+	 */
+	public static function compute_default_sale_end( $last_occurrence_end ) {
+		if ( empty( $last_occurrence_end ) ) {
+			return null;
+		}
+
+		$date = new \DateTime( $last_occurrence_end, wp_timezone() );
+		$date->setTime( 0, 0, 0 );
+		$date->modify( '+1 day' );
+
+		return $date->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Substitute the lazy default for any period with an unset sale_start
+	 * and/or sale_end, without mutating the originals. Pure → unit-testable
+	 * without a database.
+	 *
+	 * An unset sale_start becomes open (always already started). An unset
+	 * sale_end becomes $default_end when one is available; otherwise it's
+	 * left unset (pick_active_period() then never matches it as current, but
+	 * the continues-fallback can still select it, same as any closed period).
+	 *
+	 * @param object[]    $periods     Sale periods with sale_start/sale_end strings, in sort order.
+	 * @param string|null $default_end Lazy default sale_end ('Y-m-d H:i:s'), or null.
+	 * @return object[] Periods with unset windows resolved; explicit values untouched.
+	 */
+	public static function apply_default_window( $periods, $default_end ) {
+		$resolved = array();
+
+		foreach ( $periods as $period ) {
+			$resolved_period = clone $period;
+
+			if ( empty( $resolved_period->sale_start ) ) {
+				$resolved_period->sale_start = self::OPEN_START_SENTINEL;
+			}
+
+			if ( empty( $resolved_period->sale_end ) && $default_end ) {
+				$resolved_period->sale_end = $default_end;
+			}
+
+			$resolved[] = $resolved_period;
+		}
+
+		return $resolved;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Ticketing eagerly froze a concrete sale `sale_start`/`sale_end` at first setup. For a recurring event or manual series, that date lagged the first occurrence, so sales silently closed after it unless the organiser kept re-editing the window.
- `sale_start`/`sale_end` can now be stored **unset** (`NULL`) — the effective sale window is resolved lazily at read time: open start (always on sale), end on the **day after the event/series' last occurrence**. Converting a stand-alone event to a series, or changing occurrences, now shifts the effective sale end automatically with no re-editing and no stored-date rewrite.
- Explicit dates, once the organiser sets them, are still used verbatim.

## Changes

- **Schema**: `sale_start`/`sale_end` on `fair_events_ticket_sale_periods` are now nullable; idempotent `ALTER TABLE` migration (DB version 3.25.0), additive only.
- **`TicketPricing::resolve_active_sale_period()`**: new pure `apply_default_window()` helper substitutes the lazy default for any unset period before selection; `EventDates::get_last_occurrence_end()` computes the anchor (row itself + active generated occurrences).
- **`TicketsController`**: empty `sale_start`/`sale_end` now pass through as `NULL` instead of being coerced into a stored string.
- **Frontend**: `EventTickets.js` no longer seeds concrete dates on "+ Add Ticket Type"; the sale-window display shows the resolved default with a "(default)" marker instead of a blank/frozen field. `ManageEventApp.js` computes `lastOccurrenceDatetime` (max of the event's own end and its generated occurrences) and passes it down.

## Test plan

- [x] `vendor/bin/phpunit` — 80/80 passing, including new `TicketPricingTest` coverage for `apply_default_window()` / `compute_default_sale_end()`.
- [x] `npm run test:js` — 117/117 passing, including new `EventTickets.test.jsx` coverage for the resolved-default placeholder (single event, series, explicit override).
- [x] `vendor/bin/phpcs` clean on all changed files.
- [x] Manual WP-CLI `eval-file` integration check against a live WordPress instance: single event, recurring series (incl. cancelled-occurrence exclusion), past series, and explicit-override cases all resolve as expected.
- [ ] `src/API/__tests__/GetTicketsUnsetSalePeriod.api.spec.js` — written following the existing `GetTicketsRecurringMaster.api.spec.js` pattern, but couldn't be executed against the local dev Docker stack because Application Passwords are disabled there (`wp_is_application_passwords_available()` returns false — a pre-existing local environment limitation, unrelated to this change). Should run in CI.

Closes #1189
