### PR TITLE
Add e2e coverage for event-date address field

### DIFF
--- a/e2e/fair-events-event-address.spec.js
+++ b/e2e/fair-events-event-address.spec.js
@@ -1,0 +1,123 @@
+/**
+ * E2E: event-date `address` column — event-info block, calendar button,
+ * recurrence (#721).
+ *
+ * Locks in three regressions that were already fixed on main but slipped
+ * through review once (see the ticket): the event-info block ignoring
+ * `address` when no venue is set, the calendar button hook doing the same,
+ * and generated recurring children not inheriting the master's address.
+ *
+ * Each scenario seeds via `seedEvent('address', …)` inside the test body (not
+ * `beforeAll`) so the fixture's per-test teardown (event + any venue) fires
+ * automatically.
+ *
+ * Run: `npm run test:e2e -- fair-events-event-address`.
+ */
+
+import { test, expect } from './support/fixtures.js';
+import { runScript } from './support/wp-cli.js';
+
+test('single event: address renders with no venue set', async ({
+	page,
+	seedEvent,
+}) => {
+	const address = 'Calle Mayor 1, Madrid';
+	const event = seedEvent('address', { address });
+
+	await page.goto(event.pageUrl);
+
+	await expect(
+		page.locator('.wp-block-fair-events-event-info__venue-address')
+	).toContainText(address);
+	await expect(page.locator('[data-calendar-button="true"]')).toHaveAttribute(
+		'data-location',
+		address
+	);
+});
+
+test('recurring master: generated children inherit and render the address', async ({
+	page,
+	seedEvent,
+}) => {
+	const address = 'Calle Mayor 1, Madrid';
+	const event = seedEvent('address', { address, recurring: true });
+
+	// No ?event_date= param — relies on SelectedOccurrence pivoting to the
+	// upcoming generated child (the master itself is dated -10 days).
+	await page.goto(event.pageUrl);
+
+	await expect(
+		page.locator('.wp-block-fair-events-event-info__venue-address')
+	).toContainText(address);
+	await expect(page.locator('[data-calendar-button="true"]')).toHaveAttribute(
+		'data-location',
+		address
+	);
+
+	const state = runScript(
+		'event-date-address-state.php',
+		'E2E_STATE',
+		`${event.eventDateId}`
+	);
+	expect(state.masterAddress).toBe(address);
+	expect(state.children.length).toBeGreaterThan(0);
+	for (const child of state.children) {
+		expect(child.address).toBe(address);
+	}
+});
+
+test('editing the master address cascades to every generated child', async ({
+	page,
+	seedEvent,
+}) => {
+	const originalAddress = 'Calle Mayor 1, Madrid';
+	const newAddress = 'Calle Nueva 42, Madrid';
+	const event = seedEvent('address', {
+		address: originalAddress,
+		recurring: true,
+	});
+
+	const state = runScript(
+		'event-date-address-state.php',
+		'E2E_STATE',
+		`${event.eventDateId} "${newAddress}"`
+	);
+	expect(state.masterAddress).toBe(newAddress);
+	expect(state.children.length).toBeGreaterThan(0);
+	for (const child of state.children) {
+		expect(child.address).toBe(newAddress);
+	}
+
+	await page.goto(event.pageUrl);
+	await expect(
+		page.locator('.wp-block-fair-events-event-info__venue-address')
+	).toContainText(newAddress);
+});
+
+test('venue wins over a stale address column', async ({ page, seedEvent }) => {
+	const venueName = 'Test Hall';
+	const venueAddress = 'Calle Venue 1';
+	const event = seedEvent('address', {
+		createVenue: true,
+		venueName,
+		venueAddress,
+		address: 'stale address that must not render',
+	});
+
+	await page.goto(event.pageUrl);
+
+	await expect(
+		page.locator('.wp-block-fair-events-event-info__venue-name')
+	).toContainText(venueName);
+	await expect(
+		page.locator('.wp-block-fair-events-event-info__venue-address')
+	).toContainText(venueAddress);
+	await expect(
+		page.locator('.wp-block-fair-events-event-info__venue-address')
+	).not.toContainText('stale address');
+
+	await expect(page.locator('[data-calendar-button="true"]')).toHaveAttribute(
+		'data-location',
+		`${venueName}, ${venueAddress}`
+	);
+});

--- a/e2e/mu-plugins/lib/event-factory.php
+++ b/e2e/mu-plugins/lib/event-factory.php
@@ -21,6 +21,7 @@ use FairEvents\Models\TicketType;
 use FairEvents\Models\TicketPrice;
 use FairEvents\Services\RecurrenceService;
 use FairEventsExperimental\Models\TicketOption;
+use FairEventsExperimental\Models\Venue;
 
 if ( ! function_exists( 'fair_e2e_create_event' ) ) {
 	/**
@@ -255,5 +256,49 @@ if ( ! function_exists( 'fair_e2e_create_event' ) ) {
 		}
 
 		return (int) $option_id;
+	}
+
+	/**
+	 * Set the free-text address on an event date row (Venues bundle disabled path).
+	 *
+	 * @param int    $event_date_id Event date ID.
+	 * @param string $address       Address text.
+	 * @return void
+	 */
+	function fair_e2e_set_address( $event_date_id, $address ) {
+		if ( ! EventDates::update_by_id( $event_date_id, array( 'address' => $address ) ) ) {
+			WP_CLI::error( 'Failed to set event date address.' );
+		}
+	}
+
+	/**
+	 * Attach a venue to an event date row.
+	 *
+	 * @param int $event_date_id Event date ID.
+	 * @param int $venue_id      Venue ID.
+	 * @return void
+	 */
+	function fair_e2e_set_venue( $event_date_id, $venue_id ) {
+		if ( ! EventDates::update_by_id( $event_date_id, array( 'venue_id' => $venue_id ) ) ) {
+			WP_CLI::error( 'Failed to set event date venue.' );
+		}
+	}
+
+	/**
+	 * Create a venue (fair-events-experimental's venues bundle table, created
+	 * unconditionally by fair-events' own installer — no bundle flag involved).
+	 *
+	 * @param string $name    Venue name.
+	 * @param string $address Venue address.
+	 * @return int Venue ID.
+	 */
+	function fair_e2e_create_venue( $name, $address ) {
+		$venue_id = Venue::create( $name, $address );
+
+		if ( ! $venue_id ) {
+			WP_CLI::error( 'Failed to create venue.' );
+		}
+
+		return (int) $venue_id;
 	}
 }

--- a/e2e/mu-plugins/scripts/cleanup-event.php
+++ b/e2e/mu-plugins/scripts/cleanup-event.php
@@ -3,13 +3,16 @@
  * Delete an E2E-seeded event and everything hanging off it, by id.
  *
  * Run via WP-CLI against the wp-env tests instance:
- *   wp eval-file wp-content/mu-plugins/scripts/cleanup-event.php <eventId> <eventDateId>
+ *   wp eval-file wp-content/mu-plugins/scripts/cleanup-event.php <eventId> <eventDateId> [venueId]
  *
  * Removes the participants that signed up for the event date (buyers), their
  * option rows, the event-participant rows, the ticket types/prices/options/
  * sale periods/dates, and finally the fair_event post. Deleting by id keeps
  * repeated local runs from accumulating rows and guarantees no later test sees
  * a previous test's data. Captured mail is reset separately by the fixture.
+ *
+ * The optional third arg deletes a venue created for the test (0/omitted =
+ * no venue to clean up — backward compatible with every existing caller).
  *
  * Prints a single `E2E_CLEANUP:{json}` line with row counts for debuggability.
  *
@@ -20,9 +23,10 @@ global $wpdb;
 
 $event_id      = isset( $args[0] ) ? (int) $args[0] : 0;
 $event_date_id = isset( $args[1] ) ? (int) $args[1] : 0;
+$venue_id      = isset( $args[2] ) ? (int) $args[2] : 0;
 
 if ( ! $event_id || ! $event_date_id ) {
-	WP_CLI::error( 'Usage: cleanup-event.php <eventId> <eventDateId>' );
+	WP_CLI::error( 'Usage: cleanup-event.php <eventId> <eventDateId> [venueId]' );
 }
 
 $participants_table  = $wpdb->prefix . 'fair_audience_participants';
@@ -163,5 +167,9 @@ $deleted['event_dates'] = (int) $wpdb->query(
 // phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 $deleted['post'] = wp_delete_post( $event_id, true ) ? 1 : 0;
+
+if ( $venue_id ) {
+	$deleted['venue'] = \FairEventsExperimental\Models\Venue::delete( $venue_id ) ? 1 : 0;
+}
 
 echo 'E2E_CLEANUP:' . wp_json_encode( $deleted ) . "\n";

--- a/e2e/mu-plugins/scripts/event-date-address-state.php
+++ b/e2e/mu-plugins/scripts/event-date-address-state.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Optionally update, then report, an event date master's `address` column
+ * and every generated child's resolved address — for the event-date-address
+ * E2E spec (#721).
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/event-date-address-state.php <masterEventDateId> [newAddress]
+ *
+ * With a second argument, updates the master's `address` first (exactly what
+ * EventDatesController::update_item does for this field), so the spec can
+ * assert the edit cascades to every generated child through
+ * resolve_instance()'s COALESCE( child.address, master.address ) fallback.
+ * Without it, this is a read-only check.
+ *
+ * Prints a single `E2E_STATE:{json}` line: the master's address and an array
+ * of every child's id + resolved address.
+ *
+ * @package FairEventsE2E
+ */
+
+use FairEvents\Models\EventDates;
+
+$master_id   = isset( $args[0] ) ? (int) $args[0] : 0;
+$new_address = isset( $args[1] ) ? (string) $args[1] : null;
+
+if ( ! $master_id ) {
+	WP_CLI::error( 'Usage: event-date-address-state.php <masterEventDateId> [newAddress]' );
+}
+
+if ( null !== $new_address ) {
+	if ( ! EventDates::update_by_id( $master_id, array( 'address' => $new_address ) ) ) {
+		WP_CLI::error( 'Failed to update master address.' );
+	}
+}
+
+$master = EventDates::get_by_id( $master_id );
+
+if ( ! $master ) {
+	WP_CLI::error( "No event date found for id {$master_id}." );
+}
+
+$children = array();
+foreach ( EventDates::get_all_by_master_id( $master_id ) as $row ) {
+	if ( (int) $row->id === $master_id ) {
+		continue;
+	}
+	$children[] = array(
+		'id'      => (int) $row->id,
+		'address' => $row->address,
+	);
+}
+
+echo 'E2E_STATE:' . wp_json_encode(
+	array(
+		'masterAddress' => $master->address,
+		'children'      => $children,
+	)
+) . "\n";

--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -25,6 +25,16 @@
  *                        {"omitMulti":true} to skip the multiple_instances
  *                        type (single_instance + whole_series only), the
  *                        regression scenario.
+ *   address              event-info block + a calendar button, no ticket
+ *                        type/sale period (signup path untouched). Renders
+ *                        {"address":"…"} (default 'Calle Mayor 1, Madrid') via
+ *                        the event date's inline address column. Override
+ *                        {"recurring":true} to seed a 3-occurrence weekly
+ *                        series with the master dated -10 days (so the public
+ *                        page pivots to a generated child instead of the
+ *                        master). Override {"createVenue":true} (+ optional
+ *                        {"venueName":"…","venueAddress":"…"}) to attach a
+ *                        venue, which must win over any address on the row.
  *
  * Examples:
  *   wp eval-file .../seed-event.php paid
@@ -57,10 +67,16 @@ $option_names      = isset( $overrides['options'] ) ? (array) $overrides['option
 $option_price      = isset( $overrides['optionPrice'] ) ? (float) $overrides['optionPrice'] : 10.00;
 $minimum_instances = isset( $overrides['minimumInstances'] ) ? (int) $overrides['minimumInstances'] : 2;
 $omit_multi        = isset( $overrides['omitMulti'] ) && $overrides['omitMulti'];
+$address           = isset( $overrides['address'] ) ? (string) $overrides['address'] : 'Calle Mayor 1, Madrid';
+$recurring         = isset( $overrides['recurring'] ) && $overrides['recurring'];
+$create_venue      = isset( $overrides['createVenue'] ) && $overrides['createVenue'];
+$venue_name        = isset( $overrides['venueName'] ) ? (string) $overrides['venueName'] : 'Test Hall';
+$venue_address     = isset( $overrides['venueAddress'] ) ? (string) $overrides['venueAddress'] : 'Calle Venue 1';
 $ticket_type_id    = 0;
 $option_ids        = array();
 $occurrence_ids    = array();
 $extra_type_ids    = array();
+$venue_id          = 0;
 $is_paid           = true;
 
 // Which purchase block the event page carries. Default: fair-audience
@@ -94,6 +110,21 @@ if ( 'three-ticket-scopes' === $flavour ) {
 			'<!-- /wp:fair-events/event-signup -->',
 		)
 	);
+} elseif ( 'address' === $flavour ) {
+	// event-info block (renders the address/venue) + a calendar button — no
+	// signup block, since this flavour never touches the purchase path.
+	$block_content = implode(
+		"\n",
+		array(
+			'<!-- wp:fair-events/event-info /-->',
+			'',
+			'<!-- wp:buttons -->',
+			'<div class="wp-block-buttons"><!-- wp:button {"isCalendarButton":true} -->',
+			'<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Add to calendar</a></div>',
+			'<!-- /wp:button --></div>',
+			'<!-- /wp:buttons -->',
+		)
+	);
 }
 
 $event_id = fair_e2e_create_event( 'E2E ' . $flavour . ' Event ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ), $block_content );
@@ -101,10 +132,19 @@ $event_id = fair_e2e_create_event( 'E2E ' . $flavour . ' Event ' . gmdate( 'YmdH
 // three-ticket-scopes pins its occurrence to a fixed absolute date (rather than
 // fair_e2e_add_date()'s '+7 days') so the rendered dates/prices are stable and
 // reviewable as regressions across runs.
-$event_date_id  = 'three-ticket-scopes' === $flavour
-	? fair_e2e_add_date_at( $event_id, '2027-01-15 18:00:00' )
-	: fair_e2e_add_date( $event_id );
-$sale_period_id = fair_e2e_add_sale_period( $event_date_id );
+if ( 'three-ticket-scopes' === $flavour ) {
+	$event_date_id = fair_e2e_add_date_at( $event_id, '2027-01-15 18:00:00' );
+} elseif ( 'address' === $flavour && $recurring ) {
+	// The master must start in the past: get_upcoming_by_master_id() includes
+	// the master row itself when its own start is still upcoming, so a
+	// future-dated master would make SelectedOccurrence::resolve() pivot back
+	// to the master and never reach a generated child.
+	$event_date_id = fair_e2e_add_date_at( $event_id, gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) ) );
+} else {
+	$event_date_id = fair_e2e_add_date( $event_id );
+}
+// 'address' scenarios never touch the signup path — skip the sale period.
+$sale_period_id = 'address' === $flavour ? 0 : fair_e2e_add_sale_period( $event_date_id );
 
 switch ( $flavour ) {
 	case 'free':
@@ -180,8 +220,21 @@ switch ( $flavour ) {
 		}
 		break;
 
+	case 'address':
+		fair_e2e_set_address( $event_date_id, $address );
+		if ( $recurring ) {
+			$occurrence_ids = fair_e2e_add_series( $event_id, 3 );
+		}
+		if ( $create_venue ) {
+			$venue_id = fair_e2e_create_venue( $venue_name, $venue_address );
+			fair_e2e_set_venue( $event_date_id, $venue_id );
+		}
+		$is_paid = false;
+		$price   = 0.00;
+		break;
+
 	default:
-		WP_CLI::error( "Unknown flavour '{$flavour}'. Use one of: free, paid, paid-with-options, capacity-1, multiple-instances, three-ticket-scopes, audience-ticket-scopes." );
+		WP_CLI::error( "Unknown flavour '{$flavour}'. Use one of: free, paid, paid-with-options, capacity-1, multiple-instances, three-ticket-scopes, audience-ticket-scopes, address." );
 }
 
 echo 'E2E_SEED:' . wp_json_encode(
@@ -197,5 +250,6 @@ echo 'E2E_SEED:' . wp_json_encode(
 		'occurrenceIds'    => array_map( 'intval', $occurrence_ids ),
 		'minimumInstances' => (int) $minimum_instances,
 		'price'            => $is_paid ? $price : 0.00,
+		'venueId'          => (int) $venue_id,
 	)
 ) . "\n";

--- a/e2e/support/fixtures.js
+++ b/e2e/support/fixtures.js
@@ -54,7 +54,7 @@ export const test = base.extend({
 			runScript(
 				'cleanup-event.php',
 				'E2E_CLEANUP',
-				`${event.eventId} ${event.eventDateId}`
+				`${event.eventId} ${event.eventDateId} ${event.venueId || 0}`
 			);
 		}
 		resetCapturedMail();


### PR DESCRIPTION
## Summary

- Adds `e2e/fair-events-event-address.spec.js`, locking in the event-date
  `address` column across the event-info block, the calendar-button hook, and
  recurrence (all three regressions described in the ticket are already fixed
  on `main` — this PR is pure test lock-in, no production code changes).
- Extends the shared E2E seed factory (`event-factory.php`, `seed-event.php`,
  `cleanup-event.php`) with a new `'address'` seed flavour and venue
  create/cleanup helpers, plus a new mu-plugin script
  (`event-date-address-state.php`) to update/read a master + its generated
  children's resolved address.

Closes #721

## Scenarios covered

1. **Single event, address, no venue** — address renders in
   `.wp-block-fair-events-event-info__venue-address` and the calendar button's
   `data-location`.
2. **Recurring master + generated children** — the public page pivots to the
   upcoming generated child (master seeded 10 days in the past), which still
   renders the inherited address; cross-checked directly against every
   child row.
3. **Address edit on the master cascades** — updating the master's `address`
   (the same field `EventDatesController::update_item` writes) immediately
   reflects on every generated child and on the re-rendered page.
4. **Venue wins over a stale address** — with a venue attached, the block
   shows the venue's name/address and the calendar button's location, never
   the stale `address` column value.

## Acceptance criteria

- [x] New spec file (`e2e/fair-events-event-address.spec.js`) covering the
      four scenarios above.
- [x] Each scenario cleans up its seeded post + event_date rows — via the
      existing `seedEvent` fixture's automatic per-test teardown, extended to
      also delete any venue created (`cleanup-event.php`'s new optional
      `venueId` arg, wired through `fixtures.js`).
- [x] Spec runs in CI as part of `npm run test:e2e` and the existing GitHub
      workflow — it's a `.spec.js` under `e2e/`, auto-discovered by the root
      `playwright.config.js` and `.github/workflows/e2e.yml`.
- [x] Regressing any of the three already-fixed code paths (event-info
      render, calendar-button hook, `RecurrenceService` child copy) causes a
      spec failure — each is exercised by a dedicated assertion (scenarios 1,
      4, and 2/3 respectively).

## Notes

- No feature-flag toggling: `render.php`/`CalendarButtonHooks.php` decide
  venue-vs-address purely on whether `venue_id` is set, independent of the
  `venues` bundle flag.
- Scenario 3 updates the master via `EventDates::update_by_id()` (same model
  call the REST controller makes) rather than an authenticated REST `PUT` —
  the root `e2e/` harness has no nonce/cookie auth plumbing for that yet, and
  the regression being locked in lives below the controller anyway.

## Test plan

- [x] `vendor/bin/phpcs` clean on all changed/new PHP files (pre-existing
      unrelated warning only).
- [x] New spec (`fair-events-event-address.spec.js`) — 4/4 passing against a
      local wp-env tests instance.
- [x] Full local `e2e/` suite (71 tests) — all passing, no regressions from
      the shared seed/cleanup factory changes.
