### PR TITLE
Show link source in weekly digest events

### DIFF
--- a/fair-audience/__tests__/Services/WeeklyDigestRendererTest.php
+++ b/fair-audience/__tests__/Services/WeeklyDigestRendererTest.php
@@ -229,6 +229,96 @@ class WeeklyDigestRendererTest extends TestCase {
 	}
 
 	/**
+	 * Build a single-event week for source-attribution assertions.
+	 *
+	 * @param string $url Event URL.
+	 * @return array Week data with one Monday event.
+	 */
+	private function week_with_event_url( $url ) {
+		return $this->week(
+			array(
+				array(
+					'weekday'    => 'Monday',
+					'month_name' => 'July',
+					'day_num'    => '6',
+					'events'     => array(
+						array(
+							'title' => 'Weekly Standup',
+							'url'   => $url,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Reset the seeded site URL after each test so it doesn't leak between tests.
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['_fair_test_options']['siteurl'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * An external website link gets a "(by <domain>)" suffix with "www." stripped.
+	 */
+	public function test_render_appends_source_attribution_for_external_website() {
+		$GLOBALS['_fair_test_options']['siteurl'] = 'https://example.test';
+		$html                                     = WeeklyDigestRenderer::render( $this->week_with_event_url( 'https://www.example.com/event' ) );
+		$this->assertStringContainsString( '<a href="https://www.example.com/event">Weekly Standup</a> <span style="color:#666;">(by example.com)</span>', $html );
+	}
+
+	/**
+	 * An Instagram profile link gets a "(by @handle)" suffix.
+	 */
+	public function test_render_appends_instagram_handle_attribution() {
+		$GLOBALS['_fair_test_options']['siteurl'] = 'https://example.test';
+		$html                                     = WeeklyDigestRenderer::render( $this->week_with_event_url( 'https://www.instagram.com/acroyoga_valencia/' ) );
+		$this->assertStringContainsString( '(by @acroyoga_valencia)', $html );
+	}
+
+	/**
+	 * A non-profile Instagram URL falls back to the bare "instagram.com" attribution.
+	 */
+	public function test_render_falls_back_to_instagram_host_for_non_profile_urls() {
+		$GLOBALS['_fair_test_options']['siteurl'] = 'https://example.test';
+		$html                                     = WeeklyDigestRenderer::render( $this->week_with_event_url( 'https://www.instagram.com/p/abc123/' ) );
+		$this->assertStringContainsString( '(by instagram.com)', $html );
+		$this->assertStringNotContainsString( '(by @p)', $html );
+	}
+
+	/**
+	 * An internal on-site permalink renders without an attribution suffix.
+	 */
+	public function test_render_omits_attribution_for_internal_link() {
+		$GLOBALS['_fair_test_options']['siteurl'] = 'https://example.test';
+		$html                                     = WeeklyDigestRenderer::render( $this->week_with_event_url( 'https://example.test/event/1' ) );
+		$this->assertStringContainsString( '<a href="https://example.test/event/1">Weekly Standup</a></li>', $html );
+		$this->assertStringNotContainsString( '(by', $html );
+	}
+
+	/**
+	 * An event with no URL renders as plain text, unchanged.
+	 */
+	public function test_render_omits_attribution_when_no_url() {
+		$GLOBALS['_fair_test_options']['siteurl'] = 'https://example.test';
+		$week                                     = $this->week(
+			array(
+				array(
+					'weekday'    => 'Monday',
+					'month_name' => 'July',
+					'day_num'    => '6',
+					'events'     => array( array( 'title' => 'Weekly Standup' ) ),
+				),
+			)
+		);
+		$html                                     = WeeklyDigestRenderer::render( $week );
+		$this->assertStringContainsString( 'Weekly Standup', $html );
+		$this->assertStringNotContainsString( '(by', $html );
+	}
+
+	/**
 	 * Intro HTML is prepended above the day listing.
 	 */
 	public function test_render_prepends_intro_html() {

--- a/fair-audience/__tests__/bootstrap.php
+++ b/fair-audience/__tests__/bootstrap.php
@@ -164,6 +164,35 @@ if ( ! function_exists( 'esc_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	/**
+	 * Stub of WordPress wp_parse_url() — delegates to PHP's parse_url().
+	 *
+	 * @param string   $url       URL to parse.
+	 * @param int|null $component PHP_URL_* component, or null for all.
+	 * @return mixed Parsed component, full array, or false on failure.
+	 */
+	function wp_parse_url( $url, $component = -1 ) {
+		return -1 === $component ? parse_url( $url ) : parse_url( $url, $component ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- this *is* the wp_parse_url() stub.
+	}
+}
+
+if ( ! function_exists( 'get_site_url' ) ) {
+	/**
+	 * Stub of WordPress get_site_url() backed by $GLOBALS['_fair_test_options'].
+	 *
+	 * Seed via `$GLOBALS['_fair_test_options']['siteurl']` to change it; defaults
+	 * to 'https://example.test' so internal-vs-external host checks are
+	 * deterministic in tests.
+	 *
+	 * @return string Site URL.
+	 */
+	function get_site_url() {
+		$options = isset( $GLOBALS['_fair_test_options'] ) ? $GLOBALS['_fair_test_options'] : array();
+		return isset( $options['siteurl'] ) ? $options['siteurl'] : 'https://example.test';
+	}
+}
+
 if ( ! function_exists( '__' ) ) {
 	/**
 	 * Stub of WordPress __().

--- a/fair-audience/src/Services/WeeklyDigestRenderer.php
+++ b/fair-audience/src/Services/WeeklyDigestRenderer.php
@@ -126,6 +126,56 @@ class WeeklyDigestRenderer {
 	}
 
 	/**
+	 * Non-profile Instagram path segments that aren't a handle.
+	 *
+	 * @var string[]
+	 */
+	const INSTAGRAM_NON_PROFILE_SEGMENTS = array( 'p', 'reel', 'reels', 'explore', 'stories', 'tv' );
+
+	/**
+	 * Build the "(by …)" attribution to append after an event link.
+	 *
+	 * Internal links (empty host, or host matching the site) return ''.
+	 * Instagram links resolve to the profile handle when the first path
+	 * segment looks like one, else fall back to the bare host. Everything
+	 * else uses the host with a leading "www." stripped.
+	 *
+	 * @param string $url Event URL.
+	 * @return string Attribution text, e.g. "(by example.com)", or ''.
+	 */
+	private static function source_attribution( $url ) {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( empty( $host ) ) {
+			return '';
+		}
+
+		$host      = strtolower( $host );
+		$site_host = strtolower( (string) wp_parse_url( get_site_url(), PHP_URL_HOST ) );
+		if ( $host === $site_host ) {
+			return '';
+		}
+
+		if ( in_array( $host, array( 'instagram.com', 'www.instagram.com', 'm.instagram.com' ), true ) ) {
+			$path    = (string) wp_parse_url( $url, PHP_URL_PATH );
+			$segment = trim( $path, '/' );
+			$segment = false !== strpos( $segment, '/' ) ? strstr( $segment, '/', true ) : $segment;
+
+			if ( '' === $segment || in_array( $segment, self::INSTAGRAM_NON_PROFILE_SEGMENTS, true ) ) {
+				/* translators: %s: source host, e.g. "instagram.com". */
+				return sprintf( __( '(by %s)', 'fair-audience' ), 'instagram.com' );
+			}
+
+			/* translators: %s: Instagram handle, e.g. "@example". */
+			return sprintf( __( '(by @%s)', 'fair-audience' ), $segment );
+		}
+
+		$host = preg_replace( '/^www\./', '', $host );
+
+		/* translators: %s: source domain, e.g. "example.com". */
+		return sprintf( __( '(by %s)', 'fair-audience' ), $host );
+	}
+
+	/**
 	 * Render the digest's inner HTML body for a week.
 	 *
 	 * Returned HTML is the *inner* content — the caller (EmailService) wraps
@@ -165,7 +215,11 @@ class WeeklyDigestRenderer {
 
 				$title = $event['title'];
 				if ( ! empty( $event['url'] ) ) {
-					$html .= '<a href="' . esc_url( $event['url'] ) . '">' . esc_html( $title ) . '</a>';
+					$html       .= '<a href="' . esc_url( $event['url'] ) . '">' . esc_html( $title ) . '</a>';
+					$attribution = self::source_attribution( $event['url'] );
+					if ( '' !== $attribution ) {
+						$html .= ' <span style="color:#666;">' . esc_html( $attribution ) . '</span>';
+					}
 				} else {
 					$html .= esc_html( $title );
 				}


### PR DESCRIPTION
## Summary

- Digest events with off-site links now show a muted `(by <domain>)` /
  `(by @<instagram-handle>)` attribution after the title, so readers can tell
  an organizer page from an Instagram profile from our own event page before
  clicking.
- Internal on-site permalinks and events with no URL are unchanged.
- All logic lives in `WeeklyDigestRenderer::source_attribution()`, shared by
  preview, test-send, and cron send.

Closes #1104

## Test plan

- [x] `vendor/bin/phpcs` clean on the changed PHP files.
- [x] `npm run test:php` in `fair-audience` — new attribution tests (external
      website, Instagram profile, Instagram non-profile fallback, internal
      link, no-URL) all pass; the 2 pre-existing `wpautop()` failures are
      unrelated (present on `main` before this change).
- No JS/CSS changed — no build needed.
