### PR TITLE
Make EventFeedProvider ranges open-ended, drop events-list sentinels

### DIFF
--- a/fair-events/src/Helpers/QueryHelper.php
+++ b/fair-events/src/Helpers/QueryHelper.php
@@ -11,6 +11,12 @@ defined( 'WPINC' ) || die;
 
 /**
  * Helper class for custom table queries
+ *
+ * These `posts_join`/`posts_where`/`posts_orderby` filters are the one
+ * sanctioned non-provider read path: Query Loop patterns (events-list
+ * block) drive a real WP_Query, which cannot consume the DTOs that
+ * FairEvents\Services\EventFeedProvider produces, so this joins the
+ * fair_event_dates table directly into the post query instead.
  */
 class QueryHelper {
 

--- a/fair-events/src/Helpers/SelectedOccurrence.php
+++ b/fair-events/src/Helpers/SelectedOccurrence.php
@@ -17,6 +17,14 @@ defined( 'WPINC' ) || die;
  * that specific occurrence instead of the master row. This helper validates
  * the URL-provided date (or, for legacy links, the numeric id) and falls
  * back to the default row otherwise.
+ *
+ * This is the sanctioned single-event read path for display blocks/hooks
+ * (event-info, OpenGraphHooks, AdminBarHooks) — it is not superseded by
+ * FairEvents\Services\EventFeedProvider. It deliberately returns raw
+ * EventDates rows rather than feed DTOs because those consumers need
+ * venue_id/address/rrule/occurrence_type/id (not part of the DTO shape)
+ * plus the `?event_date=` URL resolution above, which a DTO accessor
+ * would not perform.
  */
 class SelectedOccurrence {
 

--- a/fair-events/src/Services/EventFeedProvider.php
+++ b/fair-events/src/Services/EventFeedProvider.php
@@ -33,15 +33,33 @@ defined( 'WPINC' ) || die;
  * every other internal consumer (EventDates, WeeklyEventsProvider, blocks)
  * already uses. Callers that need ISO 8601 (the public REST feed) convert
  * at their own boundary via DateHelper::local_to_iso8601().
+ *
+ * `get_occurrences()` accepts `null` for an open-ended start and/or end;
+ * MIN_DATETIME/MAX_DATETIME are an internal implementation detail callers
+ * should not depend on.
  */
 class EventFeedProvider {
 
 	/**
+	 * Lower bound used when `get_occurrences()` is called with a `null` start.
+	 * A private implementation detail — callers pass `null`, not this value.
+	 */
+	const MIN_DATETIME = '1970-01-01 00:00:00';
+
+	/**
+	 * Upper bound used when `get_occurrences()` is called with a `null` end.
+	 * A private implementation detail — callers pass `null`, not this value.
+	 */
+	const MAX_DATETIME = '2099-12-31 23:59:59';
+
+	/**
 	 * Get normalized occurrence DTOs for a date range, sorted by start.
 	 *
-	 * @param string $start   Range start, naive 'Y-m-d H:i:s' site-local.
-	 * @param string $end     Range end, naive 'Y-m-d H:i:s' site-local.
-	 * @param array  $filters {
+	 * @param string|null $start   Range start, naive 'Y-m-d H:i:s' site-local,
+	 *                             or null for an open-ended (unbounded) start.
+	 * @param string|null $end     Range end, naive 'Y-m-d H:i:s' site-local,
+	 *                             or null for an open-ended (unbounded) end.
+	 * @param array       $filters {
 	 *     Optional filters.
 	 *
 	 *     @type int[]  $categories           Category term IDs (OR'd with any
@@ -56,7 +74,10 @@ class EventFeedProvider {
 	 * }
 	 * @return array[] Flat array of occurrence DTOs, sorted by 'start' ASC.
 	 */
-	public function get_occurrences( $start, $end, $filters = array() ) {
+	public function get_occurrences( $start = null, $end = null, $filters = array() ) {
+		$start = null !== $start ? $start : self::MIN_DATETIME;
+		$end   = null !== $end ? $end : self::MAX_DATETIME;
+
 		$filters = array_merge(
 			array(
 				'categories'           => array(),

--- a/fair-events/src/blocks/events-list/render.php
+++ b/fair-events/src/blocks/events-list/render.php
@@ -172,13 +172,15 @@ $is_query_loop_pattern = ( strpos( $pattern_content, '<!-- wp:query' ) !== false
 		<?php
 		// For non-Query Loop patterns, render post-linked, standalone, and
 		// external (iCal/API) occurrences from the shared feed provider.
+		// `null` bounds are open-ended; the provider resolves them
+		// internally instead of callers hardcoding sentinel dates.
 		switch ( $time_filter ) {
 			case 'upcoming':
 				$range_start = $current_time;
-				$range_end   = '2099-12-31 23:59:59';
+				$range_end   = null;
 				break;
 			case 'past':
-				$range_start = '1970-01-01 00:00:00';
+				$range_start = null;
 				$range_end   = $current_time;
 				break;
 			case 'ongoing':
@@ -187,8 +189,8 @@ $is_query_loop_pattern = ( strpos( $pattern_content, '<!-- wp:query' ) !== false
 				break;
 			case 'all':
 			default:
-				$range_start = '1970-01-01 00:00:00';
-				$range_end   = '2099-12-31 23:59:59';
+				$range_start = null;
+				$range_end   = null;
 				break;
 		}
 


### PR DESCRIPTION
## Summary

Implements the reduced-scope plan from https://github.com/marcin-wosinek/fair-event-plugins/issues/1105#issuecomment-5019055008:

- `EventFeedProvider::get_occurrences()` now accepts `null` start/end for open-ended ranges. New `MIN_DATETIME`/`MAX_DATETIME` constants coalesce `null` internally — no new query paths, just the existing local/external streams driven with resolved bounds.
- `events-list/render.php`'s non-Query-Loop branch drops the `1970-01-01`…`2099-12-31` sentinel dates in favor of `null` bounds.
- `SelectedOccurrence` and `QueryHelper` get class-doc notes documenting them as the sanctioned non-DTO read paths (single-event display reads and the Query Loop `posts_join`/`posts_where`/`posts_orderby` path, respectively).

**Deviation from the comment's plan:** Layer 3 (deleting `EventRepository::get_all()`/`get_for_dropdown()` and `EventDates::get_all()` as dead code) was skipped. Re-grepping the full monorepo (the comment's plan only checked `fair-events`/`fair-audience`) turned up live callers in `fair-events-experimental` (`MediaLibraryHooks.php`, `MediaBatchActions.php`), so these are not actually dead and removing them would break that plugin.

Refs #1105

## Test plan

- [x] `npm run test:js` — 119/119 passing (fair-events)
- [x] `./vendor/bin/phpunit` — 80/80 passing (fair-events)
- [x] `phpcs` on changed files — 0 new errors/warnings (all flagged issues are pre-existing, unrelated to this diff)
- [ ] `npm run test:api` — not run; the dev docker stack (`:8080`/`:3306`) is already occupied by another running worktree of this repo, and I didn't want to stop it without checking first. The other `get_occurrences()` callers (`PublicEventsController`, `CalendarFeedController`, `WeeklyEventsProvider`, calendar/week blocks) all pass explicit bounded ranges already, so they're unaffected by the signature change — but this should be spot-checked with `npm run test:api` before merge.
