### PR TITLE
Sanitize payment gateway errors before they reach visitors

### DIFF
--- a/fair-audience/src/blocks/event-signup/frontend.js
+++ b/fair-audience/src/blocks/event-signup/frontend.js
@@ -5,6 +5,7 @@ import {
 	extractErrorMessage,
 	showNotification,
 	showMessage,
+	renderPaymentError,
 	setButtonLoading,
 	onDomReady,
 	wireNotYouButton,
@@ -1155,10 +1156,10 @@ const SCROLL_RESTORE_KEY = 'fairAudienceOccurrenceScrollY';
 					error,
 					__('Failed to sign up. Please try again.', 'fair-audience')
 				);
-				showMessage(
+				renderPaymentError(
 					messageContainer,
+					error,
 					errorMessage,
-					'error',
 					CSS_PREFIX
 				);
 				showNotification(errorMessage, 'error');
@@ -1436,10 +1437,10 @@ const SCROLL_RESTORE_KEY = 'fairAudienceOccurrenceScrollY';
 					error,
 					__('Failed to sign up. Please try again.', 'fair-audience')
 				);
-				showMessage(
+				renderPaymentError(
 					messageContainer,
+					error,
 					errorMessage,
-					'error',
 					CSS_PREFIX
 				);
 				showNotification(errorMessage, 'error');

--- a/fair-audience/src/blocks/event-signup/style.css
+++ b/fair-audience/src/blocks/event-signup/style.css
@@ -157,6 +157,20 @@
 	border: 1px solid #bee5eb;
 }
 
+.fair-audience-signup-message-text {
+	margin: 0;
+}
+
+.fair-audience-signup-message-admin-cause {
+	margin: 0.5em 0 0;
+	font-style: italic;
+}
+
+.fair-audience-signup-message-admin-links {
+	margin: 0.5em 0 0;
+	padding-left: 1.25em;
+}
+
 /* Not linked message */
 .fair-audience-signup-not-linked {
 	padding: 20px;

--- a/fair-events-shared/src/__tests__/payment-flow.test.js
+++ b/fair-events-shared/src/__tests__/payment-flow.test.js
@@ -1,0 +1,170 @@
+import { renderPaymentError } from '../payment-flow.js';
+
+describe('renderPaymentError', () => {
+	let container;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		container = document.createElement('div');
+		container.className = 'fair-payments-connector-error';
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	test('no-ops when container is null', () => {
+		expect(() =>
+			renderPaymentError(
+				null,
+				{},
+				'Default message',
+				'fair-payments-connector'
+			)
+		).not.toThrow();
+	});
+
+	test('shows the generic message and no admin block for a plain error', () => {
+		const error = { message: 'The payment could not be started.' };
+
+		renderPaymentError(
+			container,
+			error,
+			'Default message',
+			'fair-payments-connector'
+		);
+
+		expect(container.style.display).toBe('block');
+		expect(container.textContent).toContain(
+			'The payment could not be started.'
+		);
+		expect(
+			container.querySelector(
+				'.fair-payments-connector-message-admin-cause'
+			)
+		).toBeNull();
+		expect(
+			container.querySelector(
+				'.fair-payments-connector-message-admin-links'
+			)
+		).toBeNull();
+	});
+
+	test('preserves the container original class so callers can re-query it', () => {
+		renderPaymentError(
+			container,
+			{ message: 'Failed' },
+			'Default message',
+			'fair-payments-connector'
+		);
+
+		expect(
+			container.classList.contains('fair-payments-connector-error')
+		).toBe(true);
+	});
+
+	test('renders the interpreted cause and links when error.data.admin is present', () => {
+		const error = {
+			message: 'The payment could not be started.',
+			data: {
+				admin: {
+					cause: 'The connected Mollie profile has no suitable payment method enabled.',
+					links: [
+						{
+							label: 'Payment settings',
+							url: 'https://example.test/wp-admin/admin.php?page=fair-payments-connector-settings',
+						},
+						{
+							label: 'Payment log',
+							url: 'https://example.test/wp-admin/admin.php?page=fair-payments-connector-transaction&transaction_id=42',
+						},
+						{
+							label: 'Mollie dashboard',
+							url: 'https://my.mollie.com/dashboard',
+						},
+					],
+				},
+			},
+		};
+
+		renderPaymentError(
+			container,
+			error,
+			'Default message',
+			'fair-payments-connector'
+		);
+
+		const causeEl = container.querySelector(
+			'.fair-payments-connector-message-admin-cause'
+		);
+		expect(causeEl).not.toBeNull();
+		expect(causeEl.textContent).toBe(
+			'The connected Mollie profile has no suitable payment method enabled.'
+		);
+
+		const links = container.querySelectorAll(
+			'.fair-payments-connector-message-admin-links a'
+		);
+		expect(links).toHaveLength(3);
+		expect(links[0].textContent).toBe('Payment settings');
+		expect(links[0].getAttribute('href')).toBe(
+			'https://example.test/wp-admin/admin.php?page=fair-payments-connector-settings'
+		);
+		expect(links[2].textContent).toBe('Mollie dashboard');
+	});
+
+	test('does not auto-hide when admin detail is present', () => {
+		const error = {
+			message: 'The payment could not be started.',
+			data: { admin: { cause: 'Cause', links: [] } },
+		};
+
+		renderPaymentError(
+			container,
+			error,
+			'Default message',
+			'fair-payments-connector'
+		);
+		jest.advanceTimersByTime(10000);
+
+		expect(container.style.display).toBe('block');
+	});
+
+	test('auto-hides after 8s when there is no admin detail', () => {
+		renderPaymentError(
+			container,
+			{ message: 'Failed' },
+			'Default message',
+			'fair-payments-connector'
+		);
+		jest.advanceTimersByTime(8000);
+
+		expect(container.style.display).toBe('none');
+	});
+
+	test('clears previously rendered content on re-render', () => {
+		renderPaymentError(
+			container,
+			{
+				message: 'First failure',
+				data: { admin: { cause: 'First cause', links: [] } },
+			},
+			'Default message',
+			'fair-payments-connector'
+		);
+		renderPaymentError(
+			container,
+			{ message: 'Second failure' },
+			'Default message',
+			'fair-payments-connector'
+		);
+
+		expect(container.textContent).toContain('Second failure');
+		expect(container.textContent).not.toContain('First cause');
+		expect(
+			container.querySelector(
+				'.fair-payments-connector-message-admin-cause'
+			)
+		).toBeNull();
+	});
+});

--- a/fair-events-shared/src/payment-flow.js
+++ b/fair-events-shared/src/payment-flow.js
@@ -144,6 +144,82 @@ export function handlePaymentCallback({
 }
 
 /**
+ * Render a sanitized payment-creation error into a message container.
+ *
+ * Always shows the generic message from `error`/`defaultMessage` (via
+ * `extractErrorMessage`), matching plain error rendering elsewhere. When the
+ * REST error additionally carries `error.data.admin` (only present for a
+ * capability-checked admin — see `PaymentGatewayError::to_wp_error()` in the
+ * connector), it appends the interpreted cause and fix-it links below the
+ * message; both cause and link labels arrive already-translated from PHP, so
+ * no client-side string-building is needed. Adds (never replaces) CSS
+ * classes, so callers that re-query the container by its original class
+ * (e.g. `.fair-payments-connector-error`) keep finding it on retry.
+ *
+ * @param {HTMLElement|null} container    Message container element. No-op when null.
+ * @param {Object}           error        Error object from apiFetch (or any error with a `.data.admin` shape).
+ * @param {string}           defaultMessage Fallback message when the error has none.
+ * @param {string}           cssPrefix    CSS class prefix (e.g. 'fair-payments-connector').
+ */
+export function renderPaymentError(
+	container,
+	error,
+	defaultMessage,
+	cssPrefix
+) {
+	if (!container) {
+		return;
+	}
+
+	const message = extractErrorMessage(error, defaultMessage);
+	const admin = error && error.data && error.data.admin;
+
+	container.classList.add(
+		cssPrefix + '-message',
+		cssPrefix + '-message-error'
+	);
+	container.textContent = '';
+	container.style.display = 'block';
+
+	const messageEl = document.createElement('p');
+	messageEl.className = cssPrefix + '-message-text';
+	messageEl.textContent = message;
+	container.appendChild(messageEl);
+
+	if (admin && admin.cause) {
+		const causeEl = document.createElement('p');
+		causeEl.className = cssPrefix + '-message-admin-cause';
+		causeEl.textContent = admin.cause;
+		container.appendChild(causeEl);
+	}
+
+	if (admin && Array.isArray(admin.links) && admin.links.length > 0) {
+		const list = document.createElement('ul');
+		list.className = cssPrefix + '-message-admin-links';
+		admin.links.forEach(function (link) {
+			const item = document.createElement('li');
+			const anchor = document.createElement('a');
+			anchor.href = link.url;
+			anchor.textContent = link.label;
+			anchor.target = '_blank';
+			anchor.rel = 'noopener noreferrer';
+			item.appendChild(anchor);
+			list.appendChild(item);
+		});
+		container.appendChild(list);
+	}
+
+	// Auto-hide like plain error messages elsewhere, but only when there is no
+	// admin guidance to read — an admin following the links needs more than a
+	// few seconds before the container disappears under them.
+	if (!admin) {
+		setTimeout(function () {
+			container.style.display = 'none';
+		}, 8000);
+	}
+}
+
+/**
  * Wire a "try again" button that clears the callback URL params and restores
  * the form to a fresh state so the buyer can start a new payment attempt.
  *

--- a/fair-payments-connector/__tests__/Fair_Test_WPDB.php
+++ b/fair-payments-connector/__tests__/Fair_Test_WPDB.php
@@ -25,7 +25,16 @@ class Fair_Test_WPDB {
 	public $insert_id = 1;
 
 	/**
-	 * Stub of $wpdb->insert() — always succeeds.
+	 * Rows passed to insert(), in call order — lets tests assert on what a
+	 * repository actually wrote (e.g. PaymentLogRepository::log() context)
+	 * without a real database.
+	 *
+	 * @var array[]
+	 */
+	public $inserted_rows = array();
+
+	/**
+	 * Stub of $wpdb->insert() — always succeeds and records the row.
 	 *
 	 * @param string $table  Table name.
 	 * @param array  $data   Row data.
@@ -33,6 +42,7 @@ class Fair_Test_WPDB {
 	 * @return int Number of rows inserted (always 1).
 	 */
 	public function insert( $table, $data, $format = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$this->inserted_rows[] = $data;
 		return 1;
 	}
 }

--- a/fair-payments-connector/__tests__/Fair_Test_WP_Error.php
+++ b/fair-payments-connector/__tests__/Fair_Test_WP_Error.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Minimal fake WP_Error for PHPUnit bootstrap.
+ *
+ * @package FairPaymentsConnector
+ */
+
+if ( class_exists( 'WP_Error' ) ) {
+	return;
+}
+
+/**
+ * Minimal stub of WordPress' WP_Error, enough for PaymentGatewayError tests
+ * to assert on code/message/data without a full WP bootstrap.
+ */
+class WP_Error {
+
+	/**
+	 * Error code.
+	 *
+	 * @var string
+	 */
+	private $code;
+
+	/**
+	 * Error message.
+	 *
+	 * @var string
+	 */
+	private $message;
+
+	/**
+	 * Error data.
+	 *
+	 * @var mixed
+	 */
+	private $data;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $code    Error code.
+	 * @param string $message Error message.
+	 * @param mixed  $data    Optional error data.
+	 */
+	public function __construct( $code = '', $message = '', $data = null ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	/**
+	 * Get the error code.
+	 *
+	 * @return string
+	 */
+	public function get_error_code() {
+		return $this->code;
+	}
+
+	/**
+	 * Get the error message.
+	 *
+	 * @return string
+	 */
+	public function get_error_message() {
+		return $this->message;
+	}
+
+	/**
+	 * Get the error data.
+	 *
+	 * @return mixed
+	 */
+	public function get_error_data() {
+		return $this->data;
+	}
+}

--- a/fair-payments-connector/__tests__/Payment/MolliePaymentHandlerTest.php
+++ b/fair-payments-connector/__tests__/Payment/MolliePaymentHandlerTest.php
@@ -15,6 +15,8 @@ namespace FairPaymentsConnector\Tests\Payment;
 
 use PHPUnit\Framework\TestCase;
 use FairPaymentsConnector\Payment\MolliePaymentHandler;
+use FairPaymentsConnector\Payment\PaymentGatewayError;
+use FairPaymentsConnector\Payment\PaymentGatewayException;
 use FairPaymentsConnector\Database\PaymentLogRepository;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Fake\MockResponse;
@@ -38,6 +40,8 @@ class MolliePaymentHandlerTest extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['_fair_test_options']    = array();
 		$GLOBALS['_fair_test_transients'] = array();
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.
+		$GLOBALS['wpdb'] = new \Fair_Test_WPDB();
 		PaymentLogRepository::reset_request_id();
 	}
 
@@ -312,5 +316,70 @@ class MolliePaymentHandlerTest extends TestCase {
 		$this->expectExceptionMessageMatches( '/not configured/' );
 
 		$handler->get_connection_overview();
+	}
+
+	/**
+	 * Regression lock for #1209: a Mollie API error must surface as a typed
+	 * PaymentGatewayException carrying a sanitized PaymentGatewayError — never
+	 * as a raw \Exception whose message embeds the request body/IDs/URLs.
+	 */
+	public function test_create_payment_throws_payment_gateway_exception_on_api_error() {
+		$mollie = MollieApiClient::fake(
+			array(
+				CreatePaymentRequest::class => MockResponse::unprocessableEntity( 'The payment method is not activated on your account.' ),
+			)
+		);
+
+		$handler = new MolliePaymentHandler( $mollie );
+
+		try {
+			$handler->create_payment( array( 'amount' => '10.00' ) );
+			$this->fail( 'Expected PaymentGatewayException was not thrown.' );
+		} catch ( PaymentGatewayException $e ) {
+			$this->assertInstanceOf( PaymentGatewayError::class, $e->get_error() );
+			// The exception's own message (e.g. surfaced by an uncaught-exception
+			// handler/logger elsewhere) must not carry the gateway dump either.
+			$this->assertStringNotContainsString( 'Request body', $e->getMessage() );
+			$this->assertStringNotContainsString( 'redirectUrl', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * The full technical detail (including the request body) must still reach
+	 * the payment log — it moves there exclusively instead of the thrown
+	 * exception, it doesn't disappear.
+	 */
+	public function test_create_payment_logs_full_detail_on_api_error() {
+		$mollie = MollieApiClient::fake(
+			array(
+				CreatePaymentRequest::class => MockResponse::unprocessableEntity( 'The payment method is not activated on your account.' ),
+			)
+		);
+
+		$handler = new MolliePaymentHandler( $mollie );
+
+		try {
+			$handler->create_payment(
+				array(
+					'amount'   => '10.00',
+					'metadata' => array( 'transaction_id' => 7 ),
+				)
+			);
+		} catch ( PaymentGatewayException $e ) {
+			unset( $e );
+		}
+
+		$logged_rows = $GLOBALS['wpdb']->inserted_rows;
+		$failure_row = current(
+			array_filter( $logged_rows, static fn( $row ) => 'mollie_call_failed' === $row['event'] )
+		);
+
+		$this->assertNotFalse( $failure_row, 'Expected a mollie_call_failed log row.' );
+		$this->assertSame( 'error', $failure_row['level'] );
+		$this->assertSame( 7, $failure_row['transaction_id'] );
+		$this->assertStringContainsString( 'not activated', $failure_row['message'] );
+
+		$context = json_decode( $failure_row['context'], true );
+		$this->assertStringContainsString( 'not activated', $context['exception_message'] );
 	}
 }

--- a/fair-payments-connector/__tests__/Payment/PaymentGatewayErrorTest.php
+++ b/fair-payments-connector/__tests__/Payment/PaymentGatewayErrorTest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * PaymentGatewayError interpretation and sanitization tests.
+ *
+ * Locks the security-critical guarantee behind #1209: the WP_Error returned
+ * to REST consumers never carries the gateway's decorated message (request
+ * body, IDs, URLs) — only a generic visitor message plus, for a
+ * capability-checked admin, an interpreted cause and fix-it links built from
+ * stable identifiers (status + plain message).
+ *
+ * @package FairPaymentsConnector
+ */
+
+namespace FairPaymentsConnector\Tests\Payment;
+
+use PHPUnit\Framework\TestCase;
+use FairPaymentsConnector\Payment\PaymentGatewayError;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\CreatePaymentRequest;
+use Mollie\Api\Exceptions\ApiException;
+
+/**
+ * Unit tests for PaymentGatewayError.
+ */
+class PaymentGatewayErrorTest extends TestCase {
+
+	/**
+	 * Reset shared test state before each test.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['_fair_test_current_user_can'] = false;
+	}
+
+	/**
+	 * Drive a real ApiException out of the Mollie SDK's fake HTTP layer, the
+	 * same way MolliePaymentHandlerTest does, so we test against the SDK's
+	 * actual decorated-message shape rather than a hand-rolled stand-in.
+	 *
+	 * @param int    $status HTTP status code.
+	 * @param string $title  Error title (e.g. 'Unprocessable Entity').
+	 * @param string $detail Error detail — the text interpretation matches against.
+	 * @return ApiException
+	 */
+	private function api_exception( int $status, string $title, string $detail ): ApiException {
+		$mollie = MollieApiClient::fake(
+			array(
+				CreatePaymentRequest::class => MockResponse::error( $status, $title, $detail ),
+			)
+		);
+
+		try {
+			$mollie->payments->create(
+				array(
+					'amount'      => array(
+						'currency' => 'EUR',
+						'value'    => '10.00',
+					),
+					'description' => 'Test',
+					'redirectUrl' => 'https://example.test',
+				),
+				array(),
+				true
+			);
+		} catch ( ApiException $e ) {
+			return $e;
+		}
+
+		$this->fail( 'Expected ApiException was not thrown.' );
+	}
+
+	/**
+	 * The "not activated" 422 must be recognised and produce the specific
+	 * cause plus Settings, payment log, and Mollie dashboard links.
+	 */
+	public function test_not_activated_error_is_recognised_for_admin() {
+		$GLOBALS['_fair_test_current_user_can'] = true;
+
+		$e     = $this->api_exception( 422, 'Unprocessable Entity', 'The payment method is not activated on your account.' );
+		$error = PaymentGatewayError::from_api_exception( $e )->to_wp_error( 42 );
+
+		$admin = $error->get_error_data()['admin'];
+
+		$this->assertStringContainsString( 'no suitable payment method enabled', $admin['cause'] );
+
+		$labels = array_column( $admin['links'], 'label' );
+		$this->assertContains( 'Payment settings', $labels );
+		$this->assertContains( 'Payment log', $labels );
+		$this->assertContains( 'Mollie dashboard', $labels );
+
+		$log_link = current(
+			array_filter( $admin['links'], static fn( $link ) => 'Payment log' === $link['label'] )
+		);
+		$this->assertStringContainsString( 'transaction_id=42', $log_link['url'] );
+	}
+
+	/**
+	 * An unrecognised gateway error must fall back to a generic cause with
+	 * Settings + log links only — no dashboard link, since we don't know the
+	 * cause is method-activation-related.
+	 */
+	public function test_unrecognised_error_falls_back_to_generic_cause() {
+		$GLOBALS['_fair_test_current_user_can'] = true;
+
+		$e     = $this->api_exception( 500, 'Internal Server Error', 'Something unexpected happened deep in the gateway.' );
+		$error = PaymentGatewayError::from_api_exception( $e )->to_wp_error( 42 );
+
+		$admin = $error->get_error_data()['admin'];
+
+		$labels = array_column( $admin['links'], 'label' );
+		$this->assertContains( 'Payment settings', $labels );
+		$this->assertContains( 'Payment log', $labels );
+		$this->assertNotContains( 'Mollie dashboard', $labels );
+	}
+
+	/**
+	 * A non-gateway failure (no ApiException at all) must also fall back to
+	 * the generic cause — the fallback path in TransactionAPI::initiate_payment()
+	 * uses PaymentGatewayError::generic() for this case.
+	 */
+	public function test_generic_error_has_no_gateway_specific_cause() {
+		$GLOBALS['_fair_test_current_user_can'] = true;
+
+		$error = PaymentGatewayError::generic()->to_wp_error( 42 );
+		$admin = $error->get_error_data()['admin'];
+
+		$labels = array_column( $admin['links'], 'label' );
+		$this->assertContains( 'Payment settings', $labels );
+		$this->assertNotContains( 'Mollie dashboard', $labels );
+	}
+
+	/**
+	 * `data.admin` must be present only for a capability-checked admin —
+	 * never for an anonymous visitor, even for the recognised error case.
+	 */
+	public function test_admin_detail_is_capability_gated() {
+		$e = $this->api_exception( 422, 'Unprocessable Entity', 'The payment method is not activated on your account.' );
+
+		$GLOBALS['_fair_test_current_user_can'] = false;
+		$anonymous_error                        = PaymentGatewayError::from_api_exception( $e )->to_wp_error( 42 );
+		$this->assertArrayNotHasKey( 'admin', $anonymous_error->get_error_data() );
+
+		$GLOBALS['_fair_test_current_user_can'] = true;
+		$admin_error                            = PaymentGatewayError::from_api_exception( $e )->to_wp_error( 42 );
+		$this->assertArrayHasKey( 'admin', $admin_error->get_error_data() );
+	}
+
+	/**
+	 * The public message and data must never contain the gateway's raw
+	 * request-body/timestamp/documentation dump — the entire point of #1209.
+	 */
+	public function test_to_wp_error_never_leaks_raw_gateway_dump() {
+		$GLOBALS['_fair_test_current_user_can'] = true;
+
+		$e = $this->api_exception( 422, 'Unprocessable Entity', 'The payment method is not activated on your account.' );
+
+		// Sanity check: the SDK's own decorated message does contain the leak
+		// this test guards against, so the assertion below is meaningful.
+		$this->assertStringContainsString( 'Request body', $e->getMessage() );
+
+		$error = PaymentGatewayError::from_api_exception( $e )->to_wp_error( 42 );
+		$dump  = wp_json_encode(
+			array(
+				$error->get_error_message(),
+				$error->get_error_data(),
+			)
+		);
+		$this->assertStringNotContainsString( 'Request body', $dump );
+		$this->assertStringNotContainsString( 'Documentation:', $dump );
+		$this->assertStringNotContainsString( 'redirectUrl', $dump );
+	}
+
+	/**
+	 * The generic visitor-facing message itself must never vary with the
+	 * gateway cause — only `data.admin` does.
+	 */
+	public function test_public_message_is_always_the_same_generic_string() {
+		$activation_error = PaymentGatewayError::from_api_exception(
+			$this->api_exception( 422, 'Unprocessable Entity', 'The payment method is not activated on your account.' )
+		)->to_wp_error( 42 );
+
+		$unknown_error = PaymentGatewayError::generic()->to_wp_error( 42 );
+
+		$this->assertSame( $activation_error->get_error_message(), $unknown_error->get_error_message() );
+	}
+}

--- a/fair-payments-connector/__tests__/bootstrap.php
+++ b/fair-payments-connector/__tests__/bootstrap.php
@@ -107,6 +107,35 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+if ( ! function_exists( 'current_user_can' ) ) {
+	/**
+	 * Stub of WordPress current_user_can() backed by $GLOBALS['_fair_test_current_user_can'].
+	 *
+	 * Tests toggle this global to simulate an anonymous visitor (false, the
+	 * default) vs. a capability-checked admin (true).
+	 *
+	 * @param string $capability Capability to check (ignored — tests set a single bool).
+	 * @return bool
+	 */
+	function current_user_can( $capability ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return ! empty( $GLOBALS['_fair_test_current_user_can'] );
+	}
+}
+
+if ( ! function_exists( 'admin_url' ) ) {
+	/**
+	 * Stub of WordPress admin_url().
+	 *
+	 * @param string $path Path appended to the admin URL.
+	 * @return string
+	 */
+	function admin_url( $path = '' ) {
+		return 'https://example.test/wp-admin/' . ltrim( $path, '/' );
+	}
+}
+
+require_once __DIR__ . '/Fair_Test_WP_Error.php';
+
 if ( ! function_exists( 'get_current_user_id' ) ) {
 	/**
 	 * Stub of WordPress get_current_user_id() — no logged-in user in tests.

--- a/fair-payments-connector/src/API/PaymentEndpoint.php
+++ b/fair-payments-connector/src/API/PaymentEndpoint.php
@@ -363,11 +363,10 @@ class PaymentEndpoint extends WP_REST_Controller {
 					),
 				)
 			);
-			return new WP_Error(
-				'payment_initiation_failed',
-				$payment->get_error_message(),
-				array( 'status' => 500 )
-			);
+			// Return as-is: initiate_payment() already sanitizes the message and
+			// sets status/admin data, so re-wrapping here would strip data.admin
+			// and re-flatten the status to a hardcoded 500.
+			return $payment;
 		}
 
 		$logger->log(

--- a/fair-payments-connector/src/API/TransactionAPI.php
+++ b/fair-payments-connector/src/API/TransactionAPI.php
@@ -10,6 +10,8 @@ namespace FairPaymentsConnector\API;
 use FairPaymentsConnector\Models\Transaction;
 use FairPaymentsConnector\Models\LineItem;
 use FairPaymentsConnector\Payment\MolliePaymentHandler;
+use FairPaymentsConnector\Payment\PaymentGatewayError;
+use FairPaymentsConnector\Payment\PaymentGatewayException;
 use FairPaymentsConnector\Payment\WorkingDays;
 use FairPaymentsConnector\Database\PaymentLogRepository;
 
@@ -213,11 +215,23 @@ class TransactionAPI {
 		try {
 			$handler        = new MolliePaymentHandler();
 			$mollie_payment = $handler->create_payment( $payment_args );
+		} catch ( PaymentGatewayException $e ) {
+			return $e->get_error()->to_wp_error( (int) $transaction_id );
 		} catch ( \Exception $e ) {
-			return new \WP_Error(
+			// Non-gateway failure (e.g. missing API key/OAuth connection). Full
+			// detail is logged here; the public response stays fully generic —
+			// this is the security-critical fallback, since $e->getMessage()
+			// must never reach an anonymous visitor.
+			$logger->log(
 				'mollie_payment_failed',
-				$e->getMessage()
+				array(
+					'level'          => 'error',
+					'transaction_id' => (int) $transaction_id,
+					'message'        => sprintf( 'Payment initiation failed: %s', $e->getMessage() ),
+					'context'        => array( 'exception_class' => get_class( $e ) ),
+				)
 			);
+			return PaymentGatewayError::generic()->to_wp_error( (int) $transaction_id );
 		}
 
 		// 6. Update transaction.

--- a/fair-payments-connector/src/Payment/MolliePaymentHandler.php
+++ b/fair-payments-connector/src/Payment/MolliePaymentHandler.php
@@ -276,7 +276,7 @@ class MolliePaymentHandler {
 	 *
 	 * @param array $args Payment arguments.
 	 * @return array Payment data including mollie_payment_id and checkout_url.
-	 * @throws \Exception If the underlying Mollie call fails.
+	 * @throws PaymentGatewayException If the Mollie API call fails.
 	 */
 	public function create_payment( $args ) {
 		$defaults = array(
@@ -406,15 +406,8 @@ class MolliePaymentHandler {
 					),
 				)
 			);
-			throw new \Exception(
-				esc_html(
-					sprintf(
-						/* translators: %s: error message */
-						__( 'Failed to create payment: %s', 'fair-payments-connector' ),
-						$e->getMessage()
-					)
-				)
-			);
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- constructor takes a PaymentGatewayError value object, not a message string; nothing here is unescaped output.
+			throw new PaymentGatewayException( PaymentGatewayError::from_api_exception( $e ) );
 		}
 	}
 

--- a/fair-payments-connector/src/Payment/PaymentGatewayError.php
+++ b/fair-payments-connector/src/Payment/PaymentGatewayError.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Sanitized payment-gateway error
+ *
+ * @package FairPaymentsConnector
+ */
+
+namespace FairPaymentsConnector\Payment;
+
+use Mollie\Api\Exceptions\ApiException;
+use WP_Error;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Interprets a gateway failure into a visitor-safe message plus, for
+ * capability-checked admins only, a plain-language cause and links to fix it.
+ *
+ * Built from stable identifiers (HTTP status, Mollie's plain message,
+ * dashboard link) — never from the raw decorated exception message, which
+ * contains the request body, IDs, and URLs. Unrecognised errors (unknown
+ * gateway responses, or failures with no `ApiException` at all) fall back to
+ * a generic cause with no gateway-specific detail.
+ */
+class PaymentGatewayError {
+
+	/**
+	 * Fallback Mollie dashboard URL used when the exception carries none.
+	 *
+	 * @var string
+	 */
+	const DEFAULT_DASHBOARD_URL = 'https://my.mollie.com/dashboard';
+
+	/**
+	 * Gateway HTTP status code, or 0 when not derived from an ApiException.
+	 *
+	 * @var int
+	 */
+	private $status;
+
+	/**
+	 * Mollie's plain error message (no timestamp, docs link, or request body).
+	 *
+	 * @var string
+	 */
+	private $plain_message;
+
+	/**
+	 * Gateway-provided dashboard URL for this error, if any.
+	 *
+	 * @var string|null
+	 */
+	private $dashboard_url;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int         $status        Gateway HTTP status code (0 if unknown).
+	 * @param string      $plain_message Plain gateway message (no request body).
+	 * @param string|null $dashboard_url Gateway-provided dashboard URL, if any.
+	 */
+	private function __construct( int $status, string $plain_message, ?string $dashboard_url ) {
+		$this->status        = $status;
+		$this->plain_message = $plain_message;
+		$this->dashboard_url = $dashboard_url;
+	}
+
+	/**
+	 * Build from a Mollie ApiException, capturing only stable identifiers.
+	 *
+	 * @param ApiException $e The caught gateway exception.
+	 * @return self
+	 */
+	public static function from_api_exception( ApiException $e ): self {
+		return new self( $e->getStatusCode(), $e->getPlainMessage(), $e->getDashboardUrl() );
+	}
+
+	/**
+	 * Build a generic, unrecognised error (e.g. a non-gateway failure such as
+	 * a misconfigured API key, or a gateway response we don't interpret).
+	 *
+	 * @return self
+	 */
+	public static function generic(): self {
+		return new self( 0, '', null );
+	}
+
+	/**
+	 * Build the sanitized WP_Error returned to REST consumers.
+	 *
+	 * The message is always the generic visitor-facing string. Admin-only
+	 * detail (interpreted cause + fix-it links) is added under `data.admin`
+	 * only when the current user can manage the plugin.
+	 *
+	 * @param int|null $transaction_id Transaction ID, for the payment-log link.
+	 * @return WP_Error
+	 */
+	public function to_wp_error( ?int $transaction_id ): WP_Error {
+		$data = array( 'status' => 502 );
+
+		if ( current_user_can( 'manage_options' ) ) {
+			$data['admin'] = $this->build_admin_detail( $transaction_id );
+		}
+
+		return new WP_Error(
+			'payment_creation_failed',
+			__( 'The payment could not be started. Please try again later or contact the organizer.', 'fair-payments-connector' ),
+			$data
+		);
+	}
+
+	/**
+	 * Build the admin-only cause + links, keyed on stable identifiers.
+	 *
+	 * @param int|null $transaction_id Transaction ID, for the payment-log link.
+	 * @return array{cause: string, links: array<int, array{label: string, url: string}>}
+	 */
+	private function build_admin_detail( ?int $transaction_id ): array {
+		$links = array(
+			array(
+				'label' => __( 'Payment settings', 'fair-payments-connector' ),
+				'url'   => admin_url( 'admin.php?page=fair-payments-connector-settings' ),
+			),
+		);
+
+		if ( $transaction_id ) {
+			$links[] = array(
+				'label' => __( 'Payment log', 'fair-payments-connector' ),
+				'url'   => admin_url( 'admin.php?page=fair-payments-connector-transaction&transaction_id=' . $transaction_id ),
+			);
+		}
+
+		if ( $this->is_method_not_activated() ) {
+			$links[] = array(
+				'label' => __( 'Mollie dashboard', 'fair-payments-connector' ),
+				'url'   => $this->dashboard_url ? $this->dashboard_url : self::DEFAULT_DASHBOARD_URL,
+			);
+
+			return array(
+				'cause' => __( 'The connected Mollie profile has no suitable payment method enabled.', 'fair-payments-connector' ),
+				'links' => $links,
+			);
+		}
+
+		return array(
+			'cause' => __( 'The payment gateway rejected the request. See the payment log for technical details.', 'fair-payments-connector' ),
+			'links' => $links,
+		);
+	}
+
+	/**
+	 * Whether this is Mollie's "payment method is not activated on your
+	 * account" error — a 422 with a stable, identifiable plain message.
+	 *
+	 * @return bool
+	 */
+	private function is_method_not_activated(): bool {
+		return 422 === $this->status && false !== stripos( $this->plain_message, 'not activated' );
+	}
+}

--- a/fair-payments-connector/src/Payment/PaymentGatewayException.php
+++ b/fair-payments-connector/src/Payment/PaymentGatewayException.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Typed exception carrying a sanitized payment-gateway error
+ *
+ * @package FairPaymentsConnector
+ */
+
+namespace FairPaymentsConnector\Payment;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Thrown by MolliePaymentHandler::create_payment() in place of a raw
+ * \Exception so the public error path never sees the gateway's decorated
+ * message (request body, IDs, URLs) — only the already-sanitized
+ * PaymentGatewayError it carries.
+ */
+class PaymentGatewayException extends \Exception {
+
+	/**
+	 * The sanitized error to surface to REST consumers.
+	 *
+	 * @var PaymentGatewayError
+	 */
+	private $error;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param PaymentGatewayError $error Sanitized error.
+	 */
+	public function __construct( PaymentGatewayError $error ) {
+		parent::__construct( 'Payment gateway rejected the request.' );
+		$this->error = $error;
+	}
+
+	/**
+	 * Get the sanitized error.
+	 *
+	 * @return PaymentGatewayError
+	 */
+	public function get_error(): PaymentGatewayError {
+		return $this->error;
+	}
+}

--- a/fair-payments-connector/src/blocks/simple-payment/view.js
+++ b/fair-payments-connector/src/blocks/simple-payment/view.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	initiatePayment,
 	handlePaymentCallback,
+	renderPaymentError,
 	wireRestartButton,
 } from 'fair-events-shared';
 
@@ -176,11 +177,13 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 						'Failed to create payment',
 						'fair-payments-connector'
 					),
-					onError: (message) => {
-						if (errorEl) {
-							errorEl.textContent = message;
-							errorEl.style.display = 'block';
-						}
+					onError: (message, error) => {
+						renderPaymentError(
+							errorEl,
+							error,
+							message,
+							'fair-payments-connector'
+						);
 						if (loadingEl) {
 							loadingEl.style.display = 'none';
 						}


### PR DESCRIPTION
## Summary

- The raw Mollie `ApiException` message — timestamp, docs link, and the full
  `Request body` (metadata, profile ID, signed redirect URLs) — was rethrown
  almost verbatim from `MolliePaymentHandler::create_payment()` through
  `TransactionAPI::initiate_payment()` and shown to anonymous visitors on
  both the payment block and the event signup form.
- `create_payment()` now throws a typed `PaymentGatewayException` carrying a
  new `PaymentGatewayError` value object, built only from stable identifiers
  (HTTP status + Mollie's plain message) — never the decorated dump.
- `initiate_payment()` is the single sanitization boundary for both
  consumers: every visitor gets a generic "the payment could not be
  started" message; a capability-checked admin (`manage_options`)
  additionally gets `data.admin` with an interpreted cause and links to the
  payment settings page, the payment log entry, and — for the recognised
  "payment method is not activated" case — the Mollie dashboard.
- The non-gateway exception fallback in `initiate_payment()` (misconfigured
  API key, missing OAuth connection, etc.) is now also generic — previously
  it returned `$e->getMessage()` verbatim for *any* failure, not just Mollie
  API errors, which was its own smaller leak.
- `PaymentEndpoint::create_payment()` no longer re-wraps the `WP_Error` from
  `initiate_payment()`, since re-wrapping was dropping `data.admin` and
  flattening the status to a hardcoded 500.
- New shared `renderPaymentError()` helper in `fair-events-shared` renders
  the generic message everywhere, and appends the admin cause/links only
  when `error.data.admin` is present — wired into both the payment block
  (`view.js`) and the event signup flow (`frontend.js`), so interpretation
  lives once in the connector and both consumers inherit it.
- Full technical detail (including the request body) continues to be
  recorded in the payment log exclusively — verified by tests that the
  sanitized `WP_Error` never contains it, for both the recognised and
  unrecognised error cases.

Closes #1209

## Notes

- Scoped to the gateway `ApiException` path named in the ticket. Left the
  adjacent `mollie_not_configured` / `transaction_creation_failed` strings
  in `PaymentEndpoint` alone — the ticket's own implementation plan flagged
  folding those in as an open question, and neither leaks a raw gateway
  dump (the actual security issue here).
- No new `.api.spec.js` assertion for the sanitized response: CI has no
  Mollie credentials, and the SDK's HTTP transport isn't interceptable via
  `pre_http_request`, so a gateway 422 can't be driven over HTTP in that
  environment (the endpoint short-circuits at `mollie_not_configured`
  first). Covered instead at the PHPUnit boundary
  (`PaymentGatewayErrorTest`, extended `MolliePaymentHandlerTest`), which
  TESTING.md names as the right tool for exactly this situation.

## Test plan

- [x] `vendor/bin/phpcs` clean on all changed/new PHP files
- [x] `vendor/bin/phpunit` — 25/25 passing (fair-payments-connector), incl.
      new `PaymentGatewayErrorTest` and extended `MolliePaymentHandlerTest`
- [x] `npm run test:js` — passing in fair-payments-connector, fair-audience,
      and fair-events-shared (new `payment-flow.test.js` for
      `renderPaymentError`)
- [x] `npm run build` in fair-payments-connector and fair-audience
- [ ] Manual check: trigger a "payment method not activated" Mollie error as
      an anonymous visitor (generic message only) and as an admin (cause +
      settings/log/dashboard links)
