### PR TITLE
Show connected Mollie profile name and enabled methods

### DIFF
--- a/fair-payments-connector/jest.config.js
+++ b/fair-payments-connector/jest.config.js
@@ -1,7 +1,10 @@
 module.exports = {
 	preset: '@wordpress/jest-preset-default',
 	testEnvironment: 'jsdom',
-	testMatch: ['**/__tests__/**/*.js', '**/?(*.)+(spec|test).js'],
+	testMatch: [
+		'**/__tests__/**/*.[jt]s?(x)',
+		'**/?(*.)+(spec|test).[jt]s?(x)',
+	],
 	testPathIgnorePatterns: [
 		'/node_modules/',
 		'/vendor/',

--- a/fair-payments-connector/src/API/ConnectionController.php
+++ b/fair-payments-connector/src/API/ConnectionController.php
@@ -33,6 +33,48 @@ class ConnectionController extends \WP_REST_Controller {
 				},
 			)
 		);
+
+		register_rest_route(
+			'fair-payments-connector/v1',
+			'/connection/overview',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'get_connection_overview' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+	}
+
+	/**
+	 * Get the connected Mollie profile name and enabled payment methods.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_connection_overview() {
+		if ( ! get_option( 'fair_payment_mollie_connected', false ) ) {
+			return new \WP_Error(
+				'not_connected',
+				__( 'Mollie is not connected. Please connect your Mollie account first.', 'fair-payments-connector' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		try {
+			$handler  = new MolliePaymentHandler();
+			$overview = $handler->get_connection_overview();
+		} catch ( \Exception $e ) {
+			return new \WP_Error(
+				'mollie_unreachable',
+				$e->getMessage(),
+				array( 'status' => 502 )
+			);
+		}
+
+		$overview['manage_url'] = 'https://my.mollie.com/dashboard/';
+
+		return new \WP_REST_Response( $overview, 200 );
 	}
 
 	/**

--- a/fair-payments-connector/src/API/__tests__/ConnectionController.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/ConnectionController.api.spec.js
@@ -1,0 +1,50 @@
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const OVERVIEW_ENDPOINT =
+	'/wp-json/fair-payments-connector/v1/connection/overview';
+
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * Return Basic-auth headers for the WP admin account.
+ */
+function adminAuth() {
+	return {
+		Authorization:
+			'Basic ' +
+			Buffer.from(`${ADMIN_USER}:${ADMIN_PASS}`).toString('base64'),
+	};
+}
+
+test.describe('ConnectionController', () => {
+	let api;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test.describe('GET /connection/overview', () => {
+		test('returns 401 for unauthenticated requests', async () => {
+			const res = await api.get(OVERVIEW_ENDPOINT);
+			expect(res.status()).toBe(401);
+		});
+
+		test('returns a graceful error for an authenticated admin when not connected', async () => {
+			// This suite runs before any spec establishes an OAuth connection, so
+			// the site is expected to be disconnected here. The live-Mollie
+			// success path can't be exercised in CI (no real Mollie creds).
+			const res = await api.get(OVERVIEW_ENDPOINT, {
+				headers: adminAuth(),
+			});
+			expect(res.status()).toBe(400);
+			const body = await res.json();
+			expect(body.code).toBe('not_connected');
+		});
+	});
+});

--- a/fair-payments-connector/src/Admin/settings/ConnectionTab.js
+++ b/fair-payments-connector/src/Admin/settings/ConnectionTab.js
@@ -17,6 +17,7 @@ import {
  */
 import {
 	loadConnectionSettings,
+	loadConnectionOverview,
 	saveSettings,
 	testConnection,
 	fetchOAuthState,
@@ -42,6 +43,9 @@ export default function ConnectionTab({ onNotice, shouldReload }) {
 	const [isLoading, setIsLoading] = useState(false);
 	const [isRefreshing, setIsRefreshing] = useState(false);
 	const [isSaving, setIsSaving] = useState(false);
+	const [overview, setOverview] = useState(null);
+	const [overviewLoading, setOverviewLoading] = useState(false);
+	const [overviewError, setOverviewError] = useState(null);
 
 	/**
 	 * Load connection settings from API
@@ -96,6 +100,40 @@ export default function ConnectionTab({ onNotice, shouldReload }) {
 			loadSettings();
 		}
 	}, [shouldReload]);
+
+	/**
+	 * Load the connected profile name and enabled payment methods.
+	 *
+	 * Re-runs whenever the connection state or active mode changes, since the
+	 * enabled methods differ between test and live mode.
+	 */
+	useEffect(() => {
+		if (!connected) {
+			setOverview(null);
+			setOverviewError(null);
+			return;
+		}
+
+		setOverviewLoading(true);
+		setOverviewError(null);
+
+		loadConnectionOverview()
+			.then((data) => {
+				setOverview(data);
+				setOverviewLoading(false);
+			})
+			.catch((error) => {
+				setOverviewError(
+					error.message ||
+						(error.data && error.data.message) ||
+						__(
+							'Failed to load payment methods.',
+							'fair-payments-connector'
+						)
+				);
+				setOverviewLoading(false);
+			});
+	}, [connected, mode]);
 
 	/**
 	 * Handle Connect button click — fetches a CSRF state token first, then redirects.
@@ -384,6 +422,94 @@ export default function ConnectionTab({ onNotice, shouldReload }) {
 										'fair-payments-connector'
 									)}
 								</p>
+							)}
+						</div>
+
+						<div style={{ marginTop: '1rem' }}>
+							{overviewLoading && (
+								<p style={{ fontSize: '0.9em', color: '#666' }}>
+									{__(
+										'Loading payment methods…',
+										'fair-payments-connector'
+									)}
+								</p>
+							)}
+
+							{overviewError && (
+								<Notice status="warning" isDismissible={false}>
+									{overviewError}
+								</Notice>
+							)}
+
+							{overview && !overviewLoading && (
+								<>
+									<p>
+										<strong>
+											{__(
+												'Profile name:',
+												'fair-payments-connector'
+											)}
+										</strong>{' '}
+										{overview.profile_name}
+									</p>
+
+									<p style={{ marginBottom: '0.25rem' }}>
+										<strong>
+											{__(
+												'Enabled payment methods:',
+												'fair-payments-connector'
+											)}
+										</strong>
+									</p>
+									{overview.methods.length > 0 ? (
+										<ul
+											style={{
+												listStyle: 'disc',
+												marginLeft: '1.5rem',
+											}}
+										>
+											{overview.methods.map((method) => (
+												<li key={method.id}>
+													{method.image && (
+														<img
+															src={method.image}
+															alt=""
+															width="20"
+															height="20"
+															style={{
+																verticalAlign:
+																	'middle',
+																marginRight:
+																	'0.5rem',
+															}}
+														/>
+													)}
+													{method.description}
+												</li>
+											))}
+										</ul>
+									) : (
+										<p>
+											{__(
+												'No payment methods are currently enabled.',
+												'fair-payments-connector'
+											)}
+										</p>
+									)}
+
+									<p>
+										<a
+											href={overview.manage_url}
+											target="_blank"
+											rel="noreferrer"
+										>
+											{__(
+												'Manage payment methods in Mollie',
+												'fair-payments-connector'
+											)}
+										</a>
+									</p>
+								</>
 							)}
 						</div>
 

--- a/fair-payments-connector/src/Admin/settings/__tests__/ConnectionTab.test.jsx
+++ b/fair-payments-connector/src/Admin/settings/__tests__/ConnectionTab.test.jsx
@@ -1,0 +1,122 @@
+/**
+ * Component tests for the connection overview section (#1208).
+ *
+ * Exercises:
+ *   - Connected: profile name, enabled methods, and the "manage in Mollie" link render.
+ *   - Disconnected: none of the overview section renders.
+ *   - Error: the overview section shows a warning while the rest of the
+ *     connected controls (mode switch, disconnect) still render.
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import ConnectionTab from '../ConnectionTab.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const CONNECTED_SETTINGS = {
+	fair_payment_mollie_connected: true,
+	fair_payment_mode: 'test',
+	fair_payment_organization_id: 'org_123',
+	fair_payment_mollie_profile_id: 'pfl_123',
+	fair_payment_mollie_token_expires: 0,
+};
+
+const OVERVIEW = {
+	profile_name: 'My Webshop',
+	profile_id: 'pfl_123',
+	mode: 'test',
+	methods: [
+		{ id: 'ideal', description: 'iDEAL', image: '' },
+		{ id: 'creditcard', description: 'Credit card', image: '' },
+	],
+	manage_url: 'https://my.mollie.com/dashboard/',
+};
+
+function mockApiFetchFor({ connected, overview, overviewError }) {
+	apiFetch.mockImplementation(({ path }) => {
+		if (path === '/wp/v2/settings') {
+			return Promise.resolve(
+				connected
+					? CONNECTED_SETTINGS
+					: { fair_payment_mollie_connected: false }
+			);
+		}
+		if (path === '/fair-payments-connector/v1/connection/overview') {
+			if (overviewError) {
+				return Promise.reject(
+					new Error('Failed to load payment methods.')
+				);
+			}
+			return Promise.resolve(overview);
+		}
+		return Promise.resolve({});
+	});
+}
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+describe('ConnectionTab — connection overview', () => {
+	it('shows profile name, enabled methods, and the manage link when connected', async () => {
+		mockApiFetchFor({ connected: true, overview: OVERVIEW });
+		render(<ConnectionTab onNotice={() => {}} shouldReload={false} />);
+
+		expect(await screen.findByText('My Webshop')).toBeInTheDocument();
+		expect(screen.getByText('iDEAL')).toBeInTheDocument();
+		expect(screen.getByText('Credit card')).toBeInTheDocument();
+
+		const link = screen.getByRole('link', {
+			name: 'Manage payment methods in Mollie',
+		});
+		expect(link).toHaveAttribute(
+			'href',
+			'https://my.mollie.com/dashboard/'
+		);
+		expect(link).toHaveAttribute('target', '_blank');
+
+		// Pre-existing settings-load logging and the @wordpress/components
+		// ButtonGroup deprecation warning are expected, not under test here.
+		expect(console).toHaveLogged();
+		expect(console).toHaveWarned();
+	});
+
+	it('renders nothing from the overview section when disconnected', async () => {
+		mockApiFetchFor({ connected: false });
+		render(<ConnectionTab onNotice={() => {}} shouldReload={false} />);
+
+		expect(
+			await screen.findByText('Connect your Mollie account', {
+				exact: false,
+			})
+		).toBeInTheDocument();
+		expect(screen.queryByText('My Webshop')).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('link', {
+				name: 'Manage payment methods in Mollie',
+			})
+		).not.toBeInTheDocument();
+
+		expect(console).toHaveLogged();
+	});
+
+	it('shows a warning but keeps the connected controls when the overview fetch fails', async () => {
+		mockApiFetchFor({ connected: true, overviewError: true });
+		render(<ConnectionTab onNotice={() => {}} shouldReload={false} />);
+
+		const notice = await screen.findByText(
+			'Failed to load payment methods.',
+			{ selector: '.components-notice__content' }
+		);
+		expect(notice).toBeInTheDocument();
+
+		// Rest of the connected view still renders.
+		expect(screen.getByText('Mode')).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'Disconnect' })
+		).toBeInTheDocument();
+
+		expect(console).toHaveLogged();
+	});
+});

--- a/fair-payments-connector/src/Admin/settings/settings-api.js
+++ b/fair-payments-connector/src/Admin/settings/settings-api.js
@@ -72,6 +72,17 @@ export function saveOAuthCallback(data) {
 }
 
 /**
+ * Load the connected Mollie profile name and enabled payment methods.
+ *
+ * @return {Promise<Object>} Promise resolving to the connection overview
+ */
+export function loadConnectionOverview() {
+	return apiFetch({
+		path: '/fair-payments-connector/v1/connection/overview',
+	});
+}
+
+/**
  * Test Mollie connection and trigger token refresh if needed
  *
  * @return {Promise<Object>} Promise resolving to connection test result

--- a/fair-payments-connector/src/Payment/MolliePaymentHandler.php
+++ b/fair-payments-connector/src/Payment/MolliePaymentHandler.php
@@ -219,6 +219,67 @@ class MolliePaymentHandler {
 	}
 
 	/**
+	 * Get a snapshot of the connected Mollie profile and its enabled payment methods.
+	 *
+	 * Used by the settings page to show the profile name and enabled methods for
+	 * the currently selected mode. Cached briefly so an admin page load doesn't
+	 * always incur a live Mollie round trip.
+	 *
+	 * @return array Connection overview: profile_name, profile_id, mode, methods.
+	 * @throws \Exception If the Mollie profile/methods lookup fails.
+	 */
+	public function get_connection_overview() {
+		$mode      = get_option( 'fair_payment_mode', 'test' );
+		$cache_key = 'fair_payment_connection_overview_' . $mode;
+
+		$cached = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		try {
+			$profile  = $this->mollie->profiles->get( 'me' );
+			$testmode = ( 'live' !== $mode );
+			$methods  = $this->mollie->methods->allEnabled(
+				array(
+					'profileId' => $profile->id,
+					'testmode'  => $testmode,
+				)
+			);
+		} catch ( ApiException $e ) {
+			throw new \Exception(
+				esc_html(
+					sprintf(
+						/* translators: %s: error message */
+						__( 'Failed to load Mollie connection overview: %s', 'fair-payments-connector' ),
+						$e->getMessage()
+					)
+				)
+			);
+		}
+
+		$method_list = array();
+		foreach ( $methods as $method ) {
+			$method_list[] = array(
+				'id'          => $method->id,
+				'description' => $method->description,
+				'image'       => isset( $method->image->size1x ) ? $method->image->size1x : '',
+			);
+		}
+
+		$overview = array(
+			'profile_name' => $profile->name,
+			'profile_id'   => $profile->id,
+			'mode'         => $mode,
+			'methods'      => $method_list,
+		);
+
+		set_transient( $cache_key, $overview, 5 * MINUTE_IN_SECONDS );
+
+		return $overview;
+	}
+
+	/**
 	 * Create a payment
 	 *
 	 * @param array $args Payment arguments.


### PR DESCRIPTION
## Summary
- After connecting Mollie, the settings connection tab now shows the connected profile's human-readable **name**, lists the payment **methods enabled** for the active mode, and links out to the Mollie dashboard to manage them — previously only the opaque profile ID was visible.
- Backend: `MolliePaymentHandler::get_connection_overview()` fetches the profile + enabled methods from Mollie (5-minute transient cache, keyed by test/live mode) and `ConnectionController` exposes it at `GET /fair-payments-connector/v1/connection/overview` (admin-only, `manage_options`).
- Frontend: `ConnectionTab` fetches the overview whenever the connection state or active mode changes, so the list always reflects the currently selected mode. A failed fetch shows an inline warning without blocking the rest of the connected controls.
- This is the plugin's first Jest component test, so `jest.config.js`'s `testMatch` was extended to also pick up `.jsx` files (matching the pattern already used in fair-audience).

Refs #1208

## Test plan
- [x] `npm run test:js` (Jest) — new `ConnectionTab.test.jsx` covers connected (profile name, methods, manage link), disconnected (nothing renders), and error (warning shown, rest of connected controls still work) states
- [x] `npm run test:api` file added (`ConnectionController.api.spec.js`) — covers 401 unauthenticated and the graceful 400 "not connected" error shape; the live-Mollie success path isn't exercised in CI (no real Mollie creds, same limitation as the existing OAuth spec)
- [x] `npm run test:php` (existing `MolliePaymentHandlerTest.php` suite, unaffected)
- [x] `vendor/bin/phpcs` clean on changed PHP files
- [x] `npm run build` run to refresh generated admin assets
