### PR TITLE
Add CSV export and mailing filter to signups tab

### DIFF
--- a/fair-events/src/Admin/manage-event/EventSignups.js
+++ b/fair-events/src/Admin/manage-event/EventSignups.js
@@ -13,14 +13,85 @@ import {
 	CardBody,
 	Spinner,
 	Notice,
+	Button,
+	ToggleControl,
+	Flex,
+	FlexItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+
+const CSV_COLUMNS = [
+	'email',
+	'name',
+	'ticket_type',
+	'quantity',
+	'amount',
+	'status',
+	'mailing_opt_in',
+	'date',
+];
+
+/**
+ * Escape a single CSV field per RFC 4180.
+ *
+ * @param {*} value
+ * @return {string} Escaped field
+ */
+function escapeCsvField(value) {
+	const stringValue =
+		value === null || value === undefined ? '' : String(value);
+	if (/[",\r\n]/.test(stringValue)) {
+		return `"${stringValue.replace(/"/g, '""')}"`;
+	}
+	return stringValue;
+}
+
+/**
+ * Build the MailerLite-friendly CSV text for the given signups.
+ *
+ * @param {Array} rows
+ * @return {string} CSV text
+ */
+function buildSignupsCsv(rows) {
+	const lines = [CSV_COLUMNS.join(',')];
+	rows.forEach((s) => {
+		const row = [
+			s.email,
+			s.name,
+			s.ticket_type_id || '',
+			s.quantity,
+			s.amount,
+			s.status,
+			s.mailing_opt_in ? 'yes' : 'no',
+			s.created_at,
+		];
+		lines.push(row.map(escapeCsvField).join(','));
+	});
+	return lines.join('\r\n');
+}
+
+/**
+ * Trigger a client-side download of the given text as a file.
+ *
+ * @param {string} text
+ * @param {string} filename
+ */
+function downloadTextFile(text, filename) {
+	const blob = new Blob([text], { type: 'text/csv;charset=utf-8' });
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement('a');
+	link.href = url;
+	link.download = filename;
+	link.click();
+	URL.revokeObjectURL(url);
+}
 
 export default function EventSignups({ eventDateId }) {
 	const [signups, setSignups] = useState([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState(null);
+	const [mailingOnly, setMailingOnly] = useState(false);
 
 	useEffect(() => {
 		if (!eventDateId) {
@@ -61,14 +132,49 @@ export default function EventSignups({ eventDateId }) {
 		__('Date', 'fair-events'),
 	];
 
+	const visibleSignups = mailingOnly
+		? signups.filter((s) => s.mailing_opt_in)
+		: signups;
+
+	const handleDownloadCsv = () => {
+		const csv = buildSignupsCsv(visibleSignups);
+		downloadTextFile(csv, `signups-event-${eventDateId}.csv`);
+	};
+
 	return (
 		<Card style={{ marginTop: '16px' }}>
 			<CardHeader>
 				<h2>{__('Ticket Signups', 'fair-events')}</h2>
+				<Flex justify="flex-end" gap={2}>
+					<FlexItem>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={__('Mailing opt-ins only', 'fair-events')}
+							checked={mailingOnly}
+							onChange={setMailingOnly}
+						/>
+					</FlexItem>
+					<FlexItem>
+						<Button
+							variant="secondary"
+							onClick={handleDownloadCsv}
+							disabled={visibleSignups.length === 0}
+						>
+							{__('Download CSV', 'fair-events')}
+						</Button>
+					</FlexItem>
+				</Flex>
 			</CardHeader>
 			<CardBody>
-				{signups.length === 0 ? (
-					<p>{__('No signups yet.', 'fair-events')}</p>
+				{visibleSignups.length === 0 ? (
+					<p>
+						{signups.length === 0
+							? __('No signups yet.', 'fair-events')
+							: __(
+									'Nothing to export — no signups match the current filter.',
+									'fair-events'
+							  )}
+					</p>
 				) : (
 					<table
 						style={{ width: '100%', borderCollapse: 'collapse' }}
@@ -90,7 +196,7 @@ export default function EventSignups({ eventDateId }) {
 							</tr>
 						</thead>
 						<tbody>
-							{signups.map((s) => (
+							{visibleSignups.map((s) => (
 								<tr key={s.id}>
 									<td
 										style={{

--- a/fair-events/src/Admin/manage-event/__tests__/EventSignups.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventSignups.test.jsx
@@ -1,0 +1,171 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Component tests for the signups-tab CSV export (#1171).
+ *
+ * Exercises:
+ *   - Download CSV button renders and produces a CSV matching what's shown.
+ *   - Mailing opt-ins filter narrows the table rows and the exported CSV.
+ *   - Comma-containing values are quoted per RFC 4180.
+ *   - Empty state (no signups, or a filter matching nothing) disables the
+ *     button instead of allowing a header-only download.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import EventSignups from '../EventSignups.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const signups = [
+	{
+		id: 1,
+		name: 'Ada Lovelace',
+		email: 'ada@example.com',
+		ticket_type_id: 'General',
+		quantity: 1,
+		amount: '20.00',
+		status: 'paid',
+		mailing_opt_in: true,
+		created_at: '2026-07-20 10:00:00',
+	},
+	{
+		id: 2,
+		name: 'Bob, Jr.',
+		email: 'bob@example.com',
+		ticket_type_id: 'General',
+		quantity: 2,
+		amount: '40.00',
+		status: 'paid',
+		mailing_opt_in: false,
+		created_at: '2026-07-21 10:00:00',
+	},
+];
+
+function mockObjectUrlAndClick() {
+	let clickedFilename = null;
+	let capturedText = null;
+	const OriginalBlob = global.Blob;
+	global.Blob = jest.fn(function (parts, options) {
+		capturedText = parts.join('');
+		return new OriginalBlob(parts, options);
+	});
+	global.URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+	global.URL.revokeObjectURL = jest.fn();
+	const originalClick = HTMLAnchorElement.prototype.click;
+	HTMLAnchorElement.prototype.click = jest.fn(function () {
+		clickedFilename = this.download;
+	});
+	return {
+		getFilename: () => clickedFilename,
+		getText: () => capturedText,
+		restore: () => {
+			HTMLAnchorElement.prototype.click = originalClick;
+			global.Blob = OriginalBlob;
+		},
+	};
+}
+
+async function renderSignups(data = signups) {
+	apiFetch.mockResolvedValue(data);
+	render(<EventSignups eventDateId={42} />);
+	if (data.length > 0) {
+		await waitFor(() =>
+			expect(screen.getByText(data[0].name)).toBeInTheDocument()
+		);
+	} else {
+		await waitFor(() =>
+			expect(screen.getByText('No signups yet.')).toBeInTheDocument()
+		);
+	}
+}
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+describe('EventSignups — CSV export (#1171)', () => {
+	it('renders a Download CSV button', async () => {
+		await renderSignups();
+		expect(
+			screen.getByRole('button', { name: 'Download CSV' })
+		).toBeInTheDocument();
+	});
+
+	it('downloads a CSV with a header row and one row per displayed signup', async () => {
+		await renderSignups();
+		const mock = mockObjectUrlAndClick();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Download CSV' }));
+
+		const text = mock.getText();
+		const lines = text.split('\r\n');
+		expect(lines[0]).toBe(
+			'email,name,ticket_type,quantity,amount,status,mailing_opt_in,date'
+		);
+		expect(lines).toHaveLength(3);
+		expect(lines[1]).toBe(
+			'ada@example.com,Ada Lovelace,General,1,20.00,paid,yes,2026-07-20 10:00:00'
+		);
+		expect(mock.getFilename()).toBe('signups-event-42.csv');
+
+		mock.restore();
+	});
+
+	it('quotes a name containing a comma', async () => {
+		await renderSignups();
+		const mock = mockObjectUrlAndClick();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Download CSV' }));
+
+		const text = mock.getText();
+		expect(text).toContain('"Bob, Jr."');
+
+		mock.restore();
+	});
+
+	it('narrows the table and the export to mailing opt-ins when the filter is on', async () => {
+		await renderSignups();
+		const mock = mockObjectUrlAndClick();
+
+		fireEvent.click(
+			screen.getByRole('checkbox', { name: 'Mailing opt-ins only' })
+		);
+
+		expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+		expect(screen.queryByText('Bob, Jr.')).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Download CSV' }));
+
+		const text = mock.getText();
+		const lines = text.split('\r\n');
+		expect(lines).toHaveLength(2);
+		expect(lines[1]).toContain('ada@example.com');
+
+		mock.restore();
+	});
+
+	it('disables the button and explains why when there are no signups at all', async () => {
+		await renderSignups([]);
+
+		const button = screen.getByRole('button', { name: 'Download CSV' });
+		expect(button).toBeDisabled();
+		expect(screen.getByText('No signups yet.')).toBeInTheDocument();
+	});
+
+	it('disables the button when the mailing filter matches nothing', async () => {
+		await renderSignups([signups[1]]);
+
+		fireEvent.click(
+			screen.getByRole('checkbox', { name: 'Mailing opt-ins only' })
+		);
+
+		const button = screen.getByRole('button', { name: 'Download CSV' });
+		expect(button).toBeDisabled();
+		expect(
+			screen.getByText(
+				'Nothing to export — no signups match the current filter.'
+			)
+		).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a "Mailing opt-ins only" filter to the signups tab (`EventSignups.js`) — the tab had no filter before, so this is a prerequisite for a useful export.
- Adds a "Download CSV" button that exports exactly the currently displayed rows (respecting the filter) as a MailerLite-friendly, comma-delimited UTF-8 CSV with a header row (`email,name,ticket_type,quantity,amount,status,mailing_opt_in,date`).
- Generated fully client-side from the already-loaded signups data (`GetTicketsController` already ships the whole list to the admin client), so the export matches the on-screen filter by construction — no new REST endpoint, no risk of drift between table and export.
- When the current view has no rows (empty list or filter matching nothing), the button is disabled and inline text explains there's nothing to export, instead of downloading a header-only file.

Closes #1171

## Test plan

- [x] `npm run test:js` (fair-events) — 19 suites / 158 tests pass, including new `EventSignups.test.jsx` covering: button renders, CSV header/rows/escaping (comma-containing name), mailing filter narrows both table and export, empty-state disabling in both the no-signups and filter-matches-nothing cases.
- [x] `npm run format` (root) — no formatting noise beyond the two changed files.
- [x] `npm run build` (fair-events) — generated `admin/manage-event` assets rebuilt.
- [ ] Manual check in a running WP admin (not performed in this session).
