### PR TITLE
Fix budgets/transactions links to the retired Entries slug

### DIFF
--- a/.changeset/fix-entries-page-move-links.md
+++ b/.changeset/fix-entries-page-move-links.md
@@ -1,0 +1,6 @@
+---
+"fair-finance": patch
+"fair-payments-connector": patch
+---
+
+Fixed broken links left over from the Budgets/Entries/Reconciliation screens' move from Payments Connector into Finance: the budgets list's "View" links (for a specific budget and for unbudgeted entries) now point at the current `fair-finance-entries` admin page instead of the retired, unregistered slug that produced a permissions-denied page. The transactions list's entry column, whose deep link into a specific entry never actually worked, now shows the entry ids as plain text instead of a dead link.

--- a/TESTING.md
+++ b/TESTING.md
@@ -248,7 +248,7 @@ login + `WP_BASE_URL` convention; defaults to the dev wp-env on `:8888`,
 
 ```bash
 # npm run screenshot -- <path> <dimensions> <filename>
-npm run screenshot -- "/wp-admin/admin.php?page=fair-payments-connector-budgets" mobile budgets-mobile.png
+npm run screenshot -- "/wp-admin/admin.php?page=fair-finance-budgets" mobile budgets-mobile.png
 
 # dimensions: desktop | tablet | mobile | WIDTHxHEIGHT (e.g. 414x900)
 # options: --viewport (visible area only), --wait <ms>, --wait-for <selector>,

--- a/fair-finance/jest.config.js
+++ b/fair-finance/jest.config.js
@@ -1,7 +1,10 @@
 export default {
 	preset: '@wordpress/jest-preset-default',
 	testEnvironment: 'jsdom',
-	testMatch: ['**/__tests__/**/*.js', '**/?(*.)+(spec|test).js'],
+	testMatch: [
+		'**/__tests__/**/*.[jt]s?(x)',
+		'**/?(*.)+(spec|test).[jt]s?(x)',
+	],
 	testPathIgnorePatterns: [
 		'/node_modules/',
 		'/vendor/',

--- a/fair-finance/src/Admin/budgets/BudgetsApp.js
+++ b/fair-finance/src/Admin/budgets/BudgetsApp.js
@@ -201,7 +201,7 @@ const BudgetsApp = () => {
 	};
 
 	return (
-		<div className="wrap fair-payments-connector-budgets-page">
+		<div className="wrap fair-finance-budgets-page">
 			{/*
 			 * Anchor for WordPress admin notices. Core's common.js inserts
 			 * .notice elements right after `.wp-header-end` (or, lacking it,
@@ -410,12 +410,12 @@ const BudgetsApp = () => {
 													>
 														<HStack
 															spacing={2}
-															className="fair-payments-connector-budget-actions"
+															className="fair-finance-budget-actions"
 														>
 															<Button
 																variant="secondary"
 																size="small"
-																href={`admin.php?page=fair-payments-connector-entries&budget_id=${budget.id}`}
+																href={`admin.php?page=fair-finance-entries&budget_id=${budget.id}`}
 															>
 																{__(
 																	'View',
@@ -514,7 +514,7 @@ const BudgetsApp = () => {
 												<Button
 													variant="secondary"
 													size="small"
-													href="admin.php?page=fair-payments-connector-entries&budget_id=none"
+													href="admin.php?page=fair-finance-entries&budget_id=none"
 												>
 													{__(
 														'View',

--- a/fair-finance/src/Admin/budgets/__tests__/BudgetsApp.test.jsx
+++ b/fair-finance/src/Admin/budgets/__tests__/BudgetsApp.test.jsx
@@ -1,0 +1,75 @@
+/**
+ * Component tests for the budgets list "View" links (#1290).
+ *
+ * The entries screen moved to fair-finance; these links used to point at the
+ * retired `fair-payments-connector-entries` slug and 404'd. Pins the hrefs to
+ * the live `fair-finance-entries` slug for both a specific budget and the
+ * unbudgeted ("none") row.
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import BudgetsApp from '../BudgetsApp.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const BUDGETS = [{ id: 7, name: 'Venue', description: '' }];
+
+const STATS = {
+	7: {
+		total_cost: 100,
+		total_income: 0,
+		balance: -100,
+		total_count: 1,
+	},
+	unbudgeted: {
+		total_cost: 0,
+		total_income: 50,
+		balance: 50,
+		cost_count: 0,
+		income_count: 1,
+		total_count: 1,
+	},
+};
+
+beforeEach(() => {
+	apiFetch.mockImplementation(({ path }) => {
+		if (path === '/fair-finance/v1/budgets') {
+			return Promise.resolve(BUDGETS);
+		}
+		if (path === '/fair-finance/v1/budgets/stats') {
+			return Promise.resolve(STATS);
+		}
+		return Promise.resolve({});
+	});
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+describe('BudgetsApp — view entries links', () => {
+	it('links a budget row to its filtered entries on the live fair-finance slug', async () => {
+		render(<BudgetsApp />);
+
+		const links = await screen.findAllByRole('link', { name: 'View' });
+		const budgetLink = links.find(
+			(l) =>
+				l.getAttribute('href') ===
+				'admin.php?page=fair-finance-entries&budget_id=7'
+		);
+		expect(budgetLink).toBeInTheDocument();
+	});
+
+	it('links the unbudgeted row to entries filtered to budget_id=none', async () => {
+		render(<BudgetsApp />);
+
+		const links = await screen.findAllByRole('link', { name: 'View' });
+		const unbudgetedLink = links.find(
+			(l) =>
+				l.getAttribute('href') ===
+				'admin.php?page=fair-finance-entries&budget_id=none'
+		);
+		expect(unbudgetedLink).toBeInTheDocument();
+	});
+});

--- a/fair-finance/src/Admin/budgets/style.scss
+++ b/fair-finance/src/Admin/budgets/style.scss
@@ -7,17 +7,17 @@
  * mobile breakpoint we drop the table grid and render each row as a stacked
  * card with label/value pairs so the content stays readable.
  *
- * Everything is scoped under `.fair-payments-connector-budgets-page` so other
+ * Everything is scoped under `.fair-finance-budgets-page` so other
  * `wp-list-table`s in the admin are untouched, and lives inside a media query
  * so the desktop layout is unchanged.
  *
- * The selectors deliberately stack `.wrap.fair-payments-connector-budgets-page` and
+ * The selectors deliberately stack `.wrap.fair-finance-budgets-page` and
  * `.wp-list-table.widefat` to outweigh WordPress core's responsive list-table
  * rules (`...td::before { content: attr(data-colname); }`, active below 782px),
  * which would otherwise blank out our `data-label` text.
  */
 
-.wrap.fair-payments-connector-budgets-page {
+.wrap.fair-finance-budgets-page {
 	@media screen and (max-width: 600px) {
 		.wp-list-table.widefat {
 			display: block;
@@ -84,7 +84,7 @@
 			}
 
 			// Let the View / Edit / Delete buttons wrap and stay right-aligned.
-			.fair-payments-connector-budget-actions {
+			.fair-finance-budget-actions {
 				flex-wrap: wrap;
 				justify-content: flex-end;
 			}

--- a/fair-finance/src/Admin/entries/EntriesApp.js
+++ b/fair-finance/src/Admin/entries/EntriesApp.js
@@ -624,7 +624,7 @@ const EntriesApp = () => {
 	];
 
 	return (
-		<div className="wrap fair-payments-connector-entries-page">
+		<div className="wrap fair-finance-entries-page">
 			<VStack spacing={4}>
 				{/* Totals Summary */}
 				<Card>

--- a/fair-finance/src/Admin/entries/style.scss
+++ b/fair-finance/src/Admin/entries/style.scss
@@ -6,12 +6,12 @@
  * become unreadable. Below the mobile breakpoint we stack them vertically
  * instead of forcing them onto one row.
  *
- * Scoped under `.wrap.fair-payments-connector-entries-page` so nothing else
+ * Scoped under `.wrap.fair-finance-entries-page` so nothing else
  * is touched, and lives inside a media query so the desktop layout is
  * unchanged.
  */
 
-.wrap.fair-payments-connector-entries-page {
+.wrap.fair-finance-entries-page {
 	@media screen and (max-width: 600px) {
 		.fair-finance-entries-summary {
 			flex-direction: column;

--- a/fair-payments-connector/src/Admin/transactions/TransactionsApp.js
+++ b/fair-payments-connector/src/Admin/transactions/TransactionsApp.js
@@ -620,26 +620,12 @@ const TransactionsApp = () => {
 											<td>
 												{t.entry_ids &&
 												t.entry_ids.length > 0
-													? t.entry_ids.map(
-															(entryId, i) => (
-																<span
-																	key={
-																		entryId
-																	}
-																>
-																	{i > 0 &&
-																		', '}
-																	<a
-																		href={`admin.php?page=fair-payments-connector-entries&entry_id=${entryId}`}
-																	>
-																		#
-																		{
-																			entryId
-																		}
-																	</a>
-																</span>
+													? t.entry_ids
+															.map(
+																(entryId) =>
+																	`#${entryId}`
 															)
-													  )
+															.join(', ')
 													: '-'}
 											</td>
 											<td>{t.created_at}</td>

--- a/fair-payments-connector/src/Admin/transactions/__tests__/TransactionsApp.test.jsx
+++ b/fair-payments-connector/src/Admin/transactions/__tests__/TransactionsApp.test.jsx
@@ -1,0 +1,67 @@
+/**
+ * Component test for the transactions list "Entry" column (#1290).
+ *
+ * The `entry_id` deep link into the entries screen never worked (no reader,
+ * no filter, no model support), so instead of repairing it the link is
+ * dropped: entry ids render as plain, comma-separated text and no anchor
+ * points at the retired `fair-payments-connector-entries` slug.
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import TransactionsApp from '../TransactionsApp.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const TRANSACTION = {
+	id: 42,
+	amount: 12.5,
+	currency: 'EUR',
+	mollie_fee: null,
+	application_fee: null,
+	status: 'paid',
+	testmode: false,
+	description: 'Ticket purchase',
+	participant: null,
+	user_name: 'Jane Doe',
+	entry_ids: [12, 34],
+	created_at: '2026-07-01',
+};
+
+beforeEach(() => {
+	apiFetch.mockImplementation(() =>
+		Promise.resolve({
+			transactions: [TRANSACTION],
+			total: 1,
+			pages: 1,
+		})
+	);
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+describe('TransactionsApp — entry column', () => {
+	it('renders entry ids as plain text, not a link to the retired entries slug', async () => {
+		render(<TransactionsApp />);
+
+		expect(await screen.findByText('#12, #34')).toBeInTheDocument();
+		expect(
+			screen.queryByRole('link', { name: /#12|#34/ })
+		).not.toBeInTheDocument();
+
+		const staleLink = screen
+			.queryAllByRole('link')
+			.find((l) =>
+				(l.getAttribute('href') || '').includes(
+					'fair-payments-connector-entries'
+				)
+			);
+		expect(staleLink).toBeUndefined();
+
+		// Pre-existing SelectControl default-size deprecation warning, not
+		// under test here.
+		expect(console).toHaveWarned();
+	});
+});

--- a/scripts/lint-docs.js
+++ b/scripts/lint-docs.js
@@ -27,6 +27,9 @@ const BANNED_REFERENCES = [
 	'fair-team',
 	'php-ci.yml',
 	'deploy-acroyoga.yml',
+	'fair-payments-connector-entries',
+	'fair-payments-connector-budgets',
+	'fair-payments-connector-reconciliation',
 ];
 
 // Historical records are allowed to mention old names.

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -36,7 +36,7 @@
  *                       60–15552000.
  *
  * Examples:
- *   node scripts/screenshot.js "/wp-admin/admin.php?page=fair-payments-connector-budgets" mobile budgets-mobile.png
+ *   node scripts/screenshot.js "/wp-admin/admin.php?page=fair-finance-budgets" mobile budgets-mobile.png
  *   WP_BASE_URL=http://localhost:8889 node scripts/screenshot.js "/" desktop home.png --no-login
  *   node scripts/screenshot.js "/" desktop home.png --no-login --upload imgbb
  */


### PR DESCRIPTION
## Summary

- The budgets list's "View" links (a specific budget, and the unbudgeted/"none" case) now point at the live `fair-finance-entries` slug instead of the retired, unregistered `fair-payments-connector-entries` slug that produced a generic "no tienes permisos" page.
- The transactions list no longer links entry ids to the retired slug — that `entry_id` deep link never had backing support anywhere in the stack (URL reader, REST controller, or model), so the ids now render as plain, comma-separated text instead of a dead link.
- Renamed leftover `fair-payments-connector-*` wrapper/scoping classes in the entries and budgets screens to `fair-finance-*`.
- Fixed the same stale `-budgets` slug in `TESTING.md` and `scripts/screenshot.js`, and added the three retired slugs to `lint-docs.js`'s banned references so they can't rot back into the docs.
- Extended `fair-finance/jest.config.js`'s `testMatch` to pick up `.test.jsx` files (it only matched `.js` before), matching `fair-payments-connector/jest.config.js`.

Closes #1290

## Acceptance criteria

- [x] Budgets list "view entries" links (specific budget + unbudgeted) open the current, working entries screen filtered accordingly.
- [x] Transactions list "view entry" link — deferred per the implementation plan's decision: the underlying `entry_id` filter never existed, so instead of repairing a link that was never functional, it's removed and the ids render as text. Restoring real navigation is tracked in #1291.
- [x] No admin-facing link anywhere in the plugin set points at the retired address (repo-wide grep confirmed clean).
- [x] Component test coverage confirms the links/rendering (see Test plan). Per the plan's Decisions, this scope uses Jest component tests only — `test:e2e`/`test:api` aren't wired into CI for these plugins.

## Notes

- No redirect was added from the retired slugs — scope stayed on the internal links that are actively broken for every user right now, per the plan's decision.
- The text-domain mismatch in the moved fair-finance admin code (~350 `__()` calls still using `fair-payments-connector`) is out of scope and not yet ticketed.

## Test plan

- [x] `npm run test:js` passes in `fair-finance` (36 tests) and `fair-payments-connector` (8 tests), including new `BudgetsApp.test.jsx` and `TransactionsApp.test.jsx` specs that pin the fixed hrefs/text.
- [x] `npm run lint:docs` passes with the new banned references.
- [x] `npm run build` in both `fair-finance` and `fair-payments-connector`.
- [x] `npm run format` in both plugins; no formatting noise staged.
- [x] Verified live in the local WP env (`:8080`): budgets "View" links land on the working Financial Entries screen with the budget filter pre-set (including "none"); the entries screen's wrapper class is `fair-finance-entries-page`; transactions page renders cleanly with no console errors.
