### PR TITLE
Add a From-URL tab to the Quick Add Event modal

### DIFF
--- a/fair-events/src/API/EventLookupController.php
+++ b/fair-events/src/API/EventLookupController.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * REST API Controller for looking up event metadata from a URL
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\API;
+
+defined( 'WPINC' ) || die;
+
+use FairEvents\Helpers\PageMetadataParser;
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+/**
+ * Fetches a user-supplied page server-side and extracts event metadata from it
+ */
+class EventLookupController extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST API
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'fair-events/v1';
+
+	/**
+	 * Register the routes for URL lookup
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		// POST /fair-events/v1/lookup-url - Fetch a page and extract event metadata.
+		register_rest_route(
+			$this->namespace,
+			'/lookup-url',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array(
+						'url' => array(
+							'description'       => __( 'URL of the event page to look up.', 'fair-events' ),
+							'type'              => 'string',
+							'required'          => true,
+							'validate_callback' => array( $this, 'validate_url' ),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Validate that the given value is a safe http(s) URL.
+	 *
+	 * @param string $value The url param.
+	 * @return bool True when valid.
+	 */
+	public function validate_url( $value ) {
+		if ( ! is_string( $value ) || ! wp_http_validate_url( $value ) ) {
+			return false;
+		}
+
+		$scheme = wp_parse_url( $value, PHP_URL_SCHEME );
+
+		return in_array( $scheme, array( 'http', 'https' ), true );
+	}
+
+	/**
+	 * Fetch the given URL server-side and extract event metadata from it
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
+	 */
+	public function create_item( $request ) {
+		$url = $request->get_param( 'url' );
+
+		// wp_safe_remote_get() rejects redirects/targets that resolve to
+		// private/internal addresses (reject_unsafe_urls), unlike wp_remote_get().
+		$response = wp_safe_remote_get(
+			$url,
+			array(
+				'timeout'             => 5,
+				'redirection'         => 3,
+				'limit_response_size' => 2 * MB_IN_BYTES,
+				'headers'             => array(
+					'Accept' => 'text/html',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'rest_lookup_unreachable',
+				__( 'Could not reach that page.', 'fair-events' ),
+				array( 'status' => 502 )
+			);
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( $status < 200 || $status >= 300 ) {
+			return new WP_Error(
+				'rest_lookup_bad_status',
+				__( 'That page could not be fetched.', 'fair-events' ),
+				array( 'status' => 502 )
+			);
+		}
+
+		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+
+		if ( $content_type && false === stripos( $content_type, 'html' ) ) {
+			return new WP_Error(
+				'rest_lookup_not_html',
+				__( 'That URL did not return a web page.', 'fair-events' ),
+				array( 'status' => 415 )
+			);
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+
+		if ( empty( $body ) ) {
+			return new WP_Error(
+				'rest_lookup_empty',
+				__( 'That page had no content to read.', 'fair-events' ),
+				array( 'status' => 422 )
+			);
+		}
+
+		$metadata = PageMetadataParser::parse( $body );
+
+		if ( empty( $metadata['title'] ) ) {
+			return new WP_Error(
+				'rest_lookup_no_metadata',
+				__( 'Could not find any event details on that page.', 'fair-events' ),
+				array( 'status' => 422 )
+			);
+		}
+
+		return new WP_REST_Response( $metadata, 200 );
+	}
+
+	/**
+	 * Check permissions for looking up event metadata from a URL
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool|WP_Error True if user has permission, WP_Error otherwise.
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to look up event pages.', 'fair-events' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+}

--- a/fair-events/src/API/__tests__/EventLookupController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventLookupController.api.spec.js
@@ -1,0 +1,65 @@
+/**
+ * Playwright API tests for EventLookupController.
+ *
+ * Verifies POST /fair-events/v1/lookup-url rejects non-http(s) URLs,
+ * enforces the permission check, and fetches metadata from a live page.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeader = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('EventLookupController', () => {
+	let api;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test('rejects a non-http(s) URL', async () => {
+		const res = await api.post('/wp-json/fair-events/v1/lookup-url', {
+			headers: authHeader,
+			data: { url: 'ftp://example.com/event' },
+		});
+
+		expect(res.status()).toBe(400);
+	});
+
+	test('rejects requests without permission', async () => {
+		const anonymousApi = await request.newContext({ baseURL: BASE_URL });
+		const res = await anonymousApi.post(
+			'/wp-json/fair-events/v1/lookup-url',
+			{
+				data: { url: 'https://example.com' },
+			}
+		);
+
+		expect([401, 403]).toContain(res.status());
+		await anonymousApi.dispose();
+	});
+
+	test('fetches and extracts metadata from a known page', async () => {
+		const res = await api.post('/wp-json/fair-events/v1/lookup-url', {
+			headers: authHeader,
+			data: { url: 'https://example.com' },
+		});
+
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+
+		expect(body.title).toBeTruthy();
+		expect(body).toHaveProperty('found');
+	});
+});

--- a/fair-events/src/Admin/calendar/components/QuickEventModal.js
+++ b/fair-events/src/Admin/calendar/components/QuickEventModal.js
@@ -16,10 +16,13 @@ import {
 	FormTokenField,
 	PanelBody,
 	Button,
+	Notice,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import {
 	formatLocalDate,
@@ -40,6 +43,14 @@ export default function QuickEventModal({ date, onClose, onSuccess }) {
 	const [venues, setVenues] = useState([]);
 	const [isSaving, setIsSaving] = useState(false);
 	const [error, setError] = useState(null);
+
+	// From-URL tab.
+	const [activeTab, setActiveTab] = useState('manual');
+	const [lookupUrl, setLookupUrl] = useState('');
+	const [isLookingUp, setIsLookingUp] = useState(false);
+	const [lookupError, setLookupError] = useState(null);
+	const [fetchedLocation, setFetchedLocation] = useState(null);
+	const [missingFields, setMissingFields] = useState([]);
 
 	// Categories.
 	const [categories, setCategories] = useState([]);
@@ -89,6 +100,70 @@ export default function QuickEventModal({ date, onClose, onSuccess }) {
 			setSearchResults(results);
 		} catch {
 			// Ignore search errors.
+		}
+	};
+
+	const handleLookup = async () => {
+		if (!lookupUrl.trim()) {
+			setLookupError(__('Enter a URL to look up.', 'fair-events'));
+			return;
+		}
+
+		setIsLookingUp(true);
+		setLookupError(null);
+
+		// The pasted URL becomes the external link regardless of outcome.
+		setLinkType('external');
+		setExternalUrl(lookupUrl);
+
+		try {
+			const metadata = await apiFetch({
+				path: '/fair-events/v1/lookup-url',
+				method: 'POST',
+				data: { url: lookupUrl },
+			});
+
+			if (metadata.title) {
+				setTitle(metadata.title);
+			}
+
+			if (metadata.start_datetime) {
+				setAllDay(Boolean(metadata.all_day));
+				setStartDate(metadata.start_datetime.slice(0, 10));
+				setStartTime(metadata.start_datetime.slice(11, 16));
+			}
+
+			if (metadata.end_datetime) {
+				setEndDate(metadata.end_datetime.slice(0, 10));
+				setEndTime(metadata.end_datetime.slice(11, 16));
+			}
+
+			setFetchedLocation(metadata.location || null);
+
+			if (metadata.location) {
+				const match = venues.find(
+					(v) =>
+						v.name.toLowerCase() === metadata.location.toLowerCase()
+				);
+				if (match) {
+					setVenueId(String(match.id));
+				}
+			}
+
+			const found = metadata.found || [];
+			setMissingFields(
+				['start', 'end', 'location'].filter(
+					(field) => !found.includes(field)
+				)
+			);
+
+			setActiveTab('manual');
+		} catch (err) {
+			setLookupError(
+				err.message || __('Could not look up that page.', 'fair-events')
+			);
+		} finally {
+			setIsLookingUp(false);
 		}
 	};
 
@@ -181,197 +256,310 @@ export default function QuickEventModal({ date, onClose, onSuccess }) {
 						</div>
 					)}
 
-					<TextControl
-						label={__('Title', 'fair-events')}
-						value={title}
-						onChange={setTitle}
-						required
-						autoFocus
-					/>
+					<ToggleGroupControl
+						label={__('Add event', 'fair-events')}
+						hideLabelFromVision
+						value={activeTab}
+						onChange={setActiveTab}
+						isBlock
+					>
+						<ToggleGroupControlOption
+							value="manual"
+							label={__('Manual', 'fair-events')}
+						/>
+						<ToggleGroupControlOption
+							value="url"
+							label={__('From URL', 'fair-events')}
+						/>
+					</ToggleGroupControl>
 
-					<CheckboxControl
-						label={__('All day', 'fair-events')}
-						checked={allDay}
-						onChange={setAllDay}
-					/>
+					{'url' === activeTab && (
+						<VStack spacing={4}>
+							{lookupError && (
+								<div className="notice notice-error inline">
+									<p>{lookupError}</p>
+								</div>
+							)}
 
-					{allDay ? (
-						<HStack spacing={4} alignment="top">
 							<TextControl
-								label={__('Start date', 'fair-events')}
-								type="date"
-								value={startDate}
-								onChange={setStartDate}
-								required
+								label={__('Event page URL', 'fair-events')}
+								type="url"
+								value={lookupUrl}
+								onChange={setLookupUrl}
+								placeholder="https://"
+								autoFocus
 							/>
-							<TextControl
-								label={__('End date', 'fair-events')}
-								type="date"
-								value={endDate}
-								onChange={setEndDate}
-								required
-							/>
-						</HStack>
-					) : (
-						<>
-							<HStack spacing={4} alignment="top">
-								<TextControl
-									label={__('Start date', 'fair-events')}
-									type="date"
-									value={startDate}
-									onChange={setStartDate}
-									required
-								/>
-								<TextControl
-									label={__('Start time', 'fair-events')}
-									type="time"
-									value={startTime}
-									onChange={setStartTime}
-									required
-								/>
+
+							<HStack justify="flex-start">
+								<Button
+									variant="secondary"
+									isBusy={isLookingUp}
+									disabled={isLookingUp || !lookupUrl.trim()}
+									onClick={handleLookup}
+								>
+									{__('Look up', 'fair-events')}
+								</Button>
 							</HStack>
-							<HStack spacing={4} alignment="top">
-								<TextControl
-									label={__('End date', 'fair-events')}
-									type="date"
-									value={endDate}
-									onChange={setEndDate}
-									required
-								/>
-								<TextControl
-									label={__('End time', 'fair-events')}
-									type="time"
-									value={endTime}
-									onChange={setEndTime}
-									required
-								/>
-							</HStack>
-						</>
+						</VStack>
 					)}
 
-					<SelectControl
-						label={__('Venue', 'fair-events')}
-						value={venueId}
-						options={venueOptions}
-						onChange={setVenueId}
-					/>
-
-					<PanelBody
-						title={__('More options', 'fair-events')}
-						initialOpen={false}
-					>
-						<VStack spacing={4}>
-							<FormTokenField
-								label={__('Categories', 'fair-events')}
-								value={categories
-									.map((id) => {
-										const cat = availableCategories.find(
-											(c) => c.id === id
-										);
-										return cat ? cat.name : '';
+					{'manual' === activeTab && missingFields.length > 0 && (
+						<Notice status="info" isDismissible={false}>
+							{sprintf(
+								/* translators: %s: comma-separated list of missing field names */
+								__(
+									"This page didn't specify: %s. Fill these in manually.",
+									'fair-events'
+								),
+								missingFields
+									.map((field) => {
+										if ('start' === field) {
+											return __(
+												'start date',
+												'fair-events'
+											);
+										}
+										if ('end' === field) {
+											return __(
+												'end date',
+												'fair-events'
+											);
+										}
+										return __('location', 'fair-events');
 									})
-									.filter(Boolean)}
-								suggestions={availableCategories.map(
-									(c) => c.name
-								)}
-								onChange={(tokens) => {
-									const ids = tokens
-										.map((token) => {
-											const cat =
-												availableCategories.find(
-													(c) => c.name === token
-												);
-											return cat ? cat.id : null;
-										})
-										.filter((id) => id !== null);
-									setCategories(ids);
-								}}
-							/>
-
-							<RadioControl
-								label={__('Link to', 'fair-events')}
-								selected={linkType}
-								options={[
-									{
-										label: __(
-											'Nowhere — show details only',
-											'fair-events'
-										),
-										value: 'none',
-									},
-									{
-										label: __(
-											'An external website',
-											'fair-events'
-										),
-										value: 'external',
-									},
-									{
-										label: __(
-											'A page on this site',
-											'fair-events'
-										),
-										value: 'post',
-									},
-								]}
-								onChange={setLinkType}
-							/>
-
-							{linkType === 'external' && (
-								<TextControl
-									label={__('External URL', 'fair-events')}
-									type="url"
-									value={externalUrl}
-									onChange={setExternalUrl}
-									placeholder="https://"
-								/>
+									.join(', ')
 							)}
+						</Notice>
+					)}
 
-							{linkType === 'post' && (
-								<VStack spacing={2}>
+					{'manual' === activeTab && (
+						<>
+							<TextControl
+								label={__('Title', 'fair-events')}
+								value={title}
+								onChange={setTitle}
+								required
+								autoFocus
+							/>
+
+							<CheckboxControl
+								label={__('All day', 'fair-events')}
+								checked={allDay}
+								onChange={setAllDay}
+							/>
+
+							{allDay ? (
+								<HStack spacing={4} alignment="top">
 									<TextControl
-										label={__(
-											'Search posts by title',
-											'fair-events'
-										)}
-										onChange={handleSearchPosts}
-										placeholder={__(
-											'Start typing to search...',
-											'fair-events'
-										)}
+										label={__('Start date', 'fair-events')}
+										type="date"
+										value={startDate}
+										onChange={setStartDate}
+										required
 									/>
-									{searchResults.length > 0 && (
-										<SelectControl
+									<TextControl
+										label={__('End date', 'fair-events')}
+										type="date"
+										value={endDate}
+										onChange={setEndDate}
+										required
+									/>
+								</HStack>
+							) : (
+								<>
+									<HStack spacing={4} alignment="top">
+										<TextControl
 											label={__(
-												'Select a post',
+												'Start date',
 												'fair-events'
 											)}
-											value={linkPostId}
-											options={[
-												{
-													label: __(
-														'Select...',
-														'fair-events'
-													),
-													value: '',
-												},
-												...searchResults.map((r) => ({
-													label: r.title,
-													value: String(r.id),
-												})),
-											]}
-											onChange={setLinkPostId}
+											type="date"
+											value={startDate}
+											onChange={setStartDate}
+											required
 										/>
-									)}
-								</VStack>
+										<TextControl
+											label={__(
+												'Start time',
+												'fair-events'
+											)}
+											type="time"
+											value={startTime}
+											onChange={setStartTime}
+											required
+										/>
+									</HStack>
+									<HStack spacing={4} alignment="top">
+										<TextControl
+											label={__(
+												'End date',
+												'fair-events'
+											)}
+											type="date"
+											value={endDate}
+											onChange={setEndDate}
+											required
+										/>
+										<TextControl
+											label={__(
+												'End time',
+												'fair-events'
+											)}
+											type="time"
+											value={endTime}
+											onChange={setEndTime}
+											required
+										/>
+									</HStack>
+								</>
 							)}
 
-							<RecurrenceControl
-								value={recurrence}
-								onChange={setRecurrence}
+							<SelectControl
+								label={__('Venue', 'fair-events')}
+								value={venueId}
+								options={venueOptions}
+								onChange={setVenueId}
+								help={
+									fetchedLocation
+										? sprintf(
+												/* translators: %s: location name found on the source page */
+												__(
+													'From the page: %s',
+													'fair-events'
+												),
+												fetchedLocation
+										  )
+										: undefined
+								}
 							/>
-						</VStack>
-					</PanelBody>
+
+							<PanelBody
+								title={__('More options', 'fair-events')}
+								initialOpen={false}
+							>
+								<VStack spacing={4}>
+									<FormTokenField
+										label={__('Categories', 'fair-events')}
+										value={categories
+											.map((id) => {
+												const cat =
+													availableCategories.find(
+														(c) => c.id === id
+													);
+												return cat ? cat.name : '';
+											})
+											.filter(Boolean)}
+										suggestions={availableCategories.map(
+											(c) => c.name
+										)}
+										onChange={(tokens) => {
+											const ids = tokens
+												.map((token) => {
+													const cat =
+														availableCategories.find(
+															(c) =>
+																c.name === token
+														);
+													return cat ? cat.id : null;
+												})
+												.filter((id) => id !== null);
+											setCategories(ids);
+										}}
+									/>
+
+									<RadioControl
+										label={__('Link to', 'fair-events')}
+										selected={linkType}
+										options={[
+											{
+												label: __(
+													'Nowhere — show details only',
+													'fair-events'
+												),
+												value: 'none',
+											},
+											{
+												label: __(
+													'An external website',
+													'fair-events'
+												),
+												value: 'external',
+											},
+											{
+												label: __(
+													'A page on this site',
+													'fair-events'
+												),
+												value: 'post',
+											},
+										]}
+										onChange={setLinkType}
+									/>
+
+									{linkType === 'external' && (
+										<TextControl
+											label={__(
+												'External URL',
+												'fair-events'
+											)}
+											type="url"
+											value={externalUrl}
+											onChange={setExternalUrl}
+											placeholder="https://"
+										/>
+									)}
+
+									{linkType === 'post' && (
+										<VStack spacing={2}>
+											<TextControl
+												label={__(
+													'Search posts by title',
+													'fair-events'
+												)}
+												onChange={handleSearchPosts}
+												placeholder={__(
+													'Start typing to search...',
+													'fair-events'
+												)}
+											/>
+											{searchResults.length > 0 && (
+												<SelectControl
+													label={__(
+														'Select a post',
+														'fair-events'
+													)}
+													value={linkPostId}
+													options={[
+														{
+															label: __(
+																'Select...',
+																'fair-events'
+															),
+															value: '',
+														},
+														...searchResults.map(
+															(r) => ({
+																label: r.title,
+																value: String(
+																	r.id
+																),
+															})
+														),
+													]}
+													onChange={setLinkPostId}
+												/>
+											)}
+										</VStack>
+									)}
+
+									<RecurrenceControl
+										value={recurrence}
+										onChange={setRecurrence}
+									/>
+								</VStack>
+							</PanelBody>
+						</>
+					)}
 
 					<HStack justify="flex-end" spacing={2}>
 						<Button
@@ -381,14 +569,16 @@ export default function QuickEventModal({ date, onClose, onSuccess }) {
 						>
 							{__('Cancel', 'fair-events')}
 						</Button>
-						<Button
-							variant="primary"
-							type="submit"
-							isBusy={isSaving}
-							disabled={isSaving || !title.trim()}
-						>
-							{__('Create Event', 'fair-events')}
-						</Button>
+						{'manual' === activeTab && (
+							<Button
+								variant="primary"
+								type="submit"
+								isBusy={isSaving}
+								disabled={isSaving || !title.trim()}
+							>
+								{__('Create Event', 'fair-events')}
+							</Button>
+						)}
 					</HStack>
 				</VStack>
 			</form>

--- a/fair-events/src/Admin/calendar/components/__tests__/QuickEventModal.test.jsx
+++ b/fair-events/src/Admin/calendar/components/__tests__/QuickEventModal.test.jsx
@@ -10,6 +10,15 @@ import QuickEventModal from '../QuickEventModal.js';
 
 jest.mock('@wordpress/api-fetch');
 
+// ToggleGroupControl measures itself via ResizeObserver, which jsdom doesn't implement.
+global.ResizeObserver =
+	global.ResizeObserver ||
+	class ResizeObserver {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	};
+
 const availableCategories = [
 	{ id: 1, name: 'Music' },
 	{ id: 2, name: 'Sports' },
@@ -17,16 +26,27 @@ const availableCategories = [
 
 const createdEventDate = { id: 99, title: 'Test Event' };
 
+const venues = [{ id: 5, name: 'The Venue' }];
+
+let lookupResponse = null;
+
 beforeEach(() => {
+	lookupResponse = null;
 	apiFetch.mockImplementation(({ path, method }) => {
 		if (path === '/fair-events/v1/venues') {
-			return Promise.resolve([]);
+			return Promise.resolve(venues);
 		}
 		if (path === '/fair-events/v1/sources/categories') {
 			return Promise.resolve(availableCategories);
 		}
 		if (path.startsWith('/wp/v2/search')) {
 			return Promise.resolve([{ id: 7, title: 'About Us' }]);
+		}
+		if (path === '/fair-events/v1/lookup-url' && method === 'POST') {
+			if (lookupResponse instanceof Error) {
+				return Promise.reject(lookupResponse);
+			}
+			return Promise.resolve(lookupResponse);
 		}
 		if (path === '/fair-events/v1/event-dates' && method === 'POST') {
 			return Promise.resolve(createdEventDate);
@@ -175,5 +195,107 @@ describe('QuickEventModal', () => {
 		expect(createCall[0].data.rrule).toBeTruthy();
 
 		expect(console).toHaveWarned();
+	});
+
+	it('switches to the From URL tab and shows the lookup field', async () => {
+		await renderModal();
+
+		fireEvent.click(screen.getByRole('radio', { name: 'From URL' }));
+
+		expect(screen.getByLabelText('Event page URL')).toBeInTheDocument();
+		expect(screen.queryByLabelText('Title')).not.toBeInTheDocument();
+	});
+
+	it('prefills the manual form and switches tabs on a successful lookup', async () => {
+		lookupResponse = {
+			title: 'Fetched Event',
+			start_datetime: '2026-07-01 18:00:00',
+			end_datetime: '2026-07-01 20:00:00',
+			all_day: false,
+			location: 'The Venue',
+			source: 'schema',
+			found: ['title', 'start', 'end', 'location'],
+		};
+
+		await renderModal();
+
+		fireEvent.click(screen.getByRole('radio', { name: 'From URL' }));
+		fireEvent.change(screen.getByLabelText('Event page URL'), {
+			target: { value: 'https://example.com/event' },
+		});
+		fireEvent.click(screen.getByRole('button', { name: 'Look up' }));
+
+		await waitFor(() =>
+			expect(screen.getByLabelText('Title')).toHaveValue('Fetched Event')
+		);
+
+		expect(screen.getByLabelText('Start date')).toHaveValue('2026-07-01');
+		expect(screen.getByLabelText('Venue')).toHaveValue('5');
+		expect(screen.queryByText(/didn't specify/)).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Create Event' }));
+		await waitFor(() =>
+			expect(apiFetch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: '/fair-events/v1/event-dates',
+					method: 'POST',
+				})
+			)
+		);
+
+		const createCall = apiFetch.mock.calls.find(
+			([opts]) =>
+				opts.path === '/fair-events/v1/event-dates' &&
+				opts.method === 'POST'
+		);
+		expect(createCall[0].data.link_type).toBe('external');
+		expect(createCall[0].data.external_url).toBe(
+			'https://example.com/event'
+		);
+	});
+
+	it('shows a missing-fields notice for partial lookup results', async () => {
+		lookupResponse = {
+			title: 'Fetched Event',
+			start_datetime: null,
+			end_datetime: null,
+			all_day: false,
+			location: null,
+			source: 'title',
+			found: ['title'],
+		};
+
+		await renderModal();
+
+		fireEvent.click(screen.getByRole('radio', { name: 'From URL' }));
+		fireEvent.change(screen.getByLabelText('Event page URL'), {
+			target: { value: 'https://example.com/event' },
+		});
+		fireEvent.click(screen.getByRole('button', { name: 'Look up' }));
+
+		await waitFor(() =>
+			expect(screen.getByLabelText('Title')).toHaveValue('Fetched Event')
+		);
+
+		expect(screen.getAllByText(/didn't specify/).length).toBeGreaterThan(0);
+	});
+
+	it('shows an error and keeps the URL tab on a failed lookup', async () => {
+		lookupResponse = new Error('Could not reach that page.');
+
+		await renderModal();
+
+		fireEvent.click(screen.getByRole('radio', { name: 'From URL' }));
+		fireEvent.change(screen.getByLabelText('Event page URL'), {
+			target: { value: 'https://example.com/event' },
+		});
+		fireEvent.click(screen.getByRole('button', { name: 'Look up' }));
+
+		await waitFor(() =>
+			expect(
+				screen.getByText('Could not reach that page.')
+			).toBeInTheDocument()
+		);
+		expect(screen.getByLabelText('Event page URL')).toBeInTheDocument();
 	});
 });

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -162,6 +162,17 @@ class Plugin {
 			}
 		);
 
+		// Event lookup controller — registers `/fair-events/v1/lookup-url`,
+		// used by the Quick Add modal's "From URL" tab to prefill event
+		// details from a pasted event page.
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new \FairEvents\API\EventLookupController();
+				$controller->register_routes();
+			}
+		);
+
 		if ( Features::is_enabled( 'ticketing' ) ) {
 			add_action(
 				'rest_api_init',

--- a/fair-events/src/Helpers/PageMetadataParser.php
+++ b/fair-events/src/Helpers/PageMetadataParser.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Page Metadata Parser Helper for Fair Events
+ *
+ * Extracts event-ish metadata from an arbitrary HTML page: schema.org Event
+ * (JSON-LD) first, falling back field-by-field to Open Graph, then <title>.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Helpers;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * PageMetadataParser class for extracting event metadata from HTML
+ */
+class PageMetadataParser {
+
+	/**
+	 * Parse HTML and extract whatever event metadata it can find.
+	 *
+	 * @param string $html Raw HTML of the fetched page.
+	 * @return array {
+	 *     @type string|null $title          Event or page title.
+	 *     @type string|null $start_datetime Site-local 'Y-m-d H:i:s'.
+	 *     @type string|null $end_datetime   Site-local 'Y-m-d H:i:s'.
+	 *     @type bool        $all_day        Whether the source gave date-only values.
+	 *     @type string|null $location       Free-text location/venue name.
+	 *     @type string|null $source         'schema', 'opengraph', or 'title'.
+	 *     @type string[]    $found          Which of title/start/end/location were found.
+	 * }
+	 */
+	public static function parse( $html ) {
+		$result = array(
+			'title'          => null,
+			'start_datetime' => null,
+			'end_datetime'   => null,
+			'all_day'        => false,
+			'location'       => null,
+			'source'         => null,
+		);
+
+		$event = self::find_schema_event( $html );
+
+		if ( $event ) {
+			$result['source'] = 'schema';
+
+			if ( ! empty( $event['name'] ) && is_string( $event['name'] ) ) {
+				$result['title'] = sanitize_text_field( $event['name'] );
+			}
+
+			if ( ! empty( $event['startDate'] ) && is_string( $event['startDate'] ) ) {
+				$start = self::parse_schema_date( $event['startDate'] );
+				if ( $start ) {
+					$result['start_datetime'] = $start['datetime'];
+					$result['all_day']        = $start['all_day'];
+				}
+			}
+
+			if ( ! empty( $event['endDate'] ) && is_string( $event['endDate'] ) ) {
+				$end = self::parse_schema_date( $event['endDate'] );
+				if ( $end ) {
+					$result['end_datetime'] = $end['datetime'];
+				}
+			}
+
+			$location = self::extract_schema_location( $event );
+			if ( $location ) {
+				$result['location'] = $location;
+			}
+		}
+
+		$og = self::find_open_graph( $html );
+
+		if ( empty( $result['title'] ) && ! empty( $og['title'] ) ) {
+			$result['title']  = sanitize_text_field( $og['title'] );
+			$result['source'] = $result['source'] ?? 'opengraph';
+		}
+
+		if ( empty( $result['title'] ) ) {
+			$title = self::find_title_tag( $html );
+			if ( $title ) {
+				$result['title']  = sanitize_text_field( $title );
+				$result['source'] = $result['source'] ?? 'title';
+			}
+		}
+
+		$found = array();
+		foreach ( array( 'title', 'start_datetime', 'end_datetime', 'location' ) as $field ) {
+			if ( ! empty( $result[ $field ] ) ) {
+				$found[] = 'start_datetime' === $field ? 'start' : ( 'end_datetime' === $field ? 'end' : $field );
+			}
+		}
+		$result['found'] = $found;
+
+		return $result;
+	}
+
+	/**
+	 * Find the first schema.org Event (or subtype) node in JSON-LD blocks.
+	 *
+	 * @param string $html Raw HTML.
+	 * @return array|null Decoded Event node, or null if none found.
+	 */
+	private static function find_schema_event( $html ) {
+		if ( empty( $html ) || false === stripos( $html, 'application/ld+json' ) ) {
+			return null;
+		}
+
+		if ( ! preg_match_all(
+			'#<script[^>]*type=["\']application/ld\+json["\'][^>]*>(.*?)</script>#is',
+			$html,
+			$matches
+		) ) {
+			return null;
+		}
+
+		foreach ( $matches[1] as $block ) {
+			$decoded = json_decode( trim( $block ), true );
+
+			if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
+				continue;
+			}
+
+			$event = self::find_event_node( $decoded );
+			if ( $event ) {
+				return $event;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Recursively walk a decoded JSON-LD structure for an Event node.
+	 *
+	 * @param mixed $node Decoded JSON-LD value (object as array, or list).
+	 * @return array|null Event node, or null.
+	 */
+	private static function find_event_node( $node ) {
+		if ( ! is_array( $node ) ) {
+			return null;
+		}
+
+		if ( isset( $node['@type'] ) ) {
+			$type = is_array( $node['@type'] ) ? $node['@type'] : array( $node['@type'] );
+			foreach ( $type as $type_name ) {
+				if ( is_string( $type_name ) && false !== stripos( $type_name, 'event' ) ) {
+					return $node;
+				}
+			}
+		}
+
+		if ( isset( $node['@graph'] ) && is_array( $node['@graph'] ) ) {
+			$found = self::find_event_node( $node['@graph'] );
+			if ( $found ) {
+				return $found;
+			}
+		}
+
+		// A plain (non-associative) list of nodes.
+		if ( array_values( $node ) === $node ) {
+			foreach ( $node as $item ) {
+				$found = self::find_event_node( $item );
+				if ( $found ) {
+					return $found;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extract a free-text location name from a schema.org Event's `location`.
+	 *
+	 * @param array $event Decoded Event node.
+	 * @return string|null Location name, or null.
+	 */
+	private static function extract_schema_location( $event ) {
+		if ( empty( $event['location'] ) ) {
+			return null;
+		}
+
+		$location = $event['location'];
+
+		if ( is_string( $location ) ) {
+			return sanitize_text_field( $location );
+		}
+
+		if ( is_array( $location ) ) {
+			// A list of locations — use the first one.
+			if ( array_values( $location ) === $location ) {
+				$location = $location[0] ?? null;
+			}
+
+			if ( is_array( $location ) && ! empty( $location['name'] ) && is_string( $location['name'] ) ) {
+				return sanitize_text_field( $location['name'] );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Parse a schema.org date/datetime string into site-local time.
+	 *
+	 * @param string $value ISO 8601 date or datetime string.
+	 * @return array{datetime: string, all_day: bool}|null
+	 */
+	private static function parse_schema_date( $value ) {
+		$value = trim( $value );
+
+		// Date-only value (no time component) — treat as all-day.
+		if ( preg_match( '/^\d{4}-\d{2}-\d{2}$/', $value ) ) {
+			return array(
+				'datetime' => $value . ' 00:00:00',
+				'all_day'  => true,
+			);
+		}
+
+		$local = DateHelper::iso8601_to_local( $value );
+
+		if ( ! $local ) {
+			return null;
+		}
+
+		return array(
+			'datetime' => $local,
+			'all_day'  => false,
+		);
+	}
+
+	/**
+	 * Read Open Graph meta tags from the page.
+	 *
+	 * @param string $html Raw HTML.
+	 * @return array Associative array of found `og:*` properties (title only, currently).
+	 */
+	private static function find_open_graph( $html ) {
+		$og = array();
+
+		if ( preg_match(
+			'#<meta[^>]+property=["\']og:title["\'][^>]+content=["\']([^"\']*)["\'][^>]*>#i',
+			$html,
+			$match
+		) ) {
+			$og['title'] = html_entity_decode( $match[1], ENT_QUOTES );
+		}
+
+		return $og;
+	}
+
+	/**
+	 * Read the page's `<title>` tag.
+	 *
+	 * @param string $html Raw HTML.
+	 * @return string|null Title text, or null.
+	 */
+	private static function find_title_tag( $html ) {
+		if ( preg_match( '#<title[^>]*>(.*?)</title>#is', $html, $match ) ) {
+			$title = html_entity_decode( trim( $match[1] ), ENT_QUOTES );
+			return '' !== $title ? $title : null;
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a "From URL" tab to the Quick Add Event modal (admin calendar) alongside the existing manual form.
- Pasting a URL and pressing "Look up" calls a new SSRF-safe endpoint (`POST /fair-events/v1/lookup-url`) that fetches the page server-side via `wp_safe_remote_get()` and extracts event metadata in order of preference: schema.org `Event` JSON-LD → Open Graph → `<title>`.
- On success, the manual form is prefilled (title, start/end date & time, all-day flag) and the tab switches back to Manual for review; nothing is saved until the user presses Create. The pasted URL is set as the external link regardless of lookup outcome.
- For fields the page didn't declare (start/end date, location), an informational notice names what's missing so the user knows to fill it in.
- A declared location is shown as read-only help text next to the venue selector; a venue is only auto-selected on an exact (case-insensitive) name match — no venue auto-creation.
- Fetch is capability-gated (`edit_posts`), restricted to `http`/`https`, capped at ~2MB with a 5s timeout and max 3 redirects, and rejects non-HTML responses.

Closes #1206

## Test plan

- [x] `npm run test:js` — full fair-events Jest suite passes (130/130), including new `QuickEventModal` tab/lookup tests and existing tests unaffected.
- [x] `vendor/bin/phpcs` clean for the new/changed PHP files (`EventLookupController.php`, `PageMetadataParser.php`, `Plugin.php`).
- [x] `npm run build` — assets rebuilt for the `admin/calendar` entry.
- [x] Added `EventLookupController.api.spec.js` (Playwright) covering: non-http(s) URL rejected (400), unauthenticated request rejected (401/403), and a happy-path fetch against a known page.
- [ ] Manual verification in the browser (not run in this session — no live WP instance was started).
