### PR TITLE
Stack finance entries summary vertically on mobile

### DIFF
--- a/fair-finance/src/Admin/entries/EntriesApp.js
+++ b/fair-finance/src/Admin/entries/EntriesApp.js
@@ -629,7 +629,10 @@ const EntriesApp = () => {
 				{/* Totals Summary */}
 				<Card>
 					<CardBody>
-						<HStack justify="space-around">
+						<HStack
+							justify="space-around"
+							className="fair-finance-entries-summary"
+						>
 							<div style={{ textAlign: 'center' }}>
 								<div
 									style={{

--- a/fair-finance/src/Admin/entries/index.js
+++ b/fair-finance/src/Admin/entries/index.js
@@ -8,6 +8,7 @@ import { createRoot } from '@wordpress/element';
  * Internal dependencies
  */
 import EntriesApp from './EntriesApp.js';
+import './style.scss';
 
 /**
  * Initialize the entries page

--- a/fair-finance/src/Admin/entries/style.scss
+++ b/fair-finance/src/Admin/entries/style.scss
@@ -1,0 +1,22 @@
+/**
+ * Entries admin page styles.
+ *
+ * The totals summary is an `HStack justify="space-around"`, which renders a
+ * non-wrapping flex row. On narrow screens the three amounts overlap and
+ * become unreadable. Below the mobile breakpoint we stack them vertically
+ * instead of forcing them onto one row.
+ *
+ * Scoped under `.wrap.fair-payments-connector-entries-page` so nothing else
+ * is touched, and lives inside a media query so the desktop layout is
+ * unchanged.
+ */
+
+.wrap.fair-payments-connector-entries-page {
+	@media screen and (max-width: 600px) {
+		.fair-finance-entries-summary {
+			flex-direction: column;
+			gap: 1em;
+			align-items: center;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- The Financial Entries totals summary (`admin.php?page=fair-finance-entries`) used `HStack justify="space-around"`, a non-wrapping flex row, so the three 24px bold amounts overlapped and became unreadable on narrow screens.
- Adds a scoped `@media (max-width: 600px)` rule that stacks the three stats vertically instead. Desktop/tablet (≥600px) layout is unchanged.

Refs #1164

## Test plan

- [x] `npm run build` in `fair-finance`
- [x] `npm run format`
- [x] `npm test` (entries Jest suites) — pass
- [x] Manual check via docker WP env at 375px, 768px, 1280px viewports — mobile now stacks the three amounts vertically and stays readable; tablet/desktop rows unaffected
