### PR TITLE
Fix Tickets tab payments warning misfiring on every site

### DIFF
--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -90,10 +90,15 @@ export default function EventTickets({
 	// Payments are unavailable when the connector plugin is missing
 	// (connectorActive !== true) or installed but not yet configured
 	// (paymentConfigured === false). The two cases show different warnings.
-	const connectorActive =
-		window.fairPaymentsConnector?.connectorActive === true;
-	const paymentConfigured =
-		window.fairPaymentsConnector?.paymentConfigured === true;
+	// wp_localize_script casts booleans to strings ("1"/""), so read the
+	// connector flags tolerantly rather than comparing against real booleans.
+	const asBool = (v) => v === true || v === '1' || v === 1;
+	const connectorActive = asBool(
+		window.fairPaymentsConnector?.connectorActive
+	);
+	const paymentConfigured = asBool(
+		window.fairPaymentsConnector?.paymentConfigured
+	);
 	const paymentsUnavailable = !connectorActive || !paymentConfigured;
 	// Any price > 0 across every source makes at least one ticket purchasable,
 	// so the "payments not set up" warning is relevant. Free ticketing (all

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -625,9 +625,11 @@ describe('EventTickets — payments-unavailable notice (#988, #1177)', () => {
 	});
 
 	it('shows the Mollie notice when the connector is active but unconfigured and a price > 0', () => {
+		// wp_localize_script delivers booleans as strings ("1"/"") — feed
+		// that stringified transport form, not real booleans.
 		window.fairPaymentsConnector = {
-			connectorActive: true,
-			paymentConfigured: false,
+			connectorActive: '1',
+			paymentConfigured: '',
 			settingsUrl:
 				'http://example.test/wp-admin/admin.php?page=fair-payments-connector-settings',
 		};
@@ -646,7 +648,7 @@ describe('EventTickets — payments-unavailable notice (#988, #1177)', () => {
 	});
 
 	it('shows the missing-plugin notice when the connector is inactive and a price > 0', () => {
-		window.fairPaymentsConnector = { currency: 'EUR' };
+		window.fairPaymentsConnector = { connectorActive: '', currency: 'EUR' };
 		const { container } = renderTickets({
 			initialData: initialDataWithPaidTicket,
 		});
@@ -661,7 +663,7 @@ describe('EventTickets — payments-unavailable notice (#988, #1177)', () => {
 	});
 
 	it('shows the notice for add-on-only pricing', () => {
-		window.fairPaymentsConnector = { currency: 'EUR' };
+		window.fairPaymentsConnector = { connectorActive: '', currency: 'EUR' };
 		const { container } = renderTickets({
 			initialData: initialDataWithPaidAddon,
 		});
@@ -671,22 +673,35 @@ describe('EventTickets — payments-unavailable notice (#988, #1177)', () => {
 		).toBeInTheDocument();
 	});
 
-	it('does not show any notice when every price is 0', () => {
-		window.fairPaymentsConnector = { currency: 'EUR' };
-		const { container } = renderTickets({
-			initialData: initialDataWithTicketType,
-		});
+	it.each([
+		['missing/inactive', { connectorActive: '', currency: 'EUR' }],
+		[
+			'active but unconfigured',
+			{ connectorActive: '1', paymentConfigured: '', settingsUrl: 'x' },
+		],
+		[
+			'active and configured',
+			{ connectorActive: '1', paymentConfigured: '1', settingsUrl: 'x' },
+		],
+	])(
+		'does not show any notice when every price is 0 (%s)',
+		(_label, connectorState) => {
+			window.fairPaymentsConnector = connectorState;
+			const { container } = renderTickets({
+				initialData: initialDataWithTicketType,
+			});
 
-		expect(
-			within(container).queryByText(mollieRegex)
-		).not.toBeInTheDocument();
-		expect(
-			within(container).queryByText(missingPluginRegex)
-		).not.toBeInTheDocument();
-	});
+			expect(
+				within(container).queryByText(mollieRegex)
+			).not.toBeInTheDocument();
+			expect(
+				within(container).queryByText(missingPluginRegex)
+			).not.toBeInTheDocument();
+		}
+	);
 
 	it('does not show any notice when there are no tickets yet', () => {
-		window.fairPaymentsConnector = { connectorActive: false };
+		window.fairPaymentsConnector = { connectorActive: '' };
 		const { container } = renderTickets({ initialData: emptyInitialData });
 
 		expect(
@@ -698,9 +713,12 @@ describe('EventTickets — payments-unavailable notice (#988, #1177)', () => {
 	});
 
 	it('does not show any notice when payments are configured', () => {
+		// wp_localize_script delivers booleans as strings ("1"/"") — feed
+		// that stringified transport form, not real booleans. This is the
+		// green-path state the notice must correctly suppress.
 		window.fairPaymentsConnector = {
-			connectorActive: true,
-			paymentConfigured: true,
+			connectorActive: '1',
+			paymentConfigured: '1',
 			settingsUrl:
 				'http://example.test/wp-admin/admin.php?page=fair-payments-connector-settings',
 		};


### PR DESCRIPTION
## Summary

- `wp_localize_script` stringifies PHP booleans (`true` → `"1"`, `false` → `""`), but `EventTickets.js` compared `connectorActive`/`paymentConfigured` with `=== true`, so both always read `false`. The "install and activate the connector" warning showed on every site with a paid ticket, even when the connector was active and Mollie was configured — burying the "configure Mollie" state entirely.
- Read the two flags through a small tolerant coercion (`v === true || v === '1' || v === 1`) instead of a strict boolean comparison.
- Updated the payments-warning regression tests to feed the flags in the transport's actual stringified form (`'1'`/`''`), including a new "active + configured → no warning" green-path case that was previously untested.
- Swept other `wp_localize_script` call sites for the same `=== true`/`=== false` pattern against `window.*` — no other occurrences found, so no follow-up needed.

Closes #1196

## Test plan

- [x] `npm run test:js` (fair-events) — `EventTickets.test.jsx`, 50/50 passing
- [x] `npm run format` (fair-events) — no formatting noise
- [x] `npm run build` (fair-events) — bundled admin script rebuilt (build/ is gitignored)
- [x] No PHP changed — `vendor/bin/phpcs` not applicable
