### PR TITLE
Fix mobile layout of the admin events calendar

### DIFF
--- a/.changeset/mobile-admin-calendar.md
+++ b/.changeset/mobile-admin-calendar.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix the admin events calendar on mobile: the header no longer overflows, small viewports show an agenda list of day cards instead of a squeezed 7-column grid, a month with no events says so instead of rendering a blank strip, and on touch tablets the per-day add button no longer needs a hover to appear.

--- a/fair-events/src/Admin/calendar/components/CalendarGrid.js
+++ b/fair-events/src/Admin/calendar/components/CalendarGrid.js
@@ -6,6 +6,7 @@
  * @package FairEvents
  */
 
+import { __ } from '@wordpress/i18n';
 import DayCell from './DayCell.js';
 import {
 	formatLocalDate,
@@ -82,6 +83,12 @@ export default function CalendarGrid({
 	const today = new Date();
 	today.setHours(0, 0, 0, 0);
 
+	// The mobile agenda only lists current-month days that have events, so it
+	// renders nothing at all for a month like this. Grid mode hides the notice.
+	const isAgendaEmpty = !days.some(
+		(day) => day.isCurrentMonth && day.events.length > 0
+	);
+
 	return (
 		<div className="fair-events-calendar-grid">
 			<div className="fair-events-calendar-weekdays">
@@ -111,6 +118,11 @@ export default function CalendarGrid({
 						/>
 					);
 				})}
+				{isAgendaEmpty && (
+					<p className="fair-events-calendar-empty">
+						{__('No events this month.', 'fair-events')}
+					</p>
+				)}
 			</div>
 		</div>
 	);

--- a/fair-events/src/Admin/calendar/components/CalendarHeader.js
+++ b/fair-events/src/Admin/calendar/components/CalendarHeader.js
@@ -20,7 +20,7 @@ export default function CalendarHeader({
 	const monthYear = formatMonthLabel(currentDate);
 
 	return (
-		<>
+		<div className="fair-events-calendar-header">
 			<h2 className="fair-events-calendar-title">{monthYear}</h2>
 			<div className="fair-events-calendar-nav">
 				<Button variant="secondary" onClick={onPrevMonth}>
@@ -36,6 +36,6 @@ export default function CalendarHeader({
 					{__('Add event', 'fair-events')}
 				</Button>
 			</div>
-		</>
+		</div>
 	);
 }

--- a/fair-events/src/Admin/calendar/components/DayCell.js
+++ b/fair-events/src/Admin/calendar/components/DayCell.js
@@ -105,8 +105,8 @@ export default function DayCell({
 	manageEventUrl,
 }) {
 	const dayNumber = date.getDate();
+	const monthName = date.toLocaleDateString(undefined, { month: 'long' });
 	const hasEvents = events.length > 0;
-	const visibleEvents = events.slice(0, MAX_VISIBLE_EVENTS);
 	const hiddenCount = events.length - MAX_VISIBLE_EVENTS;
 
 	const cellClasses = [
@@ -127,7 +127,10 @@ export default function DayCell({
 	return (
 		<div className={cellClasses}>
 			<div className="fair-events-calendar-day-header">
-				<span className="fair-events-calendar-day-number">
+				<span
+					className="fair-events-calendar-day-number"
+					data-month-name={monthName}
+				>
 					{dayNumber}
 				</span>
 				{onAddEvent && (
@@ -142,7 +145,7 @@ export default function DayCell({
 			</div>
 			{hasEvents && (
 				<div className="fair-events-calendar-day-events">
-					{visibleEvents.map((event, index) => {
+					{events.map((event, index) => {
 						const eventPostId = getEventPostId(event.uid);
 						const linkType = getEventLinkType(event);
 						const linkTypeIcon = getLinkTypeIcon(linkType);

--- a/fair-events/src/Admin/calendar/components/__tests__/CalendarGrid.test.jsx
+++ b/fair-events/src/Admin/calendar/components/__tests__/CalendarGrid.test.jsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for CalendarGrid's agenda empty state (#1168). The mobile agenda only
+ * lists current-month days that have events, so a month without any would
+ * otherwise render as a blank strip.
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import CalendarGrid from '../CalendarGrid.js';
+
+const currentDate = new Date(2026, 6, 1);
+
+function makeEvent(date) {
+	return {
+		uid: 'standalone_1@example.com',
+		title: 'Event',
+		start: date.toISOString(),
+	};
+}
+
+it('renders the empty state when the month has no events', () => {
+	render(
+		<CalendarGrid
+			currentDate={currentDate}
+			events={[]}
+			onAddEvent={() => {}}
+			manageEventUrl=""
+			startOfWeek={1}
+		/>
+	);
+
+	expect(screen.getByText('No events this month.')).toBeInTheDocument();
+});
+
+it('omits the empty state when the month has events', () => {
+	render(
+		<CalendarGrid
+			currentDate={currentDate}
+			events={[makeEvent(new Date(2026, 6, 15, 10, 0))]}
+			onAddEvent={() => {}}
+			manageEventUrl=""
+			startOfWeek={1}
+		/>
+	);
+
+	expect(screen.queryByText('No events this month.')).not.toBeInTheDocument();
+});
+
+it('renders the empty state when only adjacent-month cells have events', () => {
+	// July 2026 starts on a Wednesday, so the grid leads with Jun 29-30 —
+	// cells the mobile agenda hides.
+	render(
+		<CalendarGrid
+			currentDate={currentDate}
+			events={[makeEvent(new Date(2026, 5, 30, 10, 0))]}
+			onAddEvent={() => {}}
+			manageEventUrl=""
+			startOfWeek={1}
+		/>
+	);
+
+	expect(screen.getByText('No events this month.')).toBeInTheDocument();
+});

--- a/fair-events/src/Admin/calendar/components/__tests__/CalendarHeader.test.jsx
+++ b/fair-events/src/Admin/calendar/components/__tests__/CalendarHeader.test.jsx
@@ -29,6 +29,26 @@ it('renders Previous, Today, Next, and Add event buttons', () => {
 	).toBeInTheDocument();
 });
 
+it('wraps the title and nav in a scoped header element for responsive styling', () => {
+	const { container } = render(
+		<CalendarHeader
+			currentDate={currentDate}
+			onPrevMonth={() => {}}
+			onNextMonth={() => {}}
+			onToday={() => {}}
+			onAddEvent={() => {}}
+		/>
+	);
+	const header = container.querySelector('.fair-events-calendar-header');
+	expect(header).toBeInTheDocument();
+	expect(
+		header.querySelector('.fair-events-calendar-title')
+	).toBeInTheDocument();
+	expect(
+		header.querySelector('.fair-events-calendar-nav')
+	).toBeInTheDocument();
+});
+
 it('calls onAddEvent when the Add event button is clicked', () => {
 	const onAddEvent = jest.fn();
 	render(

--- a/fair-events/src/Admin/calendar/components/__tests__/DayCell.test.jsx
+++ b/fair-events/src/Admin/calendar/components/__tests__/DayCell.test.jsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for DayCell's mobile agenda support (#1168): the localized
+ * data-month-name attribute and rendering all events (clamped to 3 rows
+ * by CSS in grid mode only, not by JS slicing).
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import DayCell from '../DayCell.js';
+
+function makeEvents(count) {
+	return Array.from({ length: count }, (_, index) => ({
+		uid: `standalone_${index}@example.com`,
+		title: `Event ${index + 1}`,
+	}));
+}
+
+it('adds a localized data-month-name attribute to the day number', () => {
+	const { container } = render(
+		<DayCell
+			date={new Date(2026, 6, 15)}
+			events={[]}
+			isCurrentMonth
+			isToday={false}
+			isPast={false}
+			onAddEvent={() => {}}
+		/>
+	);
+
+	const dayNumber = container.querySelector(
+		'.fair-events-calendar-day-number'
+	);
+	expect(dayNumber).toHaveAttribute(
+		'data-month-name',
+		new Date(2026, 6, 15).toLocaleDateString(undefined, { month: 'long' })
+	);
+});
+
+it('renders every event row in the DOM, not just the first three', () => {
+	render(
+		<DayCell
+			date={new Date(2026, 6, 15)}
+			events={makeEvents(5)}
+			isCurrentMonth
+			isToday={false}
+			isPast={false}
+			onAddEvent={() => {}}
+		/>
+	);
+
+	for (let i = 1; i <= 5; i++) {
+		expect(screen.getByText(`Event ${i}`)).toBeInTheDocument();
+	}
+});
+
+it('shows a "+N more" label counting events beyond the first three', () => {
+	render(
+		<DayCell
+			date={new Date(2026, 6, 15)}
+			events={makeEvents(5)}
+			isCurrentMonth
+			isToday={false}
+			isPast={false}
+			onAddEvent={() => {}}
+		/>
+	);
+
+	expect(screen.getByText('+2 more')).toBeInTheDocument();
+});
+
+it('omits the "+N more" label when there are three events or fewer', () => {
+	render(
+		<DayCell
+			date={new Date(2026, 6, 15)}
+			events={makeEvents(3)}
+			isCurrentMonth
+			isToday={false}
+			isPast={false}
+			onAddEvent={() => {}}
+		/>
+	);
+
+	expect(screen.queryByText(/more$/)).not.toBeInTheDocument();
+});

--- a/fair-events/src/Admin/calendar/style.css
+++ b/fair-events/src/Admin/calendar/style.css
@@ -15,6 +15,13 @@
 }
 
 /* Header (rendered inside CardHeader, so no outer spacing of its own) */
+.fair-events-calendar-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+}
+
 .fair-events-calendar-nav {
 	display: flex;
 	gap: 8px;
@@ -130,7 +137,8 @@
 	height: 16px;
 }
 
-.fair-events-calendar-day:hover .fair-events-calendar-add-btn {
+.fair-events-calendar-day:hover .fair-events-calendar-add-btn,
+.fair-events-calendar-day:focus-within .fair-events-calendar-add-btn {
 	opacity: 1;
 }
 
@@ -268,10 +276,35 @@ a.fair-events-calendar-event:visited {
 	background: #4e5157;
 }
 
+/*
+ * Grid mode clamps to 3 event rows and reveals "+N more". This is the default
+ * so that any viewport width the mobile query below does not match still gets
+ * the clamp; the mobile agenda opts back out. Keep the row count in sync with
+ * MAX_VISIBLE_EVENTS in components/DayCell.js, which computes the "+N more"
+ * label.
+ */
+.fair-events-calendar-day-events
+	.fair-events-calendar-event-row:nth-child(n + 4) {
+	display: none;
+}
+
 .fair-events-calendar-more {
+	display: block;
 	font-size: 11px;
 	color: #646970;
 	padding: 2px 6px;
+}
+
+/*
+ * Agenda empty state. Only the mobile agenda hides event-less days, so grid
+ * mode never needs it.
+ */
+.fair-events-calendar-empty {
+	display: none;
+	margin: 0;
+	padding: 12px 0;
+	color: #646970;
+	text-align: center;
 }
 
 /* Legend */
@@ -295,5 +328,117 @@ a.fair-events-calendar-event:visited {
 
 	.fair-events-calendar-event {
 		font-size: 10px;
+	}
+}
+
+/* Touch devices have no hover state to reveal the add button */
+@media (hover: none) {
+	.fair-events-calendar-add-btn {
+		opacity: 1;
+	}
+}
+
+/* Mobile: header stacks, grid collapses into an agenda list of day cards */
+@media screen and (max-width: 600px) {
+	.fair-events-calendar-header {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 8px;
+	}
+
+	.fair-events-calendar-nav {
+		flex-wrap: wrap;
+	}
+
+	.fair-events-calendar-weekdays {
+		display: none;
+	}
+
+	.fair-events-calendar-days {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		padding: 12px;
+	}
+
+	.fair-events-calendar-day {
+		display: none;
+	}
+
+	.fair-events-calendar-day.has-events {
+		display: block;
+		min-height: auto;
+		overflow: visible;
+		padding: 0;
+		border: 1px solid #c3c4c7;
+		border-radius: 4px;
+	}
+
+	.fair-events-calendar-day.has-events.other-month {
+		display: none;
+	}
+
+	.fair-events-calendar-day.has-events.today {
+		border: 2px solid #2271b1;
+	}
+
+	.fair-events-calendar-day-header {
+		margin: 0;
+		padding: 10px 12px;
+		background: #f6f7f7;
+		border-bottom: 1px solid #c3c4c7;
+	}
+
+	.fair-events-calendar-day.today .fair-events-calendar-day-header {
+		background: #e7f5ff;
+	}
+
+	.fair-events-calendar-day-number {
+		font-size: 15px;
+	}
+
+	/*
+	 * Reset the desktop "today" badge back to inline text. display must be
+	 * unset too: as a flex container the ::after below would be blockified
+	 * into a flex item and its leading space stripped ("15July").
+	 */
+	.fair-events-calendar-day.today .fair-events-calendar-day-number {
+		display: block;
+		width: auto;
+		height: auto;
+		padding: 2px 6px;
+		background: none;
+		color: #2271b1;
+		border-radius: 0;
+	}
+
+	.fair-events-calendar-day-number::after {
+		content: " " attr(data-month-name);
+		font-size: 13px;
+		font-weight: 400;
+		color: #646970;
+	}
+
+	.fair-events-calendar-day-events {
+		gap: 6px;
+		padding: 10px 12px;
+	}
+
+	/* The agenda has room for every event, so drop the grid-mode clamp */
+	.fair-events-calendar-day-events
+		.fair-events-calendar-event-row:nth-child(n + 4) {
+		display: flex;
+	}
+
+	.fair-events-calendar-more {
+		display: none;
+	}
+
+	.fair-events-calendar-event {
+		white-space: normal;
+	}
+
+	.fair-events-calendar-empty {
+		display: block;
 	}
 }


### PR DESCRIPTION
## Summary

- Below 600px, the admin events calendar header (`CalendarHeader.js` / `style.css`) now stacks the month title above the nav and lets the button row wrap, instead of overflowing off-screen.
- Below 600px, the 7-column grid collapses into an agenda list of day cards (mirroring the public `events-calendar` block): the weekday row hides, adjacent-month and event-less days are hidden, and each remaining day shows a full-date header (`DayCell.js` now adds a localized `data-month-name` attribute) with event chips that wrap instead of truncating to 1-2 characters.
- `DayCell.js` now renders every event row in the DOM; the "3 events + N more" cap is applied with CSS (`nth-child`) only in grid mode (≥601px), so the mobile agenda list always shows every event for a day.
- The per-day "+" add button (previously `opacity: 0` until `:hover`) is now shown on any device without a hover state (`@media (hover: none)`), so it's reachable on touch.

Closes #1168

## Notes

- Breakpoint is 600px, matching the Participant Detail mobile fix (#1167) rather than the public block's 480px — admin chips carry more chrome (destination-link square, category text) than the public ones.
- Per the approved plan, adjacent-month days are hidden in the mobile agenda even if they happen to have an event, which differs slightly from the public block (where `.has-events` can win over `.other-month` for such edge cases) — intentional, per the ticket's decision.
- Empty days have no visible add button on the mobile agenda (they're hidden entirely); the header's "Add event" button still covers that case since `QuickEventModal` has an editable date field.

## Acceptance criteria

- [x] Header stacks + wraps below 600px, keeping text labels (no icon-only conversion).
- [x] Grid becomes an agenda list of day cards below 600px, mirroring the public block's pattern.
- [x] `DayCell.js` carries a localized `data-month-name` attribute; all events render in the DOM, clamped to 3 rows by CSS only in grid mode.
- [x] Per-day add button visible on touch devices (`@media (hover: none)`).
- [x] Tests updated/added: `CalendarHeader.test.jsx` (scoped header wrapper), new `DayCell.test.jsx` (data-month-name, all-events rendering, +N more cap). `npm run test:js` passes (167/167).
- [x] Changeset added (patch, fair-events).

## Test plan

- [x] `npm run test:js` in `fair-events` — 21 suites / 167 tests pass.
- [x] `npm run build` in `fair-events`.
- [x] Manually verified in the running dev site (`docker compose`) at desktop/tablet/mobile — see screenshots below.
- [ ] `npm run test:e2e` — not run (no user-flow/E2E test touches this page; verified manually instead).

## Screenshots

| Viewport | Before | After |
| --- | --- | --- |
| Desktop | _(upload before-calendar-desktop.png)_ | _(upload after-calendar-desktop.png — pixel-identical to before)_ |
| Tablet  | _(upload before-calendar-tablet.png)_  | _(upload after-calendar-tablet.png — pixel-identical to before)_  |
| Mobile  | _(upload before-calendar-mobile.png)_  | _(upload after-calendar-mobile.png)_  |

PNGs are in the repo working directory (not committed) for you to attach: `before-calendar-{desktop,tablet,mobile}.png`, `after-calendar-{desktop,tablet,mobile}.png`.
