### PR TITLE
Derive phone question placeholder from site timezone

### DIFF
--- a/.changeset/phone-placeholder-timezone.md
+++ b/.changeset/phone-placeholder-timezone.md
@@ -1,0 +1,5 @@
+---
+"fair-form": patch
+---
+
+Derive the phone question's placeholder example from the site's timezone instead of always showing a German example — a Madrid-configured site now shows a Spanish example, a Brussels one a Belgian example, and so on across eleven countries, falling back to the German example on unmapped timezones. An explicit placeholder set on the block still always wins.

--- a/e2e/user-flows/phone-question-placeholder.spec.js
+++ b/e2e/user-flows/phone-question-placeholder.spec.js
@@ -1,0 +1,57 @@
+/**
+ * E2E: the phone question's placeholder is derived from the site timezone
+ * (#1269) — a Spanish example on a `Europe/Madrid` site, the German fallback
+ * example on an unmapped timezone. Uses the same `unified-with-phone` seed
+ * flavour as unified-signup-phone-question.spec.js (#1267).
+ */
+
+import { test, expect } from '../support/fixtures.js';
+import { wpCli } from '../support/wp-cli.js';
+
+test.describe('phone question placeholder: derived from site timezone', () => {
+	let originalTimezone;
+
+	test.beforeAll(() => {
+		originalTimezone = wpCli('option get timezone_string', {
+			allowFailure: true,
+		}).trim();
+	});
+
+	test.afterAll(() => {
+		wpCli(`option update timezone_string "${originalTimezone}"`);
+	});
+
+	test('a Europe/Madrid site shows the Spanish example placeholder', async ({
+		page,
+		seedEvent,
+	}) => {
+		wpCli('option update timezone_string Europe/Madrid');
+
+		const event = seedEvent('free', { block: 'unified-with-phone' });
+		await page.goto(event.pageUrl);
+
+		const question = page.locator('[data-question-key="mobile"]');
+		await expect(question).toBeVisible();
+		await expect(question.locator('input[type="tel"]')).toHaveAttribute(
+			'placeholder',
+			'+34 612 34 56 78'
+		);
+	});
+
+	test('an unmapped timezone shows the fallback example placeholder', async ({
+		page,
+		seedEvent,
+	}) => {
+		wpCli('option update timezone_string Pacific/Auckland');
+
+		const event = seedEvent('free', { block: 'unified-with-phone' });
+		await page.goto(event.pageUrl);
+
+		const question = page.locator('[data-question-key="mobile"]');
+		await expect(question).toBeVisible();
+		await expect(question.locator('input[type="tel"]')).toHaveAttribute(
+			'placeholder',
+			'+49 170 1234567'
+		);
+	});
+});

--- a/fair-events-shared/src/__tests__/phone-placeholder.test.js
+++ b/fair-events-shared/src/__tests__/phone-placeholder.test.js
@@ -1,0 +1,91 @@
+import { getSettings, setSettings } from '@wordpress/date';
+import { isValidPhoneNumber } from '../questionnaire.js';
+import {
+	PHONE_PLACEHOLDER_BY_TIMEZONE,
+	FALLBACK_PHONE_PLACEHOLDER,
+	getPhonePlaceholderForTimezone,
+	getSitePhonePlaceholder,
+	resolvePhonePlaceholder,
+} from '../phone-placeholder.js';
+
+describe('getPhonePlaceholderForTimezone', () => {
+	it.each(Object.entries(PHONE_PLACEHOLDER_BY_TIMEZONE))(
+		'maps %s to its listed example',
+		(timezoneString, example) => {
+			expect(getPhonePlaceholderForTimezone(timezoneString)).toBe(
+				example
+			);
+		}
+	);
+
+	it('every shipped example passes isValidPhoneNumber', () => {
+		const examples = [
+			...new Set(Object.values(PHONE_PLACEHOLDER_BY_TIMEZONE)),
+			FALLBACK_PHONE_PLACEHOLDER,
+		];
+		examples.forEach((example) => {
+			expect(isValidPhoneNumber(example)).toBe(true);
+		});
+	});
+
+	it('falls back for an unmapped timezone', () => {
+		expect(getPhonePlaceholderForTimezone('Pacific/Auckland')).toBe(
+			FALLBACK_PHONE_PLACEHOLDER
+		);
+	});
+
+	it('falls back for an empty or undefined timezone', () => {
+		expect(getPhonePlaceholderForTimezone('')).toBe(
+			FALLBACK_PHONE_PLACEHOLDER
+		);
+		expect(getPhonePlaceholderForTimezone(undefined)).toBe(
+			FALLBACK_PHONE_PLACEHOLDER
+		);
+	});
+
+	it('falls back for a legacy raw UTC offset value', () => {
+		expect(getPhonePlaceholderForTimezone('UTC+2')).toBe(
+			FALLBACK_PHONE_PLACEHOLDER
+		);
+	});
+});
+
+describe('resolvePhonePlaceholder', () => {
+	it('prefers an explicit attribute value over the derived example', () => {
+		expect(resolvePhonePlaceholder('+1 555 0100', 'Europe/Madrid')).toBe(
+			'+1 555 0100'
+		);
+	});
+
+	it('falls through to the derived example for a whitespace-only value', () => {
+		expect(resolvePhonePlaceholder('   ', 'Europe/Madrid')).toBe(
+			'+34 612 34 56 78'
+		);
+	});
+
+	it('falls through to the derived example for an empty value', () => {
+		expect(resolvePhonePlaceholder('', 'Europe/Brussels')).toBe(
+			'+32 470 12 34 56'
+		);
+	});
+});
+
+describe('getSitePhonePlaceholder', () => {
+	it('reads the timezone from @wordpress/date settings', () => {
+		const settings = getSettings();
+
+		setSettings({
+			...settings,
+			timezone: {
+				...settings.timezone,
+				string: 'Europe/Madrid',
+			},
+		});
+
+		try {
+			expect(getSitePhonePlaceholder()).toBe('+34 612 34 56 78');
+		} finally {
+			setSettings(settings);
+		}
+	});
+});

--- a/fair-events-shared/src/index.js
+++ b/fair-events-shared/src/index.js
@@ -17,6 +17,7 @@ export { default as MiniCalendar } from './MiniCalendar.js';
 export { default as RecurrenceControl } from './RecurrenceControl.js';
 export * from './recurrence.js';
 export * from './questionnaire.js';
+export * from './phone-placeholder.js';
 export * from './form-utils.js';
 export * from './question-utils.js';
 export * from './payment-flow.js';

--- a/fair-events-shared/src/phone-placeholder.js
+++ b/fair-events-shared/src/phone-placeholder.js
@@ -1,0 +1,74 @@
+/**
+ * Timezone-derived example placeholder for the `fair-form-phone` question
+ * block. Mirrored by the PHP twin `QuestionnaireService::PHONE_PLACEHOLDERS`
+ * in fair-form — keep both maps in sync.
+ */
+
+import { getSettings } from '@wordpress/date';
+
+/**
+ * Example phone number per site timezone, one entry per country in the
+ * ticket's table.
+ *
+ * @type {Object<string, string>}
+ */
+export const PHONE_PLACEHOLDER_BY_TIMEZONE = {
+	'Europe/Madrid': '+34 612 34 56 78',
+	'Europe/Berlin': '+49 170 1234567',
+	'Europe/Paris': '+33 6 12 34 56 78',
+	'Europe/Rome': '+39 312 345 6789',
+	'Europe/Amsterdam': '+31 6 12345678',
+	'Europe/Brussels': '+32 470 12 34 56',
+	'Europe/Zurich': '+41 79 123 45 67',
+	'Europe/Warsaw': '+48 512 345 678',
+	'Europe/Lisbon': '+351 912 345 678',
+	'Europe/London': '+44 7700 900123',
+	'America/New_York': '+1 201 555 0123',
+	'America/Chicago': '+1 201 555 0123',
+	'America/Denver': '+1 201 555 0123',
+	'America/Los_Angeles': '+1 201 555 0123',
+};
+
+/**
+ * Fallback example for timezones outside the mapped set, and for sites
+ * configured with a raw UTC offset instead of a city.
+ *
+ * @type {string}
+ */
+export const FALLBACK_PHONE_PLACEHOLDER = '+49 170 1234567';
+
+/**
+ * Resolve the example placeholder for a given timezone string.
+ *
+ * @param {string|null|undefined} timezoneString A WP timezone string (e.g. "Europe/Madrid"), or a raw UTC offset / empty value.
+ * @return {string} The mapped example, or the fallback.
+ */
+export function getPhonePlaceholderForTimezone(timezoneString) {
+	return (
+		PHONE_PLACEHOLDER_BY_TIMEZONE[timezoneString] ||
+		FALLBACK_PHONE_PLACEHOLDER
+	);
+}
+
+/**
+ * Resolve the example placeholder for the current site, from
+ * `@wordpress/date`'s settings (populated from `get_option( 'timezone_string' )`).
+ *
+ * @return {string} The mapped example, or the fallback.
+ */
+export function getSitePhonePlaceholder() {
+	return getPhonePlaceholderForTimezone(getSettings().timezone.string);
+}
+
+/**
+ * Resolve the placeholder to display for a phone question: an explicit
+ * author override always wins over the timezone-derived example.
+ *
+ * @param {string}                 attributeValue The block's `placeholder` attribute value.
+ * @param {string|null|undefined}  timezoneString  A WP timezone string, passed through to {@link getPhonePlaceholderForTimezone}.
+ * @return {string} The placeholder to display.
+ */
+export function resolvePhonePlaceholder(attributeValue, timezoneString) {
+	const trimmed = (attributeValue || '').trim();
+	return trimmed || getPhonePlaceholderForTimezone(timezoneString);
+}

--- a/fair-form/package.json
+++ b/fair-form/package.json
@@ -40,6 +40,7 @@
 		"@wordpress/api-fetch": "^7.12.0",
 		"@wordpress/components": "^36.0.0",
 		"@wordpress/dataviews": "^17.0.0",
+		"@wordpress/date": "^5.2.0",
 		"@wordpress/element": "^8.0.0",
 		"@wordpress/i18n": "^6.21.0",
 		"fair-events-shared": "*"

--- a/fair-form/src/Services/QuestionnaireService.php
+++ b/fair-form/src/Services/QuestionnaireService.php
@@ -71,6 +71,59 @@ class QuestionnaireService {
 	const PHONE_NORMALIZED_PATTERN = '/^\+[1-9][0-9]{6,14}$/';
 
 	/**
+	 * Example phone number per site timezone for the phone question's
+	 * placeholder, one entry per country in ticket #1269's table. Mirrored
+	 * by the JS twin `PHONE_PLACEHOLDER_BY_TIMEZONE` in
+	 * `fair-events-shared/src/phone-placeholder.js` — keep both maps in sync.
+	 *
+	 * @var array
+	 */
+	const PHONE_PLACEHOLDERS = array(
+		'Europe/Madrid'       => '+34 612 34 56 78',
+		'Europe/Berlin'       => '+49 170 1234567',
+		'Europe/Paris'        => '+33 6 12 34 56 78',
+		'Europe/Rome'         => '+39 312 345 6789',
+		'Europe/Amsterdam'    => '+31 6 12345678',
+		'Europe/Brussels'     => '+32 470 12 34 56',
+		'Europe/Zurich'       => '+41 79 123 45 67',
+		'Europe/Warsaw'       => '+48 512 345 678',
+		'Europe/Lisbon'       => '+351 912 345 678',
+		'Europe/London'       => '+44 7700 900123',
+		'America/New_York'    => '+1 201 555 0123',
+		'America/Chicago'     => '+1 201 555 0123',
+		'America/Denver'      => '+1 201 555 0123',
+		'America/Los_Angeles' => '+1 201 555 0123',
+	);
+
+	/**
+	 * Fallback example for timezones outside the mapped set, and for sites
+	 * configured with a raw UTC offset instead of a city.
+	 *
+	 * @var string
+	 */
+	const PHONE_PLACEHOLDER_FALLBACK = '+49 170 1234567';
+
+	/**
+	 * Resolve the example placeholder for a given (or the site's) timezone.
+	 *
+	 * Deliberately reads the raw `timezone_string` option rather than
+	 * `wp_timezone_string()`, which returns a `+02:00`-style offset on sites
+	 * configured with a raw UTC offset instead of a city — the same raw
+	 * value `@wordpress/date`'s `getSettings().timezone.string` sees in JS,
+	 * which is what gives editor/frontend parity.
+	 *
+	 * @param string|null $timezone_string Timezone string, or null to read the site's.
+	 * @return string The mapped example, or the fallback.
+	 */
+	public static function phone_placeholder( $timezone_string = null ) {
+		if ( null === $timezone_string ) {
+			$timezone_string = get_option( 'timezone_string' );
+		}
+
+		return self::PHONE_PLACEHOLDERS[ $timezone_string ] ?? self::PHONE_PLACEHOLDER_FALLBACK;
+	}
+
+	/**
 	 * Questionnaire submission repository instance.
 	 *
 	 * @var QuestionnaireSubmissionRepository

--- a/fair-form/src/blocks/fair-form-phone/__tests__/phone-placeholder-parity.test.js
+++ b/fair-form/src/blocks/fair-form-phone/__tests__/phone-placeholder-parity.test.js
@@ -1,0 +1,57 @@
+/**
+ * Guards editor/frontend parity (#1269): the PHP and JS timezone → phone
+ * placeholder maps are hand-maintained twins (same pattern as
+ * PHONE_HTML_PATTERN) and must stay in sync.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+	PHONE_PLACEHOLDER_BY_TIMEZONE,
+	FALLBACK_PHONE_PLACEHOLDER,
+} from 'fair-events-shared';
+
+const servicePath = path.join(
+	__dirname,
+	'../../../Services/QuestionnaireService.php'
+);
+const serviceSource = fs.readFileSync(servicePath, 'utf8');
+
+function extractPhpMap(source) {
+	const match = source.match(
+		/const PHONE_PLACEHOLDERS = array\(([\s\S]*?)\);/
+	);
+	if (!match) {
+		throw new Error('PHONE_PLACEHOLDERS constant not found in PHP source');
+	}
+	const map = {};
+	const entryPattern = /'([^']+)'\s*=>\s*'([^']+)'/g;
+	let entryMatch;
+	while ((entryMatch = entryPattern.exec(match[1])) !== null) {
+		map[entryMatch[1]] = entryMatch[2];
+	}
+	return map;
+}
+
+function extractPhpFallback(source) {
+	const match = source.match(/const PHONE_PLACEHOLDER_FALLBACK = '([^']+)';/);
+	if (!match) {
+		throw new Error(
+			'PHONE_PLACEHOLDER_FALLBACK constant not found in PHP source'
+		);
+	}
+	return match[1];
+}
+
+describe('PHP/JS phone placeholder parity', () => {
+	it('the PHP PHONE_PLACEHOLDERS map matches the JS PHONE_PLACEHOLDER_BY_TIMEZONE map', () => {
+		expect(extractPhpMap(serviceSource)).toEqual(
+			PHONE_PLACEHOLDER_BY_TIMEZONE
+		);
+	});
+
+	it('the PHP and JS fallback examples match', () => {
+		expect(extractPhpFallback(serviceSource)).toBe(
+			FALLBACK_PHONE_PLACEHOLDER
+		);
+	});
+});

--- a/fair-form/src/blocks/fair-form-phone/block.json
+++ b/fair-form/src/blocks/fair-form-phone/block.json
@@ -28,7 +28,7 @@
 		},
 		"placeholder": {
 			"type": "string",
-			"default": "+49 170 1234567"
+			"default": ""
 		}
 	},
 	"editorScript": "file:./editor.js",

--- a/fair-form/src/blocks/fair-form-phone/editor.js
+++ b/fair-form/src/blocks/fair-form-phone/editor.js
@@ -4,7 +4,12 @@ import { registerBlockType, createBlock } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { autosizeTextarea, generateQuestionKey } from 'fair-events-shared';
+import { getSettings } from '@wordpress/date';
+import {
+	autosizeTextarea,
+	generateQuestionKey,
+	resolvePhonePlaceholder,
+} from 'fair-events-shared';
 
 registerBlockType('fair-audience/fair-form-phone', {
 	transforms: {
@@ -23,6 +28,8 @@ registerBlockType('fair-audience/fair-form-phone', {
 	},
 	edit: ({ attributes, setAttributes }) => {
 		const { questionText, questionKey, required, placeholder } = attributes;
+		const timezoneString = getSettings().timezone.string;
+		const derivedPlaceholder = resolvePhonePlaceholder('', timezoneString);
 
 		const onQuestionTextChange = (value) => {
 			const updates = { questionText: value };
@@ -67,8 +74,9 @@ registerBlockType('fair-audience/fair-form-phone', {
 							onChange={(value) =>
 								setAttributes({ placeholder: value })
 							}
+							placeholder={derivedPlaceholder}
 							help={__(
-								'Must include country code with leading "+" (e.g. +49170...).',
+								'Must include country code with leading "+" (e.g. +49 170 123 45 67). Leave empty to use the example for your site’s timezone.',
 								'fair-audience'
 							)}
 						/>
@@ -98,10 +106,10 @@ registerBlockType('fair-audience/fair-form-phone', {
 						<input
 							type="tel"
 							disabled
-							placeholder={
-								placeholder ||
-								__('+49 170 1234567', 'fair-audience')
-							}
+							placeholder={resolvePhonePlaceholder(
+								placeholder,
+								timezoneString
+							)}
 						/>
 					</p>
 				</div>

--- a/fair-form/src/blocks/fair-form-phone/render.php
+++ b/fair-form/src/blocks/fair-form-phone/render.php
@@ -19,7 +19,11 @@ use FairForm\Services\QuestionnaireService;
 $question_text = $attributes['questionText'] ?? '';
 $question_key  = $attributes['questionKey'] ?? '';
 $required      = ! empty( $attributes['required'] );
-$placeholder   = $attributes['placeholder'] ?? '';
+$placeholder   = trim( $attributes['placeholder'] ?? '' );
+
+if ( '' === $placeholder ) {
+	$placeholder = QuestionnaireService::phone_placeholder();
+}
 
 // Skip rendering if no question text is set.
 if ( empty( $question_text ) ) {
@@ -60,8 +64,6 @@ $format_hint = __( 'Include the country code, starting with "+" — spaces, dash
 		<?php if ( $required ) : ?>
 			required
 		<?php endif; ?>
-		<?php if ( ! empty( $placeholder ) ) : ?>
-			placeholder="<?php echo esc_attr( $placeholder ); ?>"
-		<?php endif; ?>
+		placeholder="<?php echo esc_attr( $placeholder ); ?>"
 	/>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -288,6 +288,7 @@
 				"@wordpress/api-fetch": "^7.12.0",
 				"@wordpress/components": "^36.0.0",
 				"@wordpress/dataviews": "^17.0.0",
+				"@wordpress/date": "^5.2.0",
 				"@wordpress/element": "^8.0.0",
 				"@wordpress/i18n": "^6.21.0",
 				"fair-events-shared": "*"


### PR DESCRIPTION
## Summary

- The phone question block's placeholder no longer always shows a German example. It now shows the example matching the country implied by the site's configured timezone (Spain for `Europe/Madrid`, Belgium for `Europe/Brussels`, etc. — eleven countries), falling back to the German example for unmapped timezones and raw UTC-offset sites.
- Resolved at render/edit time from a hand-maintained PHP (`QuestionnaireService::PHONE_PLACEHOLDERS`) / JS (`fair-events-shared`'s `phone-placeholder.js`) twin map — mirroring the existing `PHONE_HTML_PATTERN` twin pattern — so nothing is baked into saved content and the example updates immediately if the site timezone changes.
- An author-set placeholder always wins; the inspector's Placeholder field shows the derived example as its own greyed-out hint while empty, and clearing an override falls back to the derived example, not to nothing.

Closes #1269

## Acceptance criteria

- [x] A phone question on a site set to `Europe/Madrid` shows the Spanish example; `Europe/Brussels` shows the Belgian one; `Europe/Zurich` shows the Swiss one; `Europe/Berlin` shows the German one — covered by the JS unit test's per-timezone table (`fair-events-shared/src/__tests__/phone-placeholder.test.js`) and the e2e Madrid case.
- [x] All eleven countries in the table have a mapped example with the correct country code and grouping — same unit test, one case per timezone key.
- [x] A site on an unmapped timezone, or on a raw UTC offset, shows the fallback example and produces no error or notice — covered by unit tests (`''`, `undefined`, `'UTC+2'`, `'Pacific/Auckland'`) and the e2e fallback case.
- [x] An author-set placeholder is preserved across timezone changes and editor reloads — it's a normal serialized block attribute; `resolvePhonePlaceholder` only derives when the attribute is empty.
- [x] Clearing an author-set placeholder falls back to the timezone-derived example rather than to an empty field — `resolvePhonePlaceholder`'s trim-and-fallback logic, unit-tested for whitespace-only and empty values.
- [x] Editor preview and published form show the same example for the same site — both resolve from the same `get_option( 'timezone_string' )` value: PHP directly, JS via `@wordpress/date`'s `getSettings().timezone.string` (populated from the same option). Guarded against drift by `phone-placeholder-parity.test.js`, which asserts the PHP and JS maps are identical.
- [x] Submitting a form with the phone field left empty stores no value — unchanged; empty answers were already skipped server-side, covered by the existing `FairFormPhoneAnswers.api.spec.js`. No `value=` attribute was added to the input.
- [x] Every shipped example is accepted by the field's own validation — unit-tested against `isValidPhoneNumber()` for every mapped example plus the fallback.
- [x] Component tests cover the timezone → example mapping, the unmapped fallback, and the author-override precedence — `fair-events-shared/src/__tests__/phone-placeholder.test.js`.
- [x] An e2e check confirms the published form renders the expected example for the configured site timezone — `e2e/user-flows/phone-question-placeholder.spec.js` (Madrid case + fallback case), run against a live wp-env instance.

## Notes

- Existing content: `block.json`'s `placeholder` default changed from the German example to `""`. This is a dynamic block (`save: () => null`) so no deprecation is needed. A block whose attribute equals the default is not serialized, so a phone question an author never touched — or one where an author had typed the exact German example — resolves to the derived example after this change, same as the ticket's open-question discussion accepted.
- No translation-catalog regeneration commit was needed: this repo doesn't check in `.pot`/`.po` files (they're built at release time / resolved from WordPress.org language packs per `I18N_SETUP.md`), so removing the translatable German-example fallback string in `editor.js` has nothing to regenerate here.
- Live editor visual verification (inspector hint, preview input) wasn't possible in this session — the chrome-devtools MCP browser profile was held by another session. Coverage instead comes from a real Playwright browser run against the live wp-env instance for the frontend-rendered case, plus unit tests for the exact precedence/resolution logic that drives the editor.

## Test plan

- [x] `fair-events-shared`: `npx jest` — 15 suites / 200 tests pass.
- [x] `fair-form`: `npm run test:js` — 4 suites / 9 tests pass, including the new parity test.
- [x] `vendor/bin/phpcs` clean on the two changed PHP files.
- [x] `npm run build` in `fair-form` — no new warnings.
- [x] `npm run format` (root) — no formatting diffs beyond the new/changed files.
- [x] e2e: `npx playwright test e2e/user-flows/phone-question-placeholder.spec.js e2e/user-flows/unified-signup-phone-question.spec.js` — 3/3 pass against a live wp-env instance (Madrid example, fallback example, and the pre-existing #1267 spaced-phone-number regression check).
