### PR TITLE
Tighten plan/PR slash-command workflows

### DIFF
--- a/.claude/commands/make-pr.md
+++ b/.claude/commands/make-pr.md
@@ -20,8 +20,18 @@ Read the issue and its discussion with `gh issue view <number> --comments`.
 When the target is a comment, find that exact comment (match the
 `#issuecomment-<id>` anchor — `gh api repos/{owner}/{repo}/issues/comments/<id>`
 fetches it directly) and treat **its** content as the spec; use the rest of the
-thread only as context. If anything about the scope is ambiguous, ask me before
-writing code.
+thread only as context.
+
+For a whole-ticket target: if the issue has an approved implementation plan
+comment (from `/plan-ticket`), **the plan is the spec** and the ticket body is
+context. Follow its "Read first" list before touching code, and honour its
+**Decisions** section. If the plan predates significant changes to the files
+it names, flag the discrepancies before implementing rather than following it
+blindly.
+
+If you hit a decision the ticket and plan don't resolve — scope **or**
+design — stop and ask me; never pick silently. After we decide, append the
+decision to the plan comment so the ticket stays the record.
 
 ## 2. Branch
 
@@ -37,12 +47,13 @@ existing sibling pattern. Follow all Critical Rules in CLAUDE.md.
 
 Before committing:
 
-- Run `npm run format` in the affected plugin (catches files touched outside
-  the format hook).
-- Run `npm run build` in the affected plugin if you changed JS/CSS, so
-  generated assets land.
-- Run the relevant tests (`npm test`, `vendor/bin/phpcs`, etc.) and report
-  results honestly.
+- Run through the **Definition of Done** in CLAUDE.md — all six items (build,
+  format, phpcs, tests, i18n, screenshots for `responsive-ui` tickets) — and
+  report results honestly.
+- For user-visible changes, verify in the running site (docker compose,
+  `:8080`) before opening the PR — tests alone don't catch layout and
+  interaction breakage.
+- If the change is user-facing, add a changeset per RELEASES.md (`/release`).
 
 ## 4. Commit, push, open the PR
 
@@ -54,6 +65,12 @@ Follow [COMMIT_GUIDE.md](../../COMMIT_GUIDE.md):
 - Put `Closes #<number>` on its own line at the bottom of the commit body, and
   also in the PR **Summary** so the link shows in the UI. Use `Refs #<number>`
   instead if the comment is only part of the larger ticket.
+- Walk the ticket's **acceptance criteria** and state in the PR body how each
+  is met (or why it is deferred).
 
 Push the branch and open the PR with `gh pr create`. Write the PR body to a
 temp file and pass `--body-file` (then remove it). Report the PR URL when done.
+
+After opening the PR, suggest running `/code-review` — and `/security-review`
+when the ticket's Risks section flags security surface (endpoints, tokens,
+uploads).

--- a/.claude/commands/plan-ticket.md
+++ b/.claude/commands/plan-ticket.md
@@ -24,15 +24,21 @@ Propose an implementation plan for GitHub issue #$ARGUMENTS.
    the implementing session reads those before touching code instead of
    guessing which docs matter.
 
-4. **Surface open questions — only if still relevant.** Re-check the ticket's Open
-   Questions against the current code: some may already be resolved. List the ones
-   that genuinely remain, with a recommended option and why, plus the alternative.
-   Drop any that no longer apply.
+4. **Collect every open fork.** Re-check the ticket's Open Questions against
+   the current code — some may already be resolved; drop those. Then add any
+   **new** fork you discovered while grounding the plan in the codebase (these
+   are usually the majority). Every fork gets a recommended option with the
+   why, plus the alternative.
 
-5. **Check it with me.** Show the full plan in chat and pause. Do **not** post
-   until I approve. Incorporate my feedback and re-confirm if I change anything.
+5. **Check it with me — and resolve the questions.** Show the full plan in
+   chat and pause. During this review, ask me to decide each remaining open
+   question. Do **not** post until I approve. Incorporate my feedback and
+   re-confirm if I change anything.
 
-6. **Post as a comment.** Once approved, write the body to a temp file and post
-   with `gh issue comment $ARGUMENTS --body-file /tmp/plan-$ARGUMENTS.md`, then
+6. **Post as a comment — decisions, not questions.** The posted plan records
+   the outcomes of step 5 under a **Decisions** heading; a plan with
+   unresolved open questions is not ready to post. Once approved, write the
+   body to a temp file and post with
+   `gh issue comment $ARGUMENTS --body-file /tmp/plan-$ARGUMENTS.md`, then
    `rm -f /tmp/plan-$ARGUMENTS.md`. Use heredoc-clean markdown (headings,
    checkboxes). Follow the no-attribution rule — no Claude footer.

--- a/.claude/commands/write-ticket.md
+++ b/.claude/commands/write-ticket.md
@@ -20,7 +20,8 @@ Follow [TICKETS.md](../../TICKETS.md). The essentials:
    Motivation, Expected behaviour, Risks, Open questions (real forks with a
    recommendation), Acceptance criteria as a `- [ ]` behaviour-level checklist.
    Linking reference docs (REST_API_BACKEND.md, TESTING.md, …) is fine — they
-   are stable; code isn't.
+   are stable; code isn't. If the behaviour splits into independently
+   shippable stages, propose separate tickets instead of one big one.
 
 3. **Pick the milestone.** Tickets go into the current sprint or the next one.
    Milestones are named `YYYY.W<week>`; `date +%G.W%V` gives the current one.


### PR DESCRIPTION
## Summary

Tightens the `/make-pr`, `/plan-ticket`, and `/write-ticket` slash-command
workflows:

- **make-pr**: treat an approved `/plan-ticket` comment as the spec (not just
  context) for whole-ticket work; stop and ask when a scope/design decision
  isn't resolved instead of guessing, and record the decision back on the
  plan comment; run through the full Definition of Done (not just
  format/build/tests) before committing; verify user-visible changes on the
  running site; add a changeset for user-facing work; walk acceptance
  criteria in the PR body; suggest `/code-review` (and `/security-review`
  when relevant) after opening the PR.
- **plan-ticket**: collect every open fork discovered while grounding the
  plan in code, not just the ones already listed on the ticket; require the
  posted plan to record resolved **Decisions**, not leave open questions for
  the implementer to guess at.
- **write-ticket**: suggest splitting into separate tickets when a ticket's
  behaviour splits into independently shippable stages.

## Notes

Docs-only change (`.claude/commands/*.md`) — no plugin code, build, or tests
affected.

## Test plan

- [x] Reviewed the diff for each command file
