### PR TITLE
Nest series occurrences under their master in All Events

### DIFF
--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -1485,6 +1485,10 @@ class EventDatesController extends WP_REST_Controller {
 		if ( ! empty( $occurrence_type ) ) {
 			$where_clauses[] = 'occurrence_type = %s';
 			$where_values[]  = $occurrence_type;
+		} else {
+			// Top level only: generated series dates ride along with their
+			// master row (attached below) rather than appearing standalone.
+			$where_clauses[] = "occurrence_type IN ('single', 'master')";
 		}
 
 		$where_sql = '';
@@ -1502,7 +1506,7 @@ class EventDatesController extends WP_REST_Controller {
 		}
 
 		// Count total items.
-		if ( ! empty( $where_values ) ) {
+		if ( ! empty( $where_clauses ) ) {
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$total = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM %i $where_sql", $table_name, ...$where_values ) );
 		} else {
@@ -1515,7 +1519,7 @@ class EventDatesController extends WP_REST_Controller {
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$order_sql = "ORDER BY `$orderby` $order LIMIT %d OFFSET %d";
 
-		if ( ! empty( $where_values ) ) {
+		if ( ! empty( $where_clauses ) ) {
 			$select_args = array_merge( array( $table_name ), $where_values, array( $per_page, $offset ) );
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM %i $where_sql $order_sql", ...$select_args ) );
@@ -1524,9 +1528,44 @@ class EventDatesController extends WP_REST_Controller {
 			$results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM %i $order_sql", $table_name, $per_page, $offset ) );
 		}
 
+		// Batch-fetch generated children for any masters on this page, in one
+		// query, so groups never split across pages and we avoid an N+1 per
+		// master (they ride with their master rather than being counted/offset).
+		$master_ids = array();
+		foreach ( $results as $result ) {
+			if ( 'master' === $result->occurrence_type ) {
+				$master_ids[] = (int) $result->id;
+			}
+		}
+
+		$children_by_master = array();
+		if ( ! empty( $master_ids ) ) {
+			$placeholders  = implode( ', ', array_fill( 0, count( $master_ids ), '%d' ) );
+			$children_args = array_merge( array( $table_name ), $master_ids, array( 'generated' ) );
+			$child_results = $wpdb->get_results(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is a fixed run of %d tokens, not request input.
+				$wpdb->prepare( "SELECT * FROM %i WHERE master_id IN ($placeholders) AND occurrence_type = %s ORDER BY start_datetime ASC", ...$children_args )
+			);
+
+			foreach ( $child_results as $child ) {
+				$children_by_master[ (int) $child->master_id ][] = $child;
+			}
+		}
+
 		$items = array();
 		foreach ( $results as $result ) {
-			$items[] = $this->prepare_event_date_summary( $result );
+			$item = $this->prepare_event_date_summary( $result );
+
+			if ( 'master' === $result->occurrence_type ) {
+				$children               = $children_by_master[ (int) $result->id ] ?? array();
+				$item['children']       = array_map(
+					array( $this, 'prepare_event_date_summary' ),
+					$children
+				);
+				$item['children_count'] = count( $children );
+			}
+
+			$items[] = $item;
 		}
 
 		$response = new WP_REST_Response( $items, 200 );
@@ -1555,6 +1594,7 @@ class EventDatesController extends WP_REST_Controller {
 			'link_type'       => $result->link_type,
 			'external_url'    => $result->external_url,
 			'venue_id'        => $result->venue_id ? (int) $result->venue_id : null,
+			'status'          => $result->status,
 		);
 
 		// Add display_url.

--- a/fair-events/src/API/__tests__/AllEventsList.api.spec.js
+++ b/fair-events/src/API/__tests__/AllEventsList.api.spec.js
@@ -1,0 +1,155 @@
+/**
+ * Playwright API tests for the grouped all-events list endpoint on
+ * EventDatesController.
+ *
+ * Exercises GET /fair-events/v1/event-dates/all against a live WordPress
+ * instance (#1202): generated series dates are nested under their master
+ * instead of appearing as independent top-level rows.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('EventDatesController — grouped all-events list', () => {
+	let api;
+	let seriesTitle;
+	let masterEventDateId;
+	let generatedIds;
+	let singleEventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		seriesTitle = `Nesting series test ${Date.now()}`;
+		const masterRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: seriesTitle,
+					start_datetime: '2037-02-01 10:00:00',
+					end_datetime: '2037-02-01 12:00:00',
+					rrule: 'FREQ=WEEKLY;COUNT=3',
+				},
+			}
+		);
+		expect(masterRes.ok()).toBeTruthy();
+		const masterBody = await masterRes.json();
+		masterEventDateId = masterBody.id;
+		generatedIds = masterBody.generated_occurrences.map((o) => o.id);
+		expect(generatedIds.length).toBe(2);
+
+		const singleRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Nesting single test ${Date.now()}`,
+					start_datetime: '2037-03-01 10:00:00',
+				},
+			}
+		);
+		expect(singleRes.ok()).toBeTruthy();
+		singleEventDateId = (await singleRes.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (masterEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (singleEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${singleEventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		await api.dispose();
+	});
+
+	test('generated occurrences are absent from the top level, master carries children ordered by date ascending', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/event-dates/all?per_page=100',
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const ids = body.map((item) => item.id);
+		generatedIds.forEach((id) => expect(ids).not.toContain(id));
+		expect(ids).toContain(masterEventDateId);
+		expect(ids).toContain(singleEventDateId);
+
+		const master = body.find((item) => item.id === masterEventDateId);
+		expect(master.occurrence_type).toBe('master');
+		expect(master.children_count).toBe(2);
+		expect(master.children.map((c) => c.id)).toEqual(generatedIds);
+		expect(
+			new Date(master.children[0].start_datetime).getTime()
+		).toBeLessThan(new Date(master.children[1].start_datetime).getTime());
+	});
+
+	test('X-WP-Total counts top-level rows only', async () => {
+		const resFiltered = await api.get(
+			`/wp-json/fair-events/v1/event-dates/all?search=${encodeURIComponent(
+				seriesTitle
+			)}`,
+			{ headers: adminHeaders }
+		);
+		expect(resFiltered.ok()).toBeTruthy();
+		const bodyFiltered = await resFiltered.json();
+		const totalFiltered = parseInt(
+			resFiltered.headers()['x-wp-total'] || '0',
+			10
+		);
+
+		// Only the master matches the search title at the top level; its
+		// generated children (which share no title of their own) don't add
+		// to the count.
+		expect(totalFiltered).toBe(1);
+		expect(bodyFiltered.length).toBe(1);
+		expect(bodyFiltered[0].id).toBe(masterEventDateId);
+	});
+
+	test('occurrence_type=generated filter still returns a flat list', async () => {
+		const res = await api.get(
+			'/wp-json/fair-events/v1/event-dates/all?occurrence_type=generated&per_page=100',
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const ids = body.map((item) => item.id);
+		generatedIds.forEach((id) => expect(ids).toContain(id));
+		body.forEach((item) => {
+			expect(item.occurrence_type).toBe('generated');
+			expect(item.children).toBeUndefined();
+		});
+	});
+
+	test('search matches masters', async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/all?search=${encodeURIComponent(
+				seriesTitle
+			)}`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		expect(body.length).toBe(1);
+		expect(body[0].id).toBe(masterEventDateId);
+		expect(body[0].occurrence_type).toBe('master');
+	});
+});

--- a/fair-events/src/Admin/all-events/AllEvents.js
+++ b/fair-events/src/Admin/all-events/AllEvents.js
@@ -1,8 +1,9 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
-import { Card, CardBody } from '@wordpress/components';
+import { Button, Card, CardBody } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
+import { chevronRight, chevronDown } from '@wordpress/icons';
 import {
 	formatSiteLocalDatetime,
 	getEventDisplayTitle,
@@ -32,6 +33,7 @@ const DEFAULT_VIEW = {
 	},
 	search: '',
 	filters: [],
+	showLevels: true,
 	fields: [
 		'title',
 		'start_datetime',
@@ -62,17 +64,96 @@ export default function AllEvents() {
 	const [totalPages, setTotalPages] = useState(0);
 	const [isLoading, setIsLoading] = useState(true);
 	const [view, setView] = useState(DEFAULT_VIEW);
+	const [expanded, setExpanded] = useState(() => new Set());
+
+	const toggleExpanded = useCallback((masterId) => {
+		setExpanded((prev) => {
+			const next = new Set(prev);
+			if (next.has(masterId)) {
+				next.delete(masterId);
+			} else {
+				next.add(masterId);
+			}
+			return next;
+		});
+	}, []);
 
 	const fields = useMemo(
 		() => [
 			{
 				id: 'title',
 				label: __('Name', 'fair-events'),
-				render: ({ item }) => (
-					<a href={`${manageEventUrl}&event_date_id=${item.id}`}>
-						{getEventDisplayTitle(item.title)}
-					</a>
-				),
+				render: ({ item }) => {
+					if (
+						item.occurrence_type === 'generated' &&
+						item.master_id
+					) {
+						const label = item.start_datetime
+							? formatSiteLocalDatetime(item.start_datetime)
+							: getEventDisplayTitle(item.title);
+						if (item.status === 'cancelled') {
+							return (
+								<span className="fair-events-all-events__cancelled">
+									{label}{' '}
+									<small>
+										({__('Cancelled', 'fair-events')})
+									</small>
+								</span>
+							);
+						}
+						return (
+							<a
+								href={`${manageEventUrl}&event_date_id=${item.id}`}
+							>
+								{label}
+							</a>
+						);
+					}
+
+					if (item.occurrence_type === 'master') {
+						const isExpanded = expanded.has(item.id);
+						const count = item.children_count || 0;
+						return (
+							<>
+								<Button
+									icon={
+										isExpanded ? chevronDown : chevronRight
+									}
+									onClick={() => toggleExpanded(item.id)}
+									aria-expanded={isExpanded}
+									label={
+										isExpanded
+											? __(
+													'Collapse series dates',
+													'fair-events'
+											  )
+											: __(
+													'Expand series dates',
+													'fair-events'
+											  )
+									}
+									showTooltip={false}
+								/>
+								<a
+									href={`${manageEventUrl}&event_date_id=${item.id}`}
+								>
+									{getEventDisplayTitle(item.title)}
+								</a>{' '}
+								{sprintf(
+									/* translators: %d: number of dates in the series. */
+									__('(%d dates)', 'fair-events'),
+									count
+								)}
+							</>
+						);
+					}
+
+					return (
+						<a href={`${manageEventUrl}&event_date_id=${item.id}`}>
+							{getEventDisplayTitle(item.title)}
+						</a>
+					);
+				},
 				enableSorting: true,
 				enableHiding: false,
 				getValue: ({ item }) => (item.title || '').toLowerCase(),
@@ -151,7 +232,7 @@ export default function AllEvents() {
 				},
 			},
 		],
-		[]
+		[expanded, toggleExpanded]
 	);
 
 	const queryArgs = useMemo(() => {
@@ -224,6 +305,32 @@ export default function AllEvents() {
 		loadEvents();
 	}, [loadEvents]);
 
+	// Stale expanded ids should not leak across pages/filters.
+	useEffect(() => {
+		setExpanded(new Set());
+	}, [queryArgs]);
+
+	const flattenedEvents = useMemo(() => {
+		const rows = [];
+		for (const event of events) {
+			rows.push(event);
+			if (
+				event.occurrence_type === 'master' &&
+				expanded.has(event.id) &&
+				event.children
+			) {
+				rows.push(...event.children);
+			}
+		}
+		return rows;
+	}, [events, expanded]);
+
+	const getItemLevel = useCallback(
+		(item) =>
+			item.occurrence_type === 'generated' && item.master_id ? 1 : 0,
+		[]
+	);
+
 	const actions = useMemo(
 		() => [
 			{
@@ -253,13 +360,14 @@ export default function AllEvents() {
 			<Card>
 				<CardBody>
 					<DataViews
-						data={events}
+						data={flattenedEvents}
 						fields={fields}
 						view={view}
 						onChangeView={setView}
 						paginationInfo={paginationInfo}
 						defaultLayouts={DEFAULT_LAYOUTS}
 						actions={actions}
+						getItemLevel={getItemLevel}
 						isLoading={isLoading}
 						getItemId={(item) => item.id}
 					/>

--- a/fair-events/src/Admin/all-events/__tests__/AllEvents.test.jsx
+++ b/fair-events/src/Admin/all-events/__tests__/AllEvents.test.jsx
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Component tests for series nesting in AllEvents (#1202).
+ *
+ * Covers:
+ *   - Series masters are collapsed by default; generated children are not rendered.
+ *   - Toggling the disclosure button reveals the nested date rows.
+ *   - Nested date rows show their date, not "(untitled event)".
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import AllEvents from '../AllEvents.js';
+
+jest.mock('@wordpress/api-fetch');
+
+function jsonResponse(data, headers = {}) {
+	return {
+		headers: {
+			get: (name) => headers[name.toLowerCase()] ?? null,
+		},
+		json: () => Promise.resolve(data),
+	};
+}
+
+const masterEvent = {
+	id: 1,
+	event_id: null,
+	title: 'Summer Workshops',
+	start_datetime: '2037-02-01 10:00:00',
+	end_datetime: '2037-02-01 12:00:00',
+	all_day: false,
+	occurrence_type: 'master',
+	master_id: null,
+	link_type: 'none',
+	external_url: null,
+	venue_id: null,
+	status: 'active',
+	display_url: null,
+	categories: [],
+	children_count: 2,
+	children: [
+		{
+			id: 2,
+			title: '',
+			start_datetime: '2037-02-01 10:00:00',
+			occurrence_type: 'generated',
+			master_id: 1,
+			status: 'active',
+			categories: [],
+		},
+		{
+			id: 3,
+			title: '',
+			start_datetime: '2037-02-08 10:00:00',
+			occurrence_type: 'generated',
+			master_id: 1,
+			status: 'active',
+			categories: [],
+		},
+	],
+};
+
+beforeEach(() => {
+	apiFetch.mockImplementation(() =>
+		Promise.resolve(
+			jsonResponse([masterEvent], {
+				'x-wp-total': '1',
+				'x-wp-totalpages': '1',
+			})
+		)
+	);
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+	jest.clearAllMocks();
+});
+
+it('renders the series collapsed by default, without its nested dates', async () => {
+	render(<AllEvents />);
+
+	await waitFor(() =>
+		expect(screen.getByText('Summer Workshops')).toBeInTheDocument()
+	);
+
+	expect(
+		screen.getByRole('button', { name: 'Expand series dates' })
+	).toBeInTheDocument();
+	expect(screen.queryByText('(untitled event)')).not.toBeInTheDocument();
+	expect(screen.getAllByRole('row')).toHaveLength(2); // header + master.
+});
+
+it('reveals nested date rows when the disclosure button is toggled', async () => {
+	render(<AllEvents />);
+
+	await waitFor(() =>
+		expect(screen.getByText('Summer Workshops')).toBeInTheDocument()
+	);
+
+	fireEvent.click(
+		screen.getByRole('button', { name: 'Expand series dates' })
+	);
+
+	await waitFor(() => expect(screen.getAllByRole('row')).toHaveLength(4)); // header + master + 2 children.
+
+	expect(screen.queryByText('(untitled event)')).not.toBeInTheDocument();
+	expect(
+		screen.getByRole('button', { name: 'Collapse series dates' })
+	).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary

- Generated series dates no longer show up as independent top-level rows in the All Events list — `get_all_items()` restricts the top level to `single`/`master` occurrences (unless an `occurrence_type` filter is applied, which keeps the flat behaviour the Type filter already relies on).
- Each series master now carries its generated children in the response (`children` / `children_count`), fetched in one batched `master_id IN (...)` query per page rather than looping per master.
- `AllEvents.js` renders masters with a collapsed-by-default disclosure toggle showing a date count (e.g. "Summer Workshops (12 dates)"), uses `DataViews`' `getItemLevel`/`showLevels` to indent nested rows, and shows each nested date row by its own date instead of "(untitled event)". Cancelled nested dates are shown muted with a "Cancelled" label.
- Pagination totals and search now operate on top-level rows only, so a series group never splits across pages.

## Notes

- Nested dates are loaded inline with their master (per the ticket's own recommendation) rather than lazy-loaded on expand; collapsed-by-default keeps render cost down. If a real series turns out to have very large occurrence counts, a follow-up could add a dedicated `GET /event-dates/{id}/generated` endpoint and fetch on expand instead.
- `prepare_event_date_summary()` still does a per-row `EventDates::get_by_id()` lookup (pre-existing N+1); this PR reuses it as-is for the new children rows for consistency rather than expanding scope. Worth a follow-up ticket to hydrate summaries from the rows already fetched.

## Test plan

- [x] `npm run test:js` — all 126 tests pass, including new `AllEvents.test.jsx` (collapsed by default, toggle reveals children, no "(untitled event)" label).
- [x] `npm run test:api` (new `AllEventsList.api.spec.js`) against a live WP instance — generated rows absent from top level, `X-WP-Total` counts top-level only, masters carry children ordered by date ascending, `occurrence_type=generated` still returns a flat list, search matches masters.
- [x] `vendor/bin/phpcs` on the changed controller — no new errors/warnings beyond the file's pre-existing ones.
- [x] `npm run build` — production assets rebuilt.

Closes #1202
