### PR TITLE
Let subscribers opt out of just the weekly events summary

### DIFF
--- a/fair-audience/__tests__/Services/RecipientResolverTest.php
+++ b/fair-audience/__tests__/Services/RecipientResolverTest.php
@@ -22,14 +22,16 @@ class RecipientResolverTest extends TestCase {
 	/**
 	 * Build a participant with the given email_profile/status.
 	 *
-	 * @param string $email_profile 'minimal' | 'marketing' | 'declined'.
-	 * @param string $status        'pending' | 'confirmed'.
+	 * @param string $email_profile          'minimal' | 'marketing' | 'declined'.
+	 * @param string $status                 'pending' | 'confirmed'.
+	 * @param bool   $weekly_summary_opt_out Whether the participant opted out of the weekly summary.
 	 * @return Participant
 	 */
-	private function participant( $email_profile, $status ) {
-		$participant                = new Participant();
-		$participant->email_profile = $email_profile;
-		$participant->status        = $status;
+	private function participant( $email_profile, $status, $weekly_summary_opt_out = false ) {
+		$participant                         = new Participant();
+		$participant->email_profile          = $email_profile;
+		$participant->status                 = $status;
+		$participant->weekly_summary_opt_out = $weekly_summary_opt_out ? 1 : 0;
 		return $participant;
 	}
 
@@ -84,6 +86,50 @@ class RecipientResolverTest extends TestCase {
 		$resolver = new RecipientResolver();
 		$this->assertFalse(
 			$resolver->can_receive_email( $this->participant( 'declined', 'confirmed' ), EmailType::MARKETING )
+		);
+	}
+
+	/**
+	 * A confirmed marketing subscriber who has not opted out receives the
+	 * weekly summary.
+	 */
+	public function test_marketing_confirmed_not_opted_out_can_receive_weekly_summary() {
+		$resolver = new RecipientResolver();
+		$this->assertTrue(
+			$resolver->can_receive_email( $this->participant( 'marketing', 'confirmed', false ), EmailType::WEEKLY_SUMMARY )
+		);
+	}
+
+	/**
+	 * A confirmed marketing subscriber who opted out of just the summary
+	 * cannot receive it.
+	 */
+	public function test_marketing_confirmed_opted_out_cannot_receive_weekly_summary() {
+		$resolver = new RecipientResolver();
+		$this->assertFalse(
+			$resolver->can_receive_email( $this->participant( 'marketing', 'confirmed', true ), EmailType::WEEKLY_SUMMARY )
+		);
+	}
+
+	/**
+	 * A summary opt-out is scoped to the summary only — the same participant
+	 * still receives other marketing sends.
+	 */
+	public function test_weekly_summary_opt_out_does_not_affect_marketing() {
+		$resolver    = new RecipientResolver();
+		$participant = $this->participant( 'marketing', 'confirmed', true );
+		$this->assertTrue( $resolver->can_receive_email( $participant, EmailType::MARKETING ) );
+		$this->assertFalse( $resolver->can_receive_email( $participant, EmailType::WEEKLY_SUMMARY ) );
+	}
+
+	/**
+	 * A minimal-profile participant never receives the weekly summary,
+	 * regardless of the opt-out flag.
+	 */
+	public function test_minimal_profile_cannot_receive_weekly_summary() {
+		$resolver = new RecipientResolver();
+		$this->assertFalse(
+			$resolver->can_receive_email( $this->participant( 'minimal', 'confirmed', false ), EmailType::WEEKLY_SUMMARY )
 		);
 	}
 }

--- a/fair-audience/e2e/manage-subscription-weekly-summary.spec.js
+++ b/fair-audience/e2e/manage-subscription-weekly-summary.spec.js
@@ -1,0 +1,175 @@
+/**
+ * E2E test for the weekly-summary opt-out preference on the public
+ * manage-subscription page (#1157).
+ *
+ * Exercises the real save flow: navigates to the tokenized manage-subscription
+ * URL as an anonymous visitor, unchecks the "Weekly summary of upcoming
+ * events" checkbox, and submits the form — then verifies the stored
+ * preference via the admin REST API while the email_profile stays
+ * unaffected. Fixtures (participant, weekly-digest config) are created via
+ * the admin REST API using Application Password credentials
+ * (WP_ADMIN_USER / WP_ADMIN_PASSWORD) and torn down at the end of the suite.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+test.describe('Manage-subscription page — weekly summary opt-out', () => {
+	let api;
+	let participantId;
+	let subscriptionUrl;
+	let originalDigestConfig;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		// Save the original weekly-digest config and enable the feature so the
+		// preference is shown on the manage page.
+		const configRes = await api.get(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{ headers: authHeaders }
+		);
+		if (configRes.ok()) {
+			originalDigestConfig = (await configRes.json()).config;
+		}
+		const enableRes = await api.put(
+			'/wp-json/fair-audience/v1/weekly-digest',
+			{ headers: authHeaders, data: { enabled: true } }
+		);
+		expect(enableRes.ok()).toBeTruthy();
+
+		// A confirmed marketing subscriber so the checkbox renders checked and
+		// enabled by default.
+		const createRes = await api.post(
+			'/wp-json/fair-audience/v1/participants',
+			{
+				headers: authHeaders,
+				data: {
+					name: 'Weekly Summary Opt-out Test',
+					email: uniqueEmail('weekly-summary'),
+					email_profile: 'marketing',
+				},
+			}
+		);
+		expect(createRes.ok()).toBeTruthy();
+		participantId = (await createRes.json()).id;
+
+		const urlRes = await api.get(
+			`/wp-json/fair-audience/v1/participants/${participantId}/subscription-url`,
+			{ headers: authHeaders }
+		);
+		expect(urlRes.ok()).toBeTruthy();
+		subscriptionUrl = (await urlRes.json()).url;
+	});
+
+	test.afterAll(async () => {
+		if (participantId) {
+			await api.delete(
+				`/wp-json/fair-audience/v1/participants/${participantId}`,
+				{ headers: authHeaders }
+			);
+		}
+		if (originalDigestConfig) {
+			await api.put('/wp-json/fair-audience/v1/weekly-digest', {
+				headers: authHeaders,
+				data: originalDigestConfig,
+			});
+		}
+		await api.dispose();
+	});
+
+	test('unchecking and saving persists the opt-out without touching email_profile', async ({
+		page,
+	}) => {
+		await page.goto(subscriptionUrl);
+
+		const summaryCheckbox = page.locator('#fair-audience-weekly-summary');
+		await expect(summaryCheckbox).toBeVisible();
+		await expect(summaryCheckbox).toBeChecked();
+		await expect(summaryCheckbox).toBeEnabled();
+
+		await summaryCheckbox.uncheck();
+		await page.click('.fair-audience-subscription-submit');
+
+		await expect(
+			page.locator('.fair-audience-subscription-message.success')
+		).toBeVisible();
+
+		const afterUncheck = page.locator('#fair-audience-weekly-summary');
+		await expect(afterUncheck).not.toBeChecked();
+
+		const getRes = await api.get(
+			`/wp-json/fair-audience/v1/participants/${participantId}`,
+			{ headers: authHeaders }
+		);
+		expect(getRes.ok()).toBeTruthy();
+		const participant = await getRes.json();
+		expect(participant.email_profile).toBe('marketing');
+		expect(participant.weekly_summary_opt_out).toBe(true);
+
+		// Re-checking and saving re-subscribes them to the summary.
+		await page.goto(subscriptionUrl);
+		const recheckCheckbox = page.locator('#fair-audience-weekly-summary');
+		await recheckCheckbox.check();
+		await page.click('.fair-audience-subscription-submit');
+		await expect(
+			page.locator('.fair-audience-subscription-message.success')
+		).toBeVisible();
+
+		const getResAfter = await api.get(
+			`/wp-json/fair-audience/v1/participants/${participantId}`,
+			{ headers: authHeaders }
+		);
+		const participantAfter = await getResAfter.json();
+		expect(participantAfter.weekly_summary_opt_out).toBe(false);
+	});
+
+	test('preference is hidden for a minimal-profile subscriber', async ({
+		page,
+	}) => {
+		const minimalRes = await api.post(
+			'/wp-json/fair-audience/v1/participants',
+			{
+				headers: authHeaders,
+				data: {
+					name: 'Minimal Profile Test',
+					email: uniqueEmail('minimal-profile'),
+					email_profile: 'minimal',
+				},
+			}
+		);
+		expect(minimalRes.ok()).toBeTruthy();
+		const minimalId = (await minimalRes.json()).id;
+
+		const urlRes = await api.get(
+			`/wp-json/fair-audience/v1/participants/${minimalId}/subscription-url`,
+			{ headers: authHeaders }
+		);
+		const minimalUrl = (await urlRes.json()).url;
+
+		await page.goto(minimalUrl);
+		await expect(
+			page.locator('#fair-audience-weekly-summary-wrap')
+		).toBeHidden();
+
+		await api.delete(
+			`/wp-json/fair-audience/v1/participants/${minimalId}`,
+			{ headers: authHeaders }
+		);
+	});
+});

--- a/fair-audience/fair-audience.php
+++ b/fair-audience/fair-audience.php
@@ -67,7 +67,7 @@ function fair_audience_activate() {
 	dbDelta( \FairAudience\Database\Schema::get_event_participant_transactions_table_sql() );
 
 	// Update database version.
-	update_option( 'fair_audience_db_version', '1.40.0' );
+	update_option( 'fair_audience_db_version', '1.41.0' );
 
 	// Link any existing fair_events_signups rows to participants by email —
 	// the fair-events migration that adds participant_id may already have
@@ -770,6 +770,21 @@ function fair_audience_maybe_upgrade_db() {
 		\FairAudience\Hooks\SignupHookBridge::backfill_signup_participant_ids();
 
 		update_option( 'fair_audience_db_version', '1.40.0' );
+	}
+
+	if ( version_compare( $db_version, '1.41.0', '<' ) ) {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'fair_audience_participants';
+
+		// DEFAULT 0 means absence = opted in, so existing subscribers keep
+		// receiving the weekly summary until they explicitly opt out.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$wpdb->query(
+			"ALTER TABLE {$table_name}
+			 ADD COLUMN IF NOT EXISTS weekly_summary_opt_out TINYINT(1) NOT NULL DEFAULT 0 AFTER email_profile"
+		);
+
+		update_option( 'fair_audience_db_version', '1.41.0' );
 	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_audience_maybe_upgrade_db' );

--- a/fair-audience/src/API/ParticipantsController.php
+++ b/fair-audience/src/API/ParticipantsController.php
@@ -844,18 +844,19 @@ class ParticipantsController extends WP_REST_Controller {
 		}
 
 		return array(
-			'id'            => $participant->id,
-			'name'          => $participant->name,
-			'surname'       => $participant->surname,
-			'email'         => $participant->email,
-			'phone'         => $participant->phone,
-			'instagram'     => $participant->instagram,
-			'email_profile' => $participant->email_profile,
-			'status'        => $participant->status,
-			'wp_user_id'    => $participant->wp_user_id,
-			'wp_user'       => $wp_user,
-			'created_at'    => $participant->created_at,
-			'updated_at'    => $participant->updated_at,
+			'id'                     => $participant->id,
+			'name'                   => $participant->name,
+			'surname'                => $participant->surname,
+			'email'                  => $participant->email,
+			'phone'                  => $participant->phone,
+			'instagram'              => $participant->instagram,
+			'email_profile'          => $participant->email_profile,
+			'weekly_summary_opt_out' => (bool) $participant->weekly_summary_opt_out,
+			'status'                 => $participant->status,
+			'wp_user_id'             => $participant->wp_user_id,
+			'wp_user'                => $wp_user,
+			'created_at'             => $participant->created_at,
+			'updated_at'             => $participant->updated_at,
 		);
 	}
 

--- a/fair-audience/src/Database/Schema.php
+++ b/fair-audience/src/Database/Schema.php
@@ -33,6 +33,7 @@ class Schema {
 			phone VARCHAR(50) DEFAULT '',
 			instagram VARCHAR(255) DEFAULT '' COMMENT 'Instagram handle without @',
 			email_profile ENUM('minimal', 'marketing', 'declined') NOT NULL DEFAULT 'minimal',
+			weekly_summary_opt_out TINYINT(1) NOT NULL DEFAULT 0,
 			status ENUM('pending', 'confirmed') NOT NULL DEFAULT 'confirmed',
 			wp_user_id BIGINT UNSIGNED DEFAULT NULL,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/fair-audience/src/Hooks/WeeklyDigestHooks.php
+++ b/fair-audience/src/Hooks/WeeklyDigestHooks.php
@@ -12,6 +12,7 @@
 namespace FairAudience\Hooks;
 
 use FairAudience\Services\EmailService;
+use FairAudience\Services\EmailType;
 use FairAudience\Services\WeeklyDigestRenderer;
 
 defined( 'WPINC' ) || die;
@@ -156,7 +157,7 @@ class WeeklyDigestHooks {
 			$html    = WeeklyDigestRenderer::render( $week, $config['intro'], $config['outro'] );
 
 			$email_service = new EmailService();
-			$results       = $email_service->send_bulk_custom_mail_to_all( $subject, $html, true );
+			$results       = $email_service->send_bulk_custom_mail_to_all( $subject, $html, true, array(), array(), EmailType::WEEKLY_SUMMARY );
 
 			self::record_result(
 				'sent',

--- a/fair-audience/src/Models/Participant.php
+++ b/fair-audience/src/Models/Participant.php
@@ -64,6 +64,16 @@ class Participant {
 	public $email_profile;
 
 	/**
+	 * Whether the participant opted out of the weekly events summary.
+	 *
+	 * Independent of email_profile: a marketing subscriber can still opt out
+	 * of just the summary while remaining reachable by other marketing sends.
+	 *
+	 * @var bool
+	 */
+	public $weekly_summary_opt_out;
+
+	/**
 	 * Subscription status (pending or confirmed).
 	 *
 	 * @var string
@@ -108,17 +118,18 @@ class Participant {
 	 * @param array $data Data array.
 	 */
 	public function populate( $data ) {
-		$this->id            = isset( $data['id'] ) ? (int) $data['id'] : null;
-		$this->name          = isset( $data['name'] ) ? sanitize_text_field( $data['name'] ) : '';
-		$this->surname       = isset( $data['surname'] ) ? sanitize_text_field( $data['surname'] ) : '';
-		$this->email         = isset( $data['email'] ) ? sanitize_email( $data['email'] ) : '';
-		$this->phone         = isset( $data['phone'] ) ? sanitize_text_field( $data['phone'] ) : '';
-		$this->instagram     = isset( $data['instagram'] ) ? sanitize_text_field( $data['instagram'] ) : '';
-		$this->email_profile = isset( $data['email_profile'] ) ? $data['email_profile'] : 'minimal';
-		$this->status        = isset( $data['status'] ) ? $data['status'] : 'confirmed';
-		$this->wp_user_id    = isset( $data['wp_user_id'] ) && $data['wp_user_id'] ? (int) $data['wp_user_id'] : null;
-		$this->created_at    = isset( $data['created_at'] ) ? $data['created_at'] : '';
-		$this->updated_at    = isset( $data['updated_at'] ) ? $data['updated_at'] : '';
+		$this->id                     = isset( $data['id'] ) ? (int) $data['id'] : null;
+		$this->name                   = isset( $data['name'] ) ? sanitize_text_field( $data['name'] ) : '';
+		$this->surname                = isset( $data['surname'] ) ? sanitize_text_field( $data['surname'] ) : '';
+		$this->email                  = isset( $data['email'] ) ? sanitize_email( $data['email'] ) : '';
+		$this->phone                  = isset( $data['phone'] ) ? sanitize_text_field( $data['phone'] ) : '';
+		$this->instagram              = isset( $data['instagram'] ) ? sanitize_text_field( $data['instagram'] ) : '';
+		$this->email_profile          = isset( $data['email_profile'] ) ? $data['email_profile'] : 'minimal';
+		$this->weekly_summary_opt_out = isset( $data['weekly_summary_opt_out'] ) ? (int) $data['weekly_summary_opt_out'] : 0;
+		$this->status                 = isset( $data['status'] ) ? $data['status'] : 'confirmed';
+		$this->wp_user_id             = isset( $data['wp_user_id'] ) && $data['wp_user_id'] ? (int) $data['wp_user_id'] : null;
+		$this->created_at             = isset( $data['created_at'] ) ? $data['created_at'] : '';
+		$this->updated_at             = isset( $data['updated_at'] ) ? $data['updated_at'] : '';
 	}
 
 	/**
@@ -155,13 +166,14 @@ class Participant {
 
 		if ( $this->id ) {
 			// Update existing - use raw query to properly handle NULL values.
-			$sql  = "UPDATE {$table_name} SET name = %s, surname = %s, phone = %s, instagram = %s, email_profile = %s, status = %s, {$email_sql}, {$wp_user_id_sql} WHERE id = %d";
+			$sql  = "UPDATE {$table_name} SET name = %s, surname = %s, phone = %s, instagram = %s, email_profile = %s, weekly_summary_opt_out = %d, status = %s, {$email_sql}, {$wp_user_id_sql} WHERE id = %d";
 			$args = array(
 				$this->name,
 				$this->surname,
 				$this->phone,
 				$this->instagram,
 				$this->email_profile,
+				(int) $this->weekly_summary_opt_out,
 				$this->status,
 			);
 			if ( null !== $email ) {
@@ -179,13 +191,14 @@ class Participant {
 			$email_col      = null === $email ? 'NULL' : '%s';
 			$wp_user_id_col = null === $this->wp_user_id ? 'NULL' : '%d';
 
-			$sql  = "INSERT INTO {$table_name} (name, surname, phone, instagram, email_profile, status, email, wp_user_id) VALUES (%s, %s, %s, %s, %s, %s, {$email_col}, {$wp_user_id_col})";
+			$sql  = "INSERT INTO {$table_name} (name, surname, phone, instagram, email_profile, weekly_summary_opt_out, status, email, wp_user_id) VALUES (%s, %s, %s, %s, %s, %d, %s, {$email_col}, {$wp_user_id_col})";
 			$args = array(
 				$this->name,
 				$this->surname,
 				$this->phone,
 				$this->instagram,
 				$this->email_profile,
+				(int) $this->weekly_summary_opt_out,
 				$this->status,
 			);
 			if ( null !== $email ) {
@@ -236,13 +249,14 @@ class Participant {
 			return false;
 		}
 
-		$this->name          = 'Deleted';
-		$this->surname       = '';
-		$this->email         = '';
-		$this->phone         = '';
-		$this->instagram     = '';
-		$this->email_profile = 'minimal';
-		$this->wp_user_id    = null;
+		$this->name                   = 'Deleted';
+		$this->surname                = '';
+		$this->email                  = '';
+		$this->phone                  = '';
+		$this->instagram              = '';
+		$this->email_profile          = 'minimal';
+		$this->weekly_summary_opt_out = 0;
+		$this->wp_user_id             = null;
 
 		return $this->save();
 	}

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -144,12 +144,22 @@ class EmailService {
 	 * Human-readable reason a participant was skipped for a marketing send.
 	 *
 	 * @param Participant $participant The skipped participant.
+	 * @param string      $email_type  The email type being sent (EmailType::MARKETING or EmailType::WEEKLY_SUMMARY).
 	 * @return string Skip reason.
 	 */
-	private function marketing_skip_reason( Participant $participant ): string {
+	private function marketing_skip_reason( Participant $participant, string $email_type = EmailType::MARKETING ): string {
 		if ( 'marketing' === $participant->email_profile && 'pending' === $participant->status ) {
 			return __( 'Participant has not yet confirmed their marketing subscription.', 'fair-audience' );
 		}
+
+		if ( EmailType::WEEKLY_SUMMARY === $email_type
+			&& 'marketing' === $participant->email_profile
+			&& 'confirmed' === $participant->status
+			&& $participant->weekly_summary_opt_out
+		) {
+			return __( 'Opted out of the weekly summary.', 'fair-audience' );
+		}
+
 		return __( 'Participant opted out of marketing emails.', 'fair-audience' );
 	}
 
@@ -1581,9 +1591,11 @@ class EmailService {
 	 * @param string $content      Email content (HTML).
 	 * @param bool   $is_marketing         Whether to filter by marketing consent.
 	 * @param array  $skip_participant_ids  Participant IDs to skip.
+	 * @param array  $group_ids    Group IDs to filter by.
+	 * @param string $email_type   EmailType constant used for the consent check (defaults to MARKETING).
 	 * @return array Results array with 'sent', 'failed', and 'skipped' keys.
 	 */
-	public function send_bulk_custom_mail_to_all( $subject, $content, $is_marketing = true, $skip_participant_ids = array(), $group_ids = array() ) {
+	public function send_bulk_custom_mail_to_all( $subject, $content, $is_marketing = true, $skip_participant_ids = array(), $group_ids = array(), $email_type = EmailType::MARKETING ) {
 		// Increase time limit for bulk sending.
 		set_time_limit( 300 ); // 5 minutes.
 
@@ -1622,11 +1634,11 @@ class EmailService {
 			}
 
 			// Check marketing consent if needed.
-			if ( $is_marketing && ! $this->can_receive_email( $participant, EmailType::MARKETING ) ) {
+			if ( $is_marketing && ! $this->can_receive_email( $participant, $email_type ) ) {
 				$results['skipped'][] = array(
 					'name'   => $participant->name,
 					'email'  => $participant->email,
-					'reason' => $this->marketing_skip_reason( $participant ),
+					'reason' => $this->marketing_skip_reason( $participant, $email_type ),
 				);
 				continue;
 			}

--- a/fair-audience/src/Services/EmailType.php
+++ b/fair-audience/src/Services/EmailType.php
@@ -16,8 +16,13 @@ defined( 'WPINC' ) || die;
  *   (gallery invitations, poll invitations, confirmation emails, signup links)
  * - MARKETING: Promotional emails for events the participant hasn't signed up for
  *   (event invitations)
+ * - WEEKLY_SUMMARY: The recurring weekly events digest. A subset of marketing
+ *   sends: requires marketing consent like MARKETING, but is additionally
+ *   gated by the participant's per-summary opt-out so they can stay on
+ *   marketing mailings while skipping just the digest.
  */
 class EmailType {
-	const MINIMAL   = 'minimal';
-	const MARKETING = 'marketing';
+	const MINIMAL        = 'minimal';
+	const MARKETING      = 'marketing';
+	const WEEKLY_SUMMARY = 'weekly_summary';
 }

--- a/fair-audience/src/Services/RecipientResolver.php
+++ b/fair-audience/src/Services/RecipientResolver.php
@@ -240,7 +240,7 @@ class RecipientResolver {
 	 * Check if a participant can receive a specific type of email.
 	 *
 	 * @param Participant $participant The participant to check.
-	 * @param string      $email_type  EmailType::MINIMAL or EmailType::MARKETING.
+	 * @param string      $email_type  EmailType::MINIMAL, EmailType::MARKETING, or EmailType::WEEKLY_SUMMARY.
 	 * @return bool True if the participant can receive the email.
 	 */
 	public function can_receive_email( Participant $participant, string $email_type ): bool {
@@ -248,8 +248,14 @@ class RecipientResolver {
 			return true;
 		}
 
-		return 'marketing' === $participant->email_profile
+		$has_marketing_consent = 'marketing' === $participant->email_profile
 			&& 'confirmed' === $participant->status;
+
+		if ( EmailType::WEEKLY_SUMMARY === $email_type ) {
+			return $has_marketing_consent && ! $participant->weekly_summary_opt_out;
+		}
+
+		return $has_marketing_consent;
 	}
 
 	/**

--- a/fair-audience/templates/manage-subscription.php
+++ b/fair-audience/templates/manage-subscription.php
@@ -64,6 +64,12 @@ if ( false === $participant_id ) {
 			if ( in_array( $new_profile, array( 'minimal', 'marketing' ), true ) ) {
 				$participant->email_profile = $new_profile;
 
+				$weekly_digest_config = get_option( 'fair_audience_weekly_digest', array() );
+				if ( ! empty( $weekly_digest_config['enabled'] ) && 'marketing' === $new_profile ) {
+					// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Public form, token provides auth.
+					$participant->weekly_summary_opt_out = isset( $_POST['weekly_summary'] ) ? 0 : 1;
+				}
+
 				if ( $participant->save() ) {
 					// Save category preferences.
 					// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Public form, token provides auth.
@@ -81,10 +87,14 @@ if ( false === $participant_id ) {
 	}
 }
 
+// Whether the weekly summary preference should be shown at all.
+$weekly_digest_option = get_option( 'fair_audience_weekly_digest', array() );
+$weekly_enabled       = ! empty( $weekly_digest_option['enabled'] );
+
 // Load mailing categories for display.
-$mailing_category_ids  = get_option( 'fair_audience_mailing_category_ids', array() );
-$mailing_categories    = array();
-$participant_cat_ids   = array();
+$mailing_category_ids = get_option( 'fair_audience_mailing_category_ids', array() );
+$mailing_categories   = array();
+$participant_cat_ids  = array();
 
 if ( ! empty( $mailing_category_ids ) && $result['success'] ) {
 	$mailing_categories = get_terms(
@@ -242,6 +252,10 @@ $site_name_header = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES
 		text-decoration: underline;
 	}
 
+	.fair-audience-subscription-weekly-summary {
+		margin: -8px 0 24px 44px;
+	}
+
 	.fair-audience-subscription-categories {
 		margin-bottom: 24px;
 		padding: 16px;
@@ -378,6 +392,25 @@ $site_name_header = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES
 						</label>
 					</div>
 
+					<?php if ( $weekly_enabled ) : ?>
+						<div
+							class="fair-audience-subscription-weekly-summary"
+							id="fair-audience-weekly-summary-wrap"
+							<?php echo 'marketing' !== $result['participant']->email_profile ? 'style="display:none;"' : ''; ?>
+						>
+							<label class="fair-audience-subscription-category-label">
+								<input
+									type="checkbox"
+									name="weekly_summary"
+									id="fair-audience-weekly-summary"
+									<?php checked( empty( $result['participant']->weekly_summary_opt_out ) ); ?>
+									<?php disabled( 'marketing' !== $result['participant']->email_profile ); ?>
+								/>
+								<?php echo esc_html__( 'Weekly summary of upcoming events', 'fair-audience' ); ?>
+							</label>
+						</div>
+					<?php endif; ?>
+
 					<?php if ( ! empty( $mailing_categories ) ) : ?>
 						<div class="fair-audience-subscription-categories">
 							<h2 class="fair-audience-subscription-categories-title">
@@ -436,6 +469,20 @@ $site_name_header = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES
 <script>
 	document.addEventListener('DOMContentLoaded', function() {
 		var options = document.querySelectorAll('.fair-audience-subscription-option');
+		var weeklySummaryWrap = document.getElementById('fair-audience-weekly-summary-wrap');
+		var weeklySummaryInput = document.getElementById('fair-audience-weekly-summary');
+
+		function updateWeeklySummaryVisibility(profile) {
+			if (!weeklySummaryWrap) {
+				return;
+			}
+			var isMarketing = 'marketing' === profile;
+			weeklySummaryWrap.style.display = isMarketing ? '' : 'none';
+			if (weeklySummaryInput) {
+				weeklySummaryInput.disabled = !isMarketing;
+			}
+		}
+
 		options.forEach(function(option) {
 			var radio = option.querySelector('input[type="radio"]');
 			radio.addEventListener('change', function() {
@@ -444,6 +491,7 @@ $site_name_header = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES
 				});
 				if (radio.checked) {
 					option.classList.add('selected');
+					updateWeeklySummaryVisibility(radio.value);
 				}
 			});
 		});


### PR DESCRIPTION
## Summary

- Adds a `weekly_summary_opt_out` flag on `Participant`, independent of `email_profile` and topic categories, so a marketing subscriber can decline just the weekly events summary while staying reachable for invitations, photos, and polls.
- `RecipientResolver::can_receive_email()` and `EmailService` gain `EmailType::WEEKLY_SUMMARY`, which layers the opt-out on top of the existing marketing-consent check; `WeeklyDigestHooks::dispatch()` now sends with that type so opted-out subscribers land in the existing skipped-count/reason reporting.
- The manage-subscription page shows a "Weekly summary of upcoming events" checkbox (default: checked) under the "All emails" option, only when the site has the weekly digest feature enabled, and only enabled/visible while that option is selected.
- Existing subscribers with no stored preference keep receiving the summary — the new column defaults to opted in.

Closes #1157

## Test plan

- [x] `vendor/bin/phpunit` — full suite passes except two pre-existing, unrelated failures (`WeeklyDigestRendererTest`, missing `wpautop()` stub in this environment) present before this change too.
- [x] Added `RecipientResolverTest` cases for `EmailType::WEEKLY_SUMMARY`: consented + not opted out → can receive; consented + opted out → cannot; opt-out doesn't affect `EmailType::MARKETING`; minimal profile never receives it.
- [x] `vendor/bin/phpcs` clean on all changed files (no new findings beyond the pre-existing, already-established pattern for other `ADD COLUMN` migrations in `fair-audience.php`).
- [x] `npm run test:js` passes (25/25).
- [ ] `npm run test:e2e` (`e2e/manage-subscription-weekly-summary.spec.js`, added): exercises the real save flow — uncheck/check the box on the tokenized manage page, verify persistence via the admin REST API, and that the checkbox is hidden for a minimal-profile subscriber. **Not run in this session** — the local docker WordPress instance on :8080 is bound to a sibling worktree's `fair-audience` checkout, not this branch, so running it here wouldn't exercise this code. Please run it against an instance with this branch checked out before merging.
