### PR TITLE
Time out unconfirmed marketing subscriptions after a week

### DIFF
--- a/fair-audience/__tests__/Hooks/PendingSubscriptionTimeoutHooksTest.php
+++ b/fair-audience/__tests__/Hooks/PendingSubscriptionTimeoutHooksTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * PendingSubscriptionTimeoutHooks cutoff tests
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Tests\Hooks;
+
+use PHPUnit\Framework\TestCase;
+use FairAudience\Hooks\PendingSubscriptionTimeoutHooks;
+
+/**
+ * Validates the one pure seam of the sweep: the timeout cutoff is exactly one
+ * week (in UTC) before the reference instant. The DB sweep and consent logging
+ * need a live database and are covered by the WP-CLI manual-check recipe, not
+ * here.
+ */
+class PendingSubscriptionTimeoutHooksTest extends TestCase {
+
+	/**
+	 * The cutoff is now minus one week, formatted as a UTC MySQL datetime.
+	 */
+	public function test_cutoff_is_one_week_before_the_reference_time() {
+		// 2026-07-22 12:00:00 UTC.
+		$now = gmmktime( 12, 0, 0, 7, 22, 2026 );
+
+		$this->assertSame(
+			'2026-07-15 12:00:00',
+			PendingSubscriptionTimeoutHooks::cutoff( $now )
+		);
+	}
+
+	/**
+	 * Called without an argument, the cutoff defaults to a week before now.
+	 */
+	public function test_cutoff_defaults_to_a_week_before_now() {
+		$expected = gmdate( 'Y-m-d H:i:s', time() - WEEK_IN_SECONDS );
+
+		// Allow a 2-second window so a clock tick between the two calls can't
+		// flake the assertion.
+		$this->assertLessThanOrEqual(
+			2,
+			abs( strtotime( PendingSubscriptionTimeoutHooks::cutoff() ) - strtotime( $expected ) )
+		);
+	}
+}

--- a/fair-audience/__tests__/bootstrap.php
+++ b/fair-audience/__tests__/bootstrap.php
@@ -14,6 +14,14 @@ if ( ! defined( 'WPINC' ) ) {
 	define( 'WPINC', 'wp-includes' );
 }
 
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+
+if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+	define( 'WEEK_IN_SECONDS', 7 * 24 * 60 * 60 );
+}
+
 // Minimal WordPress function stubs so pure digest logic can be unit tested
 // without a full WP bootstrap. Tests seed values via $GLOBALS['_fair_test_options'].
 if ( ! function_exists( 'is_wp_error' ) ) {

--- a/fair-audience/src/Core/Plugin.php
+++ b/fair-audience/src/Core/Plugin.php
@@ -92,6 +92,9 @@ class Plugin {
 		// Initialize the weekly events digest cron.
 		\FairAudience\Hooks\WeeklyDigestHooks::init();
 
+		// Initialize the pending-subscription timeout cron.
+		\FairAudience\Hooks\PendingSubscriptionTimeoutHooks::init();
+
 		// Extend fair-events' unified signup block/route for the simple
 		// anonymous/linked case via the fair_events_signup_* hook contract.
 		\FairAudience\Hooks\SignupHookBridge::init();

--- a/fair-audience/src/Database/ParticipantRepository.php
+++ b/fair-audience/src/Database/ParticipantRepository.php
@@ -87,6 +87,39 @@ class ParticipantRepository {
 	}
 
 	/**
+	 * Get marketing subscribers still pending confirmation past a cutoff.
+	 *
+	 * Used by the pending-subscription timeout sweep to find participants who
+	 * signed up for marketing mail but never confirmed. The caller reverts each
+	 * one and writes its own consent-log row, so this returns the models rather
+	 * than mutating them.
+	 *
+	 * @param string $cutoff MySQL UTC datetime; rows updated before this match.
+	 * @return Participant[] Array of expired pending-marketing participants.
+	 */
+	public function get_expired_pending_marketing( $cutoff ) {
+		global $wpdb;
+
+		$table_name = $this->get_table_name();
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM %i WHERE email_profile = 'marketing' AND status = 'pending' AND updated_at < %s",
+				$table_name,
+				$cutoff
+			),
+			ARRAY_A
+		);
+
+		return array_map(
+			function ( $row ) {
+				return new Participant( $row );
+			},
+			$results
+		);
+	}
+
+	/**
 	 * Get participant by email.
 	 *
 	 * @param string $email Email address.

--- a/fair-audience/src/Hooks/PendingSubscriptionTimeoutHooks.php
+++ b/fair-audience/src/Hooks/PendingSubscriptionTimeoutHooks.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Pending Subscription Timeout Hooks
+ *
+ * A 5-minute cron tick that times out marketing subscriptions which were never
+ * confirmed: after a week in "marketing + pending" limbo the participant is
+ * reverted to a plain minimal (confirmed) mailing profile, with an audit entry.
+ * The tick also cleans up expired email-confirmation tokens.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Hooks;
+
+use FairAudience\Database\EmailConfirmationTokenRepository;
+use FairAudience\Database\ParticipantRepository;
+use FairAudience\Models\EmailConsentLog;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Cron hooks for timing out unconfirmed marketing subscriptions.
+ */
+class PendingSubscriptionTimeoutHooks {
+
+	/**
+	 * Cron hook name for the recurring tick.
+	 */
+	const CRON_HOOK = 'fair_audience_pending_subscription_timeout_tick';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_filter( 'cron_schedules', array( static::class, 'add_cron_schedule' ) );
+
+		add_action( self::CRON_HOOK, array( static::class, 'run' ) );
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + MINUTE_IN_SECONDS, 'fair_audience_every_five_minutes', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Register the shared 5-minute cron schedule.
+	 *
+	 * Mirrors WeeklyDigestHooks::add_cron_schedule so both coexist; the
+	 * `isset()` guard makes adding the same key twice a no-op.
+	 *
+	 * @param array $schedules Existing schedules.
+	 * @return array
+	 */
+	public static function add_cron_schedule( $schedules ) {
+		if ( ! isset( $schedules['fair_audience_every_five_minutes'] ) ) {
+			$schedules['fair_audience_every_five_minutes'] = array(
+				'interval' => 5 * MINUTE_IN_SECONDS,
+				'display'  => __( 'Every 5 minutes (fair-audience)', 'fair-audience' ),
+			);
+		}
+		return $schedules;
+	}
+
+	/**
+	 * The UTC cutoff before which a pending marketing subscription has timed out.
+	 *
+	 * Compared against the participant's `updated_at` (a UTC DB timestamp), so
+	 * the cutoff is computed in UTC too — matching how
+	 * EmailConfirmationTokenRepository::delete_expired() derives its own bound.
+	 *
+	 * @param int|null $now Unix timestamp to measure from; defaults to time().
+	 * @return string MySQL UTC datetime one week before $now.
+	 */
+	public static function cutoff( $now = null ) {
+		$now = null === $now ? time() : (int) $now;
+		return gmdate( 'Y-m-d H:i:s', $now - WEEK_IN_SECONDS );
+	}
+
+	/**
+	 * Cron tick: revert timed-out pending marketing subscribers to minimal and
+	 * purge expired confirmation tokens.
+	 *
+	 * Runs unconditionally each tick; it is idempotent because only rows past
+	 * the cutoff match, and reverting them removes them from the next sweep.
+	 */
+	public static function run() {
+		$cutoff       = self::cutoff();
+		$repository   = new ParticipantRepository();
+		$participants = $repository->get_expired_pending_marketing( $cutoff );
+
+		foreach ( $participants as $participant ) {
+			$participant->email_profile = 'minimal';
+			$participant->status        = 'confirmed';
+
+			if ( ! $participant->save() ) {
+				continue;
+			}
+
+			EmailConsentLog::create(
+				array(
+					'participant_id' => $participant->id,
+					'old_profile'    => 'marketing',
+					'new_profile'    => 'minimal',
+					'source'         => 'pending_timeout',
+					'comment'        => __( 'Marketing subscription timed out after a week without confirmation.', 'fair-audience' ),
+				)
+			);
+		}
+
+		( new EmailConfirmationTokenRepository() )->delete_expired();
+	}
+}


### PR DESCRIPTION
## Summary

A double opt-in marketing signup that is never confirmed sits at
`email_profile = marketing` + `status = pending` forever, and its expired
confirmation token is never cleaned up. This adds a cron sweep that times out
those stale subscriptions after a week.

- New `Hooks/PendingSubscriptionTimeoutHooks` — a 5-minute cron tick mirroring
  `WeeklyDigestHooks` and reusing the shared `fair_audience_every_five_minutes`
  schedule (the `isset()` guard makes registering it twice a no-op). Registered
  in `Core/Plugin.php` next to `WeeklyDigestHooks::init()`.
- Each tick reverts every `marketing` + `pending` participant whose
  `updated_at` is older than one week to `minimal` + `confirmed`, and writes an
  `EmailConsentLog` row (`old_profile=marketing`, `new_profile=minimal`,
  `source=pending_timeout`) for the audit trail.
- The same tick finally calls `EmailConfirmationTokenRepository::delete_expired()`,
  which existed but was never wired up, so expired tokens stop leaking.
- `ParticipantRepository::get_expired_pending_marketing()` is a read-only select
  so the hook orchestrates the per-participant revert and its own consent-log
  entry, matching how `EventParticipantsController` logs consent at the caller.

The sweep runs unconditionally each tick; it is idempotent because only rows
past the cutoff match, and reverting them removes them from the next sweep.

Closes #1108

## Notes

- **Anchor timestamp:** `updated_at` per the ticket recommendation. A "resend
  confirmation" re-saves the participant and correctly restarts the clock; the
  accepted caveat is that an unrelated admin edit also resets it. No new
  `pending_since` column unless stricter semantics are wanted.
- **Revert target:** `minimal` (not `declined`) — "never confirmed" keeps them
  eligible for essential/event mail rather than treating them as opted out.
- **Timeout length:** hardcoded `WEEK_IN_SECONDS`; not yet exposed in settings.

## Test plan

- [x] `vendor/bin/phpcs` clean on all changed PHP (the one 5-min-cron warning is
      identical to the sibling `WeeklyDigestHooks` and accepted there too).
- [x] `PendingSubscriptionTimeoutHooksTest` covers the pure seam — the cutoff is
      exactly one week (UTC) before the reference instant.
- [x] Full `fair-audience` PHPUnit suite: no new failures (2 pre-existing
      `WeeklyDigestRendererTest` errors from a missing `wpautop()` stub are
      unrelated and also fail on `main`).
- [ ] Live-DB matrix via the WP-CLI `eval-file` recipe (pending>week reverts to
      minimal+confirmed with a `pending_timeout` log row; pending<week stays;
      confirmed/declined/minimal untouched; expired tokens deleted) — **not run**
      here: the DB port was already allocated by another environment, so a live
      WP could not be stood up in this worktree.
