### PR TITLE
Link to org-specific payment methods page in Mollie

### DIFF
--- a/fair-payments-connector/src/API/ConnectionController.php
+++ b/fair-payments-connector/src/API/ConnectionController.php
@@ -72,7 +72,11 @@ class ConnectionController extends \WP_REST_Controller {
 			);
 		}
 
-		$overview['manage_url'] = 'https://my.mollie.com/dashboard/';
+		$organization_id = get_option( 'fair_payment_organization_id', '' );
+
+		$overview['manage_url'] = $organization_id
+			? "https://my.mollie.com/dashboard/{$organization_id}/settings/payment-methods"
+			: 'https://my.mollie.com/dashboard/';
 
 		return new \WP_REST_Response( $overview, 200 );
 	}


### PR DESCRIPTION
## Summary
- The "Manage payment methods in Mollie" link on the settings connection tab pointed at the generic `https://my.mollie.com/dashboard/` root.
- It now points at the connected organization's payment methods settings page (`.../dashboard/{organization_id}/settings/payment-methods`), using the organization ID already stored at connect time (`fair_payment_organization_id`). Falls back to the dashboard root if that option is empty.

Closes #1208

## Test plan
- [x] `vendor/bin/phpcs` clean on the changed file
- [x] `npx jest src/Admin/settings/__tests__/ConnectionTab.test.jsx` passes (unaffected — mocks the API response directly)
