### PR TITLE
Match editor preview order to the frontend for Event Signup

### DIFF
--- a/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
+++ b/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
@@ -5,10 +5,17 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 
 // ServerSideRender hits the REST API for a live render; stub it to a marker
-// so we can render the block in isolation.
+// that also emits the questions slot render.php puts in preview markup, so
+// the portal logic has somewhere to land. Captures its props so tests can
+// assert on the attributes sent to the REST renderer.
+const mockServerSideRender = jest.fn(() => (
+	<div data-testid="ssr">
+		<div className="fair-events-event-signup-questions-slot" />
+	</div>
+));
 jest.mock(
 	'@wordpress/server-side-render',
-	() => () => <div data-testid="ssr" />,
+	() => (props) => mockServerSideRender(props),
 	{ virtual: true }
 );
 
@@ -92,6 +99,23 @@ describe('Event Signup EditComponent', () => {
 		expect(screen.getByTestId('ssr')).toBeInTheDocument();
 		expect(screen.getByTestId('inner-blocks')).toBeInTheDocument();
 		expect(screen.getByText('Form content')).toBeInTheDocument();
+	});
+
+	it('portals the form content area into the SSR-rendered questions slot', () => {
+		renderEdit(false);
+
+		const slot = document.querySelector(
+			'.fair-events-event-signup-questions-slot'
+		);
+		expect(slot).toContainElement(screen.getByTestId('inner-blocks'));
+		expect(slot).toContainElement(screen.getByText('Form content'));
+	});
+
+	it('flags the SSR preview as an editor preview so render.php emits a slot', () => {
+		renderEdit(false);
+
+		const [{ attributes }] = mockServerSideRender.mock.calls.at(-1);
+		expect(attributes.isEditorPreview).toBe(true);
 	});
 
 	it('only offers the fair-form question blocks once fair-form is active', () => {

--- a/fair-events/src/blocks/event-signup/block.json
+++ b/fair-events/src/blocks/event-signup/block.json
@@ -22,6 +22,10 @@
 		"submitButtonText": {
 			"type": "string",
 			"default": "Get Tickets"
+		},
+		"isEditorPreview": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"editorScript": "file:./editor.js",

--- a/fair-events/src/blocks/event-signup/editor.js
+++ b/fair-events/src/blocks/event-signup/editor.js
@@ -21,12 +21,18 @@ import {
 } from '@wordpress/block-editor';
 import { ExternalLink, PanelBody, TextControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { createPortal, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import ServerSideRender from '@wordpress/server-side-render';
 import metadata from './block.json';
 import './editor.css';
 
 const UNIFIED_NAME = 'fair-events/event-signup';
+
+// Where render.php puts an empty slot (instead of the real nested content)
+// when isEditorPreview is set, so the editor can portal the editable "Form
+// content" area into the same on-screen position as the frontend.
+const QUESTIONS_SLOT_SELECTOR = '.fair-events-event-signup-questions-slot';
 
 // Blocks always allowed in the form content area, regardless of fair-form.
 const BASE_ALLOWED_BLOCKS = ['core/heading', 'core/paragraph', 'core/list'];
@@ -81,6 +87,57 @@ registerBlockType(metadata.name, {
 			}
 		);
 
+		// The preview slot is injected into the SSR markup asynchronously
+		// (after the REST fetch resolves, and again on every re-render that
+		// changes an SSR attribute), so watch for it with a MutationObserver
+		// rather than assuming it's there on mount.
+		const previewRef = useRef(null);
+		const [slotNode, setSlotNode] = useState(null);
+
+		useEffect(() => {
+			const container = previewRef.current;
+			if (!container) {
+				return;
+			}
+
+			const findSlot = () => {
+				setSlotNode(container.querySelector(QUESTIONS_SLOT_SELECTOR));
+			};
+
+			findSlot();
+
+			const observer = new MutationObserver((records) => {
+				// The portal's own content lands inside the slot node, which
+				// is itself inside the observed subtree, so most mutations
+				// here are just React writing the editable area into place.
+				// Only re-resolve the slot when a mutation happened outside
+				// it — that's an SSR refetch replacing the preview markup.
+				const currentSlot = container.querySelector(
+					QUESTIONS_SLOT_SELECTOR
+				);
+				const isPortalOnlyChange = records.every(
+					(record) =>
+						currentSlot && currentSlot.contains(record.target)
+				);
+				if (isPortalOnlyChange) {
+					return;
+				}
+				findSlot();
+			});
+			observer.observe(container, { childList: true, subtree: true });
+
+			return () => observer.disconnect();
+		}, []);
+
+		const formContent = (
+			<>
+				<div className="fair-events-event-signup-questions-label">
+					{__('Form content', 'fair-events')}
+				</div>
+				<div {...innerBlocksProps} />
+			</>
+		);
+
 		return (
 			<>
 				<InspectorControls>
@@ -112,14 +169,18 @@ registerBlockType(metadata.name, {
 				</InspectorControls>
 
 				<div {...blockProps}>
-					<ServerSideRender
-						block={UNIFIED_NAME}
-						attributes={attributes}
-					/>
-					<div className="fair-events-event-signup-questions-label">
-						{__('Form content', 'fair-events')}
+					<div ref={previewRef}>
+						<ServerSideRender
+							block={UNIFIED_NAME}
+							attributes={{
+								...attributes,
+								isEditorPreview: true,
+							}}
+						/>
 					</div>
-					<div {...innerBlocksProps} />
+					{slotNode
+						? createPortal(formContent, slotNode)
+						: formContent}
 				</div>
 			</>
 		);

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -476,7 +476,9 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 			</div>
 		</div>
 
-		<?php if ( '' !== trim( $content ) ) : ?>
+		<?php if ( ! empty( $attributes['isEditorPreview'] ) ) : ?>
+			<div class="fair-events-event-signup-questions-slot"></div>
+		<?php elseif ( '' !== trim( $content ) ) : ?>
 			<div class="fair-events-event-signup-questions">
 				<?php echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner blocks content is already escaped by WordPress. ?>
 			</div>


### PR DESCRIPTION
## Summary

- The Event Signup block's editor showed the editable "Form content" area *below* the whole server-rendered form preview, while the frontend renders that content *above* the submit button — so organizers couldn't trust the editor to show where their content actually lands.
- `render.php` now emits an empty `.fair-events-event-signup-questions-slot` div where the nested content goes when a new `isEditorPreview` block attribute is set, instead of echoing `$content`.
- `editor.js` passes `isEditorPreview: true` to `ServerSideRender`, watches the preview container with a `MutationObserver` to find that slot, and portals the "Form content" InnerBlocks region into it — so its on-screen position always matches the frontend, with the previous below-preview placement as a fallback until the slot resolves.
- Scoped to the **base** (fair-audience-inactive) render path only. The delegated fair-audience flow keeps its current editor placement — it's slated for a refactor, so it wasn't worth touching its render template for this.

Refs #1205

## Notes

- The MutationObserver ignores mutations that happen *inside* the already-found slot (i.e. the portal writing content into it) and only re-resolves the slot when a mutation happens outside it — that's what distinguishes "React inserted the editable area" from "SSR refetched and replaced the whole preview markup" (e.g. after a `submitButtonText` change).
- Existing published blocks are unaffected: `save()` and `deprecated` are untouched, and `isEditorPreview` defaults to `false` so it's absent on the frontend.

## Test plan

- [x] `npm run test:js` — all 141 tests pass, including updated/new coverage in `editor.test.jsx` asserting the InnerBlocks region portals inside the SSR-rendered slot and that `isEditorPreview: true` is sent to `ServerSideRender`.
- [x] `vendor/bin/phpcs` clean on `render.php`.
- [x] `npm run build` in `fair-events`.
- [ ] Manual check in wp-admin: place an Event Signup block, confirm the "Form content" editable area now sits between the Quantity/newsletter row and the (frozen) submit button in the preview, both with fair-form active and inactive.
