### PR TITLE
Add group pricing and group-restricted tiers to unified signup

### DIFF
--- a/.changeset/group-pricing-restricted-tiers.md
+++ b/.changeset/group-pricing-restricted-tiers.md
@@ -1,0 +1,6 @@
+---
+"fair-events": minor
+"fair-audience": minor
+---
+
+The unified Event Signup form (used once fair-audience owns the flow, #1245) now respects group-restricted ticket types and group discount pricing: a ticket type restricted to specific groups is rejected server-side for a visitor who isn't a member, and the charged price reflects the viewer's best-matching group discount, with a note shown above the submit button. Entitlement is resolved from the signed-in/known viewer's session, never from the submitted name/email, so a crafted request can't unlock a restricted tier or a discount it isn't entitled to.

--- a/REST_API_BACKEND.md
+++ b/REST_API_BACKEND.md
@@ -574,8 +574,8 @@ companion plugin renders a richer flow) and
 create route) expose:
 
 -   **`fair_events_signup_render_context` filter** — the base render builds a
-    context array (`event_date_id`, `ticket_types`, `price_by_type_id`,
-    `active_sale_period`, `occurrences_for_picker`, `currency_symbol`,
+    context array (`event_date_id`, `pricing_event_date_id`, `ticket_types`,
+    `price_by_type_id`, `active_sale_period`, `occurrences_for_picker`, `currency_symbol`,
     `callback_status`/`callback_tx_id`/`callback_token`, `prefill_name`,
     `prefill_email`, `submit_button_text`) and runs it through this filter
     before rendering, so a companion plugin can inject viewer identity,
@@ -584,7 +584,27 @@ create route) expose:
     `fair_events_signup_render_before_form` and
     `fair_events_signup_render_after_form` (both passed the same context),
     let a companion plugin contribute UI fragments (e.g. a resume/retry card)
-    directly inside the `<form>`.
+    directly inside the `<form>`. A third action, `fair_events_signup_render_before_submit`
+    (also passed the context), fires immediately before the submit button —
+    fair-audience uses it to render a group discount note.
+-   **`fair_events_signup_ticket_type_error` filter** — `GetTicketsController::create_signup()`
+    runs this right after a submitted ticket type is validated and confirmed
+    not disabled: `apply_filters( 'fair_events_signup_ticket_type_error', null, $ticket_type_id, $event_date_id )`.
+    Returning a `WP_Error` rejects the signup with that error (fair-audience
+    returns a 403 `ticket_type_restricted` when the ticket type is
+    group-restricted and the viewer isn't a member); returning `null` (the
+    default) allows the signup to proceed. Runs once before either the
+    single- or `multiple_instances` path dispatches, so it covers both.
+-   **`fair_events_signup_unit_price` filter** — runs immediately after
+    `TicketPricing::resolve_unit_price()` in both `create_signup()` and
+    `create_multi_instance_signup()`: `apply_filters( 'fair_events_signup_unit_price', $unit_price, $ticket_type_id, $event_date_id )`.
+    A companion plugin uses this to apply participant-specific discounts (e.g.
+    a group pricing rule) on top of the base price; `$unit_price` is `null`
+    when no active sale period configures one, which a filter callback should
+    pass through unchanged. This is a dedicated seam rather than the
+    pre-existing `fair_events_resolve_ticket_price` filter (which is also the
+    base price inside `EventSignupPricing::resolve_price_for_ticket_type()` —
+    hooking it here would double-discount that path).
 -   **`fair_events_signup_created` action** — fires
     `( $signup_id, $event_date_id, $name, $email, $ticket_selection, $transaction_id )`
     after a signup row is persisted through the base create path (once per

--- a/fair-audience/__tests__/Services/GroupSignupPricingTest.php
+++ b/fair-audience/__tests__/Services/GroupSignupPricingTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * GroupSignupPricing::allowed_ticket_types() / discount_note_label() tests
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairAudience\Services\GroupSignupPricing;
+
+/**
+ * Validates the pure group-restriction filtering and discount-note formatting
+ * logic behind #1242, without needing fair-events-experimental /
+ * fair-audience-experimental loaded — both methods accept duck-typed objects
+ * (an `id` property for ticket types, `discount_type`/`discount_value`/
+ * `group_id` for a rule) rather than the concrete experimental classes.
+ */
+class GroupSignupPricingTest extends TestCase {
+
+	/**
+	 * Build a ticket type stub with the given id.
+	 *
+	 * @param int $id Ticket type ID.
+	 * @return object
+	 */
+	private function ticket_type( $id ) {
+		$type     = new \stdClass();
+		$type->id = $id;
+		return $type;
+	}
+
+	/**
+	 * Build a discount rule stub.
+	 *
+	 * @param string $discount_type  'percentage' or 'amount'.
+	 * @param float  $discount_value Discount magnitude.
+	 * @param int    $group_id       Group ID.
+	 * @return object
+	 */
+	private function rule( $discount_type, $discount_value, $group_id = 1 ) {
+		$rule                 = new \stdClass();
+		$rule->discount_type  = $discount_type;
+		$rule->discount_value = $discount_value;
+		$rule->group_id       = $group_id;
+		return $rule;
+	}
+
+	/**
+	 * An unrestricted ticket type (no entry in the restrictions map) is
+	 * always visible, anonymous or not.
+	 */
+	public function test_unrestricted_type_is_visible_to_anonymous() {
+		$types  = array( $this->ticket_type( 1 ) );
+		$result = GroupSignupPricing::allowed_ticket_types( $types, array(), array() );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 1, $result[0]->id );
+	}
+
+	/**
+	 * A restricted ticket type is hidden from an anonymous visitor
+	 * (no member group IDs at all).
+	 */
+	public function test_restricted_type_hidden_for_anonymous() {
+		$types            = array( $this->ticket_type( 1 ) );
+		$restrictions_map = array( 1 => array( 5 ) );
+		$result           = GroupSignupPricing::allowed_ticket_types( $types, $restrictions_map, array() );
+
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * A restricted ticket type is hidden from a participant who belongs to
+	 * groups, but not the permitted one.
+	 */
+	public function test_restricted_type_hidden_for_non_member() {
+		$types            = array( $this->ticket_type( 1 ) );
+		$restrictions_map = array( 1 => array( 5 ) );
+		$result           = GroupSignupPricing::allowed_ticket_types( $types, $restrictions_map, array( 6, 7 ) );
+
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * A restricted ticket type is shown to a participant who belongs to one
+	 * of the permitted groups.
+	 */
+	public function test_restricted_type_shown_for_member() {
+		$types            = array( $this->ticket_type( 1 ) );
+		$restrictions_map = array( 1 => array( 5, 6 ) );
+		$result           = GroupSignupPricing::allowed_ticket_types( $types, $restrictions_map, array( 6 ) );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 1, $result[0]->id );
+	}
+
+	/**
+	 * Mixed list: only the restricted-and-disallowed type is dropped, other
+	 * types are kept, and the result is reindexed.
+	 */
+	public function test_mixed_list_filters_only_disallowed_restricted_type() {
+		$types = array( $this->ticket_type( 1 ), $this->ticket_type( 2 ), $this->ticket_type( 3 ) );
+
+		$restrictions_map = array(
+			2 => array( 5 ), // Restricted, viewer isn't a member.
+			3 => array( 6 ), // Restricted, viewer is a member.
+		);
+
+		$result = GroupSignupPricing::allowed_ticket_types( $types, $restrictions_map, array( 6 ) );
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( array( 1, 3 ), array_map( fn( $t ) => $t->id, $result ) );
+	}
+
+	/**
+	 * Percentage discount note matches the legacy string verbatim.
+	 */
+	public function test_discount_note_label_percentage() {
+		$label = GroupSignupPricing::discount_note_label( $this->rule( 'percentage', 20 ), 'Volunteers' );
+
+		$this->assertSame( '20% discount applied (Volunteers)', $label );
+	}
+
+	/**
+	 * Amount discount note matches the legacy string verbatim.
+	 */
+	public function test_discount_note_label_amount() {
+		$label = GroupSignupPricing::discount_note_label( $this->rule( 'amount', 5 ), 'Staff' );
+
+		$this->assertSame( '€5.00 discount applied (Staff)', $label );
+	}
+}

--- a/fair-audience/__tests__/bootstrap.php
+++ b/fair-audience/__tests__/bootstrap.php
@@ -197,6 +197,20 @@ if ( ! function_exists( 'get_site_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'number_format_i18n' ) ) {
+	/**
+	 * Stub of WordPress number_format_i18n() — delegates to PHP's number_format()
+	 * without locale-specific separators, sufficient for deterministic tests.
+	 *
+	 * @param float $number   Number to format.
+	 * @param int   $decimals Number of decimal points.
+	 * @return string Formatted number.
+	 */
+	function number_format_i18n( $number, $decimals = 0 ) {
+		return number_format( (float) $number, $decimals );
+	}
+}
+
 if ( ! function_exists( '__' ) ) {
 	/**
 	 * Stub of WordPress __().

--- a/fair-audience/src/API/__tests__/EventSignupGroupPricing.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupGroupPricing.api.spec.js
@@ -1,0 +1,341 @@
+/**
+ * Playwright API tests for group-based pricing and group-restricted tiers in
+ * the unified Event Signup form (#1242): fair-events/v1/get-tickets must
+ * reject a group-restricted ticket type for a non-member (403
+ * ticket_type_restricted) and apply the viewer's best group discount rule to
+ * the charged price — server-side, so a crafted request can't buy a
+ * restricted tier or skip a discount.
+ *
+ * Viewer identity comes from a free signup on the event's unrestricted tier,
+ * which sets the fair_audience_session cookie via SignupHookBridge — the
+ * Playwright request context retains that cookie for subsequent requests,
+ * the same way a browser would. A 100% discount rule is used to exercise the
+ * paid path without a payment connector configured on the dev stack: it
+ * proves the discount is applied server-side because a member's signup
+ * confirms free while a non-member's identical request 503s
+ * payment_unavailable (mirroring the trick EventSignupBasePricing's and
+ * EventSignupSlidingScale's specs use).
+ *
+ * Skips gracefully when fair-events-experimental / fair-audience-experimental
+ * aren't both active, since group pricing/restrictions live there.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+async function createEventWithDates(api, title) {
+	const res = await api.post('/wp-json/wp/v2/fair_event', {
+		headers: authHeaders,
+		data: { title, status: 'publish' },
+	});
+	expect(res.ok()).toBeTruthy();
+	const eventId = (await res.json()).id;
+
+	const eventsRes = await api.get('/wp-json/fair-audience/v1/events', {
+		headers: authHeaders,
+		params: { per_page: 100 },
+	});
+	expect(eventsRes.ok()).toBeTruthy();
+	const match = (await eventsRes.json()).find((e) => e.event_id === eventId);
+	expect(match, 'event-date row for test event').toBeTruthy();
+	return { eventId, eventDateId: match.event_date_id };
+}
+
+async function deleteEvent(api, eventId) {
+	if (!eventId) return;
+	await api.delete(`/wp-json/wp/v2/fair_event/${eventId}`, {
+		headers: authHeaders,
+		params: { force: 'true' },
+	});
+}
+
+async function participantIdByEmail(api, email) {
+	const res = await api.get('/wp-json/fair-audience/v1/participants', {
+		headers: authHeaders,
+		params: { search: email },
+	});
+	expect(res.ok()).toBeTruthy();
+	const match = (await res.json()).find((p) => p.email === email);
+	return match ? match.id : null;
+}
+
+/** Free signup on the Open tier: establishes viewer identity (participant +
+ * fair_audience_session cookie) for the given request context, then returns
+ * the participant ID so the caller can add it to a group. */
+async function identifyAsNewParticipant(
+	memberApi,
+	adminApi,
+	event,
+	openTypeId
+) {
+	const email = uniqueEmail('member');
+	const res = await memberApi.post('/wp-json/fair-events/v1/get-tickets', {
+		data: {
+			event_date_id: event.eventDateId,
+			ticket_type_id: openTypeId,
+			name: 'Group Pricing Test Member',
+			email,
+		},
+	});
+	expect(res.ok(), await res.text()).toBeTruthy();
+
+	const participantId = await participantIdByEmail(adminApi, email);
+	expect(participantId).toBeTruthy();
+	return { participantId, email };
+}
+
+test.describe('Group-based pricing and group-restricted tiers', () => {
+	let api;
+	let groupsActive = false;
+	let event;
+	let groupId;
+	let restrictedTypeId;
+	let openTypeId;
+	let discountedTypeId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: authHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			const active = (slug) =>
+				plugins.some(
+					(p) => p.plugin?.includes(slug) && p.status === 'active'
+				);
+			groupsActive =
+				active('fair-events-experimental') &&
+				active('fair-audience-experimental');
+		}
+		if (!groupsActive) {
+			return;
+		}
+
+		event = await createEventWithDates(
+			api,
+			`Group Pricing Test ${Date.now()}`
+		);
+
+		const groupRes = await api.post('/wp-json/fair-audience/v1/groups', {
+			headers: authHeaders,
+			data: { name: `Group Pricing Test Group ${Date.now()}` },
+		});
+		expect(groupRes.ok(), await groupRes.text()).toBeTruthy();
+		groupId = (await groupRes.json()).id;
+
+		const ticketsRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${event.eventDateId}/tickets`,
+			{
+				headers: authHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'Members Only',
+							capacity: null,
+							sort_order: 0,
+							recurrence_scope: 'single_instance',
+							group_ids: [groupId],
+						},
+						{
+							name: 'Open',
+							capacity: null,
+							sort_order: 1,
+							recurrence_scope: 'single_instance',
+						},
+						{
+							name: 'Priced For Discount',
+							capacity: null,
+							sort_order: 2,
+							recurrence_scope: 'single_instance',
+						},
+					],
+					sale_periods: [
+						{
+							name: 'Always on',
+							sale_start: '2020-01-01 00:00:00',
+							sale_end: '2099-01-01 00:00:00',
+						},
+					],
+					prices: [
+						{
+							ticket_type_index: 2,
+							sale_period_index: 0,
+							price: 25,
+						},
+					],
+					settings: {},
+				},
+			}
+		);
+		expect(ticketsRes.ok(), await ticketsRes.text()).toBeTruthy();
+		const types = (await ticketsRes.json()).ticket_types || [];
+		restrictedTypeId = types.find((t) => t.name === 'Members Only')?.id;
+		openTypeId = types.find((t) => t.name === 'Open')?.id;
+		discountedTypeId = types.find(
+			(t) => t.name === 'Priced For Discount'
+		)?.id;
+		expect(restrictedTypeId).toBeTruthy();
+		expect(openTypeId).toBeTruthy();
+		expect(discountedTypeId).toBeTruthy();
+
+		// A 100% rule on the priced tier: proves the discount is applied
+		// server-side without needing a payment provider configured.
+		const ruleRes = await api.post(
+			`/wp-json/fair-events/v1/event-dates/${event.eventDateId}/group-pricing-rules`,
+			{
+				headers: authHeaders,
+				data: {
+					group_id: groupId,
+					discount_type: 'percentage',
+					discount_value: 100,
+				},
+			}
+		);
+		expect(ruleRes.ok(), await ruleRes.text()).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (groupsActive) {
+			await deleteEvent(api, event?.eventId);
+			if (groupId) {
+				await api.delete(
+					`/wp-json/fair-audience/v1/groups/${groupId}`,
+					{
+						headers: authHeaders,
+					}
+				);
+			}
+		}
+		await api.dispose();
+	});
+
+	test('a restricted ticket type rejects a non-member with 403 ticket_type_restricted', async () => {
+		test.skip(
+			!groupsActive,
+			'fair-events-experimental / fair-audience-experimental not active'
+		);
+
+		const anon = await request.newContext({ baseURL: BASE_URL });
+		const res = await anon.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: event.eventDateId,
+				ticket_type_id: restrictedTypeId,
+				name: 'Non Member',
+				email: uniqueEmail('non-member'),
+			},
+		});
+		expect(res.status()).toBe(403);
+		expect((await res.json()).code).toBe('ticket_type_restricted');
+		await anon.dispose();
+	});
+
+	test('a group member can buy the restricted ticket type', async () => {
+		test.skip(
+			!groupsActive,
+			'fair-events-experimental / fair-audience-experimental not active'
+		);
+
+		const member = await request.newContext({ baseURL: BASE_URL });
+		const { participantId, email } = await identifyAsNewParticipant(
+			member,
+			api,
+			event,
+			openTypeId
+		);
+
+		const addRes = await api.post(
+			`/wp-json/fair-audience/v1/groups/${groupId}/participants`,
+			{ headers: authHeaders, data: { participant_id: participantId } }
+		);
+		expect(addRes.ok(), await addRes.text()).toBeTruthy();
+
+		const res = await member.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: event.eventDateId,
+				ticket_type_id: restrictedTypeId,
+				name: 'Group Pricing Test Member',
+				email,
+			},
+		});
+		expect(res.ok(), await res.text()).toBeTruthy();
+		expect((await res.json()).status).toBe('confirmed');
+
+		await member.dispose();
+	});
+
+	test('a 100% group discount confirms free for a member, but 503s for a non-member', async () => {
+		test.skip(
+			!groupsActive,
+			'fair-events-experimental / fair-audience-experimental not active'
+		);
+
+		// Non-member: full price applies, and the dev stack has no payment
+		// connector configured, so the priced signup is rejected — proving the
+		// discount didn't apply to a non-member.
+		const anon = await request.newContext({ baseURL: BASE_URL });
+		const nonMemberRes = await anon.post(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				data: {
+					event_date_id: event.eventDateId,
+					ticket_type_id: discountedTypeId,
+					name: 'Non Member Buyer',
+					email: uniqueEmail('non-member-priced'),
+				},
+			}
+		);
+		expect(nonMemberRes.status()).toBe(503);
+		expect((await nonMemberRes.json()).code).toBe('payment_unavailable');
+		await anon.dispose();
+
+		// Member: the 100% rule brings the price to 0, so the free path
+		// confirms without needing a payment provider — proving the discount
+		// applied server-side.
+		const member = await request.newContext({ baseURL: BASE_URL });
+		const { participantId, email } = await identifyAsNewParticipant(
+			member,
+			api,
+			event,
+			openTypeId
+		);
+
+		const addRes = await api.post(
+			`/wp-json/fair-audience/v1/groups/${groupId}/participants`,
+			{ headers: authHeaders, data: { participant_id: participantId } }
+		);
+		expect(addRes.ok(), await addRes.text()).toBeTruthy();
+
+		const memberRes = await member.post(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				data: {
+					event_date_id: event.eventDateId,
+					ticket_type_id: discountedTypeId,
+					name: 'Group Pricing Test Member',
+					email,
+				},
+			}
+		);
+		expect(memberRes.ok(), await memberRes.text()).toBeTruthy();
+		expect((await memberRes.json()).status).toBe('confirmed');
+
+		await member.dispose();
+	});
+});

--- a/fair-audience/src/Hooks/SignupHookBridge.php
+++ b/fair-audience/src/Hooks/SignupHookBridge.php
@@ -17,6 +17,8 @@ use FairAudience\Database\EventParticipantTransactionRepository;
 use FairAudience\Models\Participant;
 use FairAudience\Services\AudienceSession;
 use FairAudience\Services\EmailService;
+use FairAudience\Services\GroupSignupPricing;
+use FairAudience\Services\SignupPriceResolver;
 
 defined( 'WPINC' ) || die;
 
@@ -36,6 +38,9 @@ class SignupHookBridge {
 	 */
 	public static function init() {
 		add_filter( 'fair_events_signup_render_context', array( static::class, 'enrich_render_context' ), 10, 1 );
+		add_action( 'fair_events_signup_render_before_submit', array( static::class, 'render_discount_note' ), 10, 1 );
+		add_filter( 'fair_events_signup_ticket_type_error', array( static::class, 'filter_ticket_type_error' ), 10, 2 );
+		add_filter( 'fair_events_signup_unit_price', array( static::class, 'filter_unit_price' ), 10, 2 );
 		add_action( 'fair_events_signup_created', array( static::class, 'link_participant' ), 10, 6 );
 		add_action( 'fair_events_signup_confirmed', array( static::class, 'handle_signup_confirmed' ), 10, 2 );
 		add_action( 'fair_events_signup_payment_failed', array( static::class, 'handle_signup_payment_failed' ), 10, 2 );
@@ -44,28 +49,144 @@ class SignupHookBridge {
 
 	/**
 	 * Inject the signed-in/known viewer's name and email into the base
-	 * form's pre-fill so returning participants don't retype them.
+	 * form's pre-fill so returning participants don't retype them, filter out
+	 * group-restricted ticket types the viewer can't buy, and re-resolve
+	 * prices through the viewer's group discounts.
 	 *
 	 * @param array $context Render context from fair-events' base render.
 	 * @return array Filtered context.
 	 */
 	public static function enrich_render_context( $context ) {
-		$participant_repository = new ParticipantRepository();
-		$participant            = null;
-
-		$participant_id = AudienceSession::get_participant_id();
-		if ( $participant_id ) {
-			$participant = $participant_repository->get_by_id( $participant_id );
-		} elseif ( get_current_user_id() ) {
-			$participant = $participant_repository->get_by_user_id( get_current_user_id() );
-		}
+		$participant    = GroupSignupPricing::resolve_viewer_participant();
+		$participant_id = $participant ? (int) $participant->id : null;
 
 		if ( $participant ) {
 			$context['prefill_name']  = trim( $participant->name . ' ' . $participant->surname );
 			$context['prefill_email'] = (string) $participant->email;
 		}
 
+		$context['group_discount_rule'] = null;
+
+		if ( empty( $context['ticket_types'] ) ) {
+			return $context;
+		}
+
+		$pricing_event_date_id = (int) $context['pricing_event_date_id'];
+
+		if ( class_exists( \FairEventsExperimental\Models\TicketTypeGroupRestriction::class ) ) {
+			$restrictions_map = \FairEventsExperimental\Models\TicketTypeGroupRestriction::get_all_by_event_date_id( $pricing_event_date_id );
+
+			if ( ! empty( $restrictions_map ) ) {
+				$member_group_ids = array();
+				if ( $participant_id && class_exists( \FairAudienceExperimental\Database\GroupParticipantRepository::class ) ) {
+					$group_participant_repo = new \FairAudienceExperimental\Database\GroupParticipantRepository();
+					$memberships            = $group_participant_repo->get_by_participant( $participant_id );
+					$member_group_ids       = array_map(
+						function ( $membership ) {
+							return (int) $membership->group_id;
+						},
+						$memberships
+					);
+				}
+
+				$context['ticket_types'] = GroupSignupPricing::allowed_ticket_types(
+					$context['ticket_types'],
+					$restrictions_map,
+					$member_group_ids
+				);
+			}
+		}
+
+		// Re-resolve prices for the surviving types through the same authority
+		// the create route uses, so the displayed price matches what gets
+		// charged. Clamped at 0 — an amount-discount larger than the price
+		// can never show (or charge) a negative amount.
+		$price_by_type_id = array();
+		foreach ( $context['ticket_types'] as $ticket_type ) {
+			$resolved = SignupPriceResolver::resolve_price_for_ticket_type( (int) $ticket_type->id, $participant_id );
+			if ( null !== $resolved ) {
+				$price_by_type_id[ (int) $ticket_type->id ] = max( 0, $resolved );
+			}
+		}
+		$context['price_by_type_id'] = $price_by_type_id;
+
+		if ( $participant_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			$context['group_discount_rule'] = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
+				$pricing_event_date_id,
+				$participant_id
+			);
+		}
+
 		return $context;
+	}
+
+	/**
+	 * Render the group discount note just before the submit button, when the
+	 * viewer's best-matching group discount rule was stashed onto the context
+	 * by enrich_render_context().
+	 *
+	 * @param array $context Render context, see fair_events_signup_render_context.
+	 * @return void
+	 */
+	public static function render_discount_note( $context ) {
+		$rule = $context['group_discount_rule'] ?? null;
+		if ( ! $rule ) {
+			return;
+		}
+
+		$group_name = '';
+		if ( class_exists( \FairAudienceExperimental\Database\GroupRepository::class ) ) {
+			$group_repo = new \FairAudienceExperimental\Database\GroupRepository();
+			$group      = $group_repo->get_by_id( (int) $rule->group_id );
+			if ( $group ) {
+				$group_name = $group->name;
+			}
+		}
+
+		echo '<p class="fair-events-get-tickets-discount-note">'
+			. esc_html( GroupSignupPricing::discount_note_label( $rule, $group_name ) )
+			. '</p>';
+	}
+
+	/**
+	 * Reject a signup for a group-restricted ticket type the viewer isn't a
+	 * member of. Hooked on fair_events_signup_ticket_type_error.
+	 *
+	 * @param WP_Error|null $error          Prior filter result — passed through unchanged if already an error.
+	 * @param int           $ticket_type_id Ticket type ID.
+	 * @return \WP_Error|null
+	 */
+	public static function filter_ticket_type_error( $error, $ticket_type_id ) {
+		if ( is_wp_error( $error ) ) {
+			return $error;
+		}
+
+		$participant = GroupSignupPricing::resolve_viewer_participant();
+		return GroupSignupPricing::restriction_error( $ticket_type_id, $participant ? (int) $participant->id : null );
+	}
+
+	/**
+	 * Re-resolve a ticket type's unit price through the viewer's group
+	 * discounts. Hooked on fair_events_signup_unit_price.
+	 *
+	 * @param float|null $unit_price     Base unit price, or null when not purchasable.
+	 * @param int        $ticket_type_id Ticket type ID.
+	 * @return float|null
+	 */
+	public static function filter_unit_price( $unit_price, $ticket_type_id ) {
+		if ( null === $unit_price ) {
+			return $unit_price;
+		}
+
+		$participant    = GroupSignupPricing::resolve_viewer_participant();
+		$participant_id = $participant ? (int) $participant->id : null;
+
+		$resolved = SignupPriceResolver::resolve_price_for_ticket_type( $ticket_type_id, $participant_id );
+		if ( null === $resolved ) {
+			return $unit_price;
+		}
+
+		return max( 0, $resolved );
 	}
 
 	/**

--- a/fair-audience/src/Services/GroupSignupPricing.php
+++ b/fair-audience/src/Services/GroupSignupPricing.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Group Signup Pricing Service
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Services;
+
+use FairAudience\Database\ParticipantRepository;
+use WP_Error;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Pure presenter logic for group-restricted tiers and group discounts in the
+ * unified Event Signup form, kept independent of the WordPress bootstrap
+ * where possible so it stays unit-testable. Experimental-only lookups
+ * (restrictions, memberships, discount rules) stay behind `class_exists()`
+ * guards at each call site, degrading to "unrestricted, undiscounted" when
+ * `fair-events-experimental` / `fair-audience-experimental` are inactive.
+ */
+class GroupSignupPricing {
+
+	/**
+	 * Resolve the viewer's fair-audience Participant from the session cookie
+	 * or the logged-in WordPress user — the same identity lookup
+	 * SignupHookBridge::enrich_render_context() already performs for pre-fill.
+	 *
+	 * @return \FairAudience\Models\Participant|null Participant, or null when anonymous/unknown.
+	 */
+	public static function resolve_viewer_participant() {
+		$participant_repository = new ParticipantRepository();
+
+		$participant_id = AudienceSession::get_participant_id();
+		if ( $participant_id ) {
+			return $participant_repository->get_by_id( $participant_id );
+		}
+
+		if ( get_current_user_id() ) {
+			return $participant_repository->get_by_user_id( get_current_user_id() );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Filter a list of ticket types down to the ones the viewer may see:
+	 * unrestricted types, plus restricted types the viewer belongs to a
+	 * permitted group for.
+	 *
+	 * @param object[] $types             Ticket type objects (each with an `id` property).
+	 * @param array    $restrictions_map  Associative array: ticket_type_id => int[] allowed group IDs
+	 *                                    (as returned by TicketTypeGroupRestriction::get_all_by_event_date_id()).
+	 * @param int[]    $member_group_ids  Group IDs the viewer belongs to (empty when anonymous/no groups).
+	 * @return object[] Filtered ticket types, reindexed.
+	 */
+	public static function allowed_ticket_types( array $types, array $restrictions_map, array $member_group_ids ) {
+		return array_values(
+			array_filter(
+				$types,
+				function ( $type ) use ( $restrictions_map, $member_group_ids ) {
+					$allowed_group_ids = $restrictions_map[ (int) $type->id ] ?? array();
+					if ( empty( $allowed_group_ids ) ) {
+						return true;
+					}
+					return ! empty( array_intersect( $allowed_group_ids, $member_group_ids ) );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Check whether a ticket type is group-restricted and, if so, whether the
+	 * given participant belongs to a permitted group. Mirrors
+	 * EventSignupController::validate_ticket_type_group_restriction().
+	 *
+	 * @param int      $ticket_type_id Ticket type ID.
+	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
+	 * @return WP_Error|null 403 `ticket_type_restricted` when disallowed, null when allowed
+	 *                       (including when the experimental classes aren't active).
+	 */
+	public static function restriction_error( $ticket_type_id, $participant_id ) {
+		if ( ! $ticket_type_id ) {
+			return null;
+		}
+
+		if ( ! class_exists( \FairEventsExperimental\Models\TicketTypeGroupRestriction::class )
+			|| ! class_exists( \FairAudienceExperimental\Database\GroupParticipantRepository::class ) ) {
+			return null;
+		}
+
+		$allowed_group_ids = \FairEventsExperimental\Models\TicketTypeGroupRestriction::get_group_ids_by_ticket_type_id( $ticket_type_id );
+		if ( empty( $allowed_group_ids ) ) {
+			return null;
+		}
+
+		$member_group_ids = array();
+		if ( $participant_id ) {
+			$group_participant_repo = new \FairAudienceExperimental\Database\GroupParticipantRepository();
+			$memberships            = $group_participant_repo->get_by_participant( $participant_id );
+			$member_group_ids       = array_map(
+				function ( $membership ) {
+					return (int) $membership->group_id;
+				},
+				$memberships
+			);
+		}
+
+		if ( empty( array_intersect( $allowed_group_ids, $member_group_ids ) ) ) {
+			return new WP_Error(
+				'ticket_type_restricted',
+				__( 'This ticket type is not available for your account.', 'fair-audience' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Build the group discount note label, reusing the legacy render's
+	 * strings verbatim so translation catalogs need no new entries.
+	 *
+	 * @param object $rule       Discount rule with `discount_type` ('percentage'|'amount')
+	 *                           and `discount_value` properties (e.g. a GroupPricingRule).
+	 * @param string $group_name Resolved group name (looked up by the caller, keeping this pure).
+	 * @return string Formatted discount note.
+	 */
+	public static function discount_note_label( $rule, $group_name ) {
+		if ( 'percentage' === $rule->discount_type ) {
+			return sprintf(
+				/* translators: 1: discount percentage, 2: group name */
+				__( '%1$s%% discount applied (%2$s)', 'fair-audience' ),
+				number_format_i18n( (float) $rule->discount_value ),
+				$group_name
+			);
+		}
+
+		return sprintf(
+			/* translators: 1: discount amount, 2: group name */
+			__( '%1$s discount applied (%2$s)', 'fair-audience' ),
+			\FairEventsShared\Money::format_inline( (float) $rule->discount_value ),
+			$group_name
+		);
+	}
+}

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -306,6 +306,15 @@ class GetTicketsController extends WP_REST_Controller {
 				);
 			}
 
+			// Extension point for plugins (e.g. fair-audience) that restrict a
+			// ticket type to specific groups. Applies to both the single- and
+			// multiple_instances paths below, since this runs before either
+			// dispatches. See REST_API_BACKEND.md.
+			$restriction_error = apply_filters( 'fair_events_signup_ticket_type_error', null, (int) $ticket_type_id, (int) $event_date_id );
+			if ( is_wp_error( $restriction_error ) ) {
+				return $restriction_error;
+			}
+
 			// 'multiple_instances' ticket types pick several specific occurrences
 			// instead of the single event_date_id above — handled by a dedicated
 			// path that creates one signup row per chosen occurrence.
@@ -315,7 +324,10 @@ class GetTicketsController extends WP_REST_Controller {
 			}
 
 			// Resolve price from the active sale period (server-side; client amount is ignored).
+			// The filter is the extension point a companion plugin uses to apply
+			// participant-specific discounts on top of this base price.
 			$unit_price = \FairEvents\Services\TicketPricing::resolve_unit_price( $ticket_type_id );
+			$unit_price = apply_filters( 'fair_events_signup_unit_price', $unit_price, (int) $ticket_type_id, (int) $event_date_id );
 			if ( null !== $unit_price ) {
 				$amount = $unit_price * $quantity;
 			}
@@ -652,6 +664,7 @@ class GetTicketsController extends WP_REST_Controller {
 
 		// Resolve the per-instance price from the active sale period (server-side; client amount is ignored).
 		$unit_price = \FairEvents\Services\TicketPricing::resolve_unit_price( $ticket_type->id );
+		$unit_price = apply_filters( 'fair_events_signup_unit_price', $unit_price, (int) $ticket_type->id, (int) $series_page_id );
 		$unit_price = null !== $unit_price ? $unit_price : 0.0;
 
 		$count        = count( $occurrences );

--- a/fair-events/src/blocks/event-signup/frontend.css
+++ b/fair-events/src/blocks/event-signup/frontend.css
@@ -88,6 +88,13 @@
 	padding: 0 4px;
 }
 
+.fair-events-get-tickets-discount-note {
+	font-size: 0.875em;
+	color: #2e7d32;
+	margin: 0 0 0.75em;
+	text-align: center;
+}
+
 .fair-events-get-tickets-form .fair-events-ticket-option {
 	display: flex;
 	align-items: center;

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -224,8 +224,8 @@ if ( class_exists( \FairEvents\Services\TicketPricing::class ) && class_exists( 
  * prices can all be layered on by filtering this context array. See
  * REST_API_BACKEND.md for the documented shape and consumers.
  *
- * @param array    $context    Render context (event_date_id, ticket_types, price_by_type_id,
- *                              active_sale_period, occurrences_for_picker,
+ * @param array    $context    Render context (event_date_id, pricing_event_date_id, ticket_types,
+ *                              price_by_type_id, active_sale_period, occurrences_for_picker,
  *                              callback_status, callback_tx_id, callback_token, callback_state,
  *                              callback_source, prefill_name, prefill_email, submit_button_text).
  * @param array    $attributes Block attributes.
@@ -235,6 +235,9 @@ $context = apply_filters(
 	'fair_events_signup_render_context',
 	array(
 		'event_date_id'          => $event_date_id,
+		// The series-master pivot config/pricing lookups already resolved to,
+		// so a companion plugin doesn't need to re-derive it.
+		'pricing_event_date_id'  => $pricing_event_date_id,
 		'ticket_types'           => $ticket_types,
 		'price_by_type_id'       => $price_by_type_id,
 		'active_sale_period'     => $active_sale_period,
@@ -636,6 +639,16 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 			autocomplete="off"
 			aria-hidden="true"
 		/>
+
+		<?php
+		/**
+		 * Fires just inside the signup <form>, immediately before the submit
+		 * button. fair-audience uses this to render a group discount note.
+		 *
+		 * @param array $context Render context, see fair_events_signup_render_context.
+		 */
+		do_action( 'fair_events_signup_render_before_submit', $context );
+		?>
 
 		<div class="form-row form-submit">
 			<button type="submit" class="form-button wp-block-button__link wp-element-button">


### PR DESCRIPTION
## Summary

- Adds two dedicated fair-events filters — `fair_events_signup_ticket_type_error` and `fair_events_signup_unit_price` — to `GetTicketsController::create_signup()` / `create_multi_instance_signup()`, plus a `fair_events_signup_render_before_submit` render slot, so a companion plugin can reject a group-restricted ticket type and re-price a ticket type without a competing create route.
- Adds `fair-audience`'s `GroupSignupPricing` service and wires it into `SignupHookBridge`: group-restricted ticket types are filtered out of the render for non-members, prices are re-resolved through the viewer's best group discount (server-side, in both the render and the create route), and a discount note renders above the submit button.
- Entitlement is resolved from the signed-in/known viewer's session only — never from the submitted name/email.

Implements the plan agreed in https://github.com/marcin-wosinek/fair-event-plugins/issues/1242#issuecomment-5096615200.

Refs #1242

## Acceptance criteria

- [x] Qualifying participant sees discounted prices and an explanatory discount note — `SignupHookBridge::enrich_render_context()` re-resolves `price_by_type_id` through `SignupPriceResolver` and stashes the best-matching rule; `render_discount_note()` renders it via `GroupSignupPricing::discount_note_label()`.
- [x] Group-restricted tiers are hidden from non-members and shown to members — `GroupSignupPricing::allowed_ticket_types()` filters the render's ticket type list; `restriction_error()` / the `fair_events_signup_ticket_type_error` filter reject a restricted purchase server-side (403 `ticket_type_restricted`) independent of the render.
- [x] Anonymous/non-member visitors see standard pricing and tiers — every lookup degrades to "no discount / no restriction" when the viewer resolves to no participant.
- [x] Falls back to standard pricing when experimental group support is inactive — every experimental class reference stays behind `class_exists()`, and `SignupPriceResolver` already degrades to base `TicketPricing`.
- [x] API spec coverage + PHPUnit coverage — `EventSignupGroupPricing.api.spec.js` (restricted-tier rejection/acceptance, 100%-discount member-vs-non-member) and `GroupSignupPricingTest.php` (pure `allowed_ticket_types()` / `discount_note_label()` logic, 7 assertions, passing).

## Notes on testing

- `npm run test:php` (fair-audience): ran locally, all 7 new `GroupSignupPricingTest` assertions pass.
- `vendor/bin/phpcs`: clean on every changed file (pre-existing warnings/errors elsewhere are unrelated to this change, confirmed by diffing against `main`).
- `npm run build` (fair-events): ran to confirm the new CSS class compiles; `build/` isn't committed (gitignored).
- **Not run**: the new `EventSignupGroupPricing.api.spec.js` Playwright spec and the WP-CLI `eval-file` manual check from the plan's Tests section. This worktree's `docker compose` dev stack shares ports (8080/3306) with the main worktree's already-running stack, so bringing it up would have required stopping that stack — deferred rather than doing that without asking. Please run `npm run test:api -w fair-audience` (with `fair-events-experimental` + `fair-audience-experimental` active) before merging.

## Deferred (per the plan's Decisions / "Spotted, not in scope")

- Simple per-date `signup_price` pricing mode is untouched — group pricing only applies to the ticket-types path, matching the plan's decision.
- The unified render's pre-existing bug (it doesn't filter out disabled/past-`disable_at` ticket types) is out of scope — tracked separately per the plan.
