### PR TITLE
Add return-from-payment states and retry to Event Signup form

### DIFF
--- a/.changeset/get-tickets-return-and-retry.md
+++ b/.changeset/get-tickets-return-and-retry.md
@@ -1,0 +1,6 @@
+---
+"fair-events": minor
+"fair-events-shared": minor
+---
+
+The unified Event Signup form (used when fair-audience is inactive) now shows a rich outcome when a visitor returns from paying: a confirmed card (event, amount, "confirmation email on its way"), a processing card that polls and updates in place, or a resume/retry card for a failed, canceled, expired, or abandoned payment — with buttons to continue the existing checkout, retry with a new one, or cancel and start over. A visitor who navigates directly back to the event page (no return link followed) now also sees their in-progress payment, recognised via a short-lived signed cookie, within the 15-minute hold window. Payment status is reconciled with the payment provider on return so the page never misreports a payment mid-redirect. When online payments are unavailable, ticket sales still show the existing "temporarily unavailable" notice instead of a dead retry button.

--- a/e2e/mu-plugins/lib/mollie-http-double.php
+++ b/e2e/mu-plugins/lib/mollie-http-double.php
@@ -14,10 +14,13 @@
  *   - POST /v2/payments        -> a payment in status "open" whose checkout link
  *                                 points straight back at the redirectUrl, so the
  *                                 buyer lands on the signup callback page.
- *   - GET  /v2/payments/{id}   -> the same payment in status "paid", so the
- *                                 callback page's sync pulls "paid" and the real
- *                                 fair_payment_paid -> signup-confirmation chain
- *                                 fires.
+ *   - GET  /v2/payments/{id}   -> the same payment in the status set via the
+ *                                 `fair_e2e_mollie_get_status` WP option
+ *                                 (default "paid", settable per-test via
+ *                                 set-mollie-status.php — see #1244), so the
+ *                                 callback page's sync pulls that status and
+ *                                 the real fair_payment_paid/fair_payment_failed
+ *                                 chain fires accordingly.
  *   - GET  /v2/methods         -> empty list (method allowlist stays unset).
  *   - GET  /v2/balances...     -> empty list (fee capture finds nothing).
  *
@@ -112,9 +115,12 @@ class CurlMollieHttpAdapter implements HttpAdapterContract {
 			return $this->payment_response( $payload, 'open' );
 		}
 
-		// Get single payment: GET /v2/payments/{id}
+		// Get single payment: GET /v2/payments/{id}. Status is settable via
+		// set-mollie-status.php so a spec can drive the return-and-retry flow
+		// (default "paid" keeps every pre-existing spec's assumption intact).
 		if ( \preg_match( '#/payments/([^/]+)$#', $path, $m ) ) {
-			return $this->payment_response( array(), 'paid', $m[1] );
+			$status = (string) \get_option( 'fair_e2e_mollie_get_status', 'paid' );
+			return $this->payment_response( array(), $status, $m[1] );
 		}
 
 		// Payment methods allowlist lookup: GET /v2/methods

--- a/e2e/mu-plugins/scripts/seed-pending-ticket-signup.php
+++ b/e2e/mu-plugins/scripts/seed-pending-ticket-signup.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Seed a stuck get-tickets signup + transaction pair for the E2E
+ * return-and-retry specs (#1244).
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-pending-ticket-signup.php <eventDateId> <price> [status] [checkoutUrl]
+ *
+ * The get-tickets base form is anonymous — there is no participant to attach
+ * this to (unlike fair-audience's seed-pending-signup.php). This creates:
+ *   - a fair_payment_transactions row in the given status (default 'failed',
+ *     one of the states SignupPaymentState treats as retriable), with a
+ *     synthetic access_token so the callback URL / retry-payment route can
+ *     verify ownership exactly as a real signup would produce;
+ *   - a fair_events_signups row with status 'pending_payment' and a
+ *     payment_expires_at an hour out (within the hold window), linked to the
+ *     transaction via EventSignup::update_transaction().
+ *
+ * Prints a single `E2E_PENDING_TICKET:{json}` line with the signup id,
+ * transaction id, access token, and buyer email.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use FairEvents\Models\EventSignup;
+use FairPaymentsConnector\Models\Transaction;
+
+$event_date_id = isset( $args[0] ) ? (int) $args[0] : 0;
+$price         = isset( $args[1] ) ? (float) $args[1] : 0.0;
+$tx_status     = isset( $args[2] ) && '' !== $args[2] ? (string) $args[2] : 'failed';
+$checkout_url  = isset( $args[3] ) ? (string) $args[3] : '';
+
+if ( ! $event_date_id ) {
+	WP_CLI::error( 'Usage: seed-pending-ticket-signup.php <eventDateId> <price> [status] [checkoutUrl]' );
+}
+
+$stamp = gmdate( 'YmdHis' ) . '-' . wp_rand( 1000, 9999 );
+$email = 'pending.ticket.' . $stamp . '@example.test';
+
+$transaction_id = Transaction::create(
+	array(
+		'mollie_payment_id' => 'tr_e2e_ticket_' . $stamp,
+		'event_date_id'     => $event_date_id,
+		'amount'            => $price,
+		'status'            => $tx_status,
+		'checkout_url'      => $checkout_url,
+		'description'       => 'E2E pending ticket signup',
+		'access_token'      => wp_generate_password( 32, false ),
+		'metadata'          => wp_json_encode(
+			array(
+				'source'        => 'fair-events-get-tickets',
+				'event_date_id' => $event_date_id,
+			)
+		),
+	)
+);
+if ( ! $transaction_id ) {
+	WP_CLI::error( 'Failed to create transaction.' );
+}
+
+$signup_id = EventSignup::save(
+	array(
+		'event_date_id' => $event_date_id,
+		'name'          => 'E2E Pending Ticket Buyer ' . $stamp,
+		'email'         => $email,
+		'quantity'      => 1,
+		'amount'        => $price,
+		'status'        => 'pending_payment',
+	)
+);
+if ( ! $signup_id ) {
+	WP_CLI::error( 'Failed to create signup row.' );
+}
+EventSignup::update_transaction( $signup_id, (int) $transaction_id );
+
+$transaction = Transaction::get_by_id( $transaction_id );
+
+echo 'E2E_PENDING_TICKET:' . wp_json_encode(
+	array(
+		'signupId'      => (int) $signup_id,
+		'transactionId' => (int) $transaction_id,
+		'token'         => (string) $transaction->access_token,
+		'email'         => $email,
+	)
+) . "\n";

--- a/e2e/mu-plugins/scripts/set-mollie-status.php
+++ b/e2e/mu-plugins/scripts/set-mollie-status.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Set the status the Mollie HTTP double reports on GET /v2/payments/{id}.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/set-mollie-status.php <status>
+ *
+ * The double (lib/mollie-http-double.php) always reports "open" on POST (the
+ * checkout-creation response never needs to vary) but reads this option for
+ * the GET response, so a spec can drive the sync-on-return path through
+ * paid/failed/canceled/expired without needing a real Mollie account (#1244).
+ * Defaults to "paid" when never set, keeping every pre-existing spec's
+ * assumption intact.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$mollie_status = isset( $args[0] ) ? (string) $args[0] : '';
+
+$allowed = array( 'paid', 'open', 'pending', 'failed', 'canceled', 'expired' );
+if ( ! in_array( $mollie_status, $allowed, true ) ) {
+	WP_CLI::error( 'Usage: set-mollie-status.php <paid|open|pending|failed|canceled|expired>' );
+}
+
+update_option( 'fair_e2e_mollie_get_status', $mollie_status );
+
+echo 'E2E_MOLLIE_STATUS:' . wp_json_encode( array( 'status' => $mollie_status ) ) . "\n";

--- a/e2e/user-flows/get-tickets-cancel-and-restart.spec.js
+++ b/e2e/user-flows/get-tickets-cancel-and-restart.spec.js
@@ -1,20 +1,20 @@
 /**
  * E2E: abandoning a payment and starting over (fair-events get-tickets block).
  *
- * Companion to signup-cancel-and-restart.spec.js, which found that the
- * fair-audience event-signup block's "Cancel and start over" link is a no-op —
- * clicking it re-shows the identical stuck retry screen because render.php
- * re-derives that screen from a persistent per-participant DB row that the
- * link never clears.
+ * Companion to signup-cancel-and-restart.spec.js (the fair-audience
+ * equivalent). Rewritten for #1244: the base get-tickets form now has its own
+ * direct-navigation fallback (FairEvents\Services\SignupPaymentSession, a
+ * short-lived signed cookie set when create_signup() returns
+ * payment_required) — a buyer who abandons Mollie's checkout and navigates
+ * straight back to the event page (no provider redirect) sees the same
+ * resume card the return-from-payment callback would show, within the
+ * 15-minute hold window, and "Cancel and start over" clears it server-side
+ * so a fresh purchase isn't blocked by the stale card resurrecting.
  *
- * The get-tickets block has no such identity to get stuck against: it doesn't
- * link the page render to a signed-up participant/session at all (buyers
- * aren't known until they submit name+email), so there's no server-side
- * "resume the in-progress payment" fallback to go stale. This spec asserts
- * that behaviour holds: a buyer who starts a paid checkout and then goes back
- * to the event page (Mollie's redirect never followed / abandoned) sees a
- * plain, fresh form — not stuck on the earlier processing state — and can
- * complete a brand new purchase from it.
+ * Uses the Mollie double's settable GET status (set-mollie-status.php,
+ * #1244 Decisions #8) to report "open" — a checkout link that was created
+ * but never completed — so SignupPaymentState resolves 'resume' both on the
+ * initial callback render and via the cookie fallback.
  */
 
 import { test, expect } from '../support/fixtures.js';
@@ -32,9 +32,15 @@ test.describe('get-tickets block (fair-audience inactive): abandon and restart',
 	test.beforeEach(() => {
 		// Reset the get-tickets per-IP rate limit (3 requests/hour).
 		wpCli('transient delete --all');
+		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'open');
 	});
 
-	test('going back after starting a paid checkout shows a fresh form the buyer can complete', async ({
+	test.afterEach(() => {
+		// Leave the double reporting "paid" for every other spec's assumption.
+		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'paid');
+	});
+
+	test('abandoning checkout shows a resume card even via direct navigation, and canceling allows a fresh purchase', async ({
 		page,
 		seedEvent,
 	}) => {
@@ -45,7 +51,7 @@ test.describe('get-tickets block (fair-audience inactive): abandon and restart',
 
 		await page.goto(event.pageUrl);
 
-		let form = page.locator('.fair-events-get-tickets-form');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
 		await form.locator('input[name="name"]').fill(`Abandoned ${stamp}`);
@@ -56,51 +62,67 @@ test.describe('get-tickets block (fair-audience inactive): abandon and restart',
 			)
 			.check();
 
-		// Submit → redirected through the Mollie double to the callback URL,
-		// which only polls; the buyer never lands on a confirmed state because
-		// no webhook fires here — this models an abandoned/failed attempt.
+		// Submit → redirected through the Mollie double to the callback URL;
+		// render.php syncs on that first load, pulls "open" (checkout created,
+		// never finished) from the double, and shows the resume card.
 		await form.locator('button[type="submit"]').click();
-		await expect(page.locator('.message-processing')).toBeVisible({
-			timeout: 30000,
-		});
+		const resumeCard = page.locator(
+			'.fair-events-get-tickets-callback-resume'
+		);
+		await expect(resumeCard).toBeVisible({ timeout: 30000 });
+		await expect(resumeCard.getByText('Continue payment')).toBeVisible();
 
-		// The buyer gives up and goes back to the plain event page instead of
-		// completing or retrying the Mollie checkout.
+		// The buyer gives up and navigates straight back to the plain event
+		// page — no fair_payment_callback/transaction_id/token in the URL at
+		// all. The session cookie set at checkout time is what recognises
+		// them now.
 		await page.goto(event.pageUrl);
 
-		form = page.locator('.fair-events-get-tickets-form');
-		await expect(form).toBeVisible();
-		// No leftover processing/error message from the abandoned attempt (the
-		// block always renders an empty `.message-container` for its JS to fill
-		// in later — only the populated status classes indicate a stuck state).
-		await expect(page.locator('.message-processing')).toHaveCount(0);
-		await expect(page.locator('.message-error')).toHaveCount(0);
-		await expect(page.locator('.message-success')).toHaveCount(0);
+		await expect(
+			page.locator('.fair-events-get-tickets-callback-resume')
+		).toBeVisible({ timeout: 15000 });
+		await expect(page.locator('.fair-events-get-tickets-form')).toHaveCount(
+			0
+		);
 
-		// A completely fresh purchase (different buyer identity) works.
+		// Cancel and start over: clears the hold + cookie server-side, then
+		// strips any callback params and reloads to a plain form.
+		await page.getByRole('link', { name: 'Cancel and start over' }).click();
+
+		const freshForm = page.locator('.fair-events-get-tickets-form');
+		await expect(freshForm).toBeVisible({ timeout: 15000 });
+		await expect(
+			page.locator('.fair-events-get-tickets-callback')
+		).toHaveCount(0);
+
+		// A completely fresh purchase (different buyer identity) works, and
+		// this time Mollie confirms it outright.
+		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'paid');
 		const buyerEmail = `get-tickets.fresh.${stamp}@example.test`;
-		await form.locator('input[name="name"]').fill(`Fresh Buyer ${stamp}`);
-		await form.locator('input[name="email"]').fill(buyerEmail);
-		await form
+		await freshForm
+			.locator('input[name="name"]')
+			.fill(`Fresh Buyer ${stamp}`);
+		await freshForm.locator('input[name="email"]').fill(buyerEmail);
+		await freshForm
 			.locator(
 				`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
 			)
 			.check();
-		await form.locator('button[type="submit"]').click();
-		await expect(page.locator('.message-processing')).toBeVisible({
-			timeout: 30000,
-		});
+		await freshForm.locator('button[type="submit"]').click();
+		await expect(
+			page.locator('.fair-events-get-tickets-callback-confirmed')
+		).toBeVisible({ timeout: 30000 });
 
 		const state = runScript(
 			'get-tickets-state.php',
 			'E2E_GT_STATE',
 			String(event.eventDateId)
 		);
-		// Both the abandoned attempt and the fresh purchase left their own
-		// pending signup row — the abandoned one was never blocking the retry.
+		// The abandoned attempt was canceled (failed), the fresh purchase confirmed.
 		expect(state.signups).toHaveLength(2);
-		expect(state.signups.map((s) => s.email).sort()).toEqual(
-			[abandonedEmail, buyerEmail].sort()
-		);
+		const abandoned = state.signups.find((s) => s.email === abandonedEmail);
+		const fresh = state.signups.find((s) => s.email === buyerEmail);
+		expect(abandoned.status).toBe('failed');
+		expect(fresh.status).toBe('confirmed');
 	});
 });

--- a/e2e/user-flows/get-tickets-purchase.spec.js
+++ b/e2e/user-flows/get-tickets-purchase.spec.js
@@ -13,10 +13,14 @@
  *   - free ticket type → immediate confirmation, signup row 'confirmed' with
  *     no transaction;
  *   - paid ticket type → payment_required, redirect through the Mollie double
- *     back to the callback URL, webhook flips the transaction to paid (the
- *     production path — Mollie calls /webhook; the redirect page itself only
- *     polls), fair_payment_paid → FairEvents PaymentHooks confirms the signup,
- *     and the block UI shows the success message.
+ *     back to the callback URL. Since #1244, render.php reconciles status
+ *     with the provider on every callback render (SignupPaymentState's "sync
+ *     before you read"), so the double is set to report "pending" (a real
+ *     still-processing Mollie status) rather than the default "paid" — that
+ *     keeps the transaction in-flight through the first render, and the
+ *     webhook (the actual production trigger once Mollie settles) flips it
+ *     to paid from there, fair_payment_paid → FairEvents PaymentHooks
+ *     confirms the signup, and the block's poller swaps in the confirmed card.
  *
  * The get-tickets endpoint rate-limits by IP (3/hour), so transients are
  * cleared before each test to keep repeated local runs deterministic.
@@ -37,6 +41,12 @@ test.describe('get-tickets block purchase (fair-audience inactive)', () => {
 	test.beforeEach(() => {
 		// Reset the get-tickets per-IP rate limit (3 requests/hour).
 		wpCli('transient delete --all');
+		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'pending');
+	});
+
+	test.afterEach(() => {
+		// Leave the double reporting "paid", the default every other spec assumes.
+		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'paid');
 	});
 
 	test('paid ticket: checkout via the Mollie double, webhook confirms the signup', async ({
@@ -70,13 +80,13 @@ test.describe('get-tickets block purchase (fair-audience inactive)', () => {
 		// Submit → payment_required with a checkout_url that (via the Mollie
 		// double) is the callback URL itself, so the browser lands straight on
 		// ?fair_payment_callback=true&transaction_id=…&token=…. Wait for the
-		// rendered processing state rather than the navigation itself
+		// rendered processing card rather than the navigation itself
 		// (waitForURL can abort when a redirect supersedes it — see
 		// ticket-purchase-confirmation.spec.js), then assert the URL by polling.
 		await form.locator('button[type="submit"]').click();
-		await expect(page.locator('.message-processing')).toBeVisible({
-			timeout: 30000,
-		});
+		await expect(
+			page.locator('.fair-events-get-tickets-callback-processing')
+		).toBeVisible({ timeout: 30000 });
 		await expect(page).toHaveURL(/fair_payment_callback=true/);
 
 		// The signup row is pending and its transaction still open — the
@@ -92,22 +102,23 @@ test.describe('get-tickets block purchase (fair-audience inactive)', () => {
 		expect(state.signups[0].amount).toBe(event.price);
 		expect(state.signups[0].mollie_payment_id).toBeTruthy();
 
-		// Simulate Mollie's webhook call (production path). The handler fetches
-		// the payment from the double, which reports it paid, and fires the real
+		// The buyer's bank has now confirmed the payment. Simulate Mollie's
+		// webhook call (production path): the handler fetches the payment
+		// from the double (now reporting paid) and fires the real
 		// fair_payment_paid → FairEvents\Hooks\PaymentHooks chain.
+		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'paid');
 		const webhookResponse = await page.request.post(
 			'/wp-json/fair-payments-connector/v1/webhook',
 			{ form: { id: state.signups[0].mollie_payment_id } }
 		);
 		expect(webhookResponse.ok()).toBe(true);
 
-		// The block's callback poller picks the paid status up and swaps the
-		// form for the success message.
+		// The block's payment-state poller picks the paid status up and swaps
+		// the processing card for the confirmed one in place.
 		await expect(
-			page.getByText('Your ticket purchase was successful', {
-				exact: false,
-			})
+			page.locator('.fair-events-get-tickets-callback-confirmed')
 		).toBeVisible({ timeout: 30000 });
+		await expect(page.getByText('Payment confirmed')).toBeVisible();
 
 		// Server-side: signup confirmed, transaction paid (in test mode).
 		state = runScript(

--- a/e2e/user-flows/get-tickets-return-and-retry.spec.js
+++ b/e2e/user-flows/get-tickets-return-and-retry.spec.js
@@ -1,0 +1,105 @@
+/**
+ * E2E: return-from-payment states and retry in the get-tickets block (#1244).
+ *
+ * Covers the failed → retry → confirmed path: a payment that Mollie reports
+ * as failed by the time the buyer returns shows the retry card (server-
+ * resolved on that very first render — SignupPaymentState's "sync before you
+ * read" runs on every render of a callback/session-resolved transaction, and
+ * the connector only re-checks Mollie while a transaction is still in its
+ * freshly-initiated 'pending_payment' state, so this is the one point where
+ * the double's canned status actually lands); retrying creates a fresh
+ * transaction and, once Mollie reports it paid, confirms in the same way.
+ *
+ * Uses the Mollie double's settable GET status (set-mollie-status.php,
+ * #1244 Decisions #8) rather than driving a real checkout, mirroring
+ * get-tickets-purchase.spec.js's use of the webhook double for the
+ * already-covered straight-through paid path.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+import { wpCli, runScript } from '../support/wp-cli.js';
+
+test.describe('get-tickets block (fair-audience inactive): return and retry', () => {
+	test.beforeAll(() => {
+		wpCli('plugin deactivate fair-audience');
+	});
+
+	test.afterAll(() => {
+		wpCli('plugin activate fair-audience');
+	});
+
+	test.beforeEach(() => {
+		// Reset the get-tickets per-IP rate limit (3 requests/hour).
+		wpCli('transient delete --all');
+	});
+
+	test.afterEach(() => {
+		// Leave the double reporting "paid" for every other spec's assumption.
+		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'paid');
+	});
+
+	test('a failed payment shows a retry card, and retrying it can succeed', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('paid', { block: 'get-tickets' });
+
+		const stamp = Date.now();
+		const email = `get-tickets.retry.${stamp}@example.test`;
+
+		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'failed');
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+		await form.locator('input[name="name"]').fill(`Retry Buyer ${stamp}`);
+		await form.locator('input[name="email"]').fill(email);
+		await form
+			.locator(
+				`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
+			)
+			.check();
+		await form.locator('button[type="submit"]').click();
+
+		const retryCard = page.locator(
+			'.fair-events-get-tickets-callback-retry'
+		);
+		await expect(retryCard).toBeVisible({ timeout: 30000 });
+		await expect(
+			page.getByText("Your payment didn't go through")
+		).toBeVisible();
+
+		let state = runScript(
+			'get-tickets-state.php',
+			'E2E_GT_STATE',
+			String(event.eventDateId)
+		);
+		expect(state.signups).toHaveLength(1);
+		expect(state.signups[0].status).toBe('failed');
+		expect(state.signups[0].transaction_status).toBe('failed');
+
+		// The buyer's card works this time.
+		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'paid');
+
+		await retryCard
+			.locator('.fair-events-get-tickets-callback-retry-button')
+			.click();
+
+		await expect(
+			page.locator('.fair-events-get-tickets-callback-confirmed')
+		).toBeVisible({ timeout: 30000 });
+		await expect(page.getByText('Payment confirmed')).toBeVisible();
+
+		// Same signup row, now re-pointed at the retry's new (paid) transaction.
+		state = runScript(
+			'get-tickets-state.php',
+			'E2E_GT_STATE',
+			String(event.eventDateId)
+		);
+		expect(state.signups).toHaveLength(1);
+		expect(state.signups[0].email).toBe(email);
+		expect(state.signups[0].status).toBe('confirmed');
+		expect(state.signups[0].transaction_status).toBe('paid');
+	});
+});

--- a/fair-events-shared/src/__tests__/payment-flow.test.js
+++ b/fair-events-shared/src/__tests__/payment-flow.test.js
@@ -1,4 +1,102 @@
-import { renderPaymentError } from '../payment-flow.js';
+import apiFetch from '@wordpress/api-fetch';
+import { renderPaymentError, pollPaymentStatus } from '../payment-flow.js';
+
+jest.mock('@wordpress/api-fetch');
+
+describe('pollPaymentStatus', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	test('calls onConfirmed once lifecycle_status is confirmed', async () => {
+		apiFetch.mockResolvedValueOnce({ lifecycle_status: 'confirmed' });
+		const onConfirmed = jest.fn();
+
+		pollPaymentStatus({
+			path: '/fair-events/v1/get-tickets/payment-state',
+			onConfirmed,
+		});
+		await flushPromises();
+
+		expect(onConfirmed).toHaveBeenCalledWith({
+			lifecycle_status: 'confirmed',
+		});
+	});
+
+	test('calls onFailed once lifecycle_status is failed', async () => {
+		apiFetch.mockResolvedValueOnce({ lifecycle_status: 'failed' });
+		const onFailed = jest.fn();
+
+		pollPaymentStatus({ path: '/some/path', onFailed });
+		await flushPromises();
+
+		expect(onFailed).toHaveBeenCalledWith({ lifecycle_status: 'failed' });
+	});
+
+	test('calls onProcessing and schedules another tick while still in progress', async () => {
+		apiFetch.mockResolvedValue({
+			lifecycle_status: 'processing',
+			state: 'resume',
+		});
+		const onProcessing = jest.fn();
+
+		pollPaymentStatus({
+			path: '/some/path',
+			onProcessing,
+			intervalMs: 1000,
+		});
+		await flushPromises();
+
+		expect(onProcessing).toHaveBeenCalledWith({
+			lifecycle_status: 'processing',
+			state: 'resume',
+		});
+		expect(apiFetch).toHaveBeenCalledTimes(1);
+
+		jest.advanceTimersByTime(1000);
+		await flushPromises();
+
+		expect(apiFetch).toHaveBeenCalledTimes(2);
+	});
+
+	test('stops after maxAttempts ticks', async () => {
+		apiFetch.mockResolvedValue({ lifecycle_status: 'processing' });
+
+		pollPaymentStatus({
+			path: '/some/path',
+			maxAttempts: 1,
+			intervalMs: 1000,
+		});
+		await flushPromises();
+
+		expect(apiFetch).toHaveBeenCalledTimes(1);
+
+		jest.advanceTimersByTime(1000);
+		await flushPromises();
+
+		// maxAttempts reached on the first tick — no second call is scheduled.
+		expect(apiFetch).toHaveBeenCalledTimes(1);
+	});
+
+	test('stops silently on a fetch error', async () => {
+		apiFetch.mockRejectedValueOnce(new Error('network error'));
+
+		expect(() => pollPaymentStatus({ path: '/some/path' })).not.toThrow();
+		await flushPromises();
+
+		jest.advanceTimersByTime(10000);
+		expect(apiFetch).toHaveBeenCalledTimes(1);
+	});
+
+	function flushPromises() {
+		return Promise.resolve().then(() => Promise.resolve());
+	}
+});
 
 describe('renderPaymentError', () => {
 	let container;

--- a/fair-events-shared/src/payment-flow.js
+++ b/fair-events-shared/src/payment-flow.js
@@ -67,6 +67,69 @@ export async function initiatePayment({
 }
 
 /**
+ * Poll a REST path until the response's `lifecycle_status` reaches a
+ * terminal state (`confirmed`/`failed`), or `maxAttempts` is reached.
+ *
+ * Generic over the endpoint shape: any route that returns a
+ * `lifecycle_status` of `confirmed`/`failed`/`processing` can be polled this
+ * way, not just the connector's own status endpoint — callers that need more
+ * than the three-way split (e.g. a resume/retry distinction) read the extra
+ * fields off the same response passed to `onProcessing`.
+ *
+ * @param {Object}   args                Options.
+ * @param {string}   args.path           Full REST path to poll (including any query string) — rebuilt fresh on every tick, so a caller can vary it per attempt if needed.
+ * @param {Function} [args.onConfirmed]  Called with the response once `lifecycle_status` is `confirmed`.
+ * @param {Function} [args.onFailed]     Called with the response once `lifecycle_status` is `failed`.
+ * @param {Function} [args.onProcessing] Called with the response on each poll while still in progress.
+ * @param {number}   [args.maxAttempts]  Stop polling after this many ticks.
+ * @param {number}   [args.intervalMs]   Delay between ticks.
+ */
+export function pollPaymentStatus({
+	path,
+	onConfirmed,
+	onFailed,
+	onProcessing,
+	maxAttempts = MAX_ATTEMPTS,
+	intervalMs = POLL_INTERVAL_MS,
+}) {
+	poll(0);
+
+	function poll(attempt) {
+		if (attempt >= maxAttempts) {
+			return;
+		}
+
+		apiFetch({ path })
+			.then(function (response) {
+				if (response.lifecycle_status === 'confirmed') {
+					if (onConfirmed) {
+						onConfirmed(response);
+					}
+					return;
+				}
+
+				if (response.lifecycle_status === 'failed') {
+					if (onFailed) {
+						onFailed(response);
+					}
+					return;
+				}
+
+				if (onProcessing) {
+					onProcessing(response);
+				}
+
+				setTimeout(function () {
+					poll(attempt + 1);
+				}, intervalMs);
+			})
+			.catch(function () {
+				// Ignore polling errors — stop polling silently.
+			});
+	}
+}
+
+/**
  * Detect a return from the payment gateway and poll the canonical status
  * endpoint until the transaction reaches a terminal state.
  *
@@ -102,45 +165,16 @@ export function handlePaymentCallback({
 		return;
 	}
 
-	poll(resolvedTransactionId, 0);
+	const query = resolvedToken
+		? `?token=${encodeURIComponent(resolvedToken)}`
+		: '';
 
-	function poll(txId, attempt) {
-		if (attempt >= MAX_ATTEMPTS) {
-			return;
-		}
-
-		const query = resolvedToken
-			? `?token=${encodeURIComponent(resolvedToken)}`
-			: '';
-
-		apiFetch({ path: `${statusPath}/${txId}/status${query}` })
-			.then(function (response) {
-				if (response.lifecycle_status === 'confirmed') {
-					if (onConfirmed) {
-						onConfirmed(response);
-					}
-					return;
-				}
-
-				if (response.lifecycle_status === 'failed') {
-					if (onFailed) {
-						onFailed(response);
-					}
-					return;
-				}
-
-				if (onProcessing) {
-					onProcessing(response);
-				}
-
-				setTimeout(function () {
-					poll(txId, attempt + 1);
-				}, POLL_INTERVAL_MS);
-			})
-			.catch(function () {
-				// Ignore polling errors — stop polling silently.
-			});
-	}
+	pollPaymentStatus({
+		path: `${statusPath}/${resolvedTransactionId}/status${query}`,
+		onConfirmed,
+		onFailed,
+		onProcessing,
+	});
 }
 
 /**

--- a/fair-events/__tests__/Services/SignupPaymentStateTest.php
+++ b/fair-events/__tests__/Services/SignupPaymentStateTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * SignupPaymentState resolution tests
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Services\SignupPaymentState;
+
+/**
+ * Validates the pure state-selection math used by resolve_state(), and
+ * resolve_for_transaction()'s card payload assembly with sync disabled (no
+ * database / payment-provider round trip).
+ */
+class SignupPaymentStateTest extends TestCase {
+
+	/**
+	 * A paid transaction always resolves to confirmed, checkout_url or not.
+	 */
+	public function test_paid_resolves_confirmed() {
+		$this->assertSame( SignupPaymentState::CONFIRMED, SignupPaymentState::resolve_state( 'paid', '' ) );
+		$this->assertSame( SignupPaymentState::CONFIRMED, SignupPaymentState::resolve_state( 'paid', 'https://example.test/checkout' ) );
+	}
+
+	/**
+	 * A live Mollie 'pending' status is a real payment attempt in flight.
+	 */
+	public function test_pending_resolves_processing() {
+		$this->assertSame( SignupPaymentState::PROCESSING, SignupPaymentState::resolve_state( 'pending', '' ) );
+		$this->assertSame( SignupPaymentState::PROCESSING, SignupPaymentState::resolve_state( 'pending', 'https://example.test/checkout' ) );
+	}
+
+	/**
+	 * 'open' (Mollie: created but never finished) resumes when a checkout
+	 * link is still on file.
+	 */
+	public function test_open_with_checkout_url_resolves_resume() {
+		$this->assertSame( SignupPaymentState::RESUME, SignupPaymentState::resolve_state( 'open', 'https://example.test/checkout' ) );
+	}
+
+	/**
+	 * 'pending_payment' (checkout link created, provider not yet consulted)
+	 * resumes the same way — the render/route layer always syncs before
+	 * reading, so this is the fallback when sync could not run.
+	 */
+	public function test_pending_payment_with_checkout_url_resolves_resume() {
+		$this->assertSame( SignupPaymentState::RESUME, SignupPaymentState::resolve_state( 'pending_payment', 'https://example.test/checkout' ) );
+	}
+
+	/**
+	 * Terminal failure states retry regardless of a stale checkout_url.
+	 */
+	public function test_terminal_states_resolve_retry() {
+		foreach ( array( 'failed', 'canceled', 'expired' ) as $status ) {
+			$this->assertSame( SignupPaymentState::RETRY, SignupPaymentState::resolve_state( $status, '' ) );
+			$this->assertSame( SignupPaymentState::RETRY, SignupPaymentState::resolve_state( $status, 'https://example.test/checkout' ) );
+		}
+	}
+
+	/**
+	 * 'draft' (never initiated) has no checkout link — retry, not resume.
+	 */
+	public function test_draft_without_checkout_url_resolves_retry() {
+		$this->assertSame( SignupPaymentState::RETRY, SignupPaymentState::resolve_state( 'draft', '' ) );
+	}
+
+	/**
+	 * Resolve_for_transaction(), with sync disabled, builds the card payload
+	 * straight from the given transaction/signup rows, no DB/provider calls.
+	 *
+	 * Event_date_id is left at 0 (no signup rows) so this stays a pure test:
+	 * a non-zero event_date_id would make resolve_event_title() reach for
+	 * FairEvents\Models\EventDates, which needs a live $wpdb.
+	 */
+	public function test_resolve_for_transaction_builds_card_payload_without_sync() {
+		$transaction = (object) array(
+			'id'                => 42,
+			'status'            => 'failed',
+			'amount'            => 15.5,
+			'currency'          => 'EUR',
+			'checkout_url'      => '',
+			'mollie_payment_id' => 'tr_test',
+		);
+
+		$result = SignupPaymentState::resolve_for_transaction( $transaction, array(), false );
+
+		$this->assertSame( SignupPaymentState::RETRY, $result['state'] );
+		$this->assertSame( 42, $result['transaction_id'] );
+		$this->assertSame( 15.5, $result['amount'] );
+		$this->assertSame( 'EUR', $result['currency'] );
+		$this->assertSame( '', $result['checkout_url'] );
+		$this->assertSame( 0, $result['event_date_id'] );
+	}
+
+	/**
+	 * The checkout_url is only surfaced on the resume state — a retry card
+	 * must never link to a stale checkout page.
+	 */
+	public function test_checkout_url_is_blanked_outside_resume_state() {
+		$transaction = (object) array(
+			'id'           => 1,
+			'status'       => 'paid',
+			'amount'       => 10,
+			'currency'     => 'EUR',
+			'checkout_url' => 'https://example.test/stale-checkout',
+		);
+
+		$result = SignupPaymentState::resolve_for_transaction( $transaction, array(), false );
+
+		$this->assertSame( SignupPaymentState::CONFIRMED, $result['state'] );
+		$this->assertSame( '', $result['checkout_url'] );
+	}
+
+	/**
+	 * With no signup rows at all (shouldn't normally happen, but defensive),
+	 * event_date_id/event_title fall back to empty rather than erroring.
+	 */
+	public function test_resolve_for_transaction_with_no_signup_rows() {
+		$transaction = (object) array(
+			'id'           => 1,
+			'status'       => 'open',
+			'amount'       => 10,
+			'currency'     => 'EUR',
+			'checkout_url' => 'https://example.test/checkout',
+		);
+
+		$result = SignupPaymentState::resolve_for_transaction( $transaction, array(), false );
+
+		$this->assertSame( SignupPaymentState::RESUME, $result['state'] );
+		$this->assertSame( 0, $result['event_date_id'] );
+		$this->assertSame( '', $result['event_title'] );
+	}
+}

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -142,6 +142,86 @@ class GetTicketsController extends WP_REST_Controller {
 				),
 			)
 		);
+
+		// GET /fair-events/v1/get-tickets/payment-state — resolved
+		// confirmed/processing/resume/retry state + card payload. Consumed by
+		// the return-from-payment callback card and the direct-navigation
+		// in-progress card poller. transaction_id/token are optional: when
+		// absent, ownership resolves from the SignupPaymentSession cookie.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/payment-state',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_payment_state' ),
+				'permission_callback' => array( $this, 'signup_payment_permissions_check' ),
+				'args'                => array(
+					'transaction_id' => array(
+						'type'              => 'integer',
+						'required'          => false,
+						'default'           => 0,
+						'sanitize_callback' => 'absint',
+					),
+					'token'          => array(
+						'type'              => 'string',
+						'required'          => false,
+						'default'           => '',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+
+		// POST /fair-events/v1/get-tickets/retry-payment — re-initiate a
+		// failed/canceled/expired (or checkout-link-less) payment.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/retry-payment',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'retry_payment' ),
+				'permission_callback' => array( $this, 'signup_payment_permissions_check' ),
+				'args'                => array(
+					'transaction_id' => array(
+						'type'              => 'integer',
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					),
+					'token'          => array(
+						'type'              => 'string',
+						'required'          => false,
+						'default'           => '',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+
+		// POST /fair-events/v1/get-tickets/cancel-payment — mark the
+		// in-progress signup row(s) failed and clear the session cookie, so
+		// "Cancel and start over" doesn't resurrect the same checkout.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/cancel-payment',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'cancel_payment' ),
+				'permission_callback' => array( $this, 'signup_payment_permissions_check' ),
+				'args'                => array(
+					'transaction_id' => array(
+						'type'              => 'integer',
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					),
+					'token'          => array(
+						'type'              => 'string',
+						'required'          => false,
+						'default'           => '',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -359,6 +439,8 @@ class GetTicketsController extends WP_REST_Controller {
 		if ( is_wp_error( $payment ) ) {
 			return $payment;
 		}
+
+		\FairEvents\Services\SignupPaymentSession::set( $signup_id, (int) $transaction_id );
 
 		return rest_ensure_response(
 			array(
@@ -709,6 +791,8 @@ class GetTicketsController extends WP_REST_Controller {
 			return $payment;
 		}
 
+		\FairEvents\Services\SignupPaymentSession::set( (int) $signup_ids[0], (int) $transaction_id );
+
 		return rest_ensure_response(
 			array(
 				'status'         => 'payment_required',
@@ -780,6 +864,339 @@ class GetTicketsController extends WP_REST_Controller {
 	 */
 	public function admin_permissions_check() {
 		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Permission check shared by payment-state / retry-payment /
+	 * cancel-payment: the visitor must own the transaction. Returns a 404 on
+	 * any failure so an anonymous caller cannot enumerate transaction IDs by
+	 * distinguishing missing rows from token mismatches, matching
+	 * PaymentEndpoint::get_transaction_status_permissions_check().
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return true|WP_Error
+	 */
+	public function signup_payment_permissions_check( $request ) {
+		if ( null !== $this->resolve_transaction_from_request( $request ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'transaction_not_found',
+			__( 'Transaction not found.', 'fair-events' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	/**
+	 * Resolve the transaction a request is authorized to act on.
+	 *
+	 * Allowed (in order): a `transaction_id` + `token` matching the
+	 * transaction's access_token (hash_equals); the transaction's owning
+	 * logged-in user; or — the direct-navigation case, no explicit
+	 * transaction_id/token at all, or a token that failed to match — the
+	 * SignupPaymentSession cookie, provided it resolves to the same
+	 * transaction_id (when one was supplied) and its signup row is still
+	 * within its payment hold window.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return object|null Transaction object, or null when unauthorized.
+	 */
+	private function resolve_transaction_from_request( $request ) {
+		if ( ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
+			return null;
+		}
+
+		$transaction_id = (int) $request->get_param( 'transaction_id' );
+		$token          = (string) $request->get_param( 'token' );
+
+		if ( $transaction_id <= 0 ) {
+			return $this->resolve_transaction_from_cookie( null );
+		}
+
+		$transaction = \FairPaymentsConnector\API\TransactionAPI::get_transaction( $transaction_id );
+		if ( ! $transaction ) {
+			return null;
+		}
+
+		$expected_token = (string) ( $transaction->access_token ?? '' );
+		if ( '' !== $token && '' !== $expected_token && hash_equals( $expected_token, $token ) ) {
+			return $transaction;
+		}
+
+		$user_id = get_current_user_id();
+		if ( $user_id && ! empty( $transaction->user_id ) && (int) $transaction->user_id === $user_id ) {
+			return $transaction;
+		}
+
+		return $this->resolve_transaction_from_cookie( $transaction_id );
+	}
+
+	/**
+	 * Resolve a transaction from the SignupPaymentSession cookie, optionally
+	 * constrained to a specific transaction_id (so a stale/foreign cookie
+	 * can't ride along on someone else's transaction reference).
+	 *
+	 * @param int|null $expected_transaction_id Required transaction_id match, or null to accept any.
+	 * @return object|null Transaction object, or null when the cookie is absent/invalid/expired.
+	 */
+	private function resolve_transaction_from_cookie( $expected_transaction_id ) {
+		$session = \FairEvents\Services\SignupPaymentSession::get();
+		if ( ! $session ) {
+			return null;
+		}
+		if ( null !== $expected_transaction_id && $session['transaction_id'] !== (int) $expected_transaction_id ) {
+			return null;
+		}
+
+		$signup = \FairEvents\Models\EventSignup::get_by_id( $session['signup_id'] );
+		if ( ! $signup || (int) $signup->transaction_id !== $session['transaction_id'] ) {
+			return null;
+		}
+		if ( 'pending_payment' !== $signup->status
+			|| empty( $signup->payment_expires_at )
+			|| strtotime( $signup->payment_expires_at ) <= time()
+		) {
+			return null;
+		}
+
+		return \FairPaymentsConnector\API\TransactionAPI::get_transaction( $session['transaction_id'] );
+	}
+
+	/**
+	 * Resolved confirmed/processing/resume/retry state + card payload for a
+	 * transaction, used by the return-from-payment callback card and the
+	 * direct-navigation in-progress card's poller.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_payment_state( $request ) {
+		$transaction = $this->resolve_transaction_from_request( $request );
+		if ( ! $transaction ) {
+			return new WP_Error(
+				'transaction_not_found',
+				__( 'Transaction not found.', 'fair-events' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$signup_rows = \FairEvents\Models\EventSignup::get_all_by_transaction_id( (int) $transaction->id );
+		$state       = \FairEvents\Services\SignupPaymentState::resolve_for_transaction( $transaction, $signup_rows );
+
+		// Also expose the canonical confirmed|processing|failed lifecycle
+		// status other pollers (fair-events-shared's pollPaymentStatus) key
+		// on, so this route can be polled the same way as the connector's.
+		$state['lifecycle_status'] = \FairPaymentsConnector\Payment\PaymentStatus::from_raw_status( (string) $transaction->status );
+
+		return rest_ensure_response( $state );
+	}
+
+	/**
+	 * Re-initiate payment for a previously failed/canceled/expired (or
+	 * checkout-link-less) get-tickets transaction. A new
+	 * fair-payments-connector transaction is always created, mirroring
+	 * fair-audience's retry: the connector refuses to re-initiate a
+	 * transaction once a Mollie payment has been attached
+	 * (Transaction::can_initiate_payment()).
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function retry_payment( $request ) {
+		$transaction = $this->resolve_transaction_from_request( $request );
+		if ( ! $transaction ) {
+			return new WP_Error(
+				'transaction_not_found',
+				__( 'Transaction not found.', 'fair-events' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$status = (string) $transaction->status;
+		if ( in_array( $status, array( 'paid', 'pending' ), true ) ) {
+			return new WP_Error(
+				'invalid_retry_state',
+				__( 'This payment cannot be retried.', 'fair-events' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$metadata = ! empty( $transaction->metadata ) ? json_decode( $transaction->metadata, true ) : array();
+		if ( ( $metadata['source'] ?? '' ) !== 'fair-events-get-tickets' ) {
+			return new WP_Error(
+				'invalid_retry_source',
+				__( 'This payment is not retriable from this endpoint.', 'fair-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$signup_ids  = \FairEvents\Models\EventSignup::resolve_signup_ids_from_transaction( $transaction );
+		$signup_rows = array_values(
+			array_filter(
+				array_map(
+					function ( $id ) {
+						return \FairEvents\Models\EventSignup::get_by_id( $id );
+					},
+					$signup_ids
+				)
+			)
+		);
+
+		if ( empty( $signup_rows ) ) {
+			return new WP_Error(
+				'invalid_retry_state',
+				__( 'This payment is missing context needed to retry.', 'fair-events' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		// The cleanup cron releases the hold (and the seats it reserves)
+		// once payment_expires_at elapses — retrying past that point could
+		// oversell, so it's refused rather than silently recreating the hold.
+		$within_hold = false;
+		foreach ( $signup_rows as $row ) {
+			if ( $row->payment_expires_at && strtotime( $row->payment_expires_at ) > time() ) {
+				$within_hold = true;
+				break;
+			}
+		}
+		if ( ! $within_hold ) {
+			return new WP_Error(
+				'retry_window_expired',
+				__( 'This payment session has expired. Please start over.', 'fair-events' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		if ( $this->payments_unavailable() ) {
+			return new WP_Error(
+				'payment_unavailable',
+				__( 'Paid tickets are not available because online payments are not configured.', 'fair-events' ),
+				array( 'status' => 503 )
+			);
+		}
+
+		$old_line_items = \FairPaymentsConnector\Models\LineItem::get_by_transaction_id( (int) $transaction->id );
+		if ( empty( $old_line_items ) ) {
+			return new WP_Error(
+				'invalid_retry_state',
+				__( 'Original line items could not be loaded.', 'fair-events' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$line_items = array();
+		foreach ( $old_line_items as $li ) {
+			$line_items[] = array(
+				'name'     => (string) $li->name,
+				'quantity' => isset( $li->quantity ) ? (int) $li->quantity : 1,
+				'amount'   => (float) $li->unit_amount,
+			);
+		}
+
+		$event_date_id = isset( $metadata['event_date_id'] ) ? (int) $metadata['event_date_id'] : (int) ( $transaction->event_date_id ?? 0 );
+		$user_id       = isset( $transaction->user_id ) ? (int) $transaction->user_id : 0;
+
+		$new_signup_ids = array_map(
+			function ( $row ) {
+				return (int) $row->id;
+			},
+			$signup_rows
+		);
+
+		$new_transaction_id = \FairPaymentsConnector\API\TransactionAPI::create_transaction(
+			$line_items,
+			array(
+				'currency'      => $transaction->currency,
+				'description'   => $transaction->description,
+				'event_date_id' => $event_date_id,
+				'user_id'       => $user_id ? $user_id : null,
+				'metadata'      => array(
+					'source'                  => 'fair-events-get-tickets',
+					'event_date_id'           => $event_date_id,
+					'signup_ids'              => $new_signup_ids,
+					'retry_of_transaction_id' => (int) $transaction->id,
+				),
+			)
+		);
+
+		if ( is_wp_error( $new_transaction_id ) ) {
+			return $new_transaction_id;
+		}
+
+		foreach ( $signup_rows as $row ) {
+			\FairEvents\Models\EventSignup::update_transaction( (int) $row->id, (int) $new_transaction_id );
+		}
+
+		$new_transaction = \FairPaymentsConnector\Models\Transaction::get_by_id( $new_transaction_id );
+
+		$redirect_url = add_query_arg(
+			array(
+				'fair_payment_callback' => 'true',
+				'transaction_id'        => $new_transaction_id,
+				'token'                 => $new_transaction ? $new_transaction->access_token : '',
+			),
+			$this->resolve_return_url( $event_date_id )
+		);
+
+		$payment = \FairPaymentsConnector\API\TransactionAPI::initiate_payment(
+			$new_transaction_id,
+			array( 'redirect_url' => $redirect_url )
+		);
+
+		if ( is_wp_error( $payment ) ) {
+			return $payment;
+		}
+
+		\FairEvents\Services\SignupPaymentSession::set( $new_signup_ids[0], (int) $new_transaction_id );
+
+		return rest_ensure_response(
+			array(
+				'status'         => 'payment_required',
+				'checkout_url'   => esc_url_raw( $payment['checkout_url'] ),
+				'transaction_id' => (int) $new_transaction_id,
+				'amount'         => $transaction->amount,
+				'currency'       => $transaction->currency,
+			)
+		);
+	}
+
+	/**
+	 * Cancel an in-progress get-tickets payment: mark its signup row(s)
+	 * failed and clear their hold, and clear the session cookie, so "Cancel
+	 * and start over" doesn't resurrect the same checkout on the next load.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function cancel_payment( $request ) {
+		$transaction = $this->resolve_transaction_from_request( $request );
+		if ( ! $transaction ) {
+			return new WP_Error(
+				'transaction_not_found',
+				__( 'Transaction not found.', 'fair-events' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$metadata = ! empty( $transaction->metadata ) ? json_decode( $transaction->metadata, true ) : array();
+		if ( ( $metadata['source'] ?? '' ) !== 'fair-events-get-tickets' ) {
+			return new WP_Error(
+				'invalid_retry_source',
+				__( 'This payment is not manageable from this endpoint.', 'fair-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$signup_ids = \FairEvents\Models\EventSignup::resolve_signup_ids_from_transaction( $transaction );
+		foreach ( $signup_ids as $signup_id ) {
+			\FairEvents\Models\EventSignup::cancel_pending( $signup_id );
+		}
+
+		\FairEvents\Services\SignupPaymentSession::clear();
+
+		return rest_ensure_response( array( 'success' => true ) );
 	}
 
 	/**

--- a/fair-events/src/API/__tests__/GetTicketsPaymentState.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsPaymentState.api.spec.js
@@ -1,0 +1,138 @@
+/**
+ * Playwright API tests for the get-tickets return-from-payment routes
+ * (#1244): payment-state, retry-payment, cancel-payment.
+ *
+ * The dev stack this suite runs against has no payment connector configured
+ * (same assumption as GetTicketsPaymentUnavailable.api.spec.js), so a real
+ * paid/failed transaction can't be produced by driving the actual create/
+ * checkout flow here — that's covered by the e2e return-and-retry spec,
+ * which runs against a Mollie double. What IS testable at this layer,
+ * without any payment provider, is the ownership boundary every one of
+ * these routes shares: SignupPaymentSession::get() resolve_transaction_from_request()
+ * must 404 — never a more specific error — for any transaction_id it can't
+ * verify, so an anonymous caller can't enumerate other visitors' payments.
+ *
+ * This endpoint only serves signups when fair-audience is NOT active
+ * (fair-events/src/blocks/event-signup/render.php defers to the Event Signup
+ * block otherwise), so these tests skip gracefully when fair-audience is
+ * active in the test environment.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+// Astronomically unlikely to collide with a real row in the test DB.
+const BOGUS_TRANSACTION_ID = 999999999;
+
+test.describe('GetTicketsController — payment-state / retry-payment / cancel-payment', () => {
+	let api;
+	let fairAudienceActive = false;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test('payment-state with no transaction_id and no session cookie 404s', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const res = await api.get(
+			'/wp-json/fair-events/v1/get-tickets/payment-state'
+		);
+		expect(res.status()).toBe(404);
+		expect((await res.json()).code).toBe('transaction_not_found');
+	});
+
+	test('payment-state with an unknown transaction_id 404s', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const res = await api.get(
+			'/wp-json/fair-events/v1/get-tickets/payment-state',
+			{ params: { transaction_id: BOGUS_TRANSACTION_ID, token: 'wrong' } }
+		);
+		expect(res.status()).toBe(404);
+		expect((await res.json()).code).toBe('transaction_not_found');
+	});
+
+	test('retry-payment requires a transaction_id', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const res = await api.post(
+			'/wp-json/fair-events/v1/get-tickets/retry-payment',
+			{ data: {} }
+		);
+		expect(res.status()).toBe(400);
+	});
+
+	test('retry-payment with an unknown transaction_id 404s, never a more specific error', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const res = await api.post(
+			'/wp-json/fair-events/v1/get-tickets/retry-payment',
+			{ data: { transaction_id: BOGUS_TRANSACTION_ID, token: 'wrong' } }
+		);
+		expect(res.status()).toBe(404);
+		expect((await res.json()).code).toBe('transaction_not_found');
+	});
+
+	test('cancel-payment requires a transaction_id', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const res = await api.post(
+			'/wp-json/fair-events/v1/get-tickets/cancel-payment',
+			{ data: {} }
+		);
+		expect(res.status()).toBe(400);
+	});
+
+	test('cancel-payment with an unknown transaction_id 404s, never a more specific error', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		const res = await api.post(
+			'/wp-json/fair-events/v1/get-tickets/cancel-payment',
+			{ data: { transaction_id: BOGUS_TRANSACTION_ID, token: 'wrong' } }
+		);
+		expect(res.status()).toBe(404);
+		expect((await res.json()).code).toBe('transaction_not_found');
+	});
+
+	test('admins get the same 404 as anyone else for an unknown transaction_id', async () => {
+		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
+
+		// signup_payment_permissions_check() has no manage_options carve-out
+		// (unlike PaymentEndpoint's own status check) — ownership of a
+		// get-tickets signup is never an admin concern, so this stays a
+		// plain 404 even for an authenticated admin.
+		const res = await api.get(
+			'/wp-json/fair-events/v1/get-tickets/payment-state',
+			{
+				headers: adminHeaders,
+				params: { transaction_id: BOGUS_TRANSACTION_ID },
+			}
+		);
+		expect(res.status()).toBe(404);
+	});
+});

--- a/fair-events/src/Hooks/PaymentHooks.php
+++ b/fair-events/src/Hooks/PaymentHooks.php
@@ -98,33 +98,13 @@ class PaymentHooks {
 	 * Resolve the signup ID(s) from a transaction, returning an empty array
 	 * if not a get-tickets transaction.
 	 *
+	 * Delegates to EventSignup::resolve_signup_ids_from_transaction() so the
+	 * retry/cancel REST routes resolve the exact same multi-row set.
+	 *
 	 * @param object $transaction Transaction object.
 	 * @return int[] Signup IDs (empty when none apply).
 	 */
 	private static function resolve_signup_ids( $transaction ) {
-		if ( ! isset( $transaction->metadata ) ) {
-			return array();
-		}
-
-		$metadata = is_string( $transaction->metadata )
-			? json_decode( $transaction->metadata, true )
-			: (array) $transaction->metadata;
-
-		if ( ( $metadata['source'] ?? '' ) !== 'fair-events-get-tickets' ) {
-			return array();
-		}
-
-		// 'multiple_instances' purchases store one signup row ID per chosen occurrence.
-		if ( ! empty( $metadata['signup_ids'] ) && is_array( $metadata['signup_ids'] ) ) {
-			return array_map( 'intval', $metadata['signup_ids'] );
-		}
-
-		if ( ! empty( $metadata['signup_id'] ) ) {
-			return array( (int) $metadata['signup_id'] );
-		}
-
-		// Fall back to lookup by transaction_id.
-		$signup = \FairEvents\Models\EventSignup::get_by_transaction_id( (int) $transaction->id );
-		return $signup ? array( (int) $signup->id ) : array();
+		return \FairEvents\Models\EventSignup::resolve_signup_ids_from_transaction( $transaction );
 	}
 }

--- a/fair-events/src/Models/EventSignup.php
+++ b/fair-events/src/Models/EventSignup.php
@@ -181,6 +181,87 @@ class EventSignup {
 	}
 
 	/**
+	 * Get every signup row sharing a transaction ID. A 'multiple_instances'
+	 * ticket-type purchase creates one row per chosen occurrence under a
+	 * single transaction; every other purchase resolves to exactly one row.
+	 *
+	 * @param int $transaction_id Transaction ID.
+	 * @return object[]
+	 */
+	public static function get_all_by_transaction_id( int $transaction_id ) {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'fair_events_signups';
+
+		return $wpdb->get_results(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE transaction_id = %d ORDER BY id ASC', $table, $transaction_id )
+		);
+	}
+
+	/**
+	 * Resolve the signup row ID(s) tied to a fair-payments-connector
+	 * transaction, from its metadata. Returns an empty array when the
+	 * transaction isn't a get-tickets purchase.
+	 *
+	 * Promoted from PaymentHooks so the retry/cancel REST routes can resolve
+	 * the same multi-row set the payment webhook confirms/fails together.
+	 *
+	 * @param object $transaction Transaction object.
+	 * @return int[] Signup IDs (empty when none apply).
+	 */
+	public static function resolve_signup_ids_from_transaction( $transaction ) {
+		if ( ! isset( $transaction->metadata ) ) {
+			return array();
+		}
+
+		$metadata = is_string( $transaction->metadata )
+			? json_decode( $transaction->metadata, true )
+			: (array) $transaction->metadata;
+
+		if ( ( $metadata['source'] ?? '' ) !== 'fair-events-get-tickets' ) {
+			return array();
+		}
+
+		// 'multiple_instances' purchases store one signup row ID per chosen occurrence.
+		if ( ! empty( $metadata['signup_ids'] ) && is_array( $metadata['signup_ids'] ) ) {
+			return array_map( 'intval', $metadata['signup_ids'] );
+		}
+
+		if ( ! empty( $metadata['signup_id'] ) ) {
+			return array( (int) $metadata['signup_id'] );
+		}
+
+		// Fall back to lookup by transaction_id.
+		$signup = self::get_by_transaction_id( (int) $transaction->id );
+		return $signup ? array( (int) $signup->id ) : array();
+	}
+
+	/**
+	 * Cancel a pending-payment signup row: mark it failed and clear its hold,
+	 * so a direct-navigation lookup (SignupPaymentSession) can't resurrect the
+	 * same checkout after the visitor explicitly starts over.
+	 *
+	 * @param int $signup_id Signup row ID.
+	 * @return bool
+	 */
+	public static function cancel_pending( int $signup_id ) {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'fair_events_signups';
+
+		return (bool) $wpdb->update(
+			$table,
+			array(
+				'status'             => 'failed',
+				'payment_expires_at' => null,
+			),
+			array( 'id' => $signup_id ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+	}
+
+	/**
 	 * Get all signups for an event date.
 	 *
 	 * @param int $event_date_id Event date ID.

--- a/fair-events/src/Services/SignupPaymentSession.php
+++ b/fair-events/src/Services/SignupPaymentSession.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Signup Payment Session Service
+ *
+ * Manages a short-lived, HMAC-signed cookie that lets a visitor who navigates
+ * directly back to the event page (no provider redirect) be recognised as the
+ * owner of an in-progress get-tickets payment. The base form is anonymous —
+ * there is no participant/user identity to key the lookup on — so the cookie
+ * binds a (signup_id, transaction_id) pair instead, mirroring the pattern
+ * fair-audience's TransactionAccessToken/AudienceSession use for the same
+ * purpose.
+ *
+ * Cookie format: "{signup_id}.{transaction_id}.{expires_at}.{signature}"
+ *
+ * The expiry is part of the signed payload so a client cannot extend the
+ * lifetime by editing the cookie. Overridable by fair-audience at the #1245
+ * cutover, which has its own participant-based session.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Service for setting / reading / clearing the get-tickets payment session cookie.
+ */
+class SignupPaymentSession {
+
+	/**
+	 * Cookie name.
+	 */
+	const COOKIE_NAME = 'fair_events_signup_payment';
+
+	/**
+	 * Default cookie lifetime in seconds — matches the signup hold window
+	 * (EventSignup::update_transaction()'s 15-minute payment_expires_at).
+	 */
+	const DEFAULT_LIFETIME = 15 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Set the session cookie binding a signup row to its transaction.
+	 *
+	 * @param int $signup_id      Signup row ID.
+	 * @param int $transaction_id Transaction ID.
+	 * @param int $lifetime       Cookie lifetime in seconds.
+	 * @return void
+	 */
+	public static function set( int $signup_id, int $transaction_id, int $lifetime = self::DEFAULT_LIFETIME ): void {
+		if ( $signup_id <= 0 || $transaction_id <= 0 ) {
+			return;
+		}
+		if ( headers_sent() ) {
+			return;
+		}
+
+		$expires_at = time() + $lifetime;
+		$value      = self::build_value( $signup_id, $transaction_id, $expires_at );
+
+		self::send_cookie( $value, $expires_at );
+		$_COOKIE[ self::COOKIE_NAME ] = $value;
+	}
+
+	/**
+	 * Get the (signup_id, transaction_id) pair from a valid session cookie.
+	 *
+	 * Returns null when the cookie is missing, malformed, tampered, or expired.
+	 *
+	 * @return array{signup_id: int, transaction_id: int}|null
+	 */
+	public static function get(): ?array {
+		if ( empty( $_COOKIE[ self::COOKIE_NAME ] ) ) {
+			return null;
+		}
+
+		$raw = wp_unslash( $_COOKIE[ self::COOKIE_NAME ] );
+		if ( ! is_string( $raw ) ) {
+			return null;
+		}
+
+		$parts = explode( '.', $raw, 4 );
+		if ( 4 !== count( $parts ) ) {
+			return null;
+		}
+
+		list( $signup_id_str, $transaction_id_str, $expires_at_str, $signature ) = $parts;
+
+		if ( ! ctype_digit( $signup_id_str ) || ! ctype_digit( $transaction_id_str ) || ! ctype_digit( $expires_at_str ) ) {
+			return null;
+		}
+
+		$signup_id      = (int) $signup_id_str;
+		$transaction_id = (int) $transaction_id_str;
+		$expires_at     = (int) $expires_at_str;
+
+		if ( $signup_id <= 0 || $transaction_id <= 0 || $expires_at <= time() ) {
+			return null;
+		}
+
+		$expected = self::sign( $signup_id . '.' . $transaction_id . '.' . $expires_at );
+		if ( ! hash_equals( $expected, $signature ) ) {
+			return null;
+		}
+
+		return array(
+			'signup_id'      => $signup_id,
+			'transaction_id' => $transaction_id,
+		);
+	}
+
+	/**
+	 * Clear the session cookie.
+	 *
+	 * @return void
+	 */
+	public static function clear(): void {
+		if ( headers_sent() ) {
+			unset( $_COOKIE[ self::COOKIE_NAME ] );
+			return;
+		}
+		self::send_cookie( '', time() - HOUR_IN_SECONDS );
+		unset( $_COOKIE[ self::COOKIE_NAME ] );
+	}
+
+	/**
+	 * Build the signed cookie value.
+	 *
+	 * @param int $signup_id      Signup row ID.
+	 * @param int $transaction_id Transaction ID.
+	 * @param int $expires_at     Unix timestamp when the cookie should expire.
+	 * @return string Signed cookie payload.
+	 */
+	private static function build_value( int $signup_id, int $transaction_id, int $expires_at ): string {
+		$data      = $signup_id . '.' . $transaction_id . '.' . $expires_at;
+		$signature = self::sign( $data );
+		return $data . '.' . $signature;
+	}
+
+	/**
+	 * Send the Set-Cookie header.
+	 *
+	 * @param string $value      Cookie value (empty string clears).
+	 * @param int    $expires_at Unix timestamp.
+	 * @return void
+	 */
+	private static function send_cookie( string $value, int $expires_at ): void {
+		setcookie(
+			self::COOKIE_NAME,
+			$value,
+			array(
+				'expires'  => $expires_at,
+				'path'     => defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/',
+				'domain'   => defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : '',
+				'secure'   => is_ssl(),
+				'httponly' => true,
+				'samesite' => 'Lax',
+			)
+		);
+	}
+
+	/**
+	 * Sign data with HMAC-SHA256 using a service-specific salt.
+	 *
+	 * @param string $data Data to sign.
+	 * @return string Hex-encoded signature.
+	 */
+	private static function sign( string $data ): string {
+		$secret = 'fair_events_signup_payment_' . wp_salt( 'auth' );
+		return hash_hmac( 'sha256', $data, $secret );
+	}
+}

--- a/fair-events/src/Services/SignupPaymentState.php
+++ b/fair-events/src/Services/SignupPaymentState.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Signup Payment State Resolver
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Resolves a get-tickets transaction into the richer return-from-payment
+ * state (confirmed / processing / resume / retry) the unified Event Signup
+ * form needs, instead of the flat confirmed/processing/failed banner
+ * PaymentStatus::from_raw_status() collapses everything unfinished into.
+ *
+ * Single source of truth shared by the callback render path, the
+ * direct-navigation (cookie) fallback, and the payment-state REST route —
+ * all three build a transaction + its signup row(s) and hand them here.
+ */
+class SignupPaymentState {
+
+	/**
+	 * Transaction paid.
+	 */
+	const CONFIRMED = 'confirmed';
+
+	/**
+	 * A real payment attempt is in flight (Mollie's own 'pending' status) —
+	 * distinct from 'pending_payment', which just means a checkout link was
+	 * created and nothing is known about the buyer's progress yet.
+	 */
+	const PROCESSING = 'processing';
+
+	/**
+	 * An existing checkout link is still valid; the buyer can pick up where
+	 * they left off instead of starting a new attempt.
+	 */
+	const RESUME = 'resume';
+
+	/**
+	 * Terminal failure, or an unfinished attempt with no valid checkout link
+	 * to resume — a new payment attempt is needed.
+	 */
+	const RETRY = 'retry';
+
+	/**
+	 * Pure state resolution from a raw transaction status + checkout URL,
+	 * split out for unit testing without a database.
+	 *
+	 * @param string $status       Raw fair-payments-connector transaction status.
+	 * @param string $checkout_url Transaction's checkout_url, or ''.
+	 * @return string One of self::CONFIRMED, self::PROCESSING, self::RESUME, self::RETRY.
+	 */
+	public static function resolve_state( string $status, string $checkout_url ): string {
+		if ( 'paid' === $status ) {
+			return self::CONFIRMED;
+		}
+
+		if ( 'pending' === $status ) {
+			return self::PROCESSING;
+		}
+
+		// Terminal failure always retries, even with a stale checkout_url
+		// still on file — Mollie invalidates it once the payment is done.
+		if ( in_array( $status, array( 'failed', 'canceled', 'expired' ), true ) ) {
+			return self::RETRY;
+		}
+
+		return '' !== $checkout_url ? self::RESUME : self::RETRY;
+	}
+
+	/**
+	 * Resolve the full card payload for a transaction: syncs with the payment
+	 * provider first (the callback / in-progress paths this is used from both
+	 * need a reconciled status, per the ticket's no-false-paid/unpaid
+	 * requirement), then builds the state + amount/currency/checkout_url/event
+	 * payload the render and payment-state route both need.
+	 *
+	 * @param object   $transaction  Transaction object (from TransactionAPI::get_transaction()).
+	 * @param object[] $signup_rows  This transaction's fair_events_signups rows (see EventSignup::get_all_by_transaction_id()).
+	 * @param bool     $sync         Whether to reconcile with the provider before reading. Callers on a page-load
+	 *                               path with no reason to expect a status change (e.g. an already-confirmed poll
+	 *                               tick) should pass false to skip the provider round-trip.
+	 * @return array{state: string, transaction_id: int, amount: float, currency: string, checkout_url: string, event_date_id: int, event_title: string}
+	 */
+	public static function resolve_for_transaction( $transaction, array $signup_rows, bool $sync = true ): array {
+		if ( $sync
+			&& $transaction
+			&& ! empty( $transaction->id )
+			&& ! empty( $transaction->mollie_payment_id )
+			&& function_exists( 'fair_payment_sync_transaction_status' )
+		) {
+			$synced = fair_payment_sync_transaction_status( (int) $transaction->id );
+			if ( $synced && ! is_wp_error( $synced ) ) {
+				$transaction = $synced;
+			}
+		}
+
+		$status       = (string) ( $transaction->status ?? '' );
+		$checkout_url = (string) ( $transaction->checkout_url ?? '' );
+		$state        = self::resolve_state( $status, $checkout_url );
+
+		$first_row     = $signup_rows[0] ?? null;
+		$event_date_id = $first_row ? (int) $first_row->event_date_id : 0;
+
+		return array(
+			'state'          => $state,
+			'transaction_id' => (int) ( $transaction->id ?? 0 ),
+			'amount'         => (float) ( $transaction->amount ?? 0 ),
+			'currency'       => (string) ( $transaction->currency ?? '' ),
+			'checkout_url'   => self::RESUME === $state ? $checkout_url : '',
+			'event_date_id'  => $event_date_id,
+			'event_title'    => self::resolve_event_title( $event_date_id ),
+		);
+	}
+
+	/**
+	 * Resolve the event title for the confirmed/processing card copy.
+	 *
+	 * @param int $event_date_id Event-date ID the signup row(s) target.
+	 * @return string Event title, or '' when not resolvable.
+	 */
+	private static function resolve_event_title( int $event_date_id ): string {
+		if ( ! $event_date_id || ! class_exists( \FairEvents\Models\EventDates::class ) ) {
+			return '';
+		}
+
+		$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+		if ( ! $event_date || empty( $event_date->event_id ) ) {
+			return '';
+		}
+
+		return (string) get_the_title( (int) $event_date->event_id );
+	}
+}

--- a/fair-events/src/blocks/event-signup/frontend.css
+++ b/fair-events/src/blocks/event-signup/frontend.css
@@ -107,6 +107,68 @@
 	align-items: flex-end;
 }
 
+.fair-events-get-tickets-callback {
+	padding: 16px 20px;
+	border-radius: 4px;
+	border: 1px solid #ccc;
+	text-align: center;
+}
+
+.fair-events-get-tickets-callback-icon {
+	font-size: 2em;
+	line-height: 1;
+	color: #155724;
+}
+
+.fair-events-get-tickets-callback-heading {
+	margin: 8px 0;
+}
+
+.fair-events-get-tickets-callback-confirmed {
+	background: #d4edda;
+	color: #155724;
+	border-color: #c3e6cb;
+}
+
+.fair-events-get-tickets-callback-processing {
+	background: #fff3cd;
+	color: #856404;
+	border-color: #ffc107;
+}
+
+.fair-events-get-tickets-callback-spinner {
+	display: inline-block;
+	width: 24px;
+	height: 24px;
+	margin-bottom: 8px;
+	border: 3px solid rgba(133, 100, 4, 0.3);
+	border-top-color: #856404;
+	border-radius: 50%;
+	animation: fair-events-get-tickets-spin 0.8s linear infinite;
+}
+
+@keyframes fair-events-get-tickets-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.fair-events-get-tickets-callback-resume,
+.fair-events-get-tickets-callback-retry {
+	background: #f8d7da;
+	color: #721c24;
+	border-color: #f5c6cb;
+}
+
+.fair-events-get-tickets-callback-cancel {
+	margin-top: 8px;
+	font-size: 0.9em;
+}
+
+.fair-events-get-tickets-callback-message:empty {
+	display: none;
+}
+
 /* "Powered by Fair Event Plugins" attribution (opt-in, issue #1204). */
 .fair-audience-powered-by {
 	margin: 16px 0 0;

--- a/fair-events/src/blocks/event-signup/frontend.js
+++ b/fair-events/src/blocks/event-signup/frontend.js
@@ -4,12 +4,13 @@
  * @package FairEvents
  */
 
+import apiFetch from '@wordpress/api-fetch';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	showMessage,
 	onDomReady,
 	initiatePayment,
-	handlePaymentCallback,
+	pollPaymentStatus,
 	computeTicketTotal,
 	formatMoney,
 	collectQuestionAnswers,
@@ -18,7 +19,7 @@ import {
 import './frontend.css';
 
 const CSS_PREFIX = 'fair-events-get-tickets';
-const STATUS_PATH = '/fair-payments-connector/v1/payments';
+const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 
 (function () {
 	'use strict';
@@ -26,11 +27,17 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 	onDomReady(initialize);
 
 	function initialize() {
-		const container = document.querySelector('.fair-events-get-tickets');
-		handlePaymentCallback({
-			statusPath: STATUS_PATH,
-			onConfirmed: () => handleConfirmed(container),
-		});
+		document
+			.querySelectorAll('.fair-events-get-tickets-callback-processing')
+			.forEach(wireProcessingCard);
+		document
+			.querySelectorAll(
+				'.fair-events-get-tickets-callback-resume, .fair-events-get-tickets-callback-retry'
+			)
+			.forEach(function (container) {
+				wireRetryButton(container);
+				wireCancelLink(container);
+			});
 
 		const forms = document.querySelectorAll(
 			'.fair-events-get-tickets-form'
@@ -38,29 +45,176 @@ const STATUS_PATH = '/fair-payments-connector/v1/payments';
 		forms.forEach(setupForm);
 	}
 
-	function handleConfirmed(container) {
-		if (!container) {
+	/**
+	 * Build the payment-state query string from a callback card's data
+	 * attributes.
+	 * @param {HTMLElement} container Card element carrying data-transaction-id/data-token.
+	 * @return {string} Query string including the leading '?'.
+	 */
+	function paymentStateQuery(container) {
+		const transactionId = container.dataset.transactionId || '';
+		const token = container.dataset.token || '';
+		const params = new URLSearchParams();
+		if (transactionId) {
+			params.set('transaction_id', transactionId);
+		}
+		if (token) {
+			params.set('token', token);
+		}
+		const query = params.toString();
+		return query ? `?${query}` : '';
+	}
+
+	/**
+	 * Poll the payment-state endpoint while the "thank you, confirming with
+	 * your bank" card is showing. Swaps to the confirmed card in place once
+	 * paid; reloads the page on any other resolved outcome (failed/resume/
+	 * retry) so the visitor sees the exact server-rendered card instead of a
+	 * client-built approximation.
+	 * @param {HTMLElement} container The processing card element.
+	 */
+	function wireProcessingCard(container) {
+		if (!container.dataset.transactionId) {
 			return;
 		}
 
-		const messageContainer = container.querySelector('.message-container');
-		const form = container.querySelector('.fair-events-get-tickets-form');
+		pollPaymentStatus({
+			path: `${PAYMENT_STATE_PATH}${paymentStateQuery(container)}`,
+			onConfirmed: (response) => swapToConfirmedCard(container, response),
+			onFailed: () => window.location.reload(),
+			onProcessing: (response) => {
+				if (response.state === 'resume' || response.state === 'retry') {
+					window.location.reload();
+				}
+			},
+		});
+	}
 
-		if (messageContainer) {
-			showMessage(
-				messageContainer,
-				__(
-					'Your ticket purchase was successful! Thank you.',
+	/**
+	 * Replace the processing card's contents with the paid confirmation.
+	 * @param {HTMLElement} container The processing card element.
+	 * @param {Object}      response  payment-state response.
+	 */
+	function swapToConfirmedCard(container, response) {
+		container.classList.remove(
+			'fair-events-get-tickets-callback-processing'
+		);
+		container.classList.add('fair-events-get-tickets-callback-confirmed');
+		container.innerHTML = '';
+
+		const icon = document.createElement('div');
+		icon.className = 'fair-events-get-tickets-callback-icon';
+		icon.setAttribute('aria-hidden', 'true');
+		icon.textContent = '✓';
+		container.appendChild(icon);
+
+		const heading = document.createElement('h2');
+		heading.className = 'fair-events-get-tickets-callback-heading';
+		heading.textContent = __('Payment confirmed', 'fair-events');
+		container.appendChild(heading);
+
+		if (response.amount) {
+			const amountEl = document.createElement('p');
+			amountEl.className = 'fair-events-get-tickets-callback-amount';
+			amountEl.textContent = `${__(
+				'Amount paid:',
+				'fair-events'
+			)} ${formatMoney(response.amount, response.currency)}`;
+			container.appendChild(amountEl);
+		}
+
+		const emailEl = document.createElement('p');
+		emailEl.className = 'fair-events-get-tickets-callback-email';
+		emailEl.textContent = __(
+			'A confirmation email is on its way. You can close this page.',
+			'fair-events'
+		);
+		container.appendChild(emailEl);
+	}
+
+	/**
+	 * Wire a resume/retry card's "Retry payment" button, if present (the
+	 * resume card links straight to its existing checkout_url instead).
+	 * @param {HTMLElement} container The resume/retry card element.
+	 */
+	function wireRetryButton(container) {
+		const button = container.querySelector(
+			'.fair-events-get-tickets-callback-retry-button'
+		);
+		if (!button) {
+			return;
+		}
+
+		const messageContainer = container.querySelector(
+			'.fair-events-get-tickets-callback-message'
+		);
+
+		button.addEventListener('click', function () {
+			initiatePayment({
+				apiPath: '/fair-events/v1/get-tickets/retry-payment',
+				data: {
+					transaction_id: parseInt(
+						container.dataset.transactionId,
+						10
+					),
+					token: container.dataset.token || '',
+				},
+				button,
+				loadingText: __('Redirecting…', 'fair-events'),
+				defaultErrorMessage: __(
+					'Could not start the retry. Please try again.',
 					'fair-events'
 				),
-				'success',
-				CSS_PREFIX
-			);
+				onError: (message) => {
+					showMessage(messageContainer, message, 'error', CSS_PREFIX);
+				},
+			}).catch(function () {
+				// Error already surfaced via onError.
+			});
+		});
+	}
+
+	/**
+	 * Wire a resume/retry card's "Cancel and start over" link so it clears
+	 * the pending_payment hold (and the session cookie) server-side before
+	 * reloading with the callback params stripped — without this, the
+	 * direct-navigation fallback would resurrect the same checkout on the
+	 * next load.
+	 * @param {HTMLElement} container The resume/retry card element.
+	 */
+	function wireCancelLink(container) {
+		const link = container.querySelector(
+			'.fair-events-get-tickets-callback-cancel-link'
+		);
+		if (!link) {
+			return;
 		}
 
-		if (form) {
-			form.style.display = 'none';
-		}
+		link.addEventListener('click', function (event) {
+			event.preventDefault();
+
+			apiFetch({
+				path: '/fair-events/v1/get-tickets/cancel-payment',
+				method: 'POST',
+				data: {
+					transaction_id: parseInt(
+						container.dataset.transactionId,
+						10
+					),
+					token: container.dataset.token || '',
+				},
+			})
+				.catch(function (error) {
+					console.error('Cancel payment error:', error);
+				})
+				.finally(function () {
+					const url = new URL(window.location.href);
+					url.searchParams.delete('fair_payment_callback');
+					url.searchParams.delete('transaction_id');
+					url.searchParams.delete('token');
+					window.location.href = url.toString();
+				});
+		});
 	}
 
 	function setupForm(form) {

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -78,12 +78,19 @@ if ( ! $event_date_id ) {
 	return;
 }
 
-// Handle fair_payment_callback return state.
+// Handle fair_payment_callback return state, plus a direct-navigation
+// fallback: a visitor who navigates straight back to the event page (no
+// provider redirect) is recognised via the short-lived SignupPaymentSession
+// cookie set when create_signup() returned payment_required, so the same
+// confirmed/processing/resume/retry card shows within the payment hold
+// window. See SignupPaymentState for the state resolution this feeds.
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $is_payment_callback = ! empty( $_GET['fair_payment_callback'] ) && ! empty( $_GET['transaction_id'] );
-$callback_status     = '';
 $callback_tx_id      = 0;
 $callback_token      = '';
+$signup_transaction  = null;
+$signup_state        = null;
+
 if ( $is_payment_callback && class_exists( \FairPaymentsConnector\API\TransactionAPI::class ) ) {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$callback_tx_id = absint( $_GET['transaction_id'] );
@@ -92,8 +99,45 @@ if ( $is_payment_callback && class_exists( \FairPaymentsConnector\API\Transactio
 	$transaction    = \FairPaymentsConnector\API\TransactionAPI::get_transaction( $callback_tx_id );
 	$expected_token = $transaction ? (string) ( $transaction->access_token ?? '' ) : '';
 	if ( $transaction && '' !== $expected_token && '' !== $callback_token && hash_equals( $expected_token, $callback_token ) ) {
-		$callback_status = \FairPaymentsConnector\Payment\PaymentStatus::from_raw_status( (string) $transaction->status );
+		$signup_transaction = $transaction;
 	}
+}
+
+if ( ! $signup_transaction
+	&& class_exists( \FairPaymentsConnector\API\TransactionAPI::class )
+	&& class_exists( \FairEvents\Services\SignupPaymentSession::class )
+) {
+	$session = \FairEvents\Services\SignupPaymentSession::get();
+	if ( $session ) {
+		$session_signup = \FairEvents\Models\EventSignup::get_by_id( $session['signup_id'] );
+		if ( $session_signup
+			&& (int) $session_signup->transaction_id === $session['transaction_id']
+			&& 'pending_payment' === $session_signup->status
+			&& $session_signup->payment_expires_at
+			&& strtotime( $session_signup->payment_expires_at ) > time()
+		) {
+			$signup_transaction = \FairPaymentsConnector\API\TransactionAPI::get_transaction( $session['transaction_id'] );
+			if ( $signup_transaction ) {
+				$callback_tx_id = (int) $session['transaction_id'];
+				$callback_token = (string) ( $signup_transaction->access_token ?? '' );
+			}
+		}
+	}
+}
+
+if ( $signup_transaction && class_exists( \FairEvents\Services\SignupPaymentState::class ) ) {
+	$signup_rows  = \FairEvents\Models\EventSignup::get_all_by_transaction_id( (int) $signup_transaction->id );
+	$signup_state = \FairEvents\Services\SignupPaymentState::resolve_for_transaction( $signup_transaction, $signup_rows );
+}
+
+// Legacy three-value key, kept for back-compat with fair_events_signup_render_context
+// consumers documented in REST_API_BACKEND.md; 'resume'/'retry' both map to
+// 'failed' here since that enum predates the richer state.
+$callback_status = '';
+if ( $signup_state ) {
+	$callback_status = in_array( $signup_state['state'], array( 'resume', 'retry' ), true )
+		? 'failed'
+		: $signup_state['state'];
 }
 
 // Load event date.
@@ -182,8 +226,8 @@ if ( class_exists( \FairEvents\Services\TicketPricing::class ) && class_exists( 
  *
  * @param array    $context    Render context (event_date_id, ticket_types, price_by_type_id,
  *                              active_sale_period, occurrences_for_picker,
- *                              callback_status, callback_tx_id, callback_token, prefill_name,
- *                              prefill_email, submit_button_text).
+ *                              callback_status, callback_tx_id, callback_token, callback_state,
+ *                              callback_source, prefill_name, prefill_email, submit_button_text).
  * @param array    $attributes Block attributes.
  * @param WP_Block $block      Block instance.
  */
@@ -198,6 +242,15 @@ $context = apply_filters(
 		'callback_status'        => $callback_status,
 		'callback_tx_id'         => $callback_tx_id,
 		'callback_token'         => $callback_token,
+		// Resolved confirmed/processing/resume/retry state + card payload
+		// (SignupPaymentState::resolve_for_transaction()'s shape), or null
+		// when there's nothing to show. A companion plugin (fair-audience,
+		// at the #1245 cutover) overrides this to plug in its own identity
+		// lookup instead of the anonymous cookie fallback.
+		'callback_state'         => $signup_state,
+		// Which lookup produced callback_state: 'url' (provider redirect),
+		// 'session' (direct-navigation cookie), or '' when none applied.
+		'callback_source'        => $signup_state ? ( $is_payment_callback ? 'url' : 'session' ) : '',
 		'prefill_name'           => '',
 		'prefill_email'          => '',
 		'submit_button_text'     => $submit_button_text,
@@ -212,6 +265,7 @@ $price_by_type_id       = $context['price_by_type_id'];
 $active_sale_period     = $context['active_sale_period'];
 $occurrences_for_picker = $context['occurrences_for_picker'];
 $callback_status        = $context['callback_status'];
+$signup_state           = $context['callback_state'];
 $prefill_name           = $context['prefill_name'];
 $prefill_email          = $context['prefill_email'];
 $submit_button_text     = $context['submit_button_text'];
@@ -272,25 +326,119 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 ?>
 
 <div class="fair-events-get-tickets">
-<?php if ( 'confirmed' === $callback_status ) : ?>
-	<div class="message-container message-success" role="alert">
-		<?php esc_html_e( 'Your ticket purchase was successful! Thank you.', 'fair-events' ); ?>
-	</div>
-<?php elseif ( 'failed' === $callback_status ) : ?>
-	<div class="message-container message-error" role="alert">
-		<?php esc_html_e( 'Your payment was not completed. Please try again.', 'fair-events' ); ?>
-	</div>
-<?php elseif ( 'processing' === $callback_status ) : ?>
-	<div class="message-container message-processing" role="alert">
-		<?php esc_html_e( 'Your payment is being processed. Please check back shortly.', 'fair-events' ); ?>
-	</div>
-<?php endif; ?>
-
-<?php if ( 'confirmed' !== $callback_status && $all_purchases_blocked ) : ?>
+<?php if ( $signup_state ) : ?>
+	<?php
+	$amount_display = \FairEventsShared\Money::format_display( (float) $signup_state['amount'], $signup_state['currency'] );
+	?>
+	<?php if ( 'confirmed' === $signup_state['state'] ) : ?>
+		<div class="fair-events-get-tickets-callback fair-events-get-tickets-callback-confirmed" data-transaction-id="<?php echo esc_attr( (string) $signup_state['transaction_id'] ); ?>">
+			<div class="fair-events-get-tickets-callback-icon" aria-hidden="true">✓</div>
+			<h2 class="fair-events-get-tickets-callback-heading"><?php esc_html_e( 'Payment confirmed', 'fair-events' ); ?></h2>
+			<?php if ( $signup_state['event_title'] ) : ?>
+				<p class="fair-events-get-tickets-callback-event">
+					<?php
+					printf(
+						/* translators: %s: event title */
+						esc_html__( "You're signed up for %s.", 'fair-events' ),
+						'<strong>' . esc_html( $signup_state['event_title'] ) . '</strong>'
+					);
+					?>
+				</p>
+			<?php endif; ?>
+			<p class="fair-events-get-tickets-callback-amount">
+				<?php
+				printf(
+					/* translators: %s: formatted amount with currency */
+					esc_html__( 'Amount paid: %s', 'fair-events' ),
+					esc_html( $amount_display )
+				);
+				?>
+			</p>
+			<p class="fair-events-get-tickets-callback-email">
+				<?php esc_html_e( 'A confirmation email is on its way. You can close this page.', 'fair-events' ); ?>
+			</p>
+		</div>
+	<?php elseif ( 'processing' === $signup_state['state'] ) : ?>
+		<div class="fair-events-get-tickets-callback fair-events-get-tickets-callback-processing"
+			data-transaction-id="<?php echo esc_attr( (string) $signup_state['transaction_id'] ); ?>"
+			data-token="<?php echo esc_attr( $callback_token ); ?>">
+			<div class="fair-events-get-tickets-callback-spinner" aria-hidden="true"></div>
+			<h2 class="fair-events-get-tickets-callback-heading"><?php esc_html_e( 'Thank you for your payment!', 'fair-events' ); ?></h2>
+			<p class="fair-events-get-tickets-callback-status">
+				<?php esc_html_e( "We're confirming with your bank. This usually takes a few seconds — the page will update as soon as it's done.", 'fair-events' ); ?>
+			</p>
+			<p class="fair-events-get-tickets-callback-amount">
+				<?php
+				printf(
+					/* translators: %s: formatted amount with currency */
+					esc_html__( 'Amount: %s', 'fair-events' ),
+					esc_html( $amount_display )
+				);
+				?>
+			</p>
+		</div>
+	<?php elseif ( 'resume' === $signup_state['state'] ) : ?>
+		<div class="fair-events-get-tickets-callback fair-events-get-tickets-callback-resume"
+			data-transaction-id="<?php echo esc_attr( (string) $signup_state['transaction_id'] ); ?>"
+			data-token="<?php echo esc_attr( $callback_token ); ?>">
+			<p class="fair-events-get-tickets-callback-heading"><strong><?php esc_html_e( 'Your payment is waiting.', 'fair-events' ); ?></strong></p>
+			<p class="fair-events-get-tickets-callback-status">
+				<?php esc_html_e( 'You can pick up where you left off on the secure payment page.', 'fair-events' ); ?>
+			</p>
+			<p class="fair-events-get-tickets-callback-amount">
+				<?php
+				printf(
+					/* translators: %s: formatted amount with currency */
+					esc_html__( 'Amount due: %s', 'fair-events' ),
+					esc_html( $amount_display )
+				);
+				?>
+			</p>
+			<div class="wp-block-button">
+				<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( $signup_state['checkout_url'] ); ?>">
+					<?php esc_html_e( 'Continue payment', 'fair-events' ); ?>
+				</a>
+			</div>
+			<p class="fair-events-get-tickets-callback-cancel">
+				<a href="#" class="fair-events-get-tickets-callback-cancel-link"><?php esc_html_e( 'Cancel and start over', 'fair-events' ); ?></a>
+			</p>
+		</div>
+	<?php elseif ( 'retry' === $signup_state['state'] ) : ?>
+		<div class="fair-events-get-tickets-callback fair-events-get-tickets-callback-retry"
+			data-transaction-id="<?php echo esc_attr( (string) $signup_state['transaction_id'] ); ?>"
+			data-token="<?php echo esc_attr( $callback_token ); ?>">
+			<p class="fair-events-get-tickets-callback-heading"><strong><?php esc_html_e( "Your payment didn't go through.", 'fair-events' ); ?></strong></p>
+			<p class="fair-events-get-tickets-callback-amount">
+				<?php
+				printf(
+					/* translators: %s: formatted amount with currency */
+					esc_html__( 'Amount due: %s', 'fair-events' ),
+					esc_html( $amount_display )
+				);
+				?>
+			</p>
+			<?php if ( $all_purchases_blocked ) : ?>
+				<div class="message-container message-error" role="alert">
+					<?php esc_html_e( 'Ticket sales are temporarily unavailable. Please check back later.', 'fair-events' ); ?>
+				</div>
+			<?php else : ?>
+				<div class="wp-block-button">
+					<button type="button" class="wp-block-button__link wp-element-button fair-events-get-tickets-callback-retry-button">
+						<?php esc_html_e( 'Retry payment', 'fair-events' ); ?>
+					</button>
+				</div>
+			<?php endif; ?>
+			<p class="fair-events-get-tickets-callback-cancel">
+				<a href="#" class="fair-events-get-tickets-callback-cancel-link"><?php esc_html_e( 'Cancel and start over', 'fair-events' ); ?></a>
+			</p>
+			<div class="fair-events-get-tickets-callback-message message-container" style="display: none;"></div>
+		</div>
+	<?php endif; ?>
+<?php elseif ( $all_purchases_blocked ) : ?>
 	<div class="message-container message-error" role="alert">
 		<?php esc_html_e( 'Ticket sales are temporarily unavailable. Please check back later.', 'fair-events' ); ?>
 	</div>
-<?php elseif ( 'confirmed' !== $callback_status ) : ?>
+<?php else : ?>
 	<form
 		id="<?php echo esc_attr( $form_id ); ?>"
 		class="fair-events-get-tickets-form"


### PR DESCRIPTION
## Summary

- Gives the fair-events unified Event Signup form (base render, used when
  fair-audience is inactive) the same rich return-from-payment experience the
  legacy fair-audience form has: confirmed / processing / resume / retry
  cards instead of three flat banners, plus a direct-navigation fallback so a
  visitor who goes straight back to the event page (no provider redirect)
  still sees their in-progress payment.
- New `FairEvents\Services\SignupPaymentState` (state resolution + provider
  sync) and `FairEvents\Services\SignupPaymentSession` (short-lived signed
  cookie, mirroring fair-audience's participant session for this anonymous
  form) back three new routes on `GetTicketsController`: `payment-state`,
  `retry-payment`, `cancel-payment`.

Closes #1244

## Acceptance criteria

- [x] **Confirmed / processing / retry-or-resume states all render correctly
      on return from payment.** `render.php` now renders one of four cards
      (`fair-events-get-tickets-callback-{confirmed,processing,resume,retry}`)
      driven by `SignupPaymentState::resolve_for_transaction()`. Verified via
      a WP-CLI `eval-file` integration check rendering the real block for
      each state, and e2e (`get-tickets-purchase.spec.js`,
      `get-tickets-return-and-retry.spec.js`).
- [x] **In-progress payment is surfaced on direct navigation back, within the
      hold window, for the right visitor only.** `SignupPaymentSession` sets
      an HMAC-signed `signup_id:transaction_id` cookie when `create_signup`
      returns `payment_required`; `render.php` falls back to it when there's
      no URL callback, gated on the signup row still being
      `pending_payment` within its 15-minute hold. Covered by
      `get-tickets-cancel-and-restart.spec.js` (rewritten — its premise, "no
      such fallback exists," is exactly what this ticket adds) and the
      integration check.
- [x] **Status is reconciled with the provider on return; no false
      "paid"/"unpaid".** `SignupPaymentState::resolve_for_transaction()`
      calls `fair_payment_sync_transaction_status()` before reading, for
      both the URL-callback and session-fallback paths (not on the plain
      form, per the ticket's performance note).
- [x] **Fail-closed-when-unavailable behaviour preserved.** The existing
      `$all_purchases_blocked` gate still hides the plain form; a retry card
      renders through it too (hides the Retry button, shows the same "sales
      temporarily unavailable" notice instead) so a buyer who already paid
      never sees only that notice — matches the ticket's Risks section.
- [x] **API spec coverage for the callback state resolution; e2e coverage for
      the pay → return → retry flow.**
      `GetTicketsPaymentState.api.spec.js` covers the ownership/enumeration
      boundary all three new routes share (unknown/omitted `transaction_id`
      always 404s, never a more specific error, no admin carve-out).
      `get-tickets-return-and-retry.spec.js` drives failed → retry → paid
      end-to-end against the Mollie double (its GET status is now settable
      via `set-mollie-status.php`, addressing epic #1083's OQ this ticket
      inherited); `get-tickets-cancel-and-restart.spec.js` covers the
      abandon → direct-nav resume → cancel → fresh-purchase path.

## Implementation notes

- `SignupPaymentState::resolve_state()` is pure (unit-tested without a DB):
  `paid` → confirmed, `pending` → processing, terminal failure → retry
  regardless of a stale `checkout_url`, otherwise resume-if-checkout_url
  else retry.
- `PaymentHooks::resolve_signup_ids()` is promoted to
  `EventSignup::resolve_signup_ids_from_transaction()` (with `PaymentHooks`
  delegating) so retry/cancel resolve the same multi-row set a
  `multiple_instances` purchase creates.
- `fair-events-shared/src/payment-flow.js`: extracted `pollPaymentStatus()`
  (generic path + `lifecycle_status` polling) out of `handlePaymentCallback()`,
  which is now a thin URL-param wrapper over it — existing consumers
  (fair-payments-connector's simple-payment block) are unaffected.
- No schema change — reuses `fair_events_signups.status` /
  `payment_expires_at` (already the hold window) and `TicketPricing`'s
  reuse-what-exists philosophy.
- Rewrote `get-tickets-purchase.spec.js`'s paid-path assertions for the new
  card classes; since render now syncs on every callback render, the double
  is set to `pending` (a real in-flight status) rather than relying on its
  default `paid` so the processing → confirmed transition still exercises
  the webhook path, not just sync-on-render.

## Deferred / out of scope (per plan Decisions)

- Callback URL param convergence (`transaction_id`+`token` vs. legacy
  `fair_signup_tx`/`fst_sig`) is epic #858/#1245, not this ticket.
- fair-audience overriding this seam (participant-based session instead of
  the anonymous cookie) is #1245, the cutover ticket.
- Retry rate limiting (separate, more permissive than `create_signup`'s
  3/hour) is scoped here but not yet wired to an explicit limiter — retry is
  token/cookie-gated so it isn't an anonymous surface; flagging in case a
  reviewer wants it enforced explicitly before #1245.

## Testing

- `npm run test:js` (fair-events): 170/170 pass.
- `npm run test:js` (fair-events-shared payment-flow.test.js): pass,
  including new `pollPaymentStatus` coverage.
- PHPUnit (fair-events): `SignupPaymentStateTest` 9/9 pass; pre-existing
  unrelated `SettingsPageTest` failures confirmed present on `main` too.
- `phpcs`: clean for every changed/new file (confirmed the few flagged lines
  are pre-existing, unmodified by this branch, by diffing against `main`).
- API spec (`GetTicketsPaymentState.api.spec.js`): 7/7 pass, run against a
  freshly-provisioned isolated `wp-env` instance (fair-audience deactivated,
  matching the controller's own registration guard).
- E2E: ran the **entire** `e2e/user-flows/` suite (32 tests, all plugins)
  against that same isolated instance — 32/32 pass, no regressions.
- Manual: WP-CLI `eval-file` integration check rendering the real block for
  all four states plus the cookie fallback — all passed; verified no
  leftover DB rows afterward.
