### PR TITLE
Replace series-modal date pickers with a click-to-pick calendar

### DIFF
--- a/fair-events-shared/src/MiniCalendar.js
+++ b/fair-events-shared/src/MiniCalendar.js
@@ -1,0 +1,325 @@
+/**
+ * MiniCalendar — shared month-grid primitive.
+ *
+ * Renders a paged set of month grids between `minDate` and `maxDate`
+ * (inclusive, Y-m-d strings) and delegates every day cell to a caller-supplied
+ * `dayProps(dateStr, date)` descriptor, so callers can render read-only
+ * highlighted calendars (fair-events' RecurrenceCalendar) and click-to-toggle
+ * pickers (fair-events' SeriesModal) through the identical grid/paging code.
+ *
+ * `dayProps` may return:
+ *   - `href`                render the cell as a link (navigation)
+ *   - `interactive`         render the cell as a button (`onActivate`, `ariaPressed`)
+ *   - `background`/`color`/`opacity`/`border`/`fontWeight`/`textDecoration`
+ *   - `ariaLabel`           overrides the default full-date label
+ *   - `tooltip`             wraps the cell in a Tooltip
+ *
+ * A day with none of `href`/`interactive` renders as a plain, non-operable
+ * cell.
+ *
+ * @package FairEventsShared
+ */
+
+import { useState, useMemo, useEffect } from '@wordpress/element';
+import {
+	Button,
+	Tooltip,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	formatLocalDate,
+	getWeekdayLabels,
+	calculateLeadingDays,
+} from './calendarUtils.js';
+
+function computeMonthRange(minDate, maxDate) {
+	if (!minDate) return [];
+	const first = new Date(`${minDate}T00:00:00`);
+	const last = new Date(`${maxDate || minDate}T00:00:00`);
+	const result = [];
+	const current = new Date(first.getFullYear(), first.getMonth(), 1);
+	const end = new Date(last.getFullYear(), last.getMonth(), 1);
+	while (current <= end) {
+		result.push(new Date(current));
+		current.setMonth(current.getMonth() + 1);
+	}
+	return result;
+}
+
+export function computeVisibleMonths(width) {
+	if (width < 600) return 1;
+	if (width < 900) return 2;
+	if (width < 1200) return 3;
+	if (width < 1500) return 4;
+	return 5;
+}
+
+/**
+ * @param {Object}   props
+ * @param {string}   [props.minDate]                First date (Y-m-d) the calendar must cover.
+ * @param {string}   [props.maxDate]                 Last date (Y-m-d) the calendar must cover.
+ * @param {Function} props.dayProps                  `(dateStr, date) => descriptor` for each day cell.
+ * @param {boolean}  [props.allowForwardBeyondRange] Keep "next months" enabled past `maxDate` (for pickers).
+ */
+export default function MiniCalendar({
+	minDate,
+	maxDate,
+	dayProps,
+	allowForwardBeyondRange = false,
+}) {
+	const dataMonths = useMemo(
+		() => computeMonthRange(minDate, maxDate),
+		[minDate, maxDate]
+	);
+
+	// Lets a picker page forward past the data-derived range; reset whenever
+	// the underlying range changes so a newly-picked date that already
+	// extends the range isn't double-counted.
+	const [extraMonths, setExtraMonths] = useState(0);
+	useEffect(() => {
+		setExtraMonths(0);
+	}, [minDate, maxDate]);
+
+	const months = useMemo(() => {
+		const result = [...dataMonths];
+		let last = result.length
+			? result[result.length - 1]
+			: new Date(new Date().getFullYear(), new Date().getMonth(), 1);
+		for (let i = 0; i < extraMonths; i++) {
+			last = new Date(last.getFullYear(), last.getMonth() + 1, 1);
+			result.push(last);
+		}
+		return result;
+	}, [dataMonths, extraMonths]);
+
+	const [startIndex, setStartIndex] = useState(0);
+	const [visibleCount, setVisibleCount] = useState(() =>
+		computeVisibleMonths(
+			typeof window !== 'undefined' ? window.innerWidth : 1280
+		)
+	);
+	useEffect(() => {
+		const onResize = () =>
+			setVisibleCount(computeVisibleMonths(window.innerWidth));
+		window.addEventListener('resize', onResize);
+		return () => window.removeEventListener('resize', onResize);
+	}, []);
+
+	// Keep the current page in range when the months list shrinks (e.g. a
+	// paged-forward extension collapses back into the data-derived range).
+	useEffect(() => {
+		setStartIndex((current) =>
+			Math.min(current, Math.max(0, months.length - visibleCount))
+		);
+	}, [months.length, visibleCount]);
+
+	if (months.length === 0) return null;
+
+	const visibleMonths = months.slice(startIndex, startIndex + visibleCount);
+	const canGoBack = startIndex > 0;
+	const canGoForward =
+		allowForwardBeyondRange || startIndex + visibleCount < months.length;
+
+	const handleForward = () => {
+		if (startIndex + visibleCount < months.length) {
+			setStartIndex(
+				Math.min(months.length - 1, startIndex + visibleCount)
+			);
+		} else if (allowForwardBeyondRange) {
+			setExtraMonths((n) => n + visibleCount);
+			setStartIndex(startIndex + visibleCount);
+		}
+	};
+
+	const weekdayLabels = getWeekdayLabels(1, { weekday: 'narrow' });
+	const todayStr = formatLocalDate(new Date());
+
+	const showNav = months.length > visibleCount || allowForwardBeyondRange;
+
+	return (
+		<div>
+			{showNav && (
+				<HStack
+					alignment="center"
+					style={{ marginBottom: '12px', justifyContent: 'flex-end' }}
+				>
+					<HStack spacing={1} style={{ width: 'auto' }}>
+						<Button
+							icon="arrow-left-alt2"
+							size="small"
+							disabled={!canGoBack}
+							label={__('Previous months', 'fair-events')}
+							onClick={() =>
+								setStartIndex(
+									Math.max(0, startIndex - visibleCount)
+								)
+							}
+						/>
+						<Button
+							icon="arrow-right-alt2"
+							size="small"
+							disabled={!canGoForward}
+							label={__('Next months', 'fair-events')}
+							onClick={handleForward}
+						/>
+					</HStack>
+				</HStack>
+			)}
+			<div style={{ display: 'flex', gap: '24px', flexWrap: 'wrap' }}>
+				{visibleMonths.map((monthDate) => (
+					<MiniMonth
+						key={`${monthDate.getFullYear()}-${monthDate.getMonth()}`}
+						monthDate={monthDate}
+						weekdayLabels={weekdayLabels}
+						todayStr={todayStr}
+						dayProps={dayProps}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function MiniMonth({ monthDate, weekdayLabels, todayStr, dayProps }) {
+	const year = monthDate.getFullYear();
+	const month = monthDate.getMonth();
+	const firstDay = new Date(year, month, 1);
+	const daysInMonth = new Date(year, month + 1, 0).getDate();
+	const leadingDays = calculateLeadingDays(firstDay, 1);
+
+	const monthLabel = firstDay.toLocaleDateString(undefined, {
+		year: 'numeric',
+		month: 'long',
+	});
+
+	const cells = [];
+
+	for (let i = 0; i < leadingDays; i++) {
+		cells.push(<div key={`lead-${i}`} />);
+	}
+
+	for (let day = 1; day <= daysInMonth; day++) {
+		const date = new Date(year, month, day);
+		const dateStr = formatLocalDate(date);
+		cells.push(
+			<DayCell
+				key={dateStr}
+				date={date}
+				dateStr={dateStr}
+				day={day}
+				todayStr={todayStr}
+				dayProps={dayProps}
+			/>
+		);
+	}
+
+	return (
+		<div style={{ minWidth: '220px' }}>
+			<div
+				style={{
+					fontWeight: 600,
+					marginBottom: '8px',
+					fontSize: '13px',
+					textAlign: 'center',
+				}}
+			>
+				{monthLabel}
+			</div>
+			<div
+				style={{
+					display: 'grid',
+					gridTemplateColumns: 'repeat(7, 28px)',
+					gap: '2px',
+					justifyContent: 'center',
+				}}
+			>
+				{weekdayLabels.map((label, i) => (
+					<div
+						key={i}
+						style={{
+							textAlign: 'center',
+							fontSize: '11px',
+							color: '#757575',
+							fontWeight: 600,
+							height: '20px',
+							lineHeight: '20px',
+						}}
+					>
+						{label}
+					</div>
+				))}
+				{cells}
+			</div>
+		</div>
+	);
+}
+
+function DayCell({ date, dateStr, day, todayStr, dayProps }) {
+	const props = dayProps(dateStr, date) || {};
+	const isToday = dateStr === todayStr;
+	const fullDateLabel = date.toLocaleDateString(undefined, {
+		weekday: 'long',
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+	});
+	const ariaLabel = props.ariaLabel || fullDateLabel;
+
+	const cellStyle = {
+		width: '28px',
+		height: '28px',
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		borderRadius: '4px',
+		fontSize: '12px',
+		fontWeight: props.fontWeight ?? 400,
+		background: props.background || 'transparent',
+		color: props.color || '#1e1e1e',
+		opacity: props.opacity ?? 1,
+		border: props.border || (isToday ? '2px solid #1e1e1e' : 'none'),
+		textDecoration: props.textDecoration || 'none',
+		position: 'relative',
+	};
+
+	let cell;
+
+	if (props.href) {
+		cell = (
+			<a
+				href={props.href}
+				aria-label={ariaLabel}
+				style={{ textDecoration: 'none', cursor: 'pointer' }}
+			>
+				<div style={cellStyle}>{day}</div>
+			</a>
+		);
+	} else if (props.interactive) {
+		cell = (
+			<button
+				type="button"
+				onClick={props.onActivate}
+				disabled={!!props.disabled}
+				aria-label={ariaLabel}
+				aria-pressed={!!props.ariaPressed}
+				style={{
+					...cellStyle,
+					cursor: props.disabled ? 'default' : 'pointer',
+					padding: 0,
+					font: 'inherit',
+				}}
+			>
+				{day}
+			</button>
+		);
+	} else {
+		cell = <div style={cellStyle}>{day}</div>;
+	}
+
+	if (props.tooltip) {
+		return <Tooltip text={props.tooltip}>{cell}</Tooltip>;
+	}
+
+	return cell;
+}

--- a/fair-events-shared/src/__tests__/MiniCalendar.test.js
+++ b/fair-events-shared/src/__tests__/MiniCalendar.test.js
@@ -1,0 +1,215 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for the shared MiniCalendar month-grid/paging primitive (#1127).
+ *
+ * Covers:
+ *   - Month range derived from minDate/maxDate.
+ *   - computeVisibleMonths width breakpoints.
+ *   - Paging (Previous/Next) within a fixed range.
+ *   - allowForwardBeyondRange keeps "Next months" enabled and pages into new
+ *     months past the data-derived range.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MiniCalendar, { computeVisibleMonths } from '../MiniCalendar.js';
+
+function setViewportWidth(width) {
+	Object.defineProperty(window, 'innerWidth', {
+		writable: true,
+		configurable: true,
+		value: width,
+	});
+}
+
+// jsdom has no layout engine; @wordpress/components' HStack/Button use
+// matchMedia for responsive spacing, which jsdom doesn't implement.
+beforeAll(() => {
+	window.matchMedia =
+		window.matchMedia ||
+		function () {
+			return {
+				matches: false,
+				addListener: () => {},
+				removeListener: () => {},
+			};
+		};
+});
+
+describe('computeVisibleMonths', () => {
+	test('narrows to one month under 600px and widens with viewport', () => {
+		expect(computeVisibleMonths(320)).toBe(1);
+		expect(computeVisibleMonths(700)).toBe(2);
+		expect(computeVisibleMonths(1000)).toBe(3);
+		expect(computeVisibleMonths(1300)).toBe(4);
+		expect(computeVisibleMonths(1600)).toBe(5);
+	});
+});
+
+describe('MiniCalendar', () => {
+	beforeEach(() => {
+		setViewportWidth(1280);
+	});
+
+	test('renders nothing when there is no date range', () => {
+		const { container } = render(<MiniCalendar dayProps={() => ({})} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	test('renders a single month grid spanning the min/max range', () => {
+		render(
+			<MiniCalendar
+				minDate="2026-07-01"
+				maxDate="2026-07-20"
+				dayProps={() => ({})}
+			/>
+		);
+
+		expect(screen.getByText('July 2026')).toBeInTheDocument();
+		expect(screen.queryByText('June 2026')).not.toBeInTheDocument();
+		expect(screen.queryByText('August 2026')).not.toBeInTheDocument();
+	});
+
+	test('spans multiple months when the range crosses a month boundary', () => {
+		render(
+			<MiniCalendar
+				minDate="2026-07-25"
+				maxDate="2026-09-05"
+				dayProps={() => ({})}
+			/>
+		);
+
+		expect(screen.getByText('July 2026')).toBeInTheDocument();
+		expect(screen.getByText('August 2026')).toBeInTheDocument();
+		expect(screen.getByText('September 2026')).toBeInTheDocument();
+	});
+
+	test('pages Previous/Next through months wider than the visible count', () => {
+		setViewportWidth(320); // computeVisibleMonths -> 1
+		render(
+			<MiniCalendar
+				minDate="2026-07-25"
+				maxDate="2026-09-05"
+				dayProps={() => ({})}
+			/>
+		);
+
+		expect(screen.getByText('July 2026')).toBeInTheDocument();
+		expect(screen.getByLabelText('Previous months')).toBeDisabled();
+
+		fireEvent.click(screen.getByLabelText('Next months'));
+		expect(screen.getByText('August 2026')).toBeInTheDocument();
+		expect(screen.queryByText('July 2026')).not.toBeInTheDocument();
+		expect(screen.getByLabelText('Previous months')).not.toBeDisabled();
+
+		fireEvent.click(screen.getByLabelText('Next months'));
+		expect(screen.getByText('September 2026')).toBeInTheDocument();
+		expect(screen.getByLabelText('Next months')).toBeDisabled();
+	});
+
+	test('allowForwardBeyondRange keeps Next enabled and pages past the data range', () => {
+		setViewportWidth(320); // computeVisibleMonths -> 1
+		render(
+			<MiniCalendar
+				minDate="2026-07-01"
+				maxDate="2026-07-01"
+				dayProps={() => ({})}
+				allowForwardBeyondRange
+			/>
+		);
+
+		expect(screen.getByText('July 2026')).toBeInTheDocument();
+		const nextButton = screen.getByLabelText('Next months');
+		expect(nextButton).not.toBeDisabled();
+
+		fireEvent.click(nextButton);
+		expect(screen.getByText('August 2026')).toBeInTheDocument();
+		expect(screen.getByLabelText('Next months')).not.toBeDisabled();
+
+		fireEvent.click(screen.getByLabelText('Next months'));
+		expect(screen.getByText('September 2026')).toBeInTheDocument();
+	});
+
+	test('routes each day cell through dayProps as a link, button, or plain cell', () => {
+		const dayProps = (dateStr) => {
+			if (dateStr === '2026-07-05') {
+				return { href: '#five', ariaLabel: 'Five' };
+			}
+			if (dateStr === '2026-07-10') {
+				return {
+					interactive: true,
+					ariaPressed: true,
+					onActivate: jest.fn(),
+					ariaLabel: 'Ten',
+				};
+			}
+			return {};
+		};
+
+		render(
+			<MiniCalendar
+				minDate="2026-07-01"
+				maxDate="2026-07-01"
+				dayProps={dayProps}
+			/>
+		);
+
+		expect(screen.getByRole('link', { name: 'Five' })).toHaveAttribute(
+			'href',
+			'#five'
+		);
+		const tenButton = screen.getByRole('button', { name: 'Ten' });
+		expect(tenButton).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	test('an interactive day fires onActivate on click', () => {
+		const onActivate = jest.fn();
+		const dayProps = (dateStr) =>
+			dateStr === '2026-07-10'
+				? {
+						interactive: true,
+						ariaPressed: false,
+						onActivate,
+						ariaLabel: 'Ten',
+				  }
+				: {};
+
+		render(
+			<MiniCalendar
+				minDate="2026-07-01"
+				maxDate="2026-07-01"
+				dayProps={dayProps}
+			/>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Ten' }));
+		expect(onActivate).toHaveBeenCalledTimes(1);
+	});
+
+	test('a disabled interactive day cannot be activated', () => {
+		const onActivate = jest.fn();
+		const dayProps = (dateStr) =>
+			dateStr === '2026-07-01'
+				? {
+						interactive: true,
+						disabled: true,
+						ariaPressed: true,
+						onActivate,
+						ariaLabel: 'Master',
+				  }
+				: {};
+
+		render(
+			<MiniCalendar
+				minDate="2026-07-01"
+				maxDate="2026-07-01"
+				dayProps={dayProps}
+			/>
+		);
+
+		const masterButton = screen.getByRole('button', { name: 'Master' });
+		expect(masterButton).toBeDisabled();
+		fireEvent.click(masterButton);
+		expect(onActivate).not.toHaveBeenCalled();
+	});
+});

--- a/fair-events-shared/src/index.js
+++ b/fair-events-shared/src/index.js
@@ -13,6 +13,7 @@ export * from './dynamicDateRegistry.js';
 export { default as DateTimeControl } from './DateTimeControl.js';
 export { DurationOptions } from './DurationOptions.js';
 export { default as EventSourceSelector } from './EventSourceSelector.js';
+export { default as MiniCalendar } from './MiniCalendar.js';
 export { default as RecurrenceControl } from './RecurrenceControl.js';
 export * from './recurrence.js';
 export * from './questionnaire.js';

--- a/fair-events/src/Admin/manage-event/RecurrenceCalendar.js
+++ b/fair-events/src/Admin/manage-event/RecurrenceCalendar.js
@@ -3,26 +3,16 @@
  *
  * Simple mini-calendar showing recurring event occurrences. Every occurrence
  * and the master cell navigate to their manage-event page; cancelling and
- * restoring occurrences happens in the "Edit instances" modal instead.
+ * restoring occurrences happens in the "Edit instances" modal instead. Thin
+ * adapter over the shared `MiniCalendar` grid/paging primitive.
  *
  * @package FairEvents
  */
 
-import { useState, useMemo, useEffect } from '@wordpress/element';
-import {
-	Button,
-	Card,
-	CardHeader,
-	CardBody,
-	Tooltip,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
+import { Card, CardHeader, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {
-	formatLocalDate,
-	getWeekdayLabels,
-	calculateLeadingDays,
-} from 'fair-events-shared';
+import { MiniCalendar } from 'fair-events-shared';
 
 export default function RecurrenceCalendar({
 	generatedOccurrences,
@@ -64,102 +54,67 @@ export default function RecurrenceCalendar({
 		return dates.sort();
 	}, [occurrences, cancelledDatesList, masterDate]);
 
-	// Calculate which months to show
-	const months = useMemo(() => {
-		if (allDates.length === 0) return [];
-		const first = new Date(allDates[0] + 'T00:00:00');
-		const last = new Date(allDates[allDates.length - 1] + 'T00:00:00');
-		const result = [];
-		const current = new Date(first.getFullYear(), first.getMonth(), 1);
-		const end = new Date(last.getFullYear(), last.getMonth(), 1);
-		while (current <= end) {
-			result.push(new Date(current));
-			current.setMonth(current.getMonth() + 1);
-		}
-		return result;
-	}, [allDates]);
-
-	// Navigation state: show months in pages, sized to viewport width.
-	const [startIndex, setStartIndex] = useState(0);
-	const [visibleCount, setVisibleCount] = useState(() =>
-		computeVisibleMonths(
-			typeof window !== 'undefined' ? window.innerWidth : 1280
-		)
-	);
-	useEffect(() => {
-		const onResize = () =>
-			setVisibleCount(computeVisibleMonths(window.innerWidth));
-		window.addEventListener('resize', onResize);
-		return () => window.removeEventListener('resize', onResize);
-	}, []);
-	const visibleMonths = months.slice(startIndex, startIndex + visibleCount);
-	const canGoBack = startIndex > 0;
-	const canGoForward = startIndex + visibleCount < months.length;
-
-	const weekdayLabels = useMemo(
-		() => getWeekdayLabels(1, { weekday: 'narrow' }),
-		[]
-	);
-	const todayStr = formatLocalDate(new Date());
-
 	if (allDates.length === 0) return null;
 
-	const navControls = months.length > visibleCount && (
-		<HStack spacing={1}>
-			<Button
-				icon="arrow-left-alt2"
-				size="small"
-				disabled={!canGoBack}
-				label={__('Previous months', 'fair-events')}
-				onClick={() =>
-					setStartIndex(Math.max(0, startIndex - visibleCount))
-				}
-			/>
-			<Button
-				icon="arrow-right-alt2"
-				size="small"
-				disabled={!canGoForward}
-				label={__('Next months', 'fair-events')}
-				onClick={() =>
-					setStartIndex(
-						Math.min(months.length - 1, startIndex + visibleCount)
-					)
-				}
-			/>
-		</HStack>
-	);
+	const dayProps = (dateStr) => {
+		const occ = occurrenceByDate[dateStr];
+		const isCancelled =
+			occ?.status === 'cancelled' || cancelledSet.has(dateStr);
+		const isOccurrence = !!occ && !isCancelled;
+		const isMaster = dateStr === masterDate;
+
+		if (!isMaster && !isOccurrence && !isCancelled) {
+			return {};
+		}
+
+		let background = 'transparent';
+		let color = '#1e1e1e';
+		let opacity = 1;
+		let textDecoration = 'none';
+
+		if (isMaster) {
+			background = '#007cba';
+			color = '#fff';
+		} else if (isCancelled) {
+			background = '#cc1818';
+			color = '#fff';
+			opacity = 0.6;
+			textDecoration = 'line-through';
+		} else if (isOccurrence) {
+			background = '#4ab866';
+			color = '#fff';
+		}
+
+		const common = {
+			background,
+			color,
+			opacity,
+			textDecoration,
+			fontWeight: 600,
+		};
+
+		if (isMaster) {
+			return {
+				...common,
+				href: `${manageEventUrl}&event_date_id=${masterEventDateId}`,
+				tooltip: __('Master event', 'fair-events'),
+			};
+		}
+
+		return {
+			...common,
+			href: `${manageEventUrl}&event_date_id=${occ.id}`,
+			tooltip: __('Open this occurrence', 'fair-events'),
+		};
+	};
 
 	const calendarBody = (
 		<>
-			{navControls && (
-				<HStack
-					alignment="center"
-					style={{ marginBottom: '12px', justifyContent: 'flex-end' }}
-				>
-					{navControls}
-				</HStack>
-			)}
-			<div
-				style={{
-					display: 'flex',
-					gap: '24px',
-					flexWrap: 'wrap',
-				}}
-			>
-				{visibleMonths.map((monthDate) => (
-					<MiniMonth
-						key={`${monthDate.getFullYear()}-${monthDate.getMonth()}`}
-						monthDate={monthDate}
-						weekdayLabels={weekdayLabels}
-						occurrenceByDate={occurrenceByDate}
-						cancelledSet={cancelledSet}
-						masterDate={masterDate}
-						todayStr={todayStr}
-						manageEventUrl={manageEventUrl}
-						masterEventDateId={masterEventDateId}
-					/>
-				))}
-			</div>
+			<MiniCalendar
+				minDate={allDates[0]}
+				maxDate={allDates[allDates.length - 1]}
+				dayProps={dayProps}
+			/>
 			<div
 				style={{
 					marginTop: '16px',
@@ -230,183 +185,4 @@ export default function RecurrenceCalendar({
 			<CardBody>{calendarBody}</CardBody>
 		</Card>
 	);
-}
-
-function MiniMonth({
-	monthDate,
-	weekdayLabels,
-	occurrenceByDate,
-	cancelledSet,
-	masterDate,
-	todayStr,
-	manageEventUrl,
-	masterEventDateId,
-}) {
-	const year = monthDate.getFullYear();
-	const month = monthDate.getMonth();
-	const firstDay = new Date(year, month, 1);
-	const daysInMonth = new Date(year, month + 1, 0).getDate();
-	const leadingDays = calculateLeadingDays(firstDay, 1);
-
-	const monthLabel = firstDay.toLocaleDateString(undefined, {
-		year: 'numeric',
-		month: 'long',
-	});
-
-	const cells = [];
-
-	// Leading empty cells
-	for (let i = 0; i < leadingDays; i++) {
-		cells.push(<div key={`lead-${i}`} />);
-	}
-
-	for (let day = 1; day <= daysInMonth; day++) {
-		const date = new Date(year, month, day);
-		const dateStr = formatLocalDate(date);
-		const occ = occurrenceByDate[dateStr];
-		const isCancelled =
-			occ?.status === 'cancelled' || cancelledSet.has(dateStr);
-		const isOccurrence = !!occ && !isCancelled;
-		const isMaster = dateStr === masterDate;
-		const isToday = dateStr === todayStr;
-		const fullDateLabel = date.toLocaleDateString(undefined, {
-			weekday: 'long',
-			year: 'numeric',
-			month: 'long',
-			day: 'numeric',
-		});
-
-		let bg = 'transparent';
-		let color = '#1e1e1e';
-		let opacity = 1;
-		let cursor = 'default';
-		let border = 'none';
-
-		if (isMaster) {
-			bg = '#007cba';
-			color = '#fff';
-		} else if (isCancelled) {
-			bg = '#cc1818';
-			color = '#fff';
-			opacity = 0.6;
-			cursor = 'pointer';
-		} else if (isOccurrence) {
-			bg = '#4ab866';
-			color = '#fff';
-			cursor = 'pointer';
-		}
-
-		if (isToday) {
-			border = '2px solid #1e1e1e';
-		}
-
-		const cellStyle = {
-			width: '28px',
-			height: '28px',
-			display: 'flex',
-			alignItems: 'center',
-			justifyContent: 'center',
-			borderRadius: '4px',
-			fontSize: '12px',
-			fontWeight: isOccurrence || isCancelled || isMaster ? 600 : 400,
-			background: bg,
-			color,
-			opacity,
-			cursor,
-			border,
-			textDecoration: isCancelled ? 'line-through' : 'none',
-			position: 'relative',
-		};
-
-		const isNavigable = (isOccurrence || isCancelled) && !isMaster;
-
-		const cellContent = (
-			<div key={dateStr} style={cellStyle}>
-				{day}
-			</div>
-		);
-
-		if (isMaster) {
-			cells.push(
-				<Tooltip key={dateStr} text={__('Master event', 'fair-events')}>
-					<a
-						href={`${manageEventUrl}&event_date_id=${masterEventDateId}`}
-						aria-label={fullDateLabel}
-						style={{ textDecoration: 'none' }}
-					>
-						{cellContent}
-					</a>
-				</Tooltip>
-			);
-		} else if (isNavigable) {
-			cells.push(
-				<Tooltip
-					key={dateStr}
-					text={__('Open this occurrence', 'fair-events')}
-				>
-					<a
-						href={`${manageEventUrl}&event_date_id=${occ.id}`}
-						aria-label={fullDateLabel}
-						style={{ textDecoration: 'none' }}
-					>
-						{cellContent}
-					</a>
-				</Tooltip>
-			);
-		} else {
-			cells.push(
-				<div key={dateStr} style={cellStyle}>
-					{day}
-				</div>
-			);
-		}
-	}
-
-	return (
-		<div style={{ minWidth: '220px' }}>
-			<div
-				style={{
-					fontWeight: 600,
-					marginBottom: '8px',
-					fontSize: '13px',
-					textAlign: 'center',
-				}}
-			>
-				{monthLabel}
-			</div>
-			<div
-				style={{
-					display: 'grid',
-					gridTemplateColumns: 'repeat(7, 28px)',
-					gap: '2px',
-					justifyContent: 'center',
-				}}
-			>
-				{weekdayLabels.map((label, i) => (
-					<div
-						key={i}
-						style={{
-							textAlign: 'center',
-							fontSize: '11px',
-							color: '#757575',
-							fontWeight: 600,
-							height: '20px',
-							lineHeight: '20px',
-						}}
-					>
-						{label}
-					</div>
-				))}
-				{cells}
-			</div>
-		</div>
-	);
-}
-
-function computeVisibleMonths(width) {
-	if (width < 600) return 1;
-	if (width < 900) return 2;
-	if (width < 1200) return 3;
-	if (width < 1500) return 4;
-	return 5;
 }

--- a/fair-events/src/Admin/manage-event/SeriesModal.js
+++ b/fair-events/src/Admin/manage-event/SeriesModal.js
@@ -4,7 +4,7 @@
  * Owns the frequency/ends fields and a live schedule preview, and saves
  * immediately on confirm (recurrence no longer rides along with the details
  * form's dirty-snapshot / Save flow). Also owns the "Irregular series"
- * hand-picked-dates editor.
+ * click-to-toggle date picker.
  *
  * @package FairEvents
  */
@@ -15,7 +15,6 @@ import {
 	Modal,
 	Notice,
 	TabPanel,
-	TextControl,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -25,6 +24,7 @@ import {
 	buildRRule,
 	expandRRulePreview,
 	parseRRule,
+	MiniCalendar,
 	RecurrenceControl,
 } from 'fair-events-shared';
 
@@ -116,27 +116,69 @@ export default function SeriesModal({
 
 	const rrule = buildRRule(recurrence);
 
+	// totalCount/lastDate cover every generated date regardless of `limit`, so
+	// a large limit doubles as "give me the full list" for the calendar.
 	const preview = useMemo(
-		() => expandRRulePreview(rrule, startDatetime, 4),
+		() => expandRRulePreview(rrule, startDatetime, Infinity),
 		[rrule, startDatetime]
 	);
+	const generatedDatesSet = useMemo(() => new Set(preview.dates), [preview]);
 
-	const filledManualDates = manualDates.filter(Boolean);
-	const allManualDates = [masterDateStr, ...filledManualDates];
+	const regularDayProps = (dateStr) => {
+		if (!generatedDatesSet.has(dateStr)) return {};
+		const isMaster = dateStr === masterDateStr;
+		return {
+			background: isMaster ? '#007cba' : '#4ab866',
+			color: '#fff',
+			fontWeight: 600,
+		};
+	};
+
+	const allManualDates = [masterDateStr, ...manualDates];
 	const uniqueManualDates = new Set(allManualDates);
 	const hasDuplicateManualDates =
 		uniqueManualDates.size !== allManualDates.length;
+	const sortedSelectedDates = [...uniqueManualDates].sort();
 
-	const updateManualDate = (index, value) => {
-		setManualDates((prev) => prev.map((d, i) => (i === index ? value : d)));
+	const toggleManualDate = (dateStr) => {
+		if (dateStr === masterDateStr) return;
+		setManualDates((prev) =>
+			prev.includes(dateStr)
+				? prev.filter((d) => d !== dateStr)
+				: [...prev, dateStr].sort()
+		);
 	};
 
-	const addManualDateRow = () => {
-		setManualDates((prev) => [...prev, '']);
-	};
+	const irregularDayProps = (dateStr) => {
+		const isMaster = dateStr === masterDateStr;
+		const isSelected = uniqueManualDates.has(dateStr);
 
-	const removeManualDateRow = (index) => {
-		setManualDates((prev) => prev.filter((_, i) => i !== index));
+		if (isMaster) {
+			return {
+				background: '#007cba',
+				color: '#fff',
+				fontWeight: 600,
+				interactive: true,
+				disabled: true,
+				ariaPressed: true,
+				tooltip: __(
+					'Master date — edit it from Event Details',
+					'fair-events'
+				),
+			};
+		}
+
+		return {
+			background: isSelected ? '#4ab866' : 'transparent',
+			color: isSelected ? '#fff' : '#1e1e1e',
+			fontWeight: isSelected ? 600 : 400,
+			interactive: true,
+			ariaPressed: isSelected,
+			onActivate: () => toggleManualDate(dateStr),
+			tooltip: isSelected
+				? __('Selected — click to remove this date', 'fair-events')
+				: __('Click to add this date', 'fair-events'),
+		};
 	};
 
 	const isManualTab = 'irregular' === activeTab;
@@ -258,37 +300,38 @@ export default function SeriesModal({
 								/>
 							</VStack>
 
-							<VStack spacing={2} style={{ minWidth: '200px' }}>
+							<VStack spacing={2} style={{ minWidth: '260px' }}>
 								<strong>
 									{__('Schedule preview', 'fair-events')}
 								</strong>
-								{preview.dates.length === 0 && (
+								{preview.dates.length === 0 ? (
 									<p>
 										{__(
 											'No dates match this schedule yet.',
 											'fair-events'
 										)}
 									</p>
-								)}
-								<ul style={{ margin: 0, paddingLeft: '20px' }}>
-									{preview.dates.map((date) => (
-										<li key={date}>
-											{formatPreviewDate(date)}
-										</li>
-									))}
-								</ul>
-								{preview.remainingCount > 0 && (
-									<p>
-										{sprintf(
-											/* translators: 1: number of remaining dates, 2: last date in the series */
-											__(
-												'… %1$d more, until %2$s',
-												'fair-events'
-											),
-											preview.remainingCount,
-											formatPreviewDate(preview.lastDate)
-										)}
-									</p>
+								) : (
+									<>
+										<MiniCalendar
+											minDate={preview.dates[0]}
+											maxDate={preview.lastDate}
+											dayProps={regularDayProps}
+										/>
+										<p>
+											{sprintf(
+												/* translators: 1: number of dates in the series, 2: last date in the series */
+												__(
+													'%1$d dates, until %2$s',
+													'fair-events'
+												),
+												preview.totalCount,
+												formatPreviewDate(
+													preview.lastDate
+												)
+											)}
+										</p>
+									</>
 								)}
 							</VStack>
 						</HStack>
@@ -316,57 +359,24 @@ export default function SeriesModal({
 								</Notice>
 							)}
 
-							<VStack spacing={2}>
-								<HStack alignment="center">
-									<TextControl
-										type="date"
-										label={__('Master date', 'fair-events')}
-										hideLabelFromVision
-										value={masterDateStr}
-										disabled
-									/>
-									<span style={{ color: '#757575' }}>
-										{__(
-											'Master date — edit it from Event Details',
-											'fair-events'
-										)}
-									</span>
-								</HStack>
-								{manualDates.map((date, index) => (
-									// eslint-disable-next-line react/no-array-index-key
-									<HStack key={index} alignment="center">
-										<TextControl
-											type="date"
-											label={sprintf(
-												/* translators: %d: 1-based row number in the extra-dates list */
-												__('Date %d', 'fair-events'),
-												index + 1
-											)}
-											hideLabelFromVision
-											value={date}
-											onChange={(value) =>
-												updateManualDate(index, value)
-											}
-										/>
-										<Button
-											variant="tertiary"
-											isDestructive
-											onClick={() =>
-												removeManualDateRow(index)
-											}
-										>
-											{__('Remove', 'fair-events')}
-										</Button>
-									</HStack>
-								))}
-							</VStack>
+							<MiniCalendar
+								minDate={sortedSelectedDates[0]}
+								maxDate={
+									sortedSelectedDates[
+										sortedSelectedDates.length - 1
+									]
+								}
+								dayProps={irregularDayProps}
+								allowForwardBeyondRange
+							/>
 
-							<Button
-								variant="secondary"
-								onClick={addManualDateRow}
-							>
-								{__('Add date', 'fair-events')}
-							</Button>
+							<p style={{ color: '#757575' }}>
+								{sprintf(
+									/* translators: %d: number of selected dates */
+									__('%d dates selected', 'fair-events'),
+									manualDateCount
+								)}
+							</p>
 						</VStack>
 					)
 				}

--- a/fair-events/src/Admin/manage-event/__tests__/SeriesModal.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/SeriesModal.test.jsx
@@ -1,16 +1,18 @@
 /**
  * @jest-environment jsdom
  *
- * Tests for the "Irregular series" hand-picked-dates editor in SeriesModal
- * (#979).
+ * Tests for SeriesModal's "Regular schedule" and "Irregular series" tabs
+ * (#979, #1127).
  *
  * Covers:
- *   - Seeding the date list from existing generated occurrences.
- *   - The master's own date row is fixed (disabled, no Remove button) —
- *     only the extra occurrence rows are editable/removable.
- *   - Duplicate-day rejection (visible Notice, confirm disabled).
- *   - Confirm sends { recurrence_mode: 'manual', manual_dates } (master date
- *     + extras) on the Irregular tab instead of { rrule }.
+ *   - Regular tab: a display-only calendar highlights every rule-generated
+ *     date and a compact "N dates, until <date>" summary line replaces the
+ *     old text list.
+ *   - Irregular tab: seeding the selection from existing generated
+ *     occurrences, the master's own date is fixed (disabled button, can't be
+ *     toggled), clicking an unselected day adds it and clicking a selected
+ *     day removes it, and confirm still sends
+ *     { recurrence_mode: 'manual', manual_dates }.
  */
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -18,6 +20,16 @@ import apiFetch from '@wordpress/api-fetch';
 import SeriesModal from '../SeriesModal.js';
 
 jest.mock('@wordpress/api-fetch');
+
+// Matches the full-date aria-label MiniCalendar builds by default.
+function fullDateLabel(dateStr) {
+	return new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
+		weekday: 'long',
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+	});
+}
 
 beforeEach(() => {
 	// The Regular schedule tab renders RecurrenceControl, which uses
@@ -28,6 +40,18 @@ beforeEach(() => {
 	// ManageEventApp.test.jsx.
 	jest.spyOn(console, 'warn').mockImplementation(() => {});
 	jest.spyOn(console, 'error').mockImplementation(() => {});
+
+	// jsdom has no layout engine; @wordpress/components' HStack/Button use
+	// matchMedia for responsive spacing, which jsdom doesn't implement.
+	window.matchMedia =
+		window.matchMedia ||
+		function () {
+			return {
+				matches: false,
+				addListener: () => {},
+				removeListener: () => {},
+			};
+		};
 });
 
 afterEach(() => {
@@ -50,7 +74,33 @@ function openIrregularTab() {
 	fireEvent.click(screen.getByRole('tab', { name: 'Irregular series' }));
 }
 
-it('seeds the date list from existing generated occurrences when editing a manual series', async () => {
+it('Regular tab shows a display-only calendar and a compact dates summary', async () => {
+	await renderModal({
+		eventDateId: 1,
+		initialRrule: null,
+		initialRecurrenceMode: null,
+		startDatetime: '2026-07-01 18:00:00',
+		generatedOccurrences: [],
+		onClose: () => {},
+		onSaved: () => {},
+		onImpact: () => {},
+	});
+
+	// Default recurrence is weekly, 10 occurrences (DEFAULT_RECURRENCE).
+	expect(screen.getByText('July 2026')).toBeInTheDocument();
+	expect(screen.getByText(/10 dates, until/)).toBeInTheDocument();
+
+	// Display-only: no toggle buttons in the calendar (aria-pressed is only
+	// used by the Irregular tab's picker).
+	expect(screen.queryAllByRole('button', { pressed: true })).toHaveLength(0);
+	expect(screen.queryAllByRole('button', { pressed: false })).toHaveLength(0);
+
+	// RecurrenceControl's SelectControl/NumberControl emit an unrelated
+	// @wordpress/components 36px-default-size deprecation notice on mount.
+	expect(console).toHaveWarned();
+});
+
+it('seeds the calendar selection from existing generated occurrences when editing a manual series', async () => {
 	await renderModal({
 		eventDateId: 1,
 		initialRrule: null,
@@ -65,15 +115,28 @@ it('seeds the date list from existing generated occurrences when editing a manua
 		onImpact: () => {},
 	});
 
-	const dateInputs = screen.getAllByDisplayValue(/2026-07-/);
-	expect(dateInputs.map((el) => el.value)).toEqual([
-		'2026-07-01',
-		'2026-07-08',
-		'2026-07-20',
-	]);
+	openIrregularTab();
+
+	const masterButton = screen.getByRole('button', {
+		name: fullDateLabel('2026-07-01'),
+	});
+	expect(masterButton).toBeDisabled();
+	expect(masterButton).toHaveAttribute('aria-pressed', 'true');
+
+	expect(
+		screen.getByRole('button', { name: fullDateLabel('2026-07-08') })
+	).toHaveAttribute('aria-pressed', 'true');
+	expect(
+		screen.getByRole('button', { name: fullDateLabel('2026-07-20') })
+	).toHaveAttribute('aria-pressed', 'true');
+	expect(
+		screen.getByRole('button', { name: fullDateLabel('2026-07-15') })
+	).toHaveAttribute('aria-pressed', 'false');
+
+	expect(screen.getByText('3 dates selected')).toBeInTheDocument();
 });
 
-it('adds and removes date rows, and keeps the master date fixed', async () => {
+it('clicking an unselected day adds it and clicking it again removes it, keeping the master date fixed', async () => {
 	await renderModal({
 		eventDateId: 1,
 		initialRrule: null,
@@ -87,49 +150,27 @@ it('adds and removes date rows, and keeps the master date fixed', async () => {
 
 	openIrregularTab();
 
-	// The master's own date row is disabled and has no Remove button.
-	const masterInput = screen.getByDisplayValue('2026-07-01');
-	expect(masterInput).toBeDisabled();
-	expect(
-		screen.queryByRole('button', { name: 'Remove' })
-	).not.toBeInTheDocument();
-
-	fireEvent.click(screen.getByRole('button', { name: 'Add date' }));
-	expect(screen.getAllByRole('button', { name: 'Remove' })).toHaveLength(1);
-
-	fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[0]);
-	expect(
-		screen.queryByRole('button', { name: 'Remove' })
-	).not.toBeInTheDocument();
-});
-
-it('shows a Notice and disables confirm when two rows share the same date', async () => {
-	await renderModal({
-		eventDateId: 1,
-		initialRrule: null,
-		initialRecurrenceMode: 'manual',
-		startDatetime: '2026-07-01 18:00:00',
-		generatedOccurrences: [
-			{ id: 2, start_datetime: '2026-07-08 18:00:00' },
-		],
-		onClose: () => {},
-		onSaved: () => {},
-		onImpact: () => {},
+	const masterButton = screen.getByRole('button', {
+		name: fullDateLabel('2026-07-01'),
 	});
+	expect(masterButton).toBeDisabled();
+	expect(screen.getByText('1 dates selected')).toBeInTheDocument();
 
-	const [firstDate, secondDate] = screen.getAllByDisplayValue(/2026-07-/);
-	fireEvent.change(secondDate, { target: { value: firstDate.value } });
+	fireEvent.click(masterButton);
+	expect(screen.getByText('1 dates selected')).toBeInTheDocument();
 
-	// The WP a11y-speak live region duplicates Notice text for screen readers,
-	// so there are two matches — assert at least one is present.
-	expect(
-		screen.getAllByText(/Each date can only be used once/).length
-	).toBeGreaterThan(0);
-
-	const confirmButton = screen.getByRole('button', {
-		name: /Update series/,
+	const dayButton = screen.getByRole('button', {
+		name: fullDateLabel('2026-07-05'),
 	});
-	expect(confirmButton).toBeDisabled();
+	expect(dayButton).toHaveAttribute('aria-pressed', 'false');
+
+	fireEvent.click(dayButton);
+	expect(dayButton).toHaveAttribute('aria-pressed', 'true');
+	expect(screen.getByText('2 dates selected')).toBeInTheDocument();
+
+	fireEvent.click(dayButton);
+	expect(dayButton).toHaveAttribute('aria-pressed', 'false');
+	expect(screen.getByText('1 dates selected')).toBeInTheDocument();
 });
 
 it('sends recurrence_mode + manual_dates on confirm from the Irregular tab', async () => {
@@ -152,9 +193,9 @@ it('sends recurrence_mode + manual_dates on confirm from the Irregular tab', asy
 	});
 
 	openIrregularTab();
-	fireEvent.click(screen.getByRole('button', { name: 'Add date' }));
-	const [, secondDate] = screen.getAllByDisplayValue(/2026-07-01|^$/);
-	fireEvent.change(secondDate, { target: { value: '2026-07-15' } });
+	fireEvent.click(
+		screen.getByRole('button', { name: fullDateLabel('2026-07-15') })
+	);
 
 	fireEvent.click(screen.getByRole('button', { name: /Create series/ }));
 


### PR DESCRIPTION
## Summary

- Extracts the recurring-occurrences mini-calendar's grid/paging logic into a shared `MiniCalendar` primitive (`fair-events-shared`), driven by a per-day `dayProps(dateStr)` descriptor so read-only and interactive calendars render through identical code.
- `RecurrenceCalendar` becomes a thin adapter over `MiniCalendar` (its 3 existing tests are unchanged and pass).
- **Regular schedule tab** in the "Turn into a series" popup: replaces the text date-list preview with a display-only calendar highlighting every generated date, updating live as frequency/end settings change, plus a compact "N dates, until \<date>" summary line.
- **Irregular series tab**: replaces the stack of date-input rows with a click-to-toggle calendar — clicking an unselected day adds it, clicking a selected day removes it; the master date renders as a disabled (non-removable) button. Selected count and the confirm button label stay in sync.
- Save/impact/confirm-enable behavior is unchanged; dates are handled as naive site-local strings throughout (no timezone re-conversion).

Closes #1127

## Test plan

- [x] `npm run test:js` in `fair-events` (120 tests) — includes updated `SeriesModal.test.jsx` and unchanged `RecurrenceCalendar.test.jsx`
- [x] `npm test` in `fair-events-shared` (130 tests) — includes new `MiniCalendar.test.js` covering month-range, paging, and `allowForwardBeyondRange`
- [x] `npm run build` in `fair-events`
