### PR TITLE
Drop event_participants.transaction_id, use ledger exclusively

### DIFF
--- a/e2e/mu-plugins/scripts/seed-pending-signup.php
+++ b/e2e/mu-plugins/scripts/seed-pending-signup.php
@@ -16,11 +16,12 @@
  *     one of the statuses event-signup/render.php treats as retriable: failed,
  *     canceled, expired, draft);
  *   - an event_participants row with label 'pending_payment' and a
- *     payment_expires_at an hour out (within the hold window), so
- *     event-signup/render.php's "no URL callback? look up an in-progress
- *     payment" fallback (issue #554) synthesises the retry UI even when the
- *     spec navigates straight to the plain participant-token URL, exactly as a
- *     buyer returning to the page directly (not via Mollie's redirect) would.
+ *     payment_expires_at an hour out (within the hold window), plus a ledger
+ *     row linking it to the transaction (#1113), so event-signup/render.php's
+ *     "no URL callback? look up an in-progress payment" fallback (issue #554)
+ *     synthesises the retry UI even when the spec navigates straight to the
+ *     plain participant-token URL, exactly as a buyer returning to the page
+ *     directly (not via Mollie's redirect) would.
  *
  * Prints a single `E2E_PENDING:{json}` line with the participant id,
  * transaction id, and participant token.
@@ -30,6 +31,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use FairAudience\Database\EventParticipantTransactionRepository;
 use FairAudience\Models\Participant;
 use FairAudience\Models\EventParticipant;
 use FairAudience\Services\ParticipantToken;
@@ -81,7 +83,6 @@ $event_participant = new EventParticipant(
 		'event_date_id'      => $event_date_id,
 		'participant_id'     => $participant->id,
 		'label'              => 'pending_payment',
-		'transaction_id'     => $transaction_id,
 		'ticket_type_id'     => $ticket_type_id ? $ticket_type_id : null,
 		'payment_expires_at' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 hour' ) ),
 	)
@@ -89,6 +90,9 @@ $event_participant = new EventParticipant(
 if ( ! $event_participant->save() ) {
 	WP_CLI::error( 'Failed to create event_participant row.' );
 }
+
+// The transaction↔registration link now lives solely in the ledger (#1113).
+( new EventParticipantTransactionRepository() )->record( (int) $event_participant->id, (int) $transaction_id, 'charge' );
 
 $token = ParticipantToken::generate( (int) $participant->id, $event_date_id );
 

--- a/fair-audience/fair-audience.php
+++ b/fair-audience/fair-audience.php
@@ -67,7 +67,7 @@ function fair_audience_activate() {
 	dbDelta( \FairAudience\Database\Schema::get_event_participant_transactions_table_sql() );
 
 	// Update database version.
-	update_option( 'fair_audience_db_version', '1.41.0' );
+	update_option( 'fair_audience_db_version', '1.42.0' );
 
 	// Link any existing fair_events_signups rows to participants by email —
 	// the fair-events migration that adds participant_id may already have
@@ -785,6 +785,42 @@ function fair_audience_maybe_upgrade_db() {
 		);
 
 		update_option( 'fair_audience_db_version', '1.41.0' );
+	}
+
+	if ( version_compare( $db_version, '1.42.0', '<' ) ) {
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'fair_audience_event_participants';
+
+		// event_participants.transaction_id is superseded by the
+		// fair_audience_event_participant_transactions ledger (#1112); every
+		// reader now resolves through it (#1113).
+		$has_index = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM information_schema.STATISTICS
+				 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s AND INDEX_NAME = %s',
+				$table_name,
+				'idx_transaction_id'
+			)
+		);
+		if ( $has_index ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+			$wpdb->query( "ALTER TABLE {$table_name} DROP INDEX idx_transaction_id" );
+		}
+
+		$has_column = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM information_schema.COLUMNS
+				 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s AND COLUMN_NAME = %s',
+				$table_name,
+				'transaction_id'
+			)
+		);
+		if ( $has_column ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+			$wpdb->query( "ALTER TABLE {$table_name} DROP COLUMN transaction_id" );
+		}
+
+		update_option( 'fair_audience_db_version', '1.42.0' );
 	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_audience_maybe_upgrade_db' );

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -976,7 +976,6 @@ class EventSignupController extends WP_REST_Controller {
 			if ( $existing_occ ) {
 				$existing_occ->label              = 'pending_payment';
 				$existing_occ->payment_expires_at = $expires_at;
-				$existing_occ->transaction_id     = null;
 				$existing_occ->ticket_type_id     = $ticket_type->id;
 				$existing_occ->save();
 				$ep = $existing_occ;
@@ -1037,14 +1036,8 @@ class EventSignupController extends WP_REST_Controller {
 
 		$ledger = new EventParticipantTransactionRepository();
 		foreach ( $event_participant_ids as $ep_id ) {
-			$ep = $this->event_participant_repository->get_by_id( $ep_id );
-			if ( $ep ) {
-				$ep->transaction_id = (int) $transaction_id;
-				$ep->save();
-
-				// One ledger row per occurrence row, all sharing this transaction.
-				$ledger->record( (int) $ep->id, (int) $transaction_id, 'charge' );
-			}
+			// One ledger row per occurrence row, all sharing this transaction.
+			$ledger->record( $ep_id, (int) $transaction_id, 'charge' );
 		}
 
 		$redirect_url = add_query_arg(
@@ -1936,7 +1929,6 @@ class EventSignupController extends WP_REST_Controller {
 		if ( $existing ) {
 			$existing->label              = 'pending_payment';
 			$existing->payment_expires_at = $expires_at;
-			$existing->transaction_id     = null;
 			$existing->ticket_type_id     = $ticket_type_id ?: null;
 			$existing->save();
 			$event_participant = $existing;
@@ -2018,12 +2010,9 @@ class EventSignupController extends WP_REST_Controller {
 			return $transaction_id;
 		}
 
-		$event_participant->transaction_id = (int) $transaction_id;
-		$event_participant->save();
-
 		// Record the ledger link at creation time, not just on webhook
-		// confirmation — a later attempt re-pointing this row's transaction_id
-		// column must not orphan this charge (see #1112).
+		// confirmation — a later attempt on this registration must not orphan
+		// this charge (see #1112).
 		( new EventParticipantTransactionRepository() )->record( (int) $event_participant->id, (int) $transaction_id, 'charge' );
 
 		$redirect_url = add_query_arg(
@@ -2105,18 +2094,7 @@ class EventSignupController extends WP_REST_Controller {
 		$resolved     = \FairAudience\Services\SignupPriceResolver::resolve_price_for_ticket_type( $ticket_type->id, $participant->id );
 		$series_price = null !== $resolved ? (float) $resolved : 0.0;
 
-		$ledger = new EventParticipantTransactionRepository();
-
-		// Backfill: rows created before the ledger existed only record their
-		// original charge in the row's own transaction_id column. Seed it so the
-		// difference is computed against what was actually paid.
-		// TODO (W30): now that every creation site records the ledger link
-		// up front (#1112), this seed is redundant for new rows — remove once
-		// #1113 drops event_participants.transaction_id.
-		if ( $existing->transaction_id ) {
-			$ledger->record( (int) $existing->id, (int) $existing->transaction_id, 'charge' );
-		}
-
+		$ledger   = new EventParticipantTransactionRepository();
 		$net_paid = $ledger->get_net_paid( (int) $existing->id );
 		$delta    = max( 0.0, $series_price - $net_paid );
 
@@ -2508,7 +2486,6 @@ class EventSignupController extends WP_REST_Controller {
 		if ( $event_participant ) {
 			$event_participant->label              = 'pending_payment';
 			$event_participant->payment_expires_at = $expires_at;
-			$event_participant->transaction_id     = null;
 			$event_participant->ticket_type_id     = $retry_ticket_type_id;
 			$event_participant->save();
 		} else {
@@ -2557,12 +2534,9 @@ class EventSignupController extends WP_REST_Controller {
 			return $new_transaction_id;
 		}
 
-		$event_participant->transaction_id = (int) $new_transaction_id;
-		$event_participant->save();
-
-		// Record the ledger link at creation time: this retry re-points the
-		// row's transaction_id column, so the ledger is the only place that
-		// still remembers the prior attempt's charge (see #1112).
+		// Record the ledger link at creation time: this retry accumulates a
+		// new charge alongside the prior attempt's, so the ledger is the only
+		// place that remembers each attempt (see #1112).
 		( new EventParticipantTransactionRepository() )->record( (int) $event_participant->id, (int) $new_transaction_id, 'charge' );
 
 		$redirect_url = add_query_arg(

--- a/fair-audience/src/API/ParticipantsController.php
+++ b/fair-audience/src/API/ParticipantsController.php
@@ -389,9 +389,13 @@ class ParticipantsController extends WP_REST_Controller {
 		$events        = array();
 		$relationships = $this->event_participant_repository->get_by_participant( $id );
 
-		$transaction_ids = array_filter( array_map( fn( $rel ) => (int) $rel->transaction_id, $relationships ) );
-		$statuses        = $has_payments && $transaction_ids
-			? $this->event_participant_transaction_repository->get_statuses_by_transaction_ids( array_unique( $transaction_ids ) )
+		$event_participant_ids        = array_map( fn( $rel ) => (int) $rel->id, $relationships );
+		$latest_transaction_ids_by_ep = $event_participant_ids
+			? $this->event_participant_transaction_repository->get_latest_charge_transaction_ids( $event_participant_ids )
+			: array();
+		$transaction_ids              = array_values( array_unique( array_filter( $latest_transaction_ids_by_ep ) ) );
+		$statuses                     = $has_payments && $transaction_ids
+			? $this->event_participant_transaction_repository->get_statuses_by_transaction_ids( $transaction_ids )
 			: array();
 
 		foreach ( $relationships as $rel ) {
@@ -404,7 +408,7 @@ class ParticipantsController extends WP_REST_Controller {
 				}
 			}
 
-			$transaction_id = $rel->transaction_id ? (int) $rel->transaction_id : null;
+			$transaction_id = $latest_transaction_ids_by_ep[ (int) $rel->id ] ?? null;
 
 			$events[] = array(
 				'id'                 => (int) $rel->id,

--- a/fair-audience/src/API/__tests__/ParticipantsActivityTransactionStatus.api.spec.js
+++ b/fair-audience/src/API/__tests__/ParticipantsActivityTransactionStatus.api.spec.js
@@ -4,12 +4,15 @@
  *
  * Each event entry now carries a `transaction_status` derived from the
  * matching fair-payments-connector transaction ('success' | 'pending' |
- * 'failed' | null). Seeding a real paid/pending/failed transaction requires
- * routing a signup through the Mollie flow, so — mirroring
- * TimelineController.api.spec.js — this suite covers the shape contract that
- * is reachable over HTTP: a free (no-transaction) signup must report
- * transaction_id/transaction_status as null. The paid/pending/failed status
- * mapping itself is exercised via the WP-CLI eval-file manual check
+ * 'failed' | null). Since #1113, both `transaction_id` and `transaction_status`
+ * are sourced from the event-participant transaction ledger (the latest
+ * charge per registration) rather than the removed
+ * event_participants.transaction_id column. Seeding a real paid/pending/failed
+ * transaction requires routing a signup through the Mollie flow, so —
+ * mirroring TimelineController.api.spec.js — this suite covers the shape
+ * contract that is reachable over HTTP: a free (no-transaction) signup must
+ * report transaction_id/transaction_status as null. The paid/pending/failed
+ * status mapping itself is exercised via the WP-CLI eval-file manual check
  * (TESTING.md).
  */
 

--- a/fair-audience/src/Database/EventParticipantRepository.php
+++ b/fair-audience/src/Database/EventParticipantRepository.php
@@ -407,66 +407,6 @@ class EventParticipantRepository {
 	}
 
 	/**
-	 * Find an event participant row by its fair-payments-connector transaction ID.
-	 *
-	 * @param int $transaction_id fair-payments-connector transaction ID.
-	 * @return EventParticipant|null Relationship or null.
-	 */
-	public function get_by_transaction_id( $transaction_id ) {
-		global $wpdb;
-
-		$table_name = $this->get_table_name();
-
-		$result = $wpdb->get_row(
-			$wpdb->prepare(
-				'SELECT * FROM %i WHERE transaction_id = %d LIMIT 1',
-				$table_name,
-				$transaction_id
-			),
-			ARRAY_A
-		);
-
-		return $result ? new EventParticipant( $result ) : null;
-	}
-
-	/**
-	 * Find all event participant rows sharing a fair-payments-connector
-	 * transaction ID. A 'multiple_instances' ticket-type purchase creates one
-	 * row per chosen occurrence under a single transaction; every other
-	 * signup path creates exactly one row, so this is a superset of
-	 * get_by_transaction_id() safe to use wherever "the rows this payment
-	 * covers" is needed.
-	 *
-	 * @param int $transaction_id fair-payments-connector transaction ID.
-	 * @return EventParticipant[] Relationships (empty array when none match).
-	 */
-	public function get_all_by_transaction_id( $transaction_id ) {
-		global $wpdb;
-
-		$table_name = $this->get_table_name();
-
-		$results = $wpdb->get_results(
-			$wpdb->prepare(
-				'SELECT * FROM %i WHERE transaction_id = %d',
-				$table_name,
-				$transaction_id
-			),
-			ARRAY_A
-		);
-
-		if ( empty( $results ) ) {
-			return array();
-		}
-
-		return array_map(
-			static function ( $row ) {
-				return new EventParticipant( $row );
-			},
-			$results
-		);
-	}
-
-	/**
 	 * Find an event participant row by its primary key.
 	 *
 	 * @param int $id Event participant row ID.

--- a/fair-audience/src/Database/EventParticipantTransactionRepository.php
+++ b/fair-audience/src/Database/EventParticipantTransactionRepository.php
@@ -14,11 +14,10 @@ defined( 'WPINC' ) || die;
  *
  * Links each registration (event_participant row) to every
  * fair-payments-connector transaction it accumulates — the initial charge, any
- * later upgrade charge, and, in the future, refunds. The event_participant row
- * only keeps the most recent transaction in its own transaction_id column, so
- * this table is the source of truth for payment history. Amounts and currency
- * are read by joining fair_payment_transactions (single source of truth),
- * mirroring FeePaymentTransactionRepository.
+ * later upgrade charge, and, in the future, refunds. This is the sole
+ * registration↔transaction link and the source of truth for payment history.
+ * Amounts and currency are read by joining fair_payment_transactions (single
+ * source of truth), mirroring FeePaymentTransactionRepository.
  *
  * phpcs:disable WordPress.DB.DirectDatabaseQuery
  */
@@ -159,6 +158,47 @@ class EventParticipantTransactionRepository {
 		);
 
 		return array_map( 'intval', $results );
+	}
+
+	/**
+	 * Batched lookup of the latest charge transaction per registration, keyed
+	 * by event_participant_id. Replaces the old single-value
+	 * event_participant.transaction_id column now that a registration can
+	 * accumulate multiple charges over time.
+	 *
+	 * @param array $event_participant_ids Event participant row IDs.
+	 * @return array Associative array: event_participant_id => transaction_id.
+	 */
+	public function get_latest_charge_transaction_ids( $event_participant_ids ) {
+		global $wpdb;
+
+		if ( empty( $event_participant_ids ) ) {
+			return array();
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $event_participant_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $placeholders is safely constructed.
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT event_participant_id, transaction_id, created_at FROM %i
+				 WHERE event_participant_id IN ($placeholders) AND kind = 'charge'
+				 ORDER BY created_at DESC",
+				array_merge( array( $this->get_table_name() ), array_map( 'intval', $event_participant_ids ) )
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		$latest = array();
+		foreach ( $results as $row ) {
+			$event_participant_id = (int) $row['event_participant_id'];
+			if ( ! isset( $latest[ $event_participant_id ] ) ) {
+				$latest[ $event_participant_id ] = (int) $row['transaction_id'];
+			}
+		}
+
+		return $latest;
 	}
 
 	/**

--- a/fair-audience/src/Database/Schema.php
+++ b/fair-audience/src/Database/Schema.php
@@ -66,7 +66,6 @@ class Schema {
 			participant_id BIGINT UNSIGNED NOT NULL,
 			label ENUM('interested', 'signed_up', 'collaborator', 'pending_payment') NOT NULL DEFAULT 'interested',
 			payment_expires_at DATETIME DEFAULT NULL,
-			transaction_id BIGINT UNSIGNED DEFAULT NULL,
 			ticket_type_id BIGINT UNSIGNED DEFAULT NULL,
 			attended_at DATETIME DEFAULT NULL,
 			admin_comment TEXT DEFAULT NULL,
@@ -78,7 +77,6 @@ class Schema {
 			KEY idx_event_date_id (event_date_id),
 			KEY idx_participant_id (participant_id),
 			KEY idx_label (label),
-			KEY idx_transaction_id (transaction_id),
 			KEY idx_payment_expires_at (payment_expires_at),
 			KEY idx_ticket_type_id (ticket_type_id)
 		) ENGINE=InnoDB $charset_collate;";
@@ -643,10 +641,10 @@ class Schema {
 	 * A registration (event_participant row) can accumulate more than one
 	 * fair-payments-connector transaction over its lifetime — e.g. an initial
 	 * single-instance charge followed by a series-pass upgrade charge, and, in
-	 * the future, refunds. The row's own transaction_id column only ever holds
-	 * the most recent transaction, so this ledger preserves the full history.
-	 * Amounts/currency are read by joining fair_payment_transactions (single
-	 * source of truth), mirroring FeePaymentTransactionRepository.
+	 * the future, refunds. This ledger is the sole registration↔transaction
+	 * link, preserving the full history. Amounts/currency are read by joining
+	 * fair_payment_transactions (single source of truth), mirroring
+	 * FeePaymentTransactionRepository.
 	 *
 	 * @return string SQL statement.
 	 */

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -153,8 +153,10 @@ class PaymentHooks {
 			$context['participant_url']        = admin_url( 'admin.php?page=fair-audience-participant-detail&participant_id=' . (int) $participant->id );
 		}
 
+		$ledger_repo            = new EventParticipantTransactionRepository();
+		$event_participant_ids  = $ledger_repo->get_event_participant_ids_by_transaction_id( (int) $transaction->id );
 		$event_participant_repo = new EventParticipantRepository();
-		$event_participant      = $event_participant_repo->get_by_transaction_id( (int) $transaction->id );
+		$event_participant      = $event_participant_ids ? $event_participant_repo->get_by_id( $event_participant_ids[0] ) : null;
 		if ( $event_participant ) {
 			$event = get_post( (int) $event_participant->event_id );
 			if ( $event ) {
@@ -408,9 +410,8 @@ class PaymentHooks {
 
 	/**
 	 * Resolve the event_participant row(s) a transaction was charged
-	 * against, via the ledger (source of truth) — falling back to the
-	 * mutable event_participants.transaction_id column only for rows
-	 * created before the ledger was populated at creation time (#1112).
+	 * against, via the ledger — the sole source of truth since every
+	 * creation site records to it (#1112).
 	 *
 	 * @param EventParticipantRepository            $repo           Event participant repository.
 	 * @param EventParticipantTransactionRepository $ledger         Ledger repository.
@@ -420,18 +421,14 @@ class PaymentHooks {
 	private static function resolve_event_participants_for_transaction( $repo, $ledger, $transaction_id ) {
 		$event_participant_ids = $ledger->get_event_participant_ids_by_transaction_id( $transaction_id );
 
-		if ( ! empty( $event_participant_ids ) ) {
-			$event_participants = array();
-			foreach ( $event_participant_ids as $event_participant_id ) {
-				$event_participant = $repo->get_by_id( $event_participant_id );
-				if ( $event_participant ) {
-					$event_participants[] = $event_participant;
-				}
+		$event_participants = array();
+		foreach ( $event_participant_ids as $event_participant_id ) {
+			$event_participant = $repo->get_by_id( $event_participant_id );
+			if ( $event_participant ) {
+				$event_participants[] = $event_participant;
 			}
-			return $event_participants;
 		}
-
-		return $repo->get_all_by_transaction_id( $transaction_id );
+		return $event_participants;
 	}
 
 	/**
@@ -450,11 +447,10 @@ class PaymentHooks {
 		$repo   = new EventParticipantRepository();
 		$ledger = new EventParticipantTransactionRepository();
 
-		// Resolve via the ledger (source of truth): a later attempt may have
-		// re-pointed the row's transaction_id column away from this paid
-		// transaction (see #1112). A 'multiple_instances' purchase links
-		// several rows to the same transaction; every other signup path
-		// links exactly one.
+		// Resolve via the ledger, the sole registration↔transaction link
+		// (see #1112, #1113). A 'multiple_instances' purchase links several
+		// rows to the same transaction; every other signup path links exactly
+		// one.
 		$event_participants = self::resolve_event_participants_for_transaction( $repo, $ledger, (int) $transaction->id );
 		if ( empty( $event_participants ) ) {
 			return;
@@ -470,10 +466,10 @@ class PaymentHooks {
 			$event_participant->payment_expires_at = null;
 			$event_participant->save();
 
-			// Preserve this charge in the ledger so a registration keeps its full
-			// payment history even when its transaction_id column is later
-			// overwritten (e.g. by a series-pass upgrade). Idempotent under
-			// webhook retries via the ledger's unique key.
+			// Preserve this charge in the ledger so a registration keeps its
+			// full payment history across later attempts (e.g. a series-pass
+			// upgrade). Idempotent under webhook retries via the ledger's
+			// unique key.
 			$ledger->record( (int) $event_participant->id, (int) $transaction->id, 'charge' );
 
 			if ( null === $confirmation_participant ) {
@@ -495,9 +491,8 @@ class PaymentHooks {
 	 * still holds capacity for the remainder of the original 15-minute window,
 	 * and the cleanup cron releases the slot when that hold expires (capacity
 	 * counts already filter out expired holds, so over-booking can't happen).
-	 * The transaction_id is overwritten when retry_payment creates a fresh
-	 * transaction, so keeping the failed id here doesn't block subsequent
-	 * retries.
+	 * retry_payment records a fresh ledger charge, so keeping the failed
+	 * transaction's ledger entry here doesn't block subsequent retries.
 	 *
 	 * @param object $payment     Mollie payment object.
 	 * @param object $transaction Transaction row from fair-payments-connector.
@@ -618,7 +613,6 @@ class PaymentHooks {
 
 		// Upgrade the ticket type in place.
 		$event_participant->ticket_type_id = $ticket_type_id;
-		$event_participant->transaction_id = (int) $transaction->id;
 		$event_participant->save();
 
 		// Preserve the upgrade charge alongside the original payment.

--- a/fair-audience/src/Hooks/SignupHookBridge.php
+++ b/fair-audience/src/Hooks/SignupHookBridge.php
@@ -147,10 +147,16 @@ class SignupHookBridge {
 		if ( $stamp_payment ) {
 			$relationship = $event_participant_repository->get_by_event_date_and_participant( $event_date_id, $participant->id );
 			if ( $relationship ) {
-				$relationship->transaction_id     = $transaction_id;
 				$relationship->ticket_type_id     = $ticket_type_id;
 				$relationship->payment_expires_at = gmdate( 'Y-m-d H:i:s', time() + 15 * MINUTE_IN_SECONDS );
 				$relationship->save();
+
+				// Record the ledger link at creation time, not just on webhook
+				// confirmation — mirrors EventSignupController's own creation
+				// sites (see #1112).
+				if ( $transaction_id ) {
+					( new EventParticipantTransactionRepository() )->record( (int) $relationship->id, (int) $transaction_id, 'charge' );
+				}
 			}
 		}
 

--- a/fair-audience/src/Models/EventParticipant.php
+++ b/fair-audience/src/Models/EventParticipant.php
@@ -57,13 +57,6 @@ class EventParticipant {
 	public $payment_expires_at;
 
 	/**
-	 * fair-payments-connector transaction ID, when the signup requires payment.
-	 *
-	 * @var int|null
-	 */
-	public $transaction_id;
-
-	/**
 	 * Ticket type ID from fair_events_ticket_types, when the signup was made against a specific ticket type.
 	 *
 	 * @var int|null
@@ -121,7 +114,6 @@ class EventParticipant {
 		$this->participant_id     = isset( $data['participant_id'] ) ? (int) $data['participant_id'] : 0;
 		$this->label              = isset( $data['label'] ) ? $data['label'] : 'interested';
 		$this->payment_expires_at = isset( $data['payment_expires_at'] ) && $data['payment_expires_at'] ? $data['payment_expires_at'] : null;
-		$this->transaction_id     = isset( $data['transaction_id'] ) && $data['transaction_id'] ? (int) $data['transaction_id'] : null;
 		$this->ticket_type_id     = isset( $data['ticket_type_id'] ) && $data['ticket_type_id'] ? (int) $data['ticket_type_id'] : null;
 		$this->attended_at        = isset( $data['attended_at'] ) && $data['attended_at'] ? $data['attended_at'] : null;
 		$this->admin_comment      = isset( $data['admin_comment'] ) && '' !== $data['admin_comment'] ? $data['admin_comment'] : null;
@@ -154,13 +146,12 @@ class EventParticipant {
 			'participant_id'     => $this->participant_id,
 			'label'              => $this->label,
 			'payment_expires_at' => $this->payment_expires_at,
-			'transaction_id'     => $this->transaction_id,
 			'ticket_type_id'     => $this->ticket_type_id,
 			'attended_at'        => $this->attended_at,
 			'admin_comment'      => $this->admin_comment,
 		);
 
-		$format = array( '%d', '%d', '%d', '%s', '%s', '%d', '%d', '%s', '%s' );
+		$format = array( '%d', '%d', '%d', '%s', '%s', '%d', '%s', '%s' );
 
 		if ( $this->id ) {
 			// Update existing.

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -15,6 +15,7 @@ defined( 'WPINC' ) || die;
 
 use FairAudience\Database\ParticipantRepository;
 use FairAudience\Database\EventParticipantRepository;
+use FairAudience\Database\EventParticipantTransactionRepository;
 use FairAudience\Services\AudienceSession;
 use FairAudience\Services\ParticipantToken;
 use FairEvents\Models\EventDates;
@@ -299,12 +300,18 @@ if ( $is_valid_post_type ) {
 				&& $pending_row->payment_expires_at
 				&& strtotime( $pending_row->payment_expires_at ) > time();
 
+			$candidate_tx_id = 0;
+			if ( $pending_row ) {
+				$latest_charge_transaction_ids = ( new EventParticipantTransactionRepository() )
+					->get_latest_charge_transaction_ids( array( (int) $pending_row->id ) );
+				$candidate_tx_id               = $latest_charge_transaction_ids[ (int) $pending_row->id ] ?? 0;
+			}
+
 			if ( $pending_row
 				&& 'pending_payment' === $pending_row->label
-				&& $pending_row->transaction_id
+				&& $candidate_tx_id
 				&& $within_hold
 			) {
-				$candidate_tx_id = (int) $pending_row->transaction_id;
 				if ( function_exists( 'fair_payment_sync_transaction_status' ) ) {
 					fair_payment_sync_transaction_status( $candidate_tx_id );
 				}


### PR DESCRIPTION
## Summary

Follow-up to the W29 ledger fix: `event_participants.transaction_id` was a single-value column overwritten by each new payment attempt — the exact source of the W29 lost-payment bug. Since every creation site now writes to the `fair_audience_event_participant_transactions` ledger, the column is redundant and misleading. This drops it and repoints the remaining readers.

- Added `EventParticipantTransactionRepository::get_latest_charge_transaction_ids()` — batched lookup of the latest charge per registration.
- Migrated the three remaining readers to the ledger: the resume/retry candidate in `render.php`, `PaymentHooks::enrich_notification_context()`, and `ParticipantsController::get_activity()` (shows the latest transaction's status per row).
- `PaymentHooks::resolve_event_participants_for_transaction()` drops its pre-ledger fallback — the ledger is now the sole resolution path.
- Removed every write to the column across `EventSignupController`, `PaymentHooks::handle_series_upgrade_paid()`, and the series-upgrade backfill seed.
- Found and fixed an additional writer the original plan missed: `SignupHookBridge::link_participant()` (the base fair-events signup bridge) also stamped the column — repointed it to record to the ledger at creation time instead, mirroring the other creation sites.
- Removed the now-dead `EventParticipantRepository::get_by_transaction_id()` / `get_all_by_transaction_id()`.
- Dropped the column + its index from `Schema.php` and added a versioned migration (`1.42.0`) with guarded `information_schema` checks (MySQL 8 has no `DROP COLUMN IF EXISTS`).
- Updated `EventParticipant` model (`populate()`, `save()`) accordingly.

Closes #1113

## Test plan

- [x] `npm run test:js` — 25/25 passing
- [x] `npm run build` — assets rebuilt (render.php is registered from `build/`)
- [x] `npm run format` — clean
- [x] `vendor/bin/phpcs` reviewed on all changed files — no new violations (verified line-by-line against pre-existing baseline; `fair-audience.php`'s DDL-interpolation warnings match the file's existing migration-block convention)
- [ ] `npm run test:api` / WP-CLI manual check — **not run**: the shared local Docker WP environment (ports 8080/3306) was already in use by another worktree's session mounting a different checkout, so I couldn't safely stand up an isolated instance to exercise this against. Recommend running `test:api` and the ledger-resolution manual check from `TESTING.md` before merge.
