### PR TITLE
Remove the Add-on collaborator discount ticket option

### DIFF
--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -1235,12 +1235,10 @@ class EventSignupController extends WP_REST_Controller {
 			);
 		}
 
-		$invitation_inviter_id = $this->resolve_invitation_inviter_id( $invitation_token, $event_date_id );
-
 		$line_items   = array();
 		$total_amount = 0;
 		foreach ( $new_options as $opt ) {
-			$opt_price     = $this->compute_option_price( $opt, $event_date_id, $invitation_inviter_id, $best_discount_rule );
+			$opt_price     = $this->compute_option_price( $opt, $event_date_id, $best_discount_rule );
 			$total_amount += $opt_price;
 			if ( 0.0 !== (float) $opt_price ) {
 				$line_items[] = array(
@@ -1735,53 +1733,15 @@ class EventSignupController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Resolve the inviter participant ID from a (possibly empty) invitation token.
+	 * Compute the effective price for a ticket option, applying the group
+	 * pricing rule when the buyer qualifies.
 	 *
-	 * Does not record any token use — that is handled by validate_invitation_token
-	 * for invitation-only ticket types. Here we only need to read the inviter so
-	 * we can apply the activity collaborator discount when relevant.
-	 *
-	 * @param string $invitation_token Token string from the request.
-	 * @param int    $event_date_id    Event date ID for cross-checking the token scope.
-	 * @return int|null Inviter participant ID, or null if no valid token applies.
-	 */
-	private function resolve_invitation_inviter_id( $invitation_token, $event_date_id ) {
-		if ( empty( $invitation_token ) || ! class_exists( \FairEvents\Models\InvitationToken::class ) ) {
-			return null;
-		}
-		$token = \FairEvents\Models\InvitationToken::get_by_token( $invitation_token );
-		if ( ! $token || ! $token->is_valid() ) {
-			return null;
-		}
-		if ( $event_date_id && (int) $token->event_date_id !== (int) $event_date_id ) {
-			return null;
-		}
-		return (int) $token->inviter_participant_id;
-	}
-
-	/**
-	 * Compute the effective price for a ticket option, applying activity
-	 * collaborator discount first (if eligible) and falling back to the
-	 * group pricing rule when no per-activity discount applies.
-	 *
-	 * @param object      $option                 TicketOption object.
-	 * @param int         $event_date_id          Event date ID.
-	 * @param int|null    $inviter_participant_id Inviter participant ID resolved from the invitation token.
-	 * @param object|null $best_discount_rule     Best group pricing rule for the buyer, if any.
+	 * @param object      $option              TicketOption object.
+	 * @param int         $event_date_id       Event date ID.
+	 * @param object|null $best_discount_rule  Best group pricing rule for the buyer, if any.
 	 * @return float Effective option price (>= 0 inputs assumed; may be 0).
 	 */
-	private function compute_option_price( $option, $event_date_id, $inviter_participant_id, $best_discount_rule ) {
-		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$invitation_price = \FairEventsExperimental\Services\EventSignupPricing::resolve_option_invitation_price(
-				$option,
-				$event_date_id,
-				$inviter_participant_id
-			);
-			if ( null !== $invitation_price ) {
-				return (float) $invitation_price;
-			}
-		}
-
+	private function compute_option_price( $option, $event_date_id, $best_discount_rule ) {
 		if ( class_exists( \FairEventsExperimental\Services\ActivityOptionPriceResolver::class ) ) {
 			$resolved  = \FairEventsExperimental\Services\ActivityOptionPriceResolver::resolve( $option );
 			$opt_price = null !== $resolved ? (float) $resolved : 0.0;
@@ -1914,15 +1874,12 @@ class EventSignupController extends WP_REST_Controller {
 			);
 		}
 
-		$invitation_inviter_id = $this->resolve_invitation_inviter_id( $invitation_token, $event_date_id );
-
 		// Option prices count towards the total even when there is no base price.
 		$options_total = 0;
 		foreach ( $option_items as $opt ) {
 			$options_total += $this->compute_option_price(
 				$opt,
 				$event_date_id,
-				$invitation_inviter_id,
 				$best_discount_rule
 			);
 		}
@@ -2019,7 +1976,6 @@ class EventSignupController extends WP_REST_Controller {
 			$opt_price = $this->compute_option_price(
 				$opt,
 				$event_date_id,
-				$invitation_inviter_id,
 				$best_discount_rule
 			);
 			if ( 0.0 !== $opt_price ) {

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -488,8 +488,6 @@ $ticket_options_for_display = array();
 if ( $pricing_event_date_id && class_exists( \FairEventsExperimental\Models\TicketOption::class ) ) {
 	$raw_options = \FairEventsExperimental\Models\TicketOption::get_all_by_event_date_id( (int) $pricing_event_date_id );
 
-	$invitation_inviter_id = $valid_invitation_token ? (int) $valid_invitation_token->inviter_participant_id : null;
-
 	foreach ( $raw_options as $opt ) {
 		$resolved_base = class_exists( \FairEventsExperimental\Services\ActivityOptionPriceResolver::class )
 			? \FairEventsExperimental\Services\ActivityOptionPriceResolver::resolve( $opt )
@@ -498,18 +496,8 @@ if ( $pricing_event_date_id && class_exists( \FairEventsExperimental\Models\Tick
 			// Derived mode with no active period / no row → option not purchasable; skip.
 			continue;
 		}
-		$opt_price        = (float) $resolved_base;
-		$invitation_price = null;
-		if ( $invitation_inviter_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$invitation_price = \FairEventsExperimental\Services\EventSignupPricing::resolve_option_invitation_price(
-				$opt,
-				(int) $pricing_event_date_id,
-				$invitation_inviter_id
-			);
-		}
-		if ( null !== $invitation_price ) {
-			$opt_price = (float) $invitation_price;
-		} elseif ( $best_discount_rule && $opt_price > 0 ) {
+		$opt_price = (float) $resolved_base;
+		if ( $best_discount_rule && $opt_price > 0 ) {
 			$opt_price = \FairEventsExperimental\Services\EventSignupPricing::apply_discount(
 				$opt_price,
 				$best_discount_rule->discount_type,

--- a/fair-events-experimental/src/Admin/manage-event/EventTickets.js
+++ b/fair-events-experimental/src/Admin/manage-event/EventTickets.js
@@ -41,7 +41,6 @@ export default function EventTickets({
 		show_ticket_type_capacity: false,
 		multiple_pricing_periods: false,
 		show_seats_per_ticket: false,
-		activity_collaborator_discount: false,
 		minimum_activities: 0,
 		show_ticket_type_minimum_activities: false,
 		activity_period_pricing: false,
@@ -393,12 +392,6 @@ export default function EventTickets({
 				name: o.name || '',
 				short_name: o.short_name || '',
 				price: o.price !== undefined ? o.price : 0,
-				discounted_price:
-					o.discounted_price !== undefined &&
-					o.discounted_price !== null &&
-					o.discounted_price !== ''
-						? o.discounted_price
-						: null,
 				capacity:
 					o.capacity !== undefined &&
 					o.capacity !== null &&
@@ -792,19 +785,14 @@ export default function EventTickets({
 			)}
 
 			<HStack spacing={2} justify="flex-end">
-				{(hasInvitationTickets ||
-					settings.activity_collaborator_discount) &&
-					manageInvitationsUrl && (
-						<Button
-							variant="secondary"
-							href={`${manageInvitationsUrl}${eventDateId}`}
-						>
-							{__(
-								'Manage Invitations',
-								'fair-events-experimental'
-							)}
-						</Button>
-					)}
+				{hasInvitationTickets && manageInvitationsUrl && (
+					<Button
+						variant="secondary"
+						href={`${manageInvitationsUrl}${eventDateId}`}
+					>
+						{__('Manage Invitations', 'fair-events-experimental')}
+					</Button>
+				)}
 				<Button
 					variant="secondary"
 					onClick={handleExport}
@@ -1989,14 +1977,6 @@ export default function EventTickets({
 														'fair-events-experimental'
 													)}
 												</th>
-												{settings.activity_collaborator_discount && (
-													<th>
-														{__(
-															'Discounted price (EUR)',
-															'fair-events-experimental'
-														)}
-													</th>
-												)}
 												<th>
 													{__(
 														'Capacity',
@@ -2145,57 +2125,6 @@ export default function EventTickets({
 																/>
 															)}
 														</td>
-														{settings.activity_collaborator_discount && (
-															<td>
-																<TextControl
-																	type="number"
-																	step="0.01"
-																	min="0"
-																	value={
-																		option.discounted_price !==
-																			null &&
-																		option.discounted_price !==
-																			undefined &&
-																		option.discounted_price !==
-																			''
-																			? String(
-																					option.discounted_price
-																			  )
-																			: ''
-																	}
-																	placeholder={__(
-																		'No discount',
-																		'fair-events-experimental'
-																	)}
-																	onChange={(
-																		v
-																	) => {
-																		const updated =
-																			[
-																				...options,
-																			];
-																		updated[
-																			index
-																		] = {
-																			...updated[
-																				index
-																			],
-																			discounted_price:
-																				v ===
-																				''
-																					? null
-																					: parseFloat(
-																							v
-																					  ),
-																		};
-																		setOptions(
-																			updated
-																		);
-																	}}
-																	__nextHasNoMarginBottom
-																/>
-															</td>
-														)}
 														<td>
 															<TextControl
 																type="number"
@@ -2339,7 +2268,6 @@ export default function EventTickets({
 											name: '',
 											short_name: '',
 											price: 0,
-											discounted_price: null,
 											capacity: null,
 											derive_price_from_sale_period: false,
 											period_prices_map: {},
@@ -2448,25 +2376,6 @@ export default function EventTickets({
 									setSettings((prev) => ({
 										...prev,
 										show_ticket_type_end_date: value,
-									}))
-								}
-							/>
-							<CheckboxControl
-								label={__(
-									'Activity collaborator discount',
-									'fair-events-experimental'
-								)}
-								help={__(
-									'Allow a discounted price on each activity option for participants invited by a collaborator linked to that activity. Adds a second price column to the activity options table and enables Manage Invitations.',
-									'fair-events-experimental'
-								)}
-								checked={
-									settings.activity_collaborator_discount
-								}
-								onChange={(value) =>
-									setSettings((prev) => ({
-										...prev,
-										activity_collaborator_discount: value,
 									}))
 								}
 							/>

--- a/fair-events-experimental/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events-experimental/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -166,3 +166,42 @@ describe('EventTickets — sliding scale toggle', () => {
 		expect(String(savedPayload.settings.sliding_scale_max)).toBe('50.25');
 	});
 });
+
+describe('EventTickets — Activity collaborator discount removed (#1139)', () => {
+	const initialDataWithOption = {
+		...emptyInitialData,
+		options: [
+			{
+				id: 5,
+				name: 'Dinner',
+				short_name: '',
+				price: 20,
+				capacity: null,
+				collaborator_ids: [],
+				period_prices: [],
+				sort_order: 0,
+			},
+		],
+	};
+
+	it('does not render the checkbox or the Discounted price column, even for a stored discount', () => {
+		renderTickets({
+			initialData: {
+				...initialDataWithOption,
+				settings: { activity_collaborator_discount: true },
+			},
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+		expect(
+			screen.queryByRole('checkbox', {
+				name: /Activity collaborator discount/i,
+			})
+		).not.toBeInTheDocument();
+
+		fireEvent.click(
+			screen.getByRole('button', { name: /Activity Options/i })
+		);
+		expect(screen.queryByText(/Discounted price/i)).not.toBeInTheDocument();
+	});
+});

--- a/fair-events-experimental/src/Services/EventSignupPricing.php
+++ b/fair-events-experimental/src/Services/EventSignupPricing.php
@@ -13,7 +13,6 @@ use FairEventsExperimental\Models\GroupPricingRule;
 use FairEvents\Models\TicketType;
 use FairEvents\Services\SignupPricing;
 use FairEvents\Services\TicketPricing;
-use FairEventsExperimental\Models\TicketOptionCollaborator;
 
 defined( 'WPINC' ) || die;
 
@@ -302,39 +301,5 @@ class EventSignupPricing {
 			return $base_price * ( 1.0 - ( $discount_value / 100.0 ) );
 		}
 		return $base_price - $discount_value;
-	}
-
-	/**
-	 * Resolve the activity-collaborator discounted price for an option.
-	 *
-	 * Returns the option's discounted_price when:
-	 * - the per-event-date setting `activity_collaborator_discount` is on,
-	 * - the option has a non-null discounted_price,
-	 * - and the given inviter participant is linked as a collaborator on that option.
-	 *
-	 * Returns null when the discount does not apply.
-	 *
-	 * @param object   $option                 TicketOption-like object exposing id and discounted_price.
-	 * @param int      $event_date_id          Event date ID the option belongs to.
-	 * @param int|null $inviter_participant_id Inviter participant ID resolved from a valid invitation token.
-	 * @return float|null Discounted price if applicable, null otherwise.
-	 */
-	public static function resolve_option_invitation_price( $option, $event_date_id, $inviter_participant_id ) {
-		if ( ! $inviter_participant_id || ! $option || ! $event_date_id ) {
-			return null;
-		}
-		if ( ! isset( $option->discounted_price ) || null === $option->discounted_price ) {
-			return null;
-		}
-		if ( '1' !== (string) EventDateSetting::get( (int) $event_date_id, 'activity_collaborator_discount' ) ) {
-			return null;
-		}
-
-		$collaborator_ids = TicketOptionCollaborator::get_participant_ids_by_option_id( (int) $option->id );
-		if ( ! in_array( (int) $inviter_participant_id, $collaborator_ids, true ) ) {
-			return null;
-		}
-
-		return (float) $option->discounted_price;
 	}
 }

--- a/fair-events/src/API/TicketsController.php
+++ b/fair-events/src/API/TicketsController.php
@@ -188,25 +188,22 @@ class TicketsController extends WP_REST_Controller {
 			$incoming_options = $body['options'] ?? array();
 			$kept_ids         = array();
 			foreach ( $incoming_options as $index => $option_data ) {
-				$name                 = sanitize_text_field( $option_data['name'] ?? '' );
-				$short_name_raw       = $option_data['short_name'] ?? null;
-				$short_name           = ( null !== $short_name_raw && '' !== $short_name_raw )
+				$name              = sanitize_text_field( $option_data['name'] ?? '' );
+				$short_name_raw    = $option_data['short_name'] ?? null;
+				$short_name        = ( null !== $short_name_raw && '' !== $short_name_raw )
 					? sanitize_text_field( $short_name_raw )
 					: null;
-				$price                = isset( $option_data['price'] ) ? (float) $option_data['price'] : 0.0;
-				$discounted_price_raw = $option_data['discounted_price'] ?? null;
-				$discounted_price     = ( null === $discounted_price_raw || '' === $discounted_price_raw )
-					? null
-					: (float) $discounted_price_raw;
-				$capacity_raw         = $option_data['capacity'] ?? null;
-				$capacity             = ( null === $capacity_raw || '' === $capacity_raw )
+				$price             = isset( $option_data['price'] ) ? (float) $option_data['price'] : 0.0;
+				$discounted_price  = null;
+				$capacity_raw      = $option_data['capacity'] ?? null;
+				$capacity          = ( null === $capacity_raw || '' === $capacity_raw )
 					? null
 					: absint( $capacity_raw );
-				$derive               = ! empty( $option_data['derive_price_from_sale_period'] );
-				$collaborator_ids     = isset( $option_data['collaborator_ids'] ) && is_array( $option_data['collaborator_ids'] )
+				$derive            = ! empty( $option_data['derive_price_from_sale_period'] );
+				$collaborator_ids  = isset( $option_data['collaborator_ids'] ) && is_array( $option_data['collaborator_ids'] )
 					? array_values( array_unique( array_filter( array_map( 'absint', $option_data['collaborator_ids'] ) ) ) )
 					: array();
-				$period_prices_raw    = isset( $option_data['period_prices'] ) && is_array( $option_data['period_prices'] )
+				$period_prices_raw = isset( $option_data['period_prices'] ) && is_array( $option_data['period_prices'] )
 					? $option_data['period_prices']
 					: array();
 				if ( '' === $name ) {
@@ -425,21 +422,18 @@ class TicketsController extends WP_REST_Controller {
 				? $body['options']
 				: array();
 			foreach ( $incoming_options as $index => $option_data ) {
-				$name                 = sanitize_text_field( $option_data['name'] ?? '' );
-				$short_name_raw       = $option_data['short_name'] ?? null;
-				$short_name           = ( null !== $short_name_raw && '' !== $short_name_raw )
+				$name             = sanitize_text_field( $option_data['name'] ?? '' );
+				$short_name_raw   = $option_data['short_name'] ?? null;
+				$short_name       = ( null !== $short_name_raw && '' !== $short_name_raw )
 					? sanitize_text_field( $short_name_raw )
 					: null;
-				$price                = isset( $option_data['price'] ) ? (float) $option_data['price'] : 0.0;
-				$discounted_price_raw = $option_data['discounted_price'] ?? null;
-				$discounted_price     = ( null === $discounted_price_raw || '' === $discounted_price_raw )
-					? null
-					: (float) $discounted_price_raw;
-				$capacity_raw         = $option_data['capacity'] ?? null;
-				$capacity             = ( null === $capacity_raw || '' === $capacity_raw )
+				$price            = isset( $option_data['price'] ) ? (float) $option_data['price'] : 0.0;
+				$discounted_price = null;
+				$capacity_raw     = $option_data['capacity'] ?? null;
+				$capacity         = ( null === $capacity_raw || '' === $capacity_raw )
 					? null
 					: absint( $capacity_raw );
-				$derive               = ! empty( $option_data['derive_price_from_sale_period'] );
+				$derive           = ! empty( $option_data['derive_price_from_sale_period'] );
 				if ( '' !== $name ) {
 					$new_id = \FairEventsExperimental\Models\TicketOption::create( $event_date_id, $name, $price, $index, $short_name, $discounted_price, $capacity, $derive );
 					if ( $new_id ) {
@@ -707,6 +701,7 @@ class TicketsController extends WP_REST_Controller {
 			'options'      => array_map(
 				function ( $o ) use ( $collaborators, $option_prices_by_option ) {
 					$data                     = $o->to_array();
+					unset( $data['discounted_price'] );
 					$data['collaborator_ids'] = $collaborators[ $o->id ] ?? array();
 					$data['period_prices']    = $option_prices_by_option[ $o->id ] ?? array();
 					return $data;

--- a/fair-events/src/API/__tests__/TicketsController.api.spec.js
+++ b/fair-events/src/API/__tests__/TicketsController.api.spec.js
@@ -395,3 +395,93 @@ test.describe('TicketsController — retired pricing-period settings (#1138)', (
 		expect(body.ticket_types?.[0]?.name).toBe('General');
 	});
 });
+
+test.describe('TicketsController — discounted_price dropped from add-on options (#1139)', () => {
+	let api;
+	let eventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Discounted-price test ${Date.now()}`,
+				start_datetime: '2030-08-01 10:00:00',
+				end_datetime: '2030-08-01 12:00:00',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		eventDateId = (await edRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (eventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+	});
+
+	test('saving an option omits discounted_price from the response', async () => {
+		const putRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [],
+					sale_periods: [],
+					prices: [],
+					settings: {},
+					options: [
+						{
+							name: 'Dinner',
+							short_name: '',
+							price: 20,
+							discounted_price: 12,
+							capacity: null,
+							collaborator_ids: [],
+						},
+					],
+				},
+			}
+		);
+		expect(putRes.ok()).toBeTruthy();
+		const body = await putRes.json();
+		expect(body.options).toHaveLength(1);
+		expect(body.options[0]).not.toHaveProperty('discounted_price');
+	});
+
+	test('importing an export that includes discounted_price succeeds and drops it', async () => {
+		const importRes = await api.post(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets/import`,
+			{
+				headers: adminHeaders,
+				data: {
+					version: 1,
+					type: 'fair-events-tickets',
+					capacity: null,
+					settings: {},
+					ticket_types: [],
+					sale_periods: [],
+					prices: [],
+					options: [
+						{
+							name: 'Dinner',
+							short_name: '',
+							price: 20,
+							discounted_price: 12,
+							capacity: null,
+							collaborator_ids: [],
+						},
+					],
+				},
+			}
+		);
+		expect(importRes.ok()).toBeTruthy();
+		const body = await importRes.json();
+		expect(body.options).toHaveLength(1);
+		expect(body.options[0]).not.toHaveProperty('discounted_price');
+	});
+});

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -55,7 +55,6 @@ export default function EventTickets({
 	const [settings, setSettings] = useState({
 		show_ticket_type_capacity: false,
 		multiple_pricing_periods: false,
-		activity_collaborator_discount: false,
 		minimum_activities: 0,
 		show_ticket_type_minimum_activities: false,
 		activity_period_pricing: false,
@@ -106,7 +105,6 @@ export default function EventTickets({
 		) ||
 		options.some((o) => {
 			if (parseFloat(o.price) > 0) return true;
-			if (parseFloat(o.discounted_price) > 0) return true;
 			return Object.values(o.period_prices_map || {}).some(
 				(v) => parseFloat(v) > 0
 			);
@@ -271,12 +269,6 @@ export default function EventTickets({
 				name: o.name || '',
 				short_name: o.short_name || '',
 				price: o.price !== undefined ? o.price : 0,
-				discounted_price:
-					o.discounted_price !== undefined &&
-					o.discounted_price !== null &&
-					o.discounted_price !== ''
-						? o.discounted_price
-						: null,
 				capacity:
 					o.capacity !== undefined &&
 					o.capacity !== null &&
@@ -919,16 +911,14 @@ export default function EventTickets({
 				>
 					{__('Save tickets', 'fair-events')}
 				</Button>
-				{(hasInvitationTickets ||
-					settings.activity_collaborator_discount) &&
-					manageInvitationsUrl && (
-						<Button
-							variant="secondary"
-							href={`${manageInvitationsUrl}${eventDateId}`}
-						>
-							{__('Manage Invitations', 'fair-events')}
-						</Button>
-					)}
+				{hasInvitationTickets && manageInvitationsUrl && (
+					<Button
+						variant="secondary"
+						href={`${manageInvitationsUrl}${eventDateId}`}
+					>
+						{__('Manage Invitations', 'fair-events')}
+					</Button>
+				)}
 			</HStack>
 			<input
 				ref={fileInputRef}
@@ -1912,19 +1902,6 @@ export default function EventTickets({
 														siteCurrency
 													)}
 												</th>
-												{settings.activity_collaborator_discount && (
-													<th>
-														{sprintf(
-															/* translators: %s: currency code */
-															__(
-																'Discounted price (%s)',
-																'fair-events'
-															),
-															siteCurrency
-														)}
-														)}
-													</th>
-												)}
 												<th>
 													{__(
 														'Capacity',
@@ -2073,57 +2050,6 @@ export default function EventTickets({
 																/>
 															)}
 														</td>
-														{settings.activity_collaborator_discount && (
-															<td>
-																<TextControl
-																	type="number"
-																	step="0.01"
-																	min="0"
-																	value={
-																		option.discounted_price !==
-																			null &&
-																		option.discounted_price !==
-																			undefined &&
-																		option.discounted_price !==
-																			''
-																			? String(
-																					option.discounted_price
-																			  )
-																			: ''
-																	}
-																	placeholder={__(
-																		'No discount',
-																		'fair-events'
-																	)}
-																	onChange={(
-																		v
-																	) => {
-																		const updated =
-																			[
-																				...options,
-																			];
-																		updated[
-																			index
-																		] = {
-																			...updated[
-																				index
-																			],
-																			discounted_price:
-																				v ===
-																				''
-																					? null
-																					: parseFloat(
-																							v
-																					  ),
-																		};
-																		setOptions(
-																			updated
-																		);
-																	}}
-																	__nextHasNoMarginBottom
-																/>
-															</td>
-														)}
 														<td>
 															<TextControl
 																type="number"
@@ -2267,7 +2193,6 @@ export default function EventTickets({
 											name: '',
 											short_name: '',
 											price: 0,
-											discounted_price: null,
 											capacity: null,
 											derive_price_from_sale_period: false,
 											period_prices_map: {},
@@ -2353,25 +2278,6 @@ export default function EventTickets({
 									setSettings((prev) => ({
 										...prev,
 										show_ticket_type_end_date: value,
-									}))
-								}
-							/>
-							<CheckboxControl
-								label={__(
-									'Add-on collaborator discount',
-									'fair-events'
-								)}
-								help={__(
-									'Allow a discounted price on each add-on for participants invited by a collaborator linked to that add-on. Adds a second price column to the add-ons table and enables Manage Invitations.',
-									'fair-events'
-								)}
-								checked={
-									settings.activity_collaborator_discount
-								}
-								onChange={(value) =>
-									setSettings((prev) => ({
-										...prev,
-										activity_collaborator_discount: value,
 									}))
 								}
 							/>

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -607,7 +607,6 @@ describe('EventTickets — payments-unavailable notice (#988, #1177)', () => {
 				name: 'Dinner',
 				short_name: '',
 				price: 20,
-				discounted_price: null,
 				capacity: null,
 				collaborator_ids: [],
 				period_prices: [],
@@ -1062,5 +1061,40 @@ describe('EventTickets — pricing an event with no stored prices (#1175)', () =
 			sale_period_index: 0,
 			price: 9,
 		});
+	});
+});
+
+describe('EventTickets — Add-on collaborator discount removed (#1139)', () => {
+	const initialDataWithOption = {
+		...initialDataWithTicketType,
+		options: [
+			{
+				id: 5,
+				name: 'Dinner',
+				short_name: '',
+				price: 20,
+				capacity: null,
+				collaborator_ids: [],
+				period_prices: [],
+				sort_order: 0,
+			},
+		],
+	};
+
+	it('does not render the checkbox or the Discounted price column, even for a stored discount', () => {
+		renderTickets({
+			initialData: {
+				...initialDataWithOption,
+				settings: { activity_collaborator_discount: true },
+			},
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		expect(
+			screen.queryByRole('checkbox', {
+				name: /Add-on collaborator discount/i,
+			})
+		).not.toBeInTheDocument();
+		expect(screen.queryByText(/Discounted price/i)).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary

- Removes the "Add-on collaborator discount" checkbox and the "Discounted price" column from the fair-events Tickets tab (and the mirrored fair-events-experimental Duplicate Event wizard), fixing a stray `)}` text artifact in the removed column header along the way.
- Stops the backend from reading/writing `discounted_price` on save/import, and drops it from the ticket-settings response and export shape. The stored column/rows are left in place for a later schema cleanup, keeping this reversible.
- The plan's grounding notes assumed the discount resolver (`EventSignupPricing::resolve_option_invitation_price()`) was dead code, but it was actually live in fair-audience's signup pricing path (`EventSignupController::compute_option_price()` and the event-signup block's `render.php`) — invited participants could still be charged a discounted add-on price. Removed those call sites too so signup always charges the regular price, matching the issue's acceptance criteria.

## Test plan

- [x] `npm run test:js` in fair-events, fair-events-experimental, fair-audience — all pass
- [x] `vendor/bin/phpcs` clean on all changed PHP files
- [x] `npm run build` in fair-events and fair-events-experimental
- [x] Added a component test asserting the checkbox/column are gone even with a stored discount, for both the fair-events and fair-events-experimental Tickets components
- [x] Added API spec coverage asserting `discounted_price` is dropped from the save/import response shape (couldn't verify these Playwright specs execute end-to-end locally — the dev environment's REST Basic Auth returns 401 for all `test:api` specs, including pre-existing ones unrelated to this change)

Closes #1139
