### PR TITLE
Mark free RSVP events as accessible for free in JSON-LD

### DIFF
--- a/fair-events/e2e/opengraph-jsonld.spec.js
+++ b/fair-events/e2e/opengraph-jsonld.spec.js
@@ -294,6 +294,73 @@ test.describe('Fair Events JSON-LD structured data', () => {
 		}).catch(() => {});
 	});
 
+	test('emits a free offer + isAccessibleForFree for a free RSVP ticket type with no price row', async ({
+		page,
+	}) => {
+		test.setTimeout(120_000);
+
+		await page.setViewportSize({ width: 1200, height: 900 });
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+		const now = new Date();
+		const start = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+		const iso = (d) => d.toISOString().slice(0, 19).replace('T', ' ');
+
+		const eventDate = await apiFetch(page, {
+			path: '/fair-events/v1/event-dates',
+			method: 'POST',
+			data: {
+				title: 'JSON-LD Test Free RSVP Event',
+				start_datetime: iso(start),
+				end_datetime: iso(
+					new Date(start.getTime() + 2 * 60 * 60 * 1000)
+				),
+				all_day: false,
+			},
+		});
+
+		const post = await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}/create-post`,
+			method: 'POST',
+			data: { post_status: 'publish' },
+		});
+		const postId = post.event_id || post.post_id;
+
+		// Free RSVP/signup: a ticket type with no sale period and no price row
+		// (the "gratis" case) — nothing that get_jsonld_offers() would treat as
+		// priced, yet the event is genuinely accessible for free.
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}/tickets`,
+			method: 'PUT',
+			data: {
+				ticket_types: [{ name: 'Sign up' }],
+				sale_periods: [],
+				prices: [],
+			},
+		});
+
+		const permalink = post.link || `/?p=${postId}`;
+		const data = await getJsonLd(page, permalink);
+
+		expect(data.offers).toHaveLength(1);
+		expect(data.offers[0].price).toBe('0');
+		expect(data.offers[0]['@type']).toBe('Offer');
+		expect(data.offers[0].validFrom).toBeUndefined();
+		expect(data.isAccessibleForFree).toBe(true);
+
+		// Cleanup.
+		await apiFetch(page, {
+			path: `/wp/v2/fair_event/${postId}?force=true`,
+			method: 'DELETE',
+		}).catch(() => {});
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}`,
+			method: 'DELETE',
+		}).catch(() => {});
+	});
+
 	test('emits og:type "event" for an event page', async ({ page }) => {
 		test.setTimeout(120_000);
 

--- a/fair-events/src/Helpers/EventSchema.php
+++ b/fair-events/src/Helpers/EventSchema.php
@@ -274,12 +274,19 @@ class EventSchema {
 	/**
 	 * Build Schema.org Offer objects for JSON-LD from the ticketing models.
 	 *
+	 * Priced ticket types yield a paid `Offer`; a genuinely free ticket type
+	 * (enabled, non-invitation, with no positive price in any sale period — the
+	 * free RSVP/signup case) yields a price-"0" `Offer` so the event can be
+	 * marked `isAccessibleForFree`. A paid type whose sale window has closed
+	 * yields nothing and is never advertised as free.
+	 *
 	 * Everything is behind class_exists() guards since a fair-events-only
 	 * site (without ticketing) must not fatal.
 	 *
 	 * @param EventDates $event_date Event date object.
 	 * @param int        $post_id    Post ID.
-	 * @return array Offer objects (empty when ticketing is unavailable or unpriced).
+	 * @return array Offer objects (empty when ticketing is unavailable, or every
+	 *               type is a paid ticket with sales closed).
 	 */
 	public static function get_jsonld_offers( EventDates $event_date, $post_id ) {
 		if ( ! class_exists( \FairEvents\Models\TicketType::class )
@@ -300,6 +307,7 @@ class EventSchema {
 			return array();
 		}
 
+		$all_prices   = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id );
 		$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $pricing_event_date_id );
 
 		$now             = current_time( 'mysql' );
@@ -317,22 +325,34 @@ class EventSchema {
 
 		// Search crawls happen outside the sale window: fall back to the
 		// nearest upcoming period's price so `offers` isn't empty just
-		// because sales haven't opened yet.
+		// because sales haven't opened yet. When no period exists at all the
+		// event can still carry free RSVP ticket types (handled below).
 		$selected_period = $active_period ? $active_period : $upcoming_period;
-		if ( ! $selected_period ) {
-			return array();
+
+		// Price for each type inside the selected window.
+		$price_by_type_id = array();
+		if ( $selected_period ) {
+			foreach ( $all_prices as $price ) {
+				if ( (int) $price->sale_period_id === (int) $selected_period->id ) {
+					$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
+				}
+			}
 		}
 
-		$price_by_type_id = array();
-		foreach ( \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id ) as $price ) {
-			if ( (int) $price->sale_period_id === (int) $selected_period->id ) {
-				$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
+		// Type IDs carrying a positive price in *any* period: paid tickets, even
+		// when the current window has none (sales closed). Never advertised free.
+		$paid_type_ids = array();
+		foreach ( $all_prices as $price ) {
+			if ( (float) $price->price > 0.0 ) {
+				$paid_type_ids[ (int) $price->ticket_type_id ] = true;
 			}
 		}
 
 		$currency   = get_option( 'fair_payment_currency', 'EUR' );
 		$permalink  = get_permalink( $post_id );
-		$valid_from = $active_period ? null : DateHelper::local_to_iso8601( $selected_period->sale_start );
+		$valid_from = ( $selected_period && ! $active_period )
+			? DateHelper::local_to_iso8601( $selected_period->sale_start )
+			: null;
 
 		$offers = array();
 		foreach ( $ticket_types as $ticket_type ) {
@@ -340,23 +360,41 @@ class EventSchema {
 				continue;
 			}
 
-			if ( ! isset( $price_by_type_id[ $ticket_type->id ] ) ) {
+			$type_id = (int) $ticket_type->id;
+
+			// Priced in the current window (the price may itself be 0).
+			if ( isset( $price_by_type_id[ $type_id ] ) ) {
+				$offer = array(
+					'@type'         => 'Offer',
+					'price'         => (string) $price_by_type_id[ $type_id ],
+					'priceCurrency' => $currency,
+					'availability'  => 'https://schema.org/InStock',
+					'url'           => $permalink,
+				);
+
+				if ( $valid_from ) {
+					$offer['validFrom'] = $valid_from;
+				}
+
+				$offers[] = $offer;
 				continue;
 			}
 
-			$offer = array(
+			// No price in the current window: a type priced elsewhere is a paid
+			// ticket with sales closed — emit nothing.
+			if ( isset( $paid_type_ids[ $type_id ] ) ) {
+				continue;
+			}
+
+			// Genuinely free ticket type (a free RSVP/signup with no price row):
+			// advertise a price-"0" offer so the event is accessible for free.
+			$offers[] = array(
 				'@type'         => 'Offer',
-				'price'         => (string) $price_by_type_id[ $ticket_type->id ],
+				'price'         => '0',
 				'priceCurrency' => $currency,
 				'availability'  => 'https://schema.org/InStock',
 				'url'           => $permalink,
 			);
-
-			if ( $valid_from ) {
-				$offer['validFrom'] = $valid_from;
-			}
-
-			$offers[] = $offer;
 		}
 
 		return $offers;


### PR DESCRIPTION
## Summary

Free events that use a **free RSVP/signup ticket type** were not marked `isAccessibleForFree` in their Schema.org JSON-LD, and had no `offers` node at all. Spotted on a live event page (`entrenamiento-gratis-al-aire-libre`) whose JSON-LD had neither `offers` nor `isAccessibleForFree`, despite the page offering a free "Sign up — gratis" ticket.

**Root cause:** a free RSVP ticket type carries no `TicketPrice` row and no sale period, so `EventSchema::get_jsonld_offers()` produced an empty offers array. An empty offer set is deliberately treated as "ticketing not configured" (not "free"), so `isAccessibleForFree` was never set — a genuinely free event was indistinguishable from one with no ticketing.

**Fix:** `get_jsonld_offers()` now emits a `price: "0"` Offer for a participatable ticket type that has no positive price in any sale period. That flows through the existing `is_free_offer_set()` check, so the event is correctly marked `isAccessibleForFree: true`. This mirrors how `event-signup/render.php` already classifies the free path (`$has_free_type`).

Guardrails preserved:
- A type priced in another (closed) sale period is still **never** advertised as free.
- An event with no ticket types stays offer-less with no flag (no regression).
- Mixed free+paid events are unchanged (no `isAccessibleForFree`), though the free ticket now appears as a `price:"0"` offer alongside the paid ones.

## Testing

- `phpcs` clean; existing `EventSchema` PHPUnit suite passes (10/10).
- Live WP-CLI integration check against the dev stack:
  - Free RSVP (no price/period) → one `price:"0"` offer, `is_free_offer_set: true`.
  - No ticket types → empty offers, no flag.
- Added an e2e test in `opengraph-jsonld.spec.js` covering the free-RSVP case (empty `sale_periods`/`prices`), asserting a single `price:"0"` offer and `isAccessibleForFree: true`.