### PR TITLE
Fix budgets page mobile styles selector mismatch

### DIFF
--- a/fair-finance/src/Admin/budgets/style.scss
+++ b/fair-finance/src/Admin/budgets/style.scss
@@ -7,17 +7,17 @@
  * mobile breakpoint we drop the table grid and render each row as a stacked
  * card with label/value pairs so the content stays readable.
  *
- * Everything is scoped under `.fair-payment-budgets-page` so other
+ * Everything is scoped under `.fair-payments-connector-budgets-page` so other
  * `wp-list-table`s in the admin are untouched, and lives inside a media query
  * so the desktop layout is unchanged.
  *
- * The selectors deliberately stack `.wrap.fair-payment-budgets-page` and
+ * The selectors deliberately stack `.wrap.fair-payments-connector-budgets-page` and
  * `.wp-list-table.widefat` to outweigh WordPress core's responsive list-table
  * rules (`...td::before { content: attr(data-colname); }`, active below 782px),
  * which would otherwise blank out our `data-label` text.
  */
 
-.wrap.fair-payment-budgets-page {
+.wrap.fair-payments-connector-budgets-page {
 	@media screen and (max-width: 600px) {
 		.wp-list-table.widefat {
 			display: block;
@@ -84,7 +84,7 @@
 			}
 
 			// Let the View / Edit / Delete buttons wrap and stay right-aligned.
-			.fair-payment-budget-actions {
+			.fair-payments-connector-budget-actions {
 				flex-wrap: wrap;
 				justify-content: flex-end;
 			}


### PR DESCRIPTION
## Summary

- Fix a selector mismatch in `fair-finance/src/Admin/budgets/style.scss` that silently disabled the budgets table's mobile responsive layout.
- The stacked-card mobile styles were scoped to `.fair-payment-budgets-page` / `.fair-payment-budget-actions`, leftover class names from before the budgets page moved from fair-payments-connector to fair-finance (`3f089040`). `BudgetsApp.js` actually renders `fair-payments-connector-budgets-page` / `fair-payments-connector-budget-actions`, so the media query never matched and the table fell back to WordPress's `fixed` layout, wrapping "Name"/"Description" one character per line on narrow screens.
- Renamed the selectors (and the file's doc comment) to match the real class names. No JS/PHP changes.

Closes #1165

## Screenshots (mobile, 375px)

| Before | After |
| --- | --- |
| ![before](https://i.ibb.co/TMcB0M4j/d6be61493ea1.png) | ![after](https://i.ibb.co/J4XJFG4/3f81315ec13a.png) |

Captured against a local WP instance with the fair-finance/fair-payments-connector plugins active and two sample budget rows. Before = original selectors rebuilt; after = this branch.

## Test plan

- [x] `npm run build` in `fair-finance` — compiled CSS now scopes to `.fair-payments-connector-budgets-page`.
- [x] Verified visually at 375px width: table renders as stacked label/value cards after the fix, vs. one-character-per-line wrapping before.
- [x] `npm run format` in `fair-finance` — no formatting diff beyond the intended change.
- [ ] No automated test coverage for this component (per the ticket, presentation-only CSS fix).
