### PR TITLE
Centralize outgoing mail behind one consent-enforcing method

### DIFF
--- a/fair-audience-experimental/src/Hooks/ScheduledMessageHooks.php
+++ b/fair-audience-experimental/src/Hooks/ScheduledMessageHooks.php
@@ -16,6 +16,7 @@ use FairAudience\Database\ParticipantRepository;
 use FairAudience\Services\RecipientResolver;
 use FairAudienceExperimental\Services\ScheduledMessageScheduler;
 use FairAudience\Services\EmailService;
+use FairAudience\Services\EmailType;
 use FairAudienceExperimental\Models\ScheduledMessage;
 
 defined( 'WPINC' ) || die;
@@ -114,6 +115,7 @@ class ScheduledMessageHooks {
 		try {
 			$context    = self::build_context( $message );
 			$recipients = $resolver->resolve_by_event_date( $message->recipients_filter, $message->event_date_id );
+			$email_type = ! empty( $message->recipients_filter['is_marketing'] ) ? EmailType::MARKETING : EmailType::MINIMAL;
 
 			foreach ( $recipients as $recipient ) {
 				if ( empty( $recipient['has_valid_email'] ) ) {
@@ -137,7 +139,8 @@ class ScheduledMessageHooks {
 					$message->subject,
 					$message->body,
 					(int) $message->event_date_id,
-					$context
+					$context,
+					$email_type
 				);
 
 				if ( $success ) {

--- a/fair-audience/src/API/__tests__/EventParticipantsMarketingConsent.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventParticipantsMarketingConsent.api.spec.js
@@ -317,3 +317,200 @@ test.describe('EventParticipantsController marketing-consent', () => {
 		expect(res.status()).toBeLessThan(404);
 	});
 });
+
+/**
+ * Issue #1107: EmailService::deliver() is now the single enforcement point
+ * for marketing consent, belt-and-suspenders behind the callers' own
+ * pre-filtering. These tests exercise the bulk custom-mail and event-invitation
+ * send paths end to end and assert a declined participant, and a pending
+ * marketing participant (the exact #1106 regression shape), land in `skipped`
+ * rather than `sent`.
+ */
+test.describe('EmailService consent enforcement (bulk sends)', () => {
+	let api;
+	let eventId;
+	let eventDateId;
+	// A second, unrelated event date — event-invitations skips participants
+	// already signed up to the target date, which would mask the consent skip
+	// under test if we reused eventDateId (linked below for the custom-mail
+	// case).
+	let invitationsEventId;
+	let invitationsEventDateId;
+	let declinedId;
+	let declinedEmail;
+	let confirmedMarketingId;
+	let confirmedMarketingEmail;
+	let pendingId;
+	let pendingEmail;
+
+	async function createTestEvent(title) {
+		const eventRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: authHeaders,
+			data: { title, status: 'publish' },
+		});
+		expect(eventRes.ok()).toBeTruthy();
+		const createdEventId = (await eventRes.json()).id;
+
+		const eventsRes = await api.get('/wp-json/fair-audience/v1/events', {
+			headers: authHeaders,
+			params: { per_page: 100 },
+		});
+		expect(eventsRes.ok()).toBeTruthy();
+		const events = await eventsRes.json();
+		const match = events.find((e) => e.event_id === createdEventId);
+		expect(match, 'event-date row for the test event').toBeTruthy();
+
+		return { eventId: createdEventId, eventDateId: match.event_date_id };
+	}
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		({ eventId, eventDateId } = await createTestEvent(
+			`Consent Enforcement Test ${Date.now()}`
+		));
+		({ eventId: invitationsEventId, eventDateId: invitationsEventDateId } =
+			await createTestEvent(
+				`Consent Enforcement Invitations Test ${Date.now()}`
+			));
+
+		declinedEmail = uniqueEmail('consent-declined');
+		declinedId = await createParticipant(api, {
+			name: 'Consent Declined',
+			email: declinedEmail,
+			email_profile: 'declined',
+		});
+
+		confirmedMarketingEmail = uniqueEmail('consent-confirmed');
+		confirmedMarketingId = await createParticipant(api, {
+			name: 'Consent Confirmed',
+			email: confirmedMarketingEmail,
+			email_profile: 'marketing',
+		});
+
+		// Mirrors the #1106 regression shape: created through the public
+		// audience-signup "keep me informed" flow, which sets
+		// email_profile=marketing but leaves status=pending until the
+		// participant clicks the confirmation link — there is no admin API
+		// to create this combination directly.
+		pendingEmail = uniqueEmail('consent-pending');
+		const signupRes = await api.post(
+			'/wp-json/fair-audience/v1/audience-signup',
+			{
+				data: {
+					name: 'Consent Pending',
+					email: pendingEmail,
+					keep_informed: true,
+				},
+			}
+		);
+		expect(signupRes.ok()).toBeTruthy();
+
+		const searchRes = await api.get(
+			'/wp-json/fair-audience/v1/participants',
+			{ headers: authHeaders, params: { search: pendingEmail } }
+		);
+		expect(searchRes.ok()).toBeTruthy();
+		const searchResults = await searchRes.json();
+		const pendingParticipant = searchResults.find(
+			(p) => p.email === pendingEmail
+		);
+		expect(
+			pendingParticipant,
+			'pending participant created via audience-signup'
+		).toBeTruthy();
+		expect(pendingParticipant.email_profile).toBe('marketing');
+		expect(pendingParticipant.status).toBe('pending');
+		pendingId = pendingParticipant.id;
+
+		// Link all three to the test event as signed_up — required for the
+		// event-scoped custom-mail send; event-invitations targets them
+		// directly via participant_ids instead (linking them here would make
+		// "already signed up" the skip reason instead of consent).
+		const linkRes = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/batch`,
+			{
+				headers: authHeaders,
+				data: {
+					participant_ids: [
+						declinedId,
+						confirmedMarketingId,
+						pendingId,
+					],
+					label: 'signed_up',
+				},
+			}
+		);
+		expect(linkRes.ok()).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		for (const id of [declinedId, confirmedMarketingId, pendingId]) {
+			if (id) {
+				await api.delete(
+					`/wp-json/fair-audience/v1/participants/${id}`,
+					{ headers: authHeaders }
+				);
+			}
+		}
+		for (const id of [eventId, invitationsEventId]) {
+			if (id) {
+				await api.delete(`/wp-json/wp/v2/fair_event/${id}`, {
+					headers: authHeaders,
+					params: { force: 'true' },
+				});
+			}
+		}
+		await api.dispose();
+	});
+
+	test('declined and pending participants are skipped on custom-mail bulk send', async () => {
+		const res = await api.post('/wp-json/fair-audience/v1/custom-mail', {
+			headers: authHeaders,
+			data: {
+				subject: 'Consent enforcement test',
+				content: '<p>Test</p>',
+				event_date_id: eventDateId,
+				is_marketing: true,
+				labels: ['signed_up'],
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const skippedEmails = body.skipped.map((r) => r.email);
+		expect(skippedEmails).toContain(declinedEmail);
+		expect(skippedEmails).toContain(pendingEmail);
+		expect(body.sent).not.toContain(declinedEmail);
+		expect(body.sent).not.toContain(pendingEmail);
+
+		// Consent isn't why the confirmed participant would be skipped —
+		// transport failure in this environment is a separate concern.
+		expect(skippedEmails).not.toContain(confirmedMarketingEmail);
+	});
+
+	test('declined and pending participants are skipped on event-invitation bulk send', async () => {
+		const res = await api.post(
+			`/wp-json/fair-audience/v1/event-dates/${invitationsEventDateId}/event-invitations`,
+			{
+				headers: authHeaders,
+				data: {
+					participant_ids: [
+						declinedId,
+						confirmedMarketingId,
+						pendingId,
+					],
+				},
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		const skippedEmails = body.skipped.map((r) => r.email);
+		expect(skippedEmails).toContain(declinedEmail);
+		expect(skippedEmails).toContain(pendingEmail);
+		expect(body.sent).not.toContain(declinedEmail);
+		expect(body.sent).not.toContain(pendingEmail);
+		expect(skippedEmails).not.toContain(confirmedMarketingEmail);
+	});
+});

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -295,26 +295,7 @@ class EmailService {
 </body>
 </html>';
 
-		// Set email content type to HTML.
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		// Send email.
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		// Reset content type to avoid conflicts.
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -539,26 +520,7 @@ class EmailService {
 </body>
 </html>';
 
-		// Set email content type to HTML.
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		// Send email.
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		// Reset content type to avoid conflicts.
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -752,26 +714,7 @@ class EmailService {
 </body>
 </html>';
 
-		// Set email content type to HTML.
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		// Send email.
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		// Reset content type to avoid conflicts.
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -875,26 +818,7 @@ class EmailService {
 </body>
 </html>';
 
-		// Set email content type to HTML.
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		// Send email.
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		// Reset content type to avoid conflicts.
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -1007,26 +931,7 @@ class EmailService {
 </body>
 </html>';
 
-		// Set email content type to HTML.
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		// Send email.
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		// Reset content type to avoid conflicts.
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -1148,26 +1053,7 @@ class EmailService {
 </body>
 </html>';
 
-		// Set email content type to HTML.
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		// Send email.
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		// Reset content type to avoid conflicts.
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -1303,14 +1189,36 @@ class EmailService {
 	}
 
 	/**
-	 * Dispatch an HTML email, toggling the content-type filter around the send.
+	 * Send an email — the only wp_mail() call site in fair-audience.
 	 *
-	 * @param string $to      Recipient email address.
-	 * @param string $subject Email subject.
-	 * @param string $message Full HTML body.
-	 * @return bool Whether wp_mail() accepted the message.
+	 * Enforces marketing consent for Participant recipients so no send path
+	 * can bypass RecipientResolver::can_receive_email() by forgetting a
+	 * caller-side check. Raw-address recipients (admin notifications, test
+	 * sends) have no participant to check consent for and are sent
+	 * unconditionally — callers must pass EmailType::MINIMAL for those.
+	 *
+	 * @param Participant|string $recipient  Participant (consent + valid-email checked) or a raw email address.
+	 * @param string             $subject    Email subject.
+	 * @param string             $message    Full HTML body.
+	 * @param string             $email_type EmailType constant describing this send.
+	 * @return string 'sent', 'skipped' (consent), or 'failed' (no valid email / wp_mail() failure).
 	 */
-	private function dispatch_html_mail( $to, $subject, $message ) {
+	private function deliver( Participant|string $recipient, string $subject, string $message, string $email_type ): string {
+		if ( $recipient instanceof Participant ) {
+			if ( ! $this->has_valid_email( $recipient ) ) {
+				return 'failed';
+			}
+
+			if ( ( EmailType::MARKETING === $email_type || EmailType::WEEKLY_SUMMARY === $email_type )
+				&& ! $this->can_receive_email( $recipient, $email_type ) ) {
+				return 'skipped';
+			}
+
+			$to = $recipient->email;
+		} else {
+			$to = $recipient;
+		}
+
 		$content_type = static function () {
 			return 'text/html';
 		};
@@ -1319,7 +1227,7 @@ class EmailService {
 		$result = wp_mail( $to, $subject, $this->append_branding_footer( $message ) );
 		remove_filter( 'wp_mail_content_type', $content_type );
 
-		return $result;
+		return $result ? 'sent' : 'failed';
 	}
 
 	/**
@@ -1359,9 +1267,10 @@ class EmailService {
 	 * @param string      $content       Body HTML with placeholders.
 	 * @param int         $event_date_id Event date ID for tokenized links.
 	 * @param array       $context       Per-message context: event_name, event_date.
+	 * @param string      $email_type    EmailType constant used for the consent check.
 	 * @return bool Success.
 	 */
-	public function send_custom_mail_rendered( $participant, $subject, $content, $event_date_id = 0, $context = array() ) {
+	public function send_custom_mail_rendered( $participant, $subject, $content, $event_date_id = 0, $context = array(), $email_type = EmailType::MARKETING ) {
 		if ( ! $this->has_valid_email( $participant ) ) {
 			return false;
 		}
@@ -1369,7 +1278,7 @@ class EmailService {
 		$content = $this->replace_placeholders( $content, $participant, $event_date_id, $context );
 		$message = $this->build_custom_mail_html( $participant, $content );
 
-		return $this->dispatch_html_mail( $participant->email, $subject, $message );
+		return 'sent' === $this->deliver( $participant, $subject, $message, $email_type );
 	}
 
 	/**
@@ -1380,9 +1289,10 @@ class EmailService {
 	 * @param string      $subject       Email subject.
 	 * @param string      $content       Email content (HTML).
 	 * @param int         $event_date_id Event date ID for placeholder replacement.
+	 * @param string      $email_type    EmailType constant used for the consent check.
 	 * @return bool Success.
 	 */
-	public function send_custom_mail( $event, $participant, $subject, $content, $event_date_id = 0 ) {
+	public function send_custom_mail( $event, $participant, $subject, $content, $event_date_id = 0, $email_type = EmailType::MARKETING ) {
 		if ( ! $this->has_valid_email( $participant ) ) {
 			return false;
 		}
@@ -1456,26 +1366,7 @@ class EmailService {
 </body>
 </html>';
 
-		// Set email content type to HTML.
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		// Send email.
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		// Reset content type to avoid conflicts.
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, $email_type );
 	}
 
 	/**
@@ -1511,6 +1402,7 @@ class EmailService {
 		}
 
 		$group_participant_ids = $this->get_participant_ids_for_groups( $group_ids );
+		$email_type            = $is_marketing ? EmailType::MARKETING : EmailType::MINIMAL;
 
 		// Get participants signed up for this event.
 		$event_participants = $this->event_participant_repository->get_by_event( $event_id );
@@ -1568,7 +1460,7 @@ class EmailService {
 			}
 
 			// Send custom mail.
-			$success = $this->send_custom_mail( $event, $participant, $subject, $content, $event_date_id );
+			$success = $this->send_custom_mail( $event, $participant, $subject, $content, $event_date_id, $email_type );
 
 			if ( $success ) {
 				$results['sent'][] = $participant->email;
@@ -1607,6 +1499,7 @@ class EmailService {
 
 		$participants          = $this->participant_repository->get_all();
 		$group_participant_ids = $this->get_participant_ids_for_groups( $group_ids );
+		$deliver_email_type    = $is_marketing ? $email_type : EmailType::MINIMAL;
 
 		foreach ( $participants as $participant ) {
 			// Filter by group membership.
@@ -1644,7 +1537,7 @@ class EmailService {
 			}
 
 			// Send custom mail (no event context).
-			$success = $this->send_custom_mail_without_event( $participant, $subject, $content );
+			$success = $this->send_custom_mail_without_event( $participant, $subject, $content, $deliver_email_type );
 
 			if ( $success ) {
 				$results['sent'][] = $participant->email;
@@ -1666,9 +1559,10 @@ class EmailService {
 	 * @param Participant $participant Participant object.
 	 * @param string      $subject     Email subject.
 	 * @param string      $content     Email content (HTML).
+	 * @param string      $email_type  EmailType constant used for the consent check.
 	 * @return bool Success.
 	 */
-	public function send_custom_mail_without_event( $participant, $subject, $content ) {
+	public function send_custom_mail_without_event( $participant, $subject, $content, $email_type = EmailType::MARKETING ) {
 		if ( ! $this->has_valid_email( $participant ) ) {
 			return false;
 		}
@@ -1742,26 +1636,7 @@ class EmailService {
 </body>
 </html>';
 
-		// Set email content type to HTML.
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		// Send email.
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		// Reset content type to avoid conflicts.
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, $email_type );
 	}
 
 	/**
@@ -1910,26 +1785,7 @@ class EmailService {
 </body>
 </html>';
 
-		// Set email content type to HTML.
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		// Send email.
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		// Reset content type to avoid conflicts.
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -2115,23 +1971,7 @@ class EmailService {
 </body>
 </html>';
 
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		$result = wp_mail( $to_email, $subject, $this->append_branding_footer( $message ) );
-
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $to_email, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -2198,23 +2038,7 @@ class EmailService {
 </body>
 </html>';
 
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		$result = wp_mail( $to_email, $subject, $this->append_branding_footer( $message ) );
-
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $to_email, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -2394,23 +2218,7 @@ class EmailService {
 </body>
 </html>';
 
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -2561,23 +2369,7 @@ class EmailService {
 </body>
 </html>';
 
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -2697,23 +2489,7 @@ class EmailService {
 </body>
 </html>';
 
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -2833,23 +2609,7 @@ class EmailService {
 </body>
 </html>';
 
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -2999,26 +2759,7 @@ class EmailService {
 </body>
 </html>';
 
-		// Set email content type to HTML.
-		add_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		// Send email.
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-
-		// Reset content type to avoid conflicts.
-		remove_filter(
-			'wp_mail_content_type',
-			function () {
-				return 'text/html';
-			}
-		);
-
-		return $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MARKETING );
 	}
 
 	/**
@@ -3267,14 +3008,7 @@ class EmailService {
 </body>
 </html>';
 
-		$content_type_filter = function () {
-			return 'text/html';
-		};
-		add_filter( 'wp_mail_content_type', $content_type_filter );
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-		remove_filter( 'wp_mail_content_type', $content_type_filter );
-
-		return (bool) $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**
@@ -3362,14 +3096,7 @@ class EmailService {
 </body>
 </html>';
 
-		$content_type_filter = function () {
-			return 'text/html';
-		};
-		add_filter( 'wp_mail_content_type', $content_type_filter );
-		$result = wp_mail( $participant->email, $subject, $this->append_branding_footer( $message ) );
-		remove_filter( 'wp_mail_content_type', $content_type_filter );
-
-		return (bool) $result;
+		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}
 
 	/**

--- a/fair-audience/src/Services/__tests__/no-direct-wp-mail.test.js
+++ b/fair-audience/src/Services/__tests__/no-direct-wp-mail.test.js
@@ -1,0 +1,66 @@
+/**
+ * Guards EmailService::deliver() as the sole wp_mail() call site in
+ * fair-audience/src. A new send path that calls wp_mail() directly bypasses
+ * the marketing-consent check centralized in deliver() — see issue #1107.
+ */
+
+import { readFileSync, readdirSync } from 'fs';
+import { join, resolve } from 'path';
+
+const srcDir = resolve(__dirname, '..', '..');
+const FUNCTION_PATTERN = /function\s+&?(\w+)\s*\(/;
+
+function collectPhpFiles(dir) {
+	const files = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (
+			entry.name === 'build' ||
+			entry.name === 'vendor' ||
+			entry.name === 'node_modules'
+		) {
+			continue;
+		}
+
+		const entryPath = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...collectPhpFiles(entryPath));
+		} else if (entry.name.endsWith('.php')) {
+			files.push(entryPath);
+		}
+	}
+	return files;
+}
+
+function enclosingFunctionName(lines, lineIndex) {
+	for (let i = lineIndex; i >= 0; i--) {
+		const match = lines[i].match(FUNCTION_PATTERN);
+		if (match) {
+			return match[1];
+		}
+	}
+	return null;
+}
+
+test('wp_mail() is only called inside EmailService::deliver()', () => {
+	const callSites = [];
+
+	for (const filePath of collectPhpFiles(srcDir)) {
+		const lines = readFileSync(filePath, 'utf8').split('\n');
+		lines.forEach((line, index) => {
+			// Distinguishes a real call — wp_mail( $to, ... ) — from the
+			// "wp_mail() failed to send." reason strings sprinkled through
+			// this file, which always call it with empty parens.
+			if (/\bwp_mail\(\s*[^)\s]/.test(line)) {
+				callSites.push({
+					location: `${filePath}:${index + 1}`,
+					enclosingFunction: enclosingFunctionName(lines, index),
+					isEmailService: filePath.endsWith('EmailService.php'),
+				});
+			}
+		});
+	}
+
+	expect(callSites).toHaveLength(1);
+	expect(callSites[0].isEmailService).toBe(true);
+	expect(callSites[0].enclosingFunction).toBe('deliver');
+});


### PR DESCRIPTION
## Summary

- `EmailService::deliver()` is now the only `wp_mail()` call site in `fair-audience/src`. It checks `RecipientResolver::can_receive_email()` for `Participant` recipients on `MARKETING`/`WEEKLY_SUMMARY` sends before dispatch, so consent enforcement no longer depends on the caller remembering to pre-check — the exact gap that let a pending subscriber get mailed (#1106).
- Every `send_*` method (poll/gallery invitations, confirmation, signup-answers, signup-link, resume-registration, fee-reminder, form notifications, payment confirmation/failure, activities-added, event-interest confirmation, mailing-list welcome, event invitation, and the custom-mail family) now routes through `deliver()` with an explicit `EmailType`.
- The custom-mail family (`send_custom_mail`, `send_custom_mail_rendered`, `send_custom_mail_without_event`) and `ScheduledMessageHooks` thread an `EmailType` derived from their existing `$is_marketing` flag; `send_event_invitation` is always `MARKETING`; everything else is `MINIMAL`.
- Bulk-loop pre-filtering (`can_receive_email`/`would_skip_marketing` checks in `send_bulk_custom_mail*`, `send_bulk_event_invitations`, `ScheduledMessageHooks`) is unchanged — it still drives the `sent`/`skipped`/`failed` counts and previews, but is no longer the enforcement layer.
- Added `fair-audience/src/Services/__tests__/no-direct-wp-mail.test.js`, a Jest guard that walks `fair-audience/src` and fails if `wp_mail(` shows up anywhere outside `EmailService::deliver()`.
- Extended `EventParticipantsMarketingConsent.api.spec.js` with a describe block covering the custom-mail and event-invitation bulk-send paths: a declined participant and a pending marketing participant (created via the public `audience-signup` "keep me informed" flow, the exact #1106 shape) land in `skipped`, while a confirmed marketing participant does not.

Closes #1107

## Notes

- `fair-payments-connector-experimental/src/Services/EmailChannel.php` is left untouched — it mails an operator-configured address, not a participant, so there's no consent to enforce; out of scope per the linked plan.
- `dispatch_html_mail()` was folded directly into `deliver()` rather than kept as a wrapper, since its only caller (`send_custom_mail_rendered`) now needs to pass the `Participant` object through for the consent check rather than a raw address string.

## Test plan

- [x] `npm run format` (fair-audience)
- [x] `vendor/bin/phpcs` on changed PHP files — clean (same 5 pre-existing, unrelated errors as baseline)
- [x] `npm run test:js` (fair-audience) — 6 suites / 26 tests pass, including the new bypass guard
- [x] `npm run test:api` (fair-audience) against the local docker stack — the two new tests plus 2 of the 7 pre-existing tests in this file fail in this environment due to a pre-existing issue unrelated to this change: creating a `fair_event` post via a bare REST POST doesn't reliably get an auto-created `fair_event_dates` row locally, so `eventDateId` resolves empty. Confirmed this is pre-existing by running the original unmodified spec file, which fails identically before any of this PR's changes.
- [x] Manual WP-CLI `eval-file` check (real WordPress + DB, `pre_wp_mail` intercepted) directly exercising `EmailService::send_event_invitation()` and `send_confirmation_email()`: declined and pending-marketing participants are skipped (no `wp_mail()` call) on the `MARKETING` send, a confirmed-marketing participant is sent, and a declined participant still receives the `MINIMAL` confirmation email. All assertions passed.
