### PR TITLE
Fix invalid VTIMEZONE and all-day dates in ICS feed

### DIFF
--- a/fair-events/src/API/CalendarFeedController.php
+++ b/fair-events/src/API/CalendarFeedController.php
@@ -197,7 +197,7 @@ class CalendarFeedController extends WP_REST_Controller {
 				continue;
 			}
 
-			$sub = $vtimezone->add( $transition['isdst'] ? 'DAYLIGHT' : 'STANDARD' );
+			$sub = $vcalendar->createComponent( $transition['isdst'] ? 'DAYLIGHT' : 'STANDARD' );
 			$sub->add( 'DTSTART', gmdate( 'Ymd\THis', $transition['ts'] + $transition['offset'] ) );
 			$sub->add( 'TZOFFSETFROM', $this->format_utc_offset( $previous_offset ) );
 			$sub->add( 'TZOFFSETTO', $this->format_utc_offset( $transition['offset'] ) );
@@ -206,13 +206,15 @@ class CalendarFeedController extends WP_REST_Controller {
 				$sub->add( 'TZNAME', $transition['abbr'] );
 			}
 
+			$vtimezone->add( $sub );
+
 			$previous_offset = $transition['offset'];
 		}
 
 		// A zone without DST transitions in range yields no STANDARD/DAYLIGHT
 		// sub-component above, but RFC 5545 requires at least one.
 		if ( 0 === count( $vtimezone->select( 'STANDARD' ) ) + count( $vtimezone->select( 'DAYLIGHT' ) ) ) {
-			$sub = $vtimezone->add( $transitions[0]['isdst'] ? 'DAYLIGHT' : 'STANDARD' );
+			$sub = $vcalendar->createComponent( $transitions[0]['isdst'] ? 'DAYLIGHT' : 'STANDARD' );
 			$sub->add( 'DTSTART', '19700101T000000' );
 			$sub->add( 'TZOFFSETFROM', $this->format_utc_offset( $transitions[0]['offset'] ) );
 			$sub->add( 'TZOFFSETTO', $this->format_utc_offset( $transitions[0]['offset'] ) );
@@ -220,6 +222,8 @@ class CalendarFeedController extends WP_REST_Controller {
 			if ( ! empty( $transitions[0]['abbr'] ) ) {
 				$sub->add( 'TZNAME', $transitions[0]['abbr'] );
 			}
+
+			$vtimezone->add( $sub );
 		}
 	}
 
@@ -265,8 +269,8 @@ class CalendarFeedController extends WP_REST_Controller {
 		}
 
 		if ( $occurrence['all_day'] ) {
-			$start_date = DateHelper::local_date( $occurrence['start'] );
-			$end_date   = DateHelper::next_date( DateHelper::local_date( $occurrence['end'] ) );
+			$start_date = new \DateTimeImmutable( DateHelper::local_date( $occurrence['start'] ) );
+			$end_date   = new \DateTimeImmutable( DateHelper::next_date( DateHelper::local_date( $occurrence['end'] ) ) );
 
 			$vevent->add( 'DTSTART', $start_date, array( 'VALUE' => 'DATE' ) );
 			$vevent->add( 'DTEND', $end_date, array( 'VALUE' => 'DATE' ) );

--- a/fair-events/src/API/__tests__/CalendarFeedController.api.spec.js
+++ b/fair-events/src/API/__tests__/CalendarFeedController.api.spec.js
@@ -202,10 +202,10 @@ test.describe('CalendarFeedController — ICS calendar feed', () => {
 			'URL;VALUE=URI:https://example.com/calendar-feed-test'
 		);
 
-		// All-day event: DATE value, exclusive end (+1 day).
+		// All-day event: DATE value (basic YYYYMMDD, no dashes), exclusive end (+1 day).
 		expect(body).toContain(`UID:standalone_${allDayEventDateId}@`);
-		expect(body).toMatch(/DTSTART;VALUE=DATE:2035-09-03/);
-		expect(body).toMatch(/DTEND;VALUE=DATE:2035-09-04/);
+		expect(body).toMatch(/DTSTART;VALUE=DATE:20350903/);
+		expect(body).toMatch(/DTEND;VALUE=DATE:20350904/);
 	});
 
 	test('categories filter narrows the feed', async () => {
@@ -238,5 +238,78 @@ test.describe('CalendarFeedController — ICS calendar feed', () => {
 		expect(nonMatchingBody).not.toContain(
 			`UID:standalone_${standaloneEventDateId}@`
 		);
+	});
+});
+
+test.describe('CalendarFeedController — VTIMEZONE block on named zones', () => {
+	let api;
+	let originalTimezone;
+	let namedZoneEventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const settingsRes = await api.get('/wp-json/wp/v2/settings', {
+			headers: adminHeaders,
+		});
+		originalTimezone = (await settingsRes.json()).timezone;
+
+		const tzRes = await api.post('/wp-json/wp/v2/settings', {
+			headers: adminHeaders,
+			data: { timezone: 'Europe/Madrid' },
+		});
+		expect(tzRes.ok()).toBeTruthy();
+
+		// Range spans the Europe/Madrid spring-forward DST transition.
+		const eventDateRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Calendar feed VTIMEZONE test ${Date.now()}`,
+					start_datetime: '2035-03-15 10:00:00',
+					end_datetime: '2035-03-15 12:00:00',
+					link_type: 'external',
+					external_url: 'https://example.com/calendar-feed-vtimezone',
+				},
+			}
+		);
+		expect(eventDateRes.ok()).toBeTruthy();
+		namedZoneEventDateId = (await eventDateRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (namedZoneEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${namedZoneEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		await api.post('/wp-json/wp/v2/settings', {
+			headers: adminHeaders,
+			data: { timezone: originalTimezone },
+		});
+	});
+
+	test('emits a real STANDARD/DAYLIGHT sub-component, not a flattened property', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/calendar.ics?start_date=2035-03-01&end_date=2035-04-30'
+		);
+		expect(res.ok()).toBeTruthy();
+		// Unfold RFC 5545 line folding before substring/regex assertions.
+		const body = (await res.text()).replace(/\r\n /g, '');
+
+		expect(body).toContain('BEGIN:VTIMEZONE');
+		expect(body).toContain('TZID:Europe/Madrid');
+
+		expect(body).toMatch(
+			/BEGIN:(STANDARD|DAYLIGHT)[\s\S]*?END:(STANDARD|DAYLIGHT)/
+		);
+		expect(body).toMatch(/TZOFFSETFROM:[+-]\d{4}/);
+		expect(body).toMatch(/TZOFFSETTO:[+-]\d{4}/);
+
+		// The bug flattened STANDARD/DAYLIGHT into a property with
+		// parameters instead of a real sub-component.
+		expect(body).not.toMatch(/^(DAYLIGHT|STANDARD);DTSTART=/m);
 	});
 });


### PR DESCRIPTION
## Summary

- Fixes two RFC 5545 defects in the public ICS calendar feed (`GET /fair-events/v1/calendar.ics`) in `fair-events/src/API/CalendarFeedController.php`:
  - **VTIMEZONE block**: `add_vtimezone()` was calling `Component::add('STANDARD'|'DAYLIGHT')`, which Sabre treats as a *property* rather than a component (those names aren't in `VCalendar`'s component map), flattening the sub-section into one invalid line and breaking calendar clients on named-timezone (non-fixed-offset) sites. Now builds real sub-components via `Document::createComponent()` and nests them explicitly.
  - **All-day dates**: `DTSTART`/`DTEND` for all-day events were serialized from `DateHelper`'s dashed `Y-m-d` strings, producing invalid `DTSTART;VALUE=DATE:2035-09-03` instead of the required basic `YYYYMMDD` form. Now passes `DateTimeImmutable` objects so Sabre's `Date` property formats them correctly.
- Fixes the test assertions that previously encoded the dashed-date bug, and adds a new test asserting a real `BEGIN:STANDARD`/`BEGIN:DAYLIGHT` sub-block (and absence of the old flattened form) when the site timezone is a named IANA zone.

Closes #1216

## Test plan

- [x] `vendor/bin/phpcs` clean on the changed PHP file
- [x] `npm run test:api` (fair-events) — all 4 `CalendarFeedController` tests pass, including the new VTIMEZONE test against `Europe/Madrid`
- [x] No `npm run build` needed (no JS/CSS changed)
