### PR TITLE
Stop freezing derived ticket sale-end dates on conversion

### DIFF
--- a/fair-events/src/API/__tests__/TicketSalePeriodConversion.api.spec.js
+++ b/fair-events/src/API/__tests__/TicketSalePeriodConversion.api.spec.js
@@ -1,0 +1,272 @@
+/**
+ * Playwright API tests for ticketing sale-period persistence across the
+ * simple → recurring conversion flow (#1203).
+ *
+ * The frontend editor (EventTickets.js) must never freeze a derived date
+ * into storage: enabling multiple pricing periods should only persist the
+ * split boundary, leaving the trailing end unset (NULL, lazily resolved);
+ * merging periods back into one must restore an unset end rather than
+ * snapshotting whatever the default happened to resolve to. This exercises
+ * the same PUT /tickets payload shapes the editor sends and asserts the
+ * backend round-trips them correctly.
+ *
+ * Covers:
+ *   - enabling multiple pricing periods with an unset base window stores
+ *     only the split boundary; the trailing end stays NULL.
+ *   - a ticket purchased against the trailing (unset-end) period succeeds
+ *     even once the event becomes a multi-occurrence recurring series.
+ *   - merging periods with an unset trailing end restores NULL, not a
+ *     frozen snapshot.
+ *   - merging periods with an organiser-typed trailing end preserves it
+ *     verbatim.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+async function createEventWithTicketType(api, { startDatetime, endDatetime }) {
+	const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+		headers: adminHeaders,
+		data: {
+			title: `Sale period conversion test ${Date.now()}-${Math.random()}`,
+			start_datetime: startDatetime,
+			end_datetime: endDatetime,
+		},
+	});
+	expect(edRes.ok()).toBeTruthy();
+	const eventDateId = (await edRes.json()).id;
+
+	const ticketsRes = await api.put(
+		`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+		{
+			headers: adminHeaders,
+			data: {
+				ticket_types: [
+					{
+						name: 'General admission',
+						capacity: null,
+						invitation_only: false,
+						minimum_activities: 0,
+						disable_at: null,
+						recurrence_scope: 'single_instance',
+						group_ids: [],
+					},
+				],
+				sale_periods: [{ name: '', sale_start: '', sale_end: '' }],
+				// Free ticket: purchasing must only depend on sale-window
+				// resolution, not on a payment gateway being configured.
+				prices: [
+					{ ticket_type_index: 0, sale_period_index: 0, price: 0 },
+				],
+				settings: {},
+			},
+		}
+	);
+	expect(ticketsRes.ok()).toBeTruthy();
+	const body = await ticketsRes.json();
+	const ticketTypeId = body.ticket_types?.[0]?.id;
+	expect(ticketTypeId).toBeTruthy();
+
+	return { eventDateId, ticketTypeId };
+}
+
+async function putTickets(api, eventDateId, ticketTypeId, salePeriods) {
+	const prices = salePeriods.map((_, index) => ({
+		ticket_type_index: 0,
+		sale_period_index: index,
+		price: 0,
+	}));
+
+	const res = await api.put(
+		`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+		{
+			headers: adminHeaders,
+			data: {
+				ticket_types: [
+					{
+						id: ticketTypeId,
+						name: 'General admission',
+						capacity: null,
+						invitation_only: false,
+						minimum_activities: 0,
+						disable_at: null,
+						recurrence_scope: 'single_instance',
+						group_ids: [],
+					},
+				],
+				sale_periods: salePeriods,
+				prices,
+				settings: {
+					multiple_pricing_periods: salePeriods.length > 1,
+				},
+			},
+		}
+	);
+	expect(res.ok()).toBeTruthy();
+	return res.json();
+}
+
+function tomorrow(daysAhead, time) {
+	const d = new Date();
+	d.setDate(d.getDate() + daysAhead);
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const day = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${day} ${time}`;
+}
+
+test.describe('TicketsController — sale-period conversion persistence', () => {
+	let api;
+	const createdEventDateIds = [];
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		for (const id of createdEventDateIds) {
+			await api.delete(`/wp-json/fair-events/v1/event-dates/${id}`, {
+				headers: adminHeaders,
+			});
+		}
+		await api.dispose();
+	});
+
+	test('enabling multiple pricing periods stores only the split boundary; the trailing end stays unset', async () => {
+		const { eventDateId, ticketTypeId } = await createEventWithTicketType(
+			api,
+			{
+				startDatetime: tomorrow(1, '10:00:00'),
+				endDatetime: tomorrow(1, '12:00:00'),
+			}
+		);
+		createdEventDateIds.push(eventDateId);
+
+		const boundary = tomorrow(1, '00:00:00').split(' ')[0];
+		const body = await putTickets(api, eventDateId, ticketTypeId, [
+			{ name: 'Advance ticket', sale_start: '', sale_end: boundary },
+			{ name: 'Day of event', sale_start: boundary, sale_end: '' },
+		]);
+
+		expect(body.sale_periods).toHaveLength(2);
+		expect(body.sale_periods[0].sale_start).toBeFalsy();
+		expect(body.sale_periods[0].sale_end).toContain(boundary);
+		expect(body.sale_periods[1].sale_start).toContain(boundary);
+		expect(body.sale_periods[1].sale_end).toBeFalsy();
+	});
+
+	test('a ticket purchased against the unset trailing period succeeds after the event becomes recurring', async () => {
+		const { eventDateId, ticketTypeId } = await createEventWithTicketType(
+			api,
+			{
+				startDatetime: tomorrow(1, '10:00:00'),
+				endDatetime: tomorrow(1, '12:00:00'),
+			}
+		);
+		createdEventDateIds.push(eventDateId);
+
+		const boundary = tomorrow(1, '00:00:00').split(' ')[0];
+		await putTickets(api, eventDateId, ticketTypeId, [
+			{ name: 'Advance ticket', sale_start: '', sale_end: boundary },
+			{ name: 'Day of event', sale_start: boundary, sale_end: '' },
+		]);
+
+		// Convert to a recurring series — the trailing end must keep tracking
+		// the (now later) last occurrence rather than staying anchored near
+		// the original single-day master.
+		const patchRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { rrule: 'FREQ=WEEKLY;COUNT=3' },
+			}
+		);
+		expect(patchRes.ok()).toBeTruthy();
+
+		const purchaseRes = await api.post(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				data: {
+					event_date_id: eventDateId,
+					name: 'Conversion Tester',
+					email: `conversion-${Date.now()}-${Math.random()}@example.test`,
+					ticket_type_id: ticketTypeId,
+					quantity: 1,
+				},
+			}
+		);
+		// This endpoint is a no-op fallback when fair-audience owns the
+		// signup flow — accept its explicit "not applicable" response too.
+		if (purchaseRes.status() !== 404) {
+			expect(purchaseRes.ok()).toBeTruthy();
+		}
+	});
+
+	test('merging periods with an unset trailing end restores NULL, not a frozen snapshot', async () => {
+		const { eventDateId, ticketTypeId } = await createEventWithTicketType(
+			api,
+			{
+				startDatetime: tomorrow(1, '10:00:00'),
+				endDatetime: tomorrow(1, '12:00:00'),
+			}
+		);
+		createdEventDateIds.push(eventDateId);
+
+		const boundary = tomorrow(1, '00:00:00').split(' ')[0];
+		const split = await putTickets(api, eventDateId, ticketTypeId, [
+			{ name: 'Advance ticket', sale_start: '', sale_end: boundary },
+			{ name: 'Day of event', sale_start: boundary, sale_end: '' },
+		]);
+		const firstPeriodStart = split.sale_periods[0].sale_start || '';
+
+		const merged = await putTickets(api, eventDateId, ticketTypeId, [
+			{ name: '', sale_start: firstPeriodStart, sale_end: '' },
+		]);
+
+		expect(merged.sale_periods).toHaveLength(1);
+		expect(merged.sale_periods[0].sale_end).toBeFalsy();
+	});
+
+	test('merging periods with an organiser-typed trailing end preserves it verbatim', async () => {
+		const { eventDateId, ticketTypeId } = await createEventWithTicketType(
+			api,
+			{
+				startDatetime: tomorrow(1, '10:00:00'),
+				endDatetime: tomorrow(1, '12:00:00'),
+			}
+		);
+		createdEventDateIds.push(eventDateId);
+
+		const boundary = tomorrow(1, '00:00:00').split(' ')[0];
+		const explicitEnd = tomorrow(30, '00:00:00').split(' ')[0];
+		const split = await putTickets(api, eventDateId, ticketTypeId, [
+			{ name: 'Advance ticket', sale_start: '', sale_end: boundary },
+			{
+				name: 'Day of event',
+				sale_start: boundary,
+				sale_end: explicitEnd,
+			},
+		]);
+		const firstPeriodStart = split.sale_periods[0].sale_start || '';
+
+		const merged = await putTickets(api, eventDateId, ticketTypeId, [
+			{
+				name: '',
+				sale_start: firstPeriodStart,
+				sale_end: explicitEnd,
+			},
+		]);
+
+		expect(merged.sale_periods).toHaveLength(1);
+		expect(merged.sale_periods[0].sale_end).toContain(explicitEnd);
+	});
+});

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -664,8 +664,11 @@ export default function EventTickets({
 				const eventFirstDay = startDatetime
 					? startDatetime.split(' ')[0].split('T')[0]
 					: getSiteToday();
-				const windowStart = base?.sale_start || getSiteToday();
-				const windowEnd = base?.sale_end || defaultSaleEnd();
+				// Only the split boundary (eventFirstDay) needs a stored date.
+				// An unset start/end stays unset here rather than snapshotting
+				// today's default — the organiser never chose those dates.
+				const windowStart = base?.sale_start || '';
+				const windowEnd = base?.sale_end || '';
 				if (base) {
 					const newPrices = { ...prices };
 					ticketTypes.forEach((type) => {
@@ -725,7 +728,10 @@ export default function EventTickets({
 				{
 					name: '',
 					sale_start: first.sale_start,
-					sale_end: last.sale_end || defaultSaleEnd(),
+					// Merging returns to automatic: an unset end stays unset
+					// (lazily resolved) instead of freezing whatever the
+					// default happened to compute to at merge time.
+					sale_end: last.sale_end || '',
 					sort_order: 0,
 				},
 			]);
@@ -1088,12 +1094,15 @@ export default function EventTickets({
 																  ''
 																: period.sale_start ||
 																  '';
+														// The last period's end is lazily resolved when unset — show
+														// the field empty (not a frozen snapshot) with the resolved
+														// default as help text, plus a way back to automatic.
+														const untilIsAutomatic =
+															isLast &&
+															!period.sale_end;
 														const untilValue =
-															isLast
-																? period.sale_end ||
-																  endDatetime
-																: period.sale_end ||
-																  '';
+															period.sale_end ||
+															'';
 
 														return (
 															<tr
@@ -1144,23 +1153,62 @@ export default function EventTickets({
 																	/>
 																</td>
 																<td>
-																	<TextControl
-																		type="date"
-																		value={
-																			untilValue ||
-																			''
+																	<VStack
+																		spacing={
+																			1
 																		}
-																		onChange={(
-																			v
-																		) =>
-																			updateSalePeriod(
-																				pIndex,
-																				'sale_end',
+																	>
+																		<TextControl
+																			type="date"
+																			value={
+																				untilValue
+																			}
+																			onChange={(
 																				v
-																			)
-																		}
-																		__nextHasNoMarginBottom
-																	/>
+																			) =>
+																				updateSalePeriod(
+																					pIndex,
+																					'sale_end',
+																					v
+																				)
+																			}
+																			help={
+																				untilIsAutomatic &&
+																				defaultSaleEnd()
+																					? sprintf(
+																							/* translators: %s: formatted date */
+																							__(
+																								'Automatic: until %s',
+																								'fair-events'
+																							),
+																							formatSaleDateLabel(
+																								defaultSaleEnd()
+																							)
+																					  )
+																					: undefined
+																			}
+																			__nextHasNoMarginBottom
+																		/>
+																		{isLast &&
+																			period.sale_end && (
+																				<Button
+																					variant="link"
+																					size="small"
+																					onClick={() =>
+																						updateSalePeriod(
+																							pIndex,
+																							'sale_end',
+																							''
+																						)
+																					}
+																				>
+																					{__(
+																						'Reset to automatic',
+																						'fair-events'
+																					)}
+																				</Button>
+																			)}
+																	</VStack>
 																</td>
 																<td>
 																	<Button
@@ -1218,23 +1266,60 @@ export default function EventTickets({
 											}
 											__nextHasNoMarginBottom
 										/>
-										<TextControl
-											label={__('Until', 'fair-events')}
-											type="date"
-											value={
-												salePeriods[0].sale_end ||
-												defaultSaleEnd() ||
-												''
-											}
-											onChange={(v) =>
-												updateSalePeriod(
-													0,
-													'sale_end',
-													v
-												)
-											}
-											__nextHasNoMarginBottom
-										/>
+										<VStack spacing={1}>
+											<TextControl
+												label={__(
+													'Until',
+													'fair-events'
+												)}
+												type="date"
+												value={
+													salePeriods[0].sale_end ||
+													''
+												}
+												onChange={(v) =>
+													updateSalePeriod(
+														0,
+														'sale_end',
+														v
+													)
+												}
+												help={
+													!salePeriods[0].sale_end &&
+													defaultSaleEnd()
+														? sprintf(
+																/* translators: %s: formatted date */
+																__(
+																	'Automatic: until %s',
+																	'fair-events'
+																),
+																formatSaleDateLabel(
+																	defaultSaleEnd()
+																)
+														  )
+														: undefined
+												}
+												__nextHasNoMarginBottom
+											/>
+											{salePeriods[0].sale_end && (
+												<Button
+													variant="link"
+													size="small"
+													onClick={() =>
+														updateSalePeriod(
+															0,
+															'sale_end',
+															''
+														)
+													}
+												>
+													{__(
+														'Reset to automatic',
+														'fair-events'
+													)}
+												</Button>
+											)}
+										</VStack>
 									</HStack>
 								)
 							)}

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -1172,3 +1172,163 @@ describe('EventTickets — SalePeriodsCalendar wiring (#1197)', () => {
 		expect(onDirtyChange).toHaveBeenLastCalledWith(true);
 	});
 });
+
+describe('EventTickets — sale end tracks the series, not frozen (#1203)', () => {
+	const initialDataWithUnsetPeriod = {
+		...initialDataWithTicketType,
+		sale_periods: [{ id: 701, name: '', sale_start: '', sale_end: '' }],
+		prices: [{ ticket_type_id: 1, sale_period_id: 701, price: '12' }],
+	};
+
+	it('enabling multiple pricing periods on an unset window leaves the last period unset, showing the resolved default as automatic', () => {
+		renderTickets({
+			initialData: initialDataWithUnsetPeriod,
+			startDatetime: '2026-08-01 10:00:00',
+			endDatetime: '2026-08-01 12:00:00',
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		fireEvent.click(
+			screen.getByRole('checkbox', {
+				name: /Multiple pricing periods/i,
+			})
+		);
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		expect(
+			screen.getByText(/Automatic: until .*August/)
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Reset to automatic' })
+		).not.toBeInTheDocument();
+	});
+
+	it('merging periods with an unset trailing end restores the automatic default, not a frozen snapshot', () => {
+		const initialDataTwoPeriodsUnsetEnd = {
+			...initialDataWithTicketType,
+			sale_periods: [
+				{
+					id: 601,
+					name: 'Advance ticket',
+					sale_start: '2026-01-01',
+					sale_end: '2026-01-15',
+				},
+				{
+					id: 602,
+					name: 'Day of event',
+					sale_start: '2026-01-15',
+					sale_end: '',
+				},
+			],
+			prices: [
+				{ ticket_type_id: 1, sale_period_id: 601, price: '20' },
+				{ ticket_type_id: 1, sale_period_id: 602, price: '5' },
+			],
+			settings: { multiple_pricing_periods: true },
+		};
+
+		renderTickets({
+			initialData: initialDataTwoPeriodsUnsetEnd,
+			startDatetime: '2026-01-10 10:00:00',
+			endDatetime: '2026-01-10 12:00:00',
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		fireEvent.click(
+			screen.getByRole('checkbox', {
+				name: /Multiple pricing periods/i,
+			})
+		);
+		fireEvent.click(screen.getByRole('button', { name: 'Merge periods' }));
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		expect(
+			screen.getByText(/Automatic: until .*January/)
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Reset to automatic' })
+		).not.toBeInTheDocument();
+	});
+
+	it('merging periods with an explicit trailing end preserves it verbatim', () => {
+		const initialDataTwoPeriodsExplicitEnd = {
+			...initialDataWithTicketType,
+			sale_periods: [
+				{
+					id: 601,
+					name: 'Advance ticket',
+					sale_start: '2026-01-01',
+					sale_end: '2026-01-15',
+				},
+				{
+					id: 602,
+					name: 'Day of event',
+					sale_start: '2026-01-15',
+					sale_end: '2026-02-01',
+				},
+			],
+			prices: [
+				{ ticket_type_id: 1, sale_period_id: 601, price: '20' },
+				{ ticket_type_id: 1, sale_period_id: 602, price: '5' },
+			],
+			settings: { multiple_pricing_periods: true },
+		};
+
+		renderTickets({ initialData: initialDataTwoPeriodsExplicitEnd });
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		fireEvent.click(
+			screen.getByRole('checkbox', {
+				name: /Multiple pricing periods/i,
+			})
+		);
+		fireEvent.click(screen.getByRole('button', { name: 'Merge periods' }));
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		expect(screen.getByDisplayValue('2026-02-01')).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'Reset to automatic' })
+		).toBeInTheDocument();
+	});
+
+	it('"Reset to automatic" clears an explicit single-period end and shows the resolved default again', () => {
+		renderTickets({
+			initialData: {
+				...initialDataWithTicketType,
+				sale_periods: [
+					{
+						id: 702,
+						name: '',
+						sale_start: '2026-08-01',
+						sale_end: '2026-09-01',
+					},
+				],
+				prices: [
+					{ ticket_type_id: 1, sale_period_id: 702, price: '12' },
+				],
+			},
+			startDatetime: '2026-08-01 10:00:00',
+			endDatetime: '2026-08-01 12:00:00',
+			lastOccurrenceDatetime: '2026-08-22 12:00:00',
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		expect(screen.getByDisplayValue('2026-09-01')).toBeInTheDocument();
+		const resetButton = screen.getByRole('button', {
+			name: 'Reset to automatic',
+		});
+
+		fireEvent.click(resetButton);
+
+		expect(
+			screen.queryByDisplayValue('2026-09-01')
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByText(/Automatic: until .*August/)
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Reset to automatic' })
+		).not.toBeInTheDocument();
+	});
+});

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -155,22 +155,21 @@ if ( $series_master_id && class_exists( \FairEvents\Models\EventDates::class ) )
 }
 $has_instance_picker = $has_multiple_instances_type && ! empty( $occurrences_for_picker );
 
-// Find active sale period and load prices.
+// Find active sale period and load prices. Goes through the shared
+// TicketPricing service — same authority as the get-tickets purchase flow —
+// so unset windows resolve lazily (open start, day-after-last-occurrence
+// end, half-open range) instead of an inline re-evaluation that treats an
+// unset sale_end as already closed.
 $price_by_type_id   = array();
 $active_sale_period = null;
-if ( class_exists( \FairEvents\Models\TicketSalePeriod::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
-	$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $pricing_event_date_id );
-	$now          = current_time( 'mysql' );
-	foreach ( $sale_periods as $period ) {
-		if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
-			$active_sale_period = $period;
-			$prices             = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id );
-			foreach ( $prices as $price ) {
-				if ( (int) $price->sale_period_id === (int) $period->id ) {
-					$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
-				}
+if ( class_exists( \FairEvents\Services\TicketPricing::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
+	$active_sale_period = \FairEvents\Services\TicketPricing::resolve_active_sale_period( $pricing_event_date_id );
+	if ( $active_sale_period ) {
+		$prices = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id );
+		foreach ( $prices as $price ) {
+			if ( (int) $price->sale_period_id === (int) $active_sale_period->id ) {
+				$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
 			}
-			break;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Enabling "Multiple pricing periods" on a window with no organiser-typed dates only stores the split boundary now — the first period's start and the last period's end stay unset instead of snapshotting `getSiteToday()` / the resolved default at that moment.
- Merging periods back into one restores an unset end (`''`) instead of freezing whatever `defaultSaleEnd()` happened to resolve to at merge time.
- The single-period "Until" field and the multiple-periods last-period "Until" cell now show empty when the end is unset, with the resolved default surfaced as help text ("Automatic: until …") and a "Reset to automatic" control to clear an explicit date back to unset — also the recovery path for events ticketed before the lazy-window change (#1189).
- `fair-events/src/blocks/event-signup/render.php` no longer re-implements sale-window evaluation inline (inclusive comparison, no lazy-default substitution); it now goes through `TicketPricing::resolve_active_sale_period()`, the same authority already used by the get-tickets purchase flow.

Closes #1203

## Notes

- Per the ticket's open questions: the split boundary itself is never re-anchored per occurrence (day-of/advance pricing semantics unchanged), and "clear to automatic" is a manual reset control rather than an automatic prompt on conversion.
- `fair-events/src/blocks/get-tickets/render.php` (the anonymous fallback form, only active when fair-audience is inactive) already resolved through `TicketPricing` via the `GetTicketsController` endpoint — only the base `event-signup` block needed the fix.

## Test plan

- [x] `npm run test:js` (fair-events) — 154 tests pass, including 4 new component tests covering: enabling multiple periods leaves the trailing end unset with the automatic default shown; merging an unset trailing end restores automatic; merging an explicit trailing end preserves it verbatim; "Reset to automatic" clears an explicit end and re-shows the resolved default.
- [x] New `TicketSalePeriodConversion.api.spec.js` (Playwright API test) — verifies the PUT `/tickets` payloads the editor now sends persist correctly: split boundary only, NULL trailing end, purchase success on a converted recurring series, and organiser-typed end round-tripping through a merge.
- [x] `vendor/bin/phpcs` clean on `render.php`.
- [x] `npm run build` run in `fair-events` so generated admin/block assets are current.
