### PR TITLE
Time out unconfirmed marketing subscriptions after a week

### DIFF
--- a/fair-audience/__tests__/Hooks/PendingSubscriptionTimeoutHooksTest.php
+++ b/fair-audience/__tests__/Hooks/PendingSubscriptionTimeoutHooksTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PendingSubscriptionTimeoutHooks cutoff test
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Tests\Hooks;
+
+use PHPUnit\Framework\TestCase;
+use FairAudience\Hooks\PendingSubscriptionTimeoutHooks;
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Validates the sweep's cutoff derivation. The DB query and per-participant
+ * writes need a live WordPress instance and are covered by the WP-CLI
+ * eval-file manual check instead (see TESTING.md).
+ */
+class PendingSubscriptionTimeoutHooksTest extends TestCase {
+
+	/**
+	 * Cutoff() resolves to exactly one week (WEEK_IN_SECONDS) before now, in UTC.
+	 */
+	public function test_cutoff_is_one_week_before_now() {
+		$before = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+
+		$cutoff = PendingSubscriptionTimeoutHooks::cutoff();
+
+		$after = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+
+		$cutoff_date = DateTime::createFromFormat( 'Y-m-d H:i:s', $cutoff, new DateTimeZone( 'UTC' ) );
+
+		$expected_earliest = ( clone $before )->modify( '-' . WEEK_IN_SECONDS . ' seconds' );
+		$expected_latest   = ( clone $after )->modify( '-' . WEEK_IN_SECONDS . ' seconds' );
+
+		$this->assertGreaterThanOrEqual( $expected_earliest->getTimestamp(), $cutoff_date->getTimestamp() );
+		$this->assertLessThanOrEqual( $expected_latest->getTimestamp(), $cutoff_date->getTimestamp() );
+	}
+}

--- a/fair-audience/__tests__/bootstrap.php
+++ b/fair-audience/__tests__/bootstrap.php
@@ -14,6 +14,10 @@ if ( ! defined( 'WPINC' ) ) {
 	define( 'WPINC', 'wp-includes' );
 }
 
+if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+	define( 'WEEK_IN_SECONDS', 7 * 24 * 60 * 60 );
+}
+
 // Minimal WordPress function stubs so pure digest logic can be unit tested
 // without a full WP bootstrap. Tests seed values via $GLOBALS['_fair_test_options'].
 if ( ! function_exists( 'is_wp_error' ) ) {

--- a/fair-audience/src/Core/Plugin.php
+++ b/fair-audience/src/Core/Plugin.php
@@ -92,6 +92,9 @@ class Plugin {
 		// Initialize the weekly events digest cron.
 		\FairAudience\Hooks\WeeklyDigestHooks::init();
 
+		// Initialize the pending-subscription timeout sweep cron.
+		\FairAudience\Hooks\PendingSubscriptionTimeoutHooks::init();
+
 		// Extend fair-events' unified signup block/route for the simple
 		// anonymous/linked case via the fair_events_signup_* hook contract.
 		\FairAudience\Hooks\SignupHookBridge::init();

--- a/fair-audience/src/Database/ParticipantRepository.php
+++ b/fair-audience/src/Database/ParticipantRepository.php
@@ -405,6 +405,38 @@ class ParticipantRepository {
 	}
 
 	/**
+	 * Get participants stuck at marketing+pending past the given cutoff.
+	 *
+	 * Used by the pending-subscription timeout sweep; rows are returned (not
+	 * bulk-updated) because each revert needs its own EmailConsentLog entry.
+	 *
+	 * @param string $cutoff Datetime string (UTC, 'Y-m-d H:i:s'); rows with
+	 *                       updated_at older than this are returned.
+	 * @return Participant[] Array of participants.
+	 */
+	public function get_expired_pending_marketing( $cutoff ) {
+		global $wpdb;
+
+		$table_name = $this->get_table_name();
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM %i WHERE email_profile = 'marketing' AND status = 'pending' AND updated_at < %s",
+				$table_name,
+				$cutoff
+			),
+			ARRAY_A
+		);
+
+		return array_map(
+			function ( $row ) {
+				return new Participant( $row );
+			},
+			$results
+		);
+	}
+
+	/**
 	 * Get audience stats: total participants, and how many are in the
 	 * mailing (marketing + confirmed), pending confirmation, or declined.
 	 *

--- a/fair-audience/src/Hooks/PendingSubscriptionTimeoutHooks.php
+++ b/fair-audience/src/Hooks/PendingSubscriptionTimeoutHooks.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Pending Subscription Timeout Hooks
+ *
+ * Drives the pending-marketing-subscription timeout sweep: a 5-minute cron
+ * tick reverts participants stuck at marketing+pending for over a week back
+ * to minimal+confirmed, logs the change, and clears expired confirmation
+ * tokens.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Hooks;
+
+use FairAudience\Database\EmailConfirmationTokenRepository;
+use FairAudience\Database\ParticipantRepository;
+use FairAudience\Models\EmailConsentLog;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Cron hooks for the pending-subscription timeout sweep.
+ */
+class PendingSubscriptionTimeoutHooks {
+
+	/**
+	 * Cron hook name for the recurring tick.
+	 */
+	const CRON_HOOK = 'fair_audience_pending_subscription_timeout_tick';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_filter( 'cron_schedules', array( static::class, 'add_cron_schedule' ) );
+
+		add_action( self::CRON_HOOK, array( static::class, 'run' ) );
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + MINUTE_IN_SECONDS, 'fair_audience_every_five_minutes', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Register the shared 5-minute cron schedule.
+	 *
+	 * Mirrors WeeklyDigestHooks::add_cron_schedule so both coexist; the
+	 * `isset()` guard makes adding the same key twice a no-op.
+	 *
+	 * @param array $schedules Existing schedules.
+	 * @return array
+	 */
+	public static function add_cron_schedule( $schedules ) {
+		if ( ! isset( $schedules['fair_audience_every_five_minutes'] ) ) {
+			$schedules['fair_audience_every_five_minutes'] = array(
+				'interval' => 5 * MINUTE_IN_SECONDS,
+				'display'  => __( 'Every 5 minutes (fair-audience)', 'fair-audience' ),
+			);
+		}
+		return $schedules;
+	}
+
+	/**
+	 * Cron tick: revert long-pending marketing subscribers to minimal and
+	 * clear expired confirmation tokens.
+	 *
+	 * Runs unconditionally each tick — idempotent, since only rows past the
+	 * cutoff match.
+	 */
+	public static function run() {
+		$repository = new ParticipantRepository();
+
+		foreach ( $repository->get_expired_pending_marketing( self::cutoff() ) as $participant ) {
+			$old_profile = $participant->email_profile;
+
+			$participant->email_profile = 'minimal';
+			$participant->status        = 'confirmed';
+
+			if ( ! $participant->save() ) {
+				continue;
+			}
+
+			EmailConsentLog::create(
+				array(
+					'participant_id' => $participant->id,
+					'old_profile'    => $old_profile,
+					'new_profile'    => 'minimal',
+					'source'         => 'pending_timeout',
+					'comment'        => __( 'Reverted to minimal: marketing subscription was never confirmed within a week.', 'fair-audience' ),
+				)
+			);
+		}
+
+		( new EmailConfirmationTokenRepository() )->delete_expired();
+	}
+
+	/**
+	 * The cutoff datetime (UTC): rows with updated_at older than this are
+	 * considered timed out.
+	 *
+	 * @return string Datetime string ('Y-m-d H:i:s').
+	 */
+	public static function cutoff() {
+		return gmdate( 'Y-m-d H:i:s', time() - WEEK_IN_SECONDS );
+	}
+}


### PR DESCRIPTION
## Summary

- Add `Hooks/PendingSubscriptionTimeoutHooks`, a 5-minute cron tick (mirroring `WeeklyDigestHooks`) that reverts participants stuck at `email_profile=marketing` + `status=pending` for over a week back to `minimal`/`confirmed`.
- Each revert is logged via `EmailConsentLog::create()` with `old_profile=marketing`, `new_profile=minimal`, `source=pending_timeout`.
- The same tick calls the previously-unused `EmailConfirmationTokenRepository::delete_expired()` so expired confirmation tokens stop leaking.
- Add `ParticipantRepository::get_expired_pending_marketing()`, a read-only select keyed on `updated_at < now - WEEK_IN_SECONDS`; the hook orchestrates the writes/logging so each participant gets its own audit row.
- Register the new hook in `Core/Plugin.php` next to `WeeklyDigestHooks::init()`.

Closes #1108

## Notes

- Anchor timestamp is `updated_at` (per the ticket's recommendation) — a resend-confirmation re-save correctly restarts the clock; an unrelated admin edit also resets it, which is an accepted trade-off.
- Revert target is `minimal` (not `declined`) per spec — keeps the participant eligible for essential/event mail rather than treating a never-confirmed opt-in as an opt-out.
- Timeout is a hardcoded `WEEK_IN_SECONDS`; not exposed as a setting.

## Test plan

- [x] `vendor/bin/phpunit` — new `PendingSubscriptionTimeoutHooksTest::test_cutoff_is_one_week_before_now` passes; the 2 pre-existing `wpautop()` failures in `WeeklyDigestRendererTest` are unrelated to this change (present on `main`).
- [x] `vendor/bin/phpcs` clean on all changed files.
- [x] WP-CLI `eval-file` manual check against the live dev DB, covering the full AC matrix:
  - pending > 1 week → reverted to `minimal` + `confirmed`, with an `EmailConsentLog` row (`old_profile=marketing`, `new_profile=minimal`, `source=pending_timeout`)
  - pending < 1 week → untouched
  - confirmed marketing, declined, and minimal participants → untouched
  - expired `EmailConfirmationToken` → deleted
