### PR TITLE
Add an edit-tickets link to the Event Signup block sidebar

### DIFF
--- a/fair-events/languages/fair-events-de_DE.po
+++ b/fair-events/languages/fair-events-de_DE.po
@@ -43,7 +43,7 @@ msgstr "Fair Events Einstellungen"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/blocks/events-list/render.php:297
+#: src/blocks/events-list/render.php:299
 msgid "No events found. Please select a valid display pattern."
 msgstr "Keine Veranstaltungen gefunden. Bitte wählen Sie ein gültiges Anzeigemuster."
 
@@ -374,10 +374,10 @@ msgstr "Titel"
 
 #: src/Admin/calendar/components/QuickEventModal.js:382
 #: src/Admin/manage-event/EditInstancesModal.js:85
-#: src/Admin/manage-event/EventTickets.js:2467
+#: src/Admin/manage-event/EventTickets.js:2310
 #: src/Admin/manage-event/ManageEventApp.js:1449
 #: src/Admin/manage-event/ManageEventApp.js:1459
-#: src/Admin/manage-event/SeriesModal.js:381
+#: src/Admin/manage-event/SeriesModal.js:391
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -478,19 +478,18 @@ msgstr "Diese Quelle ist deaktiviert."
 msgid "Date & Time"
 msgstr "Datum & Zeit"
 
-#: src/Admin/manage-event/EventTickets.js:1193
-#: src/Admin/manage-event/EventTickets.js:1868
-#: src/Admin/manage-event/EventTickets.js:2309
+#: src/Admin/manage-event/EventTickets.js:1141
+#: src/Admin/manage-event/EventTickets.js:1780
+#: src/Admin/manage-event/EventTickets.js:2173
 #: src/Admin/manage-event/PhotoDetail.js:182
-#: src/Admin/manage-event/SeriesModal.js:358
 msgid "Remove"
 msgstr "Entfernen"
 
 #: src/Admin/all-events/AllEvents.js:70
 #: src/Admin/manage-event/EventSignups.js:54
-#: src/Admin/manage-event/EventTickets.js:1069
-#: src/Admin/manage-event/EventTickets.js:1965
-#: src/Admin/manage-event/EventTickets.js:2018
+#: src/Admin/manage-event/EventTickets.js:1018
+#: src/Admin/manage-event/EventTickets.js:1893
+#: src/Admin/manage-event/EventTickets.js:1933
 msgid "Name"
 msgstr "Name"
 
@@ -617,7 +616,7 @@ msgid "Display event with time range and title"
 msgstr "Veranstaltung mit Zeitbereich und Titel anzeigen"
 
 #: src/blocks/event-proposal/editor.js:21
-#: src/blocks/event-signup/editor.js:80
+#: src/blocks/event-signup/editor.js:87
 msgid "Form Settings"
 msgstr "Formular-Einstellungen"
 
@@ -654,7 +653,7 @@ msgid "Email address for notifications"
 msgstr "E-Mail-Adresse für Benachrichtigungen"
 
 #: src/blocks/event-proposal/editor.js:75
-#: src/blocks/event-signup/editor.js:82
+#: src/blocks/event-signup/editor.js:89
 msgid "Submit Button Text"
 msgstr "Text des Absende-Buttons"
 
@@ -818,7 +817,7 @@ msgstr "Fehler beim Erstellen des Ereignisdatums."
 #: src/API/GetTicketsController.php:197
 #: src/API/TicketsController.php:117
 #: src/API/TicketsController.php:138
-#: src/API/TicketsController.php:291
+#: src/API/TicketsController.php:288
 msgid "Event date not found."
 msgstr "Ereignisdatum nicht gefunden."
 
@@ -959,7 +958,7 @@ msgstr "Startdatum"
 #: src/Admin/calendar/components/QuickEventModal.js:208
 #: src/Admin/calendar/components/QuickEventModal.js:235
 #: src/Admin/event-meta-box/EventEditForm.js:376
-#: src/Admin/manage-event/EventTickets.js:1371
+#: src/Admin/manage-event/EventTickets.js:1307
 #: src/Admin/manage-event/ManageEventApp.js:896
 #: src/Admin/manage-event/ManageEventApp.js:929
 msgid "End date"
@@ -1166,7 +1165,7 @@ msgstr "Fehler beim Verknüpfen des Beitrags."
 msgid "Back to Calendar"
 msgstr "Zurück zum Kalender"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:227
+#: src/Admin/manage-event/RecurrenceCalendar.js:182
 msgid "Recurring Occurrences"
 msgstr "Wiederkehrende Vorkommen"
 
@@ -1424,7 +1423,7 @@ msgstr "Extern"
 msgid "None"
 msgstr "Keine"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:184
+#: src/Admin/manage-event/RecurrenceCalendar.js:139
 msgid "Master"
 msgstr "Master"
 
@@ -1448,8 +1447,7 @@ msgstr "Datum zum Umschalten (Format Y-m-d)."
 msgid "Request context. Use \"edit\" to include events linked to non-published posts (requires edit_posts capability)."
 msgstr "Anfragekontexte. Verwenden Sie \"edit\", um Ereignisse einzubeziehen, die mit unveröffentlichten Beiträgen verknüpft sind (erfordert edit_posts-Berechtigung)."
 
-#: src/Admin/manage-event/EventTickets.js:945
-#: src/Admin/manage-event/EventTickets.js:1277
+#: src/Admin/manage-event/EventTickets.js:1213
 #: src/Admin/manage-event/ManageEventApp.js:717
 msgid "Tickets"
 msgstr "Tickets"
@@ -1530,70 +1528,69 @@ msgstr "Fotos auswählen"
 msgid "Add New Photos"
 msgstr "Neue Fotos hinzufügen"
 
-#: src/Admin/manage-event/EventTickets.js:195
+#: src/Admin/manage-event/EventTickets.js:192
 msgid "Failed to load tickets."
 msgstr "Fehler beim Laden von Tickets."
 
-#: src/Admin/manage-event/EventTickets.js:840
+#: src/Admin/manage-event/EventTickets.js:834
 msgid "Tickets saved successfully."
 msgstr "Tickets erfolgreich gespeichert."
 
-#: src/Admin/manage-event/EventTickets.js:843
+#: src/Admin/manage-event/EventTickets.js:837
 msgid "Failed to save tickets."
 msgstr "Fehler beim Speichern von Tickets."
 
 #: src/Admin/manage-event/EventSignups.js:56
-#: src/Admin/manage-event/EventTickets.js:1331
+#: src/Admin/manage-event/EventTickets.js:1267
 msgid "Ticket Type"
 msgstr "Tickettyp"
 
-#: src/Admin/manage-event/EventTickets.js:1426
+#: src/Admin/manage-event/EventTickets.js:1349
 msgid "(unnamed)"
 msgstr "(unbenannt)"
 
-#: src/Admin/manage-event/EventTickets.js:1315
+#: src/Admin/manage-event/EventTickets.js:1251
 msgid "Total capacity"
 msgstr "Gesamtkapazität"
 
-#: src/Admin/manage-event/EventTickets.js:1320
+#: src/Admin/manage-event/EventTickets.js:1256
 msgid "Leave empty for unlimited capacity."
 msgstr "Lassen Sie das Feld leer für unbegrenzte Kapazität."
 
-#: src/Admin/manage-event/EventTickets.js:962
-#: src/Admin/manage-event/EventTickets.js:1904
+#: src/Admin/manage-event/EventTickets.js:1833
 msgid "+ Add Ticket Type"
 msgstr "+ Tickettyp hinzufügen"
 
-#: src/Admin/manage-event/EventTickets.js:1338
-#: src/Admin/manage-event/EventTickets.js:1991
+#: src/Admin/manage-event/EventTickets.js:1274
+#: src/Admin/manage-event/EventTickets.js:1906
 msgid "Capacity"
 msgstr "Kapazität"
 
-#: src/Admin/manage-event/EventTickets.js:1124
+#: src/Admin/manage-event/EventTickets.js:1072
 msgid "Period name"
 msgstr "Zeitraumname"
 
-#: src/Admin/manage-event/EventTickets.js:1075
-#: src/Admin/manage-event/EventTickets.js:1227
+#: src/Admin/manage-event/EventTickets.js:1024
+#: src/Admin/manage-event/EventTickets.js:1172
 msgid "From"
 msgstr "Von"
 
-#: src/Admin/manage-event/EventTickets.js:1081
-#: src/Admin/manage-event/EventTickets.js:1246
+#: src/Admin/manage-event/EventTickets.js:1030
+#: src/Admin/manage-event/EventTickets.js:1187
 msgid "Until"
 msgstr "Bis"
 
-#: src/Admin/manage-event/EventTickets.js:1450
+#: src/Admin/manage-event/EventTickets.js:1370
 msgid "Type name"
 msgstr "Typname"
 
-#: src/Admin/manage-event/EventTickets.js:1485
-#: src/Admin/manage-event/EventTickets.js:2193
+#: src/Admin/manage-event/EventTickets.js:1403
+#: src/Admin/manage-event/EventTickets.js:2057
 msgid "Unlimited"
 msgstr "Unbegrenzt"
 
-#: src/Admin/manage-event/EventTickets.js:1430
-#: src/Admin/manage-event/EventTickets.js:1802
+#: src/Admin/manage-event/EventTickets.js:1353
+#: src/Admin/manage-event/EventTickets.js:1714
 msgid "Price"
 msgstr "Preis"
 
@@ -1601,7 +1598,7 @@ msgstr "Preis"
 msgid "Failed to toggle occurrence."
 msgstr "Fehler beim Umschalten des Vorkommens."
 
-#: src/Admin/manage-event/EventTickets.js:1346
+#: src/Admin/manage-event/EventTickets.js:1282
 msgid "Groups"
 msgstr "Gruppen"
 
@@ -1649,24 +1646,16 @@ msgstr "Teilnehmer suchen..."
 msgid "No participants found."
 msgstr "Keine Teilnehmer gefunden."
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:113
-msgid "Previous months"
-msgstr "Vorherige Monate"
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:122
-msgid "Next months"
-msgstr "Nächste Monate"
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:198
+#: src/Admin/manage-event/RecurrenceCalendar.js:153
 msgid "Active"
 msgstr "Aktiv"
 
 #: src/Admin/manage-event/EditInstancesModal.js:74
-#: src/Admin/manage-event/RecurrenceCalendar.js:213
+#: src/Admin/manage-event/RecurrenceCalendar.js:168
 msgid "Cancelled"
 msgstr "Abgebrochen"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:331
+#: src/Admin/manage-event/RecurrenceCalendar.js:100
 msgid "Master event"
 msgstr "Hauptveranstaltung"
 
@@ -1674,7 +1663,7 @@ msgstr "Hauptveranstaltung"
 msgid "Event Info block is disabled — no event is linked to this post."
 msgstr "Event Info Block ist deaktiviert – kein Event ist mit diesem Beitrag verknüpft."
 
-#: src/Admin/manage-event/EventTickets.js:930
+#: src/Admin/manage-event/EventTickets.js:919
 msgid "Manage Invitations"
 msgstr "Einladungen verwalten"
 
@@ -1687,59 +1676,59 @@ msgstr "Zahlungen"
 msgid "Participant"
 msgstr "Teilnehmer"
 
-#: src/Admin/manage-event/EventTickets.js:318
+#: src/Admin/manage-event/EventTickets.js:309
 msgid "Failed to export ticket configuration."
 msgstr "Fehler beim Exportieren der Ticketkonfiguration."
 
-#: src/Admin/manage-event/EventTickets.js:328
+#: src/Admin/manage-event/EventTickets.js:319
 msgid "Importing will replace all current ticket types, sale periods, prices, and settings for this event. Continue?"
 msgstr "Der Import ersetzt alle aktuellen Tickettypen, Verkaufszeiträume, Preise und Einstellungen für dieses Event. Fortfahren?"
 
-#: src/Admin/manage-event/EventTickets.js:352
+#: src/Admin/manage-event/EventTickets.js:343
 msgid "Invalid file format. Expected a fair-events-tickets export."
 msgstr "Ungültiges Dateiformat. Ein fair-events-tickets-Export wird erwartet."
 
-#: src/Admin/manage-event/EventTickets.js:367
+#: src/Admin/manage-event/EventTickets.js:358
 msgid "Ticket configuration imported successfully."
 msgstr "Ticketkonfiguration erfolgreich importiert."
 
-#: src/Admin/manage-event/EventTickets.js:375
+#: src/Admin/manage-event/EventTickets.js:366
 msgid "Failed to import ticket configuration."
 msgstr "Fehler beim Importieren der Ticketkonfiguration."
 
-#: src/Admin/manage-event/EventTickets.js:1291
+#: src/Admin/manage-event/EventTickets.js:1227
 msgid "Export ticket settings"
 msgstr "Ticketeinstellungen exportieren"
 
-#: src/Admin/manage-event/EventTickets.js:1303
+#: src/Admin/manage-event/EventTickets.js:1239
 msgid "Import ticket settings"
 msgstr "Ticketeinstellungen importieren"
 
-#: src/Admin/manage-event/EventTickets.js:1354
+#: src/Admin/manage-event/EventTickets.js:1290
 msgid "Invitation only"
 msgstr "Nur auf Einladung"
 
-#: src/Admin/manage-event/EventTickets.js:1554
+#: src/Admin/manage-event/EventTickets.js:1472
 msgid "All participants"
 msgstr "Alle Teilnehmer"
 
-#: src/Admin/manage-event/EventTickets.js:2357
+#: src/Admin/manage-event/EventTickets.js:2219
 msgid "Per-ticket-type capacity"
 msgstr "Kapazität pro Tickettyp"
 
-#: src/Admin/manage-event/EventTickets.js:2361
+#: src/Admin/manage-event/EventTickets.js:2223
 msgid "Show a Capacity input on each ticket type to cap how many can be sold of that type."
 msgstr "Zeige ein Kapazitätsfeld für jeden Tickettyp an, um zu begrenzen, wie viele von diesem Typ verkauft werden können."
 
-#: src/Admin/manage-event/EventTickets.js:2374
+#: src/Admin/manage-event/EventTickets.js:2236
 msgid "Multiple pricing periods"
 msgstr "Mehrere Preisphasen"
 
-#: src/Admin/manage-event/EventTickets.js:2378
+#: src/Admin/manage-event/EventTickets.js:2240
 msgid "Enable time-based pricing with multiple sale periods (e.g. early bird, regular, late). When off, a single flat price applies for the whole sale window."
 msgstr "Aktiviere zeitbasierte Preisgestaltung mit mehreren Verkaufsphasen (z. B. Early Bird, regulär, Last Minute). Wenn deaktiviert, gilt ein einheitlicher Preis für das gesamte Verkaufsfenster."
 
-#: src/Admin/manage-event/EventTickets.js:2342
+#: src/Admin/manage-event/EventTickets.js:2205
 msgid "+ Add Option"
 msgstr "+ Option hinzufügen"
 
@@ -1747,13 +1736,13 @@ msgstr "+ Option hinzufügen"
 msgid "View Entry"
 msgstr "Eintrag anzeigen"
 
-#: src/Admin/manage-event/EventTickets.js:1767
+#: src/Admin/manage-event/EventTickets.js:1679
 msgid "Available"
 msgstr "Verfügbar"
 
-#: src/Admin/manage-event/EventTickets.js:451
-#: src/Admin/manage-event/EventTickets.js:1014
-#: src/Admin/manage-event/EventTickets.js:1033
+#: src/Admin/manage-event/EventTickets.js:445
+#: src/Admin/manage-event/EventTickets.js:973
+#: src/Admin/manage-event/EventTickets.js:989
 msgid "—"
 msgstr "—"
 
@@ -1761,36 +1750,32 @@ msgstr "—"
 msgid "Failed Payments"
 msgstr "Fehlgeschlagene Zahlungen"
 
-#: src/Admin/manage-event/EventTickets.js:973
+#: src/Admin/manage-event/EventTickets.js:933
 msgid "Sale Periods"
 msgstr "Verkaufszeiträume"
 
-#: src/Admin/manage-event/EventTickets.js:981
+#: src/Admin/manage-event/EventTickets.js:941
 msgid "Sale start at:"
 msgstr "Verkauf beginnt um:"
 
-#: src/Admin/manage-event/EventTickets.js:1019
+#: src/Admin/manage-event/EventTickets.js:978
 msgid "Sale end at:"
 msgstr "Verkauf endet um:"
 
-#: src/Admin/manage-event/EventTickets.js:1212
+#: src/Admin/manage-event/EventTickets.js:1160
 msgid "+ Add Period"
 msgstr "+ Zeitraum hinzufügen"
 
-#: src/Admin/manage-event/EventTickets.js:2053
-#: src/Admin/manage-event/EventTickets.js:2058
+#: src/Admin/manage-event/EventTickets.js:1968
+#: src/Admin/manage-event/EventTickets.js:1973
 msgid "Short name"
 msgstr "Kurzname"
 
-#: src/Admin/manage-event/EventTickets.js:1997
+#: src/Admin/manage-event/EventTickets.js:1912
 msgid "Collaborator(s)"
 msgstr "Mitarbeiter"
 
-#: src/Admin/manage-event/EventTickets.js:2156
-msgid "No discount"
-msgstr "Kein Rabatt"
-
-#: src/Admin/manage-event/EventTickets.js:2285
+#: src/Admin/manage-event/EventTickets.js:2149
 msgid "Add participants"
 msgstr "Teilnehmer hinzufügen"
 
@@ -1818,7 +1803,7 @@ msgstr "Gezahlter Betrag minus Mollie- und Anwendungsgebühren."
 msgid "Net received"
 msgstr "Netto erhalten"
 
-#: src/Admin/manage-event/EventTickets.js:542
+#: src/Admin/manage-event/EventTickets.js:536
 msgid "Add sale periods first."
 msgstr "Fügen Sie zuerst Verkaufszeiträume hinzu."
 
@@ -1914,11 +1899,11 @@ msgstr "Gebündelte Übersetzungen"
 msgid "Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings."
 msgstr "Laden Sie .mo/.json-Dateien, die mit dem Plugin geliefert werden, anstatt sich auf WordPress.org-Sprachpakete zu verlassen. Nützlich, wenn ein Gebietsschema unter der 90%-Schwelle auf translate.wordpress.org liegt oder für laufende Zeichenketten."
 
-#: src/Admin/manage-event/EventTickets.js:2406
+#: src/Admin/manage-event/EventTickets.js:2268
 msgid "Per-ticket-type end date"
 msgstr "Enddatum pro Tickettyp"
 
-#: src/Admin/manage-event/EventTickets.js:2410
+#: src/Admin/manage-event/EventTickets.js:2272
 msgid "Show a date/time input on each ticket type to stop selling it after a fixed date, regardless of remaining capacity."
 msgstr "Zeigen Sie auf jedem Tickettyp eine Datums-/Uhrzeiteingabe an, um den Verkauf nach einem festen Datum zu beenden, unabhängig von der verbleibenden Kapazität."
 
@@ -1932,20 +1917,15 @@ msgstr "Zeige eine \"Powered by Fair Event Plugins\"-Zeile auf Anmeldeformularen
 
 #. translators: %s: "Fair Event Plugins" linked to the project site
 #: src/Services/Branding.php:57
+#, php-format
 msgid "Powered by %s"
 msgstr "Powered by %s"
 
 #. translators: %s: currency code
-#: src/Admin/manage-event/EventTickets.js:1970
+#: src/Admin/manage-event/EventTickets.js:1898
 #, js-format
 msgid "Price (%s)"
 msgstr "Preis (%s)"
-
-#. translators: %s: currency code
-#: src/Admin/manage-event/EventTickets.js:1981
-#, js-format
-msgid "Discounted price (%s)"
-msgstr "Rabattierter Preis (%s)"
 
 #: src/Admin/settings/GeneralTab.js:276
 msgid "Branding"
@@ -2053,7 +2033,7 @@ msgstr "Tickets für Veranstaltung #%d"
 msgid "Ticket for %s"
 msgstr "Ticket für %s"
 
-#: src/API/TicketsController.php:300
+#: src/API/TicketsController.php:297
 msgid "Invalid import payload."
 msgstr "Ungültige Importdaten."
 
@@ -2130,82 +2110,78 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nein"
 
-#: src/Admin/manage-event/EventTickets.js:950
-msgid "No ticket types configured yet. Add a ticket type to start selling tickets for this event."
-msgstr "Noch keine Tickettypen konfiguriert. Fügen Sie einen Tickettyp hinzu, um mit dem Verkauf von Tickets für diese Veranstaltung zu beginnen."
-
-#: src/Admin/manage-event/EventTickets.js:664
+#: src/Admin/manage-event/EventTickets.js:658
 msgid "Advance ticket"
 msgstr "Vorverkaufsticket"
 
-#: src/Admin/manage-event/EventTickets.js:670
+#: src/Admin/manage-event/EventTickets.js:664
 msgid "Day of event"
 msgstr "Veranstaltungstag"
 
-#: src/Admin/manage-event/EventTickets.js:1648
-#: src/Admin/manage-event/EventTickets.js:1680
+#: src/Admin/manage-event/EventTickets.js:1563
+#: src/Admin/manage-event/EventTickets.js:1595
 msgid "Whole series"
 msgstr "Gesamte Serie"
 
-#: src/Admin/manage-event/EventTickets.js:1654
-#: src/Admin/manage-event/EventTickets.js:1687
+#: src/Admin/manage-event/EventTickets.js:1569
+#: src/Admin/manage-event/EventTickets.js:1602
 msgid "Multiple instances"
 msgstr "Mehrere Instanzen"
 
-#: src/Admin/manage-event/EventTickets.js:1658
-#: src/Admin/manage-event/EventTickets.js:1673
+#: src/Admin/manage-event/EventTickets.js:1573
+#: src/Admin/manage-event/EventTickets.js:1588
 msgid "This instance"
 msgstr "Diese Instanz"
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1008
+#: src/Admin/manage-event/EventTickets.js:967
 #, js-format
 msgid "From %s"
 msgstr "Von %s"
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1040
+#: src/Admin/manage-event/EventTickets.js:993
 #, js-format
 msgid "until %s"
 msgstr "bis %s"
 
-#: src/Admin/manage-event/EventTickets.js:1379
+#: src/Admin/manage-event/EventTickets.js:1315
 msgid "Scope"
 msgstr "Umfang"
 
-#: src/Admin/manage-event/EventTickets.js:1473
+#: src/Admin/manage-event/EventTickets.js:1391
 msgid "Disabled — no longer on sale"
 msgstr "Deaktiviert — nicht mehr im Verkauf"
 
-#: src/Admin/manage-event/EventTickets.js:1710
+#: src/Admin/manage-event/EventTickets.js:1625
 msgid "Minimum instances"
 msgstr "Mindestanzahl von Instanzen"
 
-#: src/Admin/manage-event/EventTickets.js:1837
+#: src/Admin/manage-event/EventTickets.js:1749
 msgid "Disabled"
 msgstr "Deaktiviert"
 
-#: src/Admin/manage-event/EventTickets.js:1841
+#: src/Admin/manage-event/EventTickets.js:1753
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: src/Admin/manage-event/EventTickets.js:2480
+#: src/Admin/manage-event/EventTickets.js:2323
 msgid "Choose ticket scope"
 msgstr "Ticketumfang wählen"
 
-#: src/Admin/manage-event/EventTickets.js:2488
+#: src/Admin/manage-event/EventTickets.js:2331
 msgid "This instance — a separate ticket is needed for each date"
 msgstr "Diese Instanz — für jedes Datum wird ein separates Ticket benötigt"
 
-#: src/Admin/manage-event/EventTickets.js:2495
+#: src/Admin/manage-event/EventTickets.js:2338
 msgid "Whole series — one purchase covers every occurrence"
 msgstr "Gesamte Serie — ein Kauf deckt jedes Vorkommen ab"
 
-#: src/Admin/manage-event/EventTickets.js:2502
+#: src/Admin/manage-event/EventTickets.js:2345
 msgid "Multiple instances — buyer picks several occurrences"
 msgstr "Mehrere Instanzen — Käufer wählt mehrere Vorkommen"
 
-#: src/Admin/manage-event/EventTickets.js:2517
+#: src/Admin/manage-event/EventTickets.js:2360
 msgid "Add ticket type"
 msgstr "Tickettyp hinzufügen"
 
@@ -2278,7 +2254,7 @@ msgid "Failed to submit. Please try again."
 msgstr "Übermittlung fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #. translators: 1: formatted date, 2: number of days
-#: src/Admin/manage-event/EventTickets.js:997
+#: src/Admin/manage-event/EventTickets.js:956
 #, js-format
 msgid "From %1$s (%2$d day before event)"
 msgid_plural "From %1$s (%2$d days before event)"
@@ -2286,7 +2262,7 @@ msgstr[0] "Von %1$s (%2$d Tag vor dem Event)"
 msgstr[1] "Von %1$s (%2$d Tage vor dem Event)"
 
 #. translators: %d: sale period number
-#: src/Admin/manage-event/EventTickets.js:559
+#: src/Admin/manage-event/EventTickets.js:553
 #, js-format
 msgid "Period %d"
 msgstr "Zeitraum %d"
@@ -2358,59 +2334,51 @@ msgstr "Tickets werden in der Serie verwaltet —"
 msgid "open the master event"
 msgstr "Hauptveranstaltung öffnen"
 
-#: src/Admin/manage-event/EventTickets.js:921
+#: src/Admin/manage-event/EventTickets.js:912
 msgid "Save tickets"
 msgstr "Tickets speichern"
 
-#: src/Admin/manage-event/EventTickets.js:1363
+#: src/Admin/manage-event/EventTickets.js:1299
 msgid "Min. add-ons"
 msgstr "Min. Add-ons"
 
-#: src/Admin/manage-event/EventTickets.js:1608
+#: src/Admin/manage-event/EventTickets.js:1523
 msgid "Only raises the event-wide minimum add-ons for this ticket type. Leave 0 to inherit."
 msgstr "Erhöht nur die ereignisweite Mindestanzahl von Add-ons für diesen Tickettyp. Auf 0 setzen, um zu erben."
 
-#: src/Admin/manage-event/EventTickets.js:1923
+#: src/Admin/manage-event/EventTickets.js:1851
 msgid "Add-ons"
 msgstr "Add-ons"
 
-#: src/Admin/manage-event/EventTickets.js:1928
+#: src/Admin/manage-event/EventTickets.js:1856
 msgid "Minimum number of add-ons"
 msgstr "Mindestanzahl von Add-ons"
 
-#: src/Admin/manage-event/EventTickets.js:1932
+#: src/Admin/manage-event/EventTickets.js:1860
 msgid "Participants must select at least this many add-ons to sign up. Set to 0 to disable."
 msgstr "Teilnehmer müssen mindestens diese Anzahl von Add-ons auswählen, um sich anzumelden. Auf 0 setzen, um zu deaktivieren."
 
-#: src/Admin/manage-event/EventTickets.js:1954
+#: src/Admin/manage-event/EventTickets.js:1882
 msgid "Add selectable add-ons (checkboxes) shown to participants at signup. Each add-on has its own price added on top of the base price."
 msgstr "Fügen Sie wählbare Add-ons (Kontrollkästchen) hinzu, die den Teilnehmern bei der Anmeldung angezeigt werden. Jedes Add-on hat seinen eigenen Preis, der zum Basispreis hinzukommt."
 
-#: src/Admin/manage-event/EventTickets.js:2023
+#: src/Admin/manage-event/EventTickets.js:1938
 msgid "Add-on name"
 msgstr "Add-on-Name"
 
-#: src/Admin/manage-event/EventTickets.js:2386
+#: src/Admin/manage-event/EventTickets.js:2248
 msgid "Per-ticket-type minimum add-ons"
 msgstr "Pro-Tickettyp-Mindest-Add-ons"
 
-#: src/Admin/manage-event/EventTickets.js:2390
+#: src/Admin/manage-event/EventTickets.js:2252
 msgid "Show a Min. add-ons input on each ticket type to require more add-ons than the event-wide minimum (it only ever raises it). When off, every ticket type uses the event-wide minimum."
 msgstr "Zeigen Sie eine Eingabe für Min. Add-ons für jeden Tickettyp an, um mehr Add-ons als das ereignisweite Minimum zu erfordern (es erhöht es nur). Wenn deaktiviert, verwendet jeder Tickettyp das ereignisweite Minimum."
 
-#: src/Admin/manage-event/EventTickets.js:2423
-msgid "Add-on collaborator discount"
-msgstr "Add-on-Mitarbeiter-Rabatt"
-
-#: src/Admin/manage-event/EventTickets.js:2427
-msgid "Allow a discounted price on each add-on for participants invited by a collaborator linked to that add-on. Adds a second price column to the add-ons table and enables Manage Invitations."
-msgstr "Ermöglichen Sie einen reduzierten Preis für jedes Add-on für Teilnehmer, die von einem Mitarbeiter eingeladen wurden, der mit diesem Add-on verknüpft ist. Fügt eine zweite Preisspalte zur Add-ons-Tabelle hinzu und aktiviert Einladungen verwalten."
-
-#: src/Admin/manage-event/EventTickets.js:2442
+#: src/Admin/manage-event/EventTickets.js:2285
 msgid "Price add-ons per sale period"
 msgstr "Add-ons pro Verkaufszeitraum preislich festlegen"
 
-#: src/Admin/manage-event/EventTickets.js:2446
+#: src/Admin/manage-event/EventTickets.js:2289
 msgid "Price every add-on per sale period instead of a single flat price. The Pricing column in the add-ons table becomes one input per sale period. Requires sale periods to be defined."
 msgstr "Legen Sie den Preis für jedes Add-on pro Verkaufszeitraum fest, anstatt einen einzigen Pauschalpreis zu verwenden. Die Spalte \"Preisgestaltung\" in der Add-ons-Tabelle wird zu einer Eingabe pro Verkaufszeitraum. Erfordert, dass Verkaufszeiträume definiert sind."
 
@@ -2479,16 +2447,16 @@ msgstr "Ungültiges Datum."
 msgid "Event source not found."
 msgstr "Ereignisquelle nicht gefunden."
 
-#: src/Admin/manage-event/EventTickets.js:895
+#: src/Admin/manage-event/EventTickets.js:887
 msgid "Set up Mollie"
 msgstr "Mollie einrichten"
 
-#: src/Admin/manage-event/EventTickets.js:1280
+#: src/Admin/manage-event/EventTickets.js:1216
 msgid "More actions"
 msgstr "Weitere Aktionen"
 
 #: src/Admin/calendar/components/QuickEventModal.js:260
-#: src/Admin/manage-event/EventTickets.js:2352
+#: src/Admin/manage-event/EventTickets.js:2214
 msgid "More options"
 msgstr "Weitere Optionen"
 
@@ -2612,12 +2580,12 @@ msgstr "Fair Events › <calendarlink>%1$s</calendarlink> › %2$s"
 msgid "View public page"
 msgstr "Öffentliche Seite anzeigen"
 
-#: src/Admin/manage-event/EventTickets.js:2466
+#: src/Admin/manage-event/EventTickets.js:2309
 msgid "Merge periods"
 msgstr "Zeiträume zusammenführen"
 
 #. translators: %d: number of sale periods being merged
-#: src/Admin/manage-event/EventTickets.js:2471
+#: src/Admin/manage-event/EventTickets.js:2314
 #, js-format
 msgid "Merge to one sale window? Prices for the other %d periods will be discarded."
 msgstr "Zu einem Verkaufsfenster zusammenführen? Preise für die anderen %d Zeiträume werden verworfen."
@@ -2663,7 +2631,7 @@ msgid "This event happens once."
 msgstr "Dieses Ereignis findet einmalig statt."
 
 #: src/Admin/manage-event/ManageEventApp.js:1056
-#: src/Admin/manage-event/SeriesModal.js:228
+#: src/Admin/manage-event/SeriesModal.js:270
 msgid "Edit series"
 msgstr "Serie bearbeiten"
 
@@ -2673,83 +2641,63 @@ msgid "End series"
 msgstr "Serie beenden"
 
 #: src/Admin/manage-event/ManageEventApp.js:1081
-#: src/Admin/manage-event/SeriesModal.js:229
+#: src/Admin/manage-event/SeriesModal.js:271
 msgid "Turn into a series"
 msgstr "In eine Serie umwandeln"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:345
+#: src/Admin/manage-event/RecurrenceCalendar.js:107
 msgid "Open this occurrence"
 msgstr "Diesen Termin öffnen"
 
-#: src/Admin/manage-event/SeriesModal.js:169
+#: src/Admin/manage-event/SeriesModal.js:211
 msgid "Failed to save the series."
 msgstr "Fehler beim Speichern der Serie."
 
 #. translators: %d: number of dates in the series
-#: src/Admin/manage-event/SeriesModal.js:187
-#: src/Admin/manage-event/SeriesModal.js:198
+#: src/Admin/manage-event/SeriesModal.js:229
+#: src/Admin/manage-event/SeriesModal.js:240
 #, js-format
 msgid "Update series — %d dates"
 msgstr "Serie aktualisieren — %d Termine"
 
 #. translators: %d: number of dates in the series
-#: src/Admin/manage-event/SeriesModal.js:192
-#: src/Admin/manage-event/SeriesModal.js:203
+#: src/Admin/manage-event/SeriesModal.js:234
+#: src/Admin/manage-event/SeriesModal.js:245
 #, js-format
 msgid "Create series — %d dates"
 msgstr "Serie erstellen — %d Termine"
 
-#: src/Admin/manage-event/SeriesModal.js:216
+#: src/Admin/manage-event/SeriesModal.js:258
 msgid "Regular schedule"
 msgstr "Regelmäßiger Zeitplan"
 
-#: src/Admin/manage-event/SeriesModal.js:220
+#: src/Admin/manage-event/SeriesModal.js:262
 msgid "Irregular series"
 msgstr "Unregelmäßige Serie"
 
-#: src/Admin/manage-event/SeriesModal.js:263
+#: src/Admin/manage-event/SeriesModal.js:305
 msgid "Schedule preview"
 msgstr "Zeitplan-Vorschau"
 
-#: src/Admin/manage-event/SeriesModal.js:267
+#: src/Admin/manage-event/SeriesModal.js:309
 msgid "No dates match this schedule yet."
 msgstr "Keine Termine entsprechen diesem Zeitplan."
 
-#. translators: 1: number of remaining dates, 2: last date in the series
-#: src/Admin/manage-event/SeriesModal.js:284
-#, js-format
-msgid "… %1$d more, until %2$s"
-msgstr "… %1$d weitere, bis %2$s"
-
-#: src/Admin/manage-event/SeriesModal.js:298
+#: src/Admin/manage-event/SeriesModal.js:341
 msgid "Pick the exact dates this event happens on."
 msgstr "Wählen Sie die genauen Daten aus, an denen dieses Event stattfindet."
 
-#: src/Admin/manage-event/SeriesModal.js:304
+#: src/Admin/manage-event/SeriesModal.js:347
 msgid "One session per day. All dates share the event’s start time and length."
 msgstr "Eine Sitzung pro Tag. Alle Daten verwenden die Startzeit und Dauer des Events."
 
-#: src/Admin/manage-event/SeriesModal.js:312
+#: src/Admin/manage-event/SeriesModal.js:355
 msgid "Each date can only be used once — remove the duplicate before saving."
 msgstr "Jedes Datum kann nur einmal verwendet werden – entfernen Sie das Duplikat vor dem Speichern."
 
-#: src/Admin/manage-event/SeriesModal.js:323
-msgid "Master date"
-msgstr "Masterdatum"
-
-#: src/Admin/manage-event/SeriesModal.js:329
+#: src/Admin/manage-event/SeriesModal.js:164
 msgid "Master date — edit it from Event Details"
 msgstr "Masterdatum — bearbeiten Sie es unter Veranstaltungsdetails"
-
-#. translators: %d: 1-based row number in the extra-dates list
-#: src/Admin/manage-event/SeriesModal.js:342
-#, js-format
-msgid "Date %d"
-msgstr "Datum %d"
-
-#: src/Admin/manage-event/SeriesModal.js:368
-msgid "Add date"
-msgstr "Datum hinzufügen"
 
 #: src/Admin/settings/GeneralTab.js:293
 msgid "The Events Calendar and Events Week View blocks follow the \"Week Starts On\" setting under Settings → General."
@@ -2824,20 +2772,52 @@ msgstr "Ticketverkäufe vorübergehend nicht verfügbar"
 msgid "Choose a date"
 msgstr "Datum wählen"
 
-#: src/Admin/manage-event/EventTickets.js:900
+#: src/Admin/manage-event/EventTickets.js:892
 msgid "Paid tickets won't be sold until Mollie payments are configured."
 msgstr "Bezahlte Tickets werden erst verkauft, wenn Mollie-Zahlungen konfiguriert sind."
 
-#: src/Admin/manage-event/EventTickets.js:907
+#: src/Admin/manage-event/EventTickets.js:899
 msgid "Paid tickets need the Fair Payments Connector plugin. Install and activate it to sell tickets."
 msgstr "Bezahlte Tickets benötigen das Fair Payments Connector Plugin. Installieren und aktivieren Sie es, um Tickets zu verkaufen."
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1050
+#: src/Admin/manage-event/EventTickets.js:1001
 #, js-format
 msgid "until %s (default)"
 msgstr "bis %s (Standard)"
 
-#: src/blocks/event-signup/editor.js:97
+#: src/blocks/event-signup/editor.js:120
 msgid "Form content"
 msgstr "Formularinhalt"
+
+#: src/Admin/manage-event/EventTickets.js:1820
+msgid "No ticket types yet. Add one to start selling tickets for this event."
+msgstr ""
+
+#: src/Admin/manage-event/SeriesModal.js:179
+msgid "Selected — click to remove this date"
+msgstr ""
+
+#: src/Admin/manage-event/SeriesModal.js:180
+msgid "Click to add this date"
+msgstr ""
+
+#. translators: 1: number of dates in the series, 2: last date in the series
+#: src/Admin/manage-event/SeriesModal.js:324
+#, js-format
+msgid "%1$d dates, until %2$s"
+msgstr ""
+
+#. translators: %d: number of selected dates
+#: src/Admin/manage-event/SeriesModal.js:376
+#, js-format
+msgid "%d dates selected"
+msgstr ""
+
+#: src/blocks/event-signup/editor.js:101
+msgid "Edit tickets"
+msgstr ""
+
+#: src/blocks/event-signup/editor.js:105
+msgid "Connect this block to an event date to edit its tickets."
+msgstr ""

--- a/fair-events/languages/fair-events-es_ES.po
+++ b/fair-events/languages/fair-events-es_ES.po
@@ -28,7 +28,7 @@ msgstr "Configuración de Fair Events"
 msgid "Settings"
 msgstr "Configuración"
 
-#: src/blocks/events-list/render.php:297
+#: src/blocks/events-list/render.php:299
 msgid "No events found. Please select a valid display pattern."
 msgstr "No se encontraron eventos. Por favor, selecciona un patrón de visualización válido."
 
@@ -374,10 +374,10 @@ msgstr "Título"
 
 #: src/Admin/calendar/components/QuickEventModal.js:382
 #: src/Admin/manage-event/EditInstancesModal.js:85
-#: src/Admin/manage-event/EventTickets.js:2467
+#: src/Admin/manage-event/EventTickets.js:2310
 #: src/Admin/manage-event/ManageEventApp.js:1449
 #: src/Admin/manage-event/ManageEventApp.js:1459
-#: src/Admin/manage-event/SeriesModal.js:381
+#: src/Admin/manage-event/SeriesModal.js:391
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -478,19 +478,18 @@ msgstr "Esta fuente está deshabilitada."
 msgid "Date & Time"
 msgstr "Fecha y hora"
 
-#: src/Admin/manage-event/EventTickets.js:1193
-#: src/Admin/manage-event/EventTickets.js:1868
-#: src/Admin/manage-event/EventTickets.js:2309
+#: src/Admin/manage-event/EventTickets.js:1141
+#: src/Admin/manage-event/EventTickets.js:1780
+#: src/Admin/manage-event/EventTickets.js:2173
 #: src/Admin/manage-event/PhotoDetail.js:182
-#: src/Admin/manage-event/SeriesModal.js:358
 msgid "Remove"
 msgstr "Eliminar"
 
 #: src/Admin/all-events/AllEvents.js:70
 #: src/Admin/manage-event/EventSignups.js:54
-#: src/Admin/manage-event/EventTickets.js:1069
-#: src/Admin/manage-event/EventTickets.js:1965
-#: src/Admin/manage-event/EventTickets.js:2018
+#: src/Admin/manage-event/EventTickets.js:1018
+#: src/Admin/manage-event/EventTickets.js:1893
+#: src/Admin/manage-event/EventTickets.js:1933
 msgid "Name"
 msgstr "Nombre"
 
@@ -617,7 +616,7 @@ msgid "Display event with time range and title"
 msgstr "Mostrar evento con rango de tiempo y título"
 
 #: src/blocks/event-proposal/editor.js:21
-#: src/blocks/event-signup/editor.js:80
+#: src/blocks/event-signup/editor.js:87
 msgid "Form Settings"
 msgstr "Configuración del formulario"
 
@@ -654,7 +653,7 @@ msgid "Email address for notifications"
 msgstr "Dirección de correo electrónico para notificaciones"
 
 #: src/blocks/event-proposal/editor.js:75
-#: src/blocks/event-signup/editor.js:82
+#: src/blocks/event-signup/editor.js:89
 msgid "Submit Button Text"
 msgstr "Texto del botón de envío"
 
@@ -818,7 +817,7 @@ msgstr "Error al crear la fecha del evento."
 #: src/API/GetTicketsController.php:197
 #: src/API/TicketsController.php:117
 #: src/API/TicketsController.php:138
-#: src/API/TicketsController.php:291
+#: src/API/TicketsController.php:288
 msgid "Event date not found."
 msgstr "Fecha del evento no encontrada."
 
@@ -959,7 +958,7 @@ msgstr "Fecha de inicio"
 #: src/Admin/calendar/components/QuickEventModal.js:208
 #: src/Admin/calendar/components/QuickEventModal.js:235
 #: src/Admin/event-meta-box/EventEditForm.js:376
-#: src/Admin/manage-event/EventTickets.js:1371
+#: src/Admin/manage-event/EventTickets.js:1307
 #: src/Admin/manage-event/ManageEventApp.js:896
 #: src/Admin/manage-event/ManageEventApp.js:929
 msgid "End date"
@@ -1166,7 +1165,7 @@ msgstr "Error al vincular la entrada."
 msgid "Back to Calendar"
 msgstr "Volver al calendario"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:227
+#: src/Admin/manage-event/RecurrenceCalendar.js:182
 msgid "Recurring Occurrences"
 msgstr "Ocurrencias recurrentes"
 
@@ -1424,7 +1423,7 @@ msgstr "Externo"
 msgid "None"
 msgstr "Ninguno"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:184
+#: src/Admin/manage-event/RecurrenceCalendar.js:139
 msgid "Master"
 msgstr "Principal"
 
@@ -1448,8 +1447,7 @@ msgstr "Fecha a alternar (formato Y-m-d)."
 msgid "Request context. Use \"edit\" to include events linked to non-published posts (requires edit_posts capability)."
 msgstr "Contexto de solicitud. Utilice \"edit\" para incluir eventos vinculados a publicaciones no publicadas (requiere capacidad edit_posts)."
 
-#: src/Admin/manage-event/EventTickets.js:945
-#: src/Admin/manage-event/EventTickets.js:1277
+#: src/Admin/manage-event/EventTickets.js:1213
 #: src/Admin/manage-event/ManageEventApp.js:717
 msgid "Tickets"
 msgstr "Entradas"
@@ -1530,70 +1528,69 @@ msgstr "Seleccionar fotos"
 msgid "Add New Photos"
 msgstr "Añadir nuevas fotos"
 
-#: src/Admin/manage-event/EventTickets.js:195
+#: src/Admin/manage-event/EventTickets.js:192
 msgid "Failed to load tickets."
 msgstr "Error al cargar los tickets."
 
-#: src/Admin/manage-event/EventTickets.js:840
+#: src/Admin/manage-event/EventTickets.js:834
 msgid "Tickets saved successfully."
 msgstr "Tickets guardados correctamente."
 
-#: src/Admin/manage-event/EventTickets.js:843
+#: src/Admin/manage-event/EventTickets.js:837
 msgid "Failed to save tickets."
 msgstr "Error al guardar los tickets."
 
 #: src/Admin/manage-event/EventSignups.js:56
-#: src/Admin/manage-event/EventTickets.js:1331
+#: src/Admin/manage-event/EventTickets.js:1267
 msgid "Ticket Type"
 msgstr "Tipo de ticket"
 
-#: src/Admin/manage-event/EventTickets.js:1426
+#: src/Admin/manage-event/EventTickets.js:1349
 msgid "(unnamed)"
 msgstr "(sin nombre)"
 
-#: src/Admin/manage-event/EventTickets.js:1315
+#: src/Admin/manage-event/EventTickets.js:1251
 msgid "Total capacity"
 msgstr "Capacidad total"
 
-#: src/Admin/manage-event/EventTickets.js:1320
+#: src/Admin/manage-event/EventTickets.js:1256
 msgid "Leave empty for unlimited capacity."
 msgstr "Dejar vacío para capacidad ilimitada."
 
-#: src/Admin/manage-event/EventTickets.js:962
-#: src/Admin/manage-event/EventTickets.js:1904
+#: src/Admin/manage-event/EventTickets.js:1833
 msgid "+ Add Ticket Type"
 msgstr "+ Añadir tipo de ticket"
 
-#: src/Admin/manage-event/EventTickets.js:1338
-#: src/Admin/manage-event/EventTickets.js:1991
+#: src/Admin/manage-event/EventTickets.js:1274
+#: src/Admin/manage-event/EventTickets.js:1906
 msgid "Capacity"
 msgstr "Capacidad"
 
-#: src/Admin/manage-event/EventTickets.js:1124
+#: src/Admin/manage-event/EventTickets.js:1072
 msgid "Period name"
 msgstr "Nombre del período"
 
-#: src/Admin/manage-event/EventTickets.js:1075
-#: src/Admin/manage-event/EventTickets.js:1227
+#: src/Admin/manage-event/EventTickets.js:1024
+#: src/Admin/manage-event/EventTickets.js:1172
 msgid "From"
 msgstr "Desde"
 
-#: src/Admin/manage-event/EventTickets.js:1081
-#: src/Admin/manage-event/EventTickets.js:1246
+#: src/Admin/manage-event/EventTickets.js:1030
+#: src/Admin/manage-event/EventTickets.js:1187
 msgid "Until"
 msgstr "Hasta"
 
-#: src/Admin/manage-event/EventTickets.js:1450
+#: src/Admin/manage-event/EventTickets.js:1370
 msgid "Type name"
 msgstr "Nombre del tipo"
 
-#: src/Admin/manage-event/EventTickets.js:1485
-#: src/Admin/manage-event/EventTickets.js:2193
+#: src/Admin/manage-event/EventTickets.js:1403
+#: src/Admin/manage-event/EventTickets.js:2057
 msgid "Unlimited"
 msgstr "Ilimitado"
 
-#: src/Admin/manage-event/EventTickets.js:1430
-#: src/Admin/manage-event/EventTickets.js:1802
+#: src/Admin/manage-event/EventTickets.js:1353
+#: src/Admin/manage-event/EventTickets.js:1714
 msgid "Price"
 msgstr "Precio"
 
@@ -1601,7 +1598,7 @@ msgstr "Precio"
 msgid "Failed to toggle occurrence."
 msgstr "Error al cambiar la ocurrencia."
 
-#: src/Admin/manage-event/EventTickets.js:1346
+#: src/Admin/manage-event/EventTickets.js:1282
 msgid "Groups"
 msgstr "Grupos"
 
@@ -1649,24 +1646,16 @@ msgstr "Buscar participantes..."
 msgid "No participants found."
 msgstr "No se encontraron participantes."
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:113
-msgid "Previous months"
-msgstr "Meses anteriores"
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:122
-msgid "Next months"
-msgstr "Próximos meses"
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:198
+#: src/Admin/manage-event/RecurrenceCalendar.js:153
 msgid "Active"
 msgstr "Activo"
 
 #: src/Admin/manage-event/EditInstancesModal.js:74
-#: src/Admin/manage-event/RecurrenceCalendar.js:213
+#: src/Admin/manage-event/RecurrenceCalendar.js:168
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:331
+#: src/Admin/manage-event/RecurrenceCalendar.js:100
 msgid "Master event"
 msgstr "Evento maestro"
 
@@ -1674,7 +1663,7 @@ msgstr "Evento maestro"
 msgid "Event Info block is disabled — no event is linked to this post."
 msgstr "El bloque Event Info está deshabilitado — no hay ningún evento vinculado a esta entrada."
 
-#: src/Admin/manage-event/EventTickets.js:930
+#: src/Admin/manage-event/EventTickets.js:919
 msgid "Manage Invitations"
 msgstr "Gestionar invitaciones"
 
@@ -1687,59 +1676,59 @@ msgstr "Pagos"
 msgid "Participant"
 msgstr "Participante"
 
-#: src/Admin/manage-event/EventTickets.js:318
+#: src/Admin/manage-event/EventTickets.js:309
 msgid "Failed to export ticket configuration."
 msgstr "Error al exportar la configuración de entradas."
 
-#: src/Admin/manage-event/EventTickets.js:328
+#: src/Admin/manage-event/EventTickets.js:319
 msgid "Importing will replace all current ticket types, sale periods, prices, and settings for this event. Continue?"
 msgstr "La importación reemplazará todos los tipos de entradas actuales, períodos de venta, precios y configuración de este evento. ¿Continuar?"
 
-#: src/Admin/manage-event/EventTickets.js:352
+#: src/Admin/manage-event/EventTickets.js:343
 msgid "Invalid file format. Expected a fair-events-tickets export."
 msgstr "Formato de archivo inválido. Se esperaba una exportación de fair-events-tickets."
 
-#: src/Admin/manage-event/EventTickets.js:367
+#: src/Admin/manage-event/EventTickets.js:358
 msgid "Ticket configuration imported successfully."
 msgstr "Configuración de entradas importada correctamente."
 
-#: src/Admin/manage-event/EventTickets.js:375
+#: src/Admin/manage-event/EventTickets.js:366
 msgid "Failed to import ticket configuration."
 msgstr "Error al importar la configuración de entradas."
 
-#: src/Admin/manage-event/EventTickets.js:1291
+#: src/Admin/manage-event/EventTickets.js:1227
 msgid "Export ticket settings"
 msgstr "Exportar configuración de entradas"
 
-#: src/Admin/manage-event/EventTickets.js:1303
+#: src/Admin/manage-event/EventTickets.js:1239
 msgid "Import ticket settings"
 msgstr "Importar configuración de entradas"
 
-#: src/Admin/manage-event/EventTickets.js:1354
+#: src/Admin/manage-event/EventTickets.js:1290
 msgid "Invitation only"
 msgstr "Solo por invitación"
 
-#: src/Admin/manage-event/EventTickets.js:1554
+#: src/Admin/manage-event/EventTickets.js:1472
 msgid "All participants"
 msgstr "Todos los participantes"
 
-#: src/Admin/manage-event/EventTickets.js:2357
+#: src/Admin/manage-event/EventTickets.js:2219
 msgid "Per-ticket-type capacity"
 msgstr "Capacidad por tipo de ticket"
 
-#: src/Admin/manage-event/EventTickets.js:2361
+#: src/Admin/manage-event/EventTickets.js:2223
 msgid "Show a Capacity input on each ticket type to cap how many can be sold of that type."
 msgstr "Mostrar un campo de Capacidad en cada tipo de ticket para limitar cuántos se pueden vender de ese tipo."
 
-#: src/Admin/manage-event/EventTickets.js:2374
+#: src/Admin/manage-event/EventTickets.js:2236
 msgid "Multiple pricing periods"
 msgstr "Períodos de precios múltiples"
 
-#: src/Admin/manage-event/EventTickets.js:2378
+#: src/Admin/manage-event/EventTickets.js:2240
 msgid "Enable time-based pricing with multiple sale periods (e.g. early bird, regular, late). When off, a single flat price applies for the whole sale window."
 msgstr "Habilitar precios basados en tiempo con múltiples períodos de venta (p. ej. early bird, regular, última hora). Cuando está desactivado, se aplica un precio único fijo para toda la ventana de venta."
 
-#: src/Admin/manage-event/EventTickets.js:2342
+#: src/Admin/manage-event/EventTickets.js:2205
 msgid "+ Add Option"
 msgstr "+ Agregar opción"
 
@@ -1747,13 +1736,13 @@ msgstr "+ Agregar opción"
 msgid "View Entry"
 msgstr "Ver entrada"
 
-#: src/Admin/manage-event/EventTickets.js:1767
+#: src/Admin/manage-event/EventTickets.js:1679
 msgid "Available"
 msgstr "Disponible"
 
-#: src/Admin/manage-event/EventTickets.js:451
-#: src/Admin/manage-event/EventTickets.js:1014
-#: src/Admin/manage-event/EventTickets.js:1033
+#: src/Admin/manage-event/EventTickets.js:445
+#: src/Admin/manage-event/EventTickets.js:973
+#: src/Admin/manage-event/EventTickets.js:989
 msgid "—"
 msgstr "—"
 
@@ -1761,36 +1750,32 @@ msgstr "—"
 msgid "Failed Payments"
 msgstr "Pagos fallidos"
 
-#: src/Admin/manage-event/EventTickets.js:973
+#: src/Admin/manage-event/EventTickets.js:933
 msgid "Sale Periods"
 msgstr "Períodos de venta"
 
-#: src/Admin/manage-event/EventTickets.js:981
+#: src/Admin/manage-event/EventTickets.js:941
 msgid "Sale start at:"
 msgstr "Inicio de venta:"
 
-#: src/Admin/manage-event/EventTickets.js:1019
+#: src/Admin/manage-event/EventTickets.js:978
 msgid "Sale end at:"
 msgstr "Fin de venta:"
 
-#: src/Admin/manage-event/EventTickets.js:1212
+#: src/Admin/manage-event/EventTickets.js:1160
 msgid "+ Add Period"
 msgstr "+ Agregar período"
 
-#: src/Admin/manage-event/EventTickets.js:2053
-#: src/Admin/manage-event/EventTickets.js:2058
+#: src/Admin/manage-event/EventTickets.js:1968
+#: src/Admin/manage-event/EventTickets.js:1973
 msgid "Short name"
 msgstr "Nombre corto"
 
-#: src/Admin/manage-event/EventTickets.js:1997
+#: src/Admin/manage-event/EventTickets.js:1912
 msgid "Collaborator(s)"
 msgstr "Colaborador(es)"
 
-#: src/Admin/manage-event/EventTickets.js:2156
-msgid "No discount"
-msgstr "Sin descuento"
-
-#: src/Admin/manage-event/EventTickets.js:2285
+#: src/Admin/manage-event/EventTickets.js:2149
 msgid "Add participants"
 msgstr "Añadir participantes"
 
@@ -1818,7 +1803,7 @@ msgstr "Cantidad pagada menos las comisiones de Mollie y de la aplicación."
 msgid "Net received"
 msgstr "Neto recibido"
 
-#: src/Admin/manage-event/EventTickets.js:542
+#: src/Admin/manage-event/EventTickets.js:536
 msgid "Add sale periods first."
 msgstr "Añade primero períodos de venta."
 
@@ -1914,11 +1899,11 @@ msgstr "Traducciones incluidas"
 msgid "Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings."
 msgstr "Carga archivos .mo/.json incluidos con el plugin en lugar de depender de los paquetes de idiomas de WordPress.org. Útil cuando una configuración regional está por debajo del umbral del 90% en translate.wordpress.org o para cadenas en progreso."
 
-#: src/Admin/manage-event/EventTickets.js:2406
+#: src/Admin/manage-event/EventTickets.js:2268
 msgid "Per-ticket-type end date"
 msgstr "Fecha de finalización por tipo de entrada"
 
-#: src/Admin/manage-event/EventTickets.js:2410
+#: src/Admin/manage-event/EventTickets.js:2272
 msgid "Show a date/time input on each ticket type to stop selling it after a fixed date, regardless of remaining capacity."
 msgstr "Mostrar una entrada de fecha/hora en cada tipo de entrada para dejar de venderla después de una fecha fija, independientemente de la capacidad restante."
 
@@ -1932,20 +1917,15 @@ msgstr "Mostrar una línea «Powered by Fair Event Plugins» en formularios de r
 
 #. translators: %s: "Fair Event Plugins" linked to the project site
 #: src/Services/Branding.php:57
+#, php-format
 msgid "Powered by %s"
 msgstr "Desarrollado por %s"
 
 #. translators: %s: currency code
-#: src/Admin/manage-event/EventTickets.js:1970
+#: src/Admin/manage-event/EventTickets.js:1898
 #, js-format
 msgid "Price (%s)"
 msgstr "Precio (%s)"
-
-#. translators: %s: currency code
-#: src/Admin/manage-event/EventTickets.js:1981
-#, js-format
-msgid "Discounted price (%s)"
-msgstr "Precio con descuento (%s)"
 
 #: src/Admin/settings/GeneralTab.js:276
 msgid "Branding"
@@ -2053,7 +2033,7 @@ msgstr "Entradas para el evento #%d"
 msgid "Ticket for %s"
 msgstr "Entrada para %s"
 
-#: src/API/TicketsController.php:300
+#: src/API/TicketsController.php:297
 msgid "Invalid import payload."
 msgstr "Carga útil de importación inválida."
 
@@ -2130,82 +2110,78 @@ msgstr "Sí"
 msgid "No"
 msgstr "No"
 
-#: src/Admin/manage-event/EventTickets.js:950
-msgid "No ticket types configured yet. Add a ticket type to start selling tickets for this event."
-msgstr "Sin tipos de entrada configurados aún. Añade un tipo de entrada para comenzar a vender entradas para este evento."
-
-#: src/Admin/manage-event/EventTickets.js:664
+#: src/Admin/manage-event/EventTickets.js:658
 msgid "Advance ticket"
 msgstr "Entrada anticipada"
 
-#: src/Admin/manage-event/EventTickets.js:670
+#: src/Admin/manage-event/EventTickets.js:664
 msgid "Day of event"
 msgstr "Día del evento"
 
-#: src/Admin/manage-event/EventTickets.js:1648
-#: src/Admin/manage-event/EventTickets.js:1680
+#: src/Admin/manage-event/EventTickets.js:1563
+#: src/Admin/manage-event/EventTickets.js:1595
 msgid "Whole series"
 msgstr "Serie completa"
 
-#: src/Admin/manage-event/EventTickets.js:1654
-#: src/Admin/manage-event/EventTickets.js:1687
+#: src/Admin/manage-event/EventTickets.js:1569
+#: src/Admin/manage-event/EventTickets.js:1602
 msgid "Multiple instances"
 msgstr "Múltiples fechas"
 
-#: src/Admin/manage-event/EventTickets.js:1658
-#: src/Admin/manage-event/EventTickets.js:1673
+#: src/Admin/manage-event/EventTickets.js:1573
+#: src/Admin/manage-event/EventTickets.js:1588
 msgid "This instance"
 msgstr "Esta instancia"
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1008
+#: src/Admin/manage-event/EventTickets.js:967
 #, js-format
 msgid "From %s"
 msgstr "Desde %s"
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1040
+#: src/Admin/manage-event/EventTickets.js:993
 #, js-format
 msgid "until %s"
 msgstr "hasta %s"
 
-#: src/Admin/manage-event/EventTickets.js:1379
+#: src/Admin/manage-event/EventTickets.js:1315
 msgid "Scope"
 msgstr "Alcance"
 
-#: src/Admin/manage-event/EventTickets.js:1473
+#: src/Admin/manage-event/EventTickets.js:1391
 msgid "Disabled — no longer on sale"
 msgstr "Desactivado — ya no está a la venta"
 
-#: src/Admin/manage-event/EventTickets.js:1710
+#: src/Admin/manage-event/EventTickets.js:1625
 msgid "Minimum instances"
 msgstr "Instancias mínimas"
 
-#: src/Admin/manage-event/EventTickets.js:1837
+#: src/Admin/manage-event/EventTickets.js:1749
 msgid "Disabled"
 msgstr "Deshabilitado"
 
-#: src/Admin/manage-event/EventTickets.js:1841
+#: src/Admin/manage-event/EventTickets.js:1753
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: src/Admin/manage-event/EventTickets.js:2480
+#: src/Admin/manage-event/EventTickets.js:2323
 msgid "Choose ticket scope"
 msgstr "Elige el alcance de la entrada"
 
-#: src/Admin/manage-event/EventTickets.js:2488
+#: src/Admin/manage-event/EventTickets.js:2331
 msgid "This instance — a separate ticket is needed for each date"
 msgstr "Esta instancia — se necesita una entrada separada para cada fecha"
 
-#: src/Admin/manage-event/EventTickets.js:2495
+#: src/Admin/manage-event/EventTickets.js:2338
 msgid "Whole series — one purchase covers every occurrence"
 msgstr "Serie completa — una compra cubre todas las ocurrencias"
 
-#: src/Admin/manage-event/EventTickets.js:2502
+#: src/Admin/manage-event/EventTickets.js:2345
 msgid "Multiple instances — buyer picks several occurrences"
 msgstr "Múltiples instancias — el comprador elige varias ocurrencias"
 
-#: src/Admin/manage-event/EventTickets.js:2517
+#: src/Admin/manage-event/EventTickets.js:2360
 msgid "Add ticket type"
 msgstr "Añadir tipo de entrada"
 
@@ -2278,7 +2254,7 @@ msgid "Failed to submit. Please try again."
 msgstr "No se pudo enviar. Inténtalo de nuevo."
 
 #. translators: 1: formatted date, 2: number of days
-#: src/Admin/manage-event/EventTickets.js:997
+#: src/Admin/manage-event/EventTickets.js:956
 #, js-format
 msgid "From %1$s (%2$d day before event)"
 msgid_plural "From %1$s (%2$d days before event)"
@@ -2286,7 +2262,7 @@ msgstr[0] "Desde %1$s (%2$d día antes del evento)"
 msgstr[1] "Desde %1$s (%2$d días antes del evento)"
 
 #. translators: %d: sale period number
-#: src/Admin/manage-event/EventTickets.js:559
+#: src/Admin/manage-event/EventTickets.js:553
 #, js-format
 msgid "Period %d"
 msgstr "Período %d"
@@ -2358,59 +2334,51 @@ msgstr "Los tickets se gestionan en la serie —"
 msgid "open the master event"
 msgstr "abrir el evento principal"
 
-#: src/Admin/manage-event/EventTickets.js:921
+#: src/Admin/manage-event/EventTickets.js:912
 msgid "Save tickets"
 msgstr "Guardar tickets"
 
-#: src/Admin/manage-event/EventTickets.js:1363
+#: src/Admin/manage-event/EventTickets.js:1299
 msgid "Min. add-ons"
 msgstr "Mín. extensiones"
 
-#: src/Admin/manage-event/EventTickets.js:1608
+#: src/Admin/manage-event/EventTickets.js:1523
 msgid "Only raises the event-wide minimum add-ons for this ticket type. Leave 0 to inherit."
 msgstr "Solo aumenta el mínimo de evento para este tipo de entrada. Deja 0 para heredar."
 
-#: src/Admin/manage-event/EventTickets.js:1923
+#: src/Admin/manage-event/EventTickets.js:1851
 msgid "Add-ons"
 msgstr "Extensiones"
 
-#: src/Admin/manage-event/EventTickets.js:1928
+#: src/Admin/manage-event/EventTickets.js:1856
 msgid "Minimum number of add-ons"
 msgstr "Número mínimo de extensiones"
 
-#: src/Admin/manage-event/EventTickets.js:1932
+#: src/Admin/manage-event/EventTickets.js:1860
 msgid "Participants must select at least this many add-ons to sign up. Set to 0 to disable."
 msgstr "Los participantes deben seleccionar al menos esta cantidad de actividades para registrarse. Establece en 0 para desactivar."
 
-#: src/Admin/manage-event/EventTickets.js:1954
+#: src/Admin/manage-event/EventTickets.js:1882
 msgid "Add selectable add-ons (checkboxes) shown to participants at signup. Each add-on has its own price added on top of the base price."
 msgstr "Añade complementos seleccionables (casillas de verificación) que se muestran a los participantes en el registro. Cada complemento tiene su propio precio añadido al precio base."
 
-#: src/Admin/manage-event/EventTickets.js:2023
+#: src/Admin/manage-event/EventTickets.js:1938
 msgid "Add-on name"
 msgstr "Nombre de la extensión"
 
-#: src/Admin/manage-event/EventTickets.js:2386
+#: src/Admin/manage-event/EventTickets.js:2248
 msgid "Per-ticket-type minimum add-ons"
 msgstr "Mínimo de extensiones por tipo de entrada"
 
-#: src/Admin/manage-event/EventTickets.js:2390
+#: src/Admin/manage-event/EventTickets.js:2252
 msgid "Show a Min. add-ons input on each ticket type to require more add-ons than the event-wide minimum (it only ever raises it). When off, every ticket type uses the event-wide minimum."
 msgstr "Mostrar una entrada de Mín. actividades en cada tipo de entrada para requerir más actividades que el mínimo de evento (solo lo aumenta). Cuando está desactivado, cada tipo de entrada utiliza el mínimo de evento."
 
-#: src/Admin/manage-event/EventTickets.js:2423
-msgid "Add-on collaborator discount"
-msgstr "Descuento de extensión para colaboradores"
-
-#: src/Admin/manage-event/EventTickets.js:2427
-msgid "Allow a discounted price on each add-on for participants invited by a collaborator linked to that add-on. Adds a second price column to the add-ons table and enables Manage Invitations."
-msgstr "Permite un precio con descuento en cada opción de actividad para participantes invitados por un colaborador vinculado a esa actividad. Añade una segunda columna de precio a la tabla de opciones de actividad y habilita Gestionar invitaciones."
-
-#: src/Admin/manage-event/EventTickets.js:2442
+#: src/Admin/manage-event/EventTickets.js:2285
 msgid "Price add-ons per sale period"
 msgstr "Precio de extensión por período de venta"
 
-#: src/Admin/manage-event/EventTickets.js:2446
+#: src/Admin/manage-event/EventTickets.js:2289
 msgid "Price every add-on per sale period instead of a single flat price. The Pricing column in the add-ons table becomes one input per sale period. Requires sale periods to be defined."
 msgstr "Precio de cada opción de actividad por período de venta en lugar de un precio único. La columna Precio en la tabla de opciones de actividad se convierte en una entrada por período de venta. Requiere que se definan períodos de venta."
 
@@ -2479,16 +2447,16 @@ msgstr "Fecha no válida."
 msgid "Event source not found."
 msgstr "Origen del evento no encontrado."
 
-#: src/Admin/manage-event/EventTickets.js:895
+#: src/Admin/manage-event/EventTickets.js:887
 msgid "Set up Mollie"
 msgstr "Configurar Mollie"
 
-#: src/Admin/manage-event/EventTickets.js:1280
+#: src/Admin/manage-event/EventTickets.js:1216
 msgid "More actions"
 msgstr "Más acciones"
 
 #: src/Admin/calendar/components/QuickEventModal.js:260
-#: src/Admin/manage-event/EventTickets.js:2352
+#: src/Admin/manage-event/EventTickets.js:2214
 msgid "More options"
 msgstr "Más opciones"
 
@@ -2612,12 +2580,12 @@ msgstr "Fair Events › <calendarlink>%1$s</calendarlink> › %2$s"
 msgid "View public page"
 msgstr "Ver página pública"
 
-#: src/Admin/manage-event/EventTickets.js:2466
+#: src/Admin/manage-event/EventTickets.js:2309
 msgid "Merge periods"
 msgstr "Combinar períodos"
 
 #. translators: %d: number of sale periods being merged
-#: src/Admin/manage-event/EventTickets.js:2471
+#: src/Admin/manage-event/EventTickets.js:2314
 #, js-format
 msgid "Merge to one sale window? Prices for the other %d periods will be discarded."
 msgstr "¿Combinar en una única ventana de venta? Los precios de los otros %d períodos se descartarán."
@@ -2663,7 +2631,7 @@ msgid "This event happens once."
 msgstr "Este evento ocurre una sola vez."
 
 #: src/Admin/manage-event/ManageEventApp.js:1056
-#: src/Admin/manage-event/SeriesModal.js:228
+#: src/Admin/manage-event/SeriesModal.js:270
 msgid "Edit series"
 msgstr "Editar serie"
 
@@ -2673,83 +2641,63 @@ msgid "End series"
 msgstr "Finalizar serie"
 
 #: src/Admin/manage-event/ManageEventApp.js:1081
-#: src/Admin/manage-event/SeriesModal.js:229
+#: src/Admin/manage-event/SeriesModal.js:271
 msgid "Turn into a series"
 msgstr "Convertir en una serie"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:345
+#: src/Admin/manage-event/RecurrenceCalendar.js:107
 msgid "Open this occurrence"
 msgstr "Abrir esta ocurrencia"
 
-#: src/Admin/manage-event/SeriesModal.js:169
+#: src/Admin/manage-event/SeriesModal.js:211
 msgid "Failed to save the series."
 msgstr "No se pudo guardar la serie."
 
 #. translators: %d: number of dates in the series
-#: src/Admin/manage-event/SeriesModal.js:187
-#: src/Admin/manage-event/SeriesModal.js:198
+#: src/Admin/manage-event/SeriesModal.js:229
+#: src/Admin/manage-event/SeriesModal.js:240
 #, js-format
 msgid "Update series — %d dates"
 msgstr "Actualizar serie — %d fechas"
 
 #. translators: %d: number of dates in the series
-#: src/Admin/manage-event/SeriesModal.js:192
-#: src/Admin/manage-event/SeriesModal.js:203
+#: src/Admin/manage-event/SeriesModal.js:234
+#: src/Admin/manage-event/SeriesModal.js:245
 #, js-format
 msgid "Create series — %d dates"
 msgstr "Crear serie — %d fechas"
 
-#: src/Admin/manage-event/SeriesModal.js:216
+#: src/Admin/manage-event/SeriesModal.js:258
 msgid "Regular schedule"
 msgstr "Calendario regular"
 
-#: src/Admin/manage-event/SeriesModal.js:220
+#: src/Admin/manage-event/SeriesModal.js:262
 msgid "Irregular series"
 msgstr "Serie irregular"
 
-#: src/Admin/manage-event/SeriesModal.js:263
+#: src/Admin/manage-event/SeriesModal.js:305
 msgid "Schedule preview"
 msgstr "Vista previa del calendario"
 
-#: src/Admin/manage-event/SeriesModal.js:267
+#: src/Admin/manage-event/SeriesModal.js:309
 msgid "No dates match this schedule yet."
 msgstr "Ninguna fecha coincide con este calendario aún."
 
-#. translators: 1: number of remaining dates, 2: last date in the series
-#: src/Admin/manage-event/SeriesModal.js:284
-#, js-format
-msgid "… %1$d more, until %2$s"
-msgstr "… %1$d más, hasta %2$s"
-
-#: src/Admin/manage-event/SeriesModal.js:298
+#: src/Admin/manage-event/SeriesModal.js:341
 msgid "Pick the exact dates this event happens on."
 msgstr "Selecciona las fechas exactas en las que ocurre este evento."
 
-#: src/Admin/manage-event/SeriesModal.js:304
+#: src/Admin/manage-event/SeriesModal.js:347
 msgid "One session per day. All dates share the event’s start time and length."
 msgstr "Una sesión por día. Todas las fechas comparten la hora de inicio y duración del evento."
 
-#: src/Admin/manage-event/SeriesModal.js:312
+#: src/Admin/manage-event/SeriesModal.js:355
 msgid "Each date can only be used once — remove the duplicate before saving."
 msgstr "Cada fecha solo se puede usar una vez — elimina el duplicado antes de guardar."
 
-#: src/Admin/manage-event/SeriesModal.js:323
-msgid "Master date"
-msgstr "Fecha principal"
-
-#: src/Admin/manage-event/SeriesModal.js:329
+#: src/Admin/manage-event/SeriesModal.js:164
 msgid "Master date — edit it from Event Details"
 msgstr "Fecha principal — edítala desde Detalles del evento"
-
-#. translators: %d: 1-based row number in the extra-dates list
-#: src/Admin/manage-event/SeriesModal.js:342
-#, js-format
-msgid "Date %d"
-msgstr "Fecha %d"
-
-#: src/Admin/manage-event/SeriesModal.js:368
-msgid "Add date"
-msgstr "Añadir fecha"
 
 #: src/Admin/settings/GeneralTab.js:293
 msgid "The Events Calendar and Events Week View blocks follow the \"Week Starts On\" setting under Settings → General."
@@ -2824,20 +2772,52 @@ msgstr "venta de entradas temporalmente no disponible"
 msgid "Choose a date"
 msgstr "Elige una fecha"
 
-#: src/Admin/manage-event/EventTickets.js:900
+#: src/Admin/manage-event/EventTickets.js:892
 msgid "Paid tickets won't be sold until Mollie payments are configured."
 msgstr "Los tickets de pago no se venderán hasta que se configure Mollie."
 
-#: src/Admin/manage-event/EventTickets.js:907
+#: src/Admin/manage-event/EventTickets.js:899
 msgid "Paid tickets need the Fair Payments Connector plugin. Install and activate it to sell tickets."
 msgstr "Los tickets de pago requieren el complemento Fair Payments Connector. Instálalo y actívalo para vender entradas."
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1050
+#: src/Admin/manage-event/EventTickets.js:1001
 #, js-format
 msgid "until %s (default)"
 msgstr "hasta %s (predeterminado)"
 
-#: src/blocks/event-signup/editor.js:97
+#: src/blocks/event-signup/editor.js:120
 msgid "Form content"
 msgstr "Contenido del formulario"
+
+#: src/Admin/manage-event/EventTickets.js:1820
+msgid "No ticket types yet. Add one to start selling tickets for this event."
+msgstr ""
+
+#: src/Admin/manage-event/SeriesModal.js:179
+msgid "Selected — click to remove this date"
+msgstr ""
+
+#: src/Admin/manage-event/SeriesModal.js:180
+msgid "Click to add this date"
+msgstr ""
+
+#. translators: 1: number of dates in the series, 2: last date in the series
+#: src/Admin/manage-event/SeriesModal.js:324
+#, js-format
+msgid "%1$d dates, until %2$s"
+msgstr ""
+
+#. translators: %d: number of selected dates
+#: src/Admin/manage-event/SeriesModal.js:376
+#, js-format
+msgid "%d dates selected"
+msgstr ""
+
+#: src/blocks/event-signup/editor.js:101
+msgid "Edit tickets"
+msgstr ""
+
+#: src/blocks/event-signup/editor.js:105
+msgid "Connect this block to an event date to edit its tickets."
+msgstr ""

--- a/fair-events/languages/fair-events-fr_FR.po
+++ b/fair-events/languages/fair-events-fr_FR.po
@@ -43,7 +43,7 @@ msgstr "Paramètres Fair Events"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: src/blocks/events-list/render.php:297
+#: src/blocks/events-list/render.php:299
 msgid "No events found. Please select a valid display pattern."
 msgstr "Aucun événement trouvé. Veuillez sélectionner un modèle d'affichage valide."
 
@@ -374,10 +374,10 @@ msgstr "Titre"
 
 #: src/Admin/calendar/components/QuickEventModal.js:382
 #: src/Admin/manage-event/EditInstancesModal.js:85
-#: src/Admin/manage-event/EventTickets.js:2467
+#: src/Admin/manage-event/EventTickets.js:2310
 #: src/Admin/manage-event/ManageEventApp.js:1449
 #: src/Admin/manage-event/ManageEventApp.js:1459
-#: src/Admin/manage-event/SeriesModal.js:381
+#: src/Admin/manage-event/SeriesModal.js:391
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -478,19 +478,18 @@ msgstr "Cette source est désactivée."
 msgid "Date & Time"
 msgstr "Date & Heure"
 
-#: src/Admin/manage-event/EventTickets.js:1193
-#: src/Admin/manage-event/EventTickets.js:1868
-#: src/Admin/manage-event/EventTickets.js:2309
+#: src/Admin/manage-event/EventTickets.js:1141
+#: src/Admin/manage-event/EventTickets.js:1780
+#: src/Admin/manage-event/EventTickets.js:2173
 #: src/Admin/manage-event/PhotoDetail.js:182
-#: src/Admin/manage-event/SeriesModal.js:358
 msgid "Remove"
 msgstr "Supprimer"
 
 #: src/Admin/all-events/AllEvents.js:70
 #: src/Admin/manage-event/EventSignups.js:54
-#: src/Admin/manage-event/EventTickets.js:1069
-#: src/Admin/manage-event/EventTickets.js:1965
-#: src/Admin/manage-event/EventTickets.js:2018
+#: src/Admin/manage-event/EventTickets.js:1018
+#: src/Admin/manage-event/EventTickets.js:1893
+#: src/Admin/manage-event/EventTickets.js:1933
 msgid "Name"
 msgstr "Nom"
 
@@ -617,7 +616,7 @@ msgid "Display event with time range and title"
 msgstr "Afficher l'événement avec la plage horaire et le titre"
 
 #: src/blocks/event-proposal/editor.js:21
-#: src/blocks/event-signup/editor.js:80
+#: src/blocks/event-signup/editor.js:87
 msgid "Form Settings"
 msgstr "Paramètres du formulaire"
 
@@ -654,7 +653,7 @@ msgid "Email address for notifications"
 msgstr "Adresse e-mail pour les notifications"
 
 #: src/blocks/event-proposal/editor.js:75
-#: src/blocks/event-signup/editor.js:82
+#: src/blocks/event-signup/editor.js:89
 msgid "Submit Button Text"
 msgstr "Texte du bouton de soumission"
 
@@ -818,7 +817,7 @@ msgstr "Échec de la création de la date d'événement."
 #: src/API/GetTicketsController.php:197
 #: src/API/TicketsController.php:117
 #: src/API/TicketsController.php:138
-#: src/API/TicketsController.php:291
+#: src/API/TicketsController.php:288
 msgid "Event date not found."
 msgstr "Date d'événement non trouvée."
 
@@ -959,7 +958,7 @@ msgstr "Date de début"
 #: src/Admin/calendar/components/QuickEventModal.js:208
 #: src/Admin/calendar/components/QuickEventModal.js:235
 #: src/Admin/event-meta-box/EventEditForm.js:376
-#: src/Admin/manage-event/EventTickets.js:1371
+#: src/Admin/manage-event/EventTickets.js:1307
 #: src/Admin/manage-event/ManageEventApp.js:896
 #: src/Admin/manage-event/ManageEventApp.js:929
 msgid "End date"
@@ -1166,7 +1165,7 @@ msgstr "Échec de l'association de l'article."
 msgid "Back to Calendar"
 msgstr "Retour au calendrier"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:227
+#: src/Admin/manage-event/RecurrenceCalendar.js:182
 msgid "Recurring Occurrences"
 msgstr "Occurrences récurrentes"
 
@@ -1424,7 +1423,7 @@ msgstr "Externe"
 msgid "None"
 msgstr "Aucun"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:184
+#: src/Admin/manage-event/RecurrenceCalendar.js:139
 msgid "Master"
 msgstr "Principal"
 
@@ -1448,8 +1447,7 @@ msgstr "Date à basculer (format Y-m-d)."
 msgid "Request context. Use \"edit\" to include events linked to non-published posts (requires edit_posts capability)."
 msgstr "Contexte de la requête. Utilisez « edit » pour inclure les événements liés aux articles non publiés (nécessite la capacité edit_posts)."
 
-#: src/Admin/manage-event/EventTickets.js:945
-#: src/Admin/manage-event/EventTickets.js:1277
+#: src/Admin/manage-event/EventTickets.js:1213
 #: src/Admin/manage-event/ManageEventApp.js:717
 msgid "Tickets"
 msgstr "Billets"
@@ -1530,70 +1528,69 @@ msgstr "Sélectionner des photos"
 msgid "Add New Photos"
 msgstr "Ajouter de nouvelles photos"
 
-#: src/Admin/manage-event/EventTickets.js:195
+#: src/Admin/manage-event/EventTickets.js:192
 msgid "Failed to load tickets."
 msgstr "Échec du chargement des billets."
 
-#: src/Admin/manage-event/EventTickets.js:840
+#: src/Admin/manage-event/EventTickets.js:834
 msgid "Tickets saved successfully."
 msgstr "Billets enregistrés avec succès."
 
-#: src/Admin/manage-event/EventTickets.js:843
+#: src/Admin/manage-event/EventTickets.js:837
 msgid "Failed to save tickets."
 msgstr "Échec de l'enregistrement des billets."
 
 #: src/Admin/manage-event/EventSignups.js:56
-#: src/Admin/manage-event/EventTickets.js:1331
+#: src/Admin/manage-event/EventTickets.js:1267
 msgid "Ticket Type"
 msgstr "Type de billet"
 
-#: src/Admin/manage-event/EventTickets.js:1426
+#: src/Admin/manage-event/EventTickets.js:1349
 msgid "(unnamed)"
 msgstr "(sans nom)"
 
-#: src/Admin/manage-event/EventTickets.js:1315
+#: src/Admin/manage-event/EventTickets.js:1251
 msgid "Total capacity"
 msgstr "Capacité totale"
 
-#: src/Admin/manage-event/EventTickets.js:1320
+#: src/Admin/manage-event/EventTickets.js:1256
 msgid "Leave empty for unlimited capacity."
 msgstr "Laissez vide pour une capacité illimitée."
 
-#: src/Admin/manage-event/EventTickets.js:962
-#: src/Admin/manage-event/EventTickets.js:1904
+#: src/Admin/manage-event/EventTickets.js:1833
 msgid "+ Add Ticket Type"
 msgstr "+ Ajouter un type de billet"
 
-#: src/Admin/manage-event/EventTickets.js:1338
-#: src/Admin/manage-event/EventTickets.js:1991
+#: src/Admin/manage-event/EventTickets.js:1274
+#: src/Admin/manage-event/EventTickets.js:1906
 msgid "Capacity"
 msgstr "Capacité"
 
-#: src/Admin/manage-event/EventTickets.js:1124
+#: src/Admin/manage-event/EventTickets.js:1072
 msgid "Period name"
 msgstr "Nom de la période"
 
-#: src/Admin/manage-event/EventTickets.js:1075
-#: src/Admin/manage-event/EventTickets.js:1227
+#: src/Admin/manage-event/EventTickets.js:1024
+#: src/Admin/manage-event/EventTickets.js:1172
 msgid "From"
 msgstr "À partir de"
 
-#: src/Admin/manage-event/EventTickets.js:1081
-#: src/Admin/manage-event/EventTickets.js:1246
+#: src/Admin/manage-event/EventTickets.js:1030
+#: src/Admin/manage-event/EventTickets.js:1187
 msgid "Until"
 msgstr "Jusqu'au"
 
-#: src/Admin/manage-event/EventTickets.js:1450
+#: src/Admin/manage-event/EventTickets.js:1370
 msgid "Type name"
 msgstr "Nom du type"
 
-#: src/Admin/manage-event/EventTickets.js:1485
-#: src/Admin/manage-event/EventTickets.js:2193
+#: src/Admin/manage-event/EventTickets.js:1403
+#: src/Admin/manage-event/EventTickets.js:2057
 msgid "Unlimited"
 msgstr "Illimité"
 
-#: src/Admin/manage-event/EventTickets.js:1430
-#: src/Admin/manage-event/EventTickets.js:1802
+#: src/Admin/manage-event/EventTickets.js:1353
+#: src/Admin/manage-event/EventTickets.js:1714
 msgid "Price"
 msgstr "Prix"
 
@@ -1601,7 +1598,7 @@ msgstr "Prix"
 msgid "Failed to toggle occurrence."
 msgstr "Échec du basculement de l'occurrence."
 
-#: src/Admin/manage-event/EventTickets.js:1346
+#: src/Admin/manage-event/EventTickets.js:1282
 msgid "Groups"
 msgstr "Groupes"
 
@@ -1649,24 +1646,16 @@ msgstr "Rechercher des participants..."
 msgid "No participants found."
 msgstr "Aucun participant trouvé."
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:113
-msgid "Previous months"
-msgstr "Mois précédents"
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:122
-msgid "Next months"
-msgstr "Mois suivants"
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:198
+#: src/Admin/manage-event/RecurrenceCalendar.js:153
 msgid "Active"
 msgstr "Actif"
 
 #: src/Admin/manage-event/EditInstancesModal.js:74
-#: src/Admin/manage-event/RecurrenceCalendar.js:213
+#: src/Admin/manage-event/RecurrenceCalendar.js:168
 msgid "Cancelled"
 msgstr "Annulé"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:331
+#: src/Admin/manage-event/RecurrenceCalendar.js:100
 msgid "Master event"
 msgstr "Événement principal"
 
@@ -1674,7 +1663,7 @@ msgstr "Événement principal"
 msgid "Event Info block is disabled — no event is linked to this post."
 msgstr "Le bloc Informations sur l'événement est désactivé — aucun événement n'est lié à cet article."
 
-#: src/Admin/manage-event/EventTickets.js:930
+#: src/Admin/manage-event/EventTickets.js:919
 msgid "Manage Invitations"
 msgstr "Gérer les invitations"
 
@@ -1687,59 +1676,59 @@ msgstr "Paiements"
 msgid "Participant"
 msgstr "Participant"
 
-#: src/Admin/manage-event/EventTickets.js:318
+#: src/Admin/manage-event/EventTickets.js:309
 msgid "Failed to export ticket configuration."
 msgstr "Échec de l'export de la configuration des billets."
 
-#: src/Admin/manage-event/EventTickets.js:328
+#: src/Admin/manage-event/EventTickets.js:319
 msgid "Importing will replace all current ticket types, sale periods, prices, and settings for this event. Continue?"
 msgstr "L'importation remplacera tous les types de billets actuels, les périodes de vente, les prix et les paramètres de cet événement. Continuer ?"
 
-#: src/Admin/manage-event/EventTickets.js:352
+#: src/Admin/manage-event/EventTickets.js:343
 msgid "Invalid file format. Expected a fair-events-tickets export."
 msgstr "Format de fichier invalide. Un export fair-events-tickets était attendu."
 
-#: src/Admin/manage-event/EventTickets.js:367
+#: src/Admin/manage-event/EventTickets.js:358
 msgid "Ticket configuration imported successfully."
 msgstr "Configuration des billets importée avec succès."
 
-#: src/Admin/manage-event/EventTickets.js:375
+#: src/Admin/manage-event/EventTickets.js:366
 msgid "Failed to import ticket configuration."
 msgstr "Échec de l'import de la configuration des billets."
 
-#: src/Admin/manage-event/EventTickets.js:1291
+#: src/Admin/manage-event/EventTickets.js:1227
 msgid "Export ticket settings"
 msgstr "Exporter les paramètres des billets"
 
-#: src/Admin/manage-event/EventTickets.js:1303
+#: src/Admin/manage-event/EventTickets.js:1239
 msgid "Import ticket settings"
 msgstr "Importer les paramètres des billets"
 
-#: src/Admin/manage-event/EventTickets.js:1354
+#: src/Admin/manage-event/EventTickets.js:1290
 msgid "Invitation only"
 msgstr "Sur invitation uniquement"
 
-#: src/Admin/manage-event/EventTickets.js:1554
+#: src/Admin/manage-event/EventTickets.js:1472
 msgid "All participants"
 msgstr "Tous les participants"
 
-#: src/Admin/manage-event/EventTickets.js:2357
+#: src/Admin/manage-event/EventTickets.js:2219
 msgid "Per-ticket-type capacity"
 msgstr "Capacité par type de billet"
 
-#: src/Admin/manage-event/EventTickets.js:2361
+#: src/Admin/manage-event/EventTickets.js:2223
 msgid "Show a Capacity input on each ticket type to cap how many can be sold of that type."
 msgstr "Afficher un champ Capacité sur chaque type de billet pour limiter le nombre de billets de ce type qui peuvent être vendus."
 
-#: src/Admin/manage-event/EventTickets.js:2374
+#: src/Admin/manage-event/EventTickets.js:2236
 msgid "Multiple pricing periods"
 msgstr "Périodes tarifaires multiples"
 
-#: src/Admin/manage-event/EventTickets.js:2378
+#: src/Admin/manage-event/EventTickets.js:2240
 msgid "Enable time-based pricing with multiple sale periods (e.g. early bird, regular, late). When off, a single flat price applies for the whole sale window."
 msgstr "Activer la tarification basée sur le temps avec plusieurs périodes de vente (par exemple, tarif précoce, régulier, tardif). Lorsque désactivé, un prix unique s'applique pour toute la période de vente."
 
-#: src/Admin/manage-event/EventTickets.js:2342
+#: src/Admin/manage-event/EventTickets.js:2205
 msgid "+ Add Option"
 msgstr "+ Ajouter une option"
 
@@ -1747,13 +1736,13 @@ msgstr "+ Ajouter une option"
 msgid "View Entry"
 msgstr "Afficher l'entrée"
 
-#: src/Admin/manage-event/EventTickets.js:1767
+#: src/Admin/manage-event/EventTickets.js:1679
 msgid "Available"
 msgstr "Disponible"
 
-#: src/Admin/manage-event/EventTickets.js:451
-#: src/Admin/manage-event/EventTickets.js:1014
-#: src/Admin/manage-event/EventTickets.js:1033
+#: src/Admin/manage-event/EventTickets.js:445
+#: src/Admin/manage-event/EventTickets.js:973
+#: src/Admin/manage-event/EventTickets.js:989
 msgid "—"
 msgstr "—"
 
@@ -1761,36 +1750,32 @@ msgstr "—"
 msgid "Failed Payments"
 msgstr "Paiements échoués"
 
-#: src/Admin/manage-event/EventTickets.js:973
+#: src/Admin/manage-event/EventTickets.js:933
 msgid "Sale Periods"
 msgstr "Périodes de vente"
 
-#: src/Admin/manage-event/EventTickets.js:981
+#: src/Admin/manage-event/EventTickets.js:941
 msgid "Sale start at:"
 msgstr "Début de vente :"
 
-#: src/Admin/manage-event/EventTickets.js:1019
+#: src/Admin/manage-event/EventTickets.js:978
 msgid "Sale end at:"
 msgstr "Fin de vente :"
 
-#: src/Admin/manage-event/EventTickets.js:1212
+#: src/Admin/manage-event/EventTickets.js:1160
 msgid "+ Add Period"
 msgstr "+ Ajouter une période"
 
-#: src/Admin/manage-event/EventTickets.js:2053
-#: src/Admin/manage-event/EventTickets.js:2058
+#: src/Admin/manage-event/EventTickets.js:1968
+#: src/Admin/manage-event/EventTickets.js:1973
 msgid "Short name"
 msgstr "Nom court"
 
-#: src/Admin/manage-event/EventTickets.js:1997
+#: src/Admin/manage-event/EventTickets.js:1912
 msgid "Collaborator(s)"
 msgstr "Collaborateur(s)"
 
-#: src/Admin/manage-event/EventTickets.js:2156
-msgid "No discount"
-msgstr "Pas de réduction"
-
-#: src/Admin/manage-event/EventTickets.js:2285
+#: src/Admin/manage-event/EventTickets.js:2149
 msgid "Add participants"
 msgstr "Ajouter des participants"
 
@@ -1818,7 +1803,7 @@ msgstr "Montant payé moins les frais Mollie et les frais d'application."
 msgid "Net received"
 msgstr "Net reçu"
 
-#: src/Admin/manage-event/EventTickets.js:542
+#: src/Admin/manage-event/EventTickets.js:536
 msgid "Add sale periods first."
 msgstr "Ajoutez d'abord des périodes de vente."
 
@@ -1914,11 +1899,11 @@ msgstr "Traductions groupées"
 msgid "Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings."
 msgstr "Charger les fichiers .mo/.json fournis avec l'extension au lieu de dépendre des packs de langue de WordPress.org. Utile lorsqu'une locale est en dessous du seuil de 90 % sur translate.wordpress.org ou pour les chaînes en cours de traduction."
 
-#: src/Admin/manage-event/EventTickets.js:2406
+#: src/Admin/manage-event/EventTickets.js:2268
 msgid "Per-ticket-type end date"
 msgstr "Date de fin par type de billet"
 
-#: src/Admin/manage-event/EventTickets.js:2410
+#: src/Admin/manage-event/EventTickets.js:2272
 msgid "Show a date/time input on each ticket type to stop selling it after a fixed date, regardless of remaining capacity."
 msgstr "Afficher une entrée de date/heure sur chaque type de billet pour arrêter sa vente après une date fixe, indépendamment de la capacité restante."
 
@@ -1932,20 +1917,15 @@ msgstr "Afficher une ligne \"Powered by Fair Event Plugins\" sur les formulaires
 
 #. translators: %s: "Fair Event Plugins" linked to the project site
 #: src/Services/Branding.php:57
+#, php-format
 msgid "Powered by %s"
 msgstr "Propulsé par %s"
 
 #. translators: %s: currency code
-#: src/Admin/manage-event/EventTickets.js:1970
+#: src/Admin/manage-event/EventTickets.js:1898
 #, js-format
 msgid "Price (%s)"
 msgstr "Prix (%s)"
-
-#. translators: %s: currency code
-#: src/Admin/manage-event/EventTickets.js:1981
-#, js-format
-msgid "Discounted price (%s)"
-msgstr "Prix réduit (%s)"
 
 #: src/Admin/settings/GeneralTab.js:276
 msgid "Branding"
@@ -2053,7 +2033,7 @@ msgstr "Billets pour l'événement #%d"
 msgid "Ticket for %s"
 msgstr "Billet pour %s"
 
-#: src/API/TicketsController.php:300
+#: src/API/TicketsController.php:297
 msgid "Invalid import payload."
 msgstr "Charge d'importation invalide."
 
@@ -2130,82 +2110,78 @@ msgstr "Oui"
 msgid "No"
 msgstr "Non"
 
-#: src/Admin/manage-event/EventTickets.js:950
-msgid "No ticket types configured yet. Add a ticket type to start selling tickets for this event."
-msgstr "Aucun type de billet configuré pour le moment. Ajoutez un type de billet pour commencer à vendre des billets pour cet événement."
-
-#: src/Admin/manage-event/EventTickets.js:664
+#: src/Admin/manage-event/EventTickets.js:658
 msgid "Advance ticket"
 msgstr "Billet à l'avance"
 
-#: src/Admin/manage-event/EventTickets.js:670
+#: src/Admin/manage-event/EventTickets.js:664
 msgid "Day of event"
 msgstr "Le jour de l'événement"
 
-#: src/Admin/manage-event/EventTickets.js:1648
-#: src/Admin/manage-event/EventTickets.js:1680
+#: src/Admin/manage-event/EventTickets.js:1563
+#: src/Admin/manage-event/EventTickets.js:1595
 msgid "Whole series"
 msgstr "Série complète"
 
-#: src/Admin/manage-event/EventTickets.js:1654
-#: src/Admin/manage-event/EventTickets.js:1687
+#: src/Admin/manage-event/EventTickets.js:1569
+#: src/Admin/manage-event/EventTickets.js:1602
 msgid "Multiple instances"
 msgstr "Plusieurs instances"
 
-#: src/Admin/manage-event/EventTickets.js:1658
-#: src/Admin/manage-event/EventTickets.js:1673
+#: src/Admin/manage-event/EventTickets.js:1573
+#: src/Admin/manage-event/EventTickets.js:1588
 msgid "This instance"
 msgstr "Cette instance"
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1008
+#: src/Admin/manage-event/EventTickets.js:967
 #, js-format
 msgid "From %s"
 msgstr "À partir de %s"
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1040
+#: src/Admin/manage-event/EventTickets.js:993
 #, js-format
 msgid "until %s"
 msgstr "jusqu'à %s"
 
-#: src/Admin/manage-event/EventTickets.js:1379
+#: src/Admin/manage-event/EventTickets.js:1315
 msgid "Scope"
 msgstr "Portée"
 
-#: src/Admin/manage-event/EventTickets.js:1473
+#: src/Admin/manage-event/EventTickets.js:1391
 msgid "Disabled — no longer on sale"
 msgstr "Désactivé — plus en vente"
 
-#: src/Admin/manage-event/EventTickets.js:1710
+#: src/Admin/manage-event/EventTickets.js:1625
 msgid "Minimum instances"
 msgstr "Instances minimales"
 
-#: src/Admin/manage-event/EventTickets.js:1837
+#: src/Admin/manage-event/EventTickets.js:1749
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: src/Admin/manage-event/EventTickets.js:1841
+#: src/Admin/manage-event/EventTickets.js:1753
 msgid "Enabled"
 msgstr "Activé"
 
-#: src/Admin/manage-event/EventTickets.js:2480
+#: src/Admin/manage-event/EventTickets.js:2323
 msgid "Choose ticket scope"
 msgstr "Choisir la portée du billet"
 
-#: src/Admin/manage-event/EventTickets.js:2488
+#: src/Admin/manage-event/EventTickets.js:2331
 msgid "This instance — a separate ticket is needed for each date"
 msgstr "Cette instance — un billet séparé est nécessaire pour chaque date"
 
-#: src/Admin/manage-event/EventTickets.js:2495
+#: src/Admin/manage-event/EventTickets.js:2338
 msgid "Whole series — one purchase covers every occurrence"
 msgstr "Série complète — un achat couvre chaque occurrence"
 
-#: src/Admin/manage-event/EventTickets.js:2502
+#: src/Admin/manage-event/EventTickets.js:2345
 msgid "Multiple instances — buyer picks several occurrences"
 msgstr "Plusieurs instances — l'acheteur choisit plusieurs occurrences"
 
-#: src/Admin/manage-event/EventTickets.js:2517
+#: src/Admin/manage-event/EventTickets.js:2360
 msgid "Add ticket type"
 msgstr "Ajouter un type de billet"
 
@@ -2278,7 +2254,7 @@ msgid "Failed to submit. Please try again."
 msgstr "Échec de la soumission. Veuillez réessayer."
 
 #. translators: 1: formatted date, 2: number of days
-#: src/Admin/manage-event/EventTickets.js:997
+#: src/Admin/manage-event/EventTickets.js:956
 #, js-format
 msgid "From %1$s (%2$d day before event)"
 msgid_plural "From %1$s (%2$d days before event)"
@@ -2286,7 +2262,7 @@ msgstr[0] "À partir de %1$s (%2$d jour avant l'événement)"
 msgstr[1] "À partir de %1$s (%2$d jours avant l'événement)"
 
 #. translators: %d: sale period number
-#: src/Admin/manage-event/EventTickets.js:559
+#: src/Admin/manage-event/EventTickets.js:553
 #, js-format
 msgid "Period %d"
 msgstr "Période %d"
@@ -2358,59 +2334,51 @@ msgstr "Les tickets sont gérés sur la série —"
 msgid "open the master event"
 msgstr "ouvrir l'événement maître"
 
-#: src/Admin/manage-event/EventTickets.js:921
+#: src/Admin/manage-event/EventTickets.js:912
 msgid "Save tickets"
 msgstr "Enregistrer les tickets"
 
-#: src/Admin/manage-event/EventTickets.js:1363
+#: src/Admin/manage-event/EventTickets.js:1299
 msgid "Min. add-ons"
 msgstr "Modules complémentaires min."
 
-#: src/Admin/manage-event/EventTickets.js:1608
+#: src/Admin/manage-event/EventTickets.js:1523
 msgid "Only raises the event-wide minimum add-ons for this ticket type. Leave 0 to inherit."
 msgstr "Augmente uniquement le nombre minimum de modules complémentaires au niveau de l'événement pour ce type de ticket. Laissez 0 pour hériter."
 
-#: src/Admin/manage-event/EventTickets.js:1923
+#: src/Admin/manage-event/EventTickets.js:1851
 msgid "Add-ons"
 msgstr "Modules complémentaires"
 
-#: src/Admin/manage-event/EventTickets.js:1928
+#: src/Admin/manage-event/EventTickets.js:1856
 msgid "Minimum number of add-ons"
 msgstr "Nombre minimum de modules complémentaires"
 
-#: src/Admin/manage-event/EventTickets.js:1932
+#: src/Admin/manage-event/EventTickets.js:1860
 msgid "Participants must select at least this many add-ons to sign up. Set to 0 to disable."
 msgstr "Les participants doivent sélectionner au moins ce nombre de modules complémentaires pour s'inscrire. Réglez sur 0 pour désactiver."
 
-#: src/Admin/manage-event/EventTickets.js:1954
+#: src/Admin/manage-event/EventTickets.js:1882
 msgid "Add selectable add-ons (checkboxes) shown to participants at signup. Each add-on has its own price added on top of the base price."
 msgstr "Ajouter des modules complémentaires sélectionnables (cases à cocher) affichés aux participants lors de l'inscription. Chaque module complémentaire a son propre prix ajouté au prix de base."
 
-#: src/Admin/manage-event/EventTickets.js:2023
+#: src/Admin/manage-event/EventTickets.js:1938
 msgid "Add-on name"
 msgstr "Nom du module complémentaire"
 
-#: src/Admin/manage-event/EventTickets.js:2386
+#: src/Admin/manage-event/EventTickets.js:2248
 msgid "Per-ticket-type minimum add-ons"
 msgstr "Modules complémentaires minimums par type de billet"
 
-#: src/Admin/manage-event/EventTickets.js:2390
+#: src/Admin/manage-event/EventTickets.js:2252
 msgid "Show a Min. add-ons input on each ticket type to require more add-ons than the event-wide minimum (it only ever raises it). When off, every ticket type uses the event-wide minimum."
 msgstr "Afficher une entrée Min. modules complémentaires sur chaque type de billet pour exiger plus de modules complémentaires que le minimum à l'échelle de l'événement (cela ne l'augmente que). Lorsqu'il est désactivé, chaque type de billet utilise le minimum à l'échelle de l'événement."
 
-#: src/Admin/manage-event/EventTickets.js:2423
-msgid "Add-on collaborator discount"
-msgstr "Réduction collaborateur sur les modules complémentaires"
-
-#: src/Admin/manage-event/EventTickets.js:2427
-msgid "Allow a discounted price on each add-on for participants invited by a collaborator linked to that add-on. Adds a second price column to the add-ons table and enables Manage Invitations."
-msgstr "Permettre un prix réduit sur chaque module complémentaire pour les participants invités par un collaborateur lié à ce module complémentaire. Ajoute une deuxième colonne de prix au tableau des modules complémentaires et active Gérer les invitations."
-
-#: src/Admin/manage-event/EventTickets.js:2442
+#: src/Admin/manage-event/EventTickets.js:2285
 msgid "Price add-ons per sale period"
 msgstr "Tarifier les modules complémentaires par période de vente"
 
-#: src/Admin/manage-event/EventTickets.js:2446
+#: src/Admin/manage-event/EventTickets.js:2289
 msgid "Price every add-on per sale period instead of a single flat price. The Pricing column in the add-ons table becomes one input per sale period. Requires sale periods to be defined."
 msgstr "Tarifier chaque module complémentaire par période de vente au lieu d'un prix forfaitaire unique. La colonne Tarification du tableau des modules complémentaires devient une entrée par période de vente. Nécessite que les périodes de vente soient définies."
 
@@ -2479,16 +2447,16 @@ msgstr "Date invalide."
 msgid "Event source not found."
 msgstr "Source d'événement non trouvée."
 
-#: src/Admin/manage-event/EventTickets.js:895
+#: src/Admin/manage-event/EventTickets.js:887
 msgid "Set up Mollie"
 msgstr "Configurer Mollie"
 
-#: src/Admin/manage-event/EventTickets.js:1280
+#: src/Admin/manage-event/EventTickets.js:1216
 msgid "More actions"
 msgstr "Plus d'actions"
 
 #: src/Admin/calendar/components/QuickEventModal.js:260
-#: src/Admin/manage-event/EventTickets.js:2352
+#: src/Admin/manage-event/EventTickets.js:2214
 msgid "More options"
 msgstr "Plus d'options"
 
@@ -2612,12 +2580,12 @@ msgstr "Fair Events › <calendarlink>%1$s</calendarlink> › %2$s"
 msgid "View public page"
 msgstr "Afficher la page publique"
 
-#: src/Admin/manage-event/EventTickets.js:2466
+#: src/Admin/manage-event/EventTickets.js:2309
 msgid "Merge periods"
 msgstr "Fusionner les périodes"
 
 #. translators: %d: number of sale periods being merged
-#: src/Admin/manage-event/EventTickets.js:2471
+#: src/Admin/manage-event/EventTickets.js:2314
 #, js-format
 msgid "Merge to one sale window? Prices for the other %d periods will be discarded."
 msgstr "Fusionner en une seule fenêtre de vente ? Les prix des %d autres périodes seront supprimés."
@@ -2663,7 +2631,7 @@ msgid "This event happens once."
 msgstr "Cet événement n'a lieu qu'une seule fois."
 
 #: src/Admin/manage-event/ManageEventApp.js:1056
-#: src/Admin/manage-event/SeriesModal.js:228
+#: src/Admin/manage-event/SeriesModal.js:270
 msgid "Edit series"
 msgstr "Modifier la série"
 
@@ -2673,83 +2641,63 @@ msgid "End series"
 msgstr "Terminer la série"
 
 #: src/Admin/manage-event/ManageEventApp.js:1081
-#: src/Admin/manage-event/SeriesModal.js:229
+#: src/Admin/manage-event/SeriesModal.js:271
 msgid "Turn into a series"
 msgstr "Convertir en série"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:345
+#: src/Admin/manage-event/RecurrenceCalendar.js:107
 msgid "Open this occurrence"
 msgstr "Ouvrir cette occurrence"
 
-#: src/Admin/manage-event/SeriesModal.js:169
+#: src/Admin/manage-event/SeriesModal.js:211
 msgid "Failed to save the series."
 msgstr "Impossible d'enregistrer la série."
 
 #. translators: %d: number of dates in the series
-#: src/Admin/manage-event/SeriesModal.js:187
-#: src/Admin/manage-event/SeriesModal.js:198
+#: src/Admin/manage-event/SeriesModal.js:229
+#: src/Admin/manage-event/SeriesModal.js:240
 #, js-format
 msgid "Update series — %d dates"
 msgstr "Mettre à jour la série — %d dates"
 
 #. translators: %d: number of dates in the series
-#: src/Admin/manage-event/SeriesModal.js:192
-#: src/Admin/manage-event/SeriesModal.js:203
+#: src/Admin/manage-event/SeriesModal.js:234
+#: src/Admin/manage-event/SeriesModal.js:245
 #, js-format
 msgid "Create series — %d dates"
 msgstr "Créer une série — %d dates"
 
-#: src/Admin/manage-event/SeriesModal.js:216
+#: src/Admin/manage-event/SeriesModal.js:258
 msgid "Regular schedule"
 msgstr "Calendrier régulier"
 
-#: src/Admin/manage-event/SeriesModal.js:220
+#: src/Admin/manage-event/SeriesModal.js:262
 msgid "Irregular series"
 msgstr "Série irrégulière"
 
-#: src/Admin/manage-event/SeriesModal.js:263
+#: src/Admin/manage-event/SeriesModal.js:305
 msgid "Schedule preview"
 msgstr "Aperçu du calendrier"
 
-#: src/Admin/manage-event/SeriesModal.js:267
+#: src/Admin/manage-event/SeriesModal.js:309
 msgid "No dates match this schedule yet."
 msgstr "Aucune date ne correspond à ce calendrier pour le moment."
 
-#. translators: 1: number of remaining dates, 2: last date in the series
-#: src/Admin/manage-event/SeriesModal.js:284
-#, js-format
-msgid "… %1$d more, until %2$s"
-msgstr "… %1$d autres, jusqu'au %2$s"
-
-#: src/Admin/manage-event/SeriesModal.js:298
+#: src/Admin/manage-event/SeriesModal.js:341
 msgid "Pick the exact dates this event happens on."
 msgstr "Choisissez les dates exactes auxquelles cet événement se déroule."
 
-#: src/Admin/manage-event/SeriesModal.js:304
+#: src/Admin/manage-event/SeriesModal.js:347
 msgid "One session per day. All dates share the event’s start time and length."
 msgstr "Une session par jour. Toutes les dates partagent l'heure de début et la durée de l'événement."
 
-#: src/Admin/manage-event/SeriesModal.js:312
+#: src/Admin/manage-event/SeriesModal.js:355
 msgid "Each date can only be used once — remove the duplicate before saving."
 msgstr "Chaque date ne peut être utilisée qu'une seule fois — supprimez le doublon avant d'enregistrer."
 
-#: src/Admin/manage-event/SeriesModal.js:323
-msgid "Master date"
-msgstr "Date maître"
-
-#: src/Admin/manage-event/SeriesModal.js:329
+#: src/Admin/manage-event/SeriesModal.js:164
 msgid "Master date — edit it from Event Details"
 msgstr "Date maître — modifiez-la à partir des Détails de l'événement"
-
-#. translators: %d: 1-based row number in the extra-dates list
-#: src/Admin/manage-event/SeriesModal.js:342
-#, js-format
-msgid "Date %d"
-msgstr "Date %d"
-
-#: src/Admin/manage-event/SeriesModal.js:368
-msgid "Add date"
-msgstr "Ajouter une date"
 
 #: src/Admin/settings/GeneralTab.js:293
 msgid "The Events Calendar and Events Week View blocks follow the \"Week Starts On\" setting under Settings → General."
@@ -2824,20 +2772,52 @@ msgstr "ventes de billets temporairement indisponibles"
 msgid "Choose a date"
 msgstr "Choisir une date"
 
-#: src/Admin/manage-event/EventTickets.js:900
+#: src/Admin/manage-event/EventTickets.js:892
 msgid "Paid tickets won't be sold until Mollie payments are configured."
 msgstr "Les billets payants ne seront pas vendus jusqu'à ce que les paiements Mollie soient configurés."
 
-#: src/Admin/manage-event/EventTickets.js:907
+#: src/Admin/manage-event/EventTickets.js:899
 msgid "Paid tickets need the Fair Payments Connector plugin. Install and activate it to sell tickets."
 msgstr "Les billets payants nécessitent le plugin Fair Payments Connector. Installez et activez-le pour vendre des billets."
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1050
+#: src/Admin/manage-event/EventTickets.js:1001
 #, js-format
 msgid "until %s (default)"
 msgstr "jusqu'à %s (par défaut)"
 
-#: src/blocks/event-signup/editor.js:97
+#: src/blocks/event-signup/editor.js:120
 msgid "Form content"
 msgstr "Contenu du formulaire"
+
+#: src/Admin/manage-event/EventTickets.js:1820
+msgid "No ticket types yet. Add one to start selling tickets for this event."
+msgstr ""
+
+#: src/Admin/manage-event/SeriesModal.js:179
+msgid "Selected — click to remove this date"
+msgstr ""
+
+#: src/Admin/manage-event/SeriesModal.js:180
+msgid "Click to add this date"
+msgstr ""
+
+#. translators: 1: number of dates in the series, 2: last date in the series
+#: src/Admin/manage-event/SeriesModal.js:324
+#, js-format
+msgid "%1$d dates, until %2$s"
+msgstr ""
+
+#. translators: %d: number of selected dates
+#: src/Admin/manage-event/SeriesModal.js:376
+#, js-format
+msgid "%d dates selected"
+msgstr ""
+
+#: src/blocks/event-signup/editor.js:101
+msgid "Edit tickets"
+msgstr ""
+
+#: src/blocks/event-signup/editor.js:105
+msgid "Connect this block to an event date to edit its tickets."
+msgstr ""

--- a/fair-events/languages/fair-events-pl_PL.po
+++ b/fair-events/languages/fair-events-pl_PL.po
@@ -43,7 +43,7 @@ msgstr "Ustawienia Fair Events"
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: src/blocks/events-list/render.php:297
+#: src/blocks/events-list/render.php:299
 msgid "No events found. Please select a valid display pattern."
 msgstr "Nie znaleziono wydarzeń. Wybierz prawidłowy wzorzec wyświetlania."
 
@@ -374,10 +374,10 @@ msgstr "Tytuł"
 
 #: src/Admin/calendar/components/QuickEventModal.js:382
 #: src/Admin/manage-event/EditInstancesModal.js:85
-#: src/Admin/manage-event/EventTickets.js:2467
+#: src/Admin/manage-event/EventTickets.js:2310
 #: src/Admin/manage-event/ManageEventApp.js:1449
 #: src/Admin/manage-event/ManageEventApp.js:1459
-#: src/Admin/manage-event/SeriesModal.js:381
+#: src/Admin/manage-event/SeriesModal.js:391
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -478,19 +478,18 @@ msgstr "To źródło jest wyłączone."
 msgid "Date & Time"
 msgstr "Data i godzina"
 
-#: src/Admin/manage-event/EventTickets.js:1193
-#: src/Admin/manage-event/EventTickets.js:1868
-#: src/Admin/manage-event/EventTickets.js:2309
+#: src/Admin/manage-event/EventTickets.js:1141
+#: src/Admin/manage-event/EventTickets.js:1780
+#: src/Admin/manage-event/EventTickets.js:2173
 #: src/Admin/manage-event/PhotoDetail.js:182
-#: src/Admin/manage-event/SeriesModal.js:358
 msgid "Remove"
 msgstr "Usuń"
 
 #: src/Admin/all-events/AllEvents.js:70
 #: src/Admin/manage-event/EventSignups.js:54
-#: src/Admin/manage-event/EventTickets.js:1069
-#: src/Admin/manage-event/EventTickets.js:1965
-#: src/Admin/manage-event/EventTickets.js:2018
+#: src/Admin/manage-event/EventTickets.js:1018
+#: src/Admin/manage-event/EventTickets.js:1893
+#: src/Admin/manage-event/EventTickets.js:1933
 msgid "Name"
 msgstr "Nazwa"
 
@@ -617,7 +616,7 @@ msgid "Display event with time range and title"
 msgstr "Wyświetl wydarzenie z przedziałem czasowym i tytułem"
 
 #: src/blocks/event-proposal/editor.js:21
-#: src/blocks/event-signup/editor.js:80
+#: src/blocks/event-signup/editor.js:87
 msgid "Form Settings"
 msgstr "Ustawienia formularza"
 
@@ -654,7 +653,7 @@ msgid "Email address for notifications"
 msgstr "Adres e-mail do powiadomień"
 
 #: src/blocks/event-proposal/editor.js:75
-#: src/blocks/event-signup/editor.js:82
+#: src/blocks/event-signup/editor.js:89
 msgid "Submit Button Text"
 msgstr "Tekst przycisku Wyślij"
 
@@ -818,7 +817,7 @@ msgstr "Nie udało się utworzyć daty wydarzenia."
 #: src/API/GetTicketsController.php:197
 #: src/API/TicketsController.php:117
 #: src/API/TicketsController.php:138
-#: src/API/TicketsController.php:291
+#: src/API/TicketsController.php:288
 msgid "Event date not found."
 msgstr "Data wydarzenia nie znaleziona."
 
@@ -960,7 +959,7 @@ msgstr "Data rozpoczęcia"
 #: src/Admin/calendar/components/QuickEventModal.js:208
 #: src/Admin/calendar/components/QuickEventModal.js:235
 #: src/Admin/event-meta-box/EventEditForm.js:376
-#: src/Admin/manage-event/EventTickets.js:1371
+#: src/Admin/manage-event/EventTickets.js:1307
 #: src/Admin/manage-event/ManageEventApp.js:896
 #: src/Admin/manage-event/ManageEventApp.js:929
 msgid "End date"
@@ -1167,7 +1166,7 @@ msgstr "Nie udało się połączyć wpisu."
 msgid "Back to Calendar"
 msgstr "Powrót do kalendarza"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:227
+#: src/Admin/manage-event/RecurrenceCalendar.js:182
 msgid "Recurring Occurrences"
 msgstr "Powtarzające się wystąpienia"
 
@@ -1425,7 +1424,7 @@ msgstr "Zewnętrzny"
 msgid "None"
 msgstr "Brak"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:184
+#: src/Admin/manage-event/RecurrenceCalendar.js:139
 msgid "Master"
 msgstr "Główny"
 
@@ -1449,8 +1448,7 @@ msgstr "Data do przełączenia (format Y-m-d)."
 msgid "Request context. Use \"edit\" to include events linked to non-published posts (requires edit_posts capability)."
 msgstr "Kontekst żądania. Użyj \"edit\", aby uwzględnić wydarzenia powiązane z nieopublikowanymi postami (wymaga możliwości edit_posts)."
 
-#: src/Admin/manage-event/EventTickets.js:945
-#: src/Admin/manage-event/EventTickets.js:1277
+#: src/Admin/manage-event/EventTickets.js:1213
 #: src/Admin/manage-event/ManageEventApp.js:717
 msgid "Tickets"
 msgstr "Bilety"
@@ -1531,70 +1529,69 @@ msgstr "Wybierz zdjęcia"
 msgid "Add New Photos"
 msgstr "Dodaj nowe zdjęcia"
 
-#: src/Admin/manage-event/EventTickets.js:195
+#: src/Admin/manage-event/EventTickets.js:192
 msgid "Failed to load tickets."
 msgstr "Nie udało się załadować biletów."
 
-#: src/Admin/manage-event/EventTickets.js:840
+#: src/Admin/manage-event/EventTickets.js:834
 msgid "Tickets saved successfully."
 msgstr "Bilety zapisane pomyślnie."
 
-#: src/Admin/manage-event/EventTickets.js:843
+#: src/Admin/manage-event/EventTickets.js:837
 msgid "Failed to save tickets."
 msgstr "Nie udało się zapisać biletów."
 
 #: src/Admin/manage-event/EventSignups.js:56
-#: src/Admin/manage-event/EventTickets.js:1331
+#: src/Admin/manage-event/EventTickets.js:1267
 msgid "Ticket Type"
 msgstr "Typ biletu"
 
-#: src/Admin/manage-event/EventTickets.js:1426
+#: src/Admin/manage-event/EventTickets.js:1349
 msgid "(unnamed)"
 msgstr "(bez nazwy)"
 
-#: src/Admin/manage-event/EventTickets.js:1315
+#: src/Admin/manage-event/EventTickets.js:1251
 msgid "Total capacity"
 msgstr "Całkowita pojemność"
 
-#: src/Admin/manage-event/EventTickets.js:1320
+#: src/Admin/manage-event/EventTickets.js:1256
 msgid "Leave empty for unlimited capacity."
 msgstr "Pozostaw puste, aby uzyskać nieograniczoną pojemność."
 
-#: src/Admin/manage-event/EventTickets.js:962
-#: src/Admin/manage-event/EventTickets.js:1904
+#: src/Admin/manage-event/EventTickets.js:1833
 msgid "+ Add Ticket Type"
 msgstr "+ Dodaj typ biletu"
 
-#: src/Admin/manage-event/EventTickets.js:1338
-#: src/Admin/manage-event/EventTickets.js:1991
+#: src/Admin/manage-event/EventTickets.js:1274
+#: src/Admin/manage-event/EventTickets.js:1906
 msgid "Capacity"
 msgstr "Pojemność"
 
-#: src/Admin/manage-event/EventTickets.js:1124
+#: src/Admin/manage-event/EventTickets.js:1072
 msgid "Period name"
 msgstr "Nazwa okresu"
 
-#: src/Admin/manage-event/EventTickets.js:1075
-#: src/Admin/manage-event/EventTickets.js:1227
+#: src/Admin/manage-event/EventTickets.js:1024
+#: src/Admin/manage-event/EventTickets.js:1172
 msgid "From"
 msgstr "Od"
 
-#: src/Admin/manage-event/EventTickets.js:1081
-#: src/Admin/manage-event/EventTickets.js:1246
+#: src/Admin/manage-event/EventTickets.js:1030
+#: src/Admin/manage-event/EventTickets.js:1187
 msgid "Until"
 msgstr "Do"
 
-#: src/Admin/manage-event/EventTickets.js:1450
+#: src/Admin/manage-event/EventTickets.js:1370
 msgid "Type name"
 msgstr "Nazwa typu"
 
-#: src/Admin/manage-event/EventTickets.js:1485
-#: src/Admin/manage-event/EventTickets.js:2193
+#: src/Admin/manage-event/EventTickets.js:1403
+#: src/Admin/manage-event/EventTickets.js:2057
 msgid "Unlimited"
 msgstr "Nieograniczone"
 
-#: src/Admin/manage-event/EventTickets.js:1430
-#: src/Admin/manage-event/EventTickets.js:1802
+#: src/Admin/manage-event/EventTickets.js:1353
+#: src/Admin/manage-event/EventTickets.js:1714
 msgid "Price"
 msgstr "Cena"
 
@@ -1602,7 +1599,7 @@ msgstr "Cena"
 msgid "Failed to toggle occurrence."
 msgstr "Nie udało się przełączyć wystąpienia."
 
-#: src/Admin/manage-event/EventTickets.js:1346
+#: src/Admin/manage-event/EventTickets.js:1282
 msgid "Groups"
 msgstr "Grupy"
 
@@ -1650,24 +1647,16 @@ msgstr "Szukaj uczestników..."
 msgid "No participants found."
 msgstr "Nie znaleziono uczestników."
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:113
-msgid "Previous months"
-msgstr "Poprzednie miesiące"
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:122
-msgid "Next months"
-msgstr "Następne miesiące"
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:198
+#: src/Admin/manage-event/RecurrenceCalendar.js:153
 msgid "Active"
 msgstr "Aktywny"
 
 #: src/Admin/manage-event/EditInstancesModal.js:74
-#: src/Admin/manage-event/RecurrenceCalendar.js:213
+#: src/Admin/manage-event/RecurrenceCalendar.js:168
 msgid "Cancelled"
 msgstr "Anulowany"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:331
+#: src/Admin/manage-event/RecurrenceCalendar.js:100
 msgid "Master event"
 msgstr "Wydarzenie główne"
 
@@ -1675,7 +1664,7 @@ msgstr "Wydarzenie główne"
 msgid "Event Info block is disabled — no event is linked to this post."
 msgstr "Blok Informacje o zdarzeniu jest wyłączony — żadne zdarzenie nie jest powiązane z tym postem."
 
-#: src/Admin/manage-event/EventTickets.js:930
+#: src/Admin/manage-event/EventTickets.js:919
 msgid "Manage Invitations"
 msgstr "Zarządzaj zaproszeniami"
 
@@ -1688,59 +1677,59 @@ msgstr "Płatności"
 msgid "Participant"
 msgstr "Uczestnik"
 
-#: src/Admin/manage-event/EventTickets.js:318
+#: src/Admin/manage-event/EventTickets.js:309
 msgid "Failed to export ticket configuration."
 msgstr "Nie udało się wyeksportować konfiguracji biletów."
 
-#: src/Admin/manage-event/EventTickets.js:328
+#: src/Admin/manage-event/EventTickets.js:319
 msgid "Importing will replace all current ticket types, sale periods, prices, and settings for this event. Continue?"
 msgstr "Importowanie zastąpi wszystkie bieżące typy biletów, okresy sprzedaży, ceny i ustawienia tego wydarzenia. Kontynuować?"
 
-#: src/Admin/manage-event/EventTickets.js:352
+#: src/Admin/manage-event/EventTickets.js:343
 msgid "Invalid file format. Expected a fair-events-tickets export."
 msgstr "Nieprawidłowy format pliku. Oczekiwano eksportu fair-events-tickets."
 
-#: src/Admin/manage-event/EventTickets.js:367
+#: src/Admin/manage-event/EventTickets.js:358
 msgid "Ticket configuration imported successfully."
 msgstr "Konfiguracja biletów zaimportowana pomyślnie."
 
-#: src/Admin/manage-event/EventTickets.js:375
+#: src/Admin/manage-event/EventTickets.js:366
 msgid "Failed to import ticket configuration."
 msgstr "Nie udało się zaimportować konfiguracji biletów."
 
-#: src/Admin/manage-event/EventTickets.js:1291
+#: src/Admin/manage-event/EventTickets.js:1227
 msgid "Export ticket settings"
 msgstr "Eksportuj ustawienia biletów"
 
-#: src/Admin/manage-event/EventTickets.js:1303
+#: src/Admin/manage-event/EventTickets.js:1239
 msgid "Import ticket settings"
 msgstr "Importuj ustawienia biletów"
 
-#: src/Admin/manage-event/EventTickets.js:1354
+#: src/Admin/manage-event/EventTickets.js:1290
 msgid "Invitation only"
 msgstr "Tylko na zaproszenie"
 
-#: src/Admin/manage-event/EventTickets.js:1554
+#: src/Admin/manage-event/EventTickets.js:1472
 msgid "All participants"
 msgstr "Wszyscy uczestnicy"
 
-#: src/Admin/manage-event/EventTickets.js:2357
+#: src/Admin/manage-event/EventTickets.js:2219
 msgid "Per-ticket-type capacity"
 msgstr "Pojemność dla każdego typu biletu"
 
-#: src/Admin/manage-event/EventTickets.js:2361
+#: src/Admin/manage-event/EventTickets.js:2223
 msgid "Show a Capacity input on each ticket type to cap how many can be sold of that type."
 msgstr "Pokaż pole Pojemność dla każdego typu biletu, aby ograniczyć, ile można sprzedać tego typu."
 
-#: src/Admin/manage-event/EventTickets.js:2374
+#: src/Admin/manage-event/EventTickets.js:2236
 msgid "Multiple pricing periods"
 msgstr "Wiele okresów cenowych"
 
-#: src/Admin/manage-event/EventTickets.js:2378
+#: src/Admin/manage-event/EventTickets.js:2240
 msgid "Enable time-based pricing with multiple sale periods (e.g. early bird, regular, late). When off, a single flat price applies for the whole sale window."
 msgstr "Włącz cenę opartą na czasie z wieloma okresami sprzedaży (np. early bird, regularna, ostatnia szansa). Gdy wyłączone, jedna stała cena obowiązuje dla całego okresu sprzedaży."
 
-#: src/Admin/manage-event/EventTickets.js:2342
+#: src/Admin/manage-event/EventTickets.js:2205
 msgid "+ Add Option"
 msgstr "+ Dodaj opcję"
 
@@ -1748,13 +1737,13 @@ msgstr "+ Dodaj opcję"
 msgid "View Entry"
 msgstr "Wyświetl wpis"
 
-#: src/Admin/manage-event/EventTickets.js:1767
+#: src/Admin/manage-event/EventTickets.js:1679
 msgid "Available"
 msgstr "Dostępne"
 
-#: src/Admin/manage-event/EventTickets.js:451
-#: src/Admin/manage-event/EventTickets.js:1014
-#: src/Admin/manage-event/EventTickets.js:1033
+#: src/Admin/manage-event/EventTickets.js:445
+#: src/Admin/manage-event/EventTickets.js:973
+#: src/Admin/manage-event/EventTickets.js:989
 msgid "—"
 msgstr "—"
 
@@ -1762,36 +1751,32 @@ msgstr "—"
 msgid "Failed Payments"
 msgstr "Nieudane płatności"
 
-#: src/Admin/manage-event/EventTickets.js:973
+#: src/Admin/manage-event/EventTickets.js:933
 msgid "Sale Periods"
 msgstr "Okresy sprzedaży"
 
-#: src/Admin/manage-event/EventTickets.js:981
+#: src/Admin/manage-event/EventTickets.js:941
 msgid "Sale start at:"
 msgstr "Sprzedaż rozpoczyna się o:"
 
-#: src/Admin/manage-event/EventTickets.js:1019
+#: src/Admin/manage-event/EventTickets.js:978
 msgid "Sale end at:"
 msgstr "Sprzedaż kończy się o:"
 
-#: src/Admin/manage-event/EventTickets.js:1212
+#: src/Admin/manage-event/EventTickets.js:1160
 msgid "+ Add Period"
 msgstr "+ Dodaj okres"
 
-#: src/Admin/manage-event/EventTickets.js:2053
-#: src/Admin/manage-event/EventTickets.js:2058
+#: src/Admin/manage-event/EventTickets.js:1968
+#: src/Admin/manage-event/EventTickets.js:1973
 msgid "Short name"
 msgstr "Krótka nazwa"
 
-#: src/Admin/manage-event/EventTickets.js:1997
+#: src/Admin/manage-event/EventTickets.js:1912
 msgid "Collaborator(s)"
 msgstr "Współpracownik(cy)"
 
-#: src/Admin/manage-event/EventTickets.js:2156
-msgid "No discount"
-msgstr "Bez zniżki"
-
-#: src/Admin/manage-event/EventTickets.js:2285
+#: src/Admin/manage-event/EventTickets.js:2149
 msgid "Add participants"
 msgstr "Dodaj uczestników"
 
@@ -1819,7 +1804,7 @@ msgstr "Kwota zapłacona minus opłaty Mollie i aplikacji."
 msgid "Net received"
 msgstr "Otrzymane netto"
 
-#: src/Admin/manage-event/EventTickets.js:542
+#: src/Admin/manage-event/EventTickets.js:536
 msgid "Add sale periods first."
 msgstr "Najpierw dodaj okresy sprzedaży."
 
@@ -1915,11 +1900,11 @@ msgstr "Tłumaczenia dołączone"
 msgid "Load .mo/.json files shipped with the plugin instead of relying on WordPress.org language packs. Useful while a locale is below the 90% threshold on translate.wordpress.org or for in-progress strings."
 msgstr "Załaduj pliki .mo/.json dostarczone z wtyczką zamiast polegać na pakietach języków z WordPress.org. Przydatne, gdy lokalizacja jest poniżej progu 90% na translate.wordpress.org lub dla ciągów w trakcie opracowywania."
 
-#: src/Admin/manage-event/EventTickets.js:2406
+#: src/Admin/manage-event/EventTickets.js:2268
 msgid "Per-ticket-type end date"
 msgstr "Data końcowa dla każdego typu biletu"
 
-#: src/Admin/manage-event/EventTickets.js:2410
+#: src/Admin/manage-event/EventTickets.js:2272
 msgid "Show a date/time input on each ticket type to stop selling it after a fixed date, regardless of remaining capacity."
 msgstr "Pokaż wejście daty/godziny dla każdego typu biletu, aby zatrzymać jego sprzedaż po ustalonym dniu, niezależnie od pozostałej pojemności."
 
@@ -1933,20 +1918,15 @@ msgstr "Wyświetl linię \"Powered by Fair Event Plugins\" na formularzach rejes
 
 #. translators: %s: "Fair Event Plugins" linked to the project site
 #: src/Services/Branding.php:57
+#, php-format
 msgid "Powered by %s"
 msgstr "Zasilane przez %s"
 
 #. translators: %s: currency code
-#: src/Admin/manage-event/EventTickets.js:1970
+#: src/Admin/manage-event/EventTickets.js:1898
 #, js-format
 msgid "Price (%s)"
 msgstr "Cena (%s)"
-
-#. translators: %s: currency code
-#: src/Admin/manage-event/EventTickets.js:1981
-#, js-format
-msgid "Discounted price (%s)"
-msgstr "Cena obniżona (%s)"
 
 #: src/Admin/settings/GeneralTab.js:276
 msgid "Branding"
@@ -2055,7 +2035,7 @@ msgstr "Bilety do wydarzenia #%d"
 msgid "Ticket for %s"
 msgstr "Bilet dla %s"
 
-#: src/API/TicketsController.php:300
+#: src/API/TicketsController.php:297
 msgid "Invalid import payload."
 msgstr "Nieprawidłowy ładunek importu."
 
@@ -2132,82 +2112,78 @@ msgstr "Tak"
 msgid "No"
 msgstr "Nie"
 
-#: src/Admin/manage-event/EventTickets.js:950
-msgid "No ticket types configured yet. Add a ticket type to start selling tickets for this event."
-msgstr "Brak skonfigurowanych typów biletów. Dodaj typ biletu, aby rozpocząć sprzedaż biletów na to wydarzenie."
-
-#: src/Admin/manage-event/EventTickets.js:664
+#: src/Admin/manage-event/EventTickets.js:658
 msgid "Advance ticket"
 msgstr "Bilet z wyprzedzeniem"
 
-#: src/Admin/manage-event/EventTickets.js:670
+#: src/Admin/manage-event/EventTickets.js:664
 msgid "Day of event"
 msgstr "Dzień wydarzenia"
 
-#: src/Admin/manage-event/EventTickets.js:1648
-#: src/Admin/manage-event/EventTickets.js:1680
+#: src/Admin/manage-event/EventTickets.js:1563
+#: src/Admin/manage-event/EventTickets.js:1595
 msgid "Whole series"
 msgstr "Cała seria"
 
-#: src/Admin/manage-event/EventTickets.js:1654
-#: src/Admin/manage-event/EventTickets.js:1687
+#: src/Admin/manage-event/EventTickets.js:1569
+#: src/Admin/manage-event/EventTickets.js:1602
 msgid "Multiple instances"
 msgstr "Wiele instancji"
 
-#: src/Admin/manage-event/EventTickets.js:1658
-#: src/Admin/manage-event/EventTickets.js:1673
+#: src/Admin/manage-event/EventTickets.js:1573
+#: src/Admin/manage-event/EventTickets.js:1588
 msgid "This instance"
 msgstr "To wystąpienie"
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1008
+#: src/Admin/manage-event/EventTickets.js:967
 #, js-format
 msgid "From %s"
 msgstr "Od %s"
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1040
+#: src/Admin/manage-event/EventTickets.js:993
 #, js-format
 msgid "until %s"
 msgstr "do %s"
 
-#: src/Admin/manage-event/EventTickets.js:1379
+#: src/Admin/manage-event/EventTickets.js:1315
 msgid "Scope"
 msgstr "Zakres"
 
-#: src/Admin/manage-event/EventTickets.js:1473
+#: src/Admin/manage-event/EventTickets.js:1391
 msgid "Disabled — no longer on sale"
 msgstr "Wyłączone — już niedostępne"
 
-#: src/Admin/manage-event/EventTickets.js:1710
+#: src/Admin/manage-event/EventTickets.js:1625
 msgid "Minimum instances"
 msgstr "Minimalna liczba wystąpień"
 
-#: src/Admin/manage-event/EventTickets.js:1837
+#: src/Admin/manage-event/EventTickets.js:1749
 msgid "Disabled"
 msgstr "Wyłączone"
 
-#: src/Admin/manage-event/EventTickets.js:1841
+#: src/Admin/manage-event/EventTickets.js:1753
 msgid "Enabled"
 msgstr "Włączone"
 
-#: src/Admin/manage-event/EventTickets.js:2480
+#: src/Admin/manage-event/EventTickets.js:2323
 msgid "Choose ticket scope"
 msgstr "Wybierz zakres biletu"
 
-#: src/Admin/manage-event/EventTickets.js:2488
+#: src/Admin/manage-event/EventTickets.js:2331
 msgid "This instance — a separate ticket is needed for each date"
 msgstr "To wystąpienie — dla każdej daty potrzebny jest osobny bilet"
 
-#: src/Admin/manage-event/EventTickets.js:2495
+#: src/Admin/manage-event/EventTickets.js:2338
 msgid "Whole series — one purchase covers every occurrence"
 msgstr "Cała seria — jeden zakup obejmuje każde wystąpienie"
 
-#: src/Admin/manage-event/EventTickets.js:2502
+#: src/Admin/manage-event/EventTickets.js:2345
 msgid "Multiple instances — buyer picks several occurrences"
 msgstr "Wiele wystąpień — kupujący wybiera kilka dat"
 
-#: src/Admin/manage-event/EventTickets.js:2517
+#: src/Admin/manage-event/EventTickets.js:2360
 msgid "Add ticket type"
 msgstr "Dodaj typ biletu"
 
@@ -2280,7 +2256,7 @@ msgid "Failed to submit. Please try again."
 msgstr "Nie udało się przesłać. Proszę spróbować ponownie."
 
 #. translators: 1: formatted date, 2: number of days
-#: src/Admin/manage-event/EventTickets.js:997
+#: src/Admin/manage-event/EventTickets.js:956
 #, js-format
 msgid "From %1$s (%2$d day before event)"
 msgid_plural "From %1$s (%2$d days before event)"
@@ -2289,7 +2265,7 @@ msgstr[1] "Od %1$s (%2$d dni przed wydarzeniem)"
 msgstr[2] "Od %1$s (%2$d dni przed wydarzeniem)"
 
 #. translators: %d: sale period number
-#: src/Admin/manage-event/EventTickets.js:559
+#: src/Admin/manage-event/EventTickets.js:553
 #, js-format
 msgid "Period %d"
 msgstr "Okres %d"
@@ -2363,59 +2339,51 @@ msgstr "Bilety są zarządzane w serii —"
 msgid "open the master event"
 msgstr "otwórz główne wydarzenie"
 
-#: src/Admin/manage-event/EventTickets.js:921
+#: src/Admin/manage-event/EventTickets.js:912
 msgid "Save tickets"
 msgstr "Zapisz bilety"
 
-#: src/Admin/manage-event/EventTickets.js:1363
+#: src/Admin/manage-event/EventTickets.js:1299
 msgid "Min. add-ons"
 msgstr "Min. dodatki"
 
-#: src/Admin/manage-event/EventTickets.js:1608
+#: src/Admin/manage-event/EventTickets.js:1523
 msgid "Only raises the event-wide minimum add-ons for this ticket type. Leave 0 to inherit."
 msgstr "Podnosi tylko minimum dodatków na poziomie całego wydarzenia dla tego typu biletu. Pozostaw 0, aby dziedziczyć."
 
-#: src/Admin/manage-event/EventTickets.js:1923
+#: src/Admin/manage-event/EventTickets.js:1851
 msgid "Add-ons"
 msgstr "Dodatki"
 
-#: src/Admin/manage-event/EventTickets.js:1928
+#: src/Admin/manage-event/EventTickets.js:1856
 msgid "Minimum number of add-ons"
 msgstr "Minimalna liczba dodatków"
 
-#: src/Admin/manage-event/EventTickets.js:1932
+#: src/Admin/manage-event/EventTickets.js:1860
 msgid "Participants must select at least this many add-ons to sign up. Set to 0 to disable."
 msgstr "Uczestnicy muszą wybrać co najmniej tyle dodatków, aby się zarejestrować. Ustaw na 0, aby wyłączyć."
 
-#: src/Admin/manage-event/EventTickets.js:1954
+#: src/Admin/manage-event/EventTickets.js:1882
 msgid "Add selectable add-ons (checkboxes) shown to participants at signup. Each add-on has its own price added on top of the base price."
 msgstr "Dodaj selektywne dodatki (pola wyboru) wyświetlane uczestnikom podczas rejestracji. Każdy dodatek ma własną cenę dodawaną do ceny podstawowej."
 
-#: src/Admin/manage-event/EventTickets.js:2023
+#: src/Admin/manage-event/EventTickets.js:1938
 msgid "Add-on name"
 msgstr "Nazwa dodatku"
 
-#: src/Admin/manage-event/EventTickets.js:2386
+#: src/Admin/manage-event/EventTickets.js:2248
 msgid "Per-ticket-type minimum add-ons"
 msgstr "Minimalne dodatki dla każdego typu biletu"
 
-#: src/Admin/manage-event/EventTickets.js:2390
+#: src/Admin/manage-event/EventTickets.js:2252
 msgid "Show a Min. add-ons input on each ticket type to require more add-ons than the event-wide minimum (it only ever raises it). When off, every ticket type uses the event-wide minimum."
 msgstr "Pokaż pole Min. dodatki dla każdego typu biletu, aby wymagać więcej dodatków niż minimum na poziomie imprezy (zawsze je tylko podnosi). Gdy wyłączone, każdy typ biletu używa minimum na poziomie imprezy."
 
-#: src/Admin/manage-event/EventTickets.js:2423
-msgid "Add-on collaborator discount"
-msgstr "Rabat dla współpracownika dodatku"
-
-#: src/Admin/manage-event/EventTickets.js:2427
-msgid "Allow a discounted price on each add-on for participants invited by a collaborator linked to that add-on. Adds a second price column to the add-ons table and enables Manage Invitations."
-msgstr "Zezwól na obniżoną cenę każdego dodatku dla uczestników zaproszonych przez współpracownika powiązanego z tym dodatkiem. Dodaje drugą kolumnę ceny do tabeli dodatków i włącza Zarządzaj zaproszeniami."
-
-#: src/Admin/manage-event/EventTickets.js:2442
+#: src/Admin/manage-event/EventTickets.js:2285
 msgid "Price add-ons per sale period"
 msgstr "Cena dodatków na okres sprzedaży"
 
-#: src/Admin/manage-event/EventTickets.js:2446
+#: src/Admin/manage-event/EventTickets.js:2289
 msgid "Price every add-on per sale period instead of a single flat price. The Pricing column in the add-ons table becomes one input per sale period. Requires sale periods to be defined."
 msgstr "Ustal cenę każdego dodatku na okres sprzedaży zamiast jednej stałej ceny. Kolumna Cena w tabeli dodatków staje się jednym polem na okres sprzedaży. Wymaga zdefiniowania okresów sprzedaży."
 
@@ -2485,16 +2453,16 @@ msgstr "Nieprawidłowa data."
 msgid "Event source not found."
 msgstr "Źródło zdarzenia nie znalezione."
 
-#: src/Admin/manage-event/EventTickets.js:895
+#: src/Admin/manage-event/EventTickets.js:887
 msgid "Set up Mollie"
 msgstr "Skonfiguruj Mollie"
 
-#: src/Admin/manage-event/EventTickets.js:1280
+#: src/Admin/manage-event/EventTickets.js:1216
 msgid "More actions"
 msgstr "Więcej akcji"
 
 #: src/Admin/calendar/components/QuickEventModal.js:260
-#: src/Admin/manage-event/EventTickets.js:2352
+#: src/Admin/manage-event/EventTickets.js:2214
 msgid "More options"
 msgstr "Więcej opcji"
 
@@ -2618,12 +2586,12 @@ msgstr "Fair Events › <calendarlink>%1$s</calendarlink> › %2$s"
 msgid "View public page"
 msgstr "Wyświetl stronę publiczną"
 
-#: src/Admin/manage-event/EventTickets.js:2466
+#: src/Admin/manage-event/EventTickets.js:2309
 msgid "Merge periods"
 msgstr "Połącz okresy"
 
 #. translators: %d: number of sale periods being merged
-#: src/Admin/manage-event/EventTickets.js:2471
+#: src/Admin/manage-event/EventTickets.js:2314
 #, js-format
 msgid "Merge to one sale window? Prices for the other %d periods will be discarded."
 msgstr "Połączyć w jedno okno sprzedaży? Ceny dla pozostałych %d okresów zostaną usunięte."
@@ -2671,7 +2639,7 @@ msgid "This event happens once."
 msgstr "To zdarzenie odbywa się raz."
 
 #: src/Admin/manage-event/ManageEventApp.js:1056
-#: src/Admin/manage-event/SeriesModal.js:228
+#: src/Admin/manage-event/SeriesModal.js:270
 msgid "Edit series"
 msgstr "Edytuj serię"
 
@@ -2681,83 +2649,63 @@ msgid "End series"
 msgstr "Zakończ serię"
 
 #: src/Admin/manage-event/ManageEventApp.js:1081
-#: src/Admin/manage-event/SeriesModal.js:229
+#: src/Admin/manage-event/SeriesModal.js:271
 msgid "Turn into a series"
 msgstr "Zamień na serię"
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:345
+#: src/Admin/manage-event/RecurrenceCalendar.js:107
 msgid "Open this occurrence"
 msgstr "Otwórz to wystąpienie"
 
-#: src/Admin/manage-event/SeriesModal.js:169
+#: src/Admin/manage-event/SeriesModal.js:211
 msgid "Failed to save the series."
 msgstr "Nie udało się zapisać serii."
 
 #. translators: %d: number of dates in the series
-#: src/Admin/manage-event/SeriesModal.js:187
-#: src/Admin/manage-event/SeriesModal.js:198
+#: src/Admin/manage-event/SeriesModal.js:229
+#: src/Admin/manage-event/SeriesModal.js:240
 #, js-format
 msgid "Update series — %d dates"
 msgstr "Aktualizuj serię — %d dat"
 
 #. translators: %d: number of dates in the series
-#: src/Admin/manage-event/SeriesModal.js:192
-#: src/Admin/manage-event/SeriesModal.js:203
+#: src/Admin/manage-event/SeriesModal.js:234
+#: src/Admin/manage-event/SeriesModal.js:245
 #, js-format
 msgid "Create series — %d dates"
 msgstr "Utwórz serię — %d dat"
 
-#: src/Admin/manage-event/SeriesModal.js:216
+#: src/Admin/manage-event/SeriesModal.js:258
 msgid "Regular schedule"
 msgstr "Harmonogram regularny"
 
-#: src/Admin/manage-event/SeriesModal.js:220
+#: src/Admin/manage-event/SeriesModal.js:262
 msgid "Irregular series"
 msgstr "Seria nieregularna"
 
-#: src/Admin/manage-event/SeriesModal.js:263
+#: src/Admin/manage-event/SeriesModal.js:305
 msgid "Schedule preview"
 msgstr "Podgląd harmonogramu"
 
-#: src/Admin/manage-event/SeriesModal.js:267
+#: src/Admin/manage-event/SeriesModal.js:309
 msgid "No dates match this schedule yet."
 msgstr "Żadne daty nie pasują do tego harmonogramu."
 
-#. translators: 1: number of remaining dates, 2: last date in the series
-#: src/Admin/manage-event/SeriesModal.js:284
-#, js-format
-msgid "… %1$d more, until %2$s"
-msgstr "… %1$d więcej, do %2$s"
-
-#: src/Admin/manage-event/SeriesModal.js:298
+#: src/Admin/manage-event/SeriesModal.js:341
 msgid "Pick the exact dates this event happens on."
 msgstr "Wybierz dokładne daty, w które odbywa się to wydarzenie."
 
-#: src/Admin/manage-event/SeriesModal.js:304
+#: src/Admin/manage-event/SeriesModal.js:347
 msgid "One session per day. All dates share the event’s start time and length."
 msgstr "Jedna sesja na dzień. Wszystkie daty mają czas rozpoczęcia i długość wydarzenia."
 
-#: src/Admin/manage-event/SeriesModal.js:312
+#: src/Admin/manage-event/SeriesModal.js:355
 msgid "Each date can only be used once — remove the duplicate before saving."
 msgstr "Każdą datę można używać tylko raz — usuń duplikat przed zapisaniem."
 
-#: src/Admin/manage-event/SeriesModal.js:323
-msgid "Master date"
-msgstr "Data główna"
-
-#: src/Admin/manage-event/SeriesModal.js:329
+#: src/Admin/manage-event/SeriesModal.js:164
 msgid "Master date — edit it from Event Details"
 msgstr "Data główna — edytuj ją z Szczegółów wydarzenia"
-
-#. translators: %d: 1-based row number in the extra-dates list
-#: src/Admin/manage-event/SeriesModal.js:342
-#, js-format
-msgid "Date %d"
-msgstr "Data %d"
-
-#: src/Admin/manage-event/SeriesModal.js:368
-msgid "Add date"
-msgstr "Dodaj datę"
 
 #: src/Admin/settings/GeneralTab.js:293
 msgid "The Events Calendar and Events Week View blocks follow the \"Week Starts On\" setting under Settings → General."
@@ -2832,20 +2780,52 @@ msgstr "sprzedaż biletów czasowo niedostępna"
 msgid "Choose a date"
 msgstr "Wybierz datę"
 
-#: src/Admin/manage-event/EventTickets.js:900
+#: src/Admin/manage-event/EventTickets.js:892
 msgid "Paid tickets won't be sold until Mollie payments are configured."
 msgstr "Bilety płatne nie będą sprzedawane, dopóki nie skonfigurowane będą płatności Mollie."
 
-#: src/Admin/manage-event/EventTickets.js:907
+#: src/Admin/manage-event/EventTickets.js:899
 msgid "Paid tickets need the Fair Payments Connector plugin. Install and activate it to sell tickets."
 msgstr "Bilety płatne wymagają wtyczki Fair Payments Connector. Zainstaluj i aktywuj ją, aby sprzedawać bilety."
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1050
+#: src/Admin/manage-event/EventTickets.js:1001
 #, js-format
 msgid "until %s (default)"
 msgstr "do %s (domyślnie)"
 
-#: src/blocks/event-signup/editor.js:97
+#: src/blocks/event-signup/editor.js:120
 msgid "Form content"
 msgstr "Zawartość formularza"
+
+#: src/Admin/manage-event/EventTickets.js:1820
+msgid "No ticket types yet. Add one to start selling tickets for this event."
+msgstr ""
+
+#: src/Admin/manage-event/SeriesModal.js:179
+msgid "Selected — click to remove this date"
+msgstr ""
+
+#: src/Admin/manage-event/SeriesModal.js:180
+msgid "Click to add this date"
+msgstr ""
+
+#. translators: 1: number of dates in the series, 2: last date in the series
+#: src/Admin/manage-event/SeriesModal.js:324
+#, js-format
+msgid "%1$d dates, until %2$s"
+msgstr ""
+
+#. translators: %d: number of selected dates
+#: src/Admin/manage-event/SeriesModal.js:376
+#, js-format
+msgid "%d dates selected"
+msgstr ""
+
+#: src/blocks/event-signup/editor.js:101
+msgid "Edit tickets"
+msgstr ""
+
+#: src/blocks/event-signup/editor.js:105
+msgid "Connect this block to an event date to edit its tickets."
+msgstr ""

--- a/fair-events/languages/fair-events.pot
+++ b/fair-events/languages/fair-events.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-19T18:39:46+00:00\n"
+"POT-Creation-Date: 2026-07-20T11:12:35+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fair-events\n"
@@ -287,7 +287,7 @@ msgstr ""
 #: src/API/GetTicketsController.php:197
 #: src/API/TicketsController.php:117
 #: src/API/TicketsController.php:138
-#: src/API/TicketsController.php:291
+#: src/API/TicketsController.php:288
 msgid "Event date not found."
 msgstr ""
 
@@ -427,7 +427,7 @@ msgstr ""
 msgid "This source is disabled."
 msgstr ""
 
-#: src/API/TicketsController.php:300
+#: src/API/TicketsController.php:297
 msgid "Invalid import payload."
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Subscribed calendars refresh on your calendar app's own schedule (often hours, not instant)."
 msgstr ""
 
-#: src/blocks/events-list/render.php:297
+#: src/blocks/events-list/render.php:299
 msgid "No events found. Please select a valid display pattern."
 msgstr ""
 
@@ -881,6 +881,12 @@ msgstr ""
 msgid "Confirm Attendance"
 msgstr ""
 
+#. translators: %s: "Fair Event Plugins" linked to the project site
+#: src/Services/Branding.php:57
+#, php-format
+msgid "Powered by %s"
+msgstr ""
+
 #: src/Services/WeeklyEventsProvider.php:42
 msgid "Event source not found."
 msgstr ""
@@ -903,11 +909,6 @@ msgstr ""
 
 #: src/Settings/Settings.php:115
 msgid "Show a \"Powered by Fair Event Plugins\" line on signup forms and participant emails"
-msgstr ""
-
-#. translators: %s: "Fair Event Plugins" linked to the project site
-#: src/Services/Branding.php:57
-msgid "Powered by %s"
 msgstr ""
 
 #: src/Admin/all-events/AllEvents.js:14
@@ -936,9 +937,9 @@ msgstr ""
 
 #: src/Admin/all-events/AllEvents.js:70
 #: src/Admin/manage-event/EventSignups.js:54
-#: src/Admin/manage-event/EventTickets.js:1069
-#: src/Admin/manage-event/EventTickets.js:1965
-#: src/Admin/manage-event/EventTickets.js:2018
+#: src/Admin/manage-event/EventTickets.js:1018
+#: src/Admin/manage-event/EventTickets.js:1893
+#: src/Admin/manage-event/EventTickets.js:1933
 msgid "Name"
 msgstr ""
 
@@ -1058,7 +1059,7 @@ msgstr ""
 #: src/Admin/calendar/components/QuickEventModal.js:208
 #: src/Admin/calendar/components/QuickEventModal.js:235
 #: src/Admin/event-meta-box/EventEditForm.js:376
-#: src/Admin/manage-event/EventTickets.js:1371
+#: src/Admin/manage-event/EventTickets.js:1307
 #: src/Admin/manage-event/ManageEventApp.js:896
 #: src/Admin/manage-event/ManageEventApp.js:929
 msgid "End date"
@@ -1083,7 +1084,7 @@ msgid "Venue"
 msgstr ""
 
 #: src/Admin/calendar/components/QuickEventModal.js:260
-#: src/Admin/manage-event/EventTickets.js:2352
+#: src/Admin/manage-event/EventTickets.js:2214
 msgid "More options"
 msgstr ""
 
@@ -1133,10 +1134,10 @@ msgstr ""
 
 #: src/Admin/calendar/components/QuickEventModal.js:382
 #: src/Admin/manage-event/EditInstancesModal.js:85
-#: src/Admin/manage-event/EventTickets.js:2467
+#: src/Admin/manage-event/EventTickets.js:2310
 #: src/Admin/manage-event/ManageEventApp.js:1449
 #: src/Admin/manage-event/ManageEventApp.js:1459
-#: src/Admin/manage-event/SeriesModal.js:381
+#: src/Admin/manage-event/SeriesModal.js:391
 msgid "Cancel"
 msgstr ""
 
@@ -1232,7 +1233,7 @@ msgid "No occurrences yet."
 msgstr ""
 
 #: src/Admin/manage-event/EditInstancesModal.js:74
-#: src/Admin/manage-event/RecurrenceCalendar.js:213
+#: src/Admin/manage-event/RecurrenceCalendar.js:168
 msgid "Cancelled"
 msgstr ""
 
@@ -1474,7 +1475,7 @@ msgid "Email"
 msgstr ""
 
 #: src/Admin/manage-event/EventSignups.js:56
-#: src/Admin/manage-event/EventTickets.js:1331
+#: src/Admin/manage-event/EventTickets.js:1267
 msgid "Ticket Type"
 msgstr ""
 
@@ -1502,107 +1503,92 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:195
+#: src/Admin/manage-event/EventTickets.js:192
 msgid "Failed to load tickets."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:318
+#: src/Admin/manage-event/EventTickets.js:309
 msgid "Failed to export ticket configuration."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:328
+#: src/Admin/manage-event/EventTickets.js:319
 msgid "Importing will replace all current ticket types, sale periods, prices, and settings for this event. Continue?"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:352
+#: src/Admin/manage-event/EventTickets.js:343
 msgid "Invalid file format. Expected a fair-events-tickets export."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:367
+#: src/Admin/manage-event/EventTickets.js:358
 msgid "Ticket configuration imported successfully."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:375
+#: src/Admin/manage-event/EventTickets.js:366
 msgid "Failed to import ticket configuration."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:451
-#: src/Admin/manage-event/EventTickets.js:1014
-#: src/Admin/manage-event/EventTickets.js:1033
+#: src/Admin/manage-event/EventTickets.js:445
+#: src/Admin/manage-event/EventTickets.js:973
+#: src/Admin/manage-event/EventTickets.js:989
 msgid "—"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:542
+#: src/Admin/manage-event/EventTickets.js:536
 msgid "Add sale periods first."
 msgstr ""
 
 #. translators: %d: sale period number
-#: src/Admin/manage-event/EventTickets.js:559
+#: src/Admin/manage-event/EventTickets.js:553
 #, js-format
 msgid "Period %d"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:664
+#: src/Admin/manage-event/EventTickets.js:658
 msgid "Advance ticket"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:670
+#: src/Admin/manage-event/EventTickets.js:664
 msgid "Day of event"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:840
+#: src/Admin/manage-event/EventTickets.js:834
 msgid "Tickets saved successfully."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:843
+#: src/Admin/manage-event/EventTickets.js:837
 msgid "Failed to save tickets."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:895
+#: src/Admin/manage-event/EventTickets.js:887
 msgid "Set up Mollie"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:900
+#: src/Admin/manage-event/EventTickets.js:892
 msgid "Paid tickets won't be sold until Mollie payments are configured."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:907
+#: src/Admin/manage-event/EventTickets.js:899
 msgid "Paid tickets need the Fair Payments Connector plugin. Install and activate it to sell tickets."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:921
+#: src/Admin/manage-event/EventTickets.js:912
 msgid "Save tickets"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:930
+#: src/Admin/manage-event/EventTickets.js:919
 msgid "Manage Invitations"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:945
-#: src/Admin/manage-event/EventTickets.js:1277
-#: src/Admin/manage-event/ManageEventApp.js:717
-msgid "Tickets"
-msgstr ""
-
-#: src/Admin/manage-event/EventTickets.js:950
-msgid "No ticket types configured yet. Add a ticket type to start selling tickets for this event."
-msgstr ""
-
-#: src/Admin/manage-event/EventTickets.js:962
-#: src/Admin/manage-event/EventTickets.js:1904
-msgid "+ Add Ticket Type"
-msgstr ""
-
-#: src/Admin/manage-event/EventTickets.js:973
+#: src/Admin/manage-event/EventTickets.js:933
 msgid "Sale Periods"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:981
+#: src/Admin/manage-event/EventTickets.js:941
 msgid "Sale start at:"
 msgstr ""
 
 #. translators: 1: formatted date, 2: number of days
-#: src/Admin/manage-event/EventTickets.js:997
+#: src/Admin/manage-event/EventTickets.js:956
 #, js-format
 msgid "From %1$s (%2$d day before event)"
 msgid_plural "From %1$s (%2$d days before event)"
@@ -1610,283 +1596,277 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1008
+#: src/Admin/manage-event/EventTickets.js:967
 #, js-format
 msgid "From %s"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1019
+#: src/Admin/manage-event/EventTickets.js:978
 msgid "Sale end at:"
 msgstr ""
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1040
+#: src/Admin/manage-event/EventTickets.js:993
 #, js-format
 msgid "until %s"
 msgstr ""
 
 #. translators: %s: formatted date
-#: src/Admin/manage-event/EventTickets.js:1050
+#: src/Admin/manage-event/EventTickets.js:1001
 #, js-format
 msgid "until %s (default)"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1075
-#: src/Admin/manage-event/EventTickets.js:1227
+#: src/Admin/manage-event/EventTickets.js:1024
+#: src/Admin/manage-event/EventTickets.js:1172
 msgid "From"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1081
-#: src/Admin/manage-event/EventTickets.js:1246
+#: src/Admin/manage-event/EventTickets.js:1030
+#: src/Admin/manage-event/EventTickets.js:1187
 msgid "Until"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1124
+#: src/Admin/manage-event/EventTickets.js:1072
 msgid "Period name"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1193
-#: src/Admin/manage-event/EventTickets.js:1868
-#: src/Admin/manage-event/EventTickets.js:2309
+#: src/Admin/manage-event/EventTickets.js:1141
+#: src/Admin/manage-event/EventTickets.js:1780
+#: src/Admin/manage-event/EventTickets.js:2173
 #: src/Admin/manage-event/PhotoDetail.js:182
-#: src/Admin/manage-event/SeriesModal.js:358
 msgid "Remove"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1212
+#: src/Admin/manage-event/EventTickets.js:1160
 msgid "+ Add Period"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1280
+#: src/Admin/manage-event/EventTickets.js:1213
+#: src/Admin/manage-event/ManageEventApp.js:717
+msgid "Tickets"
+msgstr ""
+
+#: src/Admin/manage-event/EventTickets.js:1216
 msgid "More actions"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1291
+#: src/Admin/manage-event/EventTickets.js:1227
 msgid "Export ticket settings"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1303
+#: src/Admin/manage-event/EventTickets.js:1239
 msgid "Import ticket settings"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1315
+#: src/Admin/manage-event/EventTickets.js:1251
 msgid "Total capacity"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1320
+#: src/Admin/manage-event/EventTickets.js:1256
 msgid "Leave empty for unlimited capacity."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1338
-#: src/Admin/manage-event/EventTickets.js:1991
+#: src/Admin/manage-event/EventTickets.js:1274
+#: src/Admin/manage-event/EventTickets.js:1906
 msgid "Capacity"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1346
+#: src/Admin/manage-event/EventTickets.js:1282
 msgid "Groups"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1354
+#: src/Admin/manage-event/EventTickets.js:1290
 msgid "Invitation only"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1363
+#: src/Admin/manage-event/EventTickets.js:1299
 msgid "Min. add-ons"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1379
+#: src/Admin/manage-event/EventTickets.js:1315
 msgid "Scope"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1426
+#: src/Admin/manage-event/EventTickets.js:1349
 msgid "(unnamed)"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1430
-#: src/Admin/manage-event/EventTickets.js:1802
+#: src/Admin/manage-event/EventTickets.js:1353
+#: src/Admin/manage-event/EventTickets.js:1714
 msgid "Price"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1450
+#: src/Admin/manage-event/EventTickets.js:1370
 msgid "Type name"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1473
+#: src/Admin/manage-event/EventTickets.js:1391
 msgid "Disabled — no longer on sale"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1485
-#: src/Admin/manage-event/EventTickets.js:2193
+#: src/Admin/manage-event/EventTickets.js:1403
+#: src/Admin/manage-event/EventTickets.js:2057
 msgid "Unlimited"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1554
+#: src/Admin/manage-event/EventTickets.js:1472
 msgid "All participants"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1608
+#: src/Admin/manage-event/EventTickets.js:1523
 msgid "Only raises the event-wide minimum add-ons for this ticket type. Leave 0 to inherit."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1648
-#: src/Admin/manage-event/EventTickets.js:1680
+#: src/Admin/manage-event/EventTickets.js:1563
+#: src/Admin/manage-event/EventTickets.js:1595
 msgid "Whole series"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1654
-#: src/Admin/manage-event/EventTickets.js:1687
+#: src/Admin/manage-event/EventTickets.js:1569
+#: src/Admin/manage-event/EventTickets.js:1602
 msgid "Multiple instances"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1658
-#: src/Admin/manage-event/EventTickets.js:1673
+#: src/Admin/manage-event/EventTickets.js:1573
+#: src/Admin/manage-event/EventTickets.js:1588
 msgid "This instance"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1710
+#: src/Admin/manage-event/EventTickets.js:1625
 msgid "Minimum instances"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1767
+#: src/Admin/manage-event/EventTickets.js:1679
 msgid "Available"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1837
+#: src/Admin/manage-event/EventTickets.js:1749
 msgid "Disabled"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1841
+#: src/Admin/manage-event/EventTickets.js:1753
 msgid "Enabled"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1923
+#: src/Admin/manage-event/EventTickets.js:1820
+msgid "No ticket types yet. Add one to start selling tickets for this event."
+msgstr ""
+
+#: src/Admin/manage-event/EventTickets.js:1833
+msgid "+ Add Ticket Type"
+msgstr ""
+
+#: src/Admin/manage-event/EventTickets.js:1851
 msgid "Add-ons"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1928
+#: src/Admin/manage-event/EventTickets.js:1856
 msgid "Minimum number of add-ons"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1932
+#: src/Admin/manage-event/EventTickets.js:1860
 msgid "Participants must select at least this many add-ons to sign up. Set to 0 to disable."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:1954
+#: src/Admin/manage-event/EventTickets.js:1882
 msgid "Add selectable add-ons (checkboxes) shown to participants at signup. Each add-on has its own price added on top of the base price."
 msgstr ""
 
 #. translators: %s: currency code
-#: src/Admin/manage-event/EventTickets.js:1970
+#: src/Admin/manage-event/EventTickets.js:1898
 #, js-format
 msgid "Price (%s)"
 msgstr ""
 
-#. translators: %s: currency code
-#: src/Admin/manage-event/EventTickets.js:1981
-#, js-format
-msgid "Discounted price (%s)"
-msgstr ""
-
-#: src/Admin/manage-event/EventTickets.js:1997
+#: src/Admin/manage-event/EventTickets.js:1912
 msgid "Collaborator(s)"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2023
+#: src/Admin/manage-event/EventTickets.js:1938
 msgid "Add-on name"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2053
-#: src/Admin/manage-event/EventTickets.js:2058
+#: src/Admin/manage-event/EventTickets.js:1968
+#: src/Admin/manage-event/EventTickets.js:1973
 msgid "Short name"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2156
-msgid "No discount"
-msgstr ""
-
-#: src/Admin/manage-event/EventTickets.js:2285
+#: src/Admin/manage-event/EventTickets.js:2149
 msgid "Add participants"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2342
+#: src/Admin/manage-event/EventTickets.js:2205
 msgid "+ Add Option"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2357
+#: src/Admin/manage-event/EventTickets.js:2219
 msgid "Per-ticket-type capacity"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2361
+#: src/Admin/manage-event/EventTickets.js:2223
 msgid "Show a Capacity input on each ticket type to cap how many can be sold of that type."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2374
+#: src/Admin/manage-event/EventTickets.js:2236
 msgid "Multiple pricing periods"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2378
+#: src/Admin/manage-event/EventTickets.js:2240
 msgid "Enable time-based pricing with multiple sale periods (e.g. early bird, regular, late). When off, a single flat price applies for the whole sale window."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2386
+#: src/Admin/manage-event/EventTickets.js:2248
 msgid "Per-ticket-type minimum add-ons"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2390
+#: src/Admin/manage-event/EventTickets.js:2252
 msgid "Show a Min. add-ons input on each ticket type to require more add-ons than the event-wide minimum (it only ever raises it). When off, every ticket type uses the event-wide minimum."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2406
+#: src/Admin/manage-event/EventTickets.js:2268
 msgid "Per-ticket-type end date"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2410
+#: src/Admin/manage-event/EventTickets.js:2272
 msgid "Show a date/time input on each ticket type to stop selling it after a fixed date, regardless of remaining capacity."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2423
-msgid "Add-on collaborator discount"
-msgstr ""
-
-#: src/Admin/manage-event/EventTickets.js:2427
-msgid "Allow a discounted price on each add-on for participants invited by a collaborator linked to that add-on. Adds a second price column to the add-ons table and enables Manage Invitations."
-msgstr ""
-
-#: src/Admin/manage-event/EventTickets.js:2442
+#: src/Admin/manage-event/EventTickets.js:2285
 msgid "Price add-ons per sale period"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2446
+#: src/Admin/manage-event/EventTickets.js:2289
 msgid "Price every add-on per sale period instead of a single flat price. The Pricing column in the add-ons table becomes one input per sale period. Requires sale periods to be defined."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2466
+#: src/Admin/manage-event/EventTickets.js:2309
 msgid "Merge periods"
 msgstr ""
 
 #. translators: %d: number of sale periods being merged
-#: src/Admin/manage-event/EventTickets.js:2471
+#: src/Admin/manage-event/EventTickets.js:2314
 #, js-format
 msgid "Merge to one sale window? Prices for the other %d periods will be discarded."
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2480
+#: src/Admin/manage-event/EventTickets.js:2323
 msgid "Choose ticket scope"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2488
+#: src/Admin/manage-event/EventTickets.js:2331
 msgid "This instance — a separate ticket is needed for each date"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2495
+#: src/Admin/manage-event/EventTickets.js:2338
 msgid "Whole series — one purchase covers every occurrence"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2502
+#: src/Admin/manage-event/EventTickets.js:2345
 msgid "Multiple instances — buyer picks several occurrences"
 msgstr ""
 
-#: src/Admin/manage-event/EventTickets.js:2517
+#: src/Admin/manage-event/EventTickets.js:2360
 msgid "Add ticket type"
 msgstr ""
 
@@ -2025,7 +2005,7 @@ msgid "This event happens once."
 msgstr ""
 
 #: src/Admin/manage-event/ManageEventApp.js:1056
-#: src/Admin/manage-event/SeriesModal.js:228
+#: src/Admin/manage-event/SeriesModal.js:270
 msgid "Edit series"
 msgstr ""
 
@@ -2035,7 +2015,7 @@ msgid "End series"
 msgstr ""
 
 #: src/Admin/manage-event/ManageEventApp.js:1081
-#: src/Admin/manage-event/SeriesModal.js:229
+#: src/Admin/manage-event/SeriesModal.js:271
 msgid "Turn into a series"
 msgstr ""
 
@@ -2139,32 +2119,24 @@ msgstr ""
 msgid "No participants found."
 msgstr ""
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:113
-msgid "Previous months"
-msgstr ""
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:122
-msgid "Next months"
-msgstr ""
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:184
-msgid "Master"
-msgstr ""
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:198
-msgid "Active"
-msgstr ""
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:227
-msgid "Recurring Occurrences"
-msgstr ""
-
-#: src/Admin/manage-event/RecurrenceCalendar.js:331
+#: src/Admin/manage-event/RecurrenceCalendar.js:100
 msgid "Master event"
 msgstr ""
 
-#: src/Admin/manage-event/RecurrenceCalendar.js:345
+#: src/Admin/manage-event/RecurrenceCalendar.js:107
 msgid "Open this occurrence"
+msgstr ""
+
+#: src/Admin/manage-event/RecurrenceCalendar.js:139
+msgid "Master"
+msgstr ""
+
+#: src/Admin/manage-event/RecurrenceCalendar.js:153
+msgid "Active"
+msgstr ""
+
+#: src/Admin/manage-event/RecurrenceCalendar.js:182
+msgid "Recurring Occurrences"
 msgstr ""
 
 #: src/Admin/manage-event/RecurrenceImpactSummary.js:52
@@ -2205,74 +2177,74 @@ msgstr ""
 msgid "Recurrence updated: %s."
 msgstr ""
 
-#: src/Admin/manage-event/SeriesModal.js:169
+#: src/Admin/manage-event/SeriesModal.js:164
+msgid "Master date — edit it from Event Details"
+msgstr ""
+
+#: src/Admin/manage-event/SeriesModal.js:179
+msgid "Selected — click to remove this date"
+msgstr ""
+
+#: src/Admin/manage-event/SeriesModal.js:180
+msgid "Click to add this date"
+msgstr ""
+
+#: src/Admin/manage-event/SeriesModal.js:211
 msgid "Failed to save the series."
 msgstr ""
 
 #. translators: %d: number of dates in the series
-#: src/Admin/manage-event/SeriesModal.js:187
-#: src/Admin/manage-event/SeriesModal.js:198
+#: src/Admin/manage-event/SeriesModal.js:229
+#: src/Admin/manage-event/SeriesModal.js:240
 #, js-format
 msgid "Update series — %d dates"
 msgstr ""
 
 #. translators: %d: number of dates in the series
-#: src/Admin/manage-event/SeriesModal.js:192
-#: src/Admin/manage-event/SeriesModal.js:203
+#: src/Admin/manage-event/SeriesModal.js:234
+#: src/Admin/manage-event/SeriesModal.js:245
 #, js-format
 msgid "Create series — %d dates"
 msgstr ""
 
-#: src/Admin/manage-event/SeriesModal.js:216
+#: src/Admin/manage-event/SeriesModal.js:258
 msgid "Regular schedule"
 msgstr ""
 
-#: src/Admin/manage-event/SeriesModal.js:220
+#: src/Admin/manage-event/SeriesModal.js:262
 msgid "Irregular series"
 msgstr ""
 
-#: src/Admin/manage-event/SeriesModal.js:263
+#: src/Admin/manage-event/SeriesModal.js:305
 msgid "Schedule preview"
 msgstr ""
 
-#: src/Admin/manage-event/SeriesModal.js:267
+#: src/Admin/manage-event/SeriesModal.js:309
 msgid "No dates match this schedule yet."
 msgstr ""
 
-#. translators: 1: number of remaining dates, 2: last date in the series
-#: src/Admin/manage-event/SeriesModal.js:284
+#. translators: 1: number of dates in the series, 2: last date in the series
+#: src/Admin/manage-event/SeriesModal.js:324
 #, js-format
-msgid "… %1$d more, until %2$s"
+msgid "%1$d dates, until %2$s"
 msgstr ""
 
-#: src/Admin/manage-event/SeriesModal.js:298
+#: src/Admin/manage-event/SeriesModal.js:341
 msgid "Pick the exact dates this event happens on."
 msgstr ""
 
-#: src/Admin/manage-event/SeriesModal.js:304
+#: src/Admin/manage-event/SeriesModal.js:347
 msgid "One session per day. All dates share the event’s start time and length."
 msgstr ""
 
-#: src/Admin/manage-event/SeriesModal.js:312
+#: src/Admin/manage-event/SeriesModal.js:355
 msgid "Each date can only be used once — remove the duplicate before saving."
 msgstr ""
 
-#: src/Admin/manage-event/SeriesModal.js:323
-msgid "Master date"
-msgstr ""
-
-#: src/Admin/manage-event/SeriesModal.js:329
-msgid "Master date — edit it from Event Details"
-msgstr ""
-
-#. translators: %d: 1-based row number in the extra-dates list
-#: src/Admin/manage-event/SeriesModal.js:342
+#. translators: %d: number of selected dates
+#: src/Admin/manage-event/SeriesModal.js:376
 #, js-format
-msgid "Date %d"
-msgstr ""
-
-#: src/Admin/manage-event/SeriesModal.js:368
-msgid "Add date"
+msgid "%d dates selected"
 msgstr ""
 
 #: src/Admin/settings/FeaturesTab.js:55
@@ -2447,7 +2419,7 @@ msgid "Event Info block is disabled — no event is linked to this post."
 msgstr ""
 
 #: src/blocks/event-proposal/editor.js:21
-#: src/blocks/event-signup/editor.js:80
+#: src/blocks/event-signup/editor.js:87
 msgid "Form Settings"
 msgstr ""
 
@@ -2484,7 +2456,7 @@ msgid "Email address for notifications"
 msgstr ""
 
 #: src/blocks/event-proposal/editor.js:75
-#: src/blocks/event-signup/editor.js:82
+#: src/blocks/event-signup/editor.js:89
 msgid "Submit Button Text"
 msgstr ""
 
@@ -2516,7 +2488,15 @@ msgstr ""
 msgid "Notifications enabled"
 msgstr ""
 
-#: src/blocks/event-signup/editor.js:97
+#: src/blocks/event-signup/editor.js:101
+msgid "Edit tickets"
+msgstr ""
+
+#: src/blocks/event-signup/editor.js:105
+msgid "Connect this block to an event date to edit its tickets."
+msgstr ""
+
+#: src/blocks/event-signup/editor.js:120
 msgid "Form content"
 msgstr ""
 

--- a/fair-events/src/Hooks/BlockHooks.php
+++ b/fair-events/src/Hooks/BlockHooks.php
@@ -20,6 +20,7 @@ class BlockHooks {
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_blocks' ) );
 		add_action( 'init', array( $this, 'set_script_translations' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'localize_event_signup_editor_context' ) );
 	}
 
 	/**
@@ -129,6 +130,36 @@ class BlockHooks {
 			'fair-events-get-tickets-editor-script',
 			'fair-events',
 			\FairEvents\Core\Features::script_translations_path()
+		);
+	}
+
+	/**
+	 * Localize the current post's event date and manage-event link onto the
+	 * event-signup block editor script, so its sidebar can offer a direct
+	 * "Edit tickets" link. Mirrors the meta-box localization pattern.
+	 *
+	 * @return void
+	 */
+	public function localize_event_signup_editor_context() {
+		global $post;
+
+		$post_event_date_id = 0;
+		if ( $post && class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_date = \FairEvents\Models\EventDates::get_by_event_id( $post->ID );
+			if ( $event_date ) {
+				$post_event_date_id = (int) $event_date->id;
+			}
+		}
+
+		wp_localize_script(
+			'fair-events-event-signup-editor-script',
+			'fairEventsSignupBlock',
+			array(
+				'postEventDateId'  => $post_event_date_id,
+				'manageEventUrl'   => admin_url( 'admin.php?page=fair-events-manage-event' ),
+				'ticketingEnabled' => \FairEvents\Core\Features::is_enabled( 'ticketing' ),
+				'canManageEvents'  => current_user_can( 'edit_posts' ),
+			)
 		);
 	}
 }

--- a/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
+++ b/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
@@ -42,6 +42,12 @@ jest.mock('@wordpress/block-editor', () => ({
 	}),
 }));
 
+jest.mock('@wordpress/components', () => ({
+	PanelBody: ({ children }) => children,
+	TextControl: () => null,
+	ExternalLink: ({ href, children }) => <a href={href}>{children}</a>,
+}));
+
 // Capture the block settings passed to registerBlockType so the edit
 // function can be rendered directly, without a live block registry.
 let capturedSettings;
@@ -68,6 +74,10 @@ describe('Event Signup EditComponent', () => {
 			/>
 		);
 	};
+
+	afterEach(() => {
+		delete window.fairEventsSignupBlock;
+	});
 
 	it('always shows the form content region, fair-form active or not', () => {
 		const { unmount } = renderEdit(true);
@@ -103,5 +113,78 @@ describe('Event Signup EditComponent', () => {
 				'fair-audience/fair-form-conditional',
 			])
 		);
+	});
+
+	describe('ticket-editor link', () => {
+		it('shows the edit-tickets link when ticketing is enabled, the user can manage events, and an event date resolved', () => {
+			window.fairEventsSignupBlock = {
+				postEventDateId: 42,
+				manageEventUrl:
+					'http://example.test/wp-admin/admin.php?page=fair-events-manage-event',
+				ticketingEnabled: true,
+				canManageEvents: true,
+			};
+			renderEdit(false);
+
+			const link = screen.getByText('Edit tickets');
+			expect(link).toHaveAttribute(
+				'href',
+				'http://example.test/wp-admin/admin.php?page=fair-events-manage-event&event_date_id=42&tab=tickets'
+			);
+		});
+
+		it('shows a hint instead of the link when no event date resolved', () => {
+			window.fairEventsSignupBlock = {
+				postEventDateId: 0,
+				manageEventUrl:
+					'http://example.test/wp-admin/admin.php?page=fair-events-manage-event',
+				ticketingEnabled: true,
+				canManageEvents: true,
+			};
+			renderEdit(false);
+
+			expect(
+				screen.getByText(
+					'Connect this block to an event date to edit its tickets.'
+				)
+			).toBeInTheDocument();
+			expect(screen.queryByText('Edit tickets')).not.toBeInTheDocument();
+		});
+
+		it('renders nothing when ticketing is disabled', () => {
+			window.fairEventsSignupBlock = {
+				postEventDateId: 42,
+				manageEventUrl:
+					'http://example.test/wp-admin/admin.php?page=fair-events-manage-event',
+				ticketingEnabled: false,
+				canManageEvents: true,
+			};
+			renderEdit(false);
+
+			expect(screen.queryByText('Edit tickets')).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(
+					'Connect this block to an event date to edit its tickets.'
+				)
+			).not.toBeInTheDocument();
+		});
+
+		it('renders nothing when the user cannot manage events', () => {
+			window.fairEventsSignupBlock = {
+				postEventDateId: 42,
+				manageEventUrl:
+					'http://example.test/wp-admin/admin.php?page=fair-events-manage-event',
+				ticketingEnabled: true,
+				canManageEvents: false,
+			};
+			renderEdit(false);
+
+			expect(screen.queryByText('Edit tickets')).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(
+					'Connect this block to an event date to edit its tickets.'
+				)
+			).not.toBeInTheDocument();
+		});
 	});
 });

--- a/fair-events/src/blocks/event-signup/editor.js
+++ b/fair-events/src/blocks/event-signup/editor.js
@@ -19,7 +19,7 @@ import {
 	InspectorControls,
 	InnerBlocks,
 } from '@wordpress/block-editor';
-import { PanelBody, TextControl } from '@wordpress/components';
+import { ExternalLink, PanelBody, TextControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import ServerSideRender from '@wordpress/server-side-render';
@@ -66,6 +66,13 @@ registerBlockType(metadata.name, {
 			? [...BASE_ALLOWED_BLOCKS, ...FAIR_FORM_ALLOWED_BLOCKS]
 			: BASE_ALLOWED_BLOCKS;
 
+		const {
+			postEventDateId = 0,
+			manageEventUrl = '',
+			ticketingEnabled = false,
+			canManageEvents = false,
+		} = window.fairEventsSignupBlock || {};
+
 		const innerBlocksProps = useInnerBlocksProps(
 			{ className: 'fair-events-event-signup-questions' },
 			{
@@ -85,6 +92,22 @@ registerBlockType(metadata.name, {
 								setAttributes({ submitButtonText: value })
 							}
 						/>
+						{ticketingEnabled &&
+							canManageEvents &&
+							(postEventDateId > 0 ? (
+								<ExternalLink
+									href={`${manageEventUrl}&event_date_id=${postEventDateId}&tab=tickets`}
+								>
+									{__('Edit tickets', 'fair-events')}
+								</ExternalLink>
+							) : (
+								<p>
+									{__(
+										'Connect this block to an event date to edit its tickets.',
+										'fair-events'
+									)}
+								</p>
+							))}
 					</PanelBody>
 				</InspectorControls>
 


### PR DESCRIPTION
## Summary

- Adds an "Edit tickets" link to the Event Signup block's sidebar (in the existing "Form Settings" panel) that jumps straight to the ticket-editing tab for the event date the block resolves to, opening in a new tab so unsaved post content isn't lost.
- The link always targets the current post's master/single event date (mirroring the meta-box localization pattern in `Event.php`), so a series occurrence never lands on an empty ticket list.
- When ticketing is disabled or the user lacks event-management access, neither the link nor a hint is shown. When no event date has resolved yet, a short hint replaces the link.

Closes #1201

## Notes

- Backend: `BlockHooks::localize_event_signup_editor_context()` hooks `enqueue_block_editor_assets` and localizes `postEventDateId`, `manageEventUrl`, `ticketingEnabled`, `canManageEvents` onto the existing `fair-events-event-signup-editor-script` handle — no new REST endpoint.
- Frontend: `editor.js` reads `window.fairEventsSignupBlock` and renders an `ExternalLink` or hint inside the "Form Settings" `PanelBody`.
- Translation catalogs (`languages/fair-events.pot` + locale `.po` files) regenerated for the two new strings.

## Test plan

- [x] `npm run test:js` in `fair-events` — 124/124 tests pass, including 4 new cases covering the link/hint/hidden states.
- [x] `vendor/bin/phpcs` clean for `BlockHooks.php`.
- [x] `npm run build` in `fair-events` — assets rebuilt.
- [x] `npm run format` in `fair-events`.
