### PR TITLE
Add a test-payment button to connector settings

### DIFF
--- a/fair-payments-connector/src/API/ConnectionController.php
+++ b/fair-payments-connector/src/API/ConnectionController.php
@@ -8,6 +8,7 @@
 namespace FairPaymentsConnector\API;
 
 use FairPaymentsConnector\Payment\MolliePaymentHandler;
+use FairPaymentsConnector\Models\Transaction;
 
 defined( 'WPINC' ) || die;
 
@@ -40,6 +41,20 @@ class ConnectionController extends \WP_REST_Controller {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'get_connection_overview' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+
+		register_rest_route(
+			'fair-payments-connector/v1',
+			'/test-payment',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'create_test_payment' ),
+				// Admin-only: this creates a real transaction (real money in live mode)
+				// with no backing block, so it must not reuse the public payment path.
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' );
 				},
@@ -79,6 +94,96 @@ class ConnectionController extends \WP_REST_Controller {
 			: 'https://my.mollie.com/dashboard/';
 
 		return new \WP_REST_Response( $overview, 200 );
+	}
+
+	/**
+	 * Create a one-unit test payment and return its Mollie checkout URL.
+	 *
+	 * Exercises the full payment flow (transaction creation, checkout, webhook
+	 * status update) from the settings page, without a backing payment block.
+	 * Admin-only — see the permission callback on the route.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function create_test_payment() {
+		if ( ! get_option( 'fair_payment_mollie_connected', false ) ) {
+			return new \WP_Error(
+				'not_connected',
+				__( 'Mollie is not connected. Please connect your Mollie account first.', 'fair-payments-connector' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$currency    = get_option( 'fair_payment_currency', 'EUR' );
+		$mode        = get_option( 'fair_payment_mode', 'test' );
+		$description = __( 'Test payment (Fair Payments Connector settings)', 'fair-payments-connector' );
+
+		$transaction_id = TransactionAPI::create_transaction(
+			array(
+				array(
+					'name'     => $description,
+					'quantity' => 1,
+					'amount'   => 1.0,
+				),
+			),
+			array(
+				'currency'    => $currency,
+				'description' => $description,
+				'user_id'     => get_current_user_id(),
+				'metadata'    => array(
+					'test_payment' => true,
+					'user_id'      => get_current_user_id(),
+				),
+			)
+		);
+
+		if ( is_wp_error( $transaction_id ) ) {
+			return new \WP_Error(
+				'test_payment_failed',
+				$transaction_id->get_error_message(),
+				array( 'status' => 500 )
+			);
+		}
+
+		$transaction  = Transaction::get_by_id( $transaction_id );
+		$settings_url = add_query_arg( 'page', 'fair-payments-connector-settings', admin_url( 'admin.php' ) );
+
+		$redirect_url = add_query_arg(
+			array(
+				'fair_payment_callback' => 'true',
+				'transaction_id'        => $transaction_id,
+				'token'                 => $transaction ? $transaction->access_token : '',
+			),
+			$settings_url
+		);
+
+		$payment = TransactionAPI::initiate_payment(
+			$transaction_id,
+			array(
+				'redirect_url' => $redirect_url,
+				'webhook_url'  => rest_url( 'fair-payments-connector/v1/webhook' ),
+			)
+		);
+
+		if ( is_wp_error( $payment ) ) {
+			return new \WP_Error(
+				'test_payment_failed',
+				$payment->get_error_message(),
+				array( 'status' => 500 )
+			);
+		}
+
+		return new \WP_REST_Response(
+			array(
+				'success'        => true,
+				'transaction_id' => $transaction_id,
+				'checkout_url'   => $payment['checkout_url'],
+				'status'         => $payment['status'],
+				'currency'       => $currency,
+				'mode'           => $mode,
+			),
+			201
+		);
 	}
 
 	/**

--- a/fair-payments-connector/src/API/__tests__/TestPayment.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/TestPayment.api.spec.js
@@ -1,0 +1,48 @@
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const TEST_PAYMENT_ENDPOINT =
+	'/wp-json/fair-payments-connector/v1/test-payment';
+
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * Return Basic-auth headers for the WP admin account.
+ */
+function adminAuth() {
+	return {
+		Authorization:
+			'Basic ' +
+			Buffer.from(`${ADMIN_USER}:${ADMIN_PASS}`).toString('base64'),
+	};
+}
+
+test.describe('Test payment endpoint', () => {
+	let api;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test('rejects unauthenticated requests with 401', async () => {
+		const res = await api.post(TEST_PAYMENT_ENDPOINT);
+		expect(res.status()).toBe(401);
+	});
+
+	test('returns a graceful error for an authenticated admin when not connected', async () => {
+		// This suite runs without an established OAuth connection, so the site is
+		// expected to be disconnected here. The live-Mollie success path can't be
+		// exercised in CI (no real Mollie creds).
+		const res = await api.post(TEST_PAYMENT_ENDPOINT, {
+			headers: adminAuth(),
+		});
+		expect(res.status()).toBe(400);
+		const body = await res.json();
+		expect(body.code).toBe('not_connected');
+	});
+});

--- a/fair-payments-connector/src/Admin/settings/ConnectionTab.js
+++ b/fair-payments-connector/src/Admin/settings/ConnectionTab.js
@@ -20,6 +20,7 @@ import {
 	loadConnectionOverview,
 	saveSettings,
 	testConnection,
+	createTestPayment,
 	fetchOAuthState,
 } from './settings-api';
 
@@ -46,6 +47,8 @@ export default function ConnectionTab({ onNotice, shouldReload }) {
 	const [overview, setOverview] = useState(null);
 	const [overviewLoading, setOverviewLoading] = useState(false);
 	const [overviewError, setOverviewError] = useState(null);
+	const [isTestingPayment, setIsTestingPayment] = useState(false);
+	const [testCheckoutUrl, setTestCheckoutUrl] = useState(null);
 
 	/**
 	 * Load connection settings from API
@@ -332,6 +335,58 @@ export default function ConnectionTab({ onNotice, shouldReload }) {
 			});
 	};
 
+	/**
+	 * Handle Create test payment button click.
+	 *
+	 * Creates a one-unit payment and opens the Mollie checkout in a new tab. In
+	 * live mode it confirms first, since a real payment with real money is made.
+	 * The checkout URL is also kept in state so a fallback link can be shown when
+	 * the browser blocks the popup.
+	 */
+	const handleTestPayment = () => {
+		if (
+			mode === 'live' &&
+			// eslint-disable-next-line no-alert
+			!confirm(
+				__(
+					'You are in live mode. This creates a real 1-unit payment with real money and gateway fees. Continue?',
+					'fair-payments-connector'
+				)
+			)
+		) {
+			return;
+		}
+
+		setIsTestingPayment(true);
+		setTestCheckoutUrl(null);
+
+		createTestPayment()
+			.then((response) => {
+				setTestCheckoutUrl(response.checkout_url);
+				window.open(response.checkout_url, '_blank', 'noopener');
+				onNotice({
+					status: 'success',
+					message: __(
+						'Test payment created. Complete or cancel the checkout in the new tab; its status updates automatically.',
+						'fair-payments-connector'
+					),
+				});
+				setIsTestingPayment(false);
+			})
+			.catch((error) => {
+				onNotice({
+					status: 'error',
+					message:
+						error.message ||
+						__(
+							'Failed to create test payment.',
+							'fair-payments-connector'
+						),
+				});
+				setIsTestingPayment(false);
+			});
+	};
+
 	if (isLoading) {
 		return (
 			<Card>
@@ -348,251 +403,341 @@ export default function ConnectionTab({ onNotice, shouldReload }) {
 	}
 
 	return (
-		<Card>
-			<CardBody>
-				<h2>{__('Mollie Connection', 'fair-payments-connector')}</h2>
+		<>
+			<Card>
+				<CardBody>
+					<h2>
+						{__('Mollie Connection', 'fair-payments-connector')}
+					</h2>
 
-				{!connected ? (
-					<>
-						<p>
-							{__(
-								'Connect your Mollie account to accept payments. This uses secure OAuth authentication.',
-								'fair-payments-connector'
-							)}
-						</p>
-						<Button isPrimary onClick={handleConnect}>
-							{__(
-								'Connect with Mollie',
-								'fair-payments-connector'
-							)}
-						</Button>
-					</>
-				) : (
-					<>
-						<Notice status="success" isDismissible={false}>
-							{__(
-								'Connected to Mollie',
-								'fair-payments-connector'
-							)}
-						</Notice>
-
-						{organizationId && (
-							<div style={{ marginTop: '1rem' }}>
-								<p>
-									<strong>
-										{__(
-											'Organization ID:',
-											'fair-payments-connector'
-										)}
-									</strong>{' '}
-									<code>{organizationId}</code>
-								</p>
-							</div>
-						)}
-
-						<div style={{ marginTop: '0.5rem' }}>
+					{!connected ? (
+						<>
 							<p>
-								<strong>
-									{__(
-										'Profile ID:',
-										'fair-payments-connector'
-									)}
-								</strong>{' '}
-								{profileId ? (
-									<code>{profileId}</code>
-								) : (
-									<span style={{ color: '#d63638' }}>
-										{__(
-											'Missing (required for payments)',
-											'fair-payments-connector'
-										)}
-									</span>
+								{__(
+									'Connect your Mollie account to accept payments. This uses secure OAuth authentication.',
+									'fair-payments-connector'
 								)}
 							</p>
-							{!profileId && (
-								<p
-									style={{
-										fontSize: '0.9em',
-										color: '#d63638',
-										marginTop: '0.5rem',
-									}}
-								>
-									{__(
-										'Please reconnect to Mollie to fetch the profile ID.',
-										'fair-payments-connector'
-									)}
-								</p>
-							)}
-						</div>
+							<Button isPrimary onClick={handleConnect}>
+								{__(
+									'Connect with Mollie',
+									'fair-payments-connector'
+								)}
+							</Button>
+						</>
+					) : (
+						<>
+							<Notice status="success" isDismissible={false}>
+								{__(
+									'Connected to Mollie',
+									'fair-payments-connector'
+								)}
+							</Notice>
 
-						<div style={{ marginTop: '1rem' }}>
-							{overviewLoading && (
-								<p style={{ fontSize: '0.9em', color: '#666' }}>
-									{__(
-										'Loading payment methods…',
-										'fair-payments-connector'
-									)}
-								</p>
-							)}
-
-							{overviewError && (
-								<Notice status="warning" isDismissible={false}>
-									{overviewError}
-								</Notice>
-							)}
-
-							{overview && !overviewLoading && (
-								<>
+							{organizationId && (
+								<div style={{ marginTop: '1rem' }}>
 									<p>
 										<strong>
 											{__(
-												'Profile name:',
+												'Organization ID:',
 												'fair-payments-connector'
 											)}
 										</strong>{' '}
-										{overview.profile_name}
+										<code>{organizationId}</code>
 									</p>
-
-									<p style={{ marginBottom: '0.25rem' }}>
-										<strong>
-											{__(
-												'Enabled payment methods:',
-												'fair-payments-connector'
-											)}
-										</strong>
-									</p>
-									{overview.methods.length > 0 ? (
-										<ul
-											style={{
-												listStyle: 'disc',
-												marginLeft: '1.5rem',
-											}}
-										>
-											{overview.methods.map((method) => (
-												<li key={method.id}>
-													{method.image && (
-														<img
-															src={method.image}
-															alt=""
-															width="20"
-															height="20"
-															style={{
-																verticalAlign:
-																	'middle',
-																marginRight:
-																	'0.5rem',
-															}}
-														/>
-													)}
-													{method.description}
-												</li>
-											))}
-										</ul>
-									) : (
-										<p>
-											{__(
-												'No payment methods are currently enabled.',
-												'fair-payments-connector'
-											)}
-										</p>
-									)}
-
-									<p>
-										<a
-											href={overview.manage_url}
-											target="_blank"
-											rel="noreferrer"
-										>
-											{__(
-												'Manage payment methods in Mollie',
-												'fair-payments-connector'
-											)}
-										</a>
-									</p>
-								</>
+								</div>
 							)}
-						</div>
 
-						{tokenExpires && (
 							<div style={{ marginTop: '0.5rem' }}>
-								<p
-									style={{
-										fontSize: '0.9em',
-										color: '#666',
-									}}
-								>
-									{sprintf(
-										/* translators: %s: expiration date */
-										__(
-											'Token expires: %s',
+								<p>
+									<strong>
+										{__(
+											'Profile ID:',
 											'fair-payments-connector'
-										),
-										new Date(
-											tokenExpires * 1000
-										).toLocaleString()
+										)}
+									</strong>{' '}
+									{profileId ? (
+										<code>{profileId}</code>
+									) : (
+										<span style={{ color: '#d63638' }}>
+											{__(
+												'Missing (required for payments)',
+												'fair-payments-connector'
+											)}
+										</span>
 									)}
 								</p>
+								{!profileId && (
+									<p
+										style={{
+											fontSize: '0.9em',
+											color: '#d63638',
+											marginTop: '0.5rem',
+										}}
+									>
+										{__(
+											'Please reconnect to Mollie to fetch the profile ID.',
+											'fair-payments-connector'
+										)}
+									</p>
+								)}
 							</div>
-						)}
 
-						<div style={{ marginTop: '1.5rem' }}>
-							<RadioControl
-								label={__('Mode', 'fair-payments-connector')}
-								selected={mode}
-								options={[
-									{
-										label: __(
-											'Test Mode',
+							<div style={{ marginTop: '1rem' }}>
+								{overviewLoading && (
+									<p
+										style={{
+											fontSize: '0.9em',
+											color: '#666',
+										}}
+									>
+										{__(
+											'Loading payment methods…',
 											'fair-payments-connector'
-										),
-										value: 'test',
-									},
-									{
-										label: __(
-											'Live Mode',
-											'fair-payments-connector'
-										),
-										value: 'live',
-									},
-								]}
-								onChange={handleModeChange}
-								disabled={isSaving}
-							/>
-						</div>
+										)}
+									</p>
+								)}
 
-						<div style={{ marginTop: '1.5rem' }}>
-							<ButtonGroup>
-								<Button
-									isDestructive
-									onClick={handleDisconnect}
-									disabled={isSaving}
-								>
-									{__(
-										'Disconnect',
+								{overviewError && (
+									<Notice
+										status="warning"
+										isDismissible={false}
+									>
+										{overviewError}
+									</Notice>
+								)}
+
+								{overview && !overviewLoading && (
+									<>
+										<p>
+											<strong>
+												{__(
+													'Profile name:',
+													'fair-payments-connector'
+												)}
+											</strong>{' '}
+											{overview.profile_name}
+										</p>
+
+										<p style={{ marginBottom: '0.25rem' }}>
+											<strong>
+												{__(
+													'Enabled payment methods:',
+													'fair-payments-connector'
+												)}
+											</strong>
+										</p>
+										{overview.methods.length > 0 ? (
+											<ul
+												style={{
+													listStyle: 'disc',
+													marginLeft: '1.5rem',
+												}}
+											>
+												{overview.methods.map(
+													(method) => (
+														<li key={method.id}>
+															{method.image && (
+																<img
+																	src={
+																		method.image
+																	}
+																	alt=""
+																	width="20"
+																	height="20"
+																	style={{
+																		verticalAlign:
+																			'middle',
+																		marginRight:
+																			'0.5rem',
+																	}}
+																/>
+															)}
+															{method.description}
+														</li>
+													)
+												)}
+											</ul>
+										) : (
+											<p>
+												{__(
+													'No payment methods are currently enabled.',
+													'fair-payments-connector'
+												)}
+											</p>
+										)}
+
+										<p>
+											<a
+												href={overview.manage_url}
+												target="_blank"
+												rel="noreferrer"
+											>
+												{__(
+													'Manage payment methods in Mollie',
+													'fair-payments-connector'
+												)}
+											</a>
+										</p>
+									</>
+								)}
+							</div>
+
+							{tokenExpires && (
+								<div style={{ marginTop: '0.5rem' }}>
+									<p
+										style={{
+											fontSize: '0.9em',
+											color: '#666',
+										}}
+									>
+										{sprintf(
+											/* translators: %s: expiration date */
+											__(
+												'Token expires: %s',
+												'fair-payments-connector'
+											),
+											new Date(
+												tokenExpires * 1000
+											).toLocaleString()
+										)}
+									</p>
+								</div>
+							)}
+
+							<div style={{ marginTop: '1.5rem' }}>
+								<RadioControl
+									label={__(
+										'Mode',
 										'fair-payments-connector'
 									)}
-								</Button>
-								<Button
-									isSecondary
-									onClick={handleRefreshToken}
-									isBusy={isRefreshing}
-									disabled={isRefreshing}
-								>
-									{isRefreshing
-										? __(
-												'Refreshing...',
+									selected={mode}
+									options={[
+										{
+											label: __(
+												'Test Mode',
 												'fair-payments-connector'
-										  )
-										: __(
-												'Refresh Connection',
+											),
+											value: 'test',
+										},
+										{
+											label: __(
+												'Live Mode',
 												'fair-payments-connector'
-										  )}
-								</Button>
-							</ButtonGroup>
-						</div>
-					</>
-				)}
-			</CardBody>
-		</Card>
+											),
+											value: 'live',
+										},
+									]}
+									onChange={handleModeChange}
+									disabled={isSaving}
+								/>
+							</div>
+
+							<div style={{ marginTop: '1.5rem' }}>
+								<ButtonGroup>
+									<Button
+										isDestructive
+										onClick={handleDisconnect}
+										disabled={isSaving}
+									>
+										{__(
+											'Disconnect',
+											'fair-payments-connector'
+										)}
+									</Button>
+									<Button
+										isSecondary
+										onClick={handleRefreshToken}
+										isBusy={isRefreshing}
+										disabled={isRefreshing}
+									>
+										{isRefreshing
+											? __(
+													'Refreshing...',
+													'fair-payments-connector'
+											  )
+											: __(
+													'Refresh Connection',
+													'fair-payments-connector'
+											  )}
+									</Button>
+								</ButtonGroup>
+							</div>
+						</>
+					)}
+				</CardBody>
+			</Card>
+
+			<Card>
+				<CardBody>
+					<h2>{__('Test payment', 'fair-payments-connector')}</h2>
+					<p>
+						{__(
+							'Create a one-unit payment to verify the full checkout and webhook flow end to end.',
+							'fair-payments-connector'
+						)}
+					</p>
+
+					{connected && (
+						<p style={{ fontSize: '0.9em', color: '#666' }}>
+							{mode === 'live'
+								? __(
+										'Live mode: this creates a real payment with real money and gateway fees.',
+										'fair-payments-connector'
+								  )
+								: __(
+										'Test mode: no real money is charged.',
+										'fair-payments-connector'
+								  )}
+						</p>
+					)}
+
+					{testCheckoutUrl && (
+						<Notice status="success" isDismissible={false}>
+							{__(
+								'Test payment created. If the checkout did not open in a new tab, ',
+								'fair-payments-connector'
+							)}
+							<a
+								href={testCheckoutUrl}
+								target="_blank"
+								rel="noreferrer"
+							>
+								{__('open it here.', 'fair-payments-connector')}
+							</a>
+						</Notice>
+					)}
+
+					<div style={{ marginTop: '1rem' }}>
+						<Button
+							isSecondary
+							onClick={handleTestPayment}
+							isBusy={isTestingPayment}
+							disabled={!connected || isTestingPayment}
+						>
+							{__(
+								'Create test payment',
+								'fair-payments-connector'
+							)}
+						</Button>
+					</div>
+
+					{!connected && (
+						<p
+							style={{
+								fontSize: '0.9em',
+								color: '#666',
+								marginTop: '0.5rem',
+							}}
+						>
+							{__(
+								'Connect Mollie first to run a test payment.',
+								'fair-payments-connector'
+							)}
+						</p>
+					)}
+				</CardBody>
+			</Card>
+		</>
 	);
 }

--- a/fair-payments-connector/src/Admin/settings/__tests__/TestPaymentButton.test.jsx
+++ b/fair-payments-connector/src/Admin/settings/__tests__/TestPaymentButton.test.jsx
@@ -1,0 +1,130 @@
+/**
+ * Component tests for the "Create test payment" button (#1207).
+ *
+ * Exercises:
+ *   - Connected: the button is enabled and no "connect first" hint shows.
+ *   - Disconnected: the button is disabled and the hint shows.
+ *   - Clicking (connected, test mode): a payment is created, the checkout opens
+ *     in a new tab, and the fallback link renders.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import ConnectionTab from '../ConnectionTab.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const CONNECTED_SETTINGS = {
+	fair_payment_mollie_connected: true,
+	fair_payment_mode: 'test',
+	fair_payment_organization_id: 'org_123',
+	fair_payment_mollie_profile_id: 'pfl_123',
+	fair_payment_mollie_token_expires: 0,
+};
+
+const OVERVIEW = {
+	profile_name: 'My Webshop',
+	profile_id: 'pfl_123',
+	mode: 'test',
+	methods: [],
+	manage_url: 'https://my.mollie.com/dashboard/',
+};
+
+const CHECKOUT_URL = 'https://www.mollie.com/checkout/test-1';
+
+function mockApiFetch({ connected, testPaymentResult }) {
+	apiFetch.mockImplementation(({ path }) => {
+		if (path === '/wp/v2/settings') {
+			return Promise.resolve(
+				connected
+					? CONNECTED_SETTINGS
+					: { fair_payment_mollie_connected: false }
+			);
+		}
+		if (path === '/fair-payments-connector/v1/connection/overview') {
+			return Promise.resolve(OVERVIEW);
+		}
+		if (path === '/fair-payments-connector/v1/test-payment') {
+			return (
+				testPaymentResult ||
+				Promise.resolve({
+					success: true,
+					transaction_id: 42,
+					checkout_url: CHECKOUT_URL,
+					status: 'open',
+					currency: 'EUR',
+					mode: 'test',
+				})
+			);
+		}
+		return Promise.resolve({});
+	});
+}
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+describe('ConnectionTab — test payment button', () => {
+	it('enables the button and hides the hint when connected', async () => {
+		mockApiFetch({ connected: true });
+		render(<ConnectionTab onNotice={() => {}} shouldReload={false} />);
+
+		const button = await screen.findByRole('button', {
+			name: 'Create test payment',
+		});
+		expect(button).toBeEnabled();
+		expect(
+			screen.queryByText('Connect Mollie first to run a test payment.')
+		).not.toBeInTheDocument();
+
+		expect(console).toHaveLogged();
+		expect(console).toHaveWarned();
+	});
+
+	it('disables the button and shows the hint when disconnected', async () => {
+		mockApiFetch({ connected: false });
+		render(<ConnectionTab onNotice={() => {}} shouldReload={false} />);
+
+		const button = await screen.findByRole('button', {
+			name: 'Create test payment',
+		});
+		expect(button).toBeDisabled();
+		expect(
+			screen.getByText('Connect Mollie first to run a test payment.')
+		).toBeInTheDocument();
+
+		expect(console).toHaveLogged();
+	});
+
+	it('creates a payment, opens the checkout, and shows the fallback link', async () => {
+		const openSpy = jest
+			.spyOn(window, 'open')
+			.mockImplementation(() => null);
+		const onNotice = jest.fn();
+		mockApiFetch({ connected: true });
+		render(<ConnectionTab onNotice={onNotice} shouldReload={false} />);
+
+		const button = await screen.findByRole('button', {
+			name: 'Create test payment',
+		});
+		fireEvent.click(button);
+
+		await waitFor(() =>
+			expect(openSpy).toHaveBeenCalledWith(
+				CHECKOUT_URL,
+				'_blank',
+				'noopener'
+			)
+		);
+
+		const link = await screen.findByRole('link', { name: 'open it here.' });
+		expect(link).toHaveAttribute('href', CHECKOUT_URL);
+		expect(onNotice).toHaveBeenCalledWith(
+			expect.objectContaining({ status: 'success' })
+		);
+
+		openSpy.mockRestore();
+		expect(console).toHaveLogged();
+	});
+});

--- a/fair-payments-connector/src/Admin/settings/settings-api.js
+++ b/fair-payments-connector/src/Admin/settings/settings-api.js
@@ -83,6 +83,18 @@ export function loadConnectionOverview() {
 }
 
 /**
+ * Create a one-unit test payment and return its Mollie checkout details.
+ *
+ * @return {Promise<Object>} Promise resolving to { checkout_url, transaction_id, mode, currency }
+ */
+export function createTestPayment() {
+	return apiFetch({
+		path: '/fair-payments-connector/v1/test-payment',
+		method: 'POST',
+	});
+}
+
+/**
  * Test Mollie connection and trigger token refresh if needed
  *
  * @return {Promise<Object>} Promise resolving to connection test result


### PR DESCRIPTION
## Summary

Adds a one-click **Create test payment** button to the Fair Payments Connector settings connection tab, so an admin can verify that payments work end to end without building a page with a payment block and going through it as a visitor.

- New admin-only REST route `POST /fair-payments-connector/v1/test-payment` (guarded by a `manage_options` capability check) creates a transaction for **1 unit of the configured default currency** and initiates the Mollie payment. It does **not** loosen the public payment path, which stays anchored to saved block content and a form nonce.
- The button lives next to the existing connection check. It is disabled with a hint when Mollie is not connected, and it surfaces the active **test/live mode** at the point of use.
- Clicking it opens the Mollie checkout in a new tab and shows a confirmation notice with a **clickable fallback link** in case the browser blocks the popup. In **live** mode it confirms first (real money, real gateway fees).
- The test transaction flows through the normal pipeline, so it appears in the transactions list and its status updates via the usual webhook flow.
- Errors from payment creation surface as an error notice.

## Testing

- `npm run test:js` — component tests for the button states (enabled/disabled + hint, and the create→open-tab→fallback-link flow): pass.
- `vendor/bin/phpcs` — clean.
- `npm run build` — succeeds.
- API spec (`TestPayment.api.spec.js`): unauthenticated → 401 passes locally. The authenticated-admin "not connected" case requires admin Basic auth, which isn't configured in the local docker env (the pre-existing `ConnectionController.api.spec.js` fails identically there); it runs in CI. The underlying PHP path was verified directly via a WP-CLI `eval-file` check, which returned `not_connected` / 400.

Closes #1207
