### PR TITLE
Make Sale Periods calendar display-only, color-match table

### DIFF
--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -33,7 +33,7 @@ import {
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
-import SalePeriodsCalendar from './SalePeriodsCalendar.js';
+import SalePeriodsCalendar, { salePeriodColor } from './SalePeriodsCalendar.js';
 
 export default function EventTickets({
 	eventDateId,
@@ -637,21 +637,6 @@ export default function EventTickets({
 		setSalePeriods(updated);
 	};
 
-	// Maps a SalePeriodsCalendar boundary click onto the chained setter:
-	// boundary 0 is the first period's start, boundary N (the period count)
-	// is the last period's end, and everything in between is the start of
-	// the period at that index (updateSalePeriod's chaining already
-	// propagates it to the previous period's end).
-	const handleMoveSalePeriodBoundary = (boundaryIndex, dateStr) => {
-		if (boundaryIndex === 0) {
-			updateSalePeriod(0, 'sale_start', dateStr);
-		} else if (boundaryIndex === salePeriods.length) {
-			updateSalePeriod(salePeriods.length - 1, 'sale_end', dateStr);
-		} else {
-			updateSalePeriod(boundaryIndex, 'sale_start', dateStr);
-		}
-	};
-
 	// "Multiple pricing periods" toggled on: split the single sale window at
 	// the event's first day into two named, prefilled, editable periods,
 	// migrating the existing single-period prices to the first one.
@@ -1043,9 +1028,6 @@ export default function EventTickets({
 								<SalePeriodsCalendar
 									salePeriods={salePeriods}
 									eventDay={eventDay}
-									onMoveBoundary={
-										handleMoveSalePeriodBoundary
-									}
 									embedded
 								/>
 							)}
@@ -1055,6 +1037,7 @@ export default function EventTickets({
 										<table className="wp-list-table widefat striped">
 											<thead>
 												<tr>
+													<th />
 													<th>
 														{__(
 															'Name',
@@ -1110,6 +1093,22 @@ export default function EventTickets({
 																	`new-${pIndex}`
 																}
 															>
+																<td>
+																	<span
+																		style={{
+																			display:
+																				'inline-block',
+																			width: '12px',
+																			height: '12px',
+																			background:
+																				salePeriodColor(
+																					pIndex
+																				),
+																			borderRadius:
+																				'2px',
+																		}}
+																	/>
+																</td>
 																<td>
 																	<TextControl
 																		placeholder={__(

--- a/fair-events/src/Admin/manage-event/SalePeriodsCalendar.js
+++ b/fair-events/src/Admin/manage-event/SalePeriodsCalendar.js
@@ -2,11 +2,9 @@
  * Sale Periods Calendar Component
  *
  * Month-grid visualization for the "Sale Periods" panel: each day is shaded
- * with the color of the sale period it falls in, the event day carries a
- * distinct marker, and clicking a day moves the nearest period boundary
- * there. Thin adapter over the shared `MiniCalendar` grid/paging primitive,
- * modeled on RecurrenceCalendar.js (shading + legend) and SeriesModal.js's
- * irregularDayProps (the interactive click pattern).
+ * with the color of the sale period it falls in, and the event day carries a
+ * distinct marker. Display-only — thin adapter over the shared `MiniCalendar`
+ * grid/paging primitive, modeled on RecurrenceCalendar.js (shading + legend).
  *
  * @package FairEvents
  */
@@ -15,8 +13,9 @@ import { Card, CardHeader, CardBody } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { MiniCalendar } from 'fair-events-shared';
 
-// Cycled by period index; every color pairs with white cell text.
-const SALE_PERIOD_COLORS = [
+// Cycled by period index; every color pairs with white cell text. Exported
+// so the Sale Periods edit table can reuse the exact same colors.
+export const SALE_PERIOD_COLORS = [
 	'#007cba',
 	'#4ab866',
 	'#9b51e0',
@@ -24,58 +23,36 @@ const SALE_PERIOD_COLORS = [
 	'#cc1818',
 ];
 
+export function salePeriodColor(index) {
+	return SALE_PERIOD_COLORS[index % SALE_PERIOD_COLORS.length];
+}
+
 // Deliberately distinct from MiniCalendar's built-in "today" border
 // (`2px solid #1e1e1e`) so the event-day marker never blends into it when
 // the event happens to be today.
 const EVENT_DAY_BORDER = '3px solid #f0b849';
 
-function dayDiffAbs(dateStrA, dateStrB) {
-	const a = new Date(`${dateStrA}T00:00:00`);
-	const b = new Date(`${dateStrB}T00:00:00`);
-	return Math.abs(Math.round((a - b) / (1000 * 60 * 60 * 24)));
-}
-
-// Describes which boundary a click would move, e.g. "start of 'Regular'" or
-// (unnamed) "period 2". Boundary `salePeriods.length` is the trailing edge
-// of the last period ("end of ..."); every other boundary is the leading
-// edge of the period at that index ("start of ...").
-function boundaryDescriptor(boundaryIndex, salePeriods) {
-	const isLast = boundaryIndex === salePeriods.length;
-	const period = salePeriods[isLast ? salePeriods.length - 1 : boundaryIndex];
-	const periodNumber = isLast ? salePeriods.length : boundaryIndex + 1;
-
-	if (!period?.name) {
-		return sprintf(
+// The period's name, or "Period N" when unnamed — matches the legend wording.
+function periodLabel(period, index) {
+	return (
+		period.name ||
+		sprintf(
 			/* translators: %d: sale period number */
-			__('period %d', 'fair-events'),
-			periodNumber
-		);
-	}
-
-	return isLast
-		? sprintf(
-				/* translators: %s: sale period name */
-				__("end of '%s'", 'fair-events'),
-				period.name
-		  )
-		: sprintf(
-				/* translators: %s: sale period name */
-				__("start of '%s'", 'fair-events'),
-				period.name
-		  );
+			__('Period %d', 'fair-events'),
+			index + 1
+		)
+	);
 }
 
 /**
- * @param {Object}   props
- * @param {Array}    props.salePeriods    Chained sale periods (`sale_start`/`sale_end`/`name`, Y-m-d strings); consecutive periods share a boundary.
- * @param {string}   [props.eventDay]     Event start date (Y-m-d) for the event-day marker.
- * @param {Function} props.onMoveBoundary `(boundaryIndex, dateStr) => void`, called when a day is clicked.
- * @param {boolean}  [props.embedded]     Card-less render for placement inside an existing panel.
+ * @param {Object}  props
+ * @param {Array}   props.salePeriods Chained sale periods (`sale_start`/`sale_end`/`name`, Y-m-d strings); consecutive periods share a boundary.
+ * @param {string}  [props.eventDay]  Event start date (Y-m-d) for the event-day marker.
+ * @param {boolean} [props.embedded]  Card-less render for placement inside an existing panel.
  */
 export default function SalePeriodsCalendar({
 	salePeriods,
 	eventDay,
-	onMoveBoundary,
 	embedded = false,
 }) {
 	const periods = salePeriods || [];
@@ -108,54 +85,32 @@ export default function SalePeriodsCalendar({
 			(p) => p.sale_start <= dateStr && dateStr < p.sale_end
 		);
 
-	// The clicked day always sits inside (or at the edge of) some gap
-	// between two boundaries, so moving the nearest one to that day can
-	// never push it past its neighbor — ordering stays intact by construction.
-	const nearestBoundaryIndex = (dateStr) => {
-		let bestIndex = 0;
-		let bestDiff = Infinity;
-		boundaries.forEach((b, i) => {
-			const diff = dayDiffAbs(dateStr, b);
-			if (diff < bestDiff) {
-				bestDiff = diff;
-				bestIndex = i;
-			}
-		});
-		return bestIndex;
-	};
-
-	const dayProps = (dateStr, date) => {
+	const dayProps = (dateStr) => {
 		const periodIndex = periodIndexForDate(dateStr);
 		const isEventDay = dateStr === eventDay;
-		const boundaryIndex = nearestBoundaryIndex(dateStr);
 
-		const formattedDate = date.toLocaleDateString(undefined, {
-			weekday: 'long',
-			day: 'numeric',
-			month: 'long',
-			year: 'numeric',
-		});
-		const message = sprintf(
-			/* translators: 1: which boundary a click would move (e.g. "start of 'Regular'"), 2: target date */
-			__('Move the %1$s to %2$s', 'fair-events'),
-			boundaryDescriptor(boundaryIndex, periods),
-			formattedDate
-		);
+		let tooltip;
+		if (isEventDay && periodIndex !== -1) {
+			tooltip = sprintf(
+				/* translators: %s: sale period name */
+				__('%s (event day)', 'fair-events'),
+				periodLabel(periods[periodIndex], periodIndex)
+			);
+		} else if (isEventDay) {
+			tooltip = __('Event day', 'fair-events');
+		} else if (periodIndex !== -1) {
+			tooltip = periodLabel(periods[periodIndex], periodIndex);
+		}
 
 		return {
 			background:
 				periodIndex !== -1
-					? SALE_PERIOD_COLORS[
-							periodIndex % SALE_PERIOD_COLORS.length
-					  ]
+					? salePeriodColor(periodIndex)
 					: 'transparent',
 			color: periodIndex !== -1 ? '#fff' : '#1e1e1e',
 			fontWeight: periodIndex !== -1 ? 600 : 400,
 			border: isEventDay ? EVENT_DAY_BORDER : undefined,
-			interactive: true,
-			onActivate: () => onMoveBoundary(boundaryIndex, dateStr),
-			ariaLabel: message,
-			tooltip: message,
+			tooltip,
 		};
 	};
 
@@ -183,21 +138,13 @@ export default function SalePeriodsCalendar({
 								display: 'inline-block',
 								width: '12px',
 								height: '12px',
-								background:
-									SALE_PERIOD_COLORS[
-										index % SALE_PERIOD_COLORS.length
-									],
+								background: salePeriodColor(index),
 								borderRadius: '2px',
 								verticalAlign: 'middle',
 								marginRight: '4px',
 							}}
 						/>
-						{period.name ||
-							sprintf(
-								/* translators: %d: sale period number */
-								__('Period %d', 'fair-events'),
-								index + 1
-							)}
+						{periodLabel(period, index)}
 					</span>
 				))}
 				{eventDay && (

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -22,6 +22,7 @@ import {
 } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import EventTickets from '../EventTickets.js';
+import { salePeriodColor } from '../SalePeriodsCalendar.js';
 
 jest.mock('@wordpress/api-fetch');
 
@@ -1284,35 +1285,34 @@ describe('EventTickets — SalePeriodsCalendar wiring (#1197)', () => {
 		],
 	};
 
-	function moveMessage(boundaryLabel, dateStr) {
-		const formatted = new Date(`${dateStr}T00:00:00`).toLocaleDateString(
-			undefined,
-			{ weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' }
-		);
-		return `Move the ${boundaryLabel} to ${formatted}`;
+	// jsdom normalizes inline hex colors to rgb() on the CSSOM.
+	function hexToRgb(hex) {
+		const r = parseInt(hex.slice(1, 3), 16);
+		const g = parseInt(hex.slice(3, 5), 16);
+		const b = parseInt(hex.slice(5, 7), 16);
+		return `rgb(${r}, ${g}, ${b})`;
 	}
 
-	it('clicking a calendar day updates both chained date inputs and trips the dirty indicator', () => {
-		const onDirtyChange = jest.fn();
+	it('renders a swatch per Sale Periods table row matching the calendar palette', () => {
 		renderTickets({
 			initialData: initialDataWithTwoPeriods,
 			startDatetime: '2026-01-25 10:00:00',
 			endDatetime: '2026-02-01 12:00:00',
-			onDirtyChange,
 		});
 
-		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+		const toggle = screen.getByRole('button', { name: /Sale Periods/i });
+		fireEvent.click(toggle);
 
-		expect(onDirtyChange).toHaveBeenLastCalledWith(false);
-
-		const button = screen.getByRole('button', {
-			name: moveMessage("start of 'Day of event'", '2026-01-16'),
-		});
-		fireEvent.click(button);
-
-		// Both the Advance-ticket "Until" input and the Day-of-event "From"
-		// input mirror the moved boundary — updateSalePeriod() chains them.
-		expect(screen.getAllByDisplayValue('2026-01-16')).toHaveLength(2);
-		expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+		const panelBody = toggle.closest('.components-panel__body');
+		const rows = panelBody
+			.querySelector('table')
+			.querySelectorAll('tbody tr');
+		expect(rows).toHaveLength(2);
+		expect(rows[0].querySelector('td span').style.background).toBe(
+			hexToRgb(salePeriodColor(0))
+		);
+		expect(rows[1].querySelector('td span').style.background).toBe(
+			hexToRgb(salePeriodColor(1))
+		);
 	});
 });

--- a/fair-events/src/Admin/manage-event/__tests__/SalePeriodsCalendar.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/SalePeriodsCalendar.test.jsx
@@ -8,24 +8,11 @@
  *     (sale_start/sale_end chain) is set, in both single- and
  *     multi-period shapes.
  *   - Legend lists every period (name or "Period N") plus the event day.
- *   - Clicking a day calls onMoveBoundary with the *nearest* boundary
- *     index and the clicked date — a click near a middle boundary picks
- *     that boundary, not sale start.
- *   - The accessible name / tooltip names the exact boundary and target
- *     date that a click would move.
+ *   - Display-only: day cells render as plain cells, not buttons.
  */
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import SalePeriodsCalendar from '../SalePeriodsCalendar.js';
-
-// Matches the message built in SalePeriodsCalendar's dayProps().
-function moveMessage(boundaryLabel, dateStr) {
-	const formatted = new Date(`${dateStr}T00:00:00`).toLocaleDateString(
-		undefined,
-		{ weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' }
-	);
-	return `Move the ${boundaryLabel} to ${formatted}`;
-}
 
 const twoNamedPeriods = [
 	{
@@ -47,7 +34,6 @@ it('renders nothing when a boundary is unresolved (freshly seeded default)', () 
 		<SalePeriodsCalendar
 			salePeriods={[{ name: '', sale_start: '', sale_end: '' }]}
 			eventDay="2026-09-05"
-			onMoveBoundary={() => {}}
 			embedded
 		/>
 	);
@@ -56,12 +42,7 @@ it('renders nothing when a boundary is unresolved (freshly seeded default)', () 
 
 it('renders nothing when there are no sale periods', () => {
 	const { container } = render(
-		<SalePeriodsCalendar
-			salePeriods={[]}
-			eventDay="2026-09-05"
-			onMoveBoundary={() => {}}
-			embedded
-		/>
+		<SalePeriodsCalendar salePeriods={[]} eventDay="2026-09-05" embedded />
 	);
 	expect(container).toBeEmptyDOMElement();
 });
@@ -73,7 +54,6 @@ it('renders in single-period mode once both boundaries are set', () => {
 				{ name: '', sale_start: '2026-08-01', sale_end: '2026-09-01' },
 			]}
 			eventDay="2026-08-20"
-			onMoveBoundary={() => {}}
 			embedded
 		/>
 	);
@@ -86,7 +66,6 @@ it('lists every period by name (or "Period N" when unnamed) plus the event day i
 		<SalePeriodsCalendar
 			salePeriods={twoNamedPeriods}
 			eventDay="2026-08-20"
-			onMoveBoundary={() => {}}
 			embedded
 		/>
 	);
@@ -95,85 +74,13 @@ it('lists every period by name (or "Period N" when unnamed) plus the event day i
 	expect(screen.getByText('Event day')).toBeInTheDocument();
 });
 
-it('clicking a day near the middle boundary moves that boundary, not sale start', () => {
-	const onMoveBoundary = jest.fn();
+it('renders day cells as plain, non-operable cells rather than buttons', () => {
 	render(
 		<SalePeriodsCalendar
 			salePeriods={twoNamedPeriods}
 			eventDay="2026-08-20"
-			onMoveBoundary={onMoveBoundary}
 			embedded
 		/>
 	);
-
-	// One day after the shared Early-bird/Regular boundary (2026-08-15) —
-	// closer to it than to either the sale-start (08-01) or sale-end
-	// (09-01) boundary.
-	const button = screen.getByRole('button', {
-		name: moveMessage("start of 'Regular'", '2026-08-16'),
-	});
-	fireEvent.click(button);
-
-	expect(onMoveBoundary).toHaveBeenCalledWith(1, '2026-08-16');
-});
-
-it('clicking the first day of the calendar moves the sale-start boundary', () => {
-	const onMoveBoundary = jest.fn();
-	render(
-		<SalePeriodsCalendar
-			salePeriods={twoNamedPeriods}
-			eventDay="2026-08-20"
-			onMoveBoundary={onMoveBoundary}
-			embedded
-		/>
-	);
-
-	const button = screen.getByRole('button', {
-		name: moveMessage("start of 'Early bird'", '2026-08-01'),
-	});
-	fireEvent.click(button);
-
-	expect(onMoveBoundary).toHaveBeenCalledWith(0, '2026-08-01');
-});
-
-it('clicking the last day of the calendar moves the sale-end boundary', () => {
-	const onMoveBoundary = jest.fn();
-	render(
-		<SalePeriodsCalendar
-			salePeriods={twoNamedPeriods}
-			eventDay="2026-08-20"
-			onMoveBoundary={onMoveBoundary}
-			embedded
-		/>
-	);
-
-	const button = screen.getByRole('button', {
-		name: moveMessage("end of 'Regular'", '2026-09-01'),
-	});
-	fireEvent.click(button);
-
-	expect(onMoveBoundary).toHaveBeenCalledWith(2, '2026-09-01');
-});
-
-it('describes an unnamed boundary as "period N" rather than start/end wording', () => {
-	const onMoveBoundary = jest.fn();
-	const unnamedPeriods = [
-		{ id: 1, name: '', sale_start: '2026-08-01', sale_end: '2026-08-15' },
-		{ id: 2, name: '', sale_start: '2026-08-15', sale_end: '2026-09-01' },
-	];
-	render(
-		<SalePeriodsCalendar
-			salePeriods={unnamedPeriods}
-			eventDay="2026-08-20"
-			onMoveBoundary={onMoveBoundary}
-			embedded
-		/>
-	);
-
-	const button = screen.getByRole('button', {
-		name: moveMessage('period 1', '2026-08-01'),
-	});
-	fireEvent.click(button);
-
-	expect(onMoveBoundary).toHaveBeenCalledWith(0, '2026-08-01');
+	expect(screen.queryByRole('button')).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary

Follow-up to the shipped Sale Periods calendar (`c878b100`): simplify it to
**display only** and mirror its per-period colors onto the Sale Periods edit
table so the two views are easy to connect at a glance.

- `SalePeriodsCalendar.js`: removed the `onMoveBoundary` prop and the
  click-to-move-boundary machinery (`dayDiffAbs`, `nearestBoundaryIndex`,
  `boundaryDescriptor`, `interactive`/`onActivate`). Shading, the event-day
  marker, and the legend are unchanged. Day-cell tooltips now show a
  lightweight informative label (period name / "Period N", plus "event day"
  when applicable) instead of the old move message. Exported
  `SALE_PERIOD_COLORS` and `salePeriodColor(index)` as the single source of
  truth for the palette.
- `EventTickets.js`: dropped `onMoveBoundary`/`handleMoveSalePeriodBoundary`
  (dead now that the calendar is read-only). Added a narrow swatch column to
  the multi-period Sale Periods table, filled with `salePeriodColor(pIndex)`
  — row order matches the calendar's palette order.
- Updated `SalePeriodsCalendar.test.jsx` and `EventTickets.test.jsx`
  accordingly: dropped the click/boundary tests, added a "renders as plain
  cells, not buttons" assertion and a table-swatch-color assertion.

Refs #1197

## Test plan

- [x] `npm run test:js` (fair-events) — 152/152 passing
- [x] `npm run build` (fair-events)
- [x] `npm run format`
- [ ] No PHP changed — `phpcs` not applicable
