### PR TITLE
Fix Mollie profile 403 under org-level OAuth token

### DIFF
--- a/fair-payments-connector/__tests__/Payment/MolliePaymentHandlerTest.php
+++ b/fair-payments-connector/__tests__/Payment/MolliePaymentHandlerTest.php
@@ -22,8 +22,10 @@ use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\Http\Requests\CreatePaymentRequest;
 use Mollie\Api\Http\Requests\GetPaymentRequest;
 use Mollie\Api\Http\Requests\GetEnabledMethodsRequest;
+use Mollie\Api\Http\Requests\GetProfileRequest;
 use Mollie\Api\Resources\Payment;
 use Mollie\Api\Resources\MethodCollection;
+use Mollie\Api\Resources\Profile;
 
 /**
  * Unit tests for MolliePaymentHandler's test/live mode handling.
@@ -34,7 +36,8 @@ class MolliePaymentHandlerTest extends TestCase {
 	 * Reset shared test state before each test.
 	 */
 	protected function setUp(): void {
-		$GLOBALS['_fair_test_options'] = array();
+		$GLOBALS['_fair_test_options']    = array();
+		$GLOBALS['_fair_test_transients'] = array();
 		PaymentLogRepository::reset_request_id();
 	}
 
@@ -253,5 +256,61 @@ class MolliePaymentHandlerTest extends TestCase {
 		$this->assertTrue( $request->getTestmode() );
 		// The SDK stringifies query booleans ('true'/'false') for URL encoding.
 		$this->assertSame( 'true', $request->query()->get( 'testmode' ) );
+	}
+
+	/**
+	 * Regression guard for the #1208 follow-up fix: `get_connection_overview()`
+	 * must resolve the profile via the stored ID, not `/profiles/me` -- an
+	 * org-level OAuth token 403s on `/me` since it isn't bound to one profile.
+	 */
+	public function test_get_connection_overview_uses_stored_profile_id_not_me() {
+		$GLOBALS['_fair_test_options']['fair_payment_mollie_profile_id'] = 'pfl_test123';
+		$GLOBALS['_fair_test_options']['fair_payment_mode']              = 'test';
+
+		$mollie = MollieApiClient::fake(
+			array(
+				GetProfileRequest::class        => MockResponse::resource( Profile::class )
+					->with(
+						array(
+							'id'   => 'pfl_test123',
+							'name' => 'My Test Shop',
+						)
+					)->create(),
+				GetEnabledMethodsRequest::class => MockResponse::list( MethodCollection::class )
+					->add(
+						array(
+							'id'          => 'ideal',
+							'description' => 'iDEAL',
+							'resource'    => 'method',
+						)
+					)
+					->create(),
+			)
+		);
+
+		$handler  = new MolliePaymentHandler( $mollie );
+		$overview = $handler->get_connection_overview();
+
+		$profile_request = $this->sent_request( $mollie, GetProfileRequest::class );
+
+		$this->assertSame( 'profiles/pfl_test123', $profile_request->getRequest()->resolveResourcePath() );
+		$this->assertSame( 'My Test Shop', $overview['profile_name'] );
+		$this->assertSame( 'pfl_test123', $overview['profile_id'] );
+	}
+
+	/**
+	 * A missing stored profile ID must throw a clear "not configured" error
+	 * instead of attempting a `/profiles/me` call, which can only 403 under
+	 * an org-level OAuth token.
+	 */
+	public function test_get_connection_overview_throws_when_profile_id_missing() {
+		$mollie = MollieApiClient::fake( array() );
+
+		$handler = new MolliePaymentHandler( $mollie );
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessageMatches( '/not configured/' );
+
+		$handler->get_connection_overview();
 	}
 }

--- a/fair-payments-connector/__tests__/bootstrap.php
+++ b/fair-payments-connector/__tests__/bootstrap.php
@@ -153,6 +153,38 @@ if ( ! function_exists( 'wp_unslash' ) ) {
 	}
 }
 
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+	/**
+	 * Stub of WordPress get_transient() backed by $GLOBALS['_fair_test_transients'].
+	 *
+	 * @param string $key Transient key.
+	 * @return mixed Stored value, or false when unset.
+	 */
+	function get_transient( $key ) {
+		$transients = isset( $GLOBALS['_fair_test_transients'] ) ? $GLOBALS['_fair_test_transients'] : array();
+		return array_key_exists( $key, $transients ) ? $transients[ $key ] : false;
+	}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	/**
+	 * Stub of WordPress set_transient() backed by $GLOBALS['_fair_test_transients'].
+	 *
+	 * @param string $key        Transient key.
+	 * @param mixed  $value      Value to store.
+	 * @param int    $expiration Expiration in seconds (unused; test transients never expire).
+	 * @return true
+	 */
+	function set_transient( $key, $value, $expiration = 0 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$GLOBALS['_fair_test_transients'][ $key ] = $value;
+		return true;
+	}
+}
+
 require_once __DIR__ . '/Fair_Test_WPDB.php';
 
 // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.

--- a/fair-payments-connector/src/Payment/MolliePaymentHandler.php
+++ b/fair-payments-connector/src/Payment/MolliePaymentHandler.php
@@ -195,27 +195,11 @@ class MolliePaymentHandler {
 			return false;
 		}
 
-		// Check cached profile ID.
+		// Profile ID is stored at connect time. Org-level OAuth tokens can't
+		// resolve /profiles/me (it 403s), so there is no live fallback here.
 		$profile_id = get_option( 'fair_payment_mollie_profile_id' );
-		if ( ! empty( $profile_id ) ) {
-			return $profile_id;
-		}
 
-		// Fetch current profile from Mollie.
-		try {
-			$profile = $this->mollie->profiles->get( 'me' );
-			if ( $profile && ! empty( $profile->id ) ) {
-				update_option( 'fair_payment_mollie_profile_id', $profile->id );
-				return $profile->id;
-			}
-		} catch ( \Exception $e ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( 'Failed to fetch Mollie profile: ' . $e->getMessage() );
-			}
-		}
-
-		return false;
+		return ! empty( $profile_id ) ? $profile_id : false;
 	}
 
 	/**
@@ -237,8 +221,16 @@ class MolliePaymentHandler {
 			return $cached;
 		}
 
+		$profile_id = get_option( 'fair_payment_mollie_profile_id' );
+
+		if ( empty( $profile_id ) ) {
+			throw new \Exception(
+				esc_html__( 'Failed to load Mollie connection overview: Mollie profile is not configured.', 'fair-payments-connector' )
+			);
+		}
+
 		try {
-			$profile  = $this->mollie->profiles->get( 'me' );
+			$profile  = $this->mollie->profiles->get( $profile_id );
 			$testmode = ( 'live' !== $mode );
 			$methods  = $this->mollie->methods->allEnabled(
 				array(


### PR DESCRIPTION
## Summary
- Fix `MolliePaymentHandler::get_connection_overview()` 403ing under an org-level OAuth token by looking up the profile by its stored ID instead of `/profiles/me` (org tokens aren't bound to a single profile, so `/me` always rejects them).
- Remove the dead `/me` fallback in `get_profile_id()` — it only ran when the cached `fair_payment_mollie_profile_id` option was empty, and under an org token that call can only 403. It now returns `false` in that case, matching the stored option as the single source of truth.
- Guard `get_connection_overview()` against a missing stored profile ID with a clear "not configured" error instead of attempting a doomed Mollie call.

## Test plan
- [x] `vendor/bin/phpunit` in `fair-payments-connector` (17 tests, including two new regression tests: profile lookup uses the stored ID and resolves to `profiles/{id}` not `profiles/me`; missing profile ID throws a clear error)
- [x] `vendor/bin/phpcs` clean on changed files
- [ ] Live-Mollie success path can't be exercised in CI (no real Mollie creds) — unchanged from the original implementation's test note

Refs #1208
