### PR TITLE
Contain fair-form admin tables so mobile pages stop scrolling sideways

### DIFF
--- a/fair-form/src/Admin/AdminHooks.php
+++ b/fair-form/src/Admin/AdminHooks.php
@@ -250,6 +250,16 @@ class AdminHooks {
 			);
 
 			wp_enqueue_style( 'wp-components' );
+
+			$style_file = $plugin_dir . "build/admin/{$page_name}/style-index.css";
+			if ( file_exists( $style_file ) ) {
+				wp_enqueue_style(
+					"fair-form-{$page_name}",
+					plugin_dir_url( dirname( __DIR__ ) ) . "build/admin/{$page_name}/style-index.css",
+					array( 'wp-components' ),
+					$asset_data['version']
+				);
+			}
 		}
 	}
 }

--- a/fair-form/src/Admin/answers-overview/AnswersOverview.js
+++ b/fair-form/src/Admin/answers-overview/AnswersOverview.js
@@ -94,7 +94,7 @@ export default function AnswersOverview() {
 	};
 
 	return (
-		<div className="wrap">
+		<div className="wrap fair-form-answers-overview-page">
 			<h1>{__('Form Answers Overview', 'fair-form')}</h1>
 
 			<div style={{ marginBottom: '16px' }}>
@@ -124,7 +124,7 @@ export default function AnswersOverview() {
 			</p>
 
 			<Card>
-				<CardBody>
+				<CardBody className="fair-form-answers-overview__table">
 					<DataViews
 						data={groups}
 						fields={fields}

--- a/fair-form/src/Admin/answers-overview/index.js
+++ b/fair-form/src/Admin/answers-overview/index.js
@@ -1,5 +1,6 @@
 import { createRoot } from '@wordpress/element';
 import AnswersOverview from './AnswersOverview.js';
+import './style.css';
 
 const rootElement = document.getElementById('fair-form-answers-overview-root');
 if (rootElement) {

--- a/fair-form/src/Admin/answers-overview/style.css
+++ b/fair-form/src/Admin/answers-overview/style.css
@@ -1,0 +1,13 @@
+/**
+ * Form Answers Overview admin page styles.
+ *
+ * @wordpress/dataviews is bundled into this page's build (not externalised
+ * as `wp-dataviews`), so its own stylesheet is never enqueued and the
+ * groups table renders with no width containment, dragging the whole
+ * `.wrap` page sideways instead of scrolling internally. Scope the table's
+ * own scrollbar here instead of loading DataViews' full stylesheet.
+ */
+
+.fair-form-answers-overview__table {
+	overflow-x: auto;
+}

--- a/fair-form/src/Admin/form-answers/FormAnswers.js
+++ b/fair-form/src/Admin/form-answers/FormAnswers.js
@@ -244,11 +244,11 @@ export default function FormAnswers() {
 	);
 
 	return (
-		<div className="wrap">
+		<div className="wrap fair-form-form-answers-page">
 			<h1>{__('Form Answers', 'fair-form')}</h1>
 
 			<Card>
-				<CardBody>
+				<CardBody className="fair-form-form-answers__table">
 					<DataViews
 						data={submissions}
 						fields={fields}

--- a/fair-form/src/Admin/form-answers/index.js
+++ b/fair-form/src/Admin/form-answers/index.js
@@ -1,5 +1,6 @@
 import { createRoot } from '@wordpress/element';
 import FormAnswers from './FormAnswers.js';
+import './style.css';
 
 const rootElement = document.getElementById('fair-form-form-answers-root');
 if (rootElement) {

--- a/fair-form/src/Admin/form-answers/style.css
+++ b/fair-form/src/Admin/form-answers/style.css
@@ -1,0 +1,13 @@
+/**
+ * Form Answers admin page styles.
+ *
+ * @wordpress/dataviews is bundled into this page's build (not externalised
+ * as `wp-dataviews`), so its own stylesheet is never enqueued and the
+ * submissions table renders with no width containment, dragging the whole
+ * `.wrap` page sideways instead of scrolling internally. Scope the table's
+ * own scrollbar here instead of loading DataViews' full stylesheet.
+ */
+
+.fair-form-form-answers__table {
+	overflow-x: auto;
+}

--- a/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
+++ b/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
@@ -559,7 +559,7 @@ export default function QuestionnaireResponses() {
 	};
 
 	return (
-		<div className="wrap">
+		<div className="wrap fair-form-questionnaire-responses-page">
 			<h1>{__('Questionnaire Responses', 'fair-form')}</h1>
 
 			<p>
@@ -586,13 +586,7 @@ export default function QuestionnaireResponses() {
 				)}
 			</p>
 
-			<div
-				style={{
-					marginBottom: '16px',
-					display: 'flex',
-					gap: '8px',
-				}}
-			>
+			<div className="fair-form-questionnaire-responses__actions">
 				{hasParticipantData && (
 					<Button variant="primary" onClick={openGroupModal}>
 						{__('Add participants to group', 'fair-form')}
@@ -839,7 +833,7 @@ export default function QuestionnaireResponses() {
 			)}
 
 			<Card>
-				<CardBody>
+				<CardBody className="fair-form-questionnaire-responses__table">
 					<DataViews
 						data={responses}
 						fields={fields}

--- a/fair-form/src/Admin/questionnaire-responses/__tests__/QuestionnaireResponses.test.jsx
+++ b/fair-form/src/Admin/questionnaire-responses/__tests__/QuestionnaireResponses.test.jsx
@@ -171,3 +171,17 @@ describe('QuestionnaireResponses — empty state', () => {
 		expect(await screen.findByText('No results')).toBeInTheDocument();
 	});
 });
+
+describe('QuestionnaireResponses — table containment', () => {
+	it('scopes the DataViews table in a scrollable CardBody so a wide table cannot drag the page sideways', async () => {
+		mockResponses(STANDALONE_RESPONSES);
+
+		const { container } = render(<QuestionnaireResponses />);
+
+		await screen.findByText('Google');
+
+		expect(
+			container.querySelector('.fair-form-questionnaire-responses__table')
+		).toBeInTheDocument();
+	});
+});

--- a/fair-form/src/Admin/questionnaire-responses/index.js
+++ b/fair-form/src/Admin/questionnaire-responses/index.js
@@ -1,5 +1,6 @@
 import { createRoot } from '@wordpress/element';
 import QuestionnaireResponses from './QuestionnaireResponses.js';
+import './style.css';
 
 const rootElement = document.getElementById(
 	'fair-form-questionnaire-responses-root'

--- a/fair-form/src/Admin/questionnaire-responses/style.css
+++ b/fair-form/src/Admin/questionnaire-responses/style.css
@@ -1,0 +1,21 @@
+/**
+ * Questionnaire Responses admin page styles.
+ *
+ * @wordpress/dataviews is bundled into this page's build (not externalised
+ * as `wp-dataviews`), so its own stylesheet is never enqueued and the
+ * responses table renders with no width containment. With one column per
+ * question key the table can be far wider than the viewport, dragging the
+ * whole `.wrap` page sideways instead of scrolling internally. Scope the
+ * table's own scrollbar here instead of loading DataViews' full stylesheet.
+ */
+
+.fair-form-questionnaire-responses__table {
+	overflow-x: auto;
+}
+
+.fair-form-questionnaire-responses__actions {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+	margin-bottom: 16px;
+}


### PR DESCRIPTION
## Summary

- `@wordpress/dataviews` is bundled into fair-form's admin pages without its own stylesheet ever being enqueued, so the responses/answers tables render with no width containment. On mobile, a table wider than the viewport drags the whole `.wrap` page sideways instead of scrolling internally — cutting off the title, nav links, and Export button.
- Extend `AdminHooks::enqueue_page_script()` to enqueue each page's built `style-index.css` (mirroring fair-audience's existing pattern).
- Scope a `CardBody { overflow-x: auto }` rule around the DataViews table on all three fair-form DataViews pages (`questionnaire-responses`, `answers-overview`, `form-answers`), since they share the same root cause.
- Let the questionnaire-responses button row (`Add participants to group` / `Export`) wrap instead of overflowing at narrow widths.

Closes #1163

## Test plan

- [x] `npm run build` in `fair-form` — `style-index.css` now emits under `build/admin/{questionnaire-responses,answers-overview,form-answers}/`.
- [x] `npm run test:js` in `fair-form` — all specs pass, including a new assertion pinning the `…__table` CardBody class.
- [x] `vendor/bin/phpcs` clean on the changed `AdminHooks.php` (pre-existing unrelated warnings on that file left untouched).
- [x] Manual verification against a local WordPress instance with a seeded 15-question submission: before/after screenshots at all three viewports for `questionnaire-responses` (the page from the report), plus a mobile spot-check on `answers-overview` and `form-answers` confirming no regression.

## Screenshots

Seeded with a synthetic 15-question submission to reproduce the overflow; files are in `pr-1163-screenshots/` in the repo working dir (not committed) for upload here.

| Viewport | Before | After |
| --- | --- | --- |
| Desktop | _(upload before-qr-desktop.png)_ | _(upload after-qr-desktop.png)_ |
| Tablet | _(upload before-qr-tablet.png)_ | _(upload after-qr-tablet.png)_ |
| Mobile | _(upload before-qr-mobile.png)_ | _(upload after-qr-mobile.png)_ |

Also spot-checked on mobile (no regression, fixed columns didn't overflow even before the fix): `after-overview-mobile.png`, `after-answers-mobile.png`.
