### PR TITLE
Emit isAccessibleForFree for events priced free

### DIFF
--- a/fair-events/__tests__/Helpers/EventSchemaTest.php
+++ b/fair-events/__tests__/Helpers/EventSchemaTest.php
@@ -149,4 +149,63 @@ class EventSchemaTest extends TestCase {
 
 		$this->assertCount( 1, $item_list['itemListElement'] );
 	}
+
+	/**
+	 * Build a minimal Offer array with the given price.
+	 *
+	 * @param float $price Offer price.
+	 * @return array Offer object.
+	 */
+	private function make_offer( $price ): array {
+		return array(
+			'@type'         => 'Offer',
+			'price'         => (string) $price,
+			'priceCurrency' => 'EUR',
+			'availability'  => 'https://schema.org/InStock',
+			'url'           => 'https://example.com/event',
+		);
+	}
+
+	/**
+	 * An offer set where every offer is priced at zero is free.
+	 *
+	 * @return void
+	 */
+	public function test_is_free_offer_set_true_when_all_zero() {
+		$offers = array( $this->make_offer( 0 ), $this->make_offer( 0.0 ) );
+
+		$this->assertTrue( EventSchema::is_free_offer_set( $offers ) );
+	}
+
+	/**
+	 * A mix of zero-priced and priced offers is not free.
+	 *
+	 * @return void
+	 */
+	public function test_is_free_offer_set_false_when_mixed() {
+		$offers = array( $this->make_offer( 0 ), $this->make_offer( 15 ) );
+
+		$this->assertFalse( EventSchema::is_free_offer_set( $offers ) );
+	}
+
+	/**
+	 * An offer set with only priced offers is not free.
+	 *
+	 * @return void
+	 */
+	public function test_is_free_offer_set_false_when_all_priced() {
+		$offers = array( $this->make_offer( 10 ), $this->make_offer( 15 ) );
+
+		$this->assertFalse( EventSchema::is_free_offer_set( $offers ) );
+	}
+
+	/**
+	 * An empty offer set is not free — it means ticketing isn't configured,
+	 * not that the event is free, so it must not claim `isAccessibleForFree`.
+	 *
+	 * @return void
+	 */
+	public function test_is_free_offer_set_false_when_empty() {
+		$this->assertFalse( EventSchema::is_free_offer_set( array() ) );
+	}
 }

--- a/fair-events/e2e/opengraph-jsonld.spec.js
+++ b/fair-events/e2e/opengraph-jsonld.spec.js
@@ -149,6 +149,7 @@ test.describe('Fair Events JSON-LD structured data', () => {
 		expect(data.offers).toHaveLength(1);
 		expect(data.offers[0].price).toBe('15');
 		expect(data.offers[0].priceCurrency).toBeTruthy();
+		expect(data.isAccessibleForFree).toBeUndefined();
 
 		// Cleanup.
 		await apiFetch(page, {
@@ -202,6 +203,85 @@ test.describe('Fair Events JSON-LD structured data', () => {
 		expect(data.location).toBeTruthy();
 		expect(data.location['@type']).toBe('Place');
 		expect(data.offers).toBeUndefined();
+		expect(data.isAccessibleForFree).toBeUndefined();
+
+		// Cleanup.
+		await apiFetch(page, {
+			path: `/wp/v2/fair_event/${postId}?force=true`,
+			method: 'DELETE',
+		}).catch(() => {});
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}`,
+			method: 'DELETE',
+		}).catch(() => {});
+	});
+
+	test('emits isAccessibleForFree for an event with only a zero-price ticket type', async ({
+		page,
+	}) => {
+		test.setTimeout(120_000);
+
+		await page.setViewportSize({ width: 1200, height: 900 });
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+		const now = new Date();
+		const start = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+		const iso = (d) => d.toISOString().slice(0, 19).replace('T', ' ');
+
+		const eventDate = await apiFetch(page, {
+			path: '/fair-events/v1/event-dates',
+			method: 'POST',
+			data: {
+				title: 'JSON-LD Test Free Event',
+				start_datetime: iso(start),
+				end_datetime: iso(
+					new Date(start.getTime() + 2 * 60 * 60 * 1000)
+				),
+				all_day: false,
+			},
+		});
+
+		const post = await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}/create-post`,
+			method: 'POST',
+			data: { post_status: 'publish' },
+		});
+		const postId = post.event_id || post.post_id;
+
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}/tickets`,
+			method: 'PUT',
+			data: {
+				ticket_types: [{ name: 'Free Admission' }],
+				sale_periods: [
+					{
+						name: 'Main sale',
+						sale_start: iso(
+							new Date(now.getTime() - 24 * 60 * 60 * 1000)
+						),
+						sale_end: iso(
+							new Date(now.getTime() + 24 * 60 * 60 * 1000)
+						),
+					},
+				],
+				prices: [
+					{
+						ticket_type_index: 0,
+						sale_period_index: 0,
+						price: 0,
+					},
+				],
+			},
+		});
+
+		const permalink = post.link || `/?p=${postId}`;
+		const data = await getJsonLd(page, permalink);
+
+		expect(data.offers).toHaveLength(1);
+		expect(data.offers[0].price).toBe('0');
+		expect(data.isAccessibleForFree).toBe(true);
 
 		// Cleanup.
 		await apiFetch(page, {

--- a/fair-events/src/Helpers/EventSchema.php
+++ b/fair-events/src/Helpers/EventSchema.php
@@ -66,6 +66,10 @@ class EventSchema {
 		$offers = self::get_jsonld_offers( $event_date, $post_id );
 		if ( ! empty( $offers ) ) {
 			$data['offers'] = $offers;
+
+			if ( self::is_free_offer_set( $offers ) ) {
+				$data['isAccessibleForFree'] = true;
+			}
 		}
 
 		$data['organizer'] = array(
@@ -356,5 +360,29 @@ class EventSchema {
 		}
 
 		return $offers;
+	}
+
+	/**
+	 * Whether an offer set represents a genuinely free event.
+	 *
+	 * True only when every offer is priced at zero AND at least one offer
+	 * exists — an empty set means ticketing isn't configured, not that the
+	 * event is free, so it must not trigger `isAccessibleForFree`.
+	 *
+	 * @param array $offers Offer objects, as built by get_jsonld_offers().
+	 * @return bool True when every offer is priced at zero.
+	 */
+	public static function is_free_offer_set( array $offers ): bool {
+		if ( empty( $offers ) ) {
+			return false;
+		}
+
+		foreach ( $offers as $offer ) {
+			if ( 0.0 !== (float) $offer['price'] ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
## Summary

- Add `EventSchema::is_free_offer_set()`: true only when an offer set is non-empty and every offer is priced at zero — the non-empty guard keeps "ticketing not configured" (no `offers` key) from ever producing a false free claim.
- `event_to_jsonld()` now sets `isAccessibleForFree: true` when the built offer set is all-zero, inside the existing `offers`-present branch.
- Zero-price offers and the "no ticket types" → no `offers` key behavior were already correct; this closes the one remaining gap (`isAccessibleForFree`) with no new DB column, admin UI, or migration — mirrors the existing `$has_paid_type`/`$has_free_type` logic in `event-signup/render.php`.

Refs #1174

## Test plan

- [x] `vendor/bin/phpunit --filter EventSchemaTest` — 10/10 passing, including 4 new cases for `is_free_offer_set()` (all-zero, mixed, all-priced, empty)
- [x] `vendor/bin/phpcs` clean on changed PHP
- [ ] `npm run test:e2e` (added a third `opengraph-jsonld.spec.js` case seeding a zero-price ticket type and asserting `isAccessibleForFree === true`; existing priced-event and no-ticket-types tests now also assert `isAccessibleForFree` stays `undefined`) — not run locally, needs the WP e2e environment
