### PR TITLE
Accept spaced-out phone numbers in fair-form-phone

### DIFF
--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -85,6 +85,15 @@ if ( 'three-ticket-scopes' === $flavour ) {
 			'<!-- /wp:fair-events/event-signup -->',
 		)
 	);
+} elseif ( isset( $overrides['block'] ) && 'unified-with-phone' === $overrides['block'] ) {
+	$block_content = implode(
+		"\n",
+		array(
+			'<!-- wp:fair-events/event-signup -->',
+			'<!-- wp:fair-audience/fair-form-phone {"questionKey":"mobile","questionText":"Mobile"} /-->',
+			'<!-- /wp:fair-events/event-signup -->',
+		)
+	);
 }
 
 $event_id = fair_e2e_create_event( 'E2E ' . $flavour . ' Event ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ), $block_content );

--- a/e2e/user-flows/unified-signup-phone-question.spec.js
+++ b/e2e/user-flows/unified-signup-phone-question.spec.js
@@ -1,0 +1,41 @@
+/**
+ * E2E: signup with a phone question nested in the unified Event Signup block
+ * (#1267). A phone number written the way people actually write it —
+ * separators and all — must be accepted by the browser's own field
+ * constraint and complete the signup, mirroring
+ * unified-signup-nested-question.spec.js for the short-text question.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+
+test.describe('unified event-signup block: nested phone question', () => {
+	test('a free signup with a spaced-out phone number completes', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('free', { block: 'unified-with-phone' });
+		const stamp = Date.now();
+		const email = `unified.phone.${stamp}@example.test`;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-audience-signup-register');
+		await expect(form).toBeVisible();
+
+		const question = form.locator('[data-question-key="mobile"]');
+		await expect(question).toBeVisible();
+		await expect(question).toContainText('Mobile');
+
+		await form.locator('input[name="signup_name"]').fill('Unified Visitor');
+		await form.locator('input[name="signup_email"]').fill(email);
+		await question.locator('input[type="tel"]').fill('+49 170 123 45 67');
+
+		await form.locator('.fair-audience-signup-submit-button').click();
+
+		await expect(
+			page.getByText('You are signed up for this event', {
+				exact: false,
+			})
+		).toBeVisible();
+	});
+});

--- a/fair-audience/languages/fair-audience-de_DE.po
+++ b/fair-audience/languages/fair-audience-de_DE.po
@@ -3811,18 +3811,18 @@ msgstr "Abgemeldet"
 msgid "Subscribed"
 msgstr "Abonniert"
 
-#: ../fair-events-shared/src/questionnaire.js:349
+#: ../fair-events-shared/src/questionnaire.js:384
 msgid "Please answer the required question: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:371
-msgid "Please enter a valid phone number with country code (e.g. +49170...): "
-msgstr ""
-
-#: ../fair-events-shared/src/questionnaire.js:395
+#: ../fair-events-shared/src/questionnaire.js:432
 msgid "Please enter a valid email address for: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:425
+#: ../fair-events-shared/src/questionnaire.js:462
 msgid "File is too large. Maximum size is "
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:407
+msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
 msgstr ""

--- a/fair-audience/languages/fair-audience-es_ES.po
+++ b/fair-audience/languages/fair-audience-es_ES.po
@@ -3811,18 +3811,18 @@ msgstr "Rechazado"
 msgid "Subscribed"
 msgstr "Suscrito"
 
-#: ../fair-events-shared/src/questionnaire.js:349
+#: ../fair-events-shared/src/questionnaire.js:384
 msgid "Please answer the required question: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:371
-msgid "Please enter a valid phone number with country code (e.g. +49170...): "
-msgstr ""
-
-#: ../fair-events-shared/src/questionnaire.js:395
+#: ../fair-events-shared/src/questionnaire.js:432
 msgid "Please enter a valid email address for: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:425
+#: ../fair-events-shared/src/questionnaire.js:462
 msgid "File is too large. Maximum size is "
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:407
+msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
 msgstr ""

--- a/fair-audience/languages/fair-audience-fr_FR.po
+++ b/fair-audience/languages/fair-audience-fr_FR.po
@@ -3811,18 +3811,18 @@ msgstr "Désinscrit"
 msgid "Subscribed"
 msgstr "Abonné"
 
-#: ../fair-events-shared/src/questionnaire.js:349
+#: ../fair-events-shared/src/questionnaire.js:384
 msgid "Please answer the required question: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:371
-msgid "Please enter a valid phone number with country code (e.g. +49170...): "
-msgstr ""
-
-#: ../fair-events-shared/src/questionnaire.js:395
+#: ../fair-events-shared/src/questionnaire.js:432
 msgid "Please enter a valid email address for: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:425
+#: ../fair-events-shared/src/questionnaire.js:462
 msgid "File is too large. Maximum size is "
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:407
+msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
 msgstr ""

--- a/fair-audience/languages/fair-audience-pl_PL.po
+++ b/fair-audience/languages/fair-audience-pl_PL.po
@@ -3818,18 +3818,18 @@ msgstr "Zrezygnowano"
 msgid "Subscribed"
 msgstr "Subskrybowany"
 
-#: ../fair-events-shared/src/questionnaire.js:349
+#: ../fair-events-shared/src/questionnaire.js:384
 msgid "Please answer the required question: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:371
-msgid "Please enter a valid phone number with country code (e.g. +49170...): "
-msgstr ""
-
-#: ../fair-events-shared/src/questionnaire.js:395
+#: ../fair-events-shared/src/questionnaire.js:432
 msgid "Please enter a valid email address for: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:425
+#: ../fair-events-shared/src/questionnaire.js:462
 msgid "File is too large. Maximum size is "
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:407
+msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
 msgstr ""

--- a/fair-audience/languages/fair-audience.pot
+++ b/fair-audience/languages/fair-audience.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-3.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Fair Audience 1.10.0\n"
+"Project-Id-Version: Fair Audience 1.11.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/fair-audience\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-23T11:40:15+00:00\n"
+"POT-Creation-Date: 2026-07-26T14:20:48+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fair-audience\n"
@@ -3812,19 +3812,19 @@ msgctxt "block keyword"
 msgid "list"
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:349
+#: ../fair-events-shared/src/questionnaire.js:384
 msgid "Please answer the required question: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:371
-msgid "Please enter a valid phone number with country code (e.g. +49170...): "
+#: ../fair-events-shared/src/questionnaire.js:407
+msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:395
+#: ../fair-events-shared/src/questionnaire.js:432
 msgid "Please enter a valid email address for: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:425
+#: ../fair-events-shared/src/questionnaire.js:462
 msgid "File is too large. Maximum size is "
 msgstr ""
 

--- a/fair-events-shared/src/__tests__/questionnaire.test.js
+++ b/fair-events-shared/src/__tests__/questionnaire.test.js
@@ -6,6 +6,8 @@ import {
 	getQuestionValue,
 	collectQuestionAnswers,
 	validateQuestions,
+	isValidPhoneNumber,
+	PHONE_HTML_PATTERN,
 } from '../questionnaire.js';
 
 const VISIBLE = 'fair-form-conditional-visible';
@@ -279,6 +281,78 @@ describe('checkbox question type', () => {
 				consentQuestion({ checked: false, required: false })
 			);
 			expect(validateQuestions(form)).toBeNull();
+		});
+	});
+});
+
+/**
+ * Build a phone question as fair-form-phone/render.php emits it.
+ *
+ * @param {string} value Field value.
+ * @return {string} The question markup.
+ */
+function phoneQuestion(value) {
+	return (
+		'<div data-fair-form-question data-question-key="mobile" data-question-text="Mobile" data-question-type="phone" data-required="0">' +
+		`<input type="tel" value="${value}" /></div>`
+	);
+}
+
+describe('phone question type', () => {
+	// One separator per accept case is enough to prove the class is
+	// accepted anywhere between the leading `+` and the last digit; the
+	// browser pattern and isValidPhoneNumber() must agree on every case.
+	const ACCEPT = [
+		'+491701234567',
+		'+49 170 123 45 67',
+		'+49-170-123-45-67',
+		'+49.170.123.4567',
+		'+49 (170) 1234567',
+		'+49 170 123 45 67', // NBSP
+		'+49 170 1234567', // narrow NBSP
+	];
+
+	const REJECT = [
+		'49 170 1234567',
+		'+49 17a 1234',
+		'++49 1701234',
+		'+ - . ( )',
+		'+0491701234567',
+		'+491234', // 6 digits, below the 7-digit minimum
+		'+4912345678901234567',
+	];
+
+	const htmlPatternRegex = new RegExp(`^(?:${PHONE_HTML_PATTERN})$`, 'u');
+
+	describe.each(ACCEPT)('accepts %j', (value) => {
+		it('via isValidPhoneNumber()', () => {
+			expect(isValidPhoneNumber(value)).toBe(true);
+		});
+
+		it('via the HTML pattern', () => {
+			expect(htmlPatternRegex.test(value)).toBe(true);
+		});
+	});
+
+	describe.each(REJECT)('rejects %j', (value) => {
+		it('via isValidPhoneNumber()', () => {
+			expect(isValidPhoneNumber(value)).toBe(false);
+		});
+
+		it('via the HTML pattern', () => {
+			expect(htmlPatternRegex.test(value)).toBe(false);
+		});
+	});
+
+	describe('validateQuestions', () => {
+		it('passes a phone number with separators', () => {
+			const form = buildForm(phoneQuestion('+49 170 123 45 67'));
+			expect(validateQuestions(form)).toBeNull();
+		});
+
+		it('blocks a phone number without a country code', () => {
+			const form = buildForm(phoneQuestion('49 170 1234567'));
+			expect(validateQuestions(form)).toMatch(/Mobile/);
 		});
 	});
 });

--- a/fair-events-shared/src/questionnaire.js
+++ b/fair-events-shared/src/questionnaire.js
@@ -10,7 +10,42 @@
  * that renders the question blocks.
  */
 
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * HTML `pattern` attribute value for the phone question's `<input>`, shared
+ * with the server's `QuestionnaireService::PHONE_HTML_PATTERN`. Interleaved
+ * form: separators (spaces, dots, parens, hyphens) may appear anywhere after
+ * the leading `+`, since the `pattern` attribute can't post-process the
+ * typed value.
+ *
+ * @type {string}
+ */
+export const PHONE_HTML_PATTERN =
+	'[\\s\\.\\(\\)\\-]*\\+[\\s\\.\\(\\)\\-]*[1-9](?:[\\s\\.\\(\\)\\-]*[0-9]){6,14}[\\s\\.\\(\\)\\-]*';
+
+/**
+ * Strip separators (whitespace, including NBSP/narrow NBSP, dots, parens,
+ * hyphens) from a phone value, leaving `+` followed by digits only. Mirrors
+ * the server's `QuestionnaireService::normalize_phone()`.
+ *
+ * @param {string} value Raw phone value.
+ * @return {string} Normalized value.
+ */
+export function normalizePhoneNumber(value) {
+	return value.replace(/[\s.()-]/g, '');
+}
+
+/**
+ * Whether a phone value, once normalized, is a valid E.164-style number
+ * (leading `+`, no leading zero, 7-15 digits total).
+ *
+ * @param {string} value Raw phone value.
+ * @return {boolean} Whether the value is valid.
+ */
+export function isValidPhoneNumber(value) {
+	return /^\+[1-9]\d{6,14}$/.test(normalizePhoneNumber(value));
+}
 
 /**
  * Read the current value of a question element.
@@ -365,13 +400,15 @@ export function validateQuestions(form) {
 		if (!value) {
 			continue;
 		}
-		if (!/^\+[1-9]\d{6,14}$/.test(value)) {
+		if (!isValidPhoneNumber(value)) {
 			const questionText = el.dataset.questionText || '';
-			return (
+			return sprintf(
+				/* translators: %s: question text */
 				__(
-					'Please enter a valid phone number with country code (e.g. +49170...): ',
+					'Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s',
 					'fair-audience'
-				) + questionText
+				),
+				questionText
 			);
 		}
 	}

--- a/fair-events/src/API/__tests__/GetTicketsQuestionnaire.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsQuestionnaire.api.spec.js
@@ -105,6 +105,7 @@ test.describe('GetTicketsController — questionnaire_answers', () => {
 			headers: adminHeaders,
 			data: {
 				event_id: eventPostId,
+				title: `Get-tickets questionnaire test ${Date.now()}`,
 				start_datetime: '2035-06-01 10:00:00',
 				end_datetime: '2035-06-01 12:00:00',
 			},
@@ -133,6 +134,7 @@ test.describe('GetTicketsController — questionnaire_answers', () => {
 			headers: adminHeaders,
 			data: {
 				event_id: eventPostId,
+				title: `Anon signup test ${Date.now()}`,
 				start_datetime: '2035-06-02 10:00:00',
 				end_datetime: '2035-06-02 12:00:00',
 			},
@@ -219,6 +221,33 @@ test.describe('GetTicketsController — questionnaire_answers', () => {
 		expect(res.status()).toBe(400);
 		expect((await res.json()).code).toBe('invalid_phone');
 		expect(await countSignups(eventDateId)).toBe(before);
+	});
+
+	test('phone answers with separators are normalized when stored (#1267)', async () => {
+		test.skip(!fairFormActive, 'fair-form not active');
+
+		const email = uniqueEmail('phone-ok');
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: eventDateId,
+				name: 'Phone Tester',
+				email,
+				quantity: 1,
+				questionnaire_answers: [
+					nameQuestion(email),
+					phoneQuestion('+49 170 123 45 67'),
+				],
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		expect((await res.json()).status).toBe('confirmed');
+
+		const submission = await findSubmission(email);
+		expect(submission).toBeTruthy();
+		const phoneAnswer = submission.answers.find(
+			(a) => a.question_key === 'phone'
+		);
+		expect(phoneAnswer.answer_value).toBe('+491701234567');
 	});
 
 	test('answers are ignored gracefully when fair-form is inactive', async () => {

--- a/fair-form/languages/fair-form-de_DE.po
+++ b/fair-form/languages/fair-form-de_DE.po
@@ -18,7 +18,7 @@ msgstr ""
 #: src/Admin/AdminHooks.php:129
 #: src/Admin/AdminHooks.php:130
 #: src/API/FairFormController.php:238
-#: src/Services/QuestionnaireService.php:293
+#: src/Services/QuestionnaireService.php:331
 msgid "Fair Form"
 msgstr ""
 
@@ -90,7 +90,7 @@ msgstr "Legacy (keine Formular-ID)"
 
 #: src/API/QuestionnaireResponsesController.php:446
 #: src/API/QuestionnaireResponsesController.php:526
-#: src/Admin/submission-detail/SubmissionDetail.js:229
+#: src/Admin/submission-detail/SubmissionDetail.js:222
 msgid "Submission not found."
 msgstr "Einreichung nicht gefunden."
 
@@ -108,37 +108,31 @@ msgid "Response not found."
 msgstr "Antwort nicht gefunden."
 
 #. translators: %s: question text
-#: src/Services/QuestionnaireService.php:124
+#: src/Services/QuestionnaireService.php:142
 #, php-format
 msgid "Please enter a valid email address for: %s"
 msgstr "Bitte geben Sie eine gültige E-Mail-Adresse ein für: %s"
 
-#. translators: %s: question text
-#: src/Services/QuestionnaireService.php:137
-#, php-format
-msgid "Please enter a valid phone number with country code (e.g. +49170...) for: %s"
-msgstr "Bitte geben Sie eine gültige Telefonnummer mit Ländervorwahl ein (z. B. +49170...) für: %s"
-
-#: src/Services/QuestionnaireService.php:194
+#: src/Services/QuestionnaireService.php:232
 msgid "File upload failed. Please try again."
 msgstr "Datei-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: src/Services/QuestionnaireService.php:203
+#: src/Services/QuestionnaireService.php:241
 msgid "File is too large."
 msgstr "Datei ist zu groß."
 
-#: src/Services/QuestionnaireService.php:213
+#: src/Services/QuestionnaireService.php:251
 msgid "File type not allowed."
 msgstr "Dateityp nicht zulässig."
 
-#: src/Services/QuestionnaireService.php:247
+#: src/Services/QuestionnaireService.php:285
 msgid "Failed to save uploaded file."
 msgstr "Hochgeladene Datei konnte nicht gespeichert werden."
 
 #: src/Admin/answers-overview/AnswersOverview.js:54
 #: src/Admin/form-answers/FormAnswers.js:126
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:123
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:656
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:141
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:681
 msgid "Name"
 msgstr "Name"
 
@@ -173,7 +167,7 @@ msgstr "Seite"
 #: src/Admin/answers-overview/AnswersOverview.js:113
 #: src/Admin/form-answers/FormAnswers.js:152
 #: src/Admin/form-answers/FormAnswers.js:272
-#: src/Admin/submission-detail/SubmissionDetail.js:323
+#: src/Admin/submission-detail/SubmissionDetail.js:310
 msgid "Event"
 msgstr "Ereignis"
 
@@ -184,20 +178,20 @@ msgstr "Formular"
 
 #: src/Admin/form-answers/FormAnswers.js:112
 #: src/Admin/form-answers/FormAnswers.js:197
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:268
-#: src/Admin/submission-detail/SubmissionDetail.js:120
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:304
+#: src/Admin/submission-detail/SubmissionDetail.js:113
 msgid "Error: "
 msgstr "Fehler: "
 
 #: src/Admin/form-answers/FormAnswers.js:140
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:141
-#: src/Admin/submission-detail/SubmissionDetail.js:315
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:159
+#: src/Admin/submission-detail/SubmissionDetail.js:302
 msgid "Email"
 msgstr "E-Mail"
 
 #: src/Admin/form-answers/FormAnswers.js:158
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:213
-#: src/Admin/submission-detail/SubmissionDetail.js:319
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:233
+#: src/Admin/submission-detail/SubmissionDetail.js:306
 msgid "Date"
 msgstr "Datum"
 
@@ -210,21 +204,22 @@ msgid "Failed to delete submission."
 msgstr "Einreichung konnte nicht gelöscht werden."
 
 #: src/Admin/form-answers/FormAnswers.js:208
-#: src/Admin/submission-detail/SubmissionDetail.js:148
+#: src/Admin/submission-detail/SubmissionDetail.js:141
 msgid "Edit"
 msgstr "Bearbeiten"
 
 #: src/Admin/form-answers/FormAnswers.js:215
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:333
 msgid "View"
 msgstr "Anzeigen"
 
 #: src/Admin/form-answers/FormAnswers.js:224
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:297
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:342
 msgid "Delete"
 msgstr "Löschen"
 
 #: src/Admin/form-answers/FormAnswers.js:235
-#: src/Admin/submission-detail/SubmissionDetail.js:130
+#: src/Admin/submission-detail/SubmissionDetail.js:123
 msgid "— None —"
 msgstr "— Keine —"
 
@@ -237,259 +232,265 @@ msgid "Edit Submission"
 msgstr "Einreichung bearbeiten"
 
 #: src/Admin/form-answers/FormAnswers.js:289
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:594
-#: src/Admin/submission-detail/SubmissionDetail.js:172
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:619
+#: src/Admin/submission-detail/SubmissionDetail.js:165
 msgid "Cancel"
 msgstr "Abbrechen"
 
 #: src/Admin/form-answers/FormAnswers.js:297
-#: src/Admin/submission-detail/SubmissionDetail.js:169
+#: src/Admin/submission-detail/SubmissionDetail.js:162
 msgid "Save"
 msgstr "Speichern"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:147
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:165
 msgid "Status"
 msgstr "Status"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:152
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:162
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:170
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:180
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:153
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:165
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:171
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:183
 msgid "Confirmed"
 msgstr "Bestätigt"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:172
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:190
 msgid "Mailing"
 msgstr "Mailing"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:177
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:187
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:195
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:205
 msgid "Minimal"
 msgstr "Minimal"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:178
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:190
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:196
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:208
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:197
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:215
 msgid "Subscribed Categories"
 msgstr "Abonnierte Kategorien"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:270
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:306
 msgid "Failed to delete response."
 msgstr "Fehler beim Löschen der Antwort."
 
 #. translators: 1: number added, 2: number already in group
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:390
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:423
 #, js-format
 msgid "%1$d participant(s) added, %2$d already in group."
 msgstr "%1$d Teilnehmer hinzugefügt, %2$d bereits in der Gruppe."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:404
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:437
 msgid "Failed to add participants to group."
 msgstr "Fehler beim Hinzufügen von Teilnehmern zur Gruppe."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:530
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:563
 msgid "Questionnaire Responses"
 msgstr "Fragebogenantworten"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:491
-#: src/Admin/submission-detail/SubmissionDetail.js:192
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:524
+#: src/Admin/submission-detail/SubmissionDetail.js:185
 msgid "Clipboard not available."
 msgstr "Zwischenablage nicht verfügbar."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:201
+#: src/Admin/submission-detail/SubmissionDetail.js:194
 msgid "Markdown copied to clipboard. Paste into Google Docs."
 msgstr "Markdown in die Zwischenablage kopiert. In Google Docs einfügen."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:506
-#: src/Admin/submission-detail/SubmissionDetail.js:210
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:539
+#: src/Admin/submission-detail/SubmissionDetail.js:203
 msgid "Failed to copy."
 msgstr "Kopieren fehlgeschlagen."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:534
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:567
 msgid "Back to Answers Overview"
 msgstr "Zurück zur Antwortübersicht"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:542
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:575
 msgid "Event edit page"
 msgstr "Ereignisbearbeitungsseite"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:550
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:583
 msgid "Post entry"
 msgstr "Beitrag eintragen"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:568
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:601
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:592
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:626
 msgid "Add participants to group"
 msgstr "Teilnehmer zur Gruppe hinzufügen"
 
 #. translators: %d: number of unique participants
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:608
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:633
 #, js-format
 msgid "%d unique participant(s) will be added."
 msgstr "%d eindeutige(r) Teilnehmer werden hinzugefügt."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:617
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:642
 msgid "Target group"
 msgstr "Zielgruppe"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:621
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:646
 msgid "Use existing group"
 msgstr "Vorhandene Gruppe verwenden"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:625
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:650
 msgid "Create new group"
 msgstr "Neue Gruppe erstellen"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:634
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:659
 msgid "Group"
 msgstr "Gruppe"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:640
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:665
 msgid "Loading..."
 msgstr "Wird geladen..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:641
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:666
 msgid "— Select a group —"
 msgstr "— Wählen Sie eine Gruppe —"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:659
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:684
 msgid "Enter group name..."
 msgstr "Gruppennamen eingeben..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:665
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:690
 msgid "Description"
 msgstr "Beschreibung"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:668
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:693
 msgid "Enter group description (optional)..."
 msgstr "Gruppenbeschreibung eingeben (optional)..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:697
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:788
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:722
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:813
 msgid "Close"
 msgstr "Schließen"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:706
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:731
 msgid "Create group and add"
 msgstr "Gruppe erstellen und hinzufügen"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:707
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:732
 msgid "Add to group"
 msgstr "Zur Gruppe hinzufügen"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:42
+#: src/Admin/submission-detail/SubmissionDetail.js:35
 msgid "View file"
 msgstr "Datei anzeigen"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:121
+#: src/Admin/submission-detail/SubmissionDetail.js:114
 msgid "Failed to update."
 msgstr "Aktualisierung fehlgeschlagen."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:218
+#: src/Admin/submission-detail/SubmissionDetail.js:211
 msgid "No submission ID provided."
 msgstr "Keine Einreichungs-ID angegeben."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:269
+#: src/Admin/submission-detail/SubmissionDetail.js:258
 msgid "Form Submission"
 msgstr "Formulareinreichung"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:272
+#: src/Admin/submission-detail/SubmissionDetail.js:261
 msgid "Copy markdown"
 msgstr "Markdown kopieren"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:288
+#: src/Admin/submission-detail/SubmissionDetail.js:277
 msgid "Submission Info"
 msgstr "Einreichungsinformationen"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:299
+#: src/Admin/submission-detail/SubmissionDetail.js:287
 msgid "Submitted by"
 msgstr "Eingereicht von"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:336
+#: src/Admin/submission-detail/SubmissionDetail.js:323
 msgid "Answers"
 msgstr "Antworten"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:340
+#: src/Admin/submission-detail/SubmissionDetail.js:327
 msgid "No answers recorded."
 msgstr "Keine Antworten aufgezeichnet."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:349
+#: src/Admin/submission-detail/SubmissionDetail.js:335
 msgid "Question"
 msgstr "Frage"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:351
+#: src/Admin/submission-detail/SubmissionDetail.js:336
 msgid "Answer"
 msgstr "Antwort"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:64
+#: src/Admin/submission-detail/SubmissionDetail.js:57
 msgid "Yes"
 msgstr "Ja"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:65
+#: src/Admin/submission-detail/SubmissionDetail.js:58
 msgid "No"
 msgstr "Nein"
 
-#. translators: %s: participant name
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:285
+#. translators: %s: participant name, or the submission date when there is no participant
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:321
 #, js-format
 msgid "Delete the response from %s? This cannot be undone."
 msgstr "Die Antwort von %s löschen? Dies kann nicht rückgängig gemacht werden."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:289
-msgid "this participant"
-msgstr "dieser Teilnehmer"
-
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:500
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:533
 msgid "Message copied to clipboard."
 msgstr "Nachricht in die Zwischenablage kopiert."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:575
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:715
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:600
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:740
 msgid "Export"
 msgstr "Exportieren"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:593
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:618
 msgid "Delete response"
 msgstr "Antwort löschen"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:720
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:745
 msgid "Columns"
 msgstr "Spalten"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:724
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:749
 msgid "All columns"
 msgstr "Alle Spalten"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:728
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:753
 msgid "Handpicked columns"
 msgstr "Handverlesene Spalten"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:751
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:776
 msgid "Format"
 msgstr "Format"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:755
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:780
 msgid "Markdown"
 msgstr "Markdown"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:758
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:783
 msgid "CSV"
 msgstr "CSV"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:760
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:785
 msgid "One line per person"
 msgstr "Eine Zeile pro Person"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:796
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:821
 msgid "Download CSV"
 msgstr "CSV herunterladen"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:804
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:829
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
+
+#: src/blocks/fair-form-phone/render.php:43
+msgid "Include the country code, starting with \"+\" — spaces, dashes and brackets are fine (for example +49 170 123 45 67)."
+msgstr ""
+
+#. translators: %s: question text
+#: src/Services/QuestionnaireService.php:157
+#, php-format
+msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
+msgstr ""

--- a/fair-form/languages/fair-form-es_ES.po
+++ b/fair-form/languages/fair-form-es_ES.po
@@ -18,7 +18,7 @@ msgstr ""
 #: src/Admin/AdminHooks.php:129
 #: src/Admin/AdminHooks.php:130
 #: src/API/FairFormController.php:238
-#: src/Services/QuestionnaireService.php:293
+#: src/Services/QuestionnaireService.php:331
 msgid "Fair Form"
 msgstr ""
 
@@ -90,7 +90,7 @@ msgstr "Heredado (sin ID de formulario)"
 
 #: src/API/QuestionnaireResponsesController.php:446
 #: src/API/QuestionnaireResponsesController.php:526
-#: src/Admin/submission-detail/SubmissionDetail.js:229
+#: src/Admin/submission-detail/SubmissionDetail.js:222
 msgid "Submission not found."
 msgstr "Envío no encontrado."
 
@@ -108,37 +108,31 @@ msgid "Response not found."
 msgstr "Respuesta no encontrada."
 
 #. translators: %s: question text
-#: src/Services/QuestionnaireService.php:124
+#: src/Services/QuestionnaireService.php:142
 #, php-format
 msgid "Please enter a valid email address for: %s"
 msgstr "Introduce una dirección de correo válida para: %s"
 
-#. translators: %s: question text
-#: src/Services/QuestionnaireService.php:137
-#, php-format
-msgid "Please enter a valid phone number with country code (e.g. +49170...) for: %s"
-msgstr "Introduce un número de teléfono válido con código de país (p. ej. +49170...) para: %s"
-
-#: src/Services/QuestionnaireService.php:194
+#: src/Services/QuestionnaireService.php:232
 msgid "File upload failed. Please try again."
 msgstr "La carga de archivo falló. Inténtalo de nuevo."
 
-#: src/Services/QuestionnaireService.php:203
+#: src/Services/QuestionnaireService.php:241
 msgid "File is too large."
 msgstr "El archivo es demasiado grande."
 
-#: src/Services/QuestionnaireService.php:213
+#: src/Services/QuestionnaireService.php:251
 msgid "File type not allowed."
 msgstr "Tipo de archivo no permitido."
 
-#: src/Services/QuestionnaireService.php:247
+#: src/Services/QuestionnaireService.php:285
 msgid "Failed to save uploaded file."
 msgstr "No se pudo guardar el archivo cargado."
 
 #: src/Admin/answers-overview/AnswersOverview.js:54
 #: src/Admin/form-answers/FormAnswers.js:126
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:123
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:656
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:141
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:681
 msgid "Name"
 msgstr "Nombre"
 
@@ -173,7 +167,7 @@ msgstr "Página"
 #: src/Admin/answers-overview/AnswersOverview.js:113
 #: src/Admin/form-answers/FormAnswers.js:152
 #: src/Admin/form-answers/FormAnswers.js:272
-#: src/Admin/submission-detail/SubmissionDetail.js:323
+#: src/Admin/submission-detail/SubmissionDetail.js:310
 msgid "Event"
 msgstr "Evento"
 
@@ -184,20 +178,20 @@ msgstr "Formulario"
 
 #: src/Admin/form-answers/FormAnswers.js:112
 #: src/Admin/form-answers/FormAnswers.js:197
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:268
-#: src/Admin/submission-detail/SubmissionDetail.js:120
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:304
+#: src/Admin/submission-detail/SubmissionDetail.js:113
 msgid "Error: "
 msgstr "Error: "
 
 #: src/Admin/form-answers/FormAnswers.js:140
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:141
-#: src/Admin/submission-detail/SubmissionDetail.js:315
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:159
+#: src/Admin/submission-detail/SubmissionDetail.js:302
 msgid "Email"
 msgstr "Correo electrónico"
 
 #: src/Admin/form-answers/FormAnswers.js:158
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:213
-#: src/Admin/submission-detail/SubmissionDetail.js:319
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:233
+#: src/Admin/submission-detail/SubmissionDetail.js:306
 msgid "Date"
 msgstr "Fecha"
 
@@ -210,21 +204,22 @@ msgid "Failed to delete submission."
 msgstr "No se pudo eliminar el envío."
 
 #: src/Admin/form-answers/FormAnswers.js:208
-#: src/Admin/submission-detail/SubmissionDetail.js:148
+#: src/Admin/submission-detail/SubmissionDetail.js:141
 msgid "Edit"
 msgstr "Editar"
 
 #: src/Admin/form-answers/FormAnswers.js:215
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:333
 msgid "View"
 msgstr "Ver"
 
 #: src/Admin/form-answers/FormAnswers.js:224
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:297
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:342
 msgid "Delete"
 msgstr "Eliminar"
 
 #: src/Admin/form-answers/FormAnswers.js:235
-#: src/Admin/submission-detail/SubmissionDetail.js:130
+#: src/Admin/submission-detail/SubmissionDetail.js:123
 msgid "— None —"
 msgstr "— Ninguno —"
 
@@ -237,259 +232,265 @@ msgid "Edit Submission"
 msgstr "Editar envío"
 
 #: src/Admin/form-answers/FormAnswers.js:289
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:594
-#: src/Admin/submission-detail/SubmissionDetail.js:172
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:619
+#: src/Admin/submission-detail/SubmissionDetail.js:165
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/Admin/form-answers/FormAnswers.js:297
-#: src/Admin/submission-detail/SubmissionDetail.js:169
+#: src/Admin/submission-detail/SubmissionDetail.js:162
 msgid "Save"
 msgstr "Guardar"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:147
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:165
 msgid "Status"
 msgstr "Estado"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:152
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:162
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:170
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:180
 msgid "Pending"
 msgstr "Pendiente"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:153
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:165
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:171
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:183
 msgid "Confirmed"
 msgstr "Confirmado"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:172
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:190
 msgid "Mailing"
 msgstr "Correo"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:177
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:187
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:195
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:205
 msgid "Minimal"
 msgstr "Mínimo"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:178
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:190
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:196
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:208
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:197
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:215
 msgid "Subscribed Categories"
 msgstr "Categorías suscritas"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:270
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:306
 msgid "Failed to delete response."
 msgstr "No se pudo eliminar la respuesta."
 
 #. translators: 1: number added, 2: number already in group
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:390
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:423
 #, js-format
 msgid "%1$d participant(s) added, %2$d already in group."
 msgstr "%1$d participante(s) añadido(s), %2$d ya en el grupo."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:404
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:437
 msgid "Failed to add participants to group."
 msgstr "No se pudieron añadir participantes al grupo."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:530
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:563
 msgid "Questionnaire Responses"
 msgstr "Respuestas del cuestionario"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:491
-#: src/Admin/submission-detail/SubmissionDetail.js:192
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:524
+#: src/Admin/submission-detail/SubmissionDetail.js:185
 msgid "Clipboard not available."
 msgstr "Portapapeles no disponible."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:201
+#: src/Admin/submission-detail/SubmissionDetail.js:194
 msgid "Markdown copied to clipboard. Paste into Google Docs."
 msgstr "Markdown copiado al portapapeles. Pégalo en Google Docs."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:506
-#: src/Admin/submission-detail/SubmissionDetail.js:210
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:539
+#: src/Admin/submission-detail/SubmissionDetail.js:203
 msgid "Failed to copy."
 msgstr "Error al copiar."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:534
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:567
 msgid "Back to Answers Overview"
 msgstr "Volver a descripción general de respuestas"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:542
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:575
 msgid "Event edit page"
 msgstr "Página de edición del evento"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:550
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:583
 msgid "Post entry"
 msgstr "Entrada de entrada"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:568
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:601
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:592
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:626
 msgid "Add participants to group"
 msgstr "Añadir participantes al grupo"
 
 #. translators: %d: number of unique participants
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:608
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:633
 #, js-format
 msgid "%d unique participant(s) will be added."
 msgstr "%d participante(s) único(s) será(n) añadido(s)."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:617
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:642
 msgid "Target group"
 msgstr "Grupo destino"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:621
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:646
 msgid "Use existing group"
 msgstr "Usar grupo existente"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:625
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:650
 msgid "Create new group"
 msgstr "Crear nuevo grupo"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:634
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:659
 msgid "Group"
 msgstr "Grupo"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:640
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:665
 msgid "Loading..."
 msgstr "Cargando..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:641
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:666
 msgid "— Select a group —"
 msgstr "— Selecciona un grupo —"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:659
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:684
 msgid "Enter group name..."
 msgstr "Introduce el nombre del grupo..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:665
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:690
 msgid "Description"
 msgstr "Descripción"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:668
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:693
 msgid "Enter group description (optional)..."
 msgstr "Introduce la descripción del grupo (opcional)..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:697
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:788
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:722
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:813
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:706
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:731
 msgid "Create group and add"
 msgstr "Crear grupo y añadir"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:707
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:732
 msgid "Add to group"
 msgstr "Añadir al grupo"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:42
+#: src/Admin/submission-detail/SubmissionDetail.js:35
 msgid "View file"
 msgstr "Ver archivo"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:121
+#: src/Admin/submission-detail/SubmissionDetail.js:114
 msgid "Failed to update."
 msgstr "Error al actualizar."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:218
+#: src/Admin/submission-detail/SubmissionDetail.js:211
 msgid "No submission ID provided."
 msgstr "No se proporcionó ID de envío."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:269
+#: src/Admin/submission-detail/SubmissionDetail.js:258
 msgid "Form Submission"
 msgstr "Envío de formulario"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:272
+#: src/Admin/submission-detail/SubmissionDetail.js:261
 msgid "Copy markdown"
 msgstr "Copiar markdown"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:288
+#: src/Admin/submission-detail/SubmissionDetail.js:277
 msgid "Submission Info"
 msgstr "Información del envío"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:299
+#: src/Admin/submission-detail/SubmissionDetail.js:287
 msgid "Submitted by"
 msgstr "Enviado por"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:336
+#: src/Admin/submission-detail/SubmissionDetail.js:323
 msgid "Answers"
 msgstr "Respuestas"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:340
+#: src/Admin/submission-detail/SubmissionDetail.js:327
 msgid "No answers recorded."
 msgstr "No hay respuestas registradas."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:349
+#: src/Admin/submission-detail/SubmissionDetail.js:335
 msgid "Question"
 msgstr "Pregunta"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:351
+#: src/Admin/submission-detail/SubmissionDetail.js:336
 msgid "Answer"
 msgstr "Respuesta"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:64
+#: src/Admin/submission-detail/SubmissionDetail.js:57
 msgid "Yes"
 msgstr "Sí"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:65
+#: src/Admin/submission-detail/SubmissionDetail.js:58
 msgid "No"
 msgstr "No"
 
-#. translators: %s: participant name
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:285
+#. translators: %s: participant name, or the submission date when there is no participant
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:321
 #, js-format
 msgid "Delete the response from %s? This cannot be undone."
 msgstr "¿Eliminar la respuesta de %s? Esta acción no se puede deshacer."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:289
-msgid "this participant"
-msgstr "este participante"
-
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:500
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:533
 msgid "Message copied to clipboard."
 msgstr "Mensaje copiado al portapapeles."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:575
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:715
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:600
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:740
 msgid "Export"
 msgstr "Exportar"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:593
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:618
 msgid "Delete response"
 msgstr "Eliminar respuesta"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:720
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:745
 msgid "Columns"
 msgstr "Columnas"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:724
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:749
 msgid "All columns"
 msgstr "Todas las columnas"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:728
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:753
 msgid "Handpicked columns"
 msgstr "Columnas seleccionadas"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:751
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:776
 msgid "Format"
 msgstr "Formato"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:755
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:780
 msgid "Markdown"
 msgstr "Markdown"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:758
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:783
 msgid "CSV"
 msgstr "CSV"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:760
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:785
 msgid "One line per person"
 msgstr "Una línea por persona"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:796
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:821
 msgid "Download CSV"
 msgstr "Descargar CSV"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:804
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:829
 msgid "Copy to clipboard"
 msgstr "Copiar al portapapeles"
+
+#: src/blocks/fair-form-phone/render.php:43
+msgid "Include the country code, starting with \"+\" — spaces, dashes and brackets are fine (for example +49 170 123 45 67)."
+msgstr ""
+
+#. translators: %s: question text
+#: src/Services/QuestionnaireService.php:157
+#, php-format
+msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
+msgstr ""

--- a/fair-form/languages/fair-form-fr_FR.po
+++ b/fair-form/languages/fair-form-fr_FR.po
@@ -18,7 +18,7 @@ msgstr ""
 #: src/Admin/AdminHooks.php:129
 #: src/Admin/AdminHooks.php:130
 #: src/API/FairFormController.php:238
-#: src/Services/QuestionnaireService.php:293
+#: src/Services/QuestionnaireService.php:331
 msgid "Fair Form"
 msgstr ""
 
@@ -90,7 +90,7 @@ msgstr "Hérité (pas d'ID de formulaire)"
 
 #: src/API/QuestionnaireResponsesController.php:446
 #: src/API/QuestionnaireResponsesController.php:526
-#: src/Admin/submission-detail/SubmissionDetail.js:229
+#: src/Admin/submission-detail/SubmissionDetail.js:222
 msgid "Submission not found."
 msgstr "Soumission introuvable."
 
@@ -108,37 +108,31 @@ msgid "Response not found."
 msgstr "Réponse introuvable."
 
 #. translators: %s: question text
-#: src/Services/QuestionnaireService.php:124
+#: src/Services/QuestionnaireService.php:142
 #, php-format
 msgid "Please enter a valid email address for: %s"
 msgstr "Veuillez entrer une adresse e-mail valide pour : %s"
 
-#. translators: %s: question text
-#: src/Services/QuestionnaireService.php:137
-#, php-format
-msgid "Please enter a valid phone number with country code (e.g. +49170...) for: %s"
-msgstr "Veuillez entrer un numéro de téléphone valide avec l'indicatif du pays (par exemple +49170...) pour : %s"
-
-#: src/Services/QuestionnaireService.php:194
+#: src/Services/QuestionnaireService.php:232
 msgid "File upload failed. Please try again."
 msgstr "Échec du téléchargement du fichier. Veuillez réessayer."
 
-#: src/Services/QuestionnaireService.php:203
+#: src/Services/QuestionnaireService.php:241
 msgid "File is too large."
 msgstr "Le fichier est trop volumineux."
 
-#: src/Services/QuestionnaireService.php:213
+#: src/Services/QuestionnaireService.php:251
 msgid "File type not allowed."
 msgstr "Type de fichier non autorisé."
 
-#: src/Services/QuestionnaireService.php:247
+#: src/Services/QuestionnaireService.php:285
 msgid "Failed to save uploaded file."
 msgstr "Impossible d'enregistrer le fichier téléchargé."
 
 #: src/Admin/answers-overview/AnswersOverview.js:54
 #: src/Admin/form-answers/FormAnswers.js:126
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:123
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:656
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:141
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:681
 msgid "Name"
 msgstr "Nom"
 
@@ -173,7 +167,7 @@ msgstr "Page"
 #: src/Admin/answers-overview/AnswersOverview.js:113
 #: src/Admin/form-answers/FormAnswers.js:152
 #: src/Admin/form-answers/FormAnswers.js:272
-#: src/Admin/submission-detail/SubmissionDetail.js:323
+#: src/Admin/submission-detail/SubmissionDetail.js:310
 msgid "Event"
 msgstr "Événement"
 
@@ -184,20 +178,20 @@ msgstr "Formulaire"
 
 #: src/Admin/form-answers/FormAnswers.js:112
 #: src/Admin/form-answers/FormAnswers.js:197
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:268
-#: src/Admin/submission-detail/SubmissionDetail.js:120
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:304
+#: src/Admin/submission-detail/SubmissionDetail.js:113
 msgid "Error: "
 msgstr "Erreur : "
 
 #: src/Admin/form-answers/FormAnswers.js:140
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:141
-#: src/Admin/submission-detail/SubmissionDetail.js:315
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:159
+#: src/Admin/submission-detail/SubmissionDetail.js:302
 msgid "Email"
 msgstr "E-mail"
 
 #: src/Admin/form-answers/FormAnswers.js:158
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:213
-#: src/Admin/submission-detail/SubmissionDetail.js:319
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:233
+#: src/Admin/submission-detail/SubmissionDetail.js:306
 msgid "Date"
 msgstr "Date"
 
@@ -210,21 +204,22 @@ msgid "Failed to delete submission."
 msgstr "Impossible de supprimer la soumission."
 
 #: src/Admin/form-answers/FormAnswers.js:208
-#: src/Admin/submission-detail/SubmissionDetail.js:148
+#: src/Admin/submission-detail/SubmissionDetail.js:141
 msgid "Edit"
 msgstr "Modifier"
 
 #: src/Admin/form-answers/FormAnswers.js:215
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:333
 msgid "View"
 msgstr "Afficher"
 
 #: src/Admin/form-answers/FormAnswers.js:224
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:297
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:342
 msgid "Delete"
 msgstr "Supprimer"
 
 #: src/Admin/form-answers/FormAnswers.js:235
-#: src/Admin/submission-detail/SubmissionDetail.js:130
+#: src/Admin/submission-detail/SubmissionDetail.js:123
 msgid "— None —"
 msgstr "— Aucun —"
 
@@ -237,259 +232,265 @@ msgid "Edit Submission"
 msgstr "Modifier la soumission"
 
 #: src/Admin/form-answers/FormAnswers.js:289
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:594
-#: src/Admin/submission-detail/SubmissionDetail.js:172
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:619
+#: src/Admin/submission-detail/SubmissionDetail.js:165
 msgid "Cancel"
 msgstr "Annuler"
 
 #: src/Admin/form-answers/FormAnswers.js:297
-#: src/Admin/submission-detail/SubmissionDetail.js:169
+#: src/Admin/submission-detail/SubmissionDetail.js:162
 msgid "Save"
 msgstr "Enregistrer"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:147
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:165
 msgid "Status"
 msgstr "Statut"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:152
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:162
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:170
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:180
 msgid "Pending"
 msgstr "En attente"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:153
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:165
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:171
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:183
 msgid "Confirmed"
 msgstr "Confirmé"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:172
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:190
 msgid "Mailing"
 msgstr "Envoi postal"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:177
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:187
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:195
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:205
 msgid "Minimal"
 msgstr "Minimal"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:178
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:190
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:196
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:208
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:197
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:215
 msgid "Subscribed Categories"
 msgstr "Catégories abonnées"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:270
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:306
 msgid "Failed to delete response."
 msgstr "Échec de la suppression de la réponse."
 
 #. translators: 1: number added, 2: number already in group
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:390
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:423
 #, js-format
 msgid "%1$d participant(s) added, %2$d already in group."
 msgstr "%1$d participant(s) ajouté(s), %2$d déjà dans le groupe."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:404
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:437
 msgid "Failed to add participants to group."
 msgstr "Échec de l'ajout des participants au groupe."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:530
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:563
 msgid "Questionnaire Responses"
 msgstr "Réponses au questionnaire"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:491
-#: src/Admin/submission-detail/SubmissionDetail.js:192
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:524
+#: src/Admin/submission-detail/SubmissionDetail.js:185
 msgid "Clipboard not available."
 msgstr "Presse-papiers non disponible."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:201
+#: src/Admin/submission-detail/SubmissionDetail.js:194
 msgid "Markdown copied to clipboard. Paste into Google Docs."
 msgstr "Markdown copié dans le presse-papiers. Collez dans Google Docs."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:506
-#: src/Admin/submission-detail/SubmissionDetail.js:210
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:539
+#: src/Admin/submission-detail/SubmissionDetail.js:203
 msgid "Failed to copy."
 msgstr "Échec de la copie."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:534
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:567
 msgid "Back to Answers Overview"
 msgstr "Retour à l'aperçu des réponses"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:542
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:575
 msgid "Event edit page"
 msgstr "Page d'édition de l'événement"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:550
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:583
 msgid "Post entry"
 msgstr "Entrée de publication"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:568
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:601
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:592
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:626
 msgid "Add participants to group"
 msgstr "Ajouter des participants au groupe"
 
 #. translators: %d: number of unique participants
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:608
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:633
 #, js-format
 msgid "%d unique participant(s) will be added."
 msgstr "%d participant(s) unique(s) sera/seront ajouté(s)."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:617
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:642
 msgid "Target group"
 msgstr "Groupe cible"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:621
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:646
 msgid "Use existing group"
 msgstr "Utiliser un groupe existant"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:625
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:650
 msgid "Create new group"
 msgstr "Créer un nouveau groupe"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:634
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:659
 msgid "Group"
 msgstr "Groupe"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:640
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:665
 msgid "Loading..."
 msgstr "Chargement..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:641
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:666
 msgid "— Select a group —"
 msgstr "— Sélectionner un groupe —"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:659
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:684
 msgid "Enter group name..."
 msgstr "Entrez le nom du groupe..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:665
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:690
 msgid "Description"
 msgstr "Description"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:668
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:693
 msgid "Enter group description (optional)..."
 msgstr "Entrez la description du groupe (facultatif)..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:697
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:788
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:722
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:813
 msgid "Close"
 msgstr "Fermer"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:706
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:731
 msgid "Create group and add"
 msgstr "Créer le groupe et ajouter"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:707
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:732
 msgid "Add to group"
 msgstr "Ajouter au groupe"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:42
+#: src/Admin/submission-detail/SubmissionDetail.js:35
 msgid "View file"
 msgstr "Afficher le fichier"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:121
+#: src/Admin/submission-detail/SubmissionDetail.js:114
 msgid "Failed to update."
 msgstr "Échec de la mise à jour."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:218
+#: src/Admin/submission-detail/SubmissionDetail.js:211
 msgid "No submission ID provided."
 msgstr "Aucun ID de soumission fourni."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:269
+#: src/Admin/submission-detail/SubmissionDetail.js:258
 msgid "Form Submission"
 msgstr "Soumission de formulaire"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:272
+#: src/Admin/submission-detail/SubmissionDetail.js:261
 msgid "Copy markdown"
 msgstr "Copier le markdown"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:288
+#: src/Admin/submission-detail/SubmissionDetail.js:277
 msgid "Submission Info"
 msgstr "Informations de soumission"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:299
+#: src/Admin/submission-detail/SubmissionDetail.js:287
 msgid "Submitted by"
 msgstr "Soumis par"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:336
+#: src/Admin/submission-detail/SubmissionDetail.js:323
 msgid "Answers"
 msgstr "Réponses"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:340
+#: src/Admin/submission-detail/SubmissionDetail.js:327
 msgid "No answers recorded."
 msgstr "Aucune réponse enregistrée."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:349
+#: src/Admin/submission-detail/SubmissionDetail.js:335
 msgid "Question"
 msgstr "Question"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:351
+#: src/Admin/submission-detail/SubmissionDetail.js:336
 msgid "Answer"
 msgstr "Réponse"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:64
+#: src/Admin/submission-detail/SubmissionDetail.js:57
 msgid "Yes"
 msgstr "Oui"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:65
+#: src/Admin/submission-detail/SubmissionDetail.js:58
 msgid "No"
 msgstr "Non"
 
-#. translators: %s: participant name
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:285
+#. translators: %s: participant name, or the submission date when there is no participant
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:321
 #, js-format
 msgid "Delete the response from %s? This cannot be undone."
 msgstr "Supprimer la réponse de %s ? Cette action ne peut pas être annulée."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:289
-msgid "this participant"
-msgstr "ce participant"
-
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:500
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:533
 msgid "Message copied to clipboard."
 msgstr "Message copié dans le presse-papiers."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:575
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:715
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:600
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:740
 msgid "Export"
 msgstr "Exporter"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:593
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:618
 msgid "Delete response"
 msgstr "Supprimer la réponse"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:720
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:745
 msgid "Columns"
 msgstr "Colonnes"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:724
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:749
 msgid "All columns"
 msgstr "Toutes les colonnes"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:728
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:753
 msgid "Handpicked columns"
 msgstr "Colonnes sélectionnées"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:751
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:776
 msgid "Format"
 msgstr "Format"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:755
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:780
 msgid "Markdown"
 msgstr "Markdown"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:758
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:783
 msgid "CSV"
 msgstr "CSV"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:760
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:785
 msgid "One line per person"
 msgstr "Une ligne par personne"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:796
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:821
 msgid "Download CSV"
 msgstr "Télécharger CSV"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:804
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:829
 msgid "Copy to clipboard"
 msgstr "Copier dans le presse-papiers"
+
+#: src/blocks/fair-form-phone/render.php:43
+msgid "Include the country code, starting with \"+\" — spaces, dashes and brackets are fine (for example +49 170 123 45 67)."
+msgstr ""
+
+#. translators: %s: question text
+#: src/Services/QuestionnaireService.php:157
+#, php-format
+msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
+msgstr ""

--- a/fair-form/languages/fair-form-pl_PL.po
+++ b/fair-form/languages/fair-form-pl_PL.po
@@ -18,7 +18,7 @@ msgstr ""
 #: src/Admin/AdminHooks.php:129
 #: src/Admin/AdminHooks.php:130
 #: src/API/FairFormController.php:238
-#: src/Services/QuestionnaireService.php:293
+#: src/Services/QuestionnaireService.php:331
 msgid "Fair Form"
 msgstr ""
 
@@ -90,7 +90,7 @@ msgstr "Starsze (brak identyfikatora formularza)"
 
 #: src/API/QuestionnaireResponsesController.php:446
 #: src/API/QuestionnaireResponsesController.php:526
-#: src/Admin/submission-detail/SubmissionDetail.js:229
+#: src/Admin/submission-detail/SubmissionDetail.js:222
 msgid "Submission not found."
 msgstr "Zgłoszenie nie znalezione."
 
@@ -108,37 +108,31 @@ msgid "Response not found."
 msgstr "Odpowiedź nie znaleziona."
 
 #. translators: %s: question text
-#: src/Services/QuestionnaireService.php:124
+#: src/Services/QuestionnaireService.php:142
 #, php-format
 msgid "Please enter a valid email address for: %s"
 msgstr "Proszę wpisać prawidłowy adres e-mail dla: %s"
 
-#. translators: %s: question text
-#: src/Services/QuestionnaireService.php:137
-#, php-format
-msgid "Please enter a valid phone number with country code (e.g. +49170...) for: %s"
-msgstr "Proszę wpisać prawidłowy numer telefonu z kodem kraju (np. +49170...) dla: %s"
-
-#: src/Services/QuestionnaireService.php:194
+#: src/Services/QuestionnaireService.php:232
 msgid "File upload failed. Please try again."
 msgstr "Przesyłanie pliku nie powiodło się. Spróbuj ponownie."
 
-#: src/Services/QuestionnaireService.php:203
+#: src/Services/QuestionnaireService.php:241
 msgid "File is too large."
 msgstr "Plik jest zbyt duży."
 
-#: src/Services/QuestionnaireService.php:213
+#: src/Services/QuestionnaireService.php:251
 msgid "File type not allowed."
 msgstr "Typ pliku nie jest dozwolony."
 
-#: src/Services/QuestionnaireService.php:247
+#: src/Services/QuestionnaireService.php:285
 msgid "Failed to save uploaded file."
 msgstr "Nie udało się zapisać przesłanego pliku."
 
 #: src/Admin/answers-overview/AnswersOverview.js:54
 #: src/Admin/form-answers/FormAnswers.js:126
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:123
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:656
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:141
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:681
 msgid "Name"
 msgstr "Nazwa"
 
@@ -173,7 +167,7 @@ msgstr "Strona"
 #: src/Admin/answers-overview/AnswersOverview.js:113
 #: src/Admin/form-answers/FormAnswers.js:152
 #: src/Admin/form-answers/FormAnswers.js:272
-#: src/Admin/submission-detail/SubmissionDetail.js:323
+#: src/Admin/submission-detail/SubmissionDetail.js:310
 msgid "Event"
 msgstr "Zdarzenie"
 
@@ -184,20 +178,20 @@ msgstr "Formularz"
 
 #: src/Admin/form-answers/FormAnswers.js:112
 #: src/Admin/form-answers/FormAnswers.js:197
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:268
-#: src/Admin/submission-detail/SubmissionDetail.js:120
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:304
+#: src/Admin/submission-detail/SubmissionDetail.js:113
 msgid "Error: "
 msgstr "Błąd: "
 
 #: src/Admin/form-answers/FormAnswers.js:140
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:141
-#: src/Admin/submission-detail/SubmissionDetail.js:315
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:159
+#: src/Admin/submission-detail/SubmissionDetail.js:302
 msgid "Email"
 msgstr "Email"
 
 #: src/Admin/form-answers/FormAnswers.js:158
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:213
-#: src/Admin/submission-detail/SubmissionDetail.js:319
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:233
+#: src/Admin/submission-detail/SubmissionDetail.js:306
 msgid "Date"
 msgstr "Data"
 
@@ -210,21 +204,22 @@ msgid "Failed to delete submission."
 msgstr "Nie udało się usunąć zgłoszenia."
 
 #: src/Admin/form-answers/FormAnswers.js:208
-#: src/Admin/submission-detail/SubmissionDetail.js:148
+#: src/Admin/submission-detail/SubmissionDetail.js:141
 msgid "Edit"
 msgstr "Edytuj"
 
 #: src/Admin/form-answers/FormAnswers.js:215
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:333
 msgid "View"
 msgstr "Wyświetl"
 
 #: src/Admin/form-answers/FormAnswers.js:224
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:297
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:342
 msgid "Delete"
 msgstr "Usuń"
 
 #: src/Admin/form-answers/FormAnswers.js:235
-#: src/Admin/submission-detail/SubmissionDetail.js:130
+#: src/Admin/submission-detail/SubmissionDetail.js:123
 msgid "— None —"
 msgstr "— Brak —"
 
@@ -237,259 +232,265 @@ msgid "Edit Submission"
 msgstr "Edytuj zgłoszenie"
 
 #: src/Admin/form-answers/FormAnswers.js:289
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:594
-#: src/Admin/submission-detail/SubmissionDetail.js:172
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:619
+#: src/Admin/submission-detail/SubmissionDetail.js:165
 msgid "Cancel"
 msgstr "Anuluj"
 
 #: src/Admin/form-answers/FormAnswers.js:297
-#: src/Admin/submission-detail/SubmissionDetail.js:169
+#: src/Admin/submission-detail/SubmissionDetail.js:162
 msgid "Save"
 msgstr "Zapisz"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:147
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:165
 msgid "Status"
 msgstr "Status"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:152
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:162
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:170
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:180
 msgid "Pending"
 msgstr "Oczekujące"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:153
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:165
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:171
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:183
 msgid "Confirmed"
 msgstr "Potwierdzone"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:172
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:190
 msgid "Mailing"
 msgstr "Mailing"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:177
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:187
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:195
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:205
 msgid "Minimal"
 msgstr "Minimalne"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:178
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:190
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:196
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:208
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:197
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:215
 msgid "Subscribed Categories"
 msgstr "Subskrybowane kategorie"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:270
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:306
 msgid "Failed to delete response."
 msgstr "Nie udało się usunąć odpowiedzi."
 
 #. translators: 1: number added, 2: number already in group
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:390
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:423
 #, js-format
 msgid "%1$d participant(s) added, %2$d already in group."
 msgstr "%1$d uczestnik(ów) dodany(ch), %2$d już w grupie."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:404
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:437
 msgid "Failed to add participants to group."
 msgstr "Nie udało się dodać uczestników do grupy."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:530
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:563
 msgid "Questionnaire Responses"
 msgstr "Odpowiedzi ankiety"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:491
-#: src/Admin/submission-detail/SubmissionDetail.js:192
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:524
+#: src/Admin/submission-detail/SubmissionDetail.js:185
 msgid "Clipboard not available."
 msgstr "Schowek niedostępny."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:201
+#: src/Admin/submission-detail/SubmissionDetail.js:194
 msgid "Markdown copied to clipboard. Paste into Google Docs."
 msgstr "Markdown skopiowany do schowka. Wklej do Dokumentów Google."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:506
-#: src/Admin/submission-detail/SubmissionDetail.js:210
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:539
+#: src/Admin/submission-detail/SubmissionDetail.js:203
 msgid "Failed to copy."
 msgstr "Nie udało się skopiować."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:534
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:567
 msgid "Back to Answers Overview"
 msgstr "Powrót do przeglądu odpowiedzi"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:542
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:575
 msgid "Event edit page"
 msgstr "Strona edycji wydarzenia"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:550
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:583
 msgid "Post entry"
 msgstr "Wpis wpisu"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:568
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:601
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:592
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:626
 msgid "Add participants to group"
 msgstr "Dodaj uczestników do grupy"
 
 #. translators: %d: number of unique participants
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:608
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:633
 #, js-format
 msgid "%d unique participant(s) will be added."
 msgstr "%d unikalny(ch) uczestnik(ów) zostanie dodany."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:617
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:642
 msgid "Target group"
 msgstr "Grupa docelowa"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:621
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:646
 msgid "Use existing group"
 msgstr "Użyj istniejącej grupy"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:625
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:650
 msgid "Create new group"
 msgstr "Utwórz nową grupę"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:634
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:659
 msgid "Group"
 msgstr "Grupa"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:640
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:665
 msgid "Loading..."
 msgstr "Ładowanie..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:641
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:666
 msgid "— Select a group —"
 msgstr "— Wybierz grupę —"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:659
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:684
 msgid "Enter group name..."
 msgstr "Wpisz nazwę grupy..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:665
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:690
 msgid "Description"
 msgstr "Opis"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:668
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:693
 msgid "Enter group description (optional)..."
 msgstr "Wpisz opis grupy (opcjonalnie)..."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:697
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:788
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:722
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:813
 msgid "Close"
 msgstr "Zamknij"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:706
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:731
 msgid "Create group and add"
 msgstr "Utwórz grupę i dodaj"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:707
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:732
 msgid "Add to group"
 msgstr "Dodaj do grupy"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:42
+#: src/Admin/submission-detail/SubmissionDetail.js:35
 msgid "View file"
 msgstr "Wyświetl plik"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:121
+#: src/Admin/submission-detail/SubmissionDetail.js:114
 msgid "Failed to update."
 msgstr "Nie udało się zaktualizować."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:218
+#: src/Admin/submission-detail/SubmissionDetail.js:211
 msgid "No submission ID provided."
 msgstr "Nie podano identyfikatora zgłoszenia."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:269
+#: src/Admin/submission-detail/SubmissionDetail.js:258
 msgid "Form Submission"
 msgstr "Przesłanie formularza"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:272
+#: src/Admin/submission-detail/SubmissionDetail.js:261
 msgid "Copy markdown"
 msgstr "Kopiuj markdown"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:288
+#: src/Admin/submission-detail/SubmissionDetail.js:277
 msgid "Submission Info"
 msgstr "Informacje o zgłoszeniu"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:299
+#: src/Admin/submission-detail/SubmissionDetail.js:287
 msgid "Submitted by"
 msgstr "Przesłane przez"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:336
+#: src/Admin/submission-detail/SubmissionDetail.js:323
 msgid "Answers"
 msgstr "Odpowiedzi"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:340
+#: src/Admin/submission-detail/SubmissionDetail.js:327
 msgid "No answers recorded."
 msgstr "Brak zarejestrowanych odpowiedzi."
 
-#: src/Admin/submission-detail/SubmissionDetail.js:349
+#: src/Admin/submission-detail/SubmissionDetail.js:335
 msgid "Question"
 msgstr "Pytanie"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:351
+#: src/Admin/submission-detail/SubmissionDetail.js:336
 msgid "Answer"
 msgstr "Odpowiedź"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:64
+#: src/Admin/submission-detail/SubmissionDetail.js:57
 msgid "Yes"
 msgstr "Tak"
 
-#: src/Admin/submission-detail/SubmissionDetail.js:65
+#: src/Admin/submission-detail/SubmissionDetail.js:58
 msgid "No"
 msgstr "Nie"
 
-#. translators: %s: participant name
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:285
+#. translators: %s: participant name, or the submission date when there is no participant
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:321
 #, js-format
 msgid "Delete the response from %s? This cannot be undone."
 msgstr "Usunąć odpowiedź od %s? Tej czynności nie można cofnąć."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:289
-msgid "this participant"
-msgstr "ten uczestnik"
-
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:500
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:533
 msgid "Message copied to clipboard."
 msgstr "Wiadomość skopiowana do schowka."
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:575
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:715
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:600
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:740
 msgid "Export"
 msgstr "Eksportuj"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:593
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:618
 msgid "Delete response"
 msgstr "Usuń odpowiedź"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:720
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:745
 msgid "Columns"
 msgstr "Kolumny"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:724
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:749
 msgid "All columns"
 msgstr "Wszystkie kolumny"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:728
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:753
 msgid "Handpicked columns"
 msgstr "Wybrane kolumny"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:751
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:776
 msgid "Format"
 msgstr "Format"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:755
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:780
 msgid "Markdown"
 msgstr "Markdown"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:758
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:783
 msgid "CSV"
 msgstr "CSV"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:760
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:785
 msgid "One line per person"
 msgstr "Jeden wiersz na osobę"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:796
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:821
 msgid "Download CSV"
 msgstr "Pobierz CSV"
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:804
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:829
 msgid "Copy to clipboard"
 msgstr "Skopiuj do schowka"
+
+#: src/blocks/fair-form-phone/render.php:43
+msgid "Include the country code, starting with \"+\" — spaces, dashes and brackets are fine (for example +49 170 123 45 67)."
+msgstr ""
+
+#. translators: %s: question text
+#: src/Services/QuestionnaireService.php:157
+#, php-format
+msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
+msgstr ""

--- a/fair-form/languages/fair-form.pot
+++ b/fair-form/languages/fair-form.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the Private.
 msgid ""
 msgstr ""
-"Project-Id-Version: Fair Form 1.1.0\n"
+"Project-Id-Version: Fair Form 1.2.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/fair-form\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-23T09:09:47+00:00\n"
+"POT-Creation-Date: 2026-07-26T14:20:45+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fair-form\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: src/Admin/AdminHooks.php:129
 #: src/Admin/AdminHooks.php:130
 #: src/API/FairFormController.php:238
-#: src/Services/QuestionnaireService.php:293
+#: src/Services/QuestionnaireService.php:331
 msgid "Fair Form"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 
 #: src/API/QuestionnaireResponsesController.php:446
 #: src/API/QuestionnaireResponsesController.php:526
-#: src/Admin/submission-detail/SubmissionDetail.js:229
+#: src/Admin/submission-detail/SubmissionDetail.js:222
 msgid "Submission not found."
 msgstr ""
 
@@ -108,38 +108,42 @@ msgstr ""
 msgid "Response not found."
 msgstr ""
 
+#: src/blocks/fair-form-phone/render.php:43
+msgid "Include the country code, starting with \"+\" — spaces, dashes and brackets are fine (for example +49 170 123 45 67)."
+msgstr ""
+
 #. translators: %s: question text
-#: src/Services/QuestionnaireService.php:124
+#: src/Services/QuestionnaireService.php:142
 #, php-format
 msgid "Please enter a valid email address for: %s"
 msgstr ""
 
 #. translators: %s: question text
-#: src/Services/QuestionnaireService.php:137
+#: src/Services/QuestionnaireService.php:157
 #, php-format
-msgid "Please enter a valid phone number with country code (e.g. +49170...) for: %s"
+msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
 msgstr ""
 
-#: src/Services/QuestionnaireService.php:194
+#: src/Services/QuestionnaireService.php:232
 msgid "File upload failed. Please try again."
 msgstr ""
 
-#: src/Services/QuestionnaireService.php:203
+#: src/Services/QuestionnaireService.php:241
 msgid "File is too large."
 msgstr ""
 
-#: src/Services/QuestionnaireService.php:213
+#: src/Services/QuestionnaireService.php:251
 msgid "File type not allowed."
 msgstr ""
 
-#: src/Services/QuestionnaireService.php:247
+#: src/Services/QuestionnaireService.php:285
 msgid "Failed to save uploaded file."
 msgstr ""
 
 #: src/Admin/answers-overview/AnswersOverview.js:54
 #: src/Admin/form-answers/FormAnswers.js:126
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:123
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:656
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:141
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:681
 msgid "Name"
 msgstr ""
 
@@ -174,7 +178,7 @@ msgstr ""
 #: src/Admin/answers-overview/AnswersOverview.js:113
 #: src/Admin/form-answers/FormAnswers.js:152
 #: src/Admin/form-answers/FormAnswers.js:272
-#: src/Admin/submission-detail/SubmissionDetail.js:323
+#: src/Admin/submission-detail/SubmissionDetail.js:310
 msgid "Event"
 msgstr ""
 
@@ -185,20 +189,20 @@ msgstr ""
 
 #: src/Admin/form-answers/FormAnswers.js:112
 #: src/Admin/form-answers/FormAnswers.js:197
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:268
-#: src/Admin/submission-detail/SubmissionDetail.js:120
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:304
+#: src/Admin/submission-detail/SubmissionDetail.js:113
 msgid "Error: "
 msgstr ""
 
 #: src/Admin/form-answers/FormAnswers.js:140
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:141
-#: src/Admin/submission-detail/SubmissionDetail.js:315
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:159
+#: src/Admin/submission-detail/SubmissionDetail.js:302
 msgid "Email"
 msgstr ""
 
 #: src/Admin/form-answers/FormAnswers.js:158
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:213
-#: src/Admin/submission-detail/SubmissionDetail.js:319
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:233
+#: src/Admin/submission-detail/SubmissionDetail.js:306
 msgid "Date"
 msgstr ""
 
@@ -211,21 +215,22 @@ msgid "Failed to delete submission."
 msgstr ""
 
 #: src/Admin/form-answers/FormAnswers.js:208
-#: src/Admin/submission-detail/SubmissionDetail.js:148
+#: src/Admin/submission-detail/SubmissionDetail.js:141
 msgid "Edit"
 msgstr ""
 
 #: src/Admin/form-answers/FormAnswers.js:215
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:333
 msgid "View"
 msgstr ""
 
 #: src/Admin/form-answers/FormAnswers.js:224
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:297
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:342
 msgid "Delete"
 msgstr ""
 
 #: src/Admin/form-answers/FormAnswers.js:235
-#: src/Admin/submission-detail/SubmissionDetail.js:130
+#: src/Admin/submission-detail/SubmissionDetail.js:123
 msgid "— None —"
 msgstr ""
 
@@ -238,259 +243,255 @@ msgid "Edit Submission"
 msgstr ""
 
 #: src/Admin/form-answers/FormAnswers.js:289
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:594
-#: src/Admin/submission-detail/SubmissionDetail.js:172
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:619
+#: src/Admin/submission-detail/SubmissionDetail.js:165
 msgid "Cancel"
 msgstr ""
 
 #: src/Admin/form-answers/FormAnswers.js:297
-#: src/Admin/submission-detail/SubmissionDetail.js:169
+#: src/Admin/submission-detail/SubmissionDetail.js:162
 msgid "Save"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:147
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:165
 msgid "Status"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:152
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:162
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:170
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:180
 msgid "Pending"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:153
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:165
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:171
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:183
 msgid "Confirmed"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:172
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:190
 msgid "Mailing"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:177
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:187
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:195
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:205
 msgid "Minimal"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:178
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:190
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:196
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:208
 msgid "Marketing"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:197
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:215
 msgid "Subscribed Categories"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:270
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:306
 msgid "Failed to delete response."
 msgstr ""
 
-#. translators: %s: participant name
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:285
+#. translators: %s: participant name, or the submission date when there is no participant
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:321
 #, js-format
 msgid "Delete the response from %s? This cannot be undone."
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:289
-msgid "this participant"
-msgstr ""
-
 #. translators: 1: number added, 2: number already in group
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:390
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:423
 #, js-format
 msgid "%1$d participant(s) added, %2$d already in group."
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:404
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:437
 msgid "Failed to add participants to group."
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:491
-#: src/Admin/submission-detail/SubmissionDetail.js:192
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:524
+#: src/Admin/submission-detail/SubmissionDetail.js:185
 msgid "Clipboard not available."
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:500
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:533
 msgid "Message copied to clipboard."
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:506
-#: src/Admin/submission-detail/SubmissionDetail.js:210
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:539
+#: src/Admin/submission-detail/SubmissionDetail.js:203
 msgid "Failed to copy."
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:530
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:563
 msgid "Questionnaire Responses"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:534
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:567
 msgid "Back to Answers Overview"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:542
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:575
 msgid "Event edit page"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:550
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:583
 msgid "Post entry"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:568
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:601
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:592
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:626
 msgid "Add participants to group"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:575
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:715
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:600
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:740
 msgid "Export"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:593
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:618
 msgid "Delete response"
 msgstr ""
 
 #. translators: %d: number of unique participants
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:608
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:633
 #, js-format
 msgid "%d unique participant(s) will be added."
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:617
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:642
 msgid "Target group"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:621
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:646
 msgid "Use existing group"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:625
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:650
 msgid "Create new group"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:634
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:659
 msgid "Group"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:640
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:665
 msgid "Loading..."
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:641
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:666
 msgid "— Select a group —"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:659
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:684
 msgid "Enter group name..."
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:665
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:690
 msgid "Description"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:668
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:693
 msgid "Enter group description (optional)..."
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:697
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:788
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:722
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:813
 msgid "Close"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:706
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:731
 msgid "Create group and add"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:707
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:732
 msgid "Add to group"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:720
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:745
 msgid "Columns"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:724
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:749
 msgid "All columns"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:728
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:753
 msgid "Handpicked columns"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:751
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:776
 msgid "Format"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:755
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:780
 msgid "Markdown"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:758
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:783
 msgid "CSV"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:760
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:785
 msgid "One line per person"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:796
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:821
 msgid "Download CSV"
 msgstr ""
 
-#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:804
+#: src/Admin/questionnaire-responses/QuestionnaireResponses.js:829
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:42
+#: src/Admin/submission-detail/SubmissionDetail.js:35
 msgid "View file"
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:64
+#: src/Admin/submission-detail/SubmissionDetail.js:57
 msgid "Yes"
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:65
+#: src/Admin/submission-detail/SubmissionDetail.js:58
 msgid "No"
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:121
+#: src/Admin/submission-detail/SubmissionDetail.js:114
 msgid "Failed to update."
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:201
+#: src/Admin/submission-detail/SubmissionDetail.js:194
 msgid "Markdown copied to clipboard. Paste into Google Docs."
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:218
+#: src/Admin/submission-detail/SubmissionDetail.js:211
 msgid "No submission ID provided."
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:269
+#: src/Admin/submission-detail/SubmissionDetail.js:258
 msgid "Form Submission"
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:272
+#: src/Admin/submission-detail/SubmissionDetail.js:261
 msgid "Copy markdown"
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:288
+#: src/Admin/submission-detail/SubmissionDetail.js:277
 msgid "Submission Info"
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:299
+#: src/Admin/submission-detail/SubmissionDetail.js:287
 msgid "Submitted by"
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:336
+#: src/Admin/submission-detail/SubmissionDetail.js:323
 msgid "Answers"
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:340
+#: src/Admin/submission-detail/SubmissionDetail.js:327
 msgid "No answers recorded."
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:349
+#: src/Admin/submission-detail/SubmissionDetail.js:335
 msgid "Question"
 msgstr ""
 
-#: src/Admin/submission-detail/SubmissionDetail.js:351
+#: src/Admin/submission-detail/SubmissionDetail.js:336
 msgid "Answer"
 msgstr ""

--- a/fair-form/package.json
+++ b/fair-form/package.json
@@ -21,6 +21,7 @@
 		"updatepo": "wp i18n update-po languages/fair-form.pot languages/",
 		"test": "wp-scripts test-unit-js --config jest.config.js",
 		"test:js": "wp-scripts test-unit-js --config jest.config.js",
+		"test:api": "playwright test src/API/__tests__/",
 		"test:php": "vendor/bin/phpunit",
 		"svn:checkout": "svn co https://plugins.svn.wordpress.org/fair-form svn",
 		"svn:copy": "cp -r readme.txt fair-form.php composer* languages CHANGELOG.md svn/trunk"

--- a/fair-form/src/API/__tests__/FairFormPhoneAnswers.api.spec.js
+++ b/fair-form/src/API/__tests__/FairFormPhoneAnswers.api.spec.js
@@ -1,0 +1,174 @@
+/**
+ * Playwright API tests for phone-question normalization in
+ * FairFormController::create_item() / QuestionnaireService::sanitize_answers()
+ * (#1267): separators (spaces incl. NBSP, dots, parens, hyphens) are accepted
+ * on submission and stripped before the answer is stored, while anything that
+ * still fails the E.164-style rule after stripping is rejected.
+ *
+ * Every accept-case payload carries its own unique email answer so the
+ * FairFormController rate limiter (3/hour, keyed on email when present) keys
+ * per-submission instead of falling back to the shared IP key.
+ *
+ * When fair-audience is active, FairFormController opportunistically creates
+ * a Participant from that email — but Participant::save() requires a
+ * non-empty `name`, which the controller never supplies. Pre-creating each
+ * accept case's participant via the admin API (name + email) sidesteps that
+ * pre-existing gap so this spec stays focused on phone normalization; reject
+ * cases never reach participant creation (sanitize_answers() fails first).
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}-${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+const emailQuestion = (value) => ({
+	question_key: 'email',
+	question_text: 'Email?',
+	question_type: 'email',
+	answer_value: value,
+	display_order: 0,
+});
+
+const phoneQuestion = (value) => ({
+	question_key: 'mobile',
+	question_text: 'Mobile?',
+	question_type: 'phone',
+	answer_value: value,
+	display_order: 1,
+});
+
+// Every accepted variant below normalizes to this same canonical value.
+const NORMALIZED = '+491701234567';
+
+const ACCEPT_CASES = [
+	'+491701234567',
+	'+49 170 123 45 67',
+	'+49-170-123-45-67',
+	'+49.170.123.4567',
+	'+49 (170) 1234567',
+	'+49 170 123 45 67', // NBSP
+	'+49 170 1234567', // narrow NBSP
+];
+
+const REJECT_CASES = [
+	'49 170 1234567', // no leading +
+	'+49 17a 1234', // letters
+	'++49 1701234', // second +
+	'+ - . ( )', // separator-only
+	'+0491701234567', // leading zero
+	'+491234', // 6 digits, below the 7-digit minimum
+	'+4912345678901234567', // 16 digits, above the 15-digit maximum
+];
+
+test.describe('FairFormController — phone question normalization (#1267)', () => {
+	let api;
+	let fairAudienceActive = false;
+	const postId = Date.now();
+
+	async function findSubmissionByEmail(email) {
+		const res = await api.get(
+			'/wp-json/fair-form/v1/questionnaire-responses',
+			{
+				headers: adminHeaders,
+				params: { post_id: postId, title: 'Fair Form' },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const submissions = await res.json();
+		return submissions.find((s) =>
+			s.answers.some((a) => a.answer_value === email)
+		);
+	}
+
+	async function ensureParticipant(email) {
+		if (!fairAudienceActive) {
+			return;
+		}
+		await api.post('/wp-json/fair-audience/v1/participants', {
+			headers: adminHeaders,
+			data: { name: 'Phone Test', email },
+		});
+	}
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	for (const value of ACCEPT_CASES) {
+		test(`normalizes ${JSON.stringify(
+			value
+		)} to ${NORMALIZED}`, async () => {
+			const email = uniqueEmail('phone-accept');
+			await ensureParticipant(email);
+			const res = await api.post(
+				'/wp-json/fair-form/v1/fair-form-submit',
+				{
+					data: {
+						post_id: postId,
+						questionnaire_answers: [
+							emailQuestion(email),
+							phoneQuestion(value),
+						],
+					},
+				}
+			);
+			expect(res.ok()).toBeTruthy();
+
+			const submission = await findSubmissionByEmail(email);
+			expect(submission).toBeTruthy();
+			const phoneAnswer = submission.answers.find(
+				(a) => a.question_key === 'mobile'
+			);
+			expect(phoneAnswer.answer_value).toBe(NORMALIZED);
+		});
+	}
+
+	for (const value of REJECT_CASES) {
+		test(`rejects ${JSON.stringify(value)}`, async () => {
+			const email = uniqueEmail('phone-reject');
+			const res = await api.post(
+				'/wp-json/fair-form/v1/fair-form-submit',
+				{
+					data: {
+						post_id: postId,
+						questionnaire_answers: [
+							emailQuestion(email),
+							phoneQuestion(value),
+						],
+					},
+				}
+			);
+			expect(res.status()).toBe(400);
+			expect((await res.json()).code).toBe('invalid_phone');
+		});
+	}
+});

--- a/fair-form/src/Models/QuestionnaireAnswer.php
+++ b/fair-form/src/Models/QuestionnaireAnswer.php
@@ -30,6 +30,7 @@ class QuestionnaireAnswer {
 		'multiselect',
 		'file_upload',
 		'phone',
+		'email',
 	);
 
 	/**

--- a/fair-form/src/Services/QuestionnaireService.php
+++ b/fair-form/src/Services/QuestionnaireService.php
@@ -53,6 +53,24 @@ class QuestionnaireService {
 	const VALID_TYPES = array( 'radio', 'checkbox', 'short_text', 'long_text', 'select', 'number', 'date', 'multiselect', 'file_upload', 'phone', 'email' );
 
 	/**
+	 * HTML `pattern` attribute value for the phone question's `<input>`.
+	 *
+	 * Interleaved form of the normalized rule below: separators (spaces,
+	 * dots, parens, hyphens) may appear anywhere after the leading `+`,
+	 * since the `pattern` attribute can't post-process the typed value.
+	 *
+	 * @var string
+	 */
+	const PHONE_HTML_PATTERN = '[\s\.\(\)\-]*\+[\s\.\(\)\-]*[1-9](?:[\s\.\(\)\-]*[0-9]){6,14}[\s\.\(\)\-]*';
+
+	/**
+	 * Regex a normalized phone value (separators already stripped) must match.
+	 *
+	 * @var string
+	 */
+	const PHONE_NORMALIZED_PATTERN = '/^\+[1-9][0-9]{6,14}$/';
+
+	/**
 	 * Questionnaire submission repository instance.
 	 *
 	 * @var QuestionnaireSubmissionRepository
@@ -129,16 +147,20 @@ class QuestionnaireService {
 				}
 			}
 
-			if ( 'phone' === $question_type && '' !== $answer_value && ! preg_match( '/^\+[1-9][0-9]{6,14}$/', $answer_value ) ) {
-				return new WP_Error(
-					'invalid_phone',
-					sprintf(
-						/* translators: %s: question text */
-						__( 'Please enter a valid phone number with country code (e.g. +49170...) for: %s', 'fair-form' ),
-						$question_text
-					),
-					array( 'status' => 400 )
-				);
+			if ( 'phone' === $question_type && '' !== $answer_value ) {
+				$normalized = self::normalize_phone( $answer_value );
+				if ( ! preg_match( self::PHONE_NORMALIZED_PATTERN, $normalized ) ) {
+					return new WP_Error(
+						'invalid_phone',
+						sprintf(
+							/* translators: %s: question text */
+							__( 'Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s', 'fair-form' ),
+							$question_text
+						),
+						array( 'status' => 400 )
+					);
+				}
+				$answer_value = $normalized;
 			}
 
 			$sanitized[] = array(
@@ -151,6 +173,22 @@ class QuestionnaireService {
 		}
 
 		return $sanitized;
+	}
+
+	/**
+	 * Strip separators (spaces, including NBSP/narrow NBSP, dots, parens,
+	 * hyphens) from a phone value, leaving `+` followed by digits only.
+	 *
+	 * PHP's `\s` is ASCII-only even under the `/u` modifier, and
+	 * `sanitize_text_field()` (already applied upstream) only trims ASCII
+	 * whitespace, so NBSP survives to this point and must be listed via
+	 * `\p{Z}` explicitly.
+	 *
+	 * @param string $value Raw phone value.
+	 * @return string Normalized value.
+	 */
+	public static function normalize_phone( $value ) {
+		return preg_replace( '/[\p{Z}\s\x{FEFF}.()-]/u', '', $value );
 	}
 
 	/**

--- a/fair-form/src/blocks/fair-form-phone/render.php
+++ b/fair-form/src/blocks/fair-form-phone/render.php
@@ -14,6 +14,8 @@
 
 defined( 'WPINC' ) || die;
 
+use FairForm\Services\QuestionnaireService;
+
 $question_text = $attributes['questionText'] ?? '';
 $question_key  = $attributes['questionKey'] ?? '';
 $required      = ! empty( $attributes['required'] );
@@ -38,7 +40,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	)
 );
 
-$format_hint = __( 'Include country code with leading "+" (e.g. +49170...).', 'fair-audience' );
+$format_hint = __( 'Include the country code, starting with "+" — spaces, dashes and brackets are fine (for example +49 170 123 45 67).', 'fair-form' );
 ?>
 
 <div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
@@ -51,7 +53,7 @@ $format_hint = __( 'Include country code with leading "+" (e.g. +49170...).', 'f
 	<input
 		type="tel"
 		inputmode="tel"
-		pattern="^\+[1-9][0-9]{6,14}$"
+		pattern="<?php echo esc_attr( QuestionnaireService::PHONE_HTML_PATTERN ); ?>"
 		title="<?php echo esc_attr( $format_hint ); ?>"
 		id="<?php echo esc_attr( $input_id ); ?>"
 		name="<?php echo esc_attr( 'fair_form_q_' . $question_key ); ?>"


### PR DESCRIPTION
## Summary

- `fair-form-phone` now accepts spaces (incl. NBSP/narrow NBSP), dots,
  parentheses, and hyphens anywhere after the leading `+`, in all three
  validation layers: the HTML `pattern` attribute, the shared JS
  `validateQuestions()`, and `QuestionnaireService::sanitize_answers()`.
- All three layers derive from one shared rule
  (`QuestionnaireService::PHONE_HTML_PATTERN` / `PHONE_NORMALIZED_PATTERN` on
  the PHP side, `PHONE_HTML_PATTERN` / `isValidPhoneNumber()` /
  `normalizePhoneNumber()` in `fair-events-shared`), so a value the browser
  accepts is never rejected by the server.
- The stored answer is normalized (separators stripped) before it's saved;
  the participant's own input is left untouched in the field.
- Reworded the inline hint and error messages to reflect that spaces are
  fine, and fixed the hint's textdomain (`'fair-audience'` → `'fair-form'`,
  since it lives in the fair-form plugin and was previously untranslatable).
- Bonus fix found while testing: `QuestionnaireAnswer::VALID_QUESTION_TYPES`
  was missing `'email'`, even though `email` is a first-class question type
  (`QuestionnaireService::VALID_TYPES`, the `fair-form-email` block). This
  caused `QuestionnaireAnswer::save()` to fail model validation for the
  email answer, which rolled back the *entire* submission's answers via
  `QuestionnaireAnswerRepository::save_answers()`'s transaction — not just
  the email one. One-line fix, verified via the new API spec.

Closes #1267

## Test plan

- [x] `fair-events-shared`: new accept/reject case table run through both
      `isValidPhoneNumber()` and the HTML pattern regex (46 tests total).
- [x] New `fair-form/src/API/__tests__/FairFormPhoneAnswers.api.spec.js`:
      submits every accept/reject case through `POST /fair-form/v1/fair-form-submit`
      against a live WordPress instance and confirms the stored answer is
      normalized (14/14 passing).
- [x] Added a phone accept-case to `fair-events`' existing
      `GetTicketsQuestionnaire.api.spec.js` to prove the rule travels through
      the other controller (this file's `beforeAll` also needed a `title`
      param that `EventDatesController` now requires — unrelated pre-existing
      drift, fixed alongside so the file runs at all).
- [x] New E2E spec (`unified-signup-phone-question.spec.js`) drives a real
      signup with `+49 170 123 45 67` through the browser — passing.
- [x] `npm run build` in fair-form / fair-audience / fair-events;
      `vendor/bin/phpcs` clean on changed PHP files; `makepot`/`updatepo`
      regenerated for fair-form and fair-audience (new/changed strings not
      yet machine-translated — left for a follow-up `translation:ai` run).
