### PR TITLE
Bump docker WordPress image to stable 7.0.2

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
     wordpress:
-        image: wordpress:beta-7.0-php8.5
+        image: wordpress:7.0.2-php8.5
         restart: always
         ports:
             - 8080:80


### PR DESCRIPTION
## Summary
- Bump the local docker WordPress image from `beta-7.0-php8.5` to `7.0.2-php8.5` now that WordPress 7.0 has shipped stable.

## Test plan
- [x] `docker pull wordpress:7.0.2-php8.5` succeeds
