### PR TITLE
Carry event location through the public events feed

### DIFF
--- a/fair-events/src/API/CalendarFeedController.php
+++ b/fair-events/src/API/CalendarFeedController.php
@@ -268,6 +268,11 @@ class CalendarFeedController extends WP_REST_Controller {
 			$vevent->add( 'URL', $occurrence['url'] );
 		}
 
+		$location_line = $this->build_location_line( $occurrence['location'] ?? null );
+		if ( $location_line ) {
+			$vevent->add( 'LOCATION', $location_line );
+		}
+
 		if ( $occurrence['all_day'] ) {
 			$start_date = new \DateTimeImmutable( DateHelper::local_date( $occurrence['start'] ) );
 			$end_date   = new \DateTimeImmutable( DateHelper::next_date( DateHelper::local_date( $occurrence['end'] ) ) );
@@ -281,6 +286,34 @@ class CalendarFeedController extends WP_REST_Controller {
 			$vevent->add( 'DTSTART', DateHelper::local_to_ical_utc( $occurrence['start'] ) );
 			$vevent->add( 'DTEND', DateHelper::local_to_ical_utc( $occurrence['end'] ) );
 		}
+	}
+
+	/**
+	 * Build the iCalendar LOCATION text line from a neutral location shape.
+	 *
+	 * Standard `LOCATION` text only (name + address); geo stays feed-only per
+	 * the ICS recommendation. Online events use the meeting URL.
+	 *
+	 * @param array|null $location Neutral location shape (EventLocation::resolve()), or null.
+	 * @return string LOCATION text, or '' when there's nothing to show.
+	 */
+	private function build_location_line( $location ) {
+		if ( empty( $location ) ) {
+			return '';
+		}
+
+		if ( ! empty( $location['online'] ) ) {
+			return $location['url'] ?? '';
+		}
+
+		$parts = array_filter(
+			array(
+				$location['name'] ?? '',
+				$location['address'] ?? '',
+			)
+		);
+
+		return implode( ', ', $parts );
 	}
 
 	/**

--- a/fair-events/src/API/PublicEventsController.php
+++ b/fair-events/src/API/PublicEventsController.php
@@ -271,7 +271,7 @@ class PublicEventsController extends WP_REST_Controller {
 	 * @return array Formatted event data.
 	 */
 	private function format_for_response( array $occurrence ) {
-		return array(
+		$response = array(
 			'uid'             => $occurrence['uid'],
 			'event_date_id'   => $occurrence['event_date_id'],
 			'occurrence_type' => $occurrence['occurrence_type'],
@@ -283,6 +283,12 @@ class PublicEventsController extends WP_REST_Controller {
 			'url'             => $occurrence['url'] ?? '',
 			'categories'      => $occurrence['categories'],
 		);
+
+		if ( ! empty( $occurrence['location'] ) ) {
+			$response['location'] = $occurrence['location'];
+		}
+
+		return $response;
 	}
 
 	/**

--- a/fair-events/src/API/__tests__/CalendarFeedController.api.spec.js
+++ b/fair-events/src/API/__tests__/CalendarFeedController.api.spec.js
@@ -241,6 +241,94 @@ test.describe('CalendarFeedController — ICS calendar feed', () => {
 	});
 });
 
+test.describe('CalendarFeedController — LOCATION line', () => {
+	let api;
+	let addressEventDateId;
+	let noLocationEventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const addressRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Calendar feed address test ${Date.now()}`,
+					start_datetime: '2035-09-10 10:00:00',
+					end_datetime: '2035-09-10 12:00:00',
+					link_type: 'none',
+				},
+			}
+		);
+		expect(addressRes.ok()).toBeTruthy();
+		addressEventDateId = (await addressRes.json()).id;
+
+		// The create endpoint doesn't wire `address` through — a PUT is
+		// needed, same quirk as `event_id` (see the timed-event setup above).
+		const addressUpdateRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${addressEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { address: 'Calle X 1, Madrid' },
+			}
+		);
+		expect(addressUpdateRes.ok()).toBeTruthy();
+
+		const noLocationRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Calendar feed no-location test ${Date.now()}`,
+					start_datetime: '2035-09-11 10:00:00',
+					end_datetime: '2035-09-11 12:00:00',
+					link_type: 'none',
+				},
+			}
+		);
+		expect(noLocationRes.ok()).toBeTruthy();
+		noLocationEventDateId = (await noLocationRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (addressEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${addressEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (noLocationEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${noLocationEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+	});
+
+	test('emits a LOCATION line for an address event, none for a location-less one', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/calendar.ics?start_date=2035-09-10&end_date=2035-09-11'
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = (await res.text()).replace(/\r\n /g, '');
+
+		expect(body).toMatch(
+			new RegExp(
+				`UID:standalone_${addressEventDateId}@[^]*?LOCATION:Calle X 1\\\\, Madrid`
+			)
+		);
+
+		const noLocationBlock = body
+			.split('BEGIN:VEVENT')
+			.find((block) =>
+				block.includes(`standalone_${noLocationEventDateId}@`)
+			);
+		expect(noLocationBlock).toBeTruthy();
+		expect(noLocationBlock).not.toContain('LOCATION:');
+	});
+});
+
 test.describe('CalendarFeedController — VTIMEZONE block on named zones', () => {
 	let api;
 	let originalTimezone;

--- a/fair-events/src/API/__tests__/PublicEventsController.api.spec.js
+++ b/fair-events/src/API/__tests__/PublicEventsController.api.spec.js
@@ -219,6 +219,22 @@ test.describe('PublicEventsController — standalone events', () => {
 		expect(event.url).toBe(eventDate.display_url);
 	});
 
+	test('external-link event carries location as an online marker', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/events?start_date=2035-08-01&end_date=2035-08-31&per_page=500'
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const event = body.events.find((e) => e.event_date_id === eventDateId);
+
+		expect(event).toBeTruthy();
+		expect(event.location).toEqual({
+			online: true,
+			url: 'https://example.com/standalone-test',
+		});
+	});
+
 	test('categories filter narrows the feed to matching standalone events', async () => {
 		const category = await (
 			await api.get(`/wp-json/wp/v2/categories/${categoryId}`, {
@@ -249,5 +265,100 @@ test.describe('PublicEventsController — standalone events', () => {
 		expect(
 			nonMatchingBody.events.some((e) => e.event_date_id === eventDateId)
 		).toBe(false);
+	});
+});
+
+test.describe('PublicEventsController — location field', () => {
+	let api;
+	let addressEventDateId;
+	let noLocationEventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const addressRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Public feed address test ${Date.now()}`,
+					start_datetime: '2035-08-10 10:00:00',
+					end_datetime: '2035-08-10 12:00:00',
+					link_type: 'none',
+				},
+			}
+		);
+		expect(addressRes.ok()).toBeTruthy();
+		addressEventDateId = (await addressRes.json()).id;
+
+		// The create endpoint doesn't wire `address` through — a PUT is
+		// needed, same quirk as `event_id` (see the recurring-occurrences
+		// test above).
+		const addressUpdateRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${addressEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { address: 'Calle X 1, Madrid' },
+			}
+		);
+		expect(addressUpdateRes.ok()).toBeTruthy();
+
+		const noLocationRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Public feed no-location test ${Date.now()}`,
+					start_datetime: '2035-08-11 10:00:00',
+					end_datetime: '2035-08-11 12:00:00',
+					link_type: 'none',
+				},
+			}
+		);
+		expect(noLocationRes.ok()).toBeTruthy();
+		noLocationEventDateId = (await noLocationRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (addressEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${addressEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (noLocationEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${noLocationEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+	});
+
+	test('free-text address resolves to a location object', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/events?start_date=2035-08-10&end_date=2035-08-10&per_page=500'
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const event = body.events.find(
+			(e) => e.event_date_id === addressEventDateId
+		);
+		expect(event).toBeTruthy();
+		expect(event.location).toEqual({ address: 'Calle X 1, Madrid' });
+	});
+
+	test('event with no location omits the field entirely', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/events?start_date=2035-08-11&end_date=2035-08-11&per_page=500'
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const event = body.events.find(
+			(e) => e.event_date_id === noLocationEventDateId
+		);
+		expect(event).toBeTruthy();
+		expect(event).not.toHaveProperty('location');
 	});
 });

--- a/fair-events/src/Helpers/EventLocation.php
+++ b/fair-events/src/Helpers/EventLocation.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Neutral event location resolution
+ *
+ * Resolves an event date's location into a schema-agnostic shape shared by
+ * the public feed (JSON/ICS) and the Schema.org JSON-LD boundary, so both
+ * follow the same fallback chain.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Helpers;
+
+use FairEvents\Models\EventDates;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Resolves EventDates rows into a neutral location shape.
+ */
+class EventLocation {
+
+	/**
+	 * Resolve an event date's location, following the same fallback chain as
+	 * EventSchema::get_jsonld_location() minus the site-name backstop —
+	 * callers here must be able to omit the field entirely.
+	 *
+	 * @param EventDates $event_date Event date object.
+	 * @param int|null   $post_id    Linked post ID, or null for standalone events.
+	 * @return array|null Neutral location shape (keys: name, address, latitude,
+	 *                     longitude, online, url — all optional), or null when nothing resolves.
+	 */
+	public static function resolve( EventDates $event_date, $post_id ) {
+		// 1. Venue.
+		if ( ! empty( $event_date->venue_id )
+			&& class_exists( \FairEventsExperimental\Models\Venue::class ) ) {
+			$venue = \FairEventsExperimental\Models\Venue::get_by_id( $event_date->venue_id );
+			if ( $venue ) {
+				$location = array( 'name' => $venue->name );
+
+				if ( ! empty( $venue->address ) ) {
+					$location['address'] = $venue->address;
+				}
+
+				if ( ! empty( $venue->latitude ) && ! empty( $venue->longitude ) ) {
+					$location['latitude']  = $venue->latitude;
+					$location['longitude'] = $venue->longitude;
+				}
+
+				return $location;
+			}
+		}
+
+		// 2. Event date's own free-text address.
+		if ( ! empty( $event_date->address ) ) {
+			return array( 'address' => $event_date->address );
+		}
+
+		// 3. Fall back to event_location meta.
+		$meta_location = $post_id ? get_post_meta( $post_id, 'event_location', true ) : '';
+		if ( ! empty( $meta_location ) ) {
+			return array( 'address' => $meta_location );
+		}
+
+		// 4. Online event: no physical location, but an external link.
+		if ( 'external' === $event_date->link_type && ! empty( $event_date->external_url ) ) {
+			return array(
+				'online' => true,
+				'url'    => $event_date->external_url,
+			);
+		}
+
+		return null;
+	}
+}

--- a/fair-events/src/Helpers/EventSchema.php
+++ b/fair-events/src/Helpers/EventSchema.php
@@ -81,8 +81,9 @@ class EventSchema {
 	 * Build a lean Schema.org Event object from an EventFeedProvider occurrence
 	 * DTO, for use inside an `ItemList`.
 	 *
-	 * Carries `name`, `startDate`, `endDate`, `url`, `description`, and —
-	 * for post/standalone occurrences only — `location`. Does not include
+	 * Carries `name`, `startDate`, `endDate`, `url`, `description`, and
+	 * `location` (built from the DTO's carried neutral location, when
+	 * present, for every source). Does not include
 	 * `offers`/`organizer`/`image`/`eventStatus`; those stay single-page-only.
 	 *
 	 * @param array $dto Occurrence DTO, as returned by EventFeedProvider::get_occurrences().
@@ -108,12 +109,8 @@ class EventSchema {
 			$event['description'] = $dto['description'];
 		}
 
-		if ( in_array( $dto['source'], array( 'post', 'standalone' ), true ) && ! empty( $dto['event_date_id'] ) ) {
-			$event_date = EventDates::get_by_id( $dto['event_date_id'] );
-			if ( $event_date ) {
-				$location_data     = self::get_jsonld_location( $event_date, $dto['event_id'] );
-				$event['location'] = $location_data['location'];
-			}
+		if ( ! empty( $dto['location'] ) ) {
+			$event['location'] = self::location_to_jsonld( $dto['location'] );
 		}
 
 		return $event;
@@ -214,91 +211,60 @@ class EventSchema {
 	 * @return array{location: array, attendance_mode: string} Location data and eventAttendanceMode value.
 	 */
 	public static function get_jsonld_location( EventDates $event_date, $post_id ) {
-		$offline = 'https://schema.org/OfflineEventAttendanceMode';
-		$online  = 'https://schema.org/OnlineEventAttendanceMode';
+		$neutral = EventLocation::resolve( $event_date, $post_id );
 
-		// 1. Venue.
-		if ( ! empty( $event_date->venue_id )
-			&& class_exists( \FairEventsExperimental\Models\Venue::class ) ) {
-			$venue = \FairEventsExperimental\Models\Venue::get_by_id( $event_date->venue_id );
-			if ( $venue ) {
-				$location = array(
-					'@type' => 'Place',
-					'name'  => $venue->name,
-				);
-
-				if ( ! empty( $venue->address ) ) {
-					$location['address'] = array(
-						'@type' => 'PostalAddress',
-						'name'  => $venue->address,
-					);
-				}
-
-				if ( ! empty( $venue->latitude ) && ! empty( $venue->longitude ) ) {
-					$location['geo'] = array(
-						'@type'     => 'GeoCoordinates',
-						'latitude'  => $venue->latitude,
-						'longitude' => $venue->longitude,
-					);
-				}
-
-				return array(
-					'location'        => $location,
-					'attendance_mode' => $offline,
-				);
-			}
-		}
-
-		// 2. Event date's own free-text address.
-		if ( ! empty( $event_date->address ) ) {
-			return array(
-				'location'        => array(
-					'@type'   => 'Place',
-					'name'    => $event_date->address,
-					'address' => array(
-						'@type' => 'PostalAddress',
-						'name'  => $event_date->address,
-					),
-				),
-				'attendance_mode' => $offline,
-			);
-		}
-
-		// 3. Fall back to event_location meta.
-		$meta_location = $post_id ? get_post_meta( $post_id, 'event_location', true ) : '';
-		if ( ! empty( $meta_location ) ) {
-			return array(
-				'location'        => array(
-					'@type'   => 'Place',
-					'name'    => $meta_location,
-					'address' => array(
-						'@type' => 'PostalAddress',
-						'name'  => $meta_location,
-					),
-				),
-				'attendance_mode' => $offline,
-			);
-		}
-
-		// 4. Online event: no physical location, but an external link.
-		if ( 'external' === $event_date->link_type && ! empty( $event_date->external_url ) ) {
-			return array(
-				'location'        => array(
-					'@type' => 'VirtualLocation',
-					'url'   => $event_date->external_url,
-				),
-				'attendance_mode' => $online,
-			);
-		}
-
-		// 5. Final fallback so `location` is never absent.
 		return array(
-			'location'        => array(
+			'location'        => self::location_to_jsonld( $neutral ),
+			'attendance_mode' => ! empty( $neutral['online'] )
+				? 'https://schema.org/OnlineEventAttendanceMode'
+				: 'https://schema.org/OfflineEventAttendanceMode',
+		);
+	}
+
+	/**
+	 * Map a neutral location shape (EventLocation::resolve()) to a
+	 * Schema.org `Place`/`VirtualLocation` node, guaranteeing a valid,
+	 * never-null result via a site-name backstop.
+	 *
+	 * @param array|null $neutral Neutral location shape, or null when nothing resolved.
+	 * @return array Schema.org location node.
+	 */
+	public static function location_to_jsonld( $neutral ) {
+		if ( empty( $neutral ) ) {
+			return array(
 				'@type' => 'Place',
 				'name'  => get_bloginfo( 'name' ),
-			),
-			'attendance_mode' => $offline,
+			);
+		}
+
+		if ( ! empty( $neutral['online'] ) ) {
+			return array(
+				'@type' => 'VirtualLocation',
+				'url'   => $neutral['url'],
+			);
+		}
+
+		$location = array(
+			'@type' => 'Place',
+			'name'  => ! empty( $neutral['name'] ) ? $neutral['name'] : $neutral['address'],
 		);
+
+		if ( ! empty( $neutral['address'] ) ) {
+			$location['address'] = array(
+				'@type' => 'PostalAddress',
+				'name'  => $neutral['address'],
+			);
+		}
+
+		if ( ! empty( $neutral['latitude'] ) && ! empty( $neutral['longitude'] ) ) {
+			$location['geo'] = array(
+				'@type'     => 'GeoCoordinates',
+				'latitude'  => $neutral['latitude'],
+				'longitude' => $neutral['longitude'],
+			);
+		}
+
+		return $location;
 	}
 
 	/**

--- a/fair-events/src/Helpers/FairEventsApiParser.php
+++ b/fair-events/src/Helpers/FairEventsApiParser.php
@@ -128,7 +128,48 @@ class FairEventsApiParser {
 			'start'       => $start_local,
 			'end'         => $end_local,
 			'all_day'     => $event['all_day'] ?? false,
+			'location'    => self::parse_location( $event['location'] ?? null ),
 		);
+	}
+
+	/**
+	 * Sanitize an ingested feed location object into the neutral location
+	 * shape (EventLocation::resolve()).
+	 *
+	 * @param mixed $location Raw `location` value from the feed JSON.
+	 * @return array|null Neutral location shape, or null when absent/invalid.
+	 */
+	private static function parse_location( $location ) {
+		if ( empty( $location ) || ! is_array( $location ) ) {
+			return null;
+		}
+
+		$parsed = array();
+
+		if ( ! empty( $location['online'] ) ) {
+			$parsed['online'] = true;
+
+			if ( ! empty( $location['url'] ) ) {
+				$parsed['url'] = sanitize_url( $location['url'] );
+			}
+
+			return $parsed;
+		}
+
+		if ( ! empty( $location['name'] ) ) {
+			$parsed['name'] = sanitize_text_field( $location['name'] );
+		}
+
+		if ( ! empty( $location['address'] ) ) {
+			$parsed['address'] = sanitize_text_field( $location['address'] );
+		}
+
+		if ( is_numeric( $location['latitude'] ?? null ) && is_numeric( $location['longitude'] ?? null ) ) {
+			$parsed['latitude']  = (string) $location['latitude'];
+			$parsed['longitude'] = (string) $location['longitude'];
+		}
+
+		return ! empty( $parsed ) ? $parsed : null;
 	}
 
 	/**

--- a/fair-events/src/Helpers/ICalParser.php
+++ b/fair-events/src/Helpers/ICalParser.php
@@ -131,6 +131,9 @@ class ICalParser {
 			'start'       => $start_datetime,
 			'end'         => $end_datetime,
 			'all_day'     => $all_day,
+			'location'    => isset( $vevent->LOCATION ) && '' !== (string) $vevent->LOCATION
+				? array( 'address' => sanitize_text_field( (string) $vevent->LOCATION ) )
+				: null,
 		);
 	}
 

--- a/fair-events/src/Services/EventFeedProvider.php
+++ b/fair-events/src/Services/EventFeedProvider.php
@@ -13,6 +13,7 @@ namespace FairEvents\Services;
 
 use FairEvents\Database\EventSourceRepository;
 use FairEvents\Helpers\DateHelper;
+use FairEvents\Helpers\EventLocation;
 use FairEvents\Helpers\FairEventsApiParser;
 use FairEvents\Helpers\ICalParser;
 use FairEvents\Models\EventDates;
@@ -25,7 +26,8 @@ defined( 'WPINC' ) || die;
  *
  * DTO shape: uid, event_date_id, event_id, occurrence_type, title,
  * description, start, end, all_day, url, categories, source
- * ('post'|'standalone'|'ical'|'api'), is_draft, source_color.
+ * ('post'|'standalone'|'ical'|'api'), is_draft, source_color, location
+ * (neutral shape from EventLocation::resolve(), or null).
  *
  * `start`/`end` are naive site-local 'Y-m-d H:i:s' strings — the same form
  * every other internal consumer (EventDates, WeeklyEventsProvider, blocks)
@@ -252,6 +254,7 @@ class EventFeedProvider {
 			'source'          => 'post',
 			'is_draft'        => $is_draft,
 			'source_color'    => null,
+			'location'        => EventLocation::resolve( $row, $event_id ),
 		);
 	}
 
@@ -285,6 +288,7 @@ class EventFeedProvider {
 			'source'          => 'standalone',
 			'is_draft'        => false,
 			'source_color'    => null,
+			'location'        => EventLocation::resolve( $row, null ),
 		);
 	}
 
@@ -415,6 +419,7 @@ class EventFeedProvider {
 			'source'          => $source,
 			'is_draft'        => false,
 			'source_color'    => $color,
+			'location'        => $event['location'] ?? null,
 		);
 	}
 }


### PR DESCRIPTION
## Summary

The public events feed (JSON + ICS) dropped location entirely, even though the publisher already resolves it correctly on single-event pages. Consumers that ingest and republish the feed therefore emitted `Event` structured data with no `location`, which Google Search Console flags as invalid for rich results.

- Added `EventLocation::resolve()` (`fair-events/src/Helpers/EventLocation.php`) — a shared resolver producing a neutral, schema-agnostic location shape (`name`/`address`/`latitude`/`longitude`/`online`/`url`), following the same fallback chain as the existing single-page JSON-LD (venue → free-text address → `event_location` meta → external-link online marker), minus the never-null site-name backstop.
- `EventSchema::get_jsonld_location()` now builds on `EventLocation::resolve()` + a new `EventSchema::location_to_jsonld()` that maps the neutral shape to Schema.org `Place`/`VirtualLocation` (re-adding the site-name backstop for the single-page case). `occurrence_to_jsonld()` now emits `location` for **all** occurrence sources (previously only `post`/`standalone`), unifying local and republished-feed events.
- `EventFeedProvider` carries the resolved (or pass-through, for external streams) neutral location on every occurrence DTO.
- `PublicEventsController` includes `location` in the JSON feed only when non-null (additive).
- `CalendarFeedController` emits a standard `LOCATION` line (name + address, or the meeting URL for online events) in the ICS mirror.
- `FairEventsApiParser` and `ICalParser` read location back in on ingest, so consumers retain it through a republish.

## Test plan

- [x] `vendor/bin/phpcs` clean on all changed files (pre-existing unrelated errors on untouched lines confirmed against `main`)
- [x] New Playwright API spec tests (`PublicEventsController.api.spec.js`, `CalendarFeedController.api.spec.js`) covering: address fallback, no-location omission, and external/online-event location — all pass
- [x] Full existing API + JS test suites pass (one pre-existing, unrelated flaky test reproduced identically on `main`)

Closes #1173
