### PR TITLE
Stop freezing derived ticket sale-end dates on conversion

### DIFF
--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -664,8 +664,12 @@ export default function EventTickets({
 				const eventFirstDay = startDatetime
 					? startDatetime.split(' ')[0].split('T')[0]
 					: getSiteToday();
-				const windowStart = base?.sale_start || getSiteToday();
-				const windowEnd = base?.sale_end || defaultSaleEnd();
+				// Only the split boundary (eventFirstDay) needs a stored date.
+				// The outer start/end stay unset unless the organiser already
+				// typed one — an unset value must not be frozen here, or the
+				// derived default gets snapshotted as if it were explicit.
+				const windowStart = base?.sale_start || '';
+				const windowEnd = base?.sale_end || '';
 				if (base) {
 					const newPrices = { ...prices };
 					ticketTypes.forEach((type) => {
@@ -725,7 +729,9 @@ export default function EventTickets({
 				{
 					name: '',
 					sale_start: first.sale_start,
-					sale_end: last.sale_end || defaultSaleEnd(),
+					// Restores unset (automatic) rather than snapshotting
+					// whatever the default currently resolves to.
+					sale_end: last.sale_end || '',
 					sort_order: 0,
 				},
 			]);
@@ -1089,11 +1095,13 @@ export default function EventTickets({
 																: period.sale_start ||
 																  '';
 														const untilValue =
-															isLast
-																? period.sale_end ||
-																  endDatetime
-																: period.sale_end ||
-																  '';
+															period.sale_end ||
+															'';
+														const untilPlaceholder =
+															isLast &&
+															!period.sale_end
+																? defaultSaleEnd()
+																: undefined;
 
 														return (
 															<tr
@@ -1147,8 +1155,10 @@ export default function EventTickets({
 																	<TextControl
 																		type="date"
 																		value={
-																			untilValue ||
-																			''
+																			untilValue
+																		}
+																		placeholder={
+																			untilPlaceholder
 																		}
 																		onChange={(
 																			v
@@ -1161,6 +1171,25 @@ export default function EventTickets({
 																		}
 																		__nextHasNoMarginBottom
 																	/>
+																	{isLast &&
+																		period.sale_end && (
+																			<Button
+																				variant="link"
+																				size="small"
+																				onClick={() =>
+																					updateSalePeriod(
+																						pIndex,
+																						'sale_end',
+																						''
+																					)
+																				}
+																			>
+																				{__(
+																					'Reset to automatic',
+																					'fair-events'
+																				)}
+																			</Button>
+																		)}
 																</td>
 																<td>
 																	<Button
@@ -1222,9 +1251,21 @@ export default function EventTickets({
 											label={__('Until', 'fair-events')}
 											type="date"
 											value={
-												salePeriods[0].sale_end ||
-												defaultSaleEnd() ||
-												''
+												salePeriods[0].sale_end || ''
+											}
+											placeholder={
+												salePeriods[0].sale_end
+													? undefined
+													: defaultSaleEnd()
+											}
+											help={
+												!salePeriods[0].sale_end &&
+												defaultSaleEnd()
+													? __(
+															'Until the day after the last occurrence.',
+															'fair-events'
+													  )
+													: undefined
 											}
 											onChange={(v) =>
 												updateSalePeriod(
@@ -1235,6 +1276,24 @@ export default function EventTickets({
 											}
 											__nextHasNoMarginBottom
 										/>
+										{salePeriods[0].sale_end && (
+											<Button
+												variant="link"
+												size="small"
+												onClick={() =>
+													updateSalePeriod(
+														0,
+														'sale_end',
+														''
+													)
+												}
+											>
+												{__(
+													'Reset to automatic',
+													'fair-events'
+												)}
+											</Button>
+										)}
 									</HStack>
 								)
 							)}

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -969,6 +969,150 @@ describe('EventTickets — unset sale window shows the resolved default (#1189)'
 	});
 });
 
+describe('EventTickets — sale end tracks the series across conversion (#1203)', () => {
+	const initialDataWithUnsetSinglePeriod = {
+		...initialDataWithTicketType,
+		sale_periods: [{ id: 801, name: '', sale_start: '', sale_end: '' }],
+		prices: [{ ticket_type_id: 1, sale_period_id: 801, price: '12' }],
+	};
+
+	const initialDataWithSetSinglePeriod = {
+		...initialDataWithTicketType,
+		sale_periods: [
+			{
+				id: 802,
+				name: '',
+				sale_start: '2026-07-01',
+				sale_end: '2026-08-02',
+			},
+		],
+		prices: [{ ticket_type_id: 1, sale_period_id: 802, price: '12' }],
+	};
+
+	const initialDataWithTwoPeriodsUnsetEnd = {
+		...initialDataWithTicketType,
+		sale_periods: [
+			{
+				id: 601,
+				name: 'Advance ticket',
+				sale_start: '2026-07-01',
+				sale_end: '2026-08-01',
+			},
+			{
+				id: 602,
+				name: 'Day of event',
+				sale_start: '2026-08-01',
+				sale_end: '',
+			},
+		],
+		prices: [
+			{ ticket_type_id: 1, sale_period_id: 601, price: '20' },
+			{ ticket_type_id: 1, sale_period_id: 602, price: '5' },
+		],
+		settings: { multiple_pricing_periods: true },
+	};
+
+	it('turning on "Multiple pricing periods" with an unset window leaves the last period\'s end unset', () => {
+		const onDataRef = { current: null };
+		renderTickets({
+			initialData: initialDataWithUnsetSinglePeriod,
+			startDatetime: '2026-08-01 10:00:00',
+			endDatetime: '2026-08-01 12:00:00',
+			onDataRef,
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		fireEvent.click(
+			screen.getByRole('checkbox', { name: /Multiple pricing periods/i })
+		);
+
+		const payload = onDataRef.current();
+		expect(payload.sale_periods).toHaveLength(2);
+		// Only the split boundary is stored — the trailing end stays unset.
+		expect(payload.sale_periods[0].sale_start).toBe('');
+		expect(payload.sale_periods[0].sale_end).toBe('2026-08-01 00:00:00');
+		expect(payload.sale_periods[1].sale_start).toBe('2026-08-01 00:00:00');
+		expect(payload.sale_periods[1].sale_end).toBe('');
+	});
+
+	it('the last period\'s "Until" field shows the resolved default as a placeholder, not a frozen value', () => {
+		const { container } = renderTickets({
+			initialData: initialDataWithUnsetSinglePeriod,
+			startDatetime: '2026-08-01 10:00:00',
+			endDatetime: '2026-08-01 12:00:00',
+			lastOccurrenceDatetime: '2026-08-22 12:00:00',
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		fireEvent.click(
+			screen.getByRole('checkbox', { name: /Multiple pricing periods/i })
+		);
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		const dateInputs = container.querySelectorAll('input[type="date"]');
+		const lastUntilInput = dateInputs[dateInputs.length - 1];
+		expect(lastUntilInput.value).toBe('');
+		// Placeholder is anchored to the series' last occurrence (Aug 22/23
+		// depending on local TZ rounding), not the master's own day (Aug 02).
+		expect(lastUntilInput.placeholder).toMatch(/^2026-08-2[23]$/);
+	});
+
+	it('merging periods restores an unset (automatic) end', () => {
+		const onDataRef = { current: null };
+		renderTickets({
+			initialData: initialDataWithTwoPeriodsUnsetEnd,
+			onDataRef,
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		fireEvent.click(
+			screen.getByRole('checkbox', { name: /Multiple pricing periods/i })
+		);
+		fireEvent.click(screen.getByRole('button', { name: 'Merge periods' }));
+
+		const payload = onDataRef.current();
+		expect(payload.sale_periods).toHaveLength(1);
+		expect(payload.sale_periods[0].sale_end).toBe('');
+	});
+
+	it('a "Reset to automatic" control clears an explicit end back to unset', () => {
+		const onDataRef = { current: null };
+		renderTickets({
+			initialData: initialDataWithSetSinglePeriod,
+			startDatetime: '2026-07-01 10:00:00',
+			endDatetime: '2026-08-01 12:00:00',
+			onDataRef,
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Reset to automatic' })
+		);
+
+		const payload = onDataRef.current();
+		expect(payload.sale_periods[0].sale_end).toBe('');
+	});
+
+	it('an organiser-typed sale end survives turning multiple pricing periods on', () => {
+		const onDataRef = { current: null };
+		renderTickets({
+			initialData: initialDataWithSetSinglePeriod,
+			startDatetime: '2026-07-01 10:00:00',
+			endDatetime: '2026-08-01 12:00:00',
+			onDataRef,
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		fireEvent.click(
+			screen.getByRole('checkbox', { name: /Multiple pricing periods/i })
+		);
+
+		const payload = onDataRef.current();
+		expect(payload.sale_periods[1].sale_end).toBe('2026-08-02 00:00:00');
+	});
+});
+
 describe('EventTickets — pricing an event with no stored prices (#1175)', () => {
 	// A ticket type + sale period saved without any price. In single-period
 	// mode the pricing cell is seeded enabled:false and there is no "Available"

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -155,22 +155,20 @@ if ( $series_master_id && class_exists( \FairEvents\Models\EventDates::class ) )
 }
 $has_instance_picker = $has_multiple_instances_type && ! empty( $occurrences_for_picker );
 
-// Find active sale period and load prices.
+// Find active sale period and load prices. Delegates to the shared
+// TicketPricing service — the same authority the get-tickets purchase flow
+// uses — so the lazy default window and last-period fallback apply here too
+// instead of a second, divergent evaluation.
 $price_by_type_id   = array();
 $active_sale_period = null;
-if ( class_exists( \FairEvents\Models\TicketSalePeriod::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
-	$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $pricing_event_date_id );
-	$now          = current_time( 'mysql' );
-	foreach ( $sale_periods as $period ) {
-		if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
-			$active_sale_period = $period;
-			$prices             = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id );
-			foreach ( $prices as $price ) {
-				if ( (int) $price->sale_period_id === (int) $period->id ) {
-					$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
-				}
+if ( class_exists( \FairEvents\Services\TicketPricing::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
+	$active_sale_period = \FairEvents\Services\TicketPricing::resolve_active_sale_period( $pricing_event_date_id );
+	if ( $active_sale_period ) {
+		$prices = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id );
+		foreach ( $prices as $price ) {
+			if ( (int) $price->sale_period_id === (int) $active_sale_period->id ) {
+				$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
 			}
-			break;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Enabling "Multiple pricing periods" no longer freezes the trailing sale end (or the leading sale start) at whatever the currently-resolved default happens to be — only the split boundary between periods needs a stored date. Converting a single event with ticketing set up into a recurring series no longer silently stops ticket sales after the first occurrence.
- Merging periods back into one restores an unset (automatic) end instead of snapshotting the merge-time default.
- The single-period "Until" field and the multi-period last-period "Until" cell now show the resolved default as a placeholder while unset, and a **"Reset to automatic"** control appears once an end is stored — the recovery path both for newly-frozen dates and for events ticketed before the earlier lazy-window fix (#1189).
- The base event-signup form (`fair-events/src/blocks/event-signup/render.php`) now resolves its active sale period through the shared `TicketPricing::resolve_active_sale_period()` service instead of its own inline (inclusive, non-lazy) window check — it now agrees with the get-tickets purchase flow on unset windows and the last-period continues-fallback.

Refs #1203

## Test plan

- [x] `npx jest` in `fair-events` — 155 tests passing, including new coverage in `EventTickets.test.jsx` for: enabling multiple periods leaves the last end unset, the placeholder anchors to the series' last occurrence (not the master's own day), merging restores unset, the "Reset to automatic" control clears a stored end, and an organiser-typed end survives the conversion.
- [x] `vendor/bin/phpcs fair-events/src/blocks/event-signup/render.php` — clean.
- [x] `npm run build` in `fair-events` — generated admin/block assets rebuilt.
- [ ] Manual/API/e2e verification against a live WordPress environment was not run this session (a WP docker stack was already occupying the required ports from another checkout); `GetTicketsUnsetSalePeriod.api.spec.js` already covers the shared `TicketPricing` resolver end-to-end for the get-tickets endpoint and should be re-run, along with an e2e pass buying via the signup form on a converted series, before merging.
