### PR TITLE
fair-form: focus per-form responses table on standalone forms

### DIFF
--- a/.changeset/fair-form-week-batch.md
+++ b/.changeset/fair-form-week-batch.md
@@ -1,5 +1,7 @@
 ---
-"fair-form": patch
+"fair-form": minor
 ---
 
 Standardize the Fair Form block's button on core Button block styles so it inherits the active theme like other blocks.
+
+Focus the per-form Questionnaire Responses table on standalone forms: participant columns, the "Add participants to group" button, and the export column picker now only appear when a loaded response actually carries a participant link, and the submission date is a clickable primary column that opens the submission detail page.

--- a/e2e/user-flows/fair-form-standalone-responses.spec.js
+++ b/e2e/user-flows/fair-form-standalone-responses.spec.js
@@ -1,0 +1,59 @@
+/**
+ * E2E: the per-form Questionnaire Responses table for a standalone form
+ * submission (no participant link) should not show the always-empty
+ * participant columns, and its primary column must open the submission
+ * detail page (#1268).
+ *
+ * Reuses the existing seed/cleanup pair from the fair-form admin-menu
+ * mount-smoke suite (#1077), which already creates a page + submission +
+ * answer with no participant attached — exactly the standalone case.
+ */
+
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin, runScript } from '../support/wp-cli.js';
+
+test.describe('Fair Form standalone questionnaire responses', () => {
+	let seed;
+
+	test.beforeAll(() => {
+		seed = runScript('seed-fair-form-answer.php', 'E2E_FAIR_FORM_SEED');
+	});
+
+	test.afterAll(() => {
+		runScript(
+			'cleanup-fair-form-answer.php',
+			'E2E_FAIR_FORM_CLEANUP',
+			`${seed.postId} ${seed.submissionId} ${seed.answerId}`
+		);
+	});
+
+	test('hides participant columns and opens the submission detail page from the date link', async ({
+		page,
+	}) => {
+		await loginAsAdmin(page);
+		await page.goto(
+			`/wp-admin/admin.php?page=fair-form-questionnaire-responses&post_id=${seed.postId}`
+		);
+
+		await expect(
+			page.getByRole('cell', { name: 'E2E Answer Value' })
+		).toBeVisible({ timeout: 15000 });
+
+		await expect(
+			page.getByRole('columnheader', { name: 'Email' })
+		).not.toBeAttached();
+
+		const row = page.locator('tr', { hasText: 'E2E Answer Value' });
+		await row.locator('a').click();
+
+		await expect(page).toHaveURL(
+			new RegExp(
+				`page=fair-form-submission-detail&submission_id=${seed.submissionId}`
+			)
+		);
+		await expect(
+			page.getByText('How did you hear about us?')
+		).toBeVisible();
+		await expect(page.getByText('E2E Answer Value')).toBeVisible();
+	});
+});

--- a/fair-form/jest.config.js
+++ b/fair-form/jest.config.js
@@ -12,7 +12,7 @@ export default {
 		'\\.api\\.spec\\.js$',
 	],
 	transformIgnorePatterns: [
-		'/node_modules/(?!(uuid|@wordpress/components)/)',
+		'/node_modules/(?!(uuid|@wordpress/components|@wordpress/dataviews|@wordpress/ui|@wordpress/theme)/)',
 	],
 	collectCoverageFrom: [
 		'src/**/*.js',
@@ -24,9 +24,10 @@ export default {
 	],
 	coverageDirectory: 'coverage',
 	coverageReporters: ['text', 'lcov', 'html'],
+	setupFiles: ['<rootDir>/jest.setup.js'],
 	setupFilesAfterEnv: [],
 	transform: {
-		'^.+\\.[jt]sx?$': [
+		'^.+\\.(mjs|[jt]sx?)$': [
 			'babel-jest',
 			{
 				presets: [

--- a/fair-form/jest.config.js
+++ b/fair-form/jest.config.js
@@ -1,7 +1,10 @@
 export default {
 	preset: '@wordpress/jest-preset-default',
 	testEnvironment: 'jsdom',
-	testMatch: ['**/__tests__/**/*.js', '**/?(*.)+(spec|test).js'],
+	testMatch: [
+		'**/__tests__/**/*.[jt]s?(x)',
+		'**/?(*.)+(spec|test).[jt]s?(x)',
+	],
 	testPathIgnorePatterns: [
 		'/node_modules/',
 		'/vendor/',
@@ -35,6 +38,7 @@ export default {
 							},
 						},
 					],
+					['@babel/preset-react', { runtime: 'automatic' }],
 				],
 			},
 		],

--- a/fair-form/jest.setup.js
+++ b/fair-form/jest.setup.js
@@ -1,0 +1,10 @@
+// jsdom does not implement `CSS.supports()`, which @ariakit/react (used by
+// @wordpress/dataviews' menus/popovers) calls for feature detection when
+// mounting. Without this, any test that opens an Ariakit-backed dropdown
+// throws "CSS.supports is not a function".
+if (typeof window !== 'undefined') {
+	window.CSS = window.CSS || {};
+	if (typeof window.CSS.supports !== 'function') {
+		window.CSS.supports = () => false;
+	}
+}

--- a/fair-form/package.json
+++ b/fair-form/package.json
@@ -26,12 +26,19 @@
 		"svn:copy": "cp -r readme.txt fair-form.php composer* languages CHANGELOG.md svn/trunk"
 	},
 	"devDependencies": {
+		"@babel/core": "^7.28.3",
+		"@babel/preset-env": "^7.28.3",
+		"@babel/preset-react": "^7.28.3",
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",
+		"babel-jest": "^30.0.5",
 		"webpack-bundle-output": "^1.1.0"
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "^7.12.0",
 		"@wordpress/components": "^36.0.0",
+		"@wordpress/dataviews": "^17.0.0",
 		"@wordpress/element": "^8.0.0",
 		"@wordpress/i18n": "^6.21.0",
 		"fair-events-shared": "*"

--- a/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
+++ b/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
@@ -15,6 +15,7 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
+import { formatDate } from '../utils/format-date.js';
 
 const DEFAULT_VIEW = {
 	type: 'table',
@@ -115,9 +116,26 @@ export default function QuestionnaireResponses() {
 		}));
 	}, [responses]);
 
+	// Unique participant IDs from responses (skip null/0).
+	const uniqueParticipantIds = useMemo(() => {
+		const ids = new Set();
+		responses.forEach((response) => {
+			const pid = parseInt(response.participant_id, 10);
+			if (pid > 0) {
+				ids.add(pid);
+			}
+		});
+		return Array.from(ids);
+	}, [responses]);
+
+	// Whether any loaded response carries a participant link — drives the
+	// participant columns, the group button and the export picker so they
+	// can never disagree with each other.
+	const hasParticipantData = uniqueParticipantIds.length > 0;
+
 	// Build fields for DataViews.
 	const fields = useMemo(() => {
-		const baseFields = [
+		const participantFields = [
 			{
 				id: 'participant_name',
 				label: __('Name', 'fair-form'),
@@ -208,13 +226,23 @@ export default function QuestionnaireResponses() {
 					return cats.map((c) => c.name).join(', ');
 				},
 			},
-			{
-				id: 'created_at',
-				label: __('Date', 'fair-form'),
-				enableSorting: true,
-				getValue: ({ item }) => item.created_at || '',
-			},
 		];
+
+		const createdAtField = {
+			id: 'created_at',
+			label: __('Date', 'fair-form'),
+			enableSorting: true,
+			// Hideable only when it isn't the primary column.
+			enableHiding: hasParticipantData,
+			getValue: ({ item }) => item.created_at || '',
+			render: ({ item }) => (
+				<a
+					href={`admin.php?page=fair-form-submission-detail&submission_id=${item.id}`}
+				>
+					{formatDate(item.created_at) || '—'}
+				</a>
+			),
+		};
 
 		const dynamicFields = questionColumns.map((col) => ({
 			id: `question_${col.key}`,
@@ -228,18 +256,26 @@ export default function QuestionnaireResponses() {
 			},
 		}));
 
-		return [...baseFields, ...dynamicFields];
-	}, [questionColumns]);
+		return [
+			...(hasParticipantData ? participantFields : []),
+			createdAtField,
+			...dynamicFields,
+		];
+	}, [questionColumns, hasParticipantData]);
 
-	const defaultViewFields = useMemo(() => fields.map((f) => f.id), [fields]);
-
-	const viewWithFields = useMemo(
-		() => ({
+	// Reconcile the persisted view.fields against the current data-derived
+	// field set: keep the user's order/selection for fields that still exist,
+	// and append any newly-available fields (e.g. once responses load, or
+	// once participant columns appear) instead of losing them.
+	const viewWithFields = useMemo(() => {
+		const ids = fields.map((f) => f.id);
+		const selected = (view.fields || []).filter((id) => ids.includes(id));
+		const missing = ids.filter((id) => !(view.fields || []).includes(id));
+		return {
 			...view,
-			fields: view.fields || defaultViewFields,
-		}),
-		[view, defaultViewFields]
-	);
+			fields: view.fields ? [...selected, ...missing] : ids,
+		};
+	}, [view, fields]);
 
 	const paginationInfo = useMemo(
 		() => ({
@@ -281,17 +317,26 @@ export default function QuestionnaireResponses() {
 		}
 
 		return sprintf(
-			/* translators: %s: participant name */
+			/* translators: %s: participant name, or the submission date when there is no participant */
 			__(
 				'Delete the response from %s? This cannot be undone.',
 				'fair-form'
 			),
-			deleteItem.participant_name || __('this participant', 'fair-form')
+			deleteItem.participant_name || formatDate(deleteItem.created_at)
 		);
 	}, [deleteItem]);
 
 	const actions = useMemo(
 		() => [
+			{
+				id: 'view',
+				label: __('View', 'fair-form'),
+				icon: 'visibility',
+				callback: ([item]) => {
+					window.location.href = `admin.php?page=fair-form-submission-detail&submission_id=${item.id}`;
+				},
+				supportsBulk: false,
+			},
 			{
 				id: 'delete',
 				label: __('Delete', 'fair-form'),
@@ -302,18 +347,6 @@ export default function QuestionnaireResponses() {
 		],
 		[]
 	);
-
-	// Unique participant IDs from responses (skip null/0).
-	const uniqueParticipantIds = useMemo(() => {
-		const ids = new Set();
-		responses.forEach((response) => {
-			const pid = parseInt(response.participant_id, 10);
-			if (pid > 0) {
-				ids.add(pid);
-			}
-		});
-		return Array.from(ids);
-	}, [responses]);
 
 	const openGroupModal = () => {
 		setGroupMode('existing');
@@ -560,13 +593,11 @@ export default function QuestionnaireResponses() {
 					gap: '8px',
 				}}
 			>
-				<Button
-					variant="primary"
-					onClick={openGroupModal}
-					disabled={uniqueParticipantIds.length === 0}
-				>
-					{__('Add participants to group', 'fair-form')}
-				</Button>
+				{hasParticipantData && (
+					<Button variant="primary" onClick={openGroupModal}>
+						{__('Add participants to group', 'fair-form')}
+					</Button>
+				)}
 				<Button
 					variant="secondary"
 					onClick={openWaModal}

--- a/fair-form/src/Admin/questionnaire-responses/__tests__/QuestionnaireResponses.test.jsx
+++ b/fair-form/src/Admin/questionnaire-responses/__tests__/QuestionnaireResponses.test.jsx
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Component tests for the per-form Questionnaire Responses table (#1268):
+ * the participant columns, the "Add participants to group" button, and the
+ * export column picker must all follow whether the loaded responses actually
+ * carry a participant link — not the presence of fair-audience itself — so a
+ * standalone form's responses aren't shown next to five permanently empty
+ * columns and a permanently-disabled button.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import QuestionnaireResponses from '../QuestionnaireResponses.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const STANDALONE_RESPONSES = [
+	{
+		id: 1,
+		participant_id: 0,
+		participant_name: '',
+		participant_email: '',
+		participant_status: '',
+		participant_mailing: '',
+		participant_categories: [],
+		created_at: '2026-01-15 10:00:00',
+		answers: [
+			{
+				question_key: 'q1',
+				question_text: 'How did you hear about us?',
+				question_type: 'short_text',
+				answer_value: 'Google',
+			},
+		],
+	},
+];
+
+const LINKED_RESPONSES = [
+	{
+		id: 2,
+		participant_id: 7,
+		participant_name: 'Jane Doe',
+		participant_email: 'jane@example.com',
+		participant_status: 'confirmed',
+		participant_mailing: 'marketing',
+		participant_categories: [],
+		created_at: '2026-01-16 11:00:00',
+		answers: [
+			{
+				question_key: 'q1',
+				question_text: 'How did you hear about us?',
+				question_type: 'short_text',
+				answer_value: 'Friend',
+			},
+		],
+	},
+];
+
+function mockResponses(responses) {
+	apiFetch.mockImplementation(({ path }) => {
+		if (path.startsWith('/fair-form/v1/questionnaire-responses')) {
+			return Promise.resolve(responses);
+		}
+		if (path.startsWith('/fair-audience/v1/groups')) {
+			return Promise.resolve([]);
+		}
+		return Promise.resolve([]);
+	});
+}
+
+beforeEach(() => {
+	jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+	jest.clearAllMocks();
+});
+
+describe('QuestionnaireResponses — standalone (no participant link)', () => {
+	it('hides participant columns, hides the group button, and links the date to the detail view', async () => {
+		mockResponses(STANDALONE_RESPONSES);
+
+		render(<QuestionnaireResponses />);
+
+		await screen.findByText('Google');
+
+		expect(
+			screen.queryByRole('columnheader', { name: 'Email' })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('columnheader', { name: 'Status' })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('columnheader', { name: 'Mailing' })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('columnheader', {
+				name: 'Subscribed Categories',
+			})
+		).not.toBeInTheDocument();
+
+		expect(
+			screen.queryByRole('button', {
+				name: 'Add participants to group',
+			})
+		).not.toBeInTheDocument();
+
+		const dateLink = screen.getByRole('link', {
+			name: new Date('2026-01-15 10:00:00Z').toLocaleString(),
+		});
+		expect(dateLink).toHaveAttribute(
+			'href',
+			'admin.php?page=fair-form-submission-detail&submission_id=1'
+		);
+	});
+});
+
+describe('QuestionnaireResponses — linked to participants', () => {
+	it('shows participant columns and the group button', async () => {
+		mockResponses(LINKED_RESPONSES);
+
+		render(<QuestionnaireResponses />);
+
+		await screen.findByText('Friend');
+
+		expect(
+			screen.getByRole('columnheader', { name: 'Email' })
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('columnheader', { name: 'Status' })
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('columnheader', { name: 'Mailing' })
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByRole('button', { name: 'Add participants to group' })
+		).toBeInTheDocument();
+
+		const nameLink = screen.getByRole('link', { name: 'Jane Doe' });
+		expect(nameLink).toHaveAttribute(
+			'href',
+			'admin.php?page=fair-audience-participant-detail&participant_id=7'
+		);
+	});
+});
+
+describe('QuestionnaireResponses — row actions', () => {
+	it('offers a View action that navigates to the submission detail page', async () => {
+		mockResponses(STANDALONE_RESPONSES);
+
+		render(<QuestionnaireResponses />);
+		const row = (await screen.findByText('Google')).closest('tr');
+
+		fireEvent.click(within(row).getByRole('button', { name: 'Actions' }));
+
+		expect(
+			await screen.findByRole('menuitem', { name: 'View' })
+		).toBeInTheDocument();
+	});
+});
+
+describe('QuestionnaireResponses — empty state', () => {
+	it('renders without throwing when there are no responses', async () => {
+		mockResponses([]);
+
+		render(<QuestionnaireResponses />);
+
+		expect(await screen.findByText('No results')).toBeInTheDocument();
+	});
+});

--- a/fair-form/src/Admin/submission-detail/SubmissionDetail.js
+++ b/fair-form/src/Admin/submission-detail/SubmissionDetail.js
@@ -11,14 +11,7 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 import { submissionToMarkdown } from '../utils/submission-markdown.js';
-
-function formatDate(dateString) {
-	if (!dateString) {
-		return '';
-	}
-	const date = new Date(dateString + 'Z');
-	return date.toLocaleString();
-}
+import { formatDate } from '../utils/format-date.js';
 
 function AnswerDisplay({ answer }) {
 	const { question_type, answer_value, file_url } = answer;

--- a/fair-form/src/Admin/utils/format-date.js
+++ b/fair-form/src/Admin/utils/format-date.js
@@ -1,0 +1,8 @@
+// Stored datetimes are UTC without a timezone suffix — append one before parsing.
+export function formatDate(dateString) {
+	if (!dateString) {
+		return '';
+	}
+	const date = new Date(dateString + 'Z');
+	return date.toLocaleString();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -286,13 +286,233 @@
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.12.0",
 				"@wordpress/components": "^36.0.0",
+				"@wordpress/dataviews": "^17.0.0",
 				"@wordpress/element": "^8.0.0",
 				"@wordpress/i18n": "^6.21.0",
 				"fair-events-shared": "*"
 			},
 			"devDependencies": {
+				"@babel/core": "^7.28.3",
+				"@babel/preset-env": "^7.28.3",
+				"@babel/preset-react": "^7.28.3",
+				"@testing-library/jest-dom": "^6.9.1",
+				"@testing-library/react": "^16.3.2",
 				"@wordpress/scripts": "^32.4.0",
+				"babel-jest": "^30.0.5",
 				"webpack-bundle-output": "^1.1.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+			"integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@jest/types": "30.4.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"babel-plugin-istanbul": "^7.0.1",
+				"chalk": "^4.1.2",
+				"convert-source-map": "^2.0.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"pirates": "^4.0.7",
+				"slash": "^3.0.0",
+				"write-file-atomic": "^5.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-form/node_modules/@jest/types": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-form/node_modules/babel-jest": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+			"integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/transform": "30.4.1",
+				"@types/babel__core": "^7.20.5",
+				"babel-plugin-istanbul": "^7.0.1",
+				"babel-preset-jest": "30.4.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0 || ^8.0.0-0"
+			}
+		},
+		"fair-form/node_modules/babel-jest/node_modules/babel-preset-jest": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+			"integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-plugin-jest-hoist": "30.4.0",
+				"babel-preset-current-node-syntax": "^1.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+			}
+		},
+		"fair-form/node_modules/babel-plugin-istanbul": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+			"integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"workspaces": [
+				"test/babel-8"
+			],
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-instrument": "^6.0.2",
+				"test-exclude": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"fair-form/node_modules/babel-plugin-jest-hoist": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+			"integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/babel__core": "^7.20.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-form/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"fair-form/node_modules/jest-haste-map": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+			"integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"anymatch": "^3.1.3",
+				"fb-watchman": "^2.0.2",
+				"graceful-fs": "^4.2.11",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
+				"picomatch": "^4.0.3",
+				"walker": "^1.0.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "^2.3.3"
+			}
+		},
+		"fair-form/node_modules/jest-regex-util": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-form/node_modules/jest-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+			"integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-form/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"fair-form/node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"fair-payments-connector": {


### PR DESCRIPTION
## Summary

- Hide the five participant columns (Email, Status, Mailing, Subscribed Categories, and the participant-linked Name) in the Questionnaire Responses table whenever none of the loaded responses actually carry a participant link — driven off the data, not off fair-audience's presence.
- Same predicate hides the "Add participants to group" button (instead of leaving it permanently disabled); the Export column picker follows for free since it derives from the same field set.
- When there's no participant to lead with, the submission date becomes the primary, non-hideable, clickable column that opens the submission detail page — matching the "All Answers" table's existing pattern. Extracted `formatDate` to `src/Admin/utils/format-date.js`, shared with `SubmissionDetail.js`, so both interpret the stored datetime the same way.
- Added a `view` row action (opens the submission detail page) alongside the existing `delete` action.
- Fixed a latent `view.fields` bug: once DataViews writes the field list back through `onChangeView`, it becomes a frozen snapshot, so newly-available data-derived columns (question columns, and now participant columns) could silently disappear from the persisted view. `viewWithFields` now reconciles the persisted selection against the current field set instead of only filling it in when unset.
- Added Jest/RTL component-test support to `fair-form` (mirroring `fair-audience`'s `jest.config.js` and Babel/testing-library devDeps) and a new `QuestionnaireResponses.test.jsx` covering the standalone/linked column sets, the row action, and the empty-response case.
- Added an e2e spec (`fair-form-standalone-responses.spec.js`) reusing the existing standalone-submission seed/cleanup scripts to verify the real page hides the Email column and the date link opens the submission detail page.

Closes #1268

## Notes

- Export's "All columns" preset for a standalone form's responses no longer emits the five always-empty participant columns — deliberate, per the ticket discussion (empty CSV columns help nobody). Output for any explicit column selection is unchanged.
- `FormAnswers.js` ("All Answers") has the same participant columns and would be equally dead for a standalone submission, but it's out of scope here — worth a follow-up ticket.
- No new translatable strings were introduced (the delete-confirmation message and the "View" row action reuse existing `fair-form` msgids), so the translation catalog wasn't regenerated.

## Test plan

- [x] `npm run test:js` in `fair-form` — 5 new component tests pass alongside the existing suite
- [x] `npm run build` in `fair-form`
- [x] `npm run format` in `fair-form` — no diff
- [x] `npm run test:e2e -- fair-form-standalone-responses` against wp-env — passes
- [x] `npm run test:e2e -- fair-form-admin-menu` against wp-env — no regression
- [ ] `vendor/bin/phpcs` — no PHP changed, not applicable
