### PR TITLE
Fold event link management into the context header

### DIFF
--- a/fair-events/src/Admin/manage-event/EventContextHeader.js
+++ b/fair-events/src/Admin/manage-event/EventContextHeader.js
@@ -3,13 +3,14 @@
  *
  * Structured context header shown directly under the Manage Event H1:
  * breadcrumb, date/time/venue meta line, a chip row (link status, series
- * badge, categories), and a "View public page" button. For generated
- * occurrences, also explains why the Tickets tab is disabled.
+ * badge, categories), and link-state actions (view/edit the linked page,
+ * open an external link, or set one up). For generated occurrences, also
+ * explains why the Tickets tab is disabled.
  *
  * @package FairEvents
  */
 
-import { Button } from '@wordpress/components';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { dateI18n, getSettings } from '@wordpress/date';
@@ -25,12 +26,14 @@ import {
  * @param {string}      props.manageEventUrl Base Manage Event admin URL (no event_date_id).
  * @param {string}      props.calendarUrl    Base Calendar admin URL.
  * @param {Array}       props.venues         Venues loaded for the site (id, name).
+ * @param {Function}    [props.onManageLink] Called to open the link-target popup. Omitted → no link actions render (read-only contexts).
  */
 export default function EventContextHeader({
 	eventDate,
 	manageEventUrl,
 	calendarUrl,
 	venues = [],
+	onManageLink,
 }) {
 	if (!eventDate) return null;
 
@@ -45,17 +48,31 @@ export default function EventContextHeader({
 	const venueLine = venue?.name || eventDate.address || null;
 
 	const linkedPosts = eventDate.linked_posts || [];
-	let linkChip;
+
+	// Drives both the status chip and the action buttons below it, so the two
+	// never disagree about what state the event's public page is in.
+	let linkState;
+	let primaryPost = null;
 	if (eventDate.link_type === 'post' && linkedPosts.length > 0) {
+		linkState = 'post';
+		primaryPost = linkedPosts.find((lp) => lp.is_primary) || linkedPosts[0];
+	} else if (eventDate.link_type === 'external' && eventDate.external_url) {
+		linkState = 'external';
+	} else {
+		linkState = 'none';
+	}
+
+	let linkChip;
+	if (linkState === 'post') {
 		linkChip = {
 			label: sprintf(
 				/* translators: %s: title of the linked post/page */
 				__('Public page: %s', 'fair-events'),
-				linkedPosts[0].title
+				primaryPost.title
 			),
 			className: 'fair-events-context-badge is-linked',
 		};
-	} else if (eventDate.link_type === 'external' && eventDate.external_url) {
+	} else if (linkState === 'external') {
 		linkChip = {
 			label: sprintf(
 				/* translators: %s: external URL the event links to */
@@ -69,6 +86,60 @@ export default function EventContextHeader({
 			label: __('No public page yet', 'fair-events'),
 			className: 'fair-events-context-badge',
 		};
+	}
+
+	let linkActions = null;
+	if (linkState === 'post') {
+		linkActions = (
+			<HStack spacing={2} alignment="left" wrap>
+				{eventDate.display_url && (
+					<Button
+						variant="secondary"
+						href={eventDate.display_url}
+						target="_blank"
+						rel="noreferrer"
+					>
+						{__('View public page', 'fair-events')}
+					</Button>
+				)}
+				{primaryPost?.edit_url && (
+					<Button variant="secondary" href={primaryPost.edit_url}>
+						{__('Edit page', 'fair-events')}
+					</Button>
+				)}
+				{onManageLink && (
+					<Button variant="tertiary" onClick={onManageLink}>
+						{__('Change link', 'fair-events')}
+					</Button>
+				)}
+			</HStack>
+		);
+	} else if (linkState === 'external') {
+		linkActions = (
+			<HStack spacing={2} alignment="left" wrap>
+				<Button
+					variant="secondary"
+					href={eventDate.external_url}
+					target="_blank"
+					rel="noreferrer"
+				>
+					{__('Open link', 'fair-events')}
+				</Button>
+				{onManageLink && (
+					<Button variant="tertiary" onClick={onManageLink}>
+						{__('Change link', 'fair-events')}
+					</Button>
+				)}
+			</HStack>
+		);
+	} else if (onManageLink) {
+		linkActions = (
+			<HStack spacing={2} alignment="left" wrap>
+				<Button variant="primary" onClick={onManageLink}>
+					{__('Set up event page…', 'fair-events')}
+				</Button>
+			</HStack>
+		);
 	}
 
 	const isMaster = eventDate.occurrence_type === 'master';
@@ -176,17 +247,8 @@ export default function EventContextHeader({
 					</span>
 				))}
 			</p>
-			{eventDate.display_url && (
-				<p style={{ margin: '0 0 4px' }}>
-					<Button
-						variant="secondary"
-						href={eventDate.display_url}
-						target="_blank"
-						rel="noreferrer"
-					>
-						{__('View public page', 'fair-events')}
-					</Button>
-				</p>
+			{linkActions && (
+				<div style={{ margin: '0 0 4px' }}>{linkActions}</div>
 			)}
 			{isGenerated && (
 				<p style={{ margin: 0 }}>

--- a/fair-events/src/Admin/manage-event/EventLinkModal.js
+++ b/fair-events/src/Admin/manage-event/EventLinkModal.js
@@ -1,0 +1,401 @@
+/**
+ * EventLinkModal — "Where does this event link to?" popup.
+ *
+ * Owns the link-target choice (external URL, create-new-page, link-existing,
+ * or none), plus the linked-posts list with view/edit/unlink. Every change
+ * applies immediately via its own apiFetch call and reports back through
+ * onSaved(updated) — there is no separate save step (#1198).
+ *
+ * @package FairEvents
+ */
+
+import { useState } from '@wordpress/element';
+import {
+	Button,
+	Modal,
+	Notice,
+	RadioControl,
+	SelectControl,
+	TextControl,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * @param {Object}   props
+ * @param {number}   props.eventDateId      The event date being edited.
+ * @param {Object}   props.eventDate        Event date object from the REST API.
+ * @param {Array}    props.enabledPostTypes Post types the organizer can create ({ slug, label }).
+ * @param {Function} props.onClose          Called to dismiss the modal.
+ * @param {Function} props.onSaved          Called with the updated event date after any successful change.
+ */
+export default function EventLinkModal({
+	eventDateId,
+	eventDate,
+	enabledPostTypes,
+	onClose,
+	onSaved,
+}) {
+	const linkedPosts = eventDate.linked_posts || [];
+	const isLinkedToPost =
+		eventDate.link_type === 'post' && linkedPosts.length > 0;
+
+	const [linkType, setLinkType] = useState(eventDate.link_type || 'none');
+	const [externalUrl, setExternalUrl] = useState(
+		eventDate.external_url || ''
+	);
+	const [selectedPostType, setSelectedPostType] = useState(
+		enabledPostTypes[0]?.slug || 'fair_event'
+	);
+	const [linkPostId, setLinkPostId] = useState('');
+	const [searchResults, setSearchResults] = useState([]);
+	const [creatingPost, setCreatingPost] = useState(false);
+	const [linkingPost, setLinkingPost] = useState(false);
+	const [unlinkingPostId, setUnlinkingPostId] = useState(null);
+	const [applying, setApplying] = useState(false);
+	const [error, setError] = useState(null);
+
+	const handleApplyChoice = async () => {
+		setApplying(true);
+		setError(null);
+
+		try {
+			const updated = await apiFetch({
+				path: `/fair-events/v1/event-dates/${eventDateId}`,
+				method: 'PUT',
+				data: {
+					link_type: linkType,
+					external_url: linkType === 'external' ? externalUrl : null,
+				},
+			});
+			onSaved(updated);
+		} catch (err) {
+			setError(
+				err.message || __('Failed to update the link.', 'fair-events')
+			);
+		} finally {
+			setApplying(false);
+		}
+	};
+
+	const handleCreatePost = async () => {
+		setCreatingPost(true);
+		setError(null);
+
+		try {
+			const result = await apiFetch({
+				path: `/fair-events/v1/event-dates/${eventDateId}/create-post`,
+				method: 'POST',
+				data: {
+					post_type: selectedPostType,
+					post_status: 'draft',
+				},
+			});
+
+			if (result.edit_url) {
+				window.location.href = result.edit_url;
+			}
+		} catch (err) {
+			setError(
+				err.message || __('Failed to create post.', 'fair-events')
+			);
+		} finally {
+			setCreatingPost(false);
+		}
+	};
+
+	const handleSearchPosts = async (searchTerm) => {
+		if (!searchTerm || searchTerm.length < 2) {
+			setSearchResults([]);
+			return;
+		}
+
+		try {
+			const results = await apiFetch({
+				path: `/wp/v2/search?search=${encodeURIComponent(
+					searchTerm
+				)}&type=post&subtype=any&per_page=10`,
+			});
+			setSearchResults(results);
+		} catch {
+			// Ignore search errors.
+		}
+	};
+
+	const handleLinkPost = async () => {
+		if (!linkPostId) return;
+		setLinkingPost(true);
+		setError(null);
+
+		try {
+			const updated = await apiFetch({
+				path: `/fair-events/v1/event-dates/${eventDateId}/link-post`,
+				method: 'POST',
+				data: {
+					post_id: parseInt(linkPostId, 10),
+				},
+			});
+			setLinkPostId('');
+			setSearchResults([]);
+			onSaved(updated);
+		} catch (err) {
+			setError(err.message || __('Failed to link post.', 'fair-events'));
+		} finally {
+			setLinkingPost(false);
+		}
+	};
+
+	const handleUnlinkPost = async (postId) => {
+		setUnlinkingPostId(postId);
+		setError(null);
+
+		try {
+			const updated = await apiFetch({
+				path: `/fair-events/v1/event-dates/${eventDateId}/link-post`,
+				method: 'DELETE',
+				data: {
+					post_id: postId,
+				},
+			});
+			onSaved(updated);
+		} catch (err) {
+			setError(
+				err.message || __('Failed to unlink post.', 'fair-events')
+			);
+		} finally {
+			setUnlinkingPostId(null);
+		}
+	};
+
+	return (
+		<Modal
+			title={__('Where does this event link to?', 'fair-events')}
+			onRequestClose={onClose}
+			className="fair-events-event-link-modal"
+		>
+			<VStack spacing={4}>
+				{error && (
+					<Notice status="error" isDismissible={false}>
+						{error}
+					</Notice>
+				)}
+
+				{linkedPosts.length > 0 && (
+					<>
+						<Notice status="info" isDismissible={false}>
+							{sprintf(
+								/* translators: %d: number of linked posts */
+								_n(
+									'This event is linked to %d post.',
+									'This event is linked to %d posts.',
+									linkedPosts.length,
+									'fair-events'
+								),
+								linkedPosts.length
+							)}
+						</Notice>
+						{linkedPosts.map((lp) => (
+							<HStack key={lp.id} spacing={3} wrap>
+								<span>
+									<strong>{lp.title}</strong> ({lp.status})
+									{lp.is_primary && (
+										<span
+											style={{
+												marginLeft: '4px',
+												color: '#007cba',
+												fontSize: '12px',
+											}}
+										>
+											{__('Primary', 'fair-events')}
+										</span>
+									)}
+								</span>
+								{lp.view_url && (
+									<Button
+										variant="secondary"
+										href={lp.view_url}
+										target="_blank"
+										size="small"
+									>
+										{__('View Entry', 'fair-events')}
+									</Button>
+								)}
+								{lp.edit_url && (
+									<Button
+										variant="secondary"
+										href={lp.edit_url}
+										size="small"
+									>
+										{__('Edit Post', 'fair-events')}
+									</Button>
+								)}
+								<Button
+									variant="tertiary"
+									size="small"
+									isDestructive
+									isBusy={unlinkingPostId === lp.id}
+									disabled={unlinkingPostId === lp.id}
+									onClick={() => handleUnlinkPost(lp.id)}
+								>
+									{__('Unlink', 'fair-events')}
+								</Button>
+							</HStack>
+						))}
+					</>
+				)}
+
+				{!isLinkedToPost && linkedPosts.length === 0 && (
+					<>
+						<RadioControl
+							label={__('Link type', 'fair-events')}
+							hideLabelFromVision
+							selected={linkType}
+							options={[
+								{
+									label: __(
+										'A page on this site',
+										'fair-events'
+									),
+									value: 'post',
+								},
+								{
+									label: __(
+										'An external website',
+										'fair-events'
+									),
+									value: 'external',
+								},
+								{
+									label: __(
+										'Nowhere — show details only',
+										'fair-events'
+									),
+									value: 'none',
+								},
+							]}
+							onChange={setLinkType}
+						/>
+
+						{linkType === 'external' && (
+							<>
+								<TextControl
+									label={__('External URL', 'fair-events')}
+									type="url"
+									value={externalUrl}
+									onChange={setExternalUrl}
+									placeholder="https://"
+								/>
+								<HStack justify="flex-end">
+									<Button
+										variant="primary"
+										onClick={handleApplyChoice}
+										isBusy={applying}
+										disabled={applying || !externalUrl}
+									>
+										{__('Set external link', 'fair-events')}
+									</Button>
+								</HStack>
+							</>
+						)}
+
+						{linkType === 'none' && (
+							<HStack justify="flex-end">
+								<Button
+									variant="primary"
+									onClick={handleApplyChoice}
+									isBusy={applying}
+									disabled={applying}
+								>
+									{__('Confirm', 'fair-events')}
+								</Button>
+							</HStack>
+						)}
+
+						{linkType === 'post' && (
+							<>
+								<SelectControl
+									label={__('Post type', 'fair-events')}
+									value={selectedPostType}
+									options={enabledPostTypes.map((pt) => ({
+										label: pt.label,
+										value: pt.slug,
+									}))}
+									onChange={setSelectedPostType}
+								/>
+								<Button
+									variant="primary"
+									onClick={handleCreatePost}
+									isBusy={creatingPost}
+									disabled={creatingPost}
+								>
+									{__('Create New Post', 'fair-events')}
+								</Button>
+
+								<VStack spacing={2}>
+									<h3 style={{ margin: 0 }}>
+										{__(
+											'Link Existing Post',
+											'fair-events'
+										)}
+									</h3>
+									<TextControl
+										label={__(
+											'Search posts by title',
+											'fair-events'
+										)}
+										onChange={handleSearchPosts}
+										placeholder={__(
+											'Start typing to search...',
+											'fair-events'
+										)}
+									/>
+									{searchResults.length > 0 && (
+										<SelectControl
+											label={__(
+												'Select a post',
+												'fair-events'
+											)}
+											value={linkPostId}
+											options={[
+												{
+													label: __(
+														'Select...',
+														'fair-events'
+													),
+													value: '',
+												},
+												...searchResults.map((r) => ({
+													label: r.title,
+													value: String(r.id),
+												})),
+											]}
+											onChange={setLinkPostId}
+										/>
+									)}
+									{linkPostId && (
+										<Button
+											variant="primary"
+											onClick={handleLinkPost}
+											isBusy={linkingPost}
+											disabled={linkingPost}
+										>
+											{__('Link Post', 'fair-events')}
+										</Button>
+									)}
+								</VStack>
+							</>
+						)}
+					</>
+				)}
+
+				<HStack justify="flex-end" spacing={2}>
+					<Button variant="tertiary" onClick={onClose}>
+						{__('Close', 'fair-events')}
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -23,7 +23,6 @@ import {
 	TextControl,
 	CheckboxControl,
 	SelectControl,
-	RadioControl,
 	FormTokenField,
 	TabPanel,
 	__experimentalVStack as VStack,
@@ -49,6 +48,7 @@ import RecurrenceCalendar from './RecurrenceCalendar.js';
 import RecurrenceImpactSummary from './RecurrenceImpactSummary.js';
 import SeriesModal from './SeriesModal.js';
 import EditInstancesModal from './EditInstancesModal.js';
+import EventLinkModal from './EventLinkModal.js';
 import EventSignups from './EventSignups.js';
 import EventContextHeader from './EventContextHeader.js';
 
@@ -101,22 +101,14 @@ export default function ManageEventApp() {
 	const [availableCategories, setAvailableCategories] = useState([]);
 	const [creatingCategories, setCreatingCategories] = useState([]);
 
-	// Post creation state
-	const [creatingPost, setCreatingPost] = useState(false);
-	const [selectedPostType, setSelectedPostType] = useState(
-		enabledPostTypes[0]?.slug || 'fair_event'
-	);
-
-	// Link additional post state
-	const [linkingPost, setLinkingPost] = useState(false);
-	const [linkPostId, setLinkPostId] = useState('');
-	const [searchResults, setSearchResults] = useState([]);
 	const [togglingExdate, setTogglingExdate] = useState(null);
 	const [recurrenceImpact, setRecurrenceImpact] = useState(null);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const [seriesModalOpen, setSeriesModalOpen] = useState(false);
 	const [editInstancesModalOpen, setEditInstancesModalOpen] = useState(false);
 	const [endSeriesDialogOpen, setEndSeriesDialogOpen] = useState(false);
+	const [linkModalOpen, setLinkModalOpen] = useState(false);
+	const [linkModalConfirmOpen, setLinkModalConfirmOpen] = useState(false);
 
 	// Dirty-state tracking (#987): snapshot the saved form/ticket state so we
 	// can warn before losing edits and mark which tab holds them.
@@ -546,97 +538,23 @@ export default function ManageEventApp() {
 			  );
 	}, [eventDate]);
 
-	const handleCreatePost = async () => {
-		setCreatingPost(true);
-		setError(null);
-
-		try {
-			const result = await apiFetch({
-				path: `/fair-events/v1/event-dates/${eventDateId}/create-post`,
-				method: 'POST',
-				data: {
-					post_type: selectedPostType,
-					post_status: 'draft',
-				},
-			});
-
-			if (result.edit_url) {
-				window.location.href = result.edit_url;
-			}
-		} catch (err) {
-			setError(
-				err.message || __('Failed to create post.', 'fair-events')
-			);
-		} finally {
-			setCreatingPost(false);
-		}
+	const handleLinkModalSaved = (updated) => {
+		setEventDate(updated);
+		populateForm(updated);
 	};
 
-	const handleUnlinkPost = async (postId) => {
-		setSaving(true);
-		setError(null);
-
-		try {
-			const updated = await apiFetch({
-				path: `/fair-events/v1/event-dates/${eventDateId}/link-post`,
-				method: 'DELETE',
-				data: {
-					post_id: postId,
-				},
-			});
-			setEventDate(updated);
-			populateForm(updated);
-			setSuccess(__('Post unlinked successfully.', 'fair-events'));
-		} catch (err) {
-			setError(
-				err.message || __('Failed to unlink post.', 'fair-events')
-			);
-		} finally {
-			setSaving(false);
-		}
-	};
-
-	const handleLinkPost = async () => {
-		if (!linkPostId) return;
-		setLinkingPost(true);
-		setError(null);
-
-		try {
-			const updated = await apiFetch({
-				path: `/fair-events/v1/event-dates/${eventDateId}/link-post`,
-				method: 'POST',
-				data: {
-					post_id: parseInt(linkPostId, 10),
-				},
-			});
-			setEventDate(updated);
-			populateForm(updated);
-			setLinkPostId('');
-			setSearchResults([]);
-			setSuccess(__('Post linked successfully.', 'fair-events'));
-		} catch (err) {
-			setError(err.message || __('Failed to link post.', 'fair-events'));
-		} finally {
-			setLinkingPost(false);
-		}
-	};
-
-	const handleSearchPosts = async (searchTerm) => {
-		if (!searchTerm || searchTerm.length < 2) {
-			setSearchResults([]);
+	const handleManageLink = () => {
+		if (detailsDirty) {
+			setLinkModalConfirmOpen(true);
 			return;
 		}
+		setLinkModalOpen(true);
+	};
 
-		try {
-			const results = await apiFetch({
-				path: `/wp/v2/search?search=${encodeURIComponent(
-					searchTerm
-				)}&type=post&subtype=any&per_page=10`,
-			});
-			setSearchResults(results);
-		} catch {
-			// Ignore search errors.
-		}
+	const confirmSaveThenManageLink = async () => {
+		setLinkModalConfirmOpen(false);
+		await handleSave();
+		setLinkModalOpen(true);
 	};
 
 	const handleToggleExdate = async (date) => {
@@ -673,9 +591,6 @@ export default function ManageEventApp() {
 		{ label: __('— No venue —', 'fair-events'), value: '' },
 		...venues.map((v) => ({ label: v.name, value: String(v.id) })),
 	];
-
-	const isLinkedToPost =
-		eventDate?.link_type === 'post' && eventDate?.event_id;
 
 	const urlTab = useMemo(() => {
 		const urlParams = new URLSearchParams(window.location.search);
@@ -854,8 +769,6 @@ export default function ManageEventApp() {
 			</div>
 		);
 	}
-
-	const linkedPosts = eventDate.linked_posts || [];
 
 	const renderEventDetailsTab = () => (
 		<>
@@ -1130,8 +1043,6 @@ export default function ManageEventApp() {
 						</CardBody>
 					</Card>
 				)}
-
-				{renderLinksTab()}
 			</div>
 
 			<HStack
@@ -1154,201 +1065,6 @@ export default function ManageEventApp() {
 				)}
 			</HStack>
 		</>
-	);
-
-	const renderLinksTab = () => (
-		<Card className="fair-events-event-details-card">
-			<CardHeader>
-				<h2>{__('Where does this event link to?', 'fair-events')}</h2>
-			</CardHeader>
-			<CardBody>
-				<VStack spacing={4}>
-					{linkedPosts.length > 0 && (
-						<>
-							<Notice status="info" isDismissible={false}>
-								{sprintf(
-									/* translators: %d: number of linked posts */
-									_n(
-										'This event is linked to %d post.',
-										'This event is linked to %d posts.',
-										linkedPosts.length,
-										'fair-events'
-									),
-									linkedPosts.length
-								)}
-							</Notice>
-							{linkedPosts.map((lp) => (
-								<HStack key={lp.id} spacing={3} wrap>
-									<span>
-										<strong>{lp.title}</strong> ({lp.status}
-										)
-										{lp.is_primary && (
-											<span
-												style={{
-													marginLeft: '4px',
-													color: '#007cba',
-													fontSize: '12px',
-												}}
-											>
-												{__('Primary', 'fair-events')}
-											</span>
-										)}
-									</span>
-									{lp.view_url && (
-										<Button
-											variant="secondary"
-											href={lp.view_url}
-											target="_blank"
-											size="small"
-										>
-											{__('View Entry', 'fair-events')}
-										</Button>
-									)}
-									{lp.edit_url && (
-										<Button
-											variant="secondary"
-											href={lp.edit_url}
-											size="small"
-										>
-											{__('Edit Post', 'fair-events')}
-										</Button>
-									)}
-									<Button
-										variant="tertiary"
-										size="small"
-										isDestructive
-										onClick={() => handleUnlinkPost(lp.id)}
-									>
-										{__('Unlink', 'fair-events')}
-									</Button>
-								</HStack>
-							))}
-						</>
-					)}
-
-					{!isLinkedToPost && linkedPosts.length === 0 && (
-						<>
-							<RadioControl
-								label={__('Link type', 'fair-events')}
-								hideLabelFromVision
-								selected={linkType}
-								options={[
-									{
-										label: __(
-											'A page on this site',
-											'fair-events'
-										),
-										value: 'post',
-									},
-									{
-										label: __(
-											'An external website',
-											'fair-events'
-										),
-										value: 'external',
-									},
-									{
-										label: __(
-											'Nowhere — show details only',
-											'fair-events'
-										),
-										value: 'none',
-									},
-								]}
-								onChange={setLinkType}
-							/>
-
-							{linkType === 'external' && (
-								<TextControl
-									label={__('External URL', 'fair-events')}
-									type="url"
-									value={externalUrl}
-									onChange={setExternalUrl}
-									placeholder="https://"
-								/>
-							)}
-
-							{linkType === 'post' && (
-								<>
-									<SelectControl
-										label={__('Post type', 'fair-events')}
-										value={selectedPostType}
-										options={enabledPostTypes.map((pt) => ({
-											label: pt.label,
-											value: pt.slug,
-										}))}
-										onChange={setSelectedPostType}
-									/>
-									<Button
-										variant="primary"
-										onClick={handleCreatePost}
-										isBusy={creatingPost}
-										disabled={creatingPost}
-									>
-										{__('Create New Post', 'fair-events')}
-									</Button>
-
-									<VStack spacing={2}>
-										<h3 style={{ margin: 0 }}>
-											{__(
-												'Link Additional Post',
-												'fair-events'
-											)}
-										</h3>
-										<TextControl
-											label={__(
-												'Search posts by title',
-												'fair-events'
-											)}
-											onChange={handleSearchPosts}
-											placeholder={__(
-												'Start typing to search...',
-												'fair-events'
-											)}
-										/>
-										{searchResults.length > 0 && (
-											<SelectControl
-												label={__(
-													'Select a post',
-													'fair-events'
-												)}
-												value={linkPostId}
-												options={[
-													{
-														label: __(
-															'Select...',
-															'fair-events'
-														),
-														value: '',
-													},
-													...searchResults.map(
-														(r) => ({
-															label: r.title,
-															value: String(r.id),
-														})
-													),
-												]}
-												onChange={setLinkPostId}
-											/>
-										)}
-										{linkPostId && (
-											<Button
-												variant="primary"
-												onClick={handleLinkPost}
-												isBusy={linkingPost}
-												disabled={linkingPost}
-											>
-												{__('Link Post', 'fair-events')}
-											</Button>
-										)}
-									</VStack>
-								</>
-							)}
-						</>
-					)}
-				</VStack>
-			</CardBody>
-		</Card>
 	);
 
 	return (
@@ -1398,6 +1114,7 @@ export default function ManageEventApp() {
 				manageEventUrl={manageEventUrl}
 				calendarUrl={calendarUrl}
 				venues={venues}
+				onManageLink={handleManageLink}
 			/>
 
 			{error && (
@@ -1460,6 +1177,29 @@ export default function ManageEventApp() {
 			>
 				{endSeriesConfirmMessage}
 			</ConfirmDialog>
+
+			<ConfirmDialog
+				isOpen={linkModalConfirmOpen}
+				onConfirm={confirmSaveThenManageLink}
+				onCancel={() => setLinkModalConfirmOpen(false)}
+				confirmButtonText={__('Save and continue', 'fair-events')}
+				cancelButtonText={__('Cancel', 'fair-events')}
+			>
+				{__(
+					'You have unsaved changes. Save event details before setting up the link?',
+					'fair-events'
+				)}
+			</ConfirmDialog>
+
+			{linkModalOpen && (
+				<EventLinkModal
+					eventDateId={eventDateId}
+					eventDate={eventDate}
+					enabledPostTypes={enabledPostTypes}
+					onClose={() => setLinkModalOpen(false)}
+					onSaved={handleLinkModalSaved}
+				/>
+			)}
 
 			{seriesModalOpen && (
 				<SeriesModal

--- a/fair-events/src/Admin/manage-event/__tests__/EventContextHeader.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventContextHeader.test.jsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  *
- * Tests for EventContextHeader (#1049).
+ * Tests for EventContextHeader (#1049, #1198).
  *
  * Covers:
  *   - Occurrence variants: single (no series badge), master (recurring-series
@@ -9,7 +9,9 @@
  *     tickets-on-series note).
  *   - Link-status variants: post, external, none.
  *   - Breadcrumb calendar link carries &month=YYYY-MM from start_datetime.
- *   - "View public page" button present iff display_url is set.
+ *   - Link-state actions: placeholder (single "set up" button), internal
+ *     (view + edit + change link), external (open link + change link) — each
+ *     firing onManageLink.
  */
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
@@ -109,7 +111,7 @@ it('link status: post shows the linked post title', () => {
 	const eventDate = {
 		...baseEventDate,
 		link_type: 'post',
-		linked_posts: [{ id: 5, title: 'My Public Page' }],
+		linked_posts: [{ id: 5, title: 'My Public Page', is_primary: true }],
 	};
 	render(
 		<EventContextHeader
@@ -167,8 +169,99 @@ it('breadcrumb calendar link carries &month=YYYY-MM from start_datetime', () => 
 	);
 });
 
-it('"View public page" button is shown only when display_url is set', () => {
-	const { rerender } = render(
+it('link actions: placeholder shows a single "set up" button that calls onManageLink', () => {
+	const onManageLink = jest.fn();
+	render(
+		<EventContextHeader
+			eventDate={baseEventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+			onManageLink={onManageLink}
+		/>
+	);
+	const button = screen.getByRole('button', {
+		name: /Set up event page/i,
+	});
+	expect(
+		screen.queryByRole('link', { name: /View public page/i })
+	).not.toBeInTheDocument();
+	expect(
+		screen.queryByRole('button', { name: /Change link/i })
+	).not.toBeInTheDocument();
+	button.click();
+	expect(onManageLink).toHaveBeenCalledTimes(1);
+});
+
+it('link actions: internal link shows view + edit + change link', () => {
+	const onManageLink = jest.fn();
+	const eventDate = {
+		...baseEventDate,
+		link_type: 'post',
+		display_url: 'https://example.com/event',
+		linked_posts: [
+			{
+				id: 5,
+				title: 'My Public Page',
+				is_primary: true,
+				edit_url: 'https://example.com/wp-admin/post.php?post=5',
+			},
+		],
+	};
+	render(
+		<EventContextHeader
+			eventDate={eventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+			onManageLink={onManageLink}
+		/>
+	);
+
+	const viewButton = screen.getByRole('link', {
+		name: /View public page/i,
+	});
+	expect(viewButton).toHaveAttribute('href', 'https://example.com/event');
+
+	const editButton = screen.getByRole('link', { name: /Edit page/i });
+	expect(editButton).toHaveAttribute(
+		'href',
+		'https://example.com/wp-admin/post.php?post=5'
+	);
+
+	const changeLinkButton = screen.getByRole('button', {
+		name: /Change link/i,
+	});
+	changeLinkButton.click();
+	expect(onManageLink).toHaveBeenCalledTimes(1);
+});
+
+it('link actions: external link shows open link + change link', () => {
+	const onManageLink = jest.fn();
+	const eventDate = {
+		...baseEventDate,
+		link_type: 'external',
+		external_url: 'https://example.com/external',
+	};
+	render(
+		<EventContextHeader
+			eventDate={eventDate}
+			manageEventUrl={manageEventUrl}
+			calendarUrl={calendarUrl}
+			onManageLink={onManageLink}
+		/>
+	);
+
+	const openButton = screen.getByRole('link', { name: /Open link/i });
+	expect(openButton).toHaveAttribute('href', 'https://example.com/external');
+
+	const changeLinkButton = screen.getByRole('button', {
+		name: /Change link/i,
+	});
+	changeLinkButton.click();
+	expect(onManageLink).toHaveBeenCalledTimes(1);
+});
+
+it('link actions: no onManageLink prop renders no action buttons for the placeholder state', () => {
+	render(
 		<EventContextHeader
 			eventDate={baseEventDate}
 			manageEventUrl={manageEventUrl}
@@ -176,21 +269,8 @@ it('"View public page" button is shown only when display_url is set', () => {
 		/>
 	);
 	expect(
-		screen.queryByRole('link', { name: /View public page/i })
+		screen.queryByRole('button', { name: /Set up event page/i })
 	).not.toBeInTheDocument();
-
-	rerender(
-		<EventContextHeader
-			eventDate={{
-				...baseEventDate,
-				display_url: 'https://example.com/event',
-			}}
-			manageEventUrl={manageEventUrl}
-			calendarUrl={calendarUrl}
-		/>
-	);
-	const button = screen.getByRole('link', { name: /View public page/i });
-	expect(button).toHaveAttribute('href', 'https://example.com/event');
 });
 
 it('resolves the venue name from the venues prop', () => {

--- a/fair-events/src/Admin/manage-event/__tests__/EventLinkModal.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventLinkModal.test.jsx
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for EventLinkModal (#1198).
+ *
+ * Covers:
+ *   - External flow: choosing "external", entering a URL and confirming
+ *     PUTs link_type/external_url and calls onSaved.
+ *   - None flow: choosing "nowhere" and confirming PUTs link_type: 'none'.
+ *   - Linked-posts list: view/edit links render, and Unlink DELETEs and
+ *     calls onSaved.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import EventLinkModal from '../EventLinkModal.js';
+
+jest.mock('@wordpress/api-fetch');
+
+beforeEach(() => {
+	jest.spyOn(console, 'warn').mockImplementation(() => {});
+	jest.spyOn(console, 'error').mockImplementation(() => {});
+
+	window.matchMedia =
+		window.matchMedia ||
+		function () {
+			return {
+				matches: false,
+				addListener: () => {},
+				removeListener: () => {},
+			};
+		};
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+	jest.clearAllMocks();
+});
+
+const eventDateId = 1;
+const enabledPostTypes = [{ slug: 'fair_event', label: 'Event' }];
+
+const baseEventDate = {
+	link_type: 'none',
+	external_url: null,
+	linked_posts: [],
+};
+
+it('setting an external URL and confirming PUTs link_type/external_url and calls onSaved', async () => {
+	const updated = {
+		...baseEventDate,
+		link_type: 'external',
+		external_url: 'https://example.com',
+	};
+	apiFetch.mockResolvedValueOnce(updated);
+	const onSaved = jest.fn();
+
+	render(
+		<EventLinkModal
+			eventDateId={eventDateId}
+			eventDate={baseEventDate}
+			enabledPostTypes={enabledPostTypes}
+			onClose={jest.fn()}
+			onSaved={onSaved}
+		/>
+	);
+
+	fireEvent.click(screen.getByLabelText('An external website'));
+	fireEvent.change(screen.getByLabelText('External URL'), {
+		target: { value: 'https://example.com' },
+	});
+	fireEvent.click(screen.getByRole('button', { name: /Set external link/i }));
+
+	await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+	expect(apiFetch).toHaveBeenCalledWith({
+		path: `/fair-events/v1/event-dates/${eventDateId}`,
+		method: 'PUT',
+		data: {
+			link_type: 'external',
+			external_url: 'https://example.com',
+		},
+	});
+	expect(onSaved).toHaveBeenCalledWith(updated);
+});
+
+it('choosing "nowhere" and confirming PUTs link_type: none', async () => {
+	const updated = { ...baseEventDate, link_type: 'none' };
+	apiFetch.mockResolvedValueOnce(updated);
+	const onSaved = jest.fn();
+
+	render(
+		<EventLinkModal
+			eventDateId={eventDateId}
+			eventDate={baseEventDate}
+			enabledPostTypes={enabledPostTypes}
+			onClose={jest.fn()}
+			onSaved={onSaved}
+		/>
+	);
+
+	fireEvent.click(screen.getByLabelText('Nowhere — show details only'));
+	fireEvent.click(screen.getByRole('button', { name: /Confirm/i }));
+
+	await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+	expect(apiFetch).toHaveBeenCalledWith({
+		path: `/fair-events/v1/event-dates/${eventDateId}`,
+		method: 'PUT',
+		data: {
+			link_type: 'none',
+			external_url: null,
+		},
+	});
+	expect(onSaved).toHaveBeenCalledWith(updated);
+});
+
+it('linked-posts list shows view/edit links and unlink DELETEs and calls onSaved', async () => {
+	const eventDate = {
+		...baseEventDate,
+		link_type: 'post',
+		linked_posts: [
+			{
+				id: 5,
+				title: 'My Public Page',
+				status: 'publish',
+				is_primary: true,
+				view_url: 'https://example.com/event',
+				edit_url: 'https://example.com/wp-admin/post.php?post=5',
+			},
+		],
+	};
+	const updated = { ...baseEventDate, link_type: 'none', linked_posts: [] };
+	apiFetch.mockResolvedValueOnce(updated);
+	const onSaved = jest.fn();
+
+	render(
+		<EventLinkModal
+			eventDateId={eventDateId}
+			eventDate={eventDate}
+			enabledPostTypes={enabledPostTypes}
+			onClose={jest.fn()}
+			onSaved={onSaved}
+		/>
+	);
+
+	const viewLink = screen.getByRole('link', { name: /View Entry/i });
+	expect(viewLink).toHaveAttribute('href', 'https://example.com/event');
+	const editLink = screen.getByRole('link', { name: /Edit Post/i });
+	expect(editLink).toHaveAttribute(
+		'href',
+		'https://example.com/wp-admin/post.php?post=5'
+	);
+
+	fireEvent.click(screen.getByRole('button', { name: /Unlink/i }));
+
+	await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+	expect(apiFetch).toHaveBeenCalledWith({
+		path: `/fair-events/v1/event-dates/${eventDateId}/link-post`,
+		method: 'DELETE',
+		data: { post_id: 5 },
+	});
+	expect(onSaved).toHaveBeenCalledWith(updated);
+});


### PR DESCRIPTION
## Summary

- Removed the standalone "Where does this event link to?" card from the Manage Event page.
- The context header now shows link-state actions next to its status chip:
  - **Placeholder** (no link yet): a single "Set up event page…" button.
  - **Linked to a page on this site**: "View public page" + "Edit page" + a low-emphasis "Change link".
  - **External link**: "Open link" + a low-emphasis "Change link".
- "Set up event page…" / "Change link" open a new `EventLinkModal` popup where the organizer sets an external URL, creates a new page, links an existing one, or unlinks/manages multiple linked posts — every choice applies immediately (its own `apiFetch` call), no separate save step.
- If the Event Details tab has unsaved changes, opening the popup first prompts to save them via a `ConfirmDialog`, so link changes can't silently discard other edits.
- The header re-renders from the popup's `onSaved` callback — no full page reload.

Closes #1198

## Notes

- No backend changes — `prepare_event_date()` already returned everything the popup and header need, and the existing `PUT /event-dates/{id}`, `create-post`, and `link-post` endpoints are reused as-is.
- `linkType`/`externalUrl` form state stays in `ManageEventApp` for dirty-tracking and the "Save event details" payload; the popup drives them independently and refreshes that state via `onSaved`.

## Test plan

- [x] `npm test` in `fair-events` — 132/132 passing (full suite), including new/updated `EventContextHeader.test.jsx` and `EventLinkModal.test.jsx`.
- [x] `npm run build` in `fair-events` — compiles cleanly.
- [x] `npm run format` in `fair-events` — no formatting diffs left uncommitted.
- [ ] Manual check in the running admin: placeholder → popup → external/create/link flows; header updates without reload; unsaved-changes save-first prompt.
