### PR TITLE
Fix unreadable calendar subscribe button before hover

### DIFF
--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -467,15 +467,17 @@ $subscribe_urls = fair_events_build_subscribe_urls( is_array( $categories ) ? $c
 		data-wp-on-document--click="actions.handleOutsideClick"
 		data-wp-on-document--keydown="actions.handleKeydown"
 	>
-		<button
-			type="button"
-			class="fair-events-subscribe-trigger wp-block-button__link wp-element-button is-style-outline"
-			aria-haspopup="true"
-			data-wp-on--click="actions.toggle"
-			data-wp-bind--aria-expanded="state.isOpen"
-		>
-			<?php esc_html_e( 'Subscribe to calendar', 'fair-events' ); ?>
-		</button>
+		<div class="wp-block-button is-style-outline">
+			<button
+				type="button"
+				class="fair-events-subscribe-trigger wp-block-button__link wp-element-button"
+				aria-haspopup="true"
+				data-wp-on--click="actions.toggle"
+				data-wp-bind--aria-expanded="state.isOpen"
+			>
+				<?php esc_html_e( 'Subscribe to calendar', 'fair-events' ); ?>
+			</button>
+		</div>
 
 		<div class="fair-events-subscribe-panel"
 			role="menu"


### PR DESCRIPTION
## Summary
- The events-calendar block's "Subscribe to calendar" trigger put `is-style-outline` directly on the `<button>` element instead of on a wrapping `div.wp-block-button`.
- Core's outline-style CSS only targets `.wp-block-button.is-style-outline > .wp-block-button__link`, so without that wrapper the border/`currentColor` override never applied and the label was unreadable until hover/focus (a separate opacity rule happened to reveal it then).
- Wrapped the button in `<div class="wp-block-button is-style-outline">`, matching the pattern already used for the copy-summary button in `events-week/render.php`.

Refs #1153

## Test plan
- [x] `npm run build` in `fair-events` (regenerates `build/blocks/events-calendar/render.php`)
- [x] `vendor/bin/phpcs` clean on the changed file (no new warnings)
- [ ] Manually verify the "Subscribe to calendar" button text is readable at rest (not just on hover) on a page with the events-calendar block