### PR TITLE
Fix iCal import timezone conversion and add date/time test harness

### DIFF
--- a/.changeset/fix-ical-import-timezone.md
+++ b/.changeset/fix-ical-import-timezone.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix iCal feed import storing the wrong time of day for timed events whose source timezone differs from the site timezone (`DateHelper::datetime_to_local()` never converted, since Sabre's iCal parser returns `DateTimeImmutable`, not `DateTime`). Also fix floating/all-day iCal values being interpreted through UTC instead of directly as site-local, which could shift an all-day event's civil date by a day on negative-offset site timezones.

--- a/fair-events/__tests__/API/CalendarFeedControllerTest.php
+++ b/fair-events/__tests__/API/CalendarFeedControllerTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * CalendarFeedController round-trip tests.
+ *
+ * Build_vcalendar() is pure occurrence-DTO-in, VCalendar-out logic (no DB) and
+ * is reached here via Reflection since it's private. Round-trips the
+ * serialized ICS back through ICalParser to confirm export + re-import land
+ * on the same site-local instant.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\API;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\API\CalendarFeedController;
+use FairEvents\Helpers\ICalParser;
+
+/**
+ * Tests for CalendarFeedController's ICS export.
+ */
+class CalendarFeedControllerTest extends TestCase {
+
+	/**
+	 * Reset stubs after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['_fair_test_timezone'] );
+		unset( $GLOBALS['_fair_test_remote_responses'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a VCALENDAR from occurrence DTOs via the private build_vcalendar().
+	 *
+	 * @param array[] $occurrences Occurrence DTOs.
+	 * @return string Serialized ICS.
+	 */
+	private function build_ics( array $occurrences ) {
+		$controller = new CalendarFeedController();
+		$method     = new \ReflectionMethod( CalendarFeedController::class, 'build_vcalendar' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $controller, $occurrences )->serialize();
+	}
+
+	/**
+	 * Re-parse a serialized ICS string via ICalParser.
+	 *
+	 * @param string $ics Serialized ICS.
+	 * @return array Parsed events.
+	 */
+	private function reparse( $ics ) {
+		$url = 'https://example.com/round-trip.ics';
+		$GLOBALS['_fair_test_remote_responses'][ $url ] = array(
+			'response' => array( 'code' => 200 ),
+			'body'     => $ics,
+		);
+
+		return ICalParser::fetch_and_parse( $url );
+	}
+
+	/**
+	 * A timed event on a named-timezone site round-trips through export and
+	 * re-import to the same site-local instant.
+	 *
+	 * @return void
+	 */
+	public function test_timed_event_round_trips_on_named_timezone() {
+		$GLOBALS['_fair_test_timezone'] = 'America/New_York';
+
+		$occurrence = array(
+			'uid'         => 'timed-1@example.com',
+			'title'       => 'Timed event',
+			'description' => '',
+			'start'       => '2026-06-15 12:00:00',
+			'end'         => '2026-06-15 13:00:00',
+			'all_day'     => false,
+			'url'         => '',
+			'location'    => null,
+		);
+
+		$ics    = $this->build_ics( array( $occurrence ) );
+		$events = $this->reparse( $ics );
+
+		$this->assertCount( 1, $events );
+		$this->assertFalse( $events[0]['all_day'] );
+		$this->assertSame( '2026-06-15 12:00:00', $events[0]['start'] );
+		$this->assertSame( '2026-06-15 13:00:00', $events[0]['end'] );
+	}
+
+	/**
+	 * An all-day event round-trips through export and re-import to the same
+	 * site-local civil date, with the exclusive iCal end date correctly
+	 * resolved back to the inclusive stored end.
+	 *
+	 * @return void
+	 */
+	public function test_all_day_event_round_trips() {
+		$GLOBALS['_fair_test_timezone'] = 'America/New_York';
+
+		$occurrence = array(
+			'uid'         => 'allday-1@example.com',
+			'title'       => 'All day event',
+			'description' => '',
+			'start'       => '2026-05-01 00:00:00',
+			'end'         => '2026-05-02 00:00:00',
+			'all_day'     => true,
+			'url'         => '',
+			'location'    => null,
+		);
+
+		$ics    = $this->build_ics( array( $occurrence ) );
+		$events = $this->reparse( $ics );
+
+		$this->assertCount( 1, $events );
+		$this->assertTrue( $events[0]['all_day'] );
+		$this->assertSame( '2026-05-01 00:00:00', $events[0]['start'] );
+		$this->assertSame( '2026-05-02 00:00:00', $events[0]['end'] );
+	}
+
+	/**
+	 * A timed event round-trips through export and re-import to the same
+	 * site-local instant even on a fixed-offset site timezone (no named
+	 * VTIMEZONE emitted, DTSTART/DTEND use UTC 'Z' form instead).
+	 *
+	 * @return void
+	 */
+	public function test_timed_event_round_trips_on_fixed_offset_timezone() {
+		$GLOBALS['_fair_test_timezone'] = '+05:00';
+
+		$occurrence = array(
+			'uid'         => 'timed-2@example.com',
+			'title'       => 'Timed event',
+			'description' => '',
+			'start'       => '2026-06-15 18:00:00',
+			'end'         => '2026-06-15 19:00:00',
+			'all_day'     => false,
+			'url'         => '',
+			'location'    => null,
+		);
+
+		$ics    = $this->build_ics( array( $occurrence ) );
+		$events = $this->reparse( $ics );
+
+		$this->assertCount( 1, $events );
+		$this->assertSame( '2026-06-15 18:00:00', $events[0]['start'] );
+		$this->assertSame( '2026-06-15 19:00:00', $events[0]['end'] );
+	}
+}

--- a/fair-events/__tests__/Helpers/DateHelperTest.php
+++ b/fair-events/__tests__/Helpers/DateHelperTest.php
@@ -97,4 +97,40 @@ class DateHelperTest extends TestCase {
 	public function test_local_to_datetime_invalid_datetime() {
 		$this->assertFalse( DateHelper::local_to_datetime( 'not-a-date' ) );
 	}
+
+	/**
+	 * DST spring-forward gap: '2026-03-08 02:30:00' does not exist in
+	 * America/New_York (clocks jump from 02:00 to 03:00). PHP's date_create()
+	 * normalizes it by rolling forward one hour, landing already in the new
+	 * (summer) offset rather than erroring.
+	 *
+	 * @return void
+	 */
+	public function test_local_to_timestamp_dst_spring_forward_gap() {
+		$GLOBALS['_fair_test_timezone'] = 'America/New_York';
+
+		$dt = DateHelper::local_to_datetime( '2026-03-08 02:30:00' );
+
+		$this->assertInstanceOf( \DateTime::class, $dt );
+		$this->assertSame( '2026-03-08 03:30:00', $dt->format( 'Y-m-d H:i:s' ) );
+		$this->assertSame( '-04:00', $dt->format( 'P' ) );
+	}
+
+	/**
+	 * DST fall-back overlap: '2026-11-01 01:30:00' occurs twice in
+	 * America/New_York (clocks fall back from 03:00 to 02:00). PHP's
+	 * date_create() resolves the ambiguity to the first occurrence, i.e. the
+	 * still-DST offset.
+	 *
+	 * @return void
+	 */
+	public function test_local_to_timestamp_dst_fall_back_overlap() {
+		$GLOBALS['_fair_test_timezone'] = 'America/New_York';
+
+		$dt = DateHelper::local_to_datetime( '2026-11-01 01:30:00' );
+
+		$this->assertInstanceOf( \DateTime::class, $dt );
+		$this->assertSame( '2026-11-01 01:30:00', $dt->format( 'Y-m-d H:i:s' ) );
+		$this->assertSame( '-04:00', $dt->format( 'P' ) );
+	}
 }

--- a/fair-events/__tests__/Helpers/ICalParserTest.php
+++ b/fair-events/__tests__/Helpers/ICalParserTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Tests for ICalParser's timezone handling on iCal import.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Helpers\ICalParser;
+
+/**
+ * Unit tests for ICalParser::fetch_and_parse(), focused on the
+ * source-timezone-to-site-local conversion at import time.
+ */
+class ICalParserTest extends TestCase {
+
+	/**
+	 * Reset the timezone and remote-response stubs after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['_fair_test_timezone'] );
+		unset( $GLOBALS['_fair_test_remote_responses'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Feed a raw VCALENDAR string as the response for a fake URL and parse it.
+	 *
+	 * @param string $ics Raw VCALENDAR content.
+	 * @return array Parsed events.
+	 */
+	private function parse( $ics ) {
+		$url = 'https://example.com/feed.ics';
+		$GLOBALS['_fair_test_remote_responses'][ $url ] = array(
+			'response' => array( 'code' => 200 ),
+			'body'     => $ics,
+		);
+
+		return ICalParser::fetch_and_parse( $url );
+	}
+
+	/**
+	 * An all-day floating DATE must not shift civil date in a negative-offset
+	 * site timezone (the 20260501 -> 2026-04-30 regression this ticket guards
+	 * against).
+	 *
+	 * @return void
+	 */
+	public function test_all_day_event_does_not_shift_civil_date_in_negative_offset_zone() {
+		$GLOBALS['_fair_test_timezone'] = 'America/New_York';
+
+		$ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:1\r\n"
+			. "DTSTART;VALUE=DATE:20260501\r\nDTEND;VALUE=DATE:20260502\r\n"
+			. "SUMMARY:All day\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+		$events = $this->parse( $ics );
+
+		$this->assertCount( 1, $events );
+		$this->assertTrue( $events[0]['all_day'] );
+		$this->assertSame( '2026-05-01 00:00:00', $events[0]['start'] );
+		$this->assertSame( '2026-05-01 00:00:00', $events[0]['end'] );
+	}
+
+	/**
+	 * A timed event with an explicit TZID differing from the site timezone
+	 * converts to the correct site-local wall-clock time.
+	 *
+	 * @return void
+	 */
+	public function test_timed_event_with_explicit_tzid_converts_to_site_local() {
+		$GLOBALS['_fair_test_timezone'] = 'America/New_York';
+
+		$ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:2\r\n"
+			. "DTSTART;TZID=Europe/Madrid:20260615T180000\r\nDTEND;TZID=Europe/Madrid:20260615T190000\r\n"
+			. "SUMMARY:Timed TZID\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+		$events = $this->parse( $ics );
+
+		$this->assertCount( 1, $events );
+		$this->assertFalse( $events[0]['all_day'] );
+		$this->assertSame( '2026-06-15 12:00:00', $events[0]['start'] );
+		$this->assertSame( '2026-06-15 13:00:00', $events[0]['end'] );
+	}
+
+	/**
+	 * A timed event with a UTC 'Z' suffix converts to the correct site-local
+	 * wall-clock time.
+	 *
+	 * @return void
+	 */
+	public function test_timed_event_with_utc_z_converts_to_site_local() {
+		$GLOBALS['_fair_test_timezone'] = 'America/New_York';
+
+		$ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:3\r\n"
+			. "DTSTART:20260615T160000Z\r\nDTEND:20260615T170000Z\r\n"
+			. "SUMMARY:Timed UTC\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+		$events = $this->parse( $ics );
+
+		$this->assertCount( 1, $events );
+		$this->assertSame( '2026-06-15 12:00:00', $events[0]['start'] );
+		$this->assertSame( '2026-06-15 13:00:00', $events[0]['end'] );
+	}
+
+	/**
+	 * A floating timed event (no TZID, no Z) has no source timezone, so it is
+	 * interpreted directly as site-local wall-clock time — no shift.
+	 *
+	 * @return void
+	 */
+	public function test_floating_timed_event_is_interpreted_as_site_local() {
+		$GLOBALS['_fair_test_timezone'] = 'America/New_York';
+
+		$ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:4\r\n"
+			. "DTSTART:20260615T120000\r\nDTEND:20260615T130000\r\n"
+			. "SUMMARY:Floating timed\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+
+		$events = $this->parse( $ics );
+
+		$this->assertCount( 1, $events );
+		$this->assertSame( '2026-06-15 12:00:00', $events[0]['start'] );
+		$this->assertSame( '2026-06-15 13:00:00', $events[0]['end'] );
+	}
+}

--- a/fair-events/__tests__/Services/EventFeedProviderTest.php
+++ b/fair-events/__tests__/Services/EventFeedProviderTest.php
@@ -117,4 +117,40 @@ class EventFeedProviderTest extends TestCase {
 
 		$this->assertSame( array( '2026-03-10' ), array_keys( $by_day ) );
 	}
+
+	/**
+	 * A multi-day occurrence spanning a year boundary is expanded correctly —
+	 * the walk is pure civil-date string/strtotime arithmetic with no timezone
+	 * object involved, so Dec 31 -> Jan 1 needs no special handling.
+	 */
+	public function test_multi_day_occurrence_spans_year_boundary() {
+		$occurrences = array(
+			$this->make_occurrence( 'a', '2025-12-30 20:00:00', '2026-01-02 10:00:00' ),
+		);
+
+		$by_day = EventFeedProvider::group_by_day( $occurrences, '2025-12-01 00:00:00', '2026-01-31 23:59:59' );
+
+		$this->assertSame(
+			array( '2025-12-30', '2025-12-31', '2026-01-01', '2026-01-02' ),
+			array_keys( $by_day )
+		);
+
+		$this->assertTrue( $by_day['2025-12-30'][0]['is_first_day'] );
+		$this->assertTrue( $by_day['2026-01-02'][0]['is_last_day'] );
+	}
+
+	/**
+	 * A multi-day occurrence spanning the 2026 US DST spring-forward date
+	 * (March 8) is expanded correctly — group_by_day()'s civil-date walk is
+	 * unaffected by the local clock skipping an hour that day.
+	 */
+	public function test_multi_day_occurrence_spans_dst_spring_forward() {
+		$occurrences = array(
+			$this->make_occurrence( 'a', '2026-03-07 22:00:00', '2026-03-09 06:00:00' ),
+		);
+
+		$by_day = EventFeedProvider::group_by_day( $occurrences, '2026-03-01 00:00:00', '2026-03-31 23:59:59' );
+
+		$this->assertSame( array( '2026-03-07', '2026-03-08', '2026-03-09' ), array_keys( $by_day ) );
+	}
 }

--- a/fair-events/__tests__/Services/WeeklyEventsProviderTest.php
+++ b/fair-events/__tests__/Services/WeeklyEventsProviderTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * WeeklyEventsProvider unit tests.
+ *
+ * Pure-logic tests only — get_week() requires a live WordPress environment
+ * (EventSourceRepository/wpdb, EventFeedProvider::get_occurrences()) and is
+ * covered by the WP-CLI eval-file manual check instead (see TESTING.md),
+ * same as EventFeedProviderTest's get_occurrences(). format_day_event() is
+ * pure date logic (built on the new wp_date()/wp_timezone_string() bootstrap
+ * stubs) and is reached here via Reflection since it's private.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Services\WeeklyEventsProvider;
+
+/**
+ * Tests for WeeklyEventsProvider's pure date-formatting logic.
+ */
+class WeeklyEventsProviderTest extends TestCase {
+
+	/**
+	 * Reset the timezone stub after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['_fair_test_timezone'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Call the private format_day_event() method via Reflection.
+	 *
+	 * @param array         $occurrence Occurrence DTO.
+	 * @param \DateTimeZone $tz         Site timezone.
+	 * @return array Day-event shape.
+	 */
+	private function format_day_event( array $occurrence, \DateTimeZone $tz ) {
+		$provider = new WeeklyEventsProvider();
+		$method   = new \ReflectionMethod( WeeklyEventsProvider::class, 'format_day_event' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $provider, $occurrence, $tz );
+	}
+
+	/**
+	 * A multi-day occurrence spanning the 2026 US DST spring-forward date
+	 * (March 8) resolves end_weekday to the correct day name — the day-level
+	 * weekday label is unaffected by the local clock skipping an hour that day.
+	 *
+	 * @return void
+	 */
+	public function test_end_weekday_correct_across_dst_spring_forward() {
+		$GLOBALS['_fair_test_timezone'] = 'America/New_York';
+		$tz                             = new \DateTimeZone( 'America/New_York' );
+
+		$occurrence = array(
+			'title'         => 'Spans DST',
+			'start'         => '2026-03-07 20:00:00',
+			'end'           => '2026-03-09 06:00:00',
+			'all_day'       => false,
+			'url'           => '',
+			'event_id'      => 1,
+			'event_date_id' => 1,
+		);
+
+		$day_event = $this->format_day_event( $occurrence, $tz );
+
+		$this->assertSame( '2026-03-09', $day_event['end_date'] );
+		$this->assertSame( 'Monday', $day_event['end_weekday'] );
+	}
+
+	/**
+	 * A single-day occurrence has no end_date/end_weekday set.
+	 *
+	 * @return void
+	 */
+	public function test_single_day_occurrence_has_no_end_weekday() {
+		$GLOBALS['_fair_test_timezone'] = 'America/New_York';
+		$tz                             = new \DateTimeZone( 'America/New_York' );
+
+		$occurrence = array(
+			'title'         => 'Single day',
+			'start'         => '2026-03-08 09:00:00',
+			'end'           => '2026-03-08 11:00:00',
+			'all_day'       => false,
+			'url'           => '',
+			'event_id'      => 1,
+			'event_date_id' => 1,
+		);
+
+		$day_event = $this->format_day_event( $occurrence, $tz );
+
+		$this->assertNull( $day_event['end_date'] );
+		$this->assertNull( $day_event['end_weekday'] );
+	}
+
+	/**
+	 * Parse_iso_week() correctly parses a well-formed ISO week string
+	 * identifying the week containing the 2026 DST spring-forward date.
+	 *
+	 * @return void
+	 */
+	public function test_parse_iso_week_valid() {
+		$provider = new WeeklyEventsProvider();
+
+		$this->assertSame(
+			array(
+				'year' => 2026,
+				'week' => 10,
+			),
+			$provider->parse_iso_week( '2026-W10' )
+		);
+	}
+
+	/**
+	 * Parse_iso_week() rejects a malformed ISO week string.
+	 *
+	 * @return void
+	 */
+	public function test_parse_iso_week_invalid() {
+		$provider = new WeeklyEventsProvider();
+
+		$this->assertNull( $provider->parse_iso_week( 'not-a-week' ) );
+	}
+}

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -13,6 +13,22 @@ if ( ! defined( 'WPINC' ) ) {
 	define( 'WPINC', 'wp-includes' );
 }
 
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+	define( 'HOUR_IN_SECONDS', 60 * MINUTE_IN_SECONDS );
+}
+
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 24 * HOUR_IN_SECONDS );
+}
+
+if ( ! defined( 'YEAR_IN_SECONDS' ) ) {
+	define( 'YEAR_IN_SECONDS', 365 * DAY_IN_SECONDS );
+}
+
 // Minimal WordPress function stubs so pure settings logic can be unit tested
 // without a full WP bootstrap. Tests seed values via $GLOBALS['_fair_test_options'].
 if ( ! function_exists( 'sanitize_key' ) ) {
@@ -103,6 +119,45 @@ if ( ! function_exists( 'wp_timezone' ) ) {
 		$timezone = isset( $GLOBALS['_fair_test_timezone'] ) ? $GLOBALS['_fair_test_timezone'] : 'UTC';
 
 		return new \DateTimeZone( $timezone );
+	}
+}
+
+if ( ! function_exists( 'wp_timezone_string' ) ) {
+	/**
+	 * Stub of WordPress wp_timezone_string() — UTC by default, overridable via
+	 * $GLOBALS['_fair_test_timezone'] (same backing global as wp_timezone()).
+	 *
+	 * @return string Site timezone string, e.g. 'America/New_York'.
+	 */
+	function wp_timezone_string() {
+		return isset( $GLOBALS['_fair_test_timezone'] ) ? $GLOBALS['_fair_test_timezone'] : 'UTC';
+	}
+}
+
+if ( ! function_exists( 'wp_date' ) ) {
+	/**
+	 * Stub of WordPress wp_date() — formats a timestamp in the site timezone
+	 * (via wp_timezone(), overridable through $GLOBALS['_fair_test_timezone']).
+	 * No locale/i18n handling — always formats in the default PHP locale.
+	 *
+	 * @param string             $format    date() format string.
+	 * @param int|null           $timestamp Unix timestamp; defaults to now.
+	 * @param \DateTimeZone|null $timezone  Timezone to format in; defaults to the site timezone.
+	 * @return string Formatted date.
+	 */
+	function wp_date( $format, $timestamp = null, $timezone = null ) {
+		if ( null === $timestamp ) {
+			$timestamp = time();
+		}
+
+		if ( ! $timezone instanceof \DateTimeZone ) {
+			$timezone = wp_timezone();
+		}
+
+		$datetime = new \DateTime( '@' . $timestamp );
+		$datetime->setTimezone( $timezone );
+
+		return $datetime->format( $format );
 	}
 }
 
@@ -311,3 +366,66 @@ if ( ! function_exists( 'add_query_arg' ) ) {
 		return $url . $separator . rawurlencode( $key ) . '=' . rawurlencode( $value );
 	}
 }
+
+if ( ! function_exists( 'wp_remote_get' ) ) {
+	/**
+	 * Stub of WordPress wp_remote_get() backed by
+	 * $GLOBALS['_fair_test_remote_responses'][ $url ] (a raw response array
+	 * with 'response' => [ 'code' => int ] and 'body' => string). Defaults to
+	 * an HTTP 200 with an empty body when the URL is not seeded.
+	 *
+	 * @param string $url  URL to fetch.
+	 * @param array  $args Request args (ignored by this stub).
+	 * @return array Raw response array, matching the shape wp_remote_* readers expect.
+	 */
+	function wp_remote_get( $url, $args = array() ) {
+		$responses = isset( $GLOBALS['_fair_test_remote_responses'] ) ? $GLOBALS['_fair_test_remote_responses'] : array();
+
+		return array_key_exists( $url, $responses )
+			? $responses[ $url ]
+			: array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '',
+			);
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	/**
+	 * Stub of WordPress is_wp_error() — no WP_Error stub class exists here, so
+	 * this always returns false (the "instanceof" check against a class that
+	 * doesn't exist is valid PHP and simply never matches).
+	 *
+	 * @param mixed $thing Value to check.
+	 * @return bool Always false.
+	 */
+	function is_wp_error( $thing ) {
+		return $thing instanceof \WP_Error;
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+	/**
+	 * Stub of WordPress wp_remote_retrieve_response_code().
+	 *
+	 * @param array $response Raw response array from wp_remote_get().
+	 * @return int HTTP status code, or 0 if absent.
+	 */
+	function wp_remote_retrieve_response_code( $response ) {
+		return isset( $response['response']['code'] ) ? (int) $response['response']['code'] : 0;
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+	/**
+	 * Stub of WordPress wp_remote_retrieve_body().
+	 *
+	 * @param array $response Raw response array from wp_remote_get().
+	 * @return string Response body, or empty string if absent.
+	 */
+	function wp_remote_retrieve_body( $response ) {
+		return isset( $response['body'] ) ? $response['body'] : '';
+	}
+}
+
+require_once __DIR__ . '/wp-class-stubs.php';

--- a/fair-events/__tests__/wp-class-stubs.php
+++ b/fair-events/__tests__/wp-class-stubs.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Minimal WordPress class stubs for PHPUnit, kept in their own file since a
+ * PHP file can't mix function declarations (bootstrap.php) with OO structure
+ * declarations under phpcs's file-content sniff.
+ *
+ * @package FairEvents
+ */
+
+if ( ! class_exists( 'WP_REST_Controller' ) ) {
+	/**
+	 * Empty stub of WP_REST_Controller — enough for tests that reach a
+	 * controller's pure/private methods via Reflection without registering
+	 * routes or touching the REST server.
+	 */
+	class WP_REST_Controller {}
+}

--- a/fair-events/src/Helpers/DateHelper.php
+++ b/fair-events/src/Helpers/DateHelper.php
@@ -6,6 +6,15 @@
  * representing the WordPress site timezone (Settings > General > Timezone).
  * This helper provides correct conversions at import/export boundaries.
  *
+ * All-day events store an *inclusive* end date at 00:00:00 (the last day the
+ * event runs), not the exclusive day-after that iCal's DATE-typed DTEND uses.
+ * Import (ICalParser) and export (CalendarFeedController) each apply a one-day
+ * shift at their respective boundary to bridge the two conventions.
+ *
+ * Floating/timezone-less values (no TZID, no 'Z') have no source timezone of
+ * their own and are interpreted directly as site-local wall-clock time — see
+ * ICalParser's use of getDateTime( wp_timezone() ).
+ *
  * @package FairEvents
  */
 
@@ -98,15 +107,18 @@ class DateHelper {
 	/**
 	 * Convert a timezone-aware DateTime object to site-local 'Y-m-d H:i:s'.
 	 *
+	 * Accepts any \DateTimeInterface, mutable or immutable (e.g. Sabre VObject's
+	 * getDateTime() always returns a \DateTimeImmutable). setTimezone() mutates
+	 * and returns $this on \DateTime but returns a new instance on
+	 * \DateTimeImmutable, so the return value is always reassigned to handle
+	 * both.
+	 *
 	 * @param \DateTimeInterface $datetime Timezone-aware DateTime object.
 	 * @return string Site-local 'Y-m-d H:i:s'.
 	 */
 	public static function datetime_to_local( $datetime ) {
 		$dt = clone $datetime;
-
-		if ( $dt instanceof \DateTime ) {
-			$dt->setTimezone( wp_timezone() );
-		}
+		$dt = $dt->setTimezone( wp_timezone() );
 
 		return $dt->format( 'Y-m-d H:i:s' );
 	}

--- a/fair-events/src/Helpers/ICalParser.php
+++ b/fair-events/src/Helpers/ICalParser.php
@@ -97,7 +97,10 @@ class ICalParser {
 		}
 
 		// Get start date — convert from source timezone to site-local time.
-		$dtstart        = $vevent->DTSTART->getDateTime();
+		// Floating/all-day values (no TZID, no Z) have no source timezone, so
+		// Sabre defaults the reference to UTC unless one is passed explicitly;
+		// passing wp_timezone() interprets them directly as site-local instead.
+		$dtstart        = $vevent->DTSTART->getDateTime( wp_timezone() );
 		$start_datetime = DateHelper::datetime_to_local( $dtstart );
 
 		// Check if all-day event (DATE vs DATE-TIME)
@@ -105,7 +108,7 @@ class ICalParser {
 
 		// Get end date (use DTEND or DURATION, fallback to start date)
 		if ( isset( $vevent->DTEND ) ) {
-			$dtend        = $vevent->DTEND->getDateTime();
+			$dtend        = $vevent->DTEND->getDateTime( wp_timezone() );
 			$end_datetime = DateHelper::datetime_to_local( $dtend );
 		} elseif ( isset( $vevent->DURATION ) ) {
 			$dtend = clone $dtstart;

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -708,6 +708,13 @@ class EventDates {
 	 * This method fetches all event dates that fall within the given range,
 	 * including both post-linked and standalone (external/unlinked) events.
 	 *
+	 * The WHERE clause is an inclusive overlap check (start <= $end_date AND
+	 * end >= $start_date), verified against a live DB for events landing
+	 * exactly on the 00:00:00/23:59:59 boundaries (fair-events#678): an event
+	 * exactly at $start_date or $end_date is included, one second outside
+	 * either edge is excluded. No fix needed here — this comment locks the
+	 * behavior in.
+	 *
 	 * @param string $start_date Start date (Y-m-d H:i:s format).
 	 * @param string $end_date   End date (Y-m-d H:i:s format).
 	 * @return EventDates[] Array of EventDates objects.


### PR DESCRIPTION
## Summary

Fixes the confirmed date/time bug identified by the plan in #678: `DateHelper::datetime_to_local()` never actually converted timezone for iCal-imported events, because Sabre's parser returns `\DateTimeImmutable` and the code only handled `instanceof \DateTime`. A timed event with `DTSTART;TZID=Europe/Madrid:...` imported on a site set to `America/New_York` stored the Madrid wall-clock hour as if it were already New York local time. `ICalParser`'s two `getDateTime()` calls also lacked a reference timezone, so floating/all-day values silently resolved through UTC — fixing the first bug alone (without also fixing this) would have introduced a day-shift bug on negative-offset site timezones, so both land together per the plan's decision.

- `DateHelper::datetime_to_local()`: drop the `instanceof \DateTime` guard, call `setTimezone()` unconditionally and reassign the return value (handles both `\DateTime` and `\DateTimeImmutable`).
- `ICalParser.php`: pass `wp_timezone()` as the reference timezone to both `DTSTART`/`DTEND` `getDateTime()` calls.
- Extends the existing phpunit harness (`__tests__/bootstrap.php`) with `wp_timezone_string()`, `wp_date()`, `wp_remote_get()`/`is_wp_error()`/`wp_remote_retrieve_*()`, and a `WP_REST_Controller` stub, then adds regression coverage across `DateHelperTest`, a new `ICalParserTest`, `EventFeedProviderTest`, a new `WeeklyEventsProviderTest`, and a new `CalendarFeedControllerTest` (export → re-import round-trip).
- Verified the DB-level query-boundary inclusivity (events exactly at `00:00:00`/`23:59:59`) against a live WordPress instance via the WP-CLI `eval-file` manual-check recipe — already correct, no fix needed; documented in `EventDates::get_for_date_range()`'s doc comment.
- Clarifies `DateHelper.php`'s top-of-file doc comment on all-day end-exclusivity and floating-time handling.

Closes #678

## Acceptance criteria

- [x] A regression suite runs the date paths at a non-UTC, DST-observing timezone (`America/New_York` throughout the new/extended tests).
- [x] All-day iCal import no longer shifts the civil date in negative-offset zones; round-trips import → store → export losslessly (`ICalParserTest`, `CalendarFeedControllerTest`).
- [x] Calendar shows multi-day events across month/week/year boundaries; `EventFeedProviderTest` adds a Dec 31 → Jan 1 case (`group_by_day()`'s civil-date walk was already correct — no fix needed there, per the plan's grounding).
- [x] Events at `00:00:00`/`23:59:59` land in the correct calendar cell; query boundary inclusivity asserted via a live-DB manual check (see `EventDates::get_for_date_range()` doc comment) — DB-level SQL isn't practically unit-testable without a full fake query engine, so this used the WP-CLI `eval-file` recipe TESTING.md prescribes for exactly this case, rather than a real PHPUnit test.
- [x] Weekly schedule renders correctly for a week containing a DST transition — `WeeklyEventsProviderTest` covers `format_day_event()`'s weekday-label logic across the March 2026 spring-forward date via Reflection (`get_week()` itself needs a live DB, same as `EventFeedProvider::get_occurrences()`, and isn't unit-tested per the existing pattern).
- [x] DST spring-forward/fall-back local times convert without error and with documented behavior — new `DateHelperTest` cases assert PHP's normalization (rolls forward through the gap; resolves fall-back ambiguity to the first/DST occurrence).
- [x] `DateHelper`'s storage contract stays intact; doc comment updated to state the `datetime_to_local()` contract explicitly and clarify all-day end-exclusivity / floating-time handling.

## Notes

- `CalendarFeedController` (export) needed no fix — its all-day/named-timezone/UTC-offset branching was already correct; `CalendarFeedControllerTest` adds a characterization round-trip to lock that in.
- `group_by_day()`'s civil-date walk needed no fix either — it's pure string/`strtotime` arithmetic untouched by timezone objects; `EventFeedProviderTest` adds year-boundary and DST-spanning cases to lock that in too.
- Added a `WP_REST_Controller` stub and `wp_remote_*`/`is_wp_error` stubs to the test bootstrap so `CalendarFeedController`'s private `build_vcalendar()` and `ICalParser::fetch_and_parse()` are reachable without a live WordPress instance. The stub class lives in a new `__tests__/wp-class-stubs.php` file rather than inline in `bootstrap.php`, since phpcs flags a single file mixing function declarations with an OO structure declaration.

## Test plan

- [x] `vendor/bin/phpunit` (fair-events): 151 tests, 262 assertions, all passing.
- [x] `npm run test:js` (fair-events): 175 tests passing, unaffected.
- [x] `vendor/bin/phpcs` on all changed PHP files: 0 new errors (pre-existing errors in `ICalParser.php`/`EventDates.php` unrelated to this diff, confirmed identical against `main`); only pre-existing + one new unused-parameter warning in the test bootstrap stub, consistent with the existing pattern there.
- [x] WP-CLI `eval-file` manual check against the live dev instance confirmed `EventDates::get_for_date_range()`'s boundary inclusivity at `00:00:00`/`23:59:59` — 4/4 PASS, throwaway script deleted, site timezone restored.
