### PR TITLE
Add occurrence dropdown to base Event Signup form

### DIFF
--- a/e2e/user-flows/get-tickets-occurrence-dropdown.spec.js
+++ b/e2e/user-flows/get-tickets-occurrence-dropdown.spec.js
@@ -1,0 +1,147 @@
+/**
+ * E2E: single-occurrence dropdown in the base Event Signup form (fair-events
+ * alone, no fair-audience/fair-form) — a recurring series with a
+ * 'single_instance' ticket type offers a <select> of upcoming occurrences so
+ * an anonymous visitor can pick which date they're signing up for, instead of
+ * being silently registered for whichever occurrence the page resolved (#1190).
+ *
+ * fair-audience, fair-audience-experimental, and fair-events-experimental are
+ * deactivated for this describe block so the base fair-events/event-signup
+ * render path (render.php's own markup) is what's under test.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+import { wpCli, runScript } from '../support/wp-cli.js';
+
+test.describe('Occurrence dropdown for single-occurrence tickets (fair-events alone)', () => {
+	test.beforeAll(() => {
+		wpCli(
+			'plugin deactivate fair-audience fair-audience-experimental fair-events-experimental'
+		);
+	});
+
+	test.afterAll(() => {
+		wpCli(
+			'plugin activate fair-audience fair-audience-experimental fair-events-experimental'
+		);
+	});
+
+	test('single-session ticket: picking a non-default date registers the attendee against it', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('three-ticket-scopes', { price: 0 });
+		const [firstOccurrenceId, , thirdOccurrenceId] = event.occurrenceIds;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		// Single-session ticket is the first enabled type, preselected by default.
+		const ticketRadio = form.locator(
+			`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
+		);
+		await expect(ticketRadio).toBeChecked();
+
+		const dropdown = form.locator('.fair-events-occurrence-picker');
+		await expect(dropdown).toBeVisible();
+
+		const select = dropdown.locator('select[name="event_date_id_single"]');
+		await expect(select.locator('option')).toHaveCount(3);
+		// Defaults to the page's resolved occurrence (the series master, the
+		// first upcoming one here).
+		await expect(select).toHaveValue(String(firstOccurrenceId));
+
+		await select.selectOption(String(thirdOccurrenceId));
+
+		const stamp = Date.now();
+		const email = `occurrence-dropdown.${stamp}@example.test`;
+		await form
+			.locator('input[name="name"]')
+			.fill(`E2E Occurrence Dropdown ${stamp}`);
+		await form.locator('input[name="email"]').fill(email);
+
+		await form.locator('button[type="submit"]').click();
+		await expect(
+			page.getByText('You have successfully registered', { exact: false })
+		).toBeVisible({ timeout: 15000 });
+
+		const chosenState = runScript(
+			'get-tickets-state.php',
+			'E2E_GT_STATE',
+			String(thirdOccurrenceId)
+		);
+		expect(chosenState.signups).toHaveLength(1);
+		expect(chosenState.signups[0].email).toBe(email);
+
+		const defaultState = runScript(
+			'get-tickets-state.php',
+			'E2E_GT_STATE',
+			String(firstOccurrenceId)
+		);
+		expect(defaultState.signups).toHaveLength(0);
+	});
+
+	test('whole-series and multi-occurrence tickets hide the dropdown; single-session brings it back', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('three-ticket-scopes');
+		const [wholeSeriesTypeId, multiInstanceTypeId] = event.extraTypeIds;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		const dropdown = form.locator('.fair-events-occurrence-picker');
+		const instancePicker = form.locator('.fair-events-instance-picker');
+
+		// Single-session (default) — dropdown visible, checkbox picker hidden.
+		await expect(dropdown).toBeVisible();
+		await expect(instancePicker).toBeHidden();
+
+		// Whole-series pass — dropdown hidden.
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${wholeSeriesTypeId}"]`
+			)
+			.check();
+		await expect(dropdown).toBeHidden();
+		await expect(instancePicker).toBeHidden();
+
+		// Multiple-instances pass — dropdown stays hidden, checkbox picker shows.
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${multiInstanceTypeId}"]`
+			)
+			.check();
+		await expect(dropdown).toBeHidden();
+		await expect(instancePicker).toBeVisible();
+
+		// Back to single-session — dropdown reappears, checkbox picker hides.
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
+			)
+			.check();
+		await expect(dropdown).toBeVisible();
+		await expect(instancePicker).toBeHidden();
+	});
+
+	test('non-recurring event renders no occurrence dropdown', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('paid', { block: 'get-tickets' });
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+		await expect(
+			form.locator('.fair-events-occurrence-picker')
+		).toHaveCount(0);
+	});
+});

--- a/fair-events/src/blocks/event-signup/frontend.js
+++ b/fair-events/src/blocks/event-signup/frontend.js
@@ -101,6 +101,16 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 	}
 
 	/**
+	 * Whether the selected ticket type is a 'whole_series' scope pass.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 * @return {boolean} True when the selected ticket covers the whole series.
+	 */
+	function isWholeSeriesSelected(form) {
+		const option = getSelectedTicketTypeOption(form);
+		return !!option && option.dataset.recurrenceScope === 'whole_series';
+	}
+
+	/**
 	 * Checked ticket type radio input, if any.
 	 * @param {HTMLFormElement} form The get-tickets form.
 	 * @return {HTMLInputElement|null} The checked radio input element.
@@ -122,6 +132,26 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 	}
 
 	/**
+	 * Toggle the single-occurrence dropdown based on the selected ticket type's
+	 * scope: visible for 'single_instance' (or no ticket type selected), hidden
+	 * for 'whole_series' and 'multiple_instances' (the checkbox picker handles
+	 * that case instead).
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 */
+	function updateOccurrencePicker(form) {
+		const occurrencePicker = form.querySelector(
+			'.fair-events-occurrence-picker'
+		);
+		if (!occurrencePicker) {
+			return;
+		}
+
+		const active =
+			!isMultipleInstancesSelected(form) && !isWholeSeriesSelected(form);
+		occurrencePicker.style.display = active ? '' : 'none';
+	}
+
+	/**
 	 * Toggle the multi-occurrence checkbox picker (and hide the quantity field,
 	 * since v1 fixes quantity to 1 for this scope — instance count is the only
 	 * multiplier) based on the selected ticket type, and keep the minimum hint
@@ -129,6 +159,8 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 	 * @param {HTMLFormElement} form The get-tickets form.
 	 */
 	function updateInstancePicker(form) {
+		updateOccurrencePicker(form);
+
 		const instancePicker = form.querySelector(
 			'.fair-events-instance-picker'
 		);
@@ -298,10 +330,21 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 	function collectFormData(form) {
 		const data = {};
 
-		data.event_date_id = parseInt(
-			form.getAttribute('data-event-date-id') || '0',
-			10
+		const occurrenceSelect = form.querySelector(
+			'select[name="event_date_id_single"]'
 		);
+		if (
+			occurrenceSelect &&
+			!isMultipleInstancesSelected(form) &&
+			!isWholeSeriesSelected(form)
+		) {
+			data.event_date_id = parseInt(occurrenceSelect.value, 10);
+		} else {
+			data.event_date_id = parseInt(
+				form.getAttribute('data-event-date-id') || '0',
+				10
+			);
+		}
 
 		const nameField = form.querySelector('input[name="name"]');
 		if (nameField) {

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -137,8 +137,12 @@ foreach ( $ticket_types as $ticket_type ) {
 	}
 }
 
+// Loaded whenever the event is part of a recurring series, independent of
+// which ticket scopes are configured — the single-occurrence dropdown (below)
+// needs the same upcoming-occurrences list as the multi-occurrence checkbox
+// picker, even on a series with only a 'single_instance' ticket type.
 $occurrences_for_picker = array();
-if ( $has_multiple_instances_type && $series_master_id && class_exists( \FairEvents\Models\EventDates::class ) ) {
+if ( $series_master_id && class_exists( \FairEvents\Models\EventDates::class ) ) {
 	$upcoming = \FairEvents\Models\EventDates::get_upcoming_by_master_id( $series_master_id );
 	foreach ( $upcoming as $occ ) {
 		$occurrences_for_picker[] = array(
@@ -149,7 +153,7 @@ if ( $has_multiple_instances_type && $series_master_id && class_exists( \FairEve
 		);
 	}
 }
-$has_instance_picker = ! empty( $occurrences_for_picker );
+$has_instance_picker = $has_multiple_instances_type && ! empty( $occurrences_for_picker );
 
 // Find active sale period and load prices.
 $price_by_type_id   = array();
@@ -213,7 +217,6 @@ $ticket_types           = $context['ticket_types'];
 $price_by_type_id       = $context['price_by_type_id'];
 $active_sale_period     = $context['active_sale_period'];
 $occurrences_for_picker = $context['occurrences_for_picker'];
-$has_instance_picker    = ! empty( $occurrences_for_picker );
 $currency_symbol        = $context['currency_symbol'];
 $callback_status        = $context['callback_status'];
 $prefill_name           = $context['prefill_name'];
@@ -226,6 +229,21 @@ foreach ( $ticket_types as $ticket_type ) {
 	if ( $ticket_type->is_multiple_instances() ) {
 		$has_multiple_instances_type = true;
 		break;
+	}
+}
+$has_instance_picker = $has_multiple_instances_type && ! empty( $occurrences_for_picker );
+
+// Single-occurrence dropdown: offered whenever the series has more than one
+// upcoming occurrence, regardless of which ticket scopes are configured.
+// frontend.js shows/hides it based on the selected ticket type's scope.
+$has_occurrence_dropdown  = count( $occurrences_for_picker ) > 1;
+$default_occurrence_index = 0;
+if ( $has_occurrence_dropdown ) {
+	foreach ( $occurrences_for_picker as $occ_index => $occ_row ) {
+		if ( (int) $occ_row['id'] === $event_date_id ) {
+			$default_occurrence_index = $occ_index;
+			break;
+		}
 	}
 }
 
@@ -344,6 +362,28 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 						</label>
 					<?php endforeach; ?>
 				</fieldset>
+			</div>
+		<?php endif; ?>
+
+		<?php if ( $has_occurrence_dropdown ) : ?>
+			<div class="form-row fair-events-occurrence-picker" style="display: none;">
+				<label for="<?php echo esc_attr( $form_id ); ?>-occ" class="form-label">
+					<?php esc_html_e( 'Choose a date', 'fair-events' ); ?>
+				</label>
+				<select id="<?php echo esc_attr( $form_id ); ?>-occ" name="event_date_id_single" class="form-input fair-events-occurrence-select">
+					<?php foreach ( $occurrences_for_picker as $occ_index => $occ_row ) : ?>
+						<?php
+						$occ_label = \FairEvents\Helpers\DateRangeFormatter::format(
+							$occ_row['start_datetime'],
+							$occ_row['end_datetime'],
+							$occ_row['all_day']
+						);
+						?>
+						<option value="<?php echo (int) $occ_row['id']; ?>" <?php echo $occ_index === $default_occurrence_index ? 'selected' : ''; ?>>
+							<?php echo esc_html( $occ_label ); ?>
+						</option>
+					<?php endforeach; ?>
+				</select>
 			</div>
 		<?php endif; ?>
 


### PR DESCRIPTION
## Summary

- Adds a single-occurrence date dropdown to the base (fair-audience-inactive) Event Signup form (`fair-events/src/blocks/event-signup`), mirroring the picker fair-audience already ships, but kept in-form so a change doesn't reload the page and discard typed name/email.
- Shown whenever a recurring series has more than one upcoming occurrence and the selected ticket type covers a single occurrence; defers to the existing checkbox picker for `multiple_instances` tickets and stays hidden for `whole_series` passes.
- Defaults to the occurrence already resolved from the page/URL, falling back to the first upcoming one.
- No backend change needed — `GetTicketsController::create_signup` already validates the submitted `event_date_id` against the ticket type's series master.

Closes #1190

## Notes

- Implements the plan from https://github.com/marcin-wosinek/fair-event-plugins/issues/1190#issuecomment-5010773955.
- New e2e spec seeds the free-signup path (no Mollie double) to keep the test deterministic; a handful of unrelated payment/Mollie-double e2e tests in this repo currently fail on a fresh environment independent of this change (verified against unmodified `main`).

## Test plan

- [x] `npm run build` in `fair-events`
- [x] `npm run format` in `fair-events`
- [x] `vendor/bin/phpcs` clean on changed PHP files
- [x] `npm run test:js` in `fair-events` — 114 passed
- [x] New e2e spec (`get-tickets-occurrence-dropdown.spec.js`) — 3/3 passed against a fresh wp-env `tests` instance
- [x] Existing `get-tickets-form-layout.spec.js` — 2/2 passed (no regression)
- [x] Full `e2e/` suite run — 42 passed, 7 pre-existing payment/Mollie-double failures reproduced independently on unmodified `main`
