### PR TITLE
Add Organizer settings tab and sitewide Organization JSON-LD

### DIFF
--- a/fair-events/__tests__/Helpers/OrganizationSchemaTest.php
+++ b/fair-events/__tests__/Helpers/OrganizationSchemaTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Tests for OrganizationSchema JSON-LD shaping.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Helpers\OrganizationSchema;
+use FairEvents\Settings\Organizer;
+
+/**
+ * Unit tests for building the sitewide Organization/SportsClub node and the
+ * event `organizer` reference.
+ */
+class OrganizationSchemaTest extends TestCase {
+
+	/**
+	 * Reset the stubbed option/theme-mod stores before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$GLOBALS['_fair_test_options']         = array();
+		$GLOBALS['_fair_test_theme_mods']      = array();
+		$GLOBALS['_fair_test_attachment_urls'] = array();
+		$GLOBALS['_fair_test_home_url']        = 'https://example.com';
+	}
+
+	/**
+	 * With no name configured, the sitewide block is null.
+	 *
+	 * @return void
+	 */
+	public function test_organization_null_when_no_name() {
+		$this->assertNull( OrganizationSchema::organization_to_jsonld() );
+	}
+
+	/**
+	 * A configured name yields a minimal Organization node.
+	 *
+	 * @return void
+	 */
+	public function test_organization_minimal_with_name_only() {
+		$GLOBALS['_fair_test_options'][ Organizer::OPTION ] = array( 'name' => 'Acme Club' );
+
+		$org = OrganizationSchema::organization_to_jsonld();
+
+		$this->assertSame( 'Organization', $org['@type'] );
+		$this->assertSame( 'https://example.com/#organization', $org['@id'] );
+		$this->assertSame( 'Acme Club', $org['name'] );
+		$this->assertSame( 'https://example.com', $org['url'] );
+		$this->assertArrayNotHasKey( 'address', $org );
+		$this->assertArrayNotHasKey( 'sameAs', $org );
+		$this->assertArrayNotHasKey( 'logo', $org );
+	}
+
+	/**
+	 * The configured type (SportsClub) is honoured.
+	 *
+	 * @return void
+	 */
+	public function test_organization_honours_sports_club_type() {
+		$GLOBALS['_fair_test_options'][ Organizer::OPTION ] = array(
+			'name' => 'Acme Club',
+			'type' => 'SportsClub',
+		);
+
+		$this->assertSame( 'SportsClub', OrganizationSchema::organization_to_jsonld()['@type'] );
+	}
+
+	/**
+	 * A partial address only includes the filled parts.
+	 *
+	 * @return void
+	 */
+	public function test_organization_partial_address() {
+		$GLOBALS['_fair_test_options'][ Organizer::OPTION ] = array(
+			'name'             => 'Acme Club',
+			'address_locality' => 'Madrid',
+			'address_country'  => 'ES',
+		);
+
+		$address = OrganizationSchema::organization_to_jsonld()['address'];
+
+		$this->assertSame( 'PostalAddress', $address['@type'] );
+		$this->assertSame( 'Madrid', $address['addressLocality'] );
+		$this->assertSame( 'ES', $address['addressCountry'] );
+		$this->assertArrayNotHasKey( 'streetAddress', $address );
+	}
+
+	/**
+	 * The `sameAs` list is included when links are configured.
+	 *
+	 * @return void
+	 */
+	public function test_organization_includes_same_as() {
+		$GLOBALS['_fair_test_options'][ Organizer::OPTION ] = array(
+			'name'    => 'Acme Club',
+			'same_as' => array( 'https://example.com/acme' ),
+		);
+
+		$this->assertSame(
+			array( 'https://example.com/acme' ),
+			OrganizationSchema::organization_to_jsonld()['sameAs']
+		);
+	}
+
+	/**
+	 * The logo is omitted when the site has none set.
+	 *
+	 * @return void
+	 */
+	public function test_organization_omits_logo_when_unset() {
+		$GLOBALS['_fair_test_options'][ Organizer::OPTION ] = array( 'name' => 'Acme Club' );
+
+		$this->assertArrayNotHasKey( 'logo', OrganizationSchema::organization_to_jsonld() );
+	}
+
+	/**
+	 * The logo is included, resolved from the custom_logo theme mod.
+	 *
+	 * @return void
+	 */
+	public function test_organization_includes_logo_when_set() {
+		$GLOBALS['_fair_test_options'][ Organizer::OPTION ] = array( 'name' => 'Acme Club' );
+		$GLOBALS['_fair_test_theme_mods']['custom_logo']    = 42;
+		$GLOBALS['_fair_test_attachment_urls'][42]          = 'https://example.com/logo.png';
+
+		$this->assertSame(
+			'https://example.com/logo.png',
+			OrganizationSchema::organization_to_jsonld()['logo']
+		);
+	}
+
+	/**
+	 * The logo is omitted when the theme mod points at a deleted attachment.
+	 *
+	 * @return void
+	 */
+	public function test_organization_omits_logo_when_attachment_gone() {
+		$GLOBALS['_fair_test_options'][ Organizer::OPTION ] = array( 'name' => 'Acme Club' );
+		$GLOBALS['_fair_test_theme_mods']['custom_logo']    = 42;
+
+		$this->assertArrayNotHasKey( 'logo', OrganizationSchema::organization_to_jsonld() );
+	}
+
+	/**
+	 * With no name configured, organizer_ref() falls back to the site
+	 * name/home URL, verbatim, without an @id.
+	 *
+	 * @return void
+	 */
+	public function test_organizer_ref_fallback_unconfigured() {
+		$GLOBALS['_fair_test_bloginfo'] = array( 'name' => 'Test Site' );
+
+		$this->assertSame(
+			array(
+				'@type' => 'Organization',
+				'name'  => 'Test Site',
+				'url'   => 'https://example.com',
+			),
+			OrganizationSchema::organizer_ref()
+		);
+	}
+
+	/**
+	 * With a name configured, organizer_ref() references the sitewide node.
+	 *
+	 * @return void
+	 */
+	public function test_organizer_ref_uses_configured_identity() {
+		$GLOBALS['_fair_test_options'][ Organizer::OPTION ] = array(
+			'name' => 'Acme Club',
+			'type' => 'SportsClub',
+		);
+
+		$this->assertSame(
+			array(
+				'@type' => 'SportsClub',
+				'@id'   => 'https://example.com/#organization',
+				'name'  => 'Acme Club',
+				'url'   => 'https://example.com',
+			),
+			OrganizationSchema::organizer_ref()
+		);
+	}
+}

--- a/fair-events/__tests__/Settings/OrganizerTest.php
+++ b/fair-events/__tests__/Settings/OrganizerTest.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Organizer Settings Tests
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Settings;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Settings\Organizer;
+
+/**
+ * Tests for the `fair_events_organizer` option's read accessor and sanitizer.
+ */
+class OrganizerTest extends TestCase {
+
+	/**
+	 * Reset the stubbed option store before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$GLOBALS['_fair_test_options'] = array();
+	}
+
+	/**
+	 * With nothing stored, get() returns a fully-populated, empty-default shape.
+	 *
+	 * @return void
+	 */
+	public function test_get_defaults_when_nothing_stored() {
+		$this->assertSame(
+			array(
+				'name'             => '',
+				'type'             => 'Organization',
+				'street_address'   => '',
+				'address_locality' => '',
+				'address_region'   => '',
+				'postal_code'      => '',
+				'address_country'  => '',
+				'same_as'          => array(),
+			),
+			Organizer::get()
+		);
+	}
+
+	/**
+	 * Get() surfaces stored values verbatim.
+	 *
+	 * @return void
+	 */
+	public function test_get_returns_stored_values() {
+		$GLOBALS['_fair_test_options'][ Organizer::OPTION ] = array(
+			'name'    => 'Acme Club',
+			'type'    => 'SportsClub',
+			'same_as' => array( 'https://example.com/acme' ),
+		);
+
+		$organizer = Organizer::get();
+
+		$this->assertSame( 'Acme Club', $organizer['name'] );
+		$this->assertSame( 'SportsClub', $organizer['type'] );
+		$this->assertSame( array( 'https://example.com/acme' ), $organizer['same_as'] );
+	}
+
+	/**
+	 * An invalid stored type falls back to Organization.
+	 *
+	 * @return void
+	 */
+	public function test_get_clamps_invalid_type() {
+		$GLOBALS['_fair_test_options'][ Organizer::OPTION ] = array( 'type' => 'Person' );
+
+		$this->assertSame( 'Organization', Organizer::get()['type'] );
+	}
+
+	/**
+	 * Non-array stored option resolves to defaults.
+	 *
+	 * @return void
+	 */
+	public function test_get_handles_non_array_stored_value() {
+		$GLOBALS['_fair_test_options'][ Organizer::OPTION ] = 'nope';
+
+		$this->assertSame( array(), Organizer::get()['same_as'] );
+	}
+
+	/**
+	 * Empty string fields are dropped, not stored blank.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_drops_empty_strings() {
+		$sanitized = Organizer::sanitize_option(
+			array(
+				'name'           => '   ',
+				'street_address' => 'Main St 1',
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'name', $sanitized );
+		$this->assertSame( 'Main St 1', $sanitized['street_address'] );
+	}
+
+	/**
+	 * Text fields are trimmed.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_trims_text_fields() {
+		$sanitized = Organizer::sanitize_option( array( 'name' => '  Acme Club  ' ) );
+
+		$this->assertSame( 'Acme Club', $sanitized['name'] );
+	}
+
+	/**
+	 * An unknown type clamps to Organization.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_clamps_unknown_type() {
+		$this->assertSame(
+			'Organization',
+			Organizer::sanitize_option( array( 'type' => 'Person' ) )['type']
+		);
+	}
+
+	/**
+	 * A known type is preserved.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_preserves_known_type() {
+		$this->assertSame(
+			'SportsClub',
+			Organizer::sanitize_option( array( 'type' => 'SportsClub' ) )['type']
+		);
+	}
+
+	/**
+	 * Missing type defaults to Organization.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_defaults_missing_type() {
+		$this->assertSame( 'Organization', Organizer::sanitize_option( array() )['type'] );
+	}
+
+	/**
+	 * Malformed URLs are dropped from same_as.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_drops_malformed_urls() {
+		$sanitized = Organizer::sanitize_option(
+			array(
+				'same_as' => array( 'not a url', 'https://example.com/valid', '' ),
+			)
+		);
+
+		$this->assertSame( array( 'https://example.com/valid' ), $sanitized['same_as'] );
+	}
+
+	/**
+	 * Duplicate URLs collapse to one entry.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_dedupes_urls() {
+		$sanitized = Organizer::sanitize_option(
+			array(
+				'same_as' => array(
+					'https://example.com/a',
+					'https://example.com/a',
+				),
+			)
+		);
+
+		$this->assertSame( array( 'https://example.com/a' ), $sanitized['same_as'] );
+	}
+
+	/**
+	 * A non-array same_as value sanitizes to an empty list.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_non_array_same_as_returns_empty() {
+		$this->assertSame( array(), Organizer::sanitize_option( array( 'same_as' => 'nope' ) )['same_as'] );
+	}
+
+	/**
+	 * Non-array top-level input sanitizes to an empty array.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_non_array_input_returns_empty() {
+		$this->assertSame( array(), Organizer::sanitize_option( 'nope' ) );
+	}
+}

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -134,6 +134,86 @@ if ( ! function_exists( 'current_time' ) ) {
 	}
 }
 
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	/**
+	 * Stub of WordPress esc_url_raw() — a no-op pass-through for test input.
+	 *
+	 * @param string $url URL to sanitize.
+	 * @return string Unmodified URL.
+	 */
+	function esc_url_raw( $url ) {
+		return (string) $url;
+	}
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+	/**
+	 * Stub of WordPress home_url() — overridable via $GLOBALS['_fair_test_home_url'].
+	 *
+	 * @param string $path Path to append.
+	 * @return string Fake home URL.
+	 */
+	function home_url( $path = '' ) {
+		$base = isset( $GLOBALS['_fair_test_home_url'] ) ? $GLOBALS['_fair_test_home_url'] : 'https://example.com';
+		return $base . $path;
+	}
+}
+
+if ( ! function_exists( 'get_bloginfo' ) ) {
+	/**
+	 * Stub of WordPress get_bloginfo() — overridable via $GLOBALS['_fair_test_bloginfo'].
+	 *
+	 * @param string $show Which value to retrieve.
+	 * @return string Fake site info.
+	 */
+	function get_bloginfo( $show = '' ) {
+		$values = isset( $GLOBALS['_fair_test_bloginfo'] ) ? $GLOBALS['_fair_test_bloginfo'] : array();
+		return isset( $values[ $show ] ) ? $values[ $show ] : 'Test Site';
+	}
+}
+
+if ( ! function_exists( 'get_theme_mod' ) ) {
+	/**
+	 * Stub of WordPress get_theme_mod() backed by $GLOBALS['_fair_test_theme_mods'].
+	 *
+	 * @param string $name          Theme mod name.
+	 * @param mixed  $default_value Value returned when the mod is unset.
+	 * @return mixed Stored value or the default.
+	 */
+	function get_theme_mod( $name, $default_value = false ) {
+		$mods = isset( $GLOBALS['_fair_test_theme_mods'] ) ? $GLOBALS['_fair_test_theme_mods'] : array();
+		return array_key_exists( $name, $mods ) ? $mods[ $name ] : $default_value;
+	}
+}
+
+if ( ! function_exists( 'wp_get_attachment_image_url' ) ) {
+	/**
+	 * Stub of WordPress wp_get_attachment_image_url() backed by
+	 * $GLOBALS['_fair_test_attachment_urls'].
+	 *
+	 * @param int    $attachment_id Attachment ID.
+	 * @param string $size          Image size.
+	 * @return string|false Stored URL, or false when the attachment is "gone".
+	 */
+	function wp_get_attachment_image_url( $attachment_id, $size = 'thumbnail' ) {
+		$urls = isset( $GLOBALS['_fair_test_attachment_urls'] ) ? $GLOBALS['_fair_test_attachment_urls'] : array();
+		return array_key_exists( $attachment_id, $urls ) ? $urls[ $attachment_id ] : false;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	/**
+	 * Stub of WordPress apply_filters() — a no-op pass-through for test input.
+	 *
+	 * @param string $tag   Filter name (ignored).
+	 * @param mixed  $value Value to filter.
+	 * @return mixed Unmodified value.
+	 */
+	function apply_filters( $tag, $value ) {
+		return $value;
+	}
+}
+
 if ( ! function_exists( 'add_query_arg' ) ) {
 	/**
 	 * Minimal stub of WordPress add_query_arg() for a single key/value pair.

--- a/fair-events/e2e/opengraph-jsonld.spec.js
+++ b/fair-events/e2e/opengraph-jsonld.spec.js
@@ -49,11 +49,16 @@ async function login(page) {
 
 async function getJsonLd(page, url) {
 	await page.goto(url);
-	const raw = await page
+	const scripts = await page
 		.locator('script[type="application/ld+json"]')
-		.first()
-		.textContent();
-	return JSON.parse(raw);
+		.allTextContents();
+	for (const raw of scripts) {
+		const data = JSON.parse(raw);
+		if ('Event' === data['@type']) {
+			return data;
+		}
+	}
+	return null;
 }
 
 async function getMetaContent(page, url, property) {

--- a/fair-events/e2e/organizer-jsonld.spec.js
+++ b/fair-events/e2e/organizer-jsonld.spec.js
@@ -1,0 +1,153 @@
+import { test, expect } from '@playwright/test';
+
+const WP_ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const WP_ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * Verifies the sitewide Organization JSON-LD block and the event
+ * `organizer` reference built from the `fair_events_organizer` setting.
+ */
+
+async function apiFetch(page, options) {
+	const result = await page.evaluate(async (opts) => {
+		try {
+			// eslint-disable-next-line no-undef
+			const res = await wp.apiFetch(opts);
+			return { ok: true, data: res };
+		} catch (err) {
+			return {
+				ok: false,
+				error: {
+					message: err && err.message,
+					code: err && err.code,
+					data: err && err.data,
+					raw: JSON.stringify(err),
+				},
+			};
+		}
+	}, options);
+	if (!result.ok) {
+		throw new Error(
+			`apiFetch ${options.method || 'GET'} ${
+				options.path
+			} failed: ${JSON.stringify(result.error)}`
+		);
+	}
+	return result.data;
+}
+
+async function login(page) {
+	await page.goto('/wp-admin');
+	if (page.url().includes('wp-login.php')) {
+		await page.fill('#user_login', WP_ADMIN_USER);
+		await page.fill('#user_pass', WP_ADMIN_PASS);
+		await page.click('#wp-submit');
+	}
+	await page.waitForSelector('#wpadminbar');
+}
+
+async function getJsonLdByType(page, url, type) {
+	await page.goto(url);
+	const scripts = await page
+		.locator('script[type="application/ld+json"]')
+		.allTextContents();
+	for (const raw of scripts) {
+		const data = JSON.parse(raw);
+		if (type === data['@type']) {
+			return data;
+		}
+	}
+	return null;
+}
+
+test.describe('Fair Events sitewide Organization JSON-LD', () => {
+	test('emits a configured Organization block and matching event organizer, and falls back once cleared', async ({
+		page,
+	}) => {
+		test.setTimeout(120_000);
+
+		await page.setViewportSize({ width: 1200, height: 900 });
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+		await apiFetch(page, {
+			path: '/wp/v2/settings',
+			method: 'POST',
+			data: {
+				fair_events_organizer: {
+					name: 'Acme Sports Club',
+					type: 'SportsClub',
+					street_address: 'Main St 1',
+					address_locality: 'Madrid',
+					address_country: 'ES',
+					same_as: ['https://example.com/acme'],
+				},
+			},
+		});
+
+		const now = new Date();
+		const start = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+		const iso = (d) => d.toISOString().slice(0, 19).replace('T', ' ');
+
+		const eventDate = await apiFetch(page, {
+			path: '/fair-events/v1/event-dates',
+			method: 'POST',
+			data: {
+				title: 'Organizer JSON-LD Test Event',
+				start_datetime: iso(start),
+				end_datetime: iso(
+					new Date(start.getTime() + 2 * 60 * 60 * 1000)
+				),
+				all_day: false,
+			},
+		});
+
+		const post = await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}/create-post`,
+			method: 'POST',
+			data: { post_status: 'publish' },
+		});
+		const postId = post.event_id || post.post_id;
+		const permalink = post.link || `/?p=${postId}`;
+
+		// Sitewide Organization block, present on any front-end page.
+		const org = await getJsonLdByType(page, '/', 'SportsClub');
+		expect(org).toBeTruthy();
+		expect(org.name).toBe('Acme Sports Club');
+		expect(org.address.addressLocality).toBe('Madrid');
+		expect(org.sameAs).toEqual(['https://example.com/acme']);
+		const organizationId = org['@id'];
+		expect(organizationId).toBeTruthy();
+
+		// The event's organizer references the same identity node.
+		const event = await getJsonLdByType(page, permalink, 'Event');
+		expect(event.organizer['@id']).toBe(organizationId);
+		expect(event.organizer.name).toBe('Acme Sports Club');
+
+		// Clear the setting: the event organizer falls back to today's
+		// site-name/home-URL behaviour, unchanged.
+		await apiFetch(page, {
+			path: '/wp/v2/settings',
+			method: 'POST',
+			data: { fair_events_organizer: {} },
+		});
+
+		const clearedEvent = await getJsonLdByType(page, permalink, 'Event');
+		expect(clearedEvent.organizer['@id']).toBeUndefined();
+		expect(clearedEvent.organizer['@type']).toBe('Organization');
+
+		const clearedOrg = await getJsonLdByType(page, '/', 'Organization');
+		expect(clearedOrg).toBeFalsy();
+
+		// Cleanup.
+		await apiFetch(page, {
+			path: `/wp/v2/fair_event/${postId}?force=true`,
+			method: 'DELETE',
+		}).catch(() => {});
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}`,
+			method: 'DELETE',
+		}).catch(() => {});
+	});
+});

--- a/fair-events/src/API/__tests__/OrganizerSettings.api.spec.js
+++ b/fair-events/src/API/__tests__/OrganizerSettings.api.spec.js
@@ -1,0 +1,80 @@
+/**
+ * Playwright API tests for the `fair_events_organizer` setting exposed
+ * through core's /wp/v2/settings endpoint.
+ *
+ * Verifies the write -> read-back round trip is sanitized (malformed
+ * same_as entries dropped) and that the setting is gated on manage_options.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeader = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('fair_events_organizer setting', () => {
+	let api;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		// Reset to empty so later suites see the fallback organizer.
+		await api.post('/wp-json/wp/v2/settings', {
+			headers: authHeader,
+			data: { fair_events_organizer: {} },
+		});
+		await api.dispose();
+	});
+
+	test('writes then reads back a sanitized organizer identity', async () => {
+		const res = await api.post('/wp-json/wp/v2/settings', {
+			headers: authHeader,
+			data: {
+				fair_events_organizer: {
+					name: 'Acme Club',
+					type: 'SportsClub',
+					street_address: 'Main St 1',
+					address_locality: 'Madrid',
+					address_country: 'ES',
+					same_as: ['https://example.com/acme', 'not a valid url'],
+				},
+			},
+		});
+
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+
+		expect(body.fair_events_organizer.name).toBe('Acme Club');
+		expect(body.fair_events_organizer.type).toBe('SportsClub');
+		expect(body.fair_events_organizer.same_as).toEqual([
+			'https://example.com/acme',
+		]);
+
+		const read = await api.get('/wp-json/wp/v2/settings', {
+			headers: authHeader,
+		});
+		const readBody = await read.json();
+		expect(readBody.fair_events_organizer.name).toBe('Acme Club');
+		expect(readBody.fair_events_organizer.same_as).toEqual([
+			'https://example.com/acme',
+		]);
+	});
+
+	test('rejects an unauthenticated write', async () => {
+		const anonymousApi = await request.newContext({ baseURL: BASE_URL });
+		const res = await anonymousApi.post('/wp-json/wp/v2/settings', {
+			data: { fair_events_organizer: { name: 'Should Not Save' } },
+		});
+
+		expect(res.status()).toBe(401);
+		await anonymousApi.dispose();
+	});
+});

--- a/fair-events/src/Admin/settings/OrganizerTab.js
+++ b/fair-events/src/Admin/settings/OrganizerTab.js
@@ -1,0 +1,326 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import {
+	Button,
+	TextControl,
+	SelectControl,
+	Card,
+	CardHeader,
+	CardBody,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { loadOrganizerSettings, saveSettings } from './settings-api.js';
+
+/**
+ * Whether a `sameAs` entry is either empty (dropped on save) or a valid
+ * absolute http(s) URL.
+ *
+ * @param {string} value Entry value.
+ * @return {boolean} True when the entry doesn't block saving.
+ */
+function isValidLink(value) {
+	if ('' === value.trim()) {
+		return true;
+	}
+
+	try {
+		const url = new URL(value);
+		return 'http:' === url.protocol || 'https:' === url.protocol;
+	} catch (e) {
+		return false;
+	}
+}
+
+/**
+ * Organizer Tab Component
+ *
+ * Sitewide organizer identity (name, address, type, social/profile links)
+ * used to build the sitewide Organization JSON-LD block and the single-event
+ * `organizer` reference.
+ *
+ * @param {Object}   props          Props
+ * @param {Function} props.onNotice Handler for displaying notices
+ * @return {JSX.Element} The Organizer settings tab
+ */
+export default function OrganizerTab({ onNotice }) {
+	const [organizer, setOrganizer] = useState(null);
+	const [isLoading, setIsLoading] = useState(true);
+	const [isSaving, setIsSaving] = useState(false);
+
+	useEffect(() => {
+		loadOrganizerSettings()
+			.then((settings) => {
+				setOrganizer(settings);
+				setIsLoading(false);
+			})
+			.catch(() => {
+				onNotice({
+					status: 'error',
+					message: __(
+						'Failed to load organizer settings.',
+						'fair-events'
+					),
+				});
+				setIsLoading(false);
+			});
+	}, [onNotice]);
+
+	const updateField = (field, value) => {
+		setOrganizer({ ...organizer, [field]: value });
+	};
+
+	const updateLink = (index, value) => {
+		const sameAs = [...organizer.same_as];
+		sameAs[index] = value;
+		updateField('same_as', sameAs);
+	};
+
+	const addLink = () => {
+		updateField('same_as', [...organizer.same_as, '']);
+	};
+
+	const removeLink = (index) => {
+		updateField(
+			'same_as',
+			organizer.same_as.filter((_, i) => i !== index)
+		);
+	};
+
+	const hasInvalidLink =
+		organizer && organizer.same_as.some((url) => !isValidLink(url));
+
+	const handleSave = () => {
+		setIsSaving(true);
+
+		saveSettings({ fair_events_organizer: organizer })
+			.then(() => loadOrganizerSettings())
+			.then((settings) => {
+				setOrganizer(settings);
+				onNotice({
+					status: 'success',
+					message: __(
+						'Organizer settings saved successfully.',
+						'fair-events'
+					),
+				});
+				setIsSaving(false);
+			})
+			.catch(() => {
+				onNotice({
+					status: 'error',
+					message: __(
+						'Failed to save organizer settings.',
+						'fair-events'
+					),
+				});
+				setIsSaving(false);
+			});
+	};
+
+	if (isLoading || !organizer) {
+		return (
+			<Card style={{ marginTop: '16px' }}>
+				<CardBody>
+					<p>{__('Loading organizer settings...', 'fair-events')}</p>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	return (
+		<form
+			onSubmit={(e) => {
+				e.preventDefault();
+				handleSave();
+			}}
+		>
+			<VStack spacing={4} style={{ marginTop: '16px' }}>
+				<Card>
+					<CardHeader>
+						<h2>{__('Identity', 'fair-events')}</h2>
+					</CardHeader>
+					<CardBody>
+						<p className="description">
+							{__(
+								"This identity is used to build a sitewide Schema.org Organization block and to identify the event organizer, taking the place of the site name and home URL. Everything here is optional; leave it blank to keep today's behaviour.",
+								'fair-events'
+							)}
+						</p>
+						<TextControl
+							label={__('Name', 'fair-events')}
+							value={organizer.name}
+							onChange={(value) => updateField('name', value)}
+							disabled={isSaving}
+						/>
+						<SelectControl
+							__next40pxDefaultSize
+							label={__('Organization type', 'fair-events')}
+							value={organizer.type}
+							options={[
+								{
+									label: __('Organization', 'fair-events'),
+									value: 'Organization',
+								},
+								{
+									label: __('Sports club', 'fair-events'),
+									value: 'SportsClub',
+								},
+							]}
+							onChange={(value) => updateField('type', value)}
+							disabled={isSaving}
+						/>
+					</CardBody>
+				</Card>
+
+				<Card>
+					<CardHeader>
+						<h2>{__('Address', 'fair-events')}</h2>
+					</CardHeader>
+					<CardBody>
+						<TextControl
+							label={__('Street address', 'fair-events')}
+							value={organizer.street_address}
+							onChange={(value) =>
+								updateField('street_address', value)
+							}
+							disabled={isSaving}
+						/>
+						<TextControl
+							label={__('City', 'fair-events')}
+							value={organizer.address_locality}
+							onChange={(value) =>
+								updateField('address_locality', value)
+							}
+							disabled={isSaving}
+						/>
+						<TextControl
+							label={__('Region', 'fair-events')}
+							value={organizer.address_region}
+							onChange={(value) =>
+								updateField('address_region', value)
+							}
+							disabled={isSaving}
+						/>
+						<TextControl
+							label={__('Postal code', 'fair-events')}
+							value={organizer.postal_code}
+							onChange={(value) =>
+								updateField('postal_code', value)
+							}
+							disabled={isSaving}
+						/>
+						<TextControl
+							label={__('Country', 'fair-events')}
+							help={__(
+								'Use a two-letter code, e.g. ES.',
+								'fair-events'
+							)}
+							value={organizer.address_country}
+							onChange={(value) =>
+								updateField('address_country', value)
+							}
+							disabled={isSaving}
+						/>
+					</CardBody>
+				</Card>
+
+				<Card>
+					<CardHeader>
+						<h2>{__('Social & profile links', 'fair-events')}</h2>
+					</CardHeader>
+					<CardBody>
+						<p className="description">
+							{__(
+								'Links to social media profiles or other pages that identify the organization (Instagram, Facebook, etc.).',
+								'fair-events'
+							)}
+						</p>
+
+						<VStack spacing={2}>
+							{organizer.same_as.map((url, index) => {
+								const invalid = !isValidLink(url);
+								return (
+									// eslint-disable-next-line react/no-array-index-key
+									<HStack key={index} alignment="top">
+										<TextControl
+											type="url"
+											label={__(
+												'Profile URL',
+												'fair-events'
+											)}
+											hideLabelFromVision
+											value={url}
+											onChange={(value) =>
+												updateLink(index, value)
+											}
+											disabled={isSaving}
+											help={
+												invalid
+													? __(
+															'Enter a valid URL, e.g. https://example.com/profile.',
+															'fair-events'
+													  )
+													: undefined
+											}
+											className={
+												invalid
+													? 'has-error'
+													: undefined
+											}
+										/>
+										<Button
+											variant="tertiary"
+											isDestructive
+											onClick={() => removeLink(index)}
+											disabled={isSaving}
+										>
+											{__('Remove', 'fair-events')}
+										</Button>
+									</HStack>
+								);
+							})}
+						</VStack>
+
+						<Button
+							variant="secondary"
+							onClick={addLink}
+							disabled={isSaving}
+							style={{ marginTop: '0.5rem' }}
+						>
+							{__('Add link', 'fair-events')}
+						</Button>
+					</CardBody>
+				</Card>
+
+				<div>
+					<Button
+						variant="primary"
+						type="submit"
+						isBusy={isSaving}
+						disabled={isSaving || hasInvalidLink}
+					>
+						{isSaving
+							? __('Saving...', 'fair-events')
+							: __('Save organizer', 'fair-events')}
+					</Button>
+					{hasInvalidLink && (
+						<p className="description">
+							{__(
+								'Fix the invalid social/profile link above before saving.',
+								'fair-events'
+							)}
+						</p>
+					)}
+				</div>
+			</VStack>
+		</form>
+	);
+}

--- a/fair-events/src/Admin/settings/SettingsApp.js
+++ b/fair-events/src/Admin/settings/SettingsApp.js
@@ -10,6 +10,7 @@ import { Notice, TabPanel } from '@wordpress/components';
  */
 import GeneralTab from './GeneralTab.js';
 import FeaturesTab from './FeaturesTab.js';
+import OrganizerTab from './OrganizerTab.js';
 
 /**
  * Settings App Component
@@ -30,6 +31,10 @@ export default function SettingsApp() {
 			{
 				name: 'features',
 				title: __('Features', 'fair-events'),
+			},
+			{
+				name: 'organizer',
+				title: __('Organizer', 'fair-events'),
 			},
 		],
 		[]
@@ -86,6 +91,9 @@ export default function SettingsApp() {
 						)}
 						{tab.name === 'features' && (
 							<FeaturesTab onNotice={setNotice} />
+						)}
+						{tab.name === 'organizer' && (
+							<OrganizerTab onNotice={setNotice} />
 						)}
 					</div>
 				)}

--- a/fair-events/src/Admin/settings/__tests__/OrganizerTab.test.jsx
+++ b/fair-events/src/Admin/settings/__tests__/OrganizerTab.test.jsx
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import OrganizerTab from '../OrganizerTab.js';
+import { loadOrganizerSettings, saveSettings } from '../settings-api.js';
+
+jest.mock('../settings-api.js');
+
+const baseOrganizer = {
+	name: '',
+	type: 'Organization',
+	street_address: '',
+	address_locality: '',
+	address_region: '',
+	postal_code: '',
+	address_country: '',
+	same_as: [],
+};
+
+beforeEach(() => {
+	loadOrganizerSettings.mockResolvedValue({ ...baseOrganizer });
+	saveSettings.mockResolvedValue({});
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+const nameField = () => screen.getByLabelText('Name');
+const saveButton = () =>
+	screen.getByRole('button', { name: /Save organizer/i });
+
+test('renders and populates fields from loaded settings', async () => {
+	loadOrganizerSettings.mockResolvedValue({
+		...baseOrganizer,
+		name: 'Acme Club',
+		type: 'SportsClub',
+	});
+
+	render(<OrganizerTab onNotice={jest.fn()} />);
+
+	await waitFor(() => expect(nameField()).toHaveValue('Acme Club'));
+	expect(screen.getByLabelText('Organization type')).toHaveValue(
+		'SportsClub'
+	);
+});
+
+test('adding a link renders a new row, removing it takes it away', async () => {
+	render(<OrganizerTab onNotice={jest.fn()} />);
+
+	await waitFor(() => expect(nameField()).toBeInTheDocument());
+
+	fireEvent.click(screen.getByRole('button', { name: /Add link/i }));
+	expect(screen.getAllByLabelText('Profile URL')).toHaveLength(1);
+
+	fireEvent.click(screen.getByRole('button', { name: /Remove/i }));
+	expect(screen.queryAllByLabelText('Profile URL')).toHaveLength(0);
+});
+
+test('an invalid URL blocks save and shows a message', async () => {
+	render(<OrganizerTab onNotice={jest.fn()} />);
+
+	await waitFor(() => expect(nameField()).toBeInTheDocument());
+
+	fireEvent.click(screen.getByRole('button', { name: /Add link/i }));
+	fireEvent.change(screen.getByLabelText('Profile URL'), {
+		target: { value: 'not a url' },
+	});
+
+	expect(screen.getByText(/Enter a valid URL/i)).toBeInTheDocument();
+	expect(saveButton()).toBeDisabled();
+});
+
+test('save sends fair_events_organizer with the edited values', async () => {
+	render(<OrganizerTab onNotice={jest.fn()} />);
+
+	await waitFor(() => expect(nameField()).toBeInTheDocument());
+
+	fireEvent.change(nameField(), { target: { value: 'Acme Club' } });
+	fireEvent.click(saveButton());
+
+	await waitFor(() => expect(saveSettings).toHaveBeenCalledTimes(1));
+	expect(saveSettings).toHaveBeenCalledWith({
+		fair_events_organizer: expect.objectContaining({ name: 'Acme Club' }),
+	});
+});

--- a/fair-events/src/Admin/settings/settings-api.js
+++ b/fair-events/src/Admin/settings/settings-api.js
@@ -21,6 +21,27 @@ export function loadGeneralSettings() {
 }
 
 /**
+ * Load organizer settings from WordPress REST API
+ *
+ * @return {Promise<Object>} Promise resolving to the organizer identity
+ */
+export function loadOrganizerSettings() {
+	return apiFetch({ path: '/wp/v2/settings' }).then((settings) => {
+		return {
+			name: '',
+			type: 'Organization',
+			street_address: '',
+			address_locality: '',
+			address_region: '',
+			postal_code: '',
+			address_country: '',
+			same_as: [],
+			...settings.fair_events_organizer,
+		};
+	});
+}
+
+/**
  * Save settings to WordPress REST API
  *
  * @param {Object} data Settings data to save

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -74,6 +74,7 @@ class Plugin {
 		new \FairEvents\Hooks\BlockHooks();
 		new \FairEvents\Hooks\CalendarButtonHooks();
 		new \FairEvents\Hooks\OpenGraphHooks();
+		new \FairEvents\Hooks\OrganizationHooks();
 		new \FairEvents\Hooks\AdminBarHooks();
 		\FairEvents\Hooks\PaymentHooks::init();
 	}

--- a/fair-events/src/Helpers/EventSchema.php
+++ b/fair-events/src/Helpers/EventSchema.php
@@ -72,11 +72,7 @@ class EventSchema {
 			}
 		}
 
-		$data['organizer'] = array(
-			'@type' => 'Organization',
-			'name'  => get_bloginfo( 'name' ),
-			'url'   => home_url(),
-		);
+		$data['organizer'] = OrganizationSchema::organizer_ref();
 
 		return $data;
 	}

--- a/fair-events/src/Helpers/OrganizationSchema.php
+++ b/fair-events/src/Helpers/OrganizationSchema.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Schema.org Organization JSON-LD shaping
+ *
+ * Pure, static helpers for building the sitewide Organization/SportsClub
+ * identity node and the `organizer` reference embedded in event JSON-LD,
+ * from the `fair_events_organizer` setting.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Helpers;
+
+use FairEvents\Settings\Organizer;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Builds Schema.org Organization/SportsClub JSON-LD structures.
+ */
+class OrganizationSchema {
+
+	/**
+	 * The sitewide identity node's `@id`.
+	 *
+	 * @return string
+	 */
+	public static function node_id(): string {
+		return home_url( '/' ) . '#organization';
+	}
+
+	/**
+	 * Build the sitewide Schema.org Organization/SportsClub object.
+	 *
+	 * @return array|null Organization object (without `@context`), or null when no name is configured.
+	 */
+	public static function organization_to_jsonld() {
+		$organizer = Organizer::get();
+
+		if ( '' === $organizer['name'] ) {
+			return null;
+		}
+
+		$data = array(
+			'@type' => $organizer['type'],
+			'@id'   => self::node_id(),
+			'name'  => $organizer['name'],
+			'url'   => home_url(),
+		);
+
+		$address = self::build_address( $organizer );
+		if ( ! empty( $address ) ) {
+			$data['address'] = $address;
+		}
+
+		if ( ! empty( $organizer['same_as'] ) ) {
+			$data['sameAs'] = $organizer['same_as'];
+		}
+
+		$logo_url = self::get_logo_url();
+		if ( $logo_url ) {
+			$data['logo'] = $logo_url;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Build the `organizer` reference embedded in an event's JSON-LD.
+	 *
+	 * When a name is configured, references the sitewide identity node by
+	 * `@id`. Otherwise falls back to the site name/home URL, verbatim, so the
+	 * unconfigured-fallback output stays byte-identical to today's.
+	 *
+	 * @return array Organizer reference object.
+	 */
+	public static function organizer_ref(): array {
+		$organizer = Organizer::get();
+
+		if ( '' === $organizer['name'] ) {
+			return array(
+				'@type' => 'Organization',
+				'name'  => get_bloginfo( 'name' ),
+				'url'   => home_url(),
+			);
+		}
+
+		return array(
+			'@type' => $organizer['type'],
+			'@id'   => self::node_id(),
+			'name'  => $organizer['name'],
+			'url'   => home_url(),
+		);
+	}
+
+	/**
+	 * Build a Schema.org PostalAddress from the organizer's address parts.
+	 *
+	 * @param array $organizer Normalized organizer identity, as returned by Organizer::get().
+	 * @return array PostalAddress object, or an empty array when every part is empty.
+	 */
+	private static function build_address( array $organizer ): array {
+		$map = array(
+			'street_address'   => 'streetAddress',
+			'address_locality' => 'addressLocality',
+			'address_region'   => 'addressRegion',
+			'postal_code'      => 'postalCode',
+			'address_country'  => 'addressCountry',
+		);
+
+		$address = array();
+		foreach ( $map as $source_key => $schema_key ) {
+			if ( ! empty( $organizer[ $source_key ] ) ) {
+				$address[ $schema_key ] = $organizer[ $source_key ];
+			}
+		}
+
+		if ( empty( $address ) ) {
+			return array();
+		}
+
+		return array_merge( array( '@type' => 'PostalAddress' ), $address );
+	}
+
+	/**
+	 * Resolve the site's logo URL from the `custom_logo` theme mod. Block
+	 * themes' site-logo block writes to the same theme mod, so this covers
+	 * classic and block themes alike.
+	 *
+	 * @return string|null Logo URL, or null when there is no logo set (or the attachment is gone).
+	 */
+	private static function get_logo_url() {
+		$attachment_id = get_theme_mod( 'custom_logo' );
+		if ( ! $attachment_id ) {
+			return null;
+		}
+
+		$url = wp_get_attachment_image_url( $attachment_id, 'full' );
+
+		return $url ? $url : null;
+	}
+}

--- a/fair-events/src/Hooks/OrganizationHooks.php
+++ b/fair-events/src/Hooks/OrganizationHooks.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Sitewide Organization JSON-LD structured data for Fair Events
+ *
+ * Outputs a sitewide Schema.org Organization/SportsClub JSON-LD block on
+ * wp_head, built from the `fair_events_organizer` setting, so search engines
+ * and AI systems can confirm who the organizer is and connect them to their
+ * known social profiles.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Hooks;
+
+use FairEvents\Helpers\OrganizationSchema;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Handles the sitewide Organization JSON-LD block.
+ */
+class OrganizationHooks {
+
+	/**
+	 * Constructor - registers WordPress hooks
+	 */
+	public function __construct() {
+		// Priority 2, deliberately after OpenGraphHooks' priority-1 event
+		// JSON-LD, so the single-event Event block stays first in the head.
+		add_action( 'wp_head', array( $this, 'output_organization_jsonld' ), 2 );
+	}
+
+	/**
+	 * Output the sitewide Organization/SportsClub JSON-LD block.
+	 *
+	 * @return void
+	 */
+	public function output_organization_jsonld() {
+		if ( ! apply_filters( 'fair_events_output_organization_jsonld', true ) ) {
+			return;
+		}
+
+		$org = OrganizationSchema::organization_to_jsonld();
+		if ( null === $org ) {
+			return;
+		}
+
+		$data = apply_filters(
+			'fair_events_organization_jsonld',
+			array_merge( array( '@context' => 'https://schema.org' ), $org )
+		);
+
+		echo '<script type="application/ld+json">' . "\n";
+		echo wp_json_encode( $data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT );
+		echo "\n" . '</script>' . "\n";
+	}
+}

--- a/fair-events/src/Settings/Organizer.php
+++ b/fair-events/src/Settings/Organizer.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Sitewide organizer identity for Schema.org structured data.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Settings;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Pure option logic for the `fair_events_organizer` setting: read accessor +
+ * sanitizer, modeled on {@see \FairEvents\Core\Features}. No WP hooks here,
+ * so it unit-tests against the stub bootstrap.
+ *
+ * The sanitizer is a backstop, not the primary validation layer: core's
+ * settings endpoint can't surface a per-entry rejection back to the UI, so
+ * the Organizer settings tab validates URLs before submit. This class must
+ * still never let a malformed value reach stored state or JSON-LD output.
+ */
+class Organizer {
+
+	/**
+	 * Option key holding the organizer identity.
+	 */
+	public const OPTION = 'fair_events_organizer';
+
+	/**
+	 * Allowed Schema.org `@type` values for the organizer.
+	 */
+	public const TYPES = array( 'Organization', 'SportsClub' );
+
+	/**
+	 * Read the stored organizer identity, normalized so every key is always
+	 * present. Public so other plugins can read the identity (same pattern
+	 * as `Branding::is_enabled()`).
+	 *
+	 * @return array{name: string, type: string, street_address: string, address_locality: string, address_region: string, postal_code: string, address_country: string, same_as: string[]}
+	 */
+	public static function get(): array {
+		$stored = get_option( self::OPTION, array() );
+		if ( ! is_array( $stored ) ) {
+			$stored = array();
+		}
+
+		return array(
+			'name'             => isset( $stored['name'] ) ? (string) $stored['name'] : '',
+			'type'             => isset( $stored['type'] ) && in_array( $stored['type'], self::TYPES, true )
+				? $stored['type']
+				: 'Organization',
+			'street_address'   => isset( $stored['street_address'] ) ? (string) $stored['street_address'] : '',
+			'address_locality' => isset( $stored['address_locality'] ) ? (string) $stored['address_locality'] : '',
+			'address_region'   => isset( $stored['address_region'] ) ? (string) $stored['address_region'] : '',
+			'postal_code'      => isset( $stored['postal_code'] ) ? (string) $stored['postal_code'] : '',
+			'address_country'  => isset( $stored['address_country'] ) ? (string) $stored['address_country'] : '',
+			'same_as'          => isset( $stored['same_as'] ) && is_array( $stored['same_as'] )
+				? array_values( $stored['same_as'] )
+				: array(),
+		);
+	}
+
+	/**
+	 * Sanitize a raw organizer option payload.
+	 *
+	 * @param mixed $value Raw option value.
+	 * @return array Sanitized organizer identity.
+	 */
+	public static function sanitize_option( $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$out = array();
+
+		foreach ( array( 'name', 'street_address', 'address_locality', 'address_region', 'postal_code', 'address_country' ) as $key ) {
+			if ( ! empty( $value[ $key ] ) ) {
+				$sanitized = trim( sanitize_text_field( $value[ $key ] ) );
+				if ( '' !== $sanitized ) {
+					$out[ $key ] = $sanitized;
+				}
+			}
+		}
+
+		if ( isset( $value['type'] ) && in_array( $value['type'], self::TYPES, true ) ) {
+			$out['type'] = $value['type'];
+		} else {
+			$out['type'] = 'Organization';
+		}
+
+		$same_as = array();
+		if ( ! empty( $value['same_as'] ) && is_array( $value['same_as'] ) ) {
+			foreach ( $value['same_as'] as $url ) {
+				$url = esc_url_raw( (string) $url );
+				if ( '' === $url || ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
+					continue;
+				}
+				$same_as[] = $url;
+			}
+		}
+		$out['same_as'] = array_values( array_unique( $same_as ) );
+
+		return $out;
+	}
+}

--- a/fair-events/src/Settings/Settings.php
+++ b/fair-events/src/Settings/Settings.php
@@ -118,6 +118,39 @@ class Settings {
 				'default'           => false,
 			)
 		);
+
+		// Sitewide organizer identity, used to build the sitewide Organization
+		// JSON-LD block and the single-event `organizer` reference. Explicit
+		// `properties` (not `additionalProperties`) so core validates shape
+		// before Organizer::sanitize_option() runs.
+		register_setting(
+			'fair_events_settings',
+			\FairEvents\Settings\Organizer::OPTION,
+			array(
+				'type'              => 'object',
+				'description'       => __( 'Sitewide organizer identity for structured data', 'fair-events' ),
+				'sanitize_callback' => array( \FairEvents\Settings\Organizer::class, 'sanitize_option' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'name'             => array( 'type' => 'string' ),
+							'type'             => array( 'type' => 'string' ),
+							'street_address'   => array( 'type' => 'string' ),
+							'address_locality' => array( 'type' => 'string' ),
+							'address_region'   => array( 'type' => 'string' ),
+							'postal_code'      => array( 'type' => 'string' ),
+							'address_country'  => array( 'type' => 'string' ),
+							'same_as'          => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'string' ),
+							),
+						),
+					),
+				),
+				'default'           => array(),
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Adds an **Organizer** tab to the fair-events Settings page where a site owner enters name, address, organization type (`Organization` / `SportsClub`), and repeatable social/profile links, backed by a single `fair_events_organizer` option (mirroring the `Features` option pattern).
- Emits a sitewide Schema.org `Organization`/`SportsClub` JSON-LD block on all front-end pages once a name is configured, including address, `sameAs` links, and the site's own logo (`custom_logo` theme mod) — each omitted when unset. Filterable via `fair_events_output_organization_jsonld` / `fair_events_organization_jsonld` for coexistence with SEO plugins.
- The single-event JSON-LD `organizer` now references the configured identity (by `@id`) instead of a hardcoded site-name/home-URL `Organization`. With nothing configured, the fallback output is unchanged from today.
- Hardens `opengraph-jsonld.spec.js`'s JSON-LD lookup to select by `@type === 'Event'` instead of `.first()`, so the new sitewide block's emission order isn't load-bearing.

Closes #1151

## Notes

- `test:api` and `test:e2e` could not be run locally in this session — the shared WordPress dev environment (`localhost:8080`/`3306`) was already occupied by another worktree. PHP unit tests (107/107), JS unit/component tests (162/162, including the new `OrganizerTab.test.jsx`), `npm run build`, `npm run format`, and `phpcs` on all changed files all pass.
- Address parts and `sameAs` entries are all optional; the sanitizer drops empty/malformed entries as a backstop, while the UI blocks saving on an invalid URL with an inline message.

## Test plan

- [x] `npm run test:php` — 107/107 pass, including new `OrganizerTest` and `OrganizationSchemaTest`
- [x] `npm run test:js` — 162/162 pass, including new `OrganizerTab.test.jsx`
- [x] `npm run build`
- [x] `npm run format`
- [x] `vendor/bin/phpcs` clean on changed files
- [ ] `npm run test:api` (`OrganizerSettings.api.spec.js`) — not run locally (env conflict), should run in CI
- [ ] `npm run test:e2e` (`organizer-jsonld.spec.js`, plus regression on `opengraph-jsonld.spec.js` / `event-list-jsonld.spec.js`) — not run locally (env conflict), should run in CI
