### PR TITLE
Make Event Signup Form content area clickable

### DIFF
--- a/fair-events/e2e/event-signup-form-content.spec.js
+++ b/fair-events/e2e/event-signup-form-content.spec.js
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+
+const WP_ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const WP_ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * Regression for #1194: the Event Signup block's preview click-freeze also
+ * disabled the "Form content" area's add-block control, making it impossible
+ * to add extra questions/content there. The fix scopes the freeze to the
+ * `.fair-events-get-tickets` preview only.
+ */
+
+test.describe('Event Signup block "Form content" area', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/wp-admin');
+		if (page.url().includes('wp-login.php')) {
+			await page.fill('#user_login', WP_ADMIN_USER);
+			await page.fill('#user_pass', WP_ADMIN_PASS);
+			await page.click('#wp-submit');
+		}
+		await page.waitForSelector('#wpadminbar');
+	});
+
+	test('allows adding a block to the Form content area while the preview stays inert', async ({
+		page,
+	}) => {
+		await page.goto('/wp-admin/post-new.php');
+
+		const editorFrame = page.frameLocator('[name="editor-canvas"]');
+		await editorFrame.locator('.block-editor-iframe__body').waitFor();
+		await page.waitForTimeout(2000);
+
+		// Insert the Event Signup block via the main inserter.
+		await page.getByRole('button', { name: 'Block Inserter' }).click();
+		await page.fill('.block-editor-inserter__search input', 'Event Signup');
+		await page.click(
+			'.block-editor-block-types-list__item:has-text("Event Signup")'
+		);
+
+		const signupBlock = editorFrame.locator(
+			'.wp-block-fair-events-event-signup'
+		);
+		await signupBlock.waitFor();
+
+		const closeInserterButton = page.getByRole('button', {
+			name: 'Close Block Inserter',
+		});
+		if (await closeInserterButton.isVisible()) {
+			await closeInserterButton.click();
+			await page.waitForTimeout(500);
+		}
+
+		// The preview stays non-interactive: its submit button ignores clicks.
+		const previewSubmit = signupBlock
+			.locator('.fair-events-get-tickets button[type="submit"]')
+			.first();
+		if (await previewSubmit.count()) {
+			await expect(previewSubmit).toHaveCSS('pointer-events', 'none');
+		}
+
+		// The "Form content" area's add-block appender is clickable and opens
+		// the inserter.
+		const questionsArea = signupBlock.locator(
+			'.fair-events-event-signup-questions'
+		);
+		await questionsArea.waitFor();
+
+		const appender = questionsArea.locator('.block-list-appender button');
+		await appender.waitFor();
+		await appender.click();
+
+		await page.fill('.block-editor-inserter__search input', 'Paragraph');
+		await page.click(
+			'.block-editor-block-types-list__item:has-text("Paragraph")'
+		);
+
+		// The added paragraph lands inside the Form content area, and can be
+		// typed into, selected, and removed like any other block.
+		const paragraph = questionsArea.locator('p.wp-block-paragraph');
+		await paragraph.waitFor();
+		await paragraph.click();
+		await paragraph.type('Extra question text');
+		await expect(paragraph).toHaveText('Extra question text');
+	});
+});

--- a/fair-events/src/blocks/event-signup/editor.css
+++ b/fair-events/src/blocks/event-signup/editor.css
@@ -1,4 +1,4 @@
-.wp-block-fair-events-event-signup {
+.wp-block-fair-events-event-signup .fair-events-get-tickets {
 	a,
 	button,
 	input,


### PR DESCRIPTION
## Summary

The Event Signup block editor freezes the server-rendered form preview with a single CSS rule (`pointer-events: none` on the whole block wrapper). That selector also covered the "Form content" inner-blocks area, disabling its add-block appender — the area looked interactive but did nothing when clicked.

This scopes the freeze from the whole block wrapper down to `.fair-events-get-tickets`, the SSR preview's own root class, which does not wrap the questions area. The preview stays inert; "Form content" becomes fully interactive.

- `fair-events/src/blocks/event-signup/editor.css`: narrow the `pointer-events: none` selector.
- `fair-events/e2e/event-signup-form-content.spec.js`: new e2e coverage asserting the appender opens the inserter, an added block can be typed into, and the preview stays inert.

Closes #1194

## Test plan

- [x] `npm run build` (fair-events) — CSS regenerated in `build/`
- [x] `npm run test:js -- editor` — existing component tests pass
- [x] `npx playwright test e2e/event-signup-form-content.spec.js` — new e2e passes against local docker WP
