### PR TITLE
Drop leftover inline styles on Participant Detail page

### DIFF
--- a/.changeset/fix-participant-detail-mobile.md
+++ b/.changeset/fix-participant-detail-mobile.md
@@ -2,4 +2,4 @@
 "fair-audience": patch
 ---
 
-Fix the Participant Detail admin page on mobile: it now renders inside the standard `.wrap` gutter, the header and Profile card stack instead of overflowing the screen, and the Events/Form-submissions tables scroll inside their own card instead of dragging the whole page sideways.
+Fix the Participant Detail admin page on mobile: it now renders with an even `.wrap` gutter on both sides, the header and Profile card stack instead of overflowing the screen, and the Events/Form-submissions tables scroll inside their own card instead of dragging the whole page sideways.

--- a/fair-audience/src/Admin/participant-detail/ParticipantDetail.js
+++ b/fair-audience/src/Admin/participant-detail/ParticipantDetail.js
@@ -123,10 +123,7 @@ export default function ParticipantDetail() {
 
 	if (isLoading) {
 		return (
-			<div
-				className="wrap fair-audience-participant-detail"
-				style={{ textAlign: 'center' }}
-			>
+			<div className="wrap fair-audience-participant-detail fair-audience-participant-detail--loading">
 				<Spinner />
 			</div>
 		);
@@ -154,15 +151,13 @@ export default function ParticipantDetail() {
 
 	return (
 		<div className="wrap fair-audience-participant-detail">
-			<p style={{ margin: '0 0 8px' }}>
+			<p className="fair-audience-participant-detail__back">
 				<a href="admin.php?page=fair-audience-all-participants">
 					&larr; {__('All participants', 'fair-audience')}
 				</a>
 			</p>
 			<div className="fair-audience-participant-detail__header">
-				<h1 style={{ margin: 0 }}>
-					{fullName || __('Participant', 'fair-audience')}
-				</h1>
+				<h1>{fullName || __('Participant', 'fair-audience')}</h1>
 				<div className="fair-audience-participant-detail__actions">
 					<Button
 						variant="secondary"
@@ -180,17 +175,12 @@ export default function ParticipantDetail() {
 				</div>
 			</div>
 
-			<Card style={{ marginTop: '16px', marginBottom: '16px' }}>
+			<Card className="fair-audience-participant-detail__card">
 				<CardHeader>
-					<h2 style={{ margin: 0 }}>
-						{__('Profile', 'fair-audience')}
-					</h2>
+					<h2>{__('Profile', 'fair-audience')}</h2>
 				</CardHeader>
 				<CardBody>
-					<table
-						className="widefat striped fair-audience-participant-detail__profile-table"
-						style={{ border: 'none' }}
-					>
+					<table className="widefat striped fair-audience-participant-detail__profile-table">
 						<tbody>
 							<tr>
 								<th>{__('Name', 'fair-audience')}</th>
@@ -265,9 +255,9 @@ export default function ParticipantDetail() {
 				</CardBody>
 			</Card>
 
-			<Card style={{ marginBottom: '16px' }}>
+			<Card className="fair-audience-participant-detail__card">
 				<CardHeader>
-					<h2 style={{ margin: 0 }}>
+					<h2>
 						{__('Events', 'fair-audience')} ({events.length})
 					</h2>
 				</CardHeader>
@@ -375,9 +365,9 @@ export default function ParticipantDetail() {
 				</CardBody>
 			</Card>
 
-			<Card>
+			<Card className="fair-audience-participant-detail__card">
 				<CardHeader>
-					<h2 style={{ margin: 0 }}>
+					<h2>
 						{__('Form submissions', 'fair-audience')} (
 						{submissions.length})
 					</h2>

--- a/fair-audience/src/Admin/participant-detail/__tests__/ParticipantDetail.test.jsx
+++ b/fair-audience/src/Admin/participant-detail/__tests__/ParticipantDetail.test.jsx
@@ -88,6 +88,15 @@ describe('ParticipantDetail', () => {
 		);
 		expect(tables).toHaveLength(2);
 
+		const cards = container.querySelectorAll(
+			'.fair-audience-participant-detail__card'
+		);
+		expect(cards).toHaveLength(3);
+
+		expect(
+			container.querySelector('.fair-audience-participant-detail__back')
+		).toBeInTheDocument();
+
 		expect(screen.getByText('jane@example.com')).toBeInTheDocument();
 		expect(screen.getAllByText('Spring Meetup').length).toBeGreaterThan(0);
 		expect(screen.getByText('Signup form')).toBeInTheDocument();

--- a/fair-audience/src/Admin/participant-detail/style.css
+++ b/fair-audience/src/Admin/participant-detail/style.css
@@ -14,7 +14,20 @@
 
 .wrap.fair-audience-participant-detail {
 	max-width: 900px;
-	margin: 20px 0;
+	margin: 20px 20px 0 0;
+}
+
+.fair-audience-participant-detail--loading {
+	text-align: center;
+}
+
+.fair-audience-participant-detail__back {
+	margin: 0 0 8px;
+}
+
+.wrap.fair-audience-participant-detail h1,
+.wrap.fair-audience-participant-detail h2 {
+	margin: 0;
 }
 
 .fair-audience-participant-detail__header {
@@ -28,6 +41,14 @@
 .fair-audience-participant-detail__actions {
 	display: flex;
 	gap: 8px;
+}
+
+.fair-audience-participant-detail__card {
+	margin-top: 16px;
+}
+
+.fair-audience-participant-detail__profile-table {
+	border: none;
 }
 
 .fair-audience-participant-detail__profile-table th {
@@ -47,7 +68,6 @@
 	.wrap.fair-audience-participant-detail
 		.widefat.fair-audience-participant-detail__profile-table {
 		display: block;
-		border: none;
 	}
 
 	.wrap.fair-audience-participant-detail
@@ -63,7 +83,7 @@
 		.widefat.fair-audience-participant-detail__profile-table
 		td {
 		display: block;
-		width: auto !important;
+		width: auto;
 	}
 
 	.wrap.fair-audience-participant-detail


### PR DESCRIPTION
## Summary

Follow-up to #1167 (930991b0): that fix framed itself as "class names instead of inline styles" but eight inline styles survived, plus a redundant `!important` and an uneven mobile side gutter. This PR finishes the cleanup:

- Moves the remaining layout inline styles (loading state, back-link margin, `h1`/`h2` margins, card spacing, profile-table border) into the scoped `style.css`, backed by new/existing classes (`--loading`, `__back`, `__card`).
- Drops the redundant `width: auto !important` in the mobile Profile-table override — the mobile selector already outweighs the page's own `width: 200px` rule on specificity, and core's `!important` rule only targets `.wp-list-table`, which the Profile table isn't.
- Fixes the `.wrap` margin (`20px 0` → `20px 20px 0 0`) so cards get an even gutter on both sides below the mobile breakpoint, instead of running flush to the right edge.
- Rewords the still-unreleased changeset to match (it claimed the standard `.wrap` gutter before this fix landed).
- Extends the existing component test to pin the new `__card` (×3) and `__back` classes, so a future refactor can't silently break the selectors the stylesheet depends on.

The transaction-status `<span>` stays inline — its color is data-driven, not layout.

Refs #1167 (ticket is closed; work was scoped via a follow-up plan comment on it)

## Acceptance criteria (from the follow-up plan)

- [x] Layer 1 — all eight inline layout styles replaced with classes; transaction-status span left inline (data-driven).
- [x] Layer 2 — `style.css` updated: new rules for `--loading`, `__back`, `__card`, `border: none` folded into `__profile-table`; `!important` removed; `.wrap` margin fixed; header comment updated.
- [x] Layer 3 — changeset reworded.
- [x] Layer 4 — test extended to cover `__card` ×3 and `__back`.
- [x] Layer 5 — `npm run build` and `npm run format` run in `fair-audience`; `npm run test:js` (scoped) passes; no PHP changed; verified at 375px/768px/1280px against the running docker instance — even gutter on both sides, desktop spacing unchanged from the previous PR's after-shot.

## Test plan

- [x] `npx jest src/Admin/participant-detail` passes (extended assertions included)
- [x] `npm run build` in `fair-audience`
- [x] `npm run format` — no diffs outside changed files
- [x] Verified in running docker instance (`:8080`) at mobile/tablet/desktop viewports with a temporary test participant
