### PR TITLE
Show weekly-summary opt-out on participant detail page

### DIFF
--- a/fair-audience/src/Admin/participant-detail/ParticipantDetail.js
+++ b/fair-audience/src/Admin/participant-detail/ParticipantDetail.js
@@ -225,6 +225,14 @@ export default function ParticipantDetail() {
 								</td>
 							</tr>
 							<tr>
+								<th>{__('Weekly summary', 'fair-audience')}</th>
+								<td>
+									{participant.weekly_summary_opt_out
+										? __('Opted out', 'fair-audience')
+										: __('Subscribed', 'fair-audience')}
+								</td>
+							</tr>
+							<tr>
 								<th>{__('Phone', 'fair-audience')}</th>
 								<td>{participant.phone || '—'}</td>
 							</tr>


### PR DESCRIPTION
## Summary

- The participant detail admin page had no way to see whether a participant opted out of the weekly calendar summary, even though the API already returns `weekly_summary_opt_out` for the participant.
- Add a read-only "Weekly summary" row (Subscribed / Opted out) next to "Email profile" in the Profile card.

Refs #1157

## Test plan

- [x] `npm run format` in `fair-audience`
- [x] `npm run build` in `fair-audience`
- [ ] Manually verify the new row renders correctly for opted-in and opted-out participants on the participant detail page
