### PR TITLE
Add mini-calendar visualization to Sale Periods panel

### DIFF
--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -33,6 +33,7 @@ import {
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
+import SalePeriodsCalendar from './SalePeriodsCalendar.js';
 
 export default function EventTickets({
 	eventDateId,
@@ -468,6 +469,10 @@ export default function EventTickets({
 		return diff > 0 ? diff : null;
 	};
 
+	const eventDay = startDatetime
+		? startDatetime.split(' ')[0].split('T')[0]
+		: '';
+
 	// Seeds a single default sale period row so prices have somewhere to
 	// attach, but leaves sale_start/sale_end unset: the effective window is
 	// resolved lazily (open start, day-after-last-occurrence end) rather than
@@ -630,6 +635,21 @@ export default function EventTickets({
 		}
 
 		setSalePeriods(updated);
+	};
+
+	// Maps a SalePeriodsCalendar boundary click onto the chained setter:
+	// boundary 0 is the first period's start, boundary N (the period count)
+	// is the last period's end, and everything in between is the start of
+	// the period at that index (updateSalePeriod's chaining already
+	// propagates it to the previous period's end).
+	const handleMoveSalePeriodBoundary = (boundaryIndex, dateStr) => {
+		if (boundaryIndex === 0) {
+			updateSalePeriod(0, 'sale_start', dateStr);
+		} else if (boundaryIndex === salePeriods.length) {
+			updateSalePeriod(salePeriods.length - 1, 'sale_end', dateStr);
+		} else {
+			updateSalePeriod(boundaryIndex, 'sale_start', dateStr);
+		}
 	};
 
 	// "Multiple pricing periods" toggled on: split the single sale window at
@@ -1012,6 +1032,16 @@ export default function EventTickets({
 										})()}
 									</div>
 								</HStack>
+							)}
+							{salePeriods.length > 0 && (
+								<SalePeriodsCalendar
+									salePeriods={salePeriods}
+									eventDay={eventDay}
+									onMoveBoundary={
+										handleMoveSalePeriodBoundary
+									}
+									embedded
+								/>
 							)}
 							{effectiveMultiple ? (
 								<VStack spacing={3}>

--- a/fair-events/src/Admin/manage-event/SalePeriodsCalendar.js
+++ b/fair-events/src/Admin/manage-event/SalePeriodsCalendar.js
@@ -1,0 +1,237 @@
+/**
+ * Sale Periods Calendar Component
+ *
+ * Month-grid visualization for the "Sale Periods" panel: each day is shaded
+ * with the color of the sale period it falls in, the event day carries a
+ * distinct marker, and clicking a day moves the nearest period boundary
+ * there. Thin adapter over the shared `MiniCalendar` grid/paging primitive,
+ * modeled on RecurrenceCalendar.js (shading + legend) and SeriesModal.js's
+ * irregularDayProps (the interactive click pattern).
+ *
+ * @package FairEvents
+ */
+
+import { Card, CardHeader, CardBody } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { MiniCalendar } from 'fair-events-shared';
+
+// Cycled by period index; every color pairs with white cell text.
+const SALE_PERIOD_COLORS = [
+	'#007cba',
+	'#4ab866',
+	'#9b51e0',
+	'#b26200',
+	'#cc1818',
+];
+
+// Deliberately distinct from MiniCalendar's built-in "today" border
+// (`2px solid #1e1e1e`) so the event-day marker never blends into it when
+// the event happens to be today.
+const EVENT_DAY_BORDER = '3px solid #f0b849';
+
+function dayDiffAbs(dateStrA, dateStrB) {
+	const a = new Date(`${dateStrA}T00:00:00`);
+	const b = new Date(`${dateStrB}T00:00:00`);
+	return Math.abs(Math.round((a - b) / (1000 * 60 * 60 * 24)));
+}
+
+// Describes which boundary a click would move, e.g. "start of 'Regular'" or
+// (unnamed) "period 2". Boundary `salePeriods.length` is the trailing edge
+// of the last period ("end of ..."); every other boundary is the leading
+// edge of the period at that index ("start of ...").
+function boundaryDescriptor(boundaryIndex, salePeriods) {
+	const isLast = boundaryIndex === salePeriods.length;
+	const period = salePeriods[isLast ? salePeriods.length - 1 : boundaryIndex];
+	const periodNumber = isLast ? salePeriods.length : boundaryIndex + 1;
+
+	if (!period?.name) {
+		return sprintf(
+			/* translators: %d: sale period number */
+			__('period %d', 'fair-events'),
+			periodNumber
+		);
+	}
+
+	return isLast
+		? sprintf(
+				/* translators: %s: sale period name */
+				__("end of '%s'", 'fair-events'),
+				period.name
+		  )
+		: sprintf(
+				/* translators: %s: sale period name */
+				__("start of '%s'", 'fair-events'),
+				period.name
+		  );
+}
+
+/**
+ * @param {Object}   props
+ * @param {Array}    props.salePeriods    Chained sale periods (`sale_start`/`sale_end`/`name`, Y-m-d strings); consecutive periods share a boundary.
+ * @param {string}   [props.eventDay]     Event start date (Y-m-d) for the event-day marker.
+ * @param {Function} props.onMoveBoundary `(boundaryIndex, dateStr) => void`, called when a day is clicked.
+ * @param {boolean}  [props.embedded]     Card-less render for placement inside an existing panel.
+ */
+export default function SalePeriodsCalendar({
+	salePeriods,
+	eventDay,
+	onMoveBoundary,
+	embedded = false,
+}) {
+	const periods = salePeriods || [];
+
+	// N periods chain into N+1 boundaries: the first period's start, then
+	// every period's end (each shared with the next period's start).
+	const boundaries =
+		periods.length > 0
+			? [periods[0].sale_start, ...periods.map((p) => p.sale_end)]
+			: [];
+
+	// Hidden while any boundary is still unresolved (e.g. a freshly seeded
+	// default period with a lazily-resolved sale window) — nothing sensible
+	// to shade or click yet.
+	if (boundaries.length === 0 || boundaries.some((b) => !b)) {
+		return null;
+	}
+
+	const lastBoundary = boundaries[boundaries.length - 1];
+	const minDate = boundaries[0];
+	const maxDate =
+		eventDay && eventDay > lastBoundary ? eventDay : lastBoundary;
+
+	// sale_start is inclusive, sale_end is exclusive for every period
+	// (including the last), matching how updateSalePeriod() chains one
+	// period's end into the next one's start — a day never falls in two
+	// periods at once.
+	const periodIndexForDate = (dateStr) =>
+		periods.findIndex(
+			(p) => p.sale_start <= dateStr && dateStr < p.sale_end
+		);
+
+	// The clicked day always sits inside (or at the edge of) some gap
+	// between two boundaries, so moving the nearest one to that day can
+	// never push it past its neighbor — ordering stays intact by construction.
+	const nearestBoundaryIndex = (dateStr) => {
+		let bestIndex = 0;
+		let bestDiff = Infinity;
+		boundaries.forEach((b, i) => {
+			const diff = dayDiffAbs(dateStr, b);
+			if (diff < bestDiff) {
+				bestDiff = diff;
+				bestIndex = i;
+			}
+		});
+		return bestIndex;
+	};
+
+	const dayProps = (dateStr, date) => {
+		const periodIndex = periodIndexForDate(dateStr);
+		const isEventDay = dateStr === eventDay;
+		const boundaryIndex = nearestBoundaryIndex(dateStr);
+
+		const formattedDate = date.toLocaleDateString(undefined, {
+			weekday: 'long',
+			day: 'numeric',
+			month: 'long',
+			year: 'numeric',
+		});
+		const message = sprintf(
+			/* translators: 1: which boundary a click would move (e.g. "start of 'Regular'"), 2: target date */
+			__('Move the %1$s to %2$s', 'fair-events'),
+			boundaryDescriptor(boundaryIndex, periods),
+			formattedDate
+		);
+
+		return {
+			background:
+				periodIndex !== -1
+					? SALE_PERIOD_COLORS[
+							periodIndex % SALE_PERIOD_COLORS.length
+					  ]
+					: 'transparent',
+			color: periodIndex !== -1 ? '#fff' : '#1e1e1e',
+			fontWeight: periodIndex !== -1 ? 600 : 400,
+			border: isEventDay ? EVENT_DAY_BORDER : undefined,
+			interactive: true,
+			onActivate: () => onMoveBoundary(boundaryIndex, dateStr),
+			ariaLabel: message,
+			tooltip: message,
+		};
+	};
+
+	const calendarBody = (
+		<>
+			<MiniCalendar
+				minDate={minDate}
+				maxDate={maxDate}
+				dayProps={dayProps}
+			/>
+			<div
+				style={{
+					marginTop: '16px',
+					display: 'flex',
+					gap: '16px',
+					flexWrap: 'wrap',
+					fontSize: '12px',
+					color: '#757575',
+				}}
+			>
+				{periods.map((period, index) => (
+					<span key={period.id || `period-${index}`}>
+						<span
+							style={{
+								display: 'inline-block',
+								width: '12px',
+								height: '12px',
+								background:
+									SALE_PERIOD_COLORS[
+										index % SALE_PERIOD_COLORS.length
+									],
+								borderRadius: '2px',
+								verticalAlign: 'middle',
+								marginRight: '4px',
+							}}
+						/>
+						{period.name ||
+							sprintf(
+								/* translators: %d: sale period number */
+								__('Period %d', 'fair-events'),
+								index + 1
+							)}
+					</span>
+				))}
+				{eventDay && (
+					<span>
+						<span
+							style={{
+								display: 'inline-block',
+								width: '12px',
+								height: '12px',
+								border: EVENT_DAY_BORDER,
+								borderRadius: '2px',
+								verticalAlign: 'middle',
+								marginRight: '4px',
+							}}
+						/>
+						{__('Event day', 'fair-events')}
+					</span>
+				)}
+			</div>
+		</>
+	);
+
+	if (embedded) {
+		return calendarBody;
+	}
+
+	return (
+		<Card style={{ marginTop: '16px' }}>
+			<CardHeader>
+				<h2 style={{ margin: 0 }}>
+					{__('Sale Periods Timeline', 'fair-events')}
+				</h2>
+			</CardHeader>
+			<CardBody>{calendarBody}</CardBody>
+		</Card>
+	);
+}

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -1116,3 +1116,59 @@ describe('EventTickets — Add-on collaborator discount removed (#1139)', () => 
 		expect(screen.queryByText(/Discounted price/i)).not.toBeInTheDocument();
 	});
 });
+
+describe('EventTickets — SalePeriodsCalendar wiring (#1197)', () => {
+	const initialDataWithTwoPeriods = {
+		...initialDataWithTicketType,
+		sale_periods: [
+			{
+				id: 601,
+				name: 'Advance ticket',
+				sale_start: '2026-01-01',
+				sale_end: '2026-01-15',
+			},
+			{
+				id: 602,
+				name: 'Day of event',
+				sale_start: '2026-01-15',
+				sale_end: '2026-02-01',
+			},
+		],
+		prices: [
+			{ ticket_type_id: 1, sale_period_id: 601, price: '20' },
+			{ ticket_type_id: 1, sale_period_id: 602, price: '5' },
+		],
+	};
+
+	function moveMessage(boundaryLabel, dateStr) {
+		const formatted = new Date(`${dateStr}T00:00:00`).toLocaleDateString(
+			undefined,
+			{ weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' }
+		);
+		return `Move the ${boundaryLabel} to ${formatted}`;
+	}
+
+	it('clicking a calendar day updates both chained date inputs and trips the dirty indicator', () => {
+		const onDirtyChange = jest.fn();
+		renderTickets({
+			initialData: initialDataWithTwoPeriods,
+			startDatetime: '2026-01-25 10:00:00',
+			endDatetime: '2026-02-01 12:00:00',
+			onDirtyChange,
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+
+		const button = screen.getByRole('button', {
+			name: moveMessage("start of 'Day of event'", '2026-01-16'),
+		});
+		fireEvent.click(button);
+
+		// Both the Advance-ticket "Until" input and the Day-of-event "From"
+		// input mirror the moved boundary — updateSalePeriod() chains them.
+		expect(screen.getAllByDisplayValue('2026-01-16')).toHaveLength(2);
+		expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+	});
+});

--- a/fair-events/src/Admin/manage-event/__tests__/SalePeriodsCalendar.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/SalePeriodsCalendar.test.jsx
@@ -1,0 +1,179 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for SalePeriodsCalendar (#1197).
+ *
+ * Covers:
+ *   - Hidden while any boundary is unresolved; shown once every boundary
+ *     (sale_start/sale_end chain) is set, in both single- and
+ *     multi-period shapes.
+ *   - Legend lists every period (name or "Period N") plus the event day.
+ *   - Clicking a day calls onMoveBoundary with the *nearest* boundary
+ *     index and the clicked date — a click near a middle boundary picks
+ *     that boundary, not sale start.
+ *   - The accessible name / tooltip names the exact boundary and target
+ *     date that a click would move.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SalePeriodsCalendar from '../SalePeriodsCalendar.js';
+
+// Matches the message built in SalePeriodsCalendar's dayProps().
+function moveMessage(boundaryLabel, dateStr) {
+	const formatted = new Date(`${dateStr}T00:00:00`).toLocaleDateString(
+		undefined,
+		{ weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' }
+	);
+	return `Move the ${boundaryLabel} to ${formatted}`;
+}
+
+const twoNamedPeriods = [
+	{
+		id: 1,
+		name: 'Early bird',
+		sale_start: '2026-08-01',
+		sale_end: '2026-08-15',
+	},
+	{
+		id: 2,
+		name: 'Regular',
+		sale_start: '2026-08-15',
+		sale_end: '2026-09-01',
+	},
+];
+
+it('renders nothing when a boundary is unresolved (freshly seeded default)', () => {
+	const { container } = render(
+		<SalePeriodsCalendar
+			salePeriods={[{ name: '', sale_start: '', sale_end: '' }]}
+			eventDay="2026-09-05"
+			onMoveBoundary={() => {}}
+			embedded
+		/>
+	);
+	expect(container).toBeEmptyDOMElement();
+});
+
+it('renders nothing when there are no sale periods', () => {
+	const { container } = render(
+		<SalePeriodsCalendar
+			salePeriods={[]}
+			eventDay="2026-09-05"
+			onMoveBoundary={() => {}}
+			embedded
+		/>
+	);
+	expect(container).toBeEmptyDOMElement();
+});
+
+it('renders in single-period mode once both boundaries are set', () => {
+	render(
+		<SalePeriodsCalendar
+			salePeriods={[
+				{ name: '', sale_start: '2026-08-01', sale_end: '2026-09-01' },
+			]}
+			eventDay="2026-08-20"
+			onMoveBoundary={() => {}}
+			embedded
+		/>
+	);
+	expect(screen.getByText('Period 1')).toBeInTheDocument();
+	expect(screen.getByText('Event day')).toBeInTheDocument();
+});
+
+it('lists every period by name (or "Period N" when unnamed) plus the event day in the legend', () => {
+	render(
+		<SalePeriodsCalendar
+			salePeriods={twoNamedPeriods}
+			eventDay="2026-08-20"
+			onMoveBoundary={() => {}}
+			embedded
+		/>
+	);
+	expect(screen.getByText('Early bird')).toBeInTheDocument();
+	expect(screen.getByText('Regular')).toBeInTheDocument();
+	expect(screen.getByText('Event day')).toBeInTheDocument();
+});
+
+it('clicking a day near the middle boundary moves that boundary, not sale start', () => {
+	const onMoveBoundary = jest.fn();
+	render(
+		<SalePeriodsCalendar
+			salePeriods={twoNamedPeriods}
+			eventDay="2026-08-20"
+			onMoveBoundary={onMoveBoundary}
+			embedded
+		/>
+	);
+
+	// One day after the shared Early-bird/Regular boundary (2026-08-15) —
+	// closer to it than to either the sale-start (08-01) or sale-end
+	// (09-01) boundary.
+	const button = screen.getByRole('button', {
+		name: moveMessage("start of 'Regular'", '2026-08-16'),
+	});
+	fireEvent.click(button);
+
+	expect(onMoveBoundary).toHaveBeenCalledWith(1, '2026-08-16');
+});
+
+it('clicking the first day of the calendar moves the sale-start boundary', () => {
+	const onMoveBoundary = jest.fn();
+	render(
+		<SalePeriodsCalendar
+			salePeriods={twoNamedPeriods}
+			eventDay="2026-08-20"
+			onMoveBoundary={onMoveBoundary}
+			embedded
+		/>
+	);
+
+	const button = screen.getByRole('button', {
+		name: moveMessage("start of 'Early bird'", '2026-08-01'),
+	});
+	fireEvent.click(button);
+
+	expect(onMoveBoundary).toHaveBeenCalledWith(0, '2026-08-01');
+});
+
+it('clicking the last day of the calendar moves the sale-end boundary', () => {
+	const onMoveBoundary = jest.fn();
+	render(
+		<SalePeriodsCalendar
+			salePeriods={twoNamedPeriods}
+			eventDay="2026-08-20"
+			onMoveBoundary={onMoveBoundary}
+			embedded
+		/>
+	);
+
+	const button = screen.getByRole('button', {
+		name: moveMessage("end of 'Regular'", '2026-09-01'),
+	});
+	fireEvent.click(button);
+
+	expect(onMoveBoundary).toHaveBeenCalledWith(2, '2026-09-01');
+});
+
+it('describes an unnamed boundary as "period N" rather than start/end wording', () => {
+	const onMoveBoundary = jest.fn();
+	const unnamedPeriods = [
+		{ id: 1, name: '', sale_start: '2026-08-01', sale_end: '2026-08-15' },
+		{ id: 2, name: '', sale_start: '2026-08-15', sale_end: '2026-09-01' },
+	];
+	render(
+		<SalePeriodsCalendar
+			salePeriods={unnamedPeriods}
+			eventDay="2026-08-20"
+			onMoveBoundary={onMoveBoundary}
+			embedded
+		/>
+	);
+
+	const button = screen.getByRole('button', {
+		name: moveMessage('period 1', '2026-08-01'),
+	});
+	fireEvent.click(button);
+
+	expect(onMoveBoundary).toHaveBeenCalledWith(0, '2026-08-01');
+});


### PR DESCRIPTION
## Summary

- Add `SalePeriodsCalendar`, a thin adapter over the shared `MiniCalendar` primitive, that shades each day by the sale period it falls in and marks the event day with a distinct border.
- Clicking a day moves the *nearest* period boundary (sale start, a period-to-period boundary, or sale end) to that day — the tooltip/aria-label on each cell names exactly which boundary a click would move, and which date it would move to.
- Wire the calendar into `EventTickets.js`'s Sale Periods panel, above the existing name/date table, for both single- and multi-period modes. Boundary clicks reuse the existing chained `updateSalePeriod()` setter, so the date-input table, dirty indicator, and save payload all update for free.
- The calendar stays hidden while any boundary is unresolved (e.g. a freshly seeded default period with a lazily-resolved sale window).

Refs #1197

## Test plan

- [x] `npm run format` (fair-events) — no formatting noise staged
- [x] `npm run build` (fair-events) — new component builds cleanly
- [x] `npm run test:js` (fair-events) — 18 suites / 148 tests pass, including new `SalePeriodsCalendar.test.jsx` (hidden/shown states, legend, nearest-boundary click resolution, aria-label/tooltip wording) and a new wiring test in `EventTickets.test.jsx` (calendar click updates both chained date inputs and trips the dirty indicator)
- No PHP changes — `vendor/bin/phpcs` not applicable
