### PR TITLE
Centralize date-only formatting in fair-events-shared

### DIFF
--- a/fair-events-experimental/src/Admin/calendar/components/CalendarHeader.js
+++ b/fair-events-experimental/src/Admin/calendar/components/CalendarHeader.js
@@ -8,6 +8,7 @@
 
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { formatMonthLabel } from 'fair-events-shared';
 
 export default function CalendarHeader({
 	currentDate,
@@ -15,10 +16,7 @@ export default function CalendarHeader({
 	onNextMonth,
 	onToday,
 }) {
-	const monthYear = currentDate.toLocaleDateString(undefined, {
-		month: 'long',
-		year: 'numeric',
-	});
+	const monthYear = formatMonthLabel(currentDate);
 
 	return (
 		<>

--- a/fair-events-shared/src/MiniCalendar.js
+++ b/fair-events-shared/src/MiniCalendar.js
@@ -32,6 +32,7 @@ import {
 	getWeekdayLabels,
 	calculateLeadingDays,
 } from './calendarUtils.js';
+import { formatDateOnly, formatMonthLabel } from './dateTime.js';
 
 function computeMonthRange(minDate, maxDate) {
 	if (!minDate) return [];
@@ -188,10 +189,7 @@ function MiniMonth({ monthDate, weekdayLabels, todayStr, dayProps }) {
 	const daysInMonth = new Date(year, month + 1, 0).getDate();
 	const leadingDays = calculateLeadingDays(firstDay, 1);
 
-	const monthLabel = firstDay.toLocaleDateString(undefined, {
-		year: 'numeric',
-		month: 'long',
-	});
+	const monthLabel = formatMonthLabel(firstDay);
 
 	const cells = [];
 
@@ -258,12 +256,7 @@ function MiniMonth({ monthDate, weekdayLabels, todayStr, dayProps }) {
 function DayCell({ date, dateStr, day, todayStr, dayProps }) {
 	const props = dayProps(dateStr, date) || {};
 	const isToday = dateStr === todayStr;
-	const fullDateLabel = date.toLocaleDateString(undefined, {
-		weekday: 'long',
-		year: 'numeric',
-		month: 'long',
-		day: 'numeric',
-	});
+	const fullDateLabel = formatDateOnly(date, 'long');
 	const ariaLabel = props.ariaLabel || fullDateLabel;
 
 	const cellStyle = {

--- a/fair-events-shared/src/__tests__/dateTime.test.js
+++ b/fair-events-shared/src/__tests__/dateTime.test.js
@@ -1,0 +1,96 @@
+/**
+ * Tests for formatDateOnly/formatMonthLabel (#1115).
+ *
+ * Each style is asserted against the literal `toLocaleDateString(undefined,
+ * ...)` expression it replaces (rather than a hardcoded locale string), so
+ * the "output unchanged" regression guard holds regardless of which locale
+ * the environment's ICU resolves `undefined` to.
+ */
+import { formatDateOnly, formatMonthLabel } from '../dateTime.js';
+
+describe('formatDateOnly', () => {
+	test('long style matches EditInstancesModal/MiniCalendar', () => {
+		expect(formatDateOnly('2026-07-08', 'long')).toBe(
+			new Date('2026-07-08T00:00:00').toLocaleDateString(undefined, {
+				weekday: 'long',
+				year: 'numeric',
+				month: 'long',
+				day: 'numeric',
+			})
+		);
+	});
+
+	test('medium style matches RecurrenceImpactSummary (the default)', () => {
+		expect(formatDateOnly('2026-07-08')).toBe(
+			new Date('2026-07-08T00:00:00').toLocaleDateString(undefined, {
+				year: 'numeric',
+				month: 'long',
+				day: 'numeric',
+			})
+		);
+	});
+
+	test('short style matches SeriesModal/ManageEventApp', () => {
+		expect(formatDateOnly('2026-07-08', 'short')).toBe(
+			new Date('2026-07-08T00:00:00').toLocaleDateString(undefined, {
+				year: 'numeric',
+				month: 'short',
+				day: 'numeric',
+			})
+		);
+	});
+
+	test('numeric style matches fair-finance (no options bag)', () => {
+		expect(formatDateOnly('2026-07-08', 'numeric')).toBe(
+			new Date('2026-07-08T00:00:00').toLocaleDateString(undefined)
+		);
+	});
+
+	test('accepts a Y-m-d H:i:s datetime string, ignoring the time', () => {
+		expect(formatDateOnly('2026-07-08 18:00:00', 'long')).toBe(
+			formatDateOnly('2026-07-08', 'long')
+		);
+	});
+
+	test('accepts a Date object, matching MiniCalendar day cells', () => {
+		const date = new Date(2026, 6, 8);
+		expect(formatDateOnly(date, 'long')).toBe(
+			date.toLocaleDateString(undefined, {
+				weekday: 'long',
+				year: 'numeric',
+				month: 'long',
+				day: 'numeric',
+			})
+		);
+	});
+
+	test('returns an empty string for empty/null/undefined values', () => {
+		expect(formatDateOnly('')).toBe('');
+		expect(formatDateOnly(null)).toBe('');
+		expect(formatDateOnly(undefined)).toBe('');
+	});
+});
+
+describe('formatMonthLabel', () => {
+	test('matches the CalendarHeader/MiniCalendar month header', () => {
+		const date = new Date(2026, 6, 1);
+		expect(formatMonthLabel(date)).toBe(
+			date.toLocaleDateString(undefined, {
+				month: 'long',
+				year: 'numeric',
+			})
+		);
+	});
+
+	test('accepts a Y-m-d string', () => {
+		expect(formatMonthLabel('2026-07-08')).toBe(
+			formatMonthLabel(new Date(2026, 6, 8))
+		);
+	});
+
+	test('returns an empty string for empty/null/undefined values', () => {
+		expect(formatMonthLabel('')).toBe('');
+		expect(formatMonthLabel(null)).toBe('');
+		expect(formatMonthLabel(undefined)).toBe('');
+	});
+});

--- a/fair-events-shared/src/dateTime.js
+++ b/fair-events-shared/src/dateTime.js
@@ -71,3 +71,51 @@ export function formatSiteLocalTime(datetime) {
 	const { formats } = getSettings();
 	return dateI18n(formats.time, `${datetime.replace(' ', 'T')}Z`, true);
 }
+
+// Naive site-local parsing shared by formatDateOnly/formatMonthLabel: slices
+// off any time component and re-parses at local midnight so no timezone
+// re-conversion happens (see UI_GUIDELINES.md "Dates and times"). `Date`
+// inputs (e.g. from MiniCalendar's month grid) pass through unchanged.
+function toLocalDate(value) {
+	if (value instanceof Date) return value;
+	if (!value) return null;
+	const [datePart] = String(value).split(/[ T]/);
+	return new Date(`${datePart}T00:00:00`);
+}
+
+const DATE_ONLY_STYLES = {
+	long: { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' },
+	medium: { year: 'numeric', month: 'long', day: 'numeric' },
+	short: { year: 'numeric', month: 'short', day: 'numeric' },
+	numeric: undefined,
+};
+
+/**
+ * Format a date-only value (Y-m-d or Y-m-d H:i:s string, or a Date) for
+ * display, using the browser locale (these are timezone-agnostic day labels,
+ * not a site-formatted datetime — see formatSiteLocalDatetime for that).
+ *
+ * @param {string|Date|null|undefined} value Date-only/datetime string, or a Date object.
+ * @param {string} [style] One of 'long' | 'medium' | 'short' | 'numeric'.
+ * @return {string} Formatted date, or '' if value is empty.
+ */
+export function formatDateOnly(value, style = 'medium') {
+	const date = toLocalDate(value);
+	if (!date) return '';
+	return date.toLocaleDateString(undefined, DATE_ONLY_STYLES[style]);
+}
+
+/**
+ * Format a month/year header label (e.g. calendar navigation titles).
+ *
+ * @param {string|Date|null|undefined} value Date-only/datetime string, or a Date object.
+ * @return {string} Formatted "Month YYYY" label, or '' if value is empty.
+ */
+export function formatMonthLabel(value) {
+	const date = toLocalDate(value);
+	if (!date) return '';
+	return date.toLocaleDateString(undefined, {
+		month: 'long',
+		year: 'numeric',
+	});
+}

--- a/fair-events/src/Admin/calendar/components/CalendarHeader.js
+++ b/fair-events/src/Admin/calendar/components/CalendarHeader.js
@@ -8,6 +8,7 @@
 
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { formatMonthLabel } from 'fair-events-shared';
 
 export default function CalendarHeader({
 	currentDate,
@@ -16,10 +17,7 @@ export default function CalendarHeader({
 	onToday,
 	onAddEvent,
 }) {
-	const monthYear = currentDate.toLocaleDateString(undefined, {
-		month: 'long',
-		year: 'numeric',
-	});
+	const monthYear = formatMonthLabel(currentDate);
 
 	return (
 		<>

--- a/fair-events/src/Admin/manage-event/EditInstancesModal.js
+++ b/fair-events/src/Admin/manage-event/EditInstancesModal.js
@@ -14,17 +14,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-
-// Naive site-local date (no timezone re-conversion — see UI_GUIDELINES.md
-// "Dates and times"). Only the calendar date matters here.
-function formatInstanceDate(dateStr) {
-	return new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
-		weekday: 'long',
-		year: 'numeric',
-		month: 'long',
-		day: 'numeric',
-	});
-}
+import { formatDateOnly } from 'fair-events-shared';
 
 /**
  * @param {Object}   props
@@ -69,7 +59,7 @@ export default function EditInstancesModal({
 										: 'none',
 								}}
 							>
-								{formatInstanceDate(date)}
+								{formatDateOnly(date, 'long')}
 								{isCancelled &&
 									` (${__('Cancelled', 'fair-events')})`}
 							</span>

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -36,6 +36,7 @@ import {
 	DurationOptions,
 	calculateDuration,
 	isLinkOnlyEvent,
+	formatDateOnly,
 	formatSiteLocalDatetime,
 	getEventDisplayTitle,
 	parseRRule,
@@ -51,15 +52,6 @@ import EditInstancesModal from './EditInstancesModal.js';
 import EventLinkModal from './EventLinkModal.js';
 import EventSignups from './EventSignups.js';
 import EventContextHeader from './EventContextHeader.js';
-
-// Naive site-local date (no timezone re-conversion — see UI_GUIDELINES.md
-// "Dates and times"). `dateStr` may be a plain date or a full datetime.
-function formatDateOnly(dateStr) {
-	return new Date(`${dateStr.split(' ')[0]}T00:00:00`).toLocaleDateString(
-		undefined,
-		{ year: 'numeric', month: 'short', day: 'numeric' }
-	);
-}
 
 export default function ManageEventApp() {
 	const eventDateId = window.fairEventsManageEventData?.eventDateId;
@@ -513,12 +505,12 @@ export default function ManageEventApp() {
 
 		let endLabel = '';
 		if (parsed.endType === 'until' && parsed.until) {
-			endLabel = formatDateOnly(parsed.until);
+			endLabel = formatDateOnly(parsed.until, 'short');
 		} else {
 			const occurrences = eventDate.generated_occurrences || [];
 			const last = occurrences[occurrences.length - 1];
 			if (last) {
-				endLabel = formatDateOnly(last.start_datetime);
+				endLabel = formatDateOnly(last.start_datetime, 'short');
 			}
 		}
 

--- a/fair-events/src/Admin/manage-event/RecurrenceImpactSummary.js
+++ b/fair-events/src/Admin/manage-event/RecurrenceImpactSummary.js
@@ -11,14 +11,7 @@
 
 import { Notice } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-
-function formatDate(dateStr) {
-	return new Date(dateStr).toLocaleDateString(undefined, {
-		year: 'numeric',
-		month: 'long',
-		day: 'numeric',
-	});
-}
+import { formatDateOnly } from 'fair-events-shared';
 
 /**
  * @param {Object}        props
@@ -54,7 +47,7 @@ export default function RecurrenceImpactSummary({
 				<ul style={{ margin: 0, paddingLeft: '20px' }}>
 					{blockedRemovals.map((r) => (
 						<li key={r.id}>
-							{formatDate(r.start_datetime)}
+							{formatDateOnly(r.start_datetime)}
 							{r.dependents > 0 && (
 								<>
 									{' — '}

--- a/fair-events/src/Admin/manage-event/SeriesModal.js
+++ b/fair-events/src/Admin/manage-event/SeriesModal.js
@@ -24,6 +24,7 @@ import {
 	buildRRule,
 	expandRRulePreview,
 	parseRRule,
+	formatDateOnly,
 	MiniCalendar,
 	RecurrenceControl,
 } from 'fair-events-shared';
@@ -36,17 +37,7 @@ const DEFAULT_RECURRENCE = {
 	until: '',
 };
 
-// Naive site-local date (no timezone re-conversion — see UI_GUIDELINES.md
-// "Dates and times"). Only the calendar date matters for the preview.
-function formatPreviewDate(dateStr) {
-	return new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
-		year: 'numeric',
-		month: 'short',
-		day: 'numeric',
-	});
-}
-
-// Naive site-local Y-m-d slice — mirrors formatPreviewDate's no-reconversion
+// Naive site-local Y-m-d slice — mirrors formatDateOnly's no-reconversion
 // rule (UI_GUIDELINES.md "Dates and times").
 function dateOnly(datetime) {
 	return datetime ? datetime.slice(0, 10) : '';
@@ -326,8 +317,9 @@ export default function SeriesModal({
 													'fair-events'
 												),
 												preview.totalCount,
-												formatPreviewDate(
-													preview.lastDate
+												formatDateOnly(
+													preview.lastDate,
+													'short'
 												)
 											)}
 										</p>

--- a/fair-events/src/Admin/manage-event/__tests__/EditInstancesModal.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EditInstancesModal.test.jsx
@@ -10,6 +10,7 @@
  */
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { formatDateOnly } from 'fair-events-shared';
 import EditInstancesModal from '../EditInstancesModal.js';
 
 const generatedOccurrences = [
@@ -19,12 +20,7 @@ const generatedOccurrences = [
 
 // Matches the date formatting in EditInstancesModal.
 function instanceDateLabel(dateStr) {
-	return new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
-		weekday: 'long',
-		year: 'numeric',
-		month: 'long',
-		day: 'numeric',
-	});
+	return formatDateOnly(dateStr, 'long');
 }
 
 it('lists occurrences with Cancel / Restore actions', () => {

--- a/fair-events/src/Admin/manage-event/__tests__/RecurrenceCalendar.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/RecurrenceCalendar.test.jsx
@@ -12,6 +12,7 @@
  */
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import { formatDateOnly } from 'fair-events-shared';
 import RecurrenceCalendar from '../RecurrenceCalendar.js';
 
 const generatedOccurrences = [
@@ -21,12 +22,7 @@ const generatedOccurrences = [
 
 // Matches the aria-label built in RecurrenceCalendar's MiniMonth.
 function fullDateLabel(dateStr) {
-	return new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
-		weekday: 'long',
-		year: 'numeric',
-		month: 'long',
-		day: 'numeric',
-	});
+	return formatDateOnly(dateStr, 'long');
 }
 
 it('renders active occurrences as navigable links with a full-date aria-label', () => {

--- a/fair-events/src/Admin/manage-event/__tests__/SeriesModal.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/SeriesModal.test.jsx
@@ -17,18 +17,14 @@
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
+import { formatDateOnly } from 'fair-events-shared';
 import SeriesModal from '../SeriesModal.js';
 
 jest.mock('@wordpress/api-fetch');
 
 // Matches the full-date aria-label MiniCalendar builds by default.
 function fullDateLabel(dateStr) {
-	return new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
-		weekday: 'long',
-		year: 'numeric',
-		month: 'long',
-		day: 'numeric',
-	});
+	return formatDateOnly(dateStr, 'long');
 }
 
 beforeEach(() => {

--- a/fair-finance/package.json
+++ b/fair-finance/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/api-fetch": "^7.12.0",
 		"@wordpress/components": "^36.0.0",
 		"@wordpress/element": "^8.0.0",
-		"@wordpress/i18n": "^6.21.0"
+		"@wordpress/i18n": "^6.21.0",
+		"fair-events-shared": "*"
 	}
 }

--- a/fair-finance/src/Admin/entries/components/MatchModal.js
+++ b/fair-finance/src/Admin/entries/components/MatchModal.js
@@ -12,6 +12,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { formatDateOnly } from 'fair-events-shared';
 
 const MatchModal = ({ entry, onMatch, onCancel }) => {
 	const [transactions, setTransactions] = useState([]);
@@ -106,11 +107,6 @@ const MatchModal = ({ entry, onMatch, onCancel }) => {
 			);
 			setMatching(false);
 		}
-	};
-
-	const formatDate = (dateString) => {
-		const date = new Date(dateString);
-		return date.toLocaleDateString();
 	};
 
 	const formatAmount = (amount, currency = 'EUR') => {
@@ -226,7 +222,10 @@ const MatchModal = ({ entry, onMatch, onCancel }) => {
 							{transactions.map((transaction) => (
 								<tr key={transaction.id}>
 									<td>
-										{formatDate(transaction.created_at)}
+										{formatDateOnly(
+											transaction.created_at,
+											'numeric'
+										)}
 									</td>
 									<td>
 										{formatAmount(

--- a/fair-finance/src/Admin/reconciliation/ReconciliationApp.js
+++ b/fair-finance/src/Admin/reconciliation/ReconciliationApp.js
@@ -21,17 +21,13 @@ import {
  * Internal dependencies
  */
 import SettlementImportModal from './components/SettlementImportModal.js';
+import { formatDateOnly } from 'fair-events-shared';
 
 const formatAmount = (amount, currency = 'EUR') => {
 	return new Intl.NumberFormat('en-US', {
 		style: 'currency',
 		currency,
 	}).format(amount);
-};
-
-const formatDate = (dateString) => {
-	if (!dateString) return '';
-	return new Date(dateString).toLocaleDateString();
 };
 
 const ReconciliationApp = () => {
@@ -706,8 +702,9 @@ const ReconciliationApp = () => {
 																	/>
 																</td>
 																<td>
-																	{formatDate(
-																		t.created_at
+																	{formatDateOnly(
+																		t.created_at,
+																		'numeric'
 																	)}
 																</td>
 																<td>
@@ -887,8 +884,9 @@ const ReconciliationApp = () => {
 														(t) => (
 															<tr key={t.id}>
 																<td>
-																	{formatDate(
-																		t.created_at
+																	{formatDateOnly(
+																		t.created_at,
+																		'numeric'
 																	)}
 																</td>
 																<td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 			}
 		},
 		"fair-audience": {
-			"version": "1.10.0",
+			"version": "1.11.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -156,7 +156,7 @@
 			}
 		},
 		"fair-events": {
-			"version": "1.10.0",
+			"version": "1.11.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@fortawesome/fontawesome-svg-core": "^7.0.0",
@@ -190,7 +190,7 @@
 			}
 		},
 		"fair-events-experimental": {
-			"version": "1.3.2",
+			"version": "1.4.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",
@@ -242,7 +242,7 @@
 			}
 		},
 		"fair-events-shared": {
-			"version": "0.3.0",
+			"version": "0.4.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/components": "^36.0.0",
@@ -265,13 +265,14 @@
 			}
 		},
 		"fair-finance": {
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.12.0",
 				"@wordpress/components": "^36.0.0",
 				"@wordpress/element": "^8.0.0",
-				"@wordpress/i18n": "^6.21.0"
+				"@wordpress/i18n": "^6.21.0",
+				"fair-events-shared": "*"
 			},
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.9.1",
@@ -281,7 +282,7 @@
 			}
 		},
 		"fair-form": {
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "proprietary",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.12.0",
@@ -516,7 +517,7 @@
 			}
 		},
 		"fair-payments-connector": {
-			"version": "1.5.2",
+			"version": "1.6.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.2.0",


### PR DESCRIPTION
## Summary

- Centralizes date-only formatting into `fair-events-shared/src/dateTime.js`:
  `formatDateOnly(value, style = 'medium')` (`long`/`medium`/`short`/`numeric`
  styles) and `formatMonthLabel(value)`, both built on a shared naive
  local-midnight parser (`toLocalDate`) that accepts a `Y-m-d` string, a
  `Y-m-d H:i:s` string, or a `Date` object.
- Switches every consumer over to the shared formatter and deletes the local
  re-implementations: `MiniCalendar.js` (fair-events-shared), `RecurrenceImpactSummary.js`,
  `EditInstancesModal.js`, `SeriesModal.js`, `ManageEventApp.js`, and both
  `CalendarHeader.js` copies (fair-events + fair-events-experimental).
- Adds `fair-events-shared` as a `fair-finance` dependency and converts
  `ReconciliationApp.js` / `MatchModal.js`'s bare `toLocaleDateString()` calls
  to `formatDateOnly(value, 'numeric')`.
- Updates the three test files that had copied the formatting logic
  (`EditInstancesModal.test.jsx`, `RecurrenceCalendar.test.jsx`,
  `SeriesModal.test.jsx`) to import `formatDateOnly` instead, so they can no
  longer silently drift from the component they cover.
- Adds `fair-events-shared/src/__tests__/dateTime.test.js`, new for this
  module, covering each style and input shape (Y-m-d string, datetime string,
  `Date` object, empty/null) — each style is asserted against the literal
  `toLocaleDateString(undefined, …)` expression it replaces so rendered output
  is provably unchanged regardless of the environment's locale.

Closes #1115

## Notes

- `undefined` (browser locale) is kept rather than switching to the site's
  configured format (`@wordpress/date`) — these are timezone-agnostic
  date-only labels, and the whole point of this PR is unchanged output.
- Default style is `'medium'` (not `'long'`) — only one call site wanted the
  weekday, so an accidental omission elsewhere won't add one nobody asked for.

## Test plan

- [x] `npm run test:js` (root workspaces): `fair-events-shared`,
      `fair-events`, `fair-events-experimental`, `fair-finance` all pass.
- [x] `npm run build` in `fair-events`, `fair-events-experimental`,
      `fair-finance`.
- [x] `npm run format` in the affected plugins.
- [x] Verified `fair-finance`'s Jest/webpack resolve the `fair-events-shared`
      workspace symlink without config changes.
