### PR TITLE
Add e2e coverage for signup occurrence pickers across ticket scopes

### DIFF
--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -20,6 +20,11 @@
  *                        multiple_instances (default prices 15/40/10; override
  *                        {"price":N} sets the single_instance price). Always
  *                        renders the unified fair-events/event-signup block.
+ *   audience-ticket-scopes  like three-ticket-scopes, but renders the default
+ *                        fair-audience/event-signup block instead. Override
+ *                        {"omitMulti":true} to skip the multiple_instances
+ *                        type (single_instance + whole_series only), the
+ *                        regression scenario.
  *
  * Examples:
  *   wp eval-file .../seed-event.php paid
@@ -51,6 +56,7 @@ $price             = isset( $overrides['price'] ) ? (float) $overrides['price'] 
 $option_names      = isset( $overrides['options'] ) ? (array) $overrides['options'] : array( 'dinner', 'tshirt' );
 $option_price      = isset( $overrides['optionPrice'] ) ? (float) $overrides['optionPrice'] : 10.00;
 $minimum_instances = isset( $overrides['minimumInstances'] ) ? (int) $overrides['minimumInstances'] : 2;
+$omit_multi        = isset( $overrides['omitMulti'] ) && $overrides['omitMulti'];
 $ticket_type_id    = 0;
 $option_ids        = array();
 $occurrence_ids    = array();
@@ -147,8 +153,26 @@ switch ( $flavour ) {
 		$extra_type_ids = array( $whole_type_id, $multi_type_id );
 		break;
 
+	case 'audience-ticket-scopes':
+		$price = isset( $overrides['price'] ) ? (float) $overrides['price'] : 15.00;
+		// Turns the single occurrence already created above into the series
+		// master (same event_date_id/sale_period_id) plus 2 generated siblings.
+		$occurrence_ids = fair_e2e_add_series( $event_id, 3 );
+		$single_type_id = fair_e2e_add_ticket_type( $event_date_id, 'Single Session', null );
+		$whole_type_id  = fair_e2e_add_whole_series_ticket_type( $event_date_id, 'Full Series Pass' );
+		fair_e2e_add_price( $single_type_id, $sale_period_id, $price, null );
+		fair_e2e_add_price( $whole_type_id, $sale_period_id, 40.00, null );
+		$ticket_type_id = $single_type_id;
+		$extra_type_ids = array( $whole_type_id );
+		if ( ! $omit_multi ) {
+			$multi_type_id    = fair_e2e_add_multi_instance_ticket_type( $event_date_id, 'Pick your sessions', $minimum_instances );
+			$extra_type_ids[] = $multi_type_id;
+			fair_e2e_add_price( $multi_type_id, $sale_period_id, 10.00, null );
+		}
+		break;
+
 	default:
-		WP_CLI::error( "Unknown flavour '{$flavour}'. Use one of: free, paid, paid-with-options, capacity-1, multiple-instances, three-ticket-scopes." );
+		WP_CLI::error( "Unknown flavour '{$flavour}'. Use one of: free, paid, paid-with-options, capacity-1, multiple-instances, three-ticket-scopes, audience-ticket-scopes." );
 }
 
 echo 'E2E_SEED:' . wp_json_encode(

--- a/e2e/user-flows/signup-occurrence-pickers.spec.js
+++ b/e2e/user-flows/signup-occurrence-pickers.spec.js
@@ -1,0 +1,194 @@
+/**
+ * E2E: occurrence-picker visibility in the participant-aware Event Signup
+ * form (fair-audience/event-signup) across all three ticket recurrence
+ * scopes — single_instance, multiple_instances, whole_series.
+ *
+ * The picker toggling is entirely client-side (frontend.js
+ * syncOccurrencePickers()), keyed off each ticket radio's
+ * data-recurrence-scope attribute. A prior regression left the single-date
+ * dropdown visible for a whole-series pass, and it went unnoticed because no
+ * automated test exercised picker visibility. These tests assert on
+ * effective visibility (not internal state) to stay durable across markup
+ * refactors (#1178).
+ */
+
+import { test, expect } from '../support/fixtures.js';
+
+test.describe('Occurrence pickers for all three ticket scopes (fair-audience)', () => {
+	test('single-occurrence scope shows the date dropdown, not the checkbox picker', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('audience-ticket-scopes');
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-audience-signup-register');
+		await expect(form).toBeVisible();
+
+		const ticketRadio = form.locator(
+			`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
+		);
+		await expect(ticketRadio).toBeChecked();
+
+		await expect(
+			page.locator('.fair-audience-occurrence-picker')
+		).toBeVisible();
+		await expect(
+			form.locator('.fair-audience-instance-picker')
+		).toBeHidden();
+	});
+
+	test('multiple-occurrence scope shows the checkbox picker, not the date dropdown', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('audience-ticket-scopes');
+		const [, multiInstanceTypeId] = event.extraTypeIds;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-audience-signup-register');
+		await expect(form).toBeVisible();
+
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${multiInstanceTypeId}"]`
+			)
+			.check();
+
+		await expect(
+			form.locator('.fair-audience-instance-picker')
+		).toBeVisible();
+		await expect(
+			page.locator('.fair-audience-occurrence-picker')
+		).toBeHidden();
+	});
+
+	test('whole-series scope shows neither picker', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('audience-ticket-scopes');
+		const [wholeSeriesTypeId] = event.extraTypeIds;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-audience-signup-register');
+		await expect(form).toBeVisible();
+
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${wholeSeriesTypeId}"]`
+			)
+			.check();
+
+		await expect(
+			page.locator('.fair-audience-occurrence-picker')
+		).toBeHidden();
+		await expect(
+			form.locator('.fair-audience-instance-picker')
+		).toBeHidden();
+	});
+
+	test('switching ticket types updates the visible picker live and clears a stale checkbox selection', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('audience-ticket-scopes');
+		const [wholeSeriesTypeId, multiInstanceTypeId] = event.extraTypeIds;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-audience-signup-register');
+		await expect(form).toBeVisible();
+
+		const dropdown = page.locator('.fair-audience-occurrence-picker');
+		const instancePicker = form.locator('.fair-audience-instance-picker');
+
+		// Single-session (default) — dropdown visible, checkbox picker hidden.
+		await expect(dropdown).toBeVisible();
+		await expect(instancePicker).toBeHidden();
+
+		// Whole-series pass — neither picker shown.
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${wholeSeriesTypeId}"]`
+			)
+			.check();
+		await expect(dropdown).toBeHidden();
+		await expect(instancePicker).toBeHidden();
+
+		// Multiple-instances pass — checkbox picker shows.
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${multiInstanceTypeId}"]`
+			)
+			.check();
+		await expect(instancePicker).toBeVisible();
+		await expect(dropdown).toBeHidden();
+
+		const [firstOccurrenceId] = event.occurrenceIds;
+		const checkbox = instancePicker.locator(
+			`input[name="event_date_ids[]"][value="${firstOccurrenceId}"]`
+		);
+		await checkbox.check();
+		await expect(checkbox).toBeChecked();
+
+		// Switch away to whole-series, then back — the stale checkbox
+		// selection must not survive the round-trip.
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${wholeSeriesTypeId}"]`
+			)
+			.check();
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${multiInstanceTypeId}"]`
+			)
+			.check();
+		await expect(instancePicker).toBeVisible();
+		await expect(checkbox).not.toBeChecked();
+
+		// Back to single-session — dropdown reappears, checkbox picker hides.
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
+			)
+			.check();
+		await expect(dropdown).toBeVisible();
+		await expect(instancePicker).toBeHidden();
+	});
+
+	test('regression: single + whole-series only (no multiple-occurrence type)', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('audience-ticket-scopes', {
+			omitMulti: true,
+		});
+		const [wholeSeriesTypeId] = event.extraTypeIds;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-audience-signup-register');
+		await expect(form).toBeVisible();
+
+		const dropdown = page.locator('.fair-audience-occurrence-picker');
+
+		// Single-session (default) — dropdown visible.
+		await expect(dropdown).toBeVisible();
+
+		// Whole-series pass — dropdown hidden; there is no instance picker at
+		// all since this event has no multiple_instances ticket type.
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${wholeSeriesTypeId}"]`
+			)
+			.check();
+		await expect(dropdown).toBeHidden();
+		await expect(
+			form.locator('.fair-audience-instance-picker')
+		).toHaveCount(0);
+	});
+});


### PR DESCRIPTION
## Summary

- Add e2e coverage for the fair-audience Event Signup form's occurrence-picker visibility across all three ticket recurrence scopes (single-occurrence, multiple-occurrence, whole-series). The base fair-events form already had coverage for this; the fair-audience form did not, and a prior regression there (the single-date dropdown left visible for a whole-series pass) went unnoticed for exactly that reason.
- New seed flavour `audience-ticket-scopes` in `e2e/mu-plugins/scripts/seed-event.php` mirrors `three-ticket-scopes` but renders the default fair-audience block instead of forcing the fair-events one, and supports `{"omitMulti": true}` to reproduce the regression scenario (single + whole-series only, no multiple-occurrence type).
- New spec `e2e/user-flows/signup-occurrence-pickers.spec.js` covers: each scope's picker visibility in isolation, live switching between all three scopes with no page reload, checkbox-selection clearing when switching away from the multiple-occurrence type, and the regression scenario.

Closes #1178

## Test plan

- [x] `npm run test:e2e -- signup-occurrence-pickers` — 5/5 pass
- [x] `npm run test:e2e -- e2e/user-flows` (full suite) — 23/23 pass
- [x] `vendor/bin/phpcs` clean on the changed PHP file
- [x] `npx wp-scripts format` run on the changed JS spec
