### PR TITLE
Fix mobile layout of the Participant Detail page

### DIFF
--- a/.changeset/fix-participant-detail-mobile.md
+++ b/.changeset/fix-participant-detail-mobile.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": patch
+---
+
+Fix the Participant Detail admin page on mobile: it now renders inside the standard `.wrap` gutter, the header and Profile card stack instead of overflowing the screen, and the Events/Form-submissions tables scroll inside their own card instead of dragging the whole page sideways.

--- a/fair-audience/src/Admin/participant-detail/ParticipantDetail.js
+++ b/fair-audience/src/Admin/participant-detail/ParticipantDetail.js
@@ -123,7 +123,10 @@ export default function ParticipantDetail() {
 
 	if (isLoading) {
 		return (
-			<div style={{ padding: '20px', textAlign: 'center' }}>
+			<div
+				className="wrap fair-audience-participant-detail"
+				style={{ textAlign: 'center' }}
+			>
 				<Spinner />
 			</div>
 		);
@@ -131,7 +134,7 @@ export default function ParticipantDetail() {
 
 	if (error) {
 		return (
-			<div style={{ maxWidth: '900px', margin: '20px 0' }}>
+			<div className="wrap fair-audience-participant-detail">
 				<Notice status="error" isDismissible={false}>
 					{error}
 				</Notice>
@@ -150,24 +153,17 @@ export default function ParticipantDetail() {
 	const submissions = activity?.submissions || [];
 
 	return (
-		<div style={{ maxWidth: '900px', margin: '20px 0' }}>
+		<div className="wrap fair-audience-participant-detail">
 			<p style={{ margin: '0 0 8px' }}>
 				<a href="admin.php?page=fair-audience-all-participants">
 					&larr; {__('All participants', 'fair-audience')}
 				</a>
 			</p>
-			<div
-				style={{
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'space-between',
-					gap: '16px',
-				}}
-			>
+			<div className="fair-audience-participant-detail__header">
 				<h1 style={{ margin: 0 }}>
 					{fullName || __('Participant', 'fair-audience')}
 				</h1>
-				<div style={{ display: 'flex', gap: '8px' }}>
+				<div className="fair-audience-participant-detail__actions">
 					<Button
 						variant="secondary"
 						onClick={() => setIsEditModalOpen(true)}
@@ -192,14 +188,12 @@ export default function ParticipantDetail() {
 				</CardHeader>
 				<CardBody>
 					<table
-						className="widefat striped"
+						className="widefat striped fair-audience-participant-detail__profile-table"
 						style={{ border: 'none' }}
 					>
 						<tbody>
 							<tr>
-								<th style={{ width: '200px' }}>
-									{__('Name', 'fair-audience')}
-								</th>
+								<th>{__('Name', 'fair-audience')}</th>
 								<td>{fullName || '—'}</td>
 							</tr>
 							<tr>
@@ -277,7 +271,7 @@ export default function ParticipantDetail() {
 						{__('Events', 'fair-audience')} ({events.length})
 					</h2>
 				</CardHeader>
-				<CardBody>
+				<CardBody className="fair-audience-participant-detail__table">
 					{events.length === 0 ? (
 						<p>{__('No events yet.', 'fair-audience')}</p>
 					) : (
@@ -388,7 +382,7 @@ export default function ParticipantDetail() {
 						{submissions.length})
 					</h2>
 				</CardHeader>
-				<CardBody>
+				<CardBody className="fair-audience-participant-detail__table">
 					{submissions.length === 0 ? (
 						<p>{__('No form submissions yet.', 'fair-audience')}</p>
 					) : (

--- a/fair-audience/src/Admin/participant-detail/__tests__/ParticipantDetail.test.jsx
+++ b/fair-audience/src/Admin/participant-detail/__tests__/ParticipantDetail.test.jsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Component test for the Participant Detail page (#1167): the mobile layout
+ * fix relies on the root carrying `wrap fair-audience-participant-detail`
+ * and the activity tables carrying `fair-audience-participant-detail__table`
+ * so the scoped stylesheet actually applies — pin that class contract, plus
+ * that the Profile rows and both activity tables render, so a future
+ * refactor can't silently break the selector the CSS depends on.
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import ParticipantDetail from '../ParticipantDetail.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const PARTICIPANT = {
+	id: 144,
+	name: 'Jane',
+	surname: 'Doe',
+	email: 'jane@example.com',
+	status: 'confirmed',
+	email_profile: 'marketing',
+	weekly_summary_opt_out: false,
+	phone: '',
+	instagram: '',
+	wp_user: null,
+	created_at: '2026-01-15 10:00:00',
+};
+
+const ACTIVITY = {
+	events: [
+		{
+			id: 1,
+			event_date_id: 5,
+			event_title: 'Spring Meetup',
+			start_datetime: '2026-03-01 18:00:00',
+			label: 'signed_up',
+			created_at: '2026-01-15 10:00:00',
+			transaction_id: 0,
+			transaction_status: null,
+		},
+	],
+	submissions: [
+		{
+			id: 9,
+			title: 'Signup form',
+			page_title: 'Signup',
+			event_title: 'Spring Meetup',
+			created_at: '2026-01-15 10:00:00',
+		},
+	],
+};
+
+beforeEach(() => {
+	window.history.pushState(
+		{},
+		'',
+		'/wp-admin/admin.php?page=fair-audience-participant-detail&participant_id=144'
+	);
+	apiFetch.mockImplementation(({ path }) => {
+		if (path.endsWith('/activity')) {
+			return Promise.resolve(ACTIVITY);
+		}
+		return Promise.resolve(PARTICIPANT);
+	});
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+	jest.clearAllMocks();
+});
+
+describe('ParticipantDetail', () => {
+	it('renders the root with the wrap and page classes, and both activity tables', async () => {
+		const { container } = render(<ParticipantDetail />);
+
+		await screen.findAllByText('Jane Doe');
+
+		const root = container.querySelector(
+			'.wrap.fair-audience-participant-detail'
+		);
+		expect(root).toBeInTheDocument();
+
+		const tables = container.querySelectorAll(
+			'.fair-audience-participant-detail__table'
+		);
+		expect(tables).toHaveLength(2);
+
+		expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+		expect(screen.getAllByText('Spring Meetup').length).toBeGreaterThan(0);
+		expect(screen.getByText('Signup form')).toBeInTheDocument();
+	});
+});

--- a/fair-audience/src/Admin/participant-detail/index.js
+++ b/fair-audience/src/Admin/participant-detail/index.js
@@ -1,5 +1,6 @@
 import { createRoot } from '@wordpress/element';
 import ParticipantDetail from './ParticipantDetail.js';
+import './style.css';
 
 const rootElement = document.getElementById(
 	'fair-audience-participant-detail-root'

--- a/fair-audience/src/Admin/participant-detail/style.css
+++ b/fair-audience/src/Admin/participant-detail/style.css
@@ -1,0 +1,87 @@
+/**
+ * Participant Detail admin page styles.
+ *
+ * The page used to render outside `.wrap`, with inline flex/width styles
+ * that a media query can't override without `!important`. The Events and
+ * Form-submissions tables scroll inside their own card instead of pushing
+ * the page sideways, and below the mobile breakpoint the header stacks and
+ * the Profile table becomes full-width label/value cards.
+ *
+ * The selectors deliberately stack `.wrap.fair-audience-participant-detail`
+ * and `.widefat` to outweigh WordPress core's responsive list-table rules
+ * (active below 782px).
+ */
+
+.wrap.fair-audience-participant-detail {
+	max-width: 900px;
+	margin: 20px 0;
+}
+
+.fair-audience-participant-detail__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: 16px;
+}
+
+.fair-audience-participant-detail__actions {
+	display: flex;
+	gap: 8px;
+}
+
+.fair-audience-participant-detail__profile-table th {
+	width: 200px;
+}
+
+.fair-audience-participant-detail__table {
+	overflow-x: auto;
+}
+
+@media screen and (max-width: 600px) {
+	.fair-audience-participant-detail__header {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.wrap.fair-audience-participant-detail
+		.widefat.fair-audience-participant-detail__profile-table {
+		display: block;
+		border: none;
+	}
+
+	.wrap.fair-audience-participant-detail
+		.widefat.fair-audience-participant-detail__profile-table
+		tbody,
+	.wrap.fair-audience-participant-detail
+		.widefat.fair-audience-participant-detail__profile-table
+		tr,
+	.wrap.fair-audience-participant-detail
+		.widefat.fair-audience-participant-detail__profile-table
+		th,
+	.wrap.fair-audience-participant-detail
+		.widefat.fair-audience-participant-detail__profile-table
+		td {
+		display: block;
+		width: auto !important;
+	}
+
+	.wrap.fair-audience-participant-detail
+		.widefat.fair-audience-participant-detail__profile-table
+		tr {
+		margin: 0 0 1em;
+		padding: 0.25em 0.75em;
+		border: 1px solid #c3c4c7;
+		border-radius: 4px;
+		background: #fff;
+	}
+
+	.wrap.fair-audience-participant-detail
+		.widefat.fair-audience-participant-detail__profile-table
+		th,
+	.wrap.fair-audience-participant-detail
+		.widefat.fair-audience-participant-detail__profile-table
+		td {
+		overflow-wrap: anywhere;
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes the mobile layout of the fair-audience Participant Detail admin
  page (`/wp-admin/admin.php?page=fair-audience-participant-detail&participant_id=…`),
  which rendered outside `.wrap` with inline `maxWidth`/flex/column-width
  styles that a media query couldn't override — pushing the header, back
  link and Profile card off-screen below 782px, the same class of bug
  already fixed on Submission Detail (#1166).
- Root and header/actions now use scoped class names instead of inline
  styles; a new `style.css` (imported from `index.js`, already picked up
  by `AdminHooks::enqueue_page_script()` — no PHP change needed) stacks
  the header and turns the Profile table into label/value cards below
  600px, while the Events and Form-submissions tables scroll inside their
  own card instead of dragging the whole page sideways.
- Adds a component test pinning the `.wrap.fair-audience-participant-detail`
  root class and the `.fair-audience-participant-detail__table` class on
  both activity `CardBody`s, so a future refactor can't silently break the
  selector contract the CSS depends on (as happened for #1166 in `7331b65b`).

Closes #1167

## Acceptance criteria (from the implementation plan)

- [x] Layer 1 — Markup: all three return branches carry `wrap fair-audience-participant-detail`; header/actions get `__header`/`__actions`; Profile table gets `__profile-table` with the inline `width: 200px` dropped; both activity tables wrapped in `CardBody className="fair-audience-participant-detail__table"`; transaction-status `<span>` colour left inline (data-driven).
- [x] Layer 2 — Styles: new plain `style.css` (no SCSS, matching the rest of fair-audience), imported from `index.js`. Desktop rules unchanged (`max-width: 900px`, header flex, `__profile-table th { width: 200px }`); `__table { overflow-x: auto }` always on; `max-width: 600px` media query stacks the header and turns the Profile table into full-width label/value cards, stacking `.wrap.fair-audience-participant-detail` + `.widefat` selectors to outweigh core's below-782px rules.
- [x] Layer 3 — Tests: new `ParticipantDetail.test.jsx` mocking the two `apiFetch` calls (`/participants/:id` and `/participants/:id/activity`), pinning the root and table classes, asserting Profile rows and both tables render.
- [x] Layer 4 — Verification: `npm run build` run in `fair-audience` (confirmed `style-index.css` is emitted and picked up); `npm run format`; `npm run test:js` (27/27 passing); no PHP changed so no phpcs run; screenshots captured at all three presets against the running docker instance (below), before-shots captured before the fix was applied.
- [x] Scope: left `all-participants` untouched — spot-checked it at 375px against the running instance and it already renders inside `.wrap` with `overflow-x: auto` on its table, so it isn't affected by this bug.

## Screenshots

Captured against the docker dev instance (`:8080`) with a seeded participant that has one event signup and one form submission, so the Events/Form-submissions tables have real (wide) content. PNGs are left in the repo working directory (not committed) for upload here — filenames below.

| Viewport | Before | After |
| --- | --- | --- |
| Desktop | `before-participant-detail-desktop.png` | `after-participant-detail-desktop.png` |
| Tablet  | `before-participant-detail-tablet.png`  | `after-participant-detail-tablet.png`  |
| Mobile  | `before-participant-detail-mobile.png`  | `after-participant-detail-mobile.png`  |

Desktop and tablet are visually unchanged. On mobile, the header now stacks under the title, the Profile table becomes full-width label/value cards, and the Events/Form-submissions tables scroll horizontally inside their own card instead of pushing the whole page sideways.

## Test plan

- [x] `npm run build` in `fair-audience`
- [x] `npm run format` in `fair-audience`
- [x] `npm run test:js` in `fair-audience` (27/27 pass)
- [x] Manually verified in the running docker instance at mobile/tablet/desktop
