### PR TITLE
Standardize remaining buttons on core Button block styles

### DIFF
--- a/fair-audience/src/blocks/event-signup/style.css
+++ b/fair-audience/src/blocks/event-signup/style.css
@@ -318,6 +318,12 @@
 	cursor: not-allowed;
 }
 
+.fair-audience-add-activities-button:disabled,
+.fair-audience-add-activities-button.is-disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
 /* Recurrence occurrence picker */
 .fair-audience-occurrence-picker {
 	border: 1px solid #ccc;

--- a/fair-events/src/blocks/event-proposal/block.json
+++ b/fair-events/src/blocks/event-proposal/block.json
@@ -35,6 +35,6 @@
 	"editorScript": "file:./editor.js",
 	"editorStyle": "file:./editor.css",
 	"viewScript": "file:./frontend.js",
-	"style": "file:./frontend.css",
+	"style": ["wp-block-button", "file:./frontend.css"],
 	"render": "file:./render.php"
 }

--- a/fair-events/src/blocks/event-proposal/frontend.css
+++ b/fair-events/src/blocks/event-proposal/frontend.css
@@ -105,24 +105,8 @@
 	margin-top: 0.5rem;
 }
 
-.form-button {
-	padding: 0.75rem 1.5rem;
-	background: #2271b1;
-	color: #fff;
-	border: none;
-	border-radius: 4px;
-	font-size: 1rem;
-	font-weight: 600;
-	cursor: pointer;
-	transition: background 0.2s ease;
-}
-
-.form-button:hover {
-	background: #135e96;
-}
-
 .form-button:disabled {
-	background: #8c8f94;
+	opacity: 0.5;
 	cursor: not-allowed;
 }
 
@@ -154,7 +138,11 @@
 		padding: 0 1rem;
 	}
 
-	.form-button {
+	.form-submit {
+		width: 100%;
+	}
+
+	.form-submit .wp-block-button__link {
 		width: 100%;
 	}
 }

--- a/fair-events/src/blocks/event-proposal/render.php
+++ b/fair-events/src/blocks/event-proposal/render.php
@@ -197,8 +197,8 @@ $duration_options = array(
 			aria-hidden="true"
 		/>
 
-		<div class="form-row form-submit">
-			<button type="submit" class="form-button">
+		<div class="form-row form-submit wp-block-button">
+			<button type="submit" class="form-button wp-block-button__link wp-element-button">
 				<?php echo esc_html( $submit_button_text ); ?>
 			</button>
 		</div>

--- a/fair-events/src/blocks/events-calendar/block.json
+++ b/fair-events/src/blocks/events-calendar/block.json
@@ -65,7 +65,7 @@
 	},
 	"editorScript": "file:./editor.js",
 	"editorStyle": "file:./editor.css",
-	"style": "file:./style-editor.css",
+	"style": ["wp-block-button", "file:./style-editor.css"],
 	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/fair-events/src/blocks/events-calendar/style.scss
+++ b/fair-events/src/blocks/events-calendar/style.scss
@@ -246,14 +246,7 @@
 	}
 
 	.fair-events-subscribe-trigger {
-		display: inline-block;
-		padding: 0.375rem 0.875rem;
-		background: transparent;
-		border: 1px solid currentColor;
-		border-radius: 4px;
-		cursor: pointer;
 		font-size: 0.8125rem;
-		color: #1e1e1e;
 		opacity: 0.7;
 
 		&:hover,

--- a/fair-events/src/blocks/events-week/block.json
+++ b/fair-events/src/blocks/events-week/block.json
@@ -53,7 +53,7 @@
 	},
 	"editorScript": "file:./editor.js",
 	"editorStyle": "file:./editor.css",
-	"style": "file:./style-editor.css",
+	"style": ["wp-block-button", "file:./style-editor.css"],
 	"viewScriptModule": "file:./view.js",
 	"render": "file:./render.php"
 }

--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -314,12 +314,14 @@ if ( $show_copy_summary ) {
 		);
 		?>
 	>
-		<button
-			class="fair-events-copy-summary-btn"
-			type="button"
-			data-wp-on--click="actions.copy"
-			data-wp-text="state.label"
-		></button>
+		<div class="wp-block-button is-style-outline">
+			<button
+				class="fair-events-copy-summary-btn wp-block-button__link wp-element-button"
+				type="button"
+				data-wp-on--click="actions.copy"
+				data-wp-text="state.label"
+			></button>
+		</div>
 	</div>
 	<?php endif; ?>
 

--- a/fair-events/src/blocks/events-week/style.scss
+++ b/fair-events/src/blocks/events-week/style.scss
@@ -201,11 +201,6 @@
 	}
 
 	.fair-events-copy-summary-btn {
-		padding: 0.375rem 0.875rem;
-		background: transparent;
-		border: 1px solid currentColor;
-		border-radius: 4px;
-		cursor: pointer;
 		font-size: 0.8125rem;
 		opacity: 0.7;
 

--- a/fair-form/src/blocks/fair-form/style.css
+++ b/fair-form/src/blocks/fair-form/style.css
@@ -80,6 +80,11 @@
 	color: #d63638;
 }
 
+.fair-form-submit-button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
 /* "Powered by Fair Event Plugins" attribution (opt-in, issue #864). */
 .fair-audience-powered-by {
 	margin: 16px 0 0;

--- a/fair-payments-connector/src/blocks/simple-payment/block.json
+++ b/fair-payments-connector/src/blocks/simple-payment/block.json
@@ -11,6 +11,7 @@
 	"editorScript": "file:./index.js",
 	"render": "file:./render.php",
 	"viewScript": "file:./view.js",
+	"style": ["wp-block-button"],
 	"attributes": {
 		"blockId": {
 			"type": "string",

--- a/fair-payments-connector/src/blocks/simple-payment/render.php
+++ b/fair-payments-connector/src/blocks/simple-payment/render.php
@@ -68,12 +68,16 @@ $wrapper_id = 'fair-payments-connector-' . wp_unique_id();
 				<p><?php esc_html_e( 'Your payment was not completed. Please try again.', 'fair-payments-connector' ); ?></p>
 			</div>
 
-			<button type="button" class="fair-payments-connector-callback-dismiss wp-element-button" style="<?php echo esc_attr( 'failed' === $callback_status ? 'display: none;' : '' ); ?>">
-				<?php esc_html_e( 'Continue', 'fair-payments-connector' ); ?>
-			</button>
-			<button type="button" class="fair-payments-connector-restart wp-element-button" style="<?php echo esc_attr( 'failed' === $callback_status ? '' : 'display: none;' ); ?>">
-				<?php esc_html_e( 'Try Again', 'fair-payments-connector' ); ?>
-			</button>
+			<div class="wp-block-button is-style-outline fair-payments-connector-callback-dismiss" style="<?php echo esc_attr( 'failed' === $callback_status ? 'display: none;' : '' ); ?>">
+				<button type="button" class="wp-block-button__link wp-element-button">
+					<?php esc_html_e( 'Continue', 'fair-payments-connector' ); ?>
+				</button>
+			</div>
+			<div class="wp-block-button is-style-outline fair-payments-connector-restart" style="<?php echo esc_attr( 'failed' === $callback_status ? '' : 'display: none;' ); ?>">
+				<button type="button" class="wp-block-button__link wp-element-button">
+					<?php esc_html_e( 'Try Again', 'fair-payments-connector' ); ?>
+				</button>
+			</div>
 		</div>
 
 		<div class="fair-payments-connector-payment-form" style="<?php echo esc_attr( $is_callback ? 'display: none;' : '' ); ?>">
@@ -85,16 +89,18 @@ $wrapper_id = 'fair-payments-connector-' . wp_unique_id();
 			</div>
 
 			<?php if ( $is_configured ) : ?>
-				<button
-					class="fair-payments-connector-button wp-element-button"
-					data-amount="<?php echo esc_attr( $amount ); ?>"
-					data-currency="<?php echo esc_attr( $currency ); ?>"
-					data-description="<?php echo esc_attr( $description ); ?>"
-					data-post-id="<?php echo esc_attr( $current_post_id ); ?>"
-					data-block-id="<?php echo esc_attr( $block_id ); ?>"
-				>
-					<?php esc_html_e( 'Pay Now', 'fair-payments-connector' ); ?>
-				</button>
+				<div class="wp-block-button">
+					<button
+						class="fair-payments-connector-button wp-block-button__link wp-element-button"
+						data-amount="<?php echo esc_attr( $amount ); ?>"
+						data-currency="<?php echo esc_attr( $currency ); ?>"
+						data-description="<?php echo esc_attr( $description ); ?>"
+						data-post-id="<?php echo esc_attr( $current_post_id ); ?>"
+						data-block-id="<?php echo esc_attr( $block_id ); ?>"
+					>
+						<?php esc_html_e( 'Pay Now', 'fair-payments-connector' ); ?>
+					</button>
+				</div>
 				<div class="fair-payments-connector-loading" style="display: none;">
 					<?php esc_html_e( 'Processing payment...', 'fair-payments-connector' ); ?>
 				</div>


### PR DESCRIPTION
## Summary

Implements the remaining work identified in the [implementation plan comment](https://github.com/marcin-wosinek/fair-event-plugins/issues/1153#issuecomment-5021545485) on #1153. Most of the ticket was already done (fair-audience, fair-form, and `fair-events/event-signup` already render core Button markup); this PR converts the four blocks that were still using bespoke button CSS:

- **fair-payments-connector `simple-payment`**: added the missing `style` field (`wp-block-button`), wrapped Pay Now / Continue / Try Again in core button markup. The dismiss/restart show-hide classes moved from the `<button>` to its `wp-block-button` wrapper so hiding the control doesn't leave an empty styled box behind.
- **fair-events `event-proposal`**: `.form-button` now carries the core classes; removed the hand-painted background/hover/disabled CSS, keeping a `:disabled` opacity rule so the disabled state doesn't regress.
- **fair-events `events-week`**: the copy-summary button is now a core `is-style-outline` button; removed its custom border/background paint, kept the opacity/hover treatment.
- **fair-events `events-calendar`**: markup was already correct — fixed the `block.json` `style` field (was a bare string with no `wp-block-button` dependency) and removed the CSS that was repainting the button regardless of theme.
- **fair-audience `event-signup`**: added a `:disabled` / `.is-disabled` rule for `.fair-audience-add-activities-button`, which had no disabled styling at all.
- **fair-form `fair-form`**: added a `:disabled` rule for the submit button for the same reason.

Two open questions from the plan (the "not you" link-styled control, and the signup mode tabs) are intentionally left out of scope per the plan's own recommendation — converting either would be a real UX regression, not a style fix.

Closes #1153

## Notes

- No markup or CSS changes for the blocks already using core styles (see table in the plan comment).
- e2e/env note: this session's local WP Docker environment had every plugin deactivated at the start, so the existing Playwright specs (`events-week-copy-summary`, `events-calendar-subscribe`) couldn't run end-to-end here (`waitForFunction: window.wp.apiFetch` timed out — unrelated to this change, reproduced on an unrelated spec too). I verified the affected `render.php` output directly via the WP-CLI `eval-file` recipe instead (confirmed correct core classes on all four blocks) and did a manual visual check on a fresh page in the default Twenty Twenty-Five theme — see below.
- Classic-theme legibility (last acceptance-criteria bullet) wasn't separately verified in this session; no classic theme was installed in the local environment.

## Test plan

- [x] `npm run build` in fair-events, fair-payments-connector, fair-audience, fair-form
- [x] `npm run format` in the same four plugins
- [x] `vendor/bin/phpcs` on the changed PHP files — clean (pre-existing unrelated warnings on unrelated lines in `event-proposal/render.php` and `events-week/render.php` left untouched)
- [x] Verified rendered markup for all four blocks via WP-CLI `eval-file` (core classes present, dismiss/restart wrapper toggling correct, no duplicate classes)
- [x] Manual visual check: Pay Now / Copy summary / Subscribe to calendar all pick up Twenty Twenty-Five's button styling consistently (filled vs. outline)
- [ ] `npm run test:e2e` — blocked locally by an unrelated environment issue (see Notes); not run in this session
- [ ] Classic-theme visual check — not run in this session
