### PR TITLE
Add selectable activities to the unified Event Signup form

### DIFF
--- a/.changeset/unified-signup-activities.md
+++ b/.changeset/unified-signup-activities.md
@@ -1,0 +1,6 @@
+---
+"fair-events": minor
+"fair-audience": minor
+---
+
+The unified Event Signup form (used once fair-audience owns the flow, #1245) now supports selectable activities (ticket options): a participant can pick zero or more paid or free add-on activities at signup, subject to a minimum-activities requirement (global or raised by the selected ticket type), and a signed-up participant can add further activities to an existing registration. Capacity, pricing, and group discounts are all enforced server-side, so a crafted request can't buy a full activity, skip the minimum, or dodge the charge.

--- a/REST_API_BACKEND.md
+++ b/REST_API_BACKEND.md
@@ -576,14 +576,27 @@ create route) expose:
 -   **`fair_events_signup_render_context` filter** — the base render builds a
     context array (`event_date_id`, `pricing_event_date_id`, `ticket_types`,
     `price_by_type_id`, `active_sale_period`, `occurrences_for_picker`, `currency_symbol`,
+    `ticket_options`, `minimum_activities`,
     `callback_status`/`callback_tx_id`/`callback_token`, `prefill_name`,
     `prefill_email`, `submit_button_text`) and runs it through this filter
     before rendering, so a companion plugin can inject viewer identity,
     session pre-fill, or participant-filtered ticket types/prices without a
-    parallel template. Two render-slot actions,
+    parallel template. `ticket_options` is a list of
+    `[ id, name, short_name, price, is_full ]` (empty unless both
+    `fair-events-experimental`'s activity catalogue and fair-audience — the
+    only consumer that can persist a selection — are active); fair-audience's
+    `SignupHookBridge::enrich_render_context()` overrides each option's
+    `price`/`is_full` with participant-aware resolution (group discount,
+    live capacity) and, for a recognised viewer already signed up for this
+    event date, adds `addable_options` (options they don't already have) and
+    `current_activity_names`. `minimum_activities` is the event-date global
+    requirement, capped at `count( $ticket_options )`; a ticket type can raise
+    it further via its own `minimum_activities` property — see
+    `frontend.js`' `getEffectiveMinimum()`. Two render-slot actions,
     `fair_events_signup_render_before_form` and
     `fair_events_signup_render_after_form` (both passed the same context),
-    let a companion plugin contribute UI fragments (e.g. a resume/retry card)
+    let a companion plugin contribute UI fragments (e.g. a resume/retry card,
+    or fair-audience's "add activities" section for a signed-up viewer)
     directly inside the `<form>`. A third action, `fair_events_signup_render_before_submit`
     (also passed the context), fires immediately before the submit button —
     fair-audience uses it to render a group discount note.
@@ -605,6 +618,29 @@ create route) expose:
     pre-existing `fair_events_resolve_ticket_price` filter (which is also the
     base price inside `EventSignupPricing::resolve_price_for_ticket_type()` —
     hooking it here would double-discount that path).
+-   **`fair_events_signup_options_error` filter** — `GetTicketsController::create_signup()`
+    runs this once, unconditionally (outside the `if ( $ticket_type_id )`
+    block, so a global minimum-activities requirement still applies to a
+    signup with no ticket type):
+    `apply_filters( 'fair_events_signup_options_error', null, $ticket_option_ids, $config_event_date_id, $ticket_type_id )`,
+    where `$ticket_option_ids` is the sanitized (deduped, capped at 50)
+    submitted array and `$config_event_date_id` is the series-master-resolved
+    event date the ticket-type validation above already computed. Returning a
+    `WP_Error` rejects the signup (fair-audience returns 400
+    `invalid_ticket_option` for an ID that doesn't belong to the event date,
+    409 `ticket_option_full` naming the activity when it has no capacity
+    left, or 400 `minimum_activities_not_met` when the selection is short);
+    `null` (the default) allows the signup to proceed.
+-   **`fair_events_signup_option_line_items` filter** — runs immediately
+    after the filter above, once validation passed:
+    `apply_filters( 'fair_events_signup_option_line_items', array(), $ticket_option_ids, $config_event_date_id )`.
+    A companion plugin resolves each selected option to a priced line item
+    (`[ 'name', 'quantity', 'amount' ]`, participant discounts applied);
+    `create_signup()` sums them into `$amount` and appends them to the paid
+    transaction's line items as their own entries — never folded into the
+    ticket line — so the finance ledger names what was bought. Quantity is
+    forced to 1 server-side (and client-side) whenever any activity is
+    selected, since activities attach to a single `EventParticipant` row.
 -   **`fair_events_signup_created` action** — fires
     `( $signup_id, $event_date_id, $name, $email, $ticket_selection, $transaction_id )`
     after a signup row is persisted through the base create path (once per
@@ -627,10 +663,16 @@ create route) expose:
 it hooks `fair_events_signup_created` to link a `Participant`/`EventParticipant`
 for the anonymous/linked signup case, and `fair_events_signup_confirmed` /
 `fair_events_signup_payment_failed` to flip that `EventParticipant`'s label
-and (on confirmation) record the charge in its transaction ledger. Richer
-identity flows (resume/retry payment, group-restricted ticket types) still
-go through `fair-audience/v1`'s own routes — this contract only covers the
-simple path; see issue #1083 for the phased migration.
+and (on confirmation) record the charge in its transaction ledger. It also
+hooks `fair_events_signup_options_error` / `fair_events_signup_option_line_items`
+(delegating the actual validation/pricing logic to
+`fair-audience/src/Services/SignupActivities.php`, mirroring
+`GroupSignupPricing.php` from #1242) and, once `link_participant()` creates or
+finds the `EventParticipant` row, attaches the selected `ticket_option_ids`
+via `EventParticipantRepository::add_options()`. Richer identity flows
+(resume/retry payment, group-restricted ticket types) still go through
+`fair-audience/v1`'s own routes — this contract only covers the simple path;
+see issue #1083 for the phased migration.
 
 ### Canonical signup store — participant write-back and multiplicity
 

--- a/e2e/mu-plugins/lib/event-factory.php
+++ b/e2e/mu-plugins/lib/event-factory.php
@@ -16,6 +16,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use FairEvents\Models\EventDates;
+use FairEvents\Models\EventDateSetting;
 use FairEvents\Models\TicketSalePeriod;
 use FairEvents\Models\TicketType;
 use FairEvents\Models\TicketPrice;
@@ -241,15 +242,16 @@ if ( ! function_exists( 'fair_e2e_create_event' ) ) {
 	/**
 	 * Add a ticket option (activity-style add-on) carrying a short_name.
 	 *
-	 * @param int    $event_date_id Event date ID.
-	 * @param string $name          Option name.
-	 * @param float  $price         Option price.
-	 * @param string $short_name    Short name.
-	 * @param int    $sort_order    Sort order.
+	 * @param int      $event_date_id Event date ID.
+	 * @param string   $name          Option name.
+	 * @param float    $price         Option price.
+	 * @param string   $short_name    Short name.
+	 * @param int      $sort_order    Sort order.
+	 * @param int|null $capacity      Max signups for this option (null = unlimited).
 	 * @return int Option ID.
 	 */
-	function fair_e2e_add_option( $event_date_id, $name, $price, $short_name, $sort_order = 0 ) {
-		$option_id = TicketOption::create( $event_date_id, $name, $price, $sort_order, $short_name );
+	function fair_e2e_add_option( $event_date_id, $name, $price, $short_name, $sort_order = 0, $capacity = null ) {
+		$option_id = TicketOption::create( $event_date_id, $name, $price, $sort_order, $short_name, null, $capacity );
 
 		if ( ! $option_id ) {
 			WP_CLI::error( 'Failed to create ticket option.' );
@@ -300,5 +302,17 @@ if ( ! function_exists( 'fair_e2e_create_event' ) ) {
 		}
 
 		return (int) $venue_id;
+	}
+
+	/**
+	 * Set an event-date-scoped setting (e.g. the minimum-activities requirement).
+	 *
+	 * @param int    $event_date_id Event date ID.
+	 * @param string $key           Setting key.
+	 * @param mixed  $value         Setting value.
+	 * @return void
+	 */
+	function fair_e2e_set_event_date_setting( $event_date_id, $key, $value ) {
+		EventDateSetting::set( $event_date_id, $key, $value );
 	}
 }

--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -35,6 +35,13 @@
  *                        master). Override {"createVenue":true} (+ optional
  *                        {"venueName":"…","venueAddress":"…"}) to attach a
  *                        venue, which must win over any address on the row.
+ *   unified-with-options like paid-with-options, but renders the unified
+ *                        fair-events/event-signup block (instead of the
+ *                        default fair-audience/event-signup) so the base
+ *                        plugin's own activities fieldset is under test.
+ *                        Override {"minimumActivities":N} to set the
+ *                        event-date global minimum-activities requirement
+ *                        (default 0 = none).
  *
  * Examples:
  *   wp eval-file .../seed-event.php paid
@@ -62,22 +69,23 @@ if ( isset( $args[1] ) && '' !== $args[1] ) {
 	$overrides = $decoded;
 }
 
-$price             = isset( $overrides['price'] ) ? (float) $overrides['price'] : 25.00;
-$option_names      = isset( $overrides['options'] ) ? (array) $overrides['options'] : array( 'dinner', 'tshirt' );
-$option_price      = isset( $overrides['optionPrice'] ) ? (float) $overrides['optionPrice'] : 10.00;
-$minimum_instances = isset( $overrides['minimumInstances'] ) ? (int) $overrides['minimumInstances'] : 2;
-$omit_multi        = isset( $overrides['omitMulti'] ) && $overrides['omitMulti'];
-$address           = isset( $overrides['address'] ) ? (string) $overrides['address'] : 'Calle Mayor 1, Madrid';
-$recurring         = isset( $overrides['recurring'] ) && $overrides['recurring'];
-$create_venue      = isset( $overrides['createVenue'] ) && $overrides['createVenue'];
-$venue_name        = isset( $overrides['venueName'] ) ? (string) $overrides['venueName'] : 'Test Hall';
-$venue_address     = isset( $overrides['venueAddress'] ) ? (string) $overrides['venueAddress'] : 'Calle Venue 1';
-$ticket_type_id    = 0;
-$option_ids        = array();
-$occurrence_ids    = array();
-$extra_type_ids    = array();
-$venue_id          = 0;
-$is_paid           = true;
+$price              = isset( $overrides['price'] ) ? (float) $overrides['price'] : 25.00;
+$option_names       = isset( $overrides['options'] ) ? (array) $overrides['options'] : array( 'dinner', 'tshirt' );
+$option_price       = isset( $overrides['optionPrice'] ) ? (float) $overrides['optionPrice'] : 10.00;
+$minimum_instances  = isset( $overrides['minimumInstances'] ) ? (int) $overrides['minimumInstances'] : 2;
+$minimum_activities = isset( $overrides['minimumActivities'] ) ? (int) $overrides['minimumActivities'] : 0;
+$omit_multi         = isset( $overrides['omitMulti'] ) && $overrides['omitMulti'];
+$address            = isset( $overrides['address'] ) ? (string) $overrides['address'] : 'Calle Mayor 1, Madrid';
+$recurring          = isset( $overrides['recurring'] ) && $overrides['recurring'];
+$create_venue       = isset( $overrides['createVenue'] ) && $overrides['createVenue'];
+$venue_name         = isset( $overrides['venueName'] ) ? (string) $overrides['venueName'] : 'Test Hall';
+$venue_address      = isset( $overrides['venueAddress'] ) ? (string) $overrides['venueAddress'] : 'Calle Venue 1';
+$ticket_type_id     = 0;
+$option_ids         = array();
+$occurrence_ids     = array();
+$extra_type_ids     = array();
+$venue_id           = 0;
+$is_paid            = true;
 
 // Which purchase block the event page carries. Default: fair-audience
 // event-signup. Override {"block":"get-tickets"} for specs that exercise the
@@ -101,6 +109,8 @@ if ( 'three-ticket-scopes' === $flavour ) {
 			'<!-- /wp:fair-events/event-signup -->',
 		)
 	);
+} elseif ( 'unified-with-options' === $flavour ) {
+	$block_content = '<!-- wp:fair-events/event-signup /-->';
 } elseif ( isset( $overrides['block'] ) && 'unified-with-phone' === $overrides['block'] ) {
 	$block_content = implode(
 		"\n",
@@ -172,6 +182,27 @@ switch ( $flavour ) {
 		}
 		break;
 
+	case 'unified-with-options':
+		// Override {"fullOptionIndex":N} pre-fills that option's capacity to 0
+		// (already full, no seed signup needed) for full-option render specs.
+		$full_option_index = isset( $overrides['fullOptionIndex'] ) ? (int) $overrides['fullOptionIndex'] : -1;
+		$ticket_type_id    = fair_e2e_add_ticket_type( $event_date_id, 'General Admission', null );
+		fair_e2e_add_price( $ticket_type_id, $sale_period_id, $price, null );
+		foreach ( array_values( $option_names ) as $index => $name ) {
+			$option_ids[] = fair_e2e_add_option(
+				$event_date_id,
+				(string) $name,
+				$option_price,
+				substr( (string) $name, 0, 12 ),
+				$index,
+				$index === $full_option_index ? 0 : null
+			);
+		}
+		if ( $minimum_activities > 0 ) {
+			fair_e2e_set_event_date_setting( $event_date_id, 'minimum_activities', $minimum_activities );
+		}
+		break;
+
 	case 'capacity-1':
 		$ticket_type_id = fair_e2e_add_ticket_type( $event_date_id, 'Limited Admission', 1 );
 		fair_e2e_add_price( $ticket_type_id, $sale_period_id, $price, 1 );
@@ -234,7 +265,7 @@ switch ( $flavour ) {
 		break;
 
 	default:
-		WP_CLI::error( "Unknown flavour '{$flavour}'. Use one of: free, paid, paid-with-options, capacity-1, multiple-instances, three-ticket-scopes, audience-ticket-scopes, address." );
+		WP_CLI::error( "Unknown flavour '{$flavour}'. Use one of: free, paid, paid-with-options, capacity-1, multiple-instances, three-ticket-scopes, audience-ticket-scopes, address, unified-with-options." );
 }
 
 echo 'E2E_SEED:' . wp_json_encode(

--- a/e2e/mu-plugins/scripts/signup-state.php
+++ b/e2e/mu-plugins/scripts/signup-state.php
@@ -6,11 +6,12 @@
  *   wp eval-file wp-content/mu-plugins/scripts/signup-state.php <email> <event_date_id>
  *
  * Prints a single `E2E_STATE:{json}` line with the participant's marketing
- * profile, the event-participant label, and the mail captured for this buyer
- * (including the HTML body, so a spec can pull a link out of it, e.g. a
- * resume-registration URL), so the spec can assert that consent was recorded
- * only when opted in, that payment flipped the row to signed_up, and that the
- * confirmation email was delivered.
+ * profile, the event-participant label, the attached activity (ticket option)
+ * ids, and the mail captured for this buyer (including the HTML body, so a
+ * spec can pull a link out of it, e.g. a resume-registration URL), so the
+ * spec can assert that consent was recorded only when opted in, that payment
+ * flipped the row to signed_up, that selected activities were attached, and
+ * that the confirmation email was delivered.
  *
  * @package FairEventsE2E
  */
@@ -32,13 +33,18 @@ if ( ! $participant ) {
 	return;
 }
 
-$label = null;
+$label      = null;
+$option_ids = array();
 if ( $event_date_id ) {
-	$event_participant = ( new EventParticipantRepository() )->get_by_event_date_and_participant(
+	$event_participant_repository = new EventParticipantRepository();
+	$event_participant            = $event_participant_repository->get_by_event_date_and_participant(
 		$event_date_id,
 		$participant->id
 	);
-	$label             = $event_participant ? $event_participant->label : null;
+	$label                        = $event_participant ? $event_participant->label : null;
+	if ( $event_participant ) {
+		$option_ids = $event_participant_repository->get_option_ids_for_event_participant( (int) $event_participant->id );
+	}
 }
 
 // Mail addressed to this buyer, captured by fair-e2e-support.php.
@@ -60,6 +66,7 @@ echo 'E2E_STATE:' . wp_json_encode(
 		'email_profile' => $participant->email_profile,
 		'status'        => $participant->status,
 		'label'         => $label,
+		'option_ids'    => $option_ids,
 		'mail'          => $mail,
 	)
 ) . "\n";

--- a/e2e/user-flows/unified-signup-activities.spec.js
+++ b/e2e/user-flows/unified-signup-activities.spec.js
@@ -1,0 +1,67 @@
+/**
+ * E2E: selectable activities (ticket options) in the unified Event Signup
+ * form (#1243).
+ *
+ * IMPORTANT SCOPE NOTE: fair-events' own `event-signup` block render
+ * (render.php) only runs its own markup when fair-audience is *inactive* —
+ * whenever fair-audience is active, render.php delegates entirely to the
+ * legacy `fair-audience/event-signup` block (see
+ * `unified-signup-nested-question.spec.js`). But the activities fieldset
+ * this ticket adds is itself gated on fair-audience being *active*
+ * (`class_exists( \FairAudience\API\EventSignupController::class )`), since
+ * selections can only be persisted through fair-audience's options table.
+ * Those two preconditions are mutually exclusive under the current
+ * pre-#1245-cutover architecture — the same gap affects #1242's group-pricing
+ * render-context work, which also has no e2e coverage for this reason. So the
+ * only thing actually reachable/testable end-to-end today is the negative
+ * case below: a base-alone site (fair-audience absent) must never render a
+ * dead (unsubmittable) activities fieldset, even when activity options are
+ * configured. Full fieldset-render coverage (checkbox display, minimum
+ * enforcement, live total, add-activities section) will become reachable
+ * once #1245 removes the render delegation guard; API-level coverage for the
+ * create-route validation/pricing logic lives in
+ * fair-audience/src/API/__tests__/EventSignupActivities.api.spec.js (same
+ * reachability caveat, matching EventSignupGroupPricing.api.spec.js's
+ * existing precedent).
+ */
+
+import { test, expect } from '../support/fixtures.js';
+import { wpCli } from '../support/wp-cli.js';
+
+test.describe('Activities fieldset base-alone guard (fair-audience inactive)', () => {
+	test.beforeAll(() => {
+		wpCli('plugin deactivate fair-audience fair-audience-experimental');
+	});
+
+	test.afterAll(() => {
+		wpCli('plugin activate fair-audience fair-audience-experimental');
+	});
+
+	test('activities configured on the event never render dead checkboxes when fair-audience is absent', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('unified-with-options', {
+			options: ['dinner', 'tshirt'],
+		});
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		// Selections could never be persisted without fair-audience's options
+		// table, so the fieldset must be entirely absent — not just hidden.
+		await expect(form.locator('.fair-events-ticket-options')).toHaveCount(
+			0
+		);
+		await expect(
+			form.locator('input[name="ticket_option_ids[]"]')
+		).toHaveCount(0);
+
+		// The rest of the form still works unaffected.
+		await expect(form.locator('input[name="ticket_type_id"]')).toHaveCount(
+			1
+		);
+	});
+});

--- a/fair-audience/__tests__/Services/SignupActivitiesTest.php
+++ b/fair-audience/__tests__/Services/SignupActivitiesTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * SignupActivities pure logic tests
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairAudience\Services\SignupActivities;
+
+/**
+ * Validates the pure effective-minimum, capacity, and discount-pricing logic
+ * behind #1243, without needing fair-events-experimental loaded — mirrors
+ * GroupSignupPricingTest from #1242. Duck-typed rule objects (`discount_type`/
+ * `discount_value`) are used instead of the concrete experimental class.
+ */
+class SignupActivitiesTest extends TestCase {
+
+	/**
+	 * Build a discount rule stub.
+	 *
+	 * @param string $discount_type  'percentage' or 'amount'.
+	 * @param float  $discount_value Discount magnitude.
+	 * @return object
+	 */
+	private function rule( $discount_type, $discount_value ) {
+		$rule                 = new \stdClass();
+		$rule->discount_type  = $discount_type;
+		$rule->discount_value = $discount_value;
+		return $rule;
+	}
+
+	/**
+	 * No minimum applies when neither the event-date global nor the ticket
+	 * type raises it.
+	 */
+	public function test_effective_minimum_is_zero_when_unconfigured() {
+		$this->assertSame( 0, SignupActivities::effective_minimum( 5, 0, 0 ) );
+	}
+
+	/**
+	 * The event-date global applies when the ticket type doesn't raise it.
+	 */
+	public function test_effective_minimum_uses_global_when_type_does_not_raise() {
+		$this->assertSame( 2, SignupActivities::effective_minimum( 5, 2, 0 ) );
+	}
+
+	/**
+	 * A ticket type can raise the requirement above the event-date global.
+	 */
+	public function test_effective_minimum_uses_type_when_it_raises_above_global() {
+		$this->assertSame( 3, SignupActivities::effective_minimum( 5, 1, 3 ) );
+	}
+
+	/**
+	 * The requirement is capped at the number of options actually available,
+	 * so it's never impossible to satisfy.
+	 */
+	public function test_effective_minimum_is_capped_at_option_count() {
+		$this->assertSame( 2, SignupActivities::effective_minimum( 2, 5, 0 ) );
+	}
+
+	/**
+	 * Reserved count below capacity is not full.
+	 */
+	public function test_capacity_reached_false_below_capacity() {
+		$this->assertFalse( SignupActivities::capacity_reached( 3, 5 ) );
+	}
+
+	/**
+	 * Reserved count at or above capacity is full.
+	 */
+	public function test_capacity_reached_true_at_or_above_capacity() {
+		$this->assertTrue( SignupActivities::capacity_reached( 5, 5 ) );
+		$this->assertTrue( SignupActivities::capacity_reached( 6, 5 ) );
+	}
+
+	/**
+	 * A percentage discount reduces the price proportionally.
+	 */
+	public function test_apply_discount_percentage() {
+		$this->assertEqualsWithDelta( 8.0, SignupActivities::apply_discount( 10.0, 'percentage', 20 ), 0.0001 );
+	}
+
+	/**
+	 * An amount discount subtracts a flat value.
+	 */
+	public function test_apply_discount_amount() {
+		$this->assertEqualsWithDelta( 7.0, SignupActivities::apply_discount( 10.0, 'amount', 3 ), 0.0001 );
+	}
+
+	/**
+	 * Without a discount rule, the base price passes through unchanged.
+	 */
+	public function test_resolve_price_without_discount_rule() {
+		$this->assertSame( 10.0, SignupActivities::resolve_price( 10.0, null ) );
+	}
+
+	/**
+	 * With a discount rule and a positive base price, the discount is applied.
+	 */
+	public function test_resolve_price_with_discount_rule() {
+		$price = SignupActivities::resolve_price( 10.0, $this->rule( 'percentage', 50 ) );
+		$this->assertEqualsWithDelta( 5.0, $price, 0.0001 );
+	}
+
+	/**
+	 * A free (zero-price) option is never discounted below zero — the
+	 * discount is skipped entirely, matching the legacy render's
+	 * `$opt_price > 0` guard.
+	 */
+	public function test_resolve_price_skips_discount_on_free_option() {
+		$price = SignupActivities::resolve_price( 0.0, $this->rule( 'amount', 5 ) );
+		$this->assertSame( 0.0, $price );
+	}
+}

--- a/fair-audience/src/API/__tests__/EventSignupActivities.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupActivities.api.spec.js
@@ -1,0 +1,210 @@
+/**
+ * Playwright API tests for selectable activities (ticket options) in the
+ * unified Event Signup form (#1243): fair-events/v1/get-tickets must enforce
+ * the minimum-activities requirement, reject an unknown or full activity, and
+ * charge a selected activity's price into the signup amount — server-side, so
+ * a crafted request can't skip the minimum, buy a full activity, or dodge the
+ * charge. Activities are exercised here with no ticket type configured (the
+ * "activity-only" case the two new filters were added to cover, per #1243's
+ * Decisions), proving the new filters run unconditionally.
+ *
+ * The dev stack has no payment connector configured, so a priced-activity
+ * signup 503s payment_unavailable instead of confirming — the same trick
+ * EventSignupGroupPricing.api.spec.js uses to prove server-side pricing
+ * without needing a real payment provider.
+ *
+ * The existing "add activities" delta flow (POST .../add-activities) is
+ * unchanged by #1243 (the unified form's JS submits to the same route) and
+ * already covered by EventSignupAddActivities.api.spec.js — not re-tested
+ * here.
+ *
+ * Skips gracefully when fair-events-experimental isn't active, since the
+ * activity catalogue (TicketOption) lives there.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const authHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}+${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+async function createEventWithDates(api, title) {
+	const res = await api.post('/wp-json/wp/v2/fair_event', {
+		headers: authHeaders,
+		data: { title, status: 'publish' },
+	});
+	expect(res.ok()).toBeTruthy();
+	const eventId = (await res.json()).id;
+
+	const eventsRes = await api.get('/wp-json/fair-audience/v1/events', {
+		headers: authHeaders,
+		params: { per_page: 100 },
+	});
+	expect(eventsRes.ok()).toBeTruthy();
+	const match = (await eventsRes.json()).find((e) => e.event_id === eventId);
+	expect(match, 'event-date row for test event').toBeTruthy();
+	return { eventId, eventDateId: match.event_date_id };
+}
+
+async function deleteEvent(api, eventId) {
+	if (!eventId) return;
+	await api.delete(`/wp-json/wp/v2/fair_event/${eventId}`, {
+		headers: authHeaders,
+		params: { force: 'true' },
+	});
+}
+
+test.describe('Selectable activities in the unified Event Signup form (#1243)', () => {
+	let api;
+	let experimentalActive = false;
+	let event;
+	let freeOptionId;
+	let paidOptionId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: authHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			experimentalActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-events-experimental') &&
+					p.status === 'active'
+			);
+		}
+		if (!experimentalActive) {
+			return;
+		}
+
+		event = await createEventWithDates(
+			api,
+			`Signup Activities Test ${Date.now()}`
+		);
+
+		const ticketsRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${event.eventDateId}/tickets`,
+			{
+				headers: authHeaders,
+				data: {
+					ticket_types: [],
+					sale_periods: [],
+					prices: [],
+					options: [
+						{
+							name: 'Free Activity',
+							price: 0,
+							capacity: 1,
+						},
+						{
+							name: 'Paid Activity',
+							price: 15,
+							capacity: null,
+						},
+					],
+					settings: { minimum_activities: 1 },
+				},
+			}
+		);
+		expect(ticketsRes.ok(), await ticketsRes.text()).toBeTruthy();
+		const options = (await ticketsRes.json()).options || [];
+		freeOptionId = options.find((o) => o.name === 'Free Activity')?.id;
+		paidOptionId = options.find((o) => o.name === 'Paid Activity')?.id;
+		expect(freeOptionId).toBeTruthy();
+		expect(paidOptionId).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (experimentalActive) {
+			await deleteEvent(api, event?.eventId);
+		}
+		await api.dispose();
+	});
+
+	test('a signup with no activities selected is rejected with 400 minimum_activities_not_met', async () => {
+		test.skip(!experimentalActive, 'fair-events-experimental not active');
+
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: event.eventDateId,
+				name: 'No Activities Buyer',
+				email: uniqueEmail('no-activities'),
+			},
+		});
+		expect(res.status()).toBe(400);
+		expect((await res.json()).code).toBe('minimum_activities_not_met');
+	});
+
+	test('an unknown activity id is rejected with 400 invalid_ticket_option', async () => {
+		test.skip(!experimentalActive, 'fair-events-experimental not active');
+
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: event.eventDateId,
+				name: 'Invalid Option Buyer',
+				email: uniqueEmail('invalid-option'),
+				ticket_option_ids: [999999999],
+			},
+		});
+		expect(res.status()).toBe(400);
+		expect((await res.json()).code).toBe('invalid_ticket_option');
+	});
+
+	test('a paid activity is charged into the signup amount (503 without a payment connector proves it)', async () => {
+		test.skip(!experimentalActive, 'fair-events-experimental not active');
+
+		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: event.eventDateId,
+				name: 'Paid Activity Buyer',
+				email: uniqueEmail('paid-activity'),
+				ticket_option_ids: [paidOptionId],
+			},
+		});
+		expect(res.status()).toBe(503);
+		expect((await res.json()).code).toBe('payment_unavailable');
+	});
+
+	test('a free activity confirms immediately, then a capacity-1 activity 409s ticket_option_full for the next buyer', async () => {
+		test.skip(!experimentalActive, 'fair-events-experimental not active');
+
+		const firstRes = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: event.eventDateId,
+				name: 'Free Activity Buyer',
+				email: uniqueEmail('free-activity'),
+				ticket_option_ids: [freeOptionId],
+			},
+		});
+		expect(firstRes.ok(), await firstRes.text()).toBeTruthy();
+		expect((await firstRes.json()).status).toBe('confirmed');
+
+		const secondRes = await api.post(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				data: {
+					event_date_id: event.eventDateId,
+					name: 'Second Free Activity Buyer',
+					email: uniqueEmail('free-activity-full'),
+					ticket_option_ids: [freeOptionId],
+				},
+			}
+		);
+		expect(secondRes.status()).toBe(409);
+		expect((await secondRes.json()).code).toBe('ticket_option_full');
+	});
+});

--- a/fair-audience/src/Hooks/SignupHookBridge.php
+++ b/fair-audience/src/Hooks/SignupHookBridge.php
@@ -18,6 +18,7 @@ use FairAudience\Models\Participant;
 use FairAudience\Services\AudienceSession;
 use FairAudience\Services\EmailService;
 use FairAudience\Services\GroupSignupPricing;
+use FairAudience\Services\SignupActivities;
 use FairAudience\Services\SignupPriceResolver;
 
 defined( 'WPINC' ) || die;
@@ -41,6 +42,9 @@ class SignupHookBridge {
 		add_action( 'fair_events_signup_render_before_submit', array( static::class, 'render_discount_note' ), 10, 1 );
 		add_filter( 'fair_events_signup_ticket_type_error', array( static::class, 'filter_ticket_type_error' ), 10, 2 );
 		add_filter( 'fair_events_signup_unit_price', array( static::class, 'filter_unit_price' ), 10, 2 );
+		add_filter( 'fair_events_signup_options_error', array( static::class, 'filter_options_error' ), 10, 3 );
+		add_filter( 'fair_events_signup_option_line_items', array( static::class, 'filter_option_line_items' ), 10, 2 );
+		add_action( 'fair_events_signup_render_after_form', array( static::class, 'render_add_activities' ), 10, 1 );
 		add_action( 'fair_events_signup_created', array( static::class, 'link_participant' ), 10, 6 );
 		add_action( 'fair_events_signup_confirmed', array( static::class, 'handle_signup_confirmed' ), 10, 2 );
 		add_action( 'fair_events_signup_payment_failed', array( static::class, 'handle_signup_payment_failed' ), 10, 2 );
@@ -67,55 +71,58 @@ class SignupHookBridge {
 
 		$context['group_discount_rule'] = null;
 
-		if ( empty( $context['ticket_types'] ) ) {
-			return $context;
-		}
+		if ( ! empty( $context['ticket_types'] ) ) {
+			$pricing_event_date_id = (int) $context['pricing_event_date_id'];
 
-		$pricing_event_date_id = (int) $context['pricing_event_date_id'];
+			if ( class_exists( \FairEventsExperimental\Models\TicketTypeGroupRestriction::class ) ) {
+				$restrictions_map = \FairEventsExperimental\Models\TicketTypeGroupRestriction::get_all_by_event_date_id( $pricing_event_date_id );
 
-		if ( class_exists( \FairEventsExperimental\Models\TicketTypeGroupRestriction::class ) ) {
-			$restrictions_map = \FairEventsExperimental\Models\TicketTypeGroupRestriction::get_all_by_event_date_id( $pricing_event_date_id );
+				if ( ! empty( $restrictions_map ) ) {
+					$member_group_ids = array();
+					if ( $participant_id && class_exists( \FairAudienceExperimental\Database\GroupParticipantRepository::class ) ) {
+						$group_participant_repo = new \FairAudienceExperimental\Database\GroupParticipantRepository();
+						$memberships            = $group_participant_repo->get_by_participant( $participant_id );
+						$member_group_ids       = array_map(
+							function ( $membership ) {
+								return (int) $membership->group_id;
+							},
+							$memberships
+						);
+					}
 
-			if ( ! empty( $restrictions_map ) ) {
-				$member_group_ids = array();
-				if ( $participant_id && class_exists( \FairAudienceExperimental\Database\GroupParticipantRepository::class ) ) {
-					$group_participant_repo = new \FairAudienceExperimental\Database\GroupParticipantRepository();
-					$memberships            = $group_participant_repo->get_by_participant( $participant_id );
-					$member_group_ids       = array_map(
-						function ( $membership ) {
-							return (int) $membership->group_id;
-						},
-						$memberships
+					$context['ticket_types'] = GroupSignupPricing::allowed_ticket_types(
+						$context['ticket_types'],
+						$restrictions_map,
+						$member_group_ids
 					);
 				}
+			}
 
-				$context['ticket_types'] = GroupSignupPricing::allowed_ticket_types(
-					$context['ticket_types'],
-					$restrictions_map,
-					$member_group_ids
+			// Re-resolve prices for the surviving types through the same authority
+			// the create route uses, so the displayed price matches what gets
+			// charged. Clamped at 0 — an amount-discount larger than the price
+			// can never show (or charge) a negative amount.
+			$price_by_type_id = array();
+			foreach ( $context['ticket_types'] as $ticket_type ) {
+				$resolved = SignupPriceResolver::resolve_price_for_ticket_type( (int) $ticket_type->id, $participant_id );
+				if ( null !== $resolved ) {
+					$price_by_type_id[ (int) $ticket_type->id ] = max( 0, $resolved );
+				}
+			}
+			$context['price_by_type_id'] = $price_by_type_id;
+
+			if ( $participant_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+				$context['group_discount_rule'] = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
+					$pricing_event_date_id,
+					$participant_id
 				);
 			}
 		}
 
-		// Re-resolve prices for the surviving types through the same authority
-		// the create route uses, so the displayed price matches what gets
-		// charged. Clamped at 0 — an amount-discount larger than the price
-		// can never show (or charge) a negative amount.
-		$price_by_type_id = array();
-		foreach ( $context['ticket_types'] as $ticket_type ) {
-			$resolved = SignupPriceResolver::resolve_price_for_ticket_type( (int) $ticket_type->id, $participant_id );
-			if ( null !== $resolved ) {
-				$price_by_type_id[ (int) $ticket_type->id ] = max( 0, $resolved );
-			}
-		}
-		$context['price_by_type_id'] = $price_by_type_id;
-
-		if ( $participant_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$context['group_discount_rule'] = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
-				$pricing_event_date_id,
-				$participant_id
-			);
-		}
+		// Activities (ticket options) are independent of ticket types — an
+		// event can sell activities alongside a free, type-less signup — so
+		// this runs unconditionally.
+		$context = SignupActivities::enrich_render_context( $context, $participant_id );
 
 		return $context;
 	}
@@ -187,6 +194,132 @@ class SignupHookBridge {
 		}
 
 		return max( 0, $resolved );
+	}
+
+	/**
+	 * Validate a submitted activity (ticket option) selection: belongs to the
+	 * event date, not full, and meets the effective minimum-activities
+	 * requirement. Hooked on fair_events_signup_options_error.
+	 *
+	 * @param WP_Error|null $error                 Prior filter result — passed through unchanged if already an error.
+	 * @param int[]         $ticket_option_ids      Submitted option IDs.
+	 * @param int           $pricing_event_date_id Event date the activity catalogue belongs to.
+	 * @param int           $ticket_type_id         Selected ticket type ID, or 0 for none.
+	 * @return \WP_Error|null
+	 */
+	public static function filter_options_error( $error, $ticket_option_ids, $pricing_event_date_id, $ticket_type_id ) {
+		if ( is_wp_error( $error ) ) {
+			return $error;
+		}
+
+		return SignupActivities::validate_selection( (array) $ticket_option_ids, (int) $pricing_event_date_id, (int) $ticket_type_id );
+	}
+
+	/**
+	 * Resolve priced line items for a submitted activity selection, applying
+	 * the viewer's best group discount rule. Hooked on
+	 * fair_events_signup_option_line_items.
+	 *
+	 * @param array $line_items            Prior filter result (empty by default).
+	 * @param int[] $ticket_option_ids     Submitted option IDs.
+	 * @param int   $pricing_event_date_id Event date the activity catalogue belongs to.
+	 * @return array[]
+	 */
+	public static function filter_option_line_items( $line_items, $ticket_option_ids, $pricing_event_date_id ) {
+		if ( empty( $ticket_option_ids ) ) {
+			return $line_items;
+		}
+
+		$participant    = GroupSignupPricing::resolve_viewer_participant();
+		$participant_id = $participant ? (int) $participant->id : null;
+
+		return array_merge(
+			$line_items,
+			SignupActivities::line_items( (array) $ticket_option_ids, (int) $pricing_event_date_id, $participant_id )
+		);
+	}
+
+	/**
+	 * Render the "add activities" section for a signed-up viewer, listing
+	 * only the activities they don't already have (stashed onto the context
+	 * as 'addable_options' by enrich_render_context()). No-op when there's
+	 * nothing to add. Reuses the legacy form's markup/behaviour, submitting
+	 * through fair-audience's existing add-activities route — the path a
+	 * companion plugin owns is read from a data attribute so the base plugin
+	 * never hardcodes it.
+	 *
+	 * @param array $context Render context, see fair_events_signup_render_context.
+	 * @return void
+	 */
+	public static function render_add_activities( $context ) {
+		$addable_options = $context['addable_options'] ?? array();
+		if ( empty( $addable_options ) ) {
+			return;
+		}
+
+		$event_date_id = (int) ( $context['event_date_id'] ?? 0 );
+		$event_id      = 0;
+		if ( $event_date_id && class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+			if ( $event_date ) {
+				$event_id = (int) $event_date->get_resolved_event_id();
+			}
+		}
+		if ( ! $event_id ) {
+			return;
+		}
+
+		$participant = GroupSignupPricing::resolve_viewer_participant();
+		$token       = $participant ? \FairAudience\Services\ParticipantToken::generate( (int) $participant->id, $event_date_id ) : '';
+
+		echo '<div class="fair-events-add-activities"'
+			. ' data-event-id="' . esc_attr( (string) $event_id ) . '"'
+			. ' data-event-date-id="' . esc_attr( (string) $event_date_id ) . '"'
+			. ' data-participant-token="' . esc_attr( $token ) . '">';
+		echo '<fieldset>';
+		echo '<legend>' . esc_html__( 'Add activities', 'fair-audience' ) . '</legend>';
+
+		if ( ! empty( $context['current_activity_names'] ) ) {
+			echo '<p>' . esc_html__( 'Your activities:', 'fair-audience' ) . '</p><ul>';
+			foreach ( $context['current_activity_names'] as $activity_name ) {
+				echo '<li>' . esc_html( $activity_name ) . '</li>';
+			}
+			echo '</ul>';
+		}
+
+		foreach ( $addable_options as $option ) {
+			$is_full      = ! empty( $option['is_full'] );
+			$option_label = $option['name'];
+			if ( $option['price'] > 0 ) {
+				$option_label .= ' — ' . \FairEventsShared\Money::format_inline( $option['price'] );
+			} elseif ( $option['price'] < 0 ) {
+				$option_label .= ' — -' . \FairEventsShared\Money::format_inline( abs( $option['price'] ) );
+			} else {
+				$option_label .= ' — ' . __( 'free', 'fair-audience' );
+			}
+			if ( $is_full ) {
+				$option_label .= ' — ' . __( 'full', 'fair-audience' );
+			}
+			$checkbox_id = 'fair-events-add-opt-' . (int) $option['id'];
+			$classes     = 'fair-events-ticket-option-item';
+			if ( $is_full ) {
+				$classes .= ' fair-events-ticket-option-full';
+			}
+			echo '<label class="' . esc_attr( $classes ) . '" for="' . esc_attr( $checkbox_id ) . '">';
+			echo '<input type="checkbox" name="add_option_ids[]" id="' . esc_attr( $checkbox_id ) . '" value="' . (int) $option['id'] . '"'
+				. ' data-option-price="' . esc_attr( \FairEventsShared\Money::format_value( $option['price'] ) ) . '"'
+				. ( $is_full ? ' disabled' : '' ) . ' /> ';
+			echo esc_html( $option_label );
+			echo '</label>';
+		}
+
+		echo '<div class="wp-block-button">';
+		echo '<button type="button" class="wp-block-button__link wp-element-button fair-events-add-activities-button" disabled>';
+		echo esc_html__( 'Add activities', 'fair-audience' );
+		echo '</button>';
+		echo '</div>';
+		echo '</fieldset>';
+		echo '</div>';
 	}
 
 	/**
@@ -278,6 +411,26 @@ class SignupHookBridge {
 				if ( $transaction_id ) {
 					( new EventParticipantTransactionRepository() )->record( (int) $relationship->id, (int) $transaction_id, 'charge' );
 				}
+			}
+		}
+
+		// Attach selected activities on both the free and pending_payment
+		// paths, matching the legacy form. Uses $existing (already fetched
+		// above) when the relationship pre-existed, otherwise re-fetches the
+		// row add_participant_to_event() just created.
+		if ( ! empty( $ticket_selection['ticket_option_ids'] ) && class_exists( \FairEventsExperimental\Models\TicketOption::class ) ) {
+			$relationship_for_options = $existing
+				? $existing
+				: $event_participant_repository->get_by_event_date_and_participant( $event_date_id, $participant->id );
+			if ( $relationship_for_options ) {
+				$options = array();
+				foreach ( $ticket_selection['ticket_option_ids'] as $option_id ) {
+					$option = \FairEventsExperimental\Models\TicketOption::get_by_id( (int) $option_id );
+					if ( $option ) {
+						$options[] = $option;
+					}
+				}
+				$event_participant_repository->add_options( (int) $relationship_for_options->id, $options );
 			}
 		}
 

--- a/fair-audience/src/Services/SignupActivities.php
+++ b/fair-audience/src/Services/SignupActivities.php
@@ -1,0 +1,320 @@
+<?php
+/**
+ * Signup Activities Service
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Services;
+
+use FairAudience\Database\EventParticipantRepository;
+use WP_Error;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Pure presenter/validation logic for selectable activities (ticket options)
+ * in the unified Event Signup form, kept independent of the WordPress
+ * bootstrap where possible so it stays unit-testable — mirrors
+ * GroupSignupPricing from #1242. Experimental-only lookups (the option
+ * catalogue, capacity, discount rules) stay behind `class_exists()` guards at
+ * each call site, degrading to "no activities" when `fair-events-experimental`
+ * is inactive.
+ */
+class SignupActivities {
+
+	/**
+	 * Compute the effective minimum number of activities a buyer must select:
+	 * the event-date global baseline, possibly raised by the selected ticket
+	 * type, capped at the number of options actually available so the
+	 * requirement is never impossible to satisfy. Mirrors frontend.js'
+	 * getEffectiveMinimum().
+	 *
+	 * @param int $option_count Number of activity options available.
+	 * @param int $global_min   Event-date global minimum-activities setting.
+	 * @param int $type_min     Selected ticket type's minimum_activities (0 = inherit global).
+	 * @return int Effective minimum (0 = no requirement).
+	 */
+	public static function effective_minimum( $option_count, $global_min, $type_min ) {
+		return min( (int) $option_count, max( (int) $global_min, (int) $type_min ) );
+	}
+
+	/**
+	 * Whether a capacity-limited option has no seats left.
+	 *
+	 * @param int $reserved Active signups currently held against the option.
+	 * @param int $capacity Configured capacity.
+	 * @return bool True when full.
+	 */
+	public static function capacity_reached( $reserved, $capacity ) {
+		return (int) $reserved >= (int) $capacity;
+	}
+
+	/**
+	 * Apply a discount rule to a base price. Duplicates the small formula in
+	 * `FairEventsExperimental\Services\EventSignupPricing::apply_discount()`
+	 * rather than depending on that class here, so this stays testable
+	 * without fair-events-experimental loaded.
+	 *
+	 * @param float  $base_price     Original price.
+	 * @param string $discount_type  'percentage' or 'amount'.
+	 * @param float  $discount_value Discount magnitude.
+	 * @return float Discounted price (not clamped).
+	 */
+	public static function apply_discount( $base_price, $discount_type, $discount_value ) {
+		if ( 'percentage' === $discount_type ) {
+			return $base_price * ( 1.0 - ( $discount_value / 100.0 ) );
+		}
+		return $base_price - $discount_value;
+	}
+
+	/**
+	 * Resolve an activity option's price for the viewer, applying their best
+	 * group discount rule (if any) on top of a positive base price. Mirrors
+	 * the legacy render's `compute_option_price()`.
+	 *
+	 * @param float       $base_price    Base (undiscounted) option price.
+	 * @param object|null $discount_rule Discount rule with `discount_type`/`discount_value`, or null.
+	 * @return float Resolved price.
+	 */
+	public static function resolve_price( $base_price, $discount_rule ) {
+		if ( ! $discount_rule || $base_price <= 0 ) {
+			return $base_price;
+		}
+		return self::apply_discount( $base_price, $discount_rule->discount_type, (float) $discount_rule->discount_value );
+	}
+
+	/**
+	 * Whether a raw TicketOption is full, based on its configured capacity.
+	 *
+	 * @param object                     $option Raw TicketOption row (needs `id`, `capacity`).
+	 * @param EventParticipantRepository $repository Repository used to count active signups.
+	 * @return bool True when full.
+	 */
+	public static function is_full( $option, EventParticipantRepository $repository ) {
+		if ( null === $option->capacity ) {
+			return false;
+		}
+		$reserved = $repository->count_signups_for_ticket_option( (int) $option->id );
+		return self::capacity_reached( $reserved, (int) $option->capacity );
+	}
+
+	/**
+	 * Resolve the effective minimum for a signup request: the event-date
+	 * global setting, possibly raised by the given ticket type.
+	 *
+	 * @param int $pricing_event_date_id Event date the activity catalogue/settings belong to.
+	 * @param int $ticket_type_id        Selected ticket type ID, or 0 for none.
+	 * @param int $option_count          Number of activity options available.
+	 * @return int Effective minimum.
+	 */
+	public static function effective_minimum_for_selection( $pricing_event_date_id, $ticket_type_id, $option_count ) {
+		$global_min = class_exists( \FairEvents\Models\EventDateSetting::class )
+			? (int) \FairEvents\Models\EventDateSetting::get( $pricing_event_date_id, 'minimum_activities' )
+			: 0;
+
+		$type_min = 0;
+		if ( $ticket_type_id && class_exists( \FairEvents\Models\TicketType::class ) ) {
+			$ticket_type = \FairEvents\Models\TicketType::get_by_id( $ticket_type_id );
+			if ( $ticket_type ) {
+				$type_min = (int) $ticket_type->minimum_activities;
+			}
+		}
+
+		return self::effective_minimum( $option_count, $global_min, $type_min );
+	}
+
+	/**
+	 * Validate a submitted activity selection: every ID must belong to the
+	 * event date and not be full, and the selection must meet the effective
+	 * minimum. Hooked on `fair_events_signup_options_error`.
+	 *
+	 * @param int[] $ticket_option_ids     Submitted option IDs.
+	 * @param int   $pricing_event_date_id Event date the activity catalogue belongs to.
+	 * @param int   $ticket_type_id        Selected ticket type ID, or 0 for none.
+	 * @return WP_Error|null 400/409 on failure, null when the selection is valid.
+	 */
+	public static function validate_selection( array $ticket_option_ids, $pricing_event_date_id, $ticket_type_id ) {
+		if ( ! class_exists( \FairEventsExperimental\Models\TicketOption::class ) ) {
+			// No activity catalogue active: a non-empty selection can't be valid.
+			if ( empty( $ticket_option_ids ) ) {
+				return null;
+			}
+			return new WP_Error(
+				'invalid_ticket_option',
+				__( 'One of the selected activities is not available for this event.', 'fair-audience' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$available = \FairEventsExperimental\Models\TicketOption::get_all_by_event_date_id( $pricing_event_date_id );
+
+		$available_by_id = array();
+		foreach ( $available as $option ) {
+			$available_by_id[ (int) $option->id ] = $option;
+		}
+
+		$repository = new EventParticipantRepository();
+
+		foreach ( $ticket_option_ids as $option_id ) {
+			$option = $available_by_id[ (int) $option_id ] ?? null;
+			if ( ! $option ) {
+				return new WP_Error(
+					'invalid_ticket_option',
+					__( 'One of the selected activities is not available for this event.', 'fair-audience' ),
+					array( 'status' => 400 )
+				);
+			}
+			if ( self::is_full( $option, $repository ) ) {
+				return new WP_Error(
+					'ticket_option_full',
+					sprintf(
+						/* translators: %s: activity name */
+						__( '"%s" is full.', 'fair-audience' ),
+						$option->name
+					),
+					array( 'status' => 409 )
+				);
+			}
+		}
+
+		$minimum = self::effective_minimum_for_selection( $pricing_event_date_id, $ticket_type_id, count( $available ) );
+		if ( count( $ticket_option_ids ) < $minimum ) {
+			return new WP_Error(
+				'minimum_activities_not_met',
+				sprintf(
+					/* translators: %d: minimum number of activities required */
+					_n(
+						'Please select at least %d activity to sign up.',
+						'Please select at least %d activities to sign up.',
+						$minimum,
+						'fair-audience'
+					),
+					$minimum
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve priced line items for a submitted activity selection, applying
+	 * the participant's best group discount rule. Hooked on
+	 * `fair_events_signup_option_line_items`. Assumes the selection was
+	 * already validated by validate_selection() — an ID that no longer
+	 * resolves is skipped rather than erroring.
+	 *
+	 * @param int[]    $ticket_option_ids     Submitted option IDs.
+	 * @param int      $pricing_event_date_id Event date the activity catalogue belongs to.
+	 * @param int|null $participant_id        Viewer's participant ID, or null for anonymous.
+	 * @return array[] List of `[ 'name' => string, 'quantity' => 1, 'amount' => float ]`.
+	 */
+	public static function line_items( array $ticket_option_ids, $pricing_event_date_id, $participant_id ) {
+		if ( empty( $ticket_option_ids ) || ! class_exists( \FairEventsExperimental\Models\TicketOption::class ) ) {
+			return array();
+		}
+
+		$discount_rule = null;
+		if ( $participant_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			$discount_rule = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
+				$pricing_event_date_id,
+				$participant_id
+			);
+		}
+
+		$line_items = array();
+		foreach ( $ticket_option_ids as $option_id ) {
+			$option = \FairEventsExperimental\Models\TicketOption::get_by_id( (int) $option_id );
+			if ( ! $option ) {
+				continue;
+			}
+
+			$base_price = class_exists( \FairEventsExperimental\Services\ActivityOptionPriceResolver::class )
+				? \FairEventsExperimental\Services\ActivityOptionPriceResolver::resolve( $option )
+				: (float) $option->price;
+			if ( null === $base_price ) {
+				continue;
+			}
+
+			$line_items[] = array(
+				'name'     => $option->name,
+				'quantity' => 1,
+				'amount'   => self::resolve_price( (float) $base_price, $discount_rule ),
+			);
+		}
+
+		return $line_items;
+	}
+
+	/**
+	 * Recompute `price`/`is_full` on the base-resolved `ticket_options`
+	 * render-context entries for the viewer, and add `addable_options` /
+	 * `current_activity_names` when the viewer is already signed up for this
+	 * event date. Called from SignupHookBridge::enrich_render_context().
+	 *
+	 * @param array    $context        Render context from fair-events' base render.
+	 * @param int|null $participant_id Viewer's participant ID, or null for anonymous.
+	 * @return array Filtered context.
+	 */
+	public static function enrich_render_context( array $context, $participant_id ) {
+		$context['addable_options']        = array();
+		$context['current_activity_names'] = array();
+
+		if ( empty( $context['ticket_options'] ) ) {
+			return $context;
+		}
+
+		$pricing_event_date_id = (int) $context['pricing_event_date_id'];
+
+		$discount_rule = null;
+		if ( $participant_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			$discount_rule = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
+				$pricing_event_date_id,
+				$participant_id
+			);
+		}
+
+		$event_participant_repository = new EventParticipantRepository();
+
+		$signed_row = null;
+		if ( $participant_id ) {
+			$candidate = $event_participant_repository->get_by_event_date_and_participant(
+				(int) $context['event_date_id'],
+				$participant_id
+			);
+			if ( $candidate && 'signed_up' === $candidate->label ) {
+				$signed_row = $candidate;
+			}
+		}
+
+		$current_option_ids = $signed_row
+			? $event_participant_repository->get_option_ids_for_event_participant( (int) $signed_row->id )
+			: array();
+
+		foreach ( $context['ticket_options'] as &$option ) {
+			$option['price'] = self::resolve_price( (float) $option['price'], $discount_rule );
+
+			$is_full = false;
+			if ( class_exists( \FairEventsExperimental\Models\TicketOption::class ) ) {
+				$raw_option = \FairEventsExperimental\Models\TicketOption::get_by_id( (int) $option['id'] );
+				if ( $raw_option ) {
+					$is_full = self::is_full( $raw_option, $event_participant_repository );
+				}
+			}
+			$option['is_full'] = $is_full;
+
+			if ( $signed_row ) {
+				if ( in_array( (int) $option['id'], $current_option_ids, true ) ) {
+					$context['current_activity_names'][] = $option['name'];
+				} else {
+					$context['addable_options'][] = $option;
+				}
+			}
+		}
+		unset( $option );
+
+		return $context;
+	}
+}

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -111,6 +111,17 @@ class GetTicketsController extends WP_REST_Controller {
 								return ! is_array( $value ) || count( $value ) <= 50;
 							},
 						),
+						// Chosen activity (ticket option) IDs. Capped, mirroring
+						// event_date_ids above. Ignored on the 'multiple_instances'
+						// path, which never reads this param.
+						'ticket_option_ids'     => array(
+							'type'              => 'array',
+							'items'             => array( 'type' => 'integer' ),
+							'required'          => false,
+							'validate_callback' => function ( $value ) {
+								return ! is_array( $value ) || count( $value ) <= 50;
+							},
+						),
 						'_honeypot'             => array(
 							'type'     => 'string',
 							'required' => false,
@@ -257,6 +268,18 @@ class GetTicketsController extends WP_REST_Controller {
 		$quantity       = max( 1, min( 100, (int) $request->get_param( 'quantity' ) ) );
 		$mailing_opt_in = (bool) $request->get_param( 'mailing_opt_in' );
 
+		// Chosen activity (ticket option) IDs, deduped/cast defensively even
+		// though the route arg already caps the count — see register_routes().
+		$ticket_option_ids = $request->get_param( 'ticket_option_ids' ) ?? array();
+		$ticket_option_ids = array_values( array_filter( array_unique( array_map( 'absint', (array) $ticket_option_ids ) ) ) );
+
+		// Activities attach to a single EventParticipant row, so a crafted
+		// request can't multiply an activity set by ticket quantity — pinned
+		// before $amount is derived from quantity below.
+		if ( ! empty( $ticket_option_ids ) ) {
+			$quantity = 1;
+		}
+
 		$questionnaire_answers = $this->prepare_questionnaire_answers( $request );
 		if ( is_wp_error( $questionnaire_answers ) ) {
 			return $questionnaire_answers;
@@ -333,10 +356,30 @@ class GetTicketsController extends WP_REST_Controller {
 			}
 		}
 
+		// Extension point for plugins (e.g. fair-audience) that sell selectable
+		// activities (ticket options) alongside a signup. Runs unconditionally
+		// — even a signup with no ticket type can carry a minimum-activities
+		// requirement. See REST_API_BACKEND.md.
+		$options_error = apply_filters( 'fair_events_signup_options_error', null, $ticket_option_ids, (int) $config_event_date_id, (int) $ticket_type_id );
+		if ( is_wp_error( $options_error ) ) {
+			return $options_error;
+		}
+
+		// fair-audience resolves discounted per-activity prices; summed here
+		// into $amount and kept as separate line items (below) so the finance
+		// ledger names what was bought instead of folding it into the ticket line.
+		$option_line_items = apply_filters( 'fair_events_signup_option_line_items', array(), $ticket_option_ids, (int) $config_event_date_id );
+		$ticket_amount     = $amount;
+		foreach ( $option_line_items as $item ) {
+			$amount += (float) $item['quantity'] * (float) $item['amount'];
+		}
+
 		// Fail closed: a priced ticket must never be saved when payment can't
 		// be collected. Rejecting up front avoids the orphaned pending_payment
 		// row left by the connector-unconfigured case and the silent
-		// free-confirmation the old connector-absent fallback produced.
+		// free-confirmation the old connector-absent fallback produced. Covers
+		// activity-only pricing too (free ticket type + paid activity), since
+		// $amount already includes the options total above.
 		if ( $amount > 0 && $this->payments_unavailable() ) {
 			return new WP_Error(
 				'payment_unavailable',
@@ -370,8 +413,9 @@ class GetTicketsController extends WP_REST_Controller {
 		}
 
 		$ticket_selection = array(
-			'ticket_type_id' => $ticket_type_id ? $ticket_type_id : null,
-			'quantity'       => $quantity,
+			'ticket_type_id'    => $ticket_type_id ? $ticket_type_id : null,
+			'quantity'          => $quantity,
+			'ticket_option_ids' => $ticket_option_ids,
 		);
 
 		// Free path.
@@ -396,13 +440,22 @@ class GetTicketsController extends WP_REST_Controller {
 			$event_date_id
 		);
 
-		$line_items = array(
-			array(
+		// Activities get their own line item(s) (from $option_line_items,
+		// resolved above) instead of being folded into the ticket line, so the
+		// finance ledger names what was bought. The ticket line is only added
+		// when there's an actual ticket price — a pure activity-only signup
+		// (free/no ticket type + paid activity) skips a nonsensical €0 line.
+		$line_items = array();
+		if ( $ticket_amount > 0 ) {
+			$line_items[] = array(
 				'name'     => $description,
 				'quantity' => $quantity,
-				'amount'   => $amount / $quantity,
-			),
-		);
+				'amount'   => $ticket_amount / $quantity,
+			);
+		}
+		foreach ( $option_line_items as $item ) {
+			$line_items[] = $item;
+		}
 
 		$user_id        = get_current_user_id();
 		$transaction_id = \FairPaymentsConnector\API\TransactionAPI::create_transaction(

--- a/fair-events/src/blocks/event-signup/frontend.css
+++ b/fair-events/src/blocks/event-signup/frontend.css
@@ -114,6 +114,81 @@
 	align-items: flex-end;
 }
 
+/* Activities (ticket options) */
+.fair-events-get-tickets-form .fair-events-ticket-options {
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	padding: 12px 16px;
+	margin: 0;
+}
+
+.fair-events-get-tickets-form .fair-events-ticket-options legend {
+	padding: 0 4px;
+}
+
+.fair-events-get-tickets-form .fair-events-ticket-option-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-weight: normal;
+	cursor: pointer;
+	padding: 4px 0;
+}
+
+.fair-events-get-tickets-form
+	.fair-events-ticket-option-item
+	input[type="checkbox"] {
+	width: 18px;
+	height: 18px;
+	cursor: pointer;
+	flex-shrink: 0;
+}
+
+/* Name + "(+price)" tag share one flex item so the price wraps with the name
+   as a single text flow rather than landing on its own line. */
+.fair-events-get-tickets-form .fair-events-ticket-option-text {
+	min-width: 0;
+}
+
+.fair-events-get-tickets-form .fair-events-ticket-option-addon {
+	white-space: nowrap;
+}
+
+.fair-events-get-tickets-form .fair-events-ticket-option-full {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.fair-events-get-tickets-form
+	.fair-events-ticket-option-full
+	input[type="checkbox"] {
+	cursor: not-allowed;
+}
+
+.fair-events-get-tickets-form button[type="submit"]:disabled,
+.fair-events-get-tickets-form button[type="submit"].is-disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+/* "Add activities" section (signed-up viewer), rendered by fair-audience. */
+.fair-events-add-activities {
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	padding: 12px 16px;
+	margin: 16px 0 0;
+}
+
+.fair-events-add-activities legend {
+	padding: 0 4px;
+}
+
+.fair-events-add-activities-button:disabled,
+.fair-events-add-activities-button.is-disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
 .fair-events-get-tickets-callback {
 	padding: 16px 20px;
 	border-radius: 4px;

--- a/fair-events/src/blocks/event-signup/frontend.js
+++ b/fair-events/src/blocks/event-signup/frontend.js
@@ -15,6 +15,8 @@ import {
 	formatMoney,
 	collectQuestionAnswers,
 	validateQuestions,
+	extractErrorMessage,
+	setButtonLoading,
 } from 'fair-events-shared';
 import './frontend.css';
 
@@ -234,7 +236,7 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 		);
 		ticketTypeFields.forEach(function (field) {
 			field.addEventListener('change', function () {
-				updateInstancePicker(form);
+				refreshSignupState(form);
 			});
 		});
 
@@ -246,12 +248,38 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 				.querySelectorAll('input[name="event_date_ids[]"]')
 				.forEach(function (checkbox) {
 					checkbox.addEventListener('change', function () {
-						updateInstancePicker(form);
+						refreshSignupState(form);
 					});
 				});
 		}
 
+		const ticketOptions = form.querySelector('.fair-events-ticket-options');
+		if (ticketOptions) {
+			ticketOptions
+				.querySelectorAll('input[name="ticket_option_ids[]"]')
+				.forEach(function (checkbox) {
+					checkbox.addEventListener('change', function () {
+						refreshSignupState(form);
+					});
+				});
+		}
+
+		wireAddActivities(form);
+
+		refreshSignupState(form);
+	}
+
+	/**
+	 * Recompute every selection-dependent piece of UI (occurrence/instance
+	 * picker, ticket-options fieldset, submit gate) in one pass. Wired to every
+	 * input whose change can affect any of them, so the instance and activity
+	 * gates always compose correctly regardless of which one changed.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 */
+	function refreshSignupState(form) {
 		updateInstancePicker(form);
+		updateTicketOptions(form);
+		updateSubmitGate(form);
 	}
 
 	/**
@@ -389,6 +417,354 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 		}
 	}
 
+	/**
+	 * Whether the event date has an activities (ticket options) fieldset at
+	 * all — used to pin quantity to 1, same treatment 'multiple_instances'
+	 * ticket types get, since activities attach to a single EventParticipant
+	 * row.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 * @return {boolean} True when an activities fieldset is present.
+	 */
+	function hasActivityOptions(form) {
+		return !!form.querySelector('.fair-events-ticket-options');
+	}
+
+	/**
+	 * Compute the effective minimum number of activities: the event-date
+	 * global baseline, possibly raised by the selected ticket type, capped at
+	 * the number of options available so the requirement is never impossible
+	 * to satisfy.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 * @return {number} The effective minimum (0 when no minimum applies).
+	 */
+	function getEffectiveActivityMinimum(form) {
+		const globalMin = parseInt(form.dataset.minActivities || '0', 10);
+		const selectedTicketType = getSelectedTicketTypeOption(form);
+		const typeMin = selectedTicketType
+			? parseInt(selectedTicketType.dataset.minActivities || '0', 10)
+			: 0;
+		const optionCount = form.querySelectorAll(
+			'input[name="ticket_option_ids[]"]'
+		).length;
+
+		return Math.min(Math.max(globalMin, typeMin), optionCount);
+	}
+
+	/**
+	 * Whether enough activities are currently checked to satisfy the
+	 * effective minimum. Always true when the fieldset is hidden
+	 * ('multiple_instances' ignores activities) or there's no minimum.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 * @return {boolean} True when the requirement is satisfied.
+	 */
+	function meetsActivityMinimum(form) {
+		if (!hasActivityOptions(form) || isMultipleInstancesSelected(form)) {
+			return true;
+		}
+		const effectiveMin = getEffectiveActivityMinimum(form);
+		if (!effectiveMin) {
+			return true;
+		}
+		const checkedCount = form.querySelectorAll(
+			'input[name="ticket_option_ids[]"]:checked'
+		).length;
+		return checkedCount >= effectiveMin;
+	}
+
+	/**
+	 * Whether enough occurrences are checked to satisfy the selected
+	 * 'multiple_instances' ticket type's minimum. Always true when that scope
+	 * isn't active.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 * @return {boolean} True when the requirement is satisfied.
+	 */
+	function meetsInstanceMinimum(form) {
+		if (!isMultipleInstancesSelected(form)) {
+			return true;
+		}
+		const option = getSelectedTicketTypeOption(form);
+		const min = Math.max(
+			1,
+			parseInt(option.dataset.minInstances || '0', 10)
+		);
+		const checked = form.querySelectorAll(
+			'input[name="event_date_ids[]"]:checked'
+		).length;
+		return checked >= min;
+	}
+
+	/**
+	 * Disable the submit button until both the instance and activity
+	 * minimums (independent gates that must both hold) are satisfied. Also
+	 * pins quantity to 1 whenever activities are configured, since
+	 * updateInstancePicker() only knows about the 'multiple_instances' case.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 */
+	function updateSubmitGate(form) {
+		const quantityRow = form.querySelector('.fair-events-quantity-row');
+		const quantityField = form.querySelector('input[name="quantity"]');
+		if (
+			hasActivityOptions(form) &&
+			!isMultipleInstancesSelected(form) &&
+			quantityField
+		) {
+			if (quantityRow) {
+				quantityRow.style.display = 'none';
+			}
+			quantityField.value = '1';
+		}
+
+		const submitButton = form.querySelector('button[type="submit"]');
+		if (!submitButton) {
+			return;
+		}
+		const enabled =
+			meetsInstanceMinimum(form) && meetsActivityMinimum(form);
+		submitButton.disabled = !enabled;
+		submitButton.classList.toggle('is-disabled', !enabled);
+	}
+
+	/**
+	 * Toggle the activities (ticket options) fieldset based on the selected
+	 * ticket type ('multiple_instances' ignores activities, mirroring the
+	 * legacy form), and keep its minimum hint, per-option add-on price tags,
+	 * and live total in sync.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 */
+	function updateTicketOptions(form) {
+		const fieldset = form.querySelector('.fair-events-ticket-options');
+		if (!fieldset) {
+			return;
+		}
+		const row = fieldset.closest('.form-row') || fieldset;
+
+		const hidden = isMultipleInstancesSelected(form);
+		row.style.display = hidden ? 'none' : '';
+		if (hidden) {
+			fieldset
+				.querySelectorAll('input[type="checkbox"]')
+				.forEach(function (cb) {
+					cb.checked = false;
+				});
+		}
+
+		const effectiveMin = getEffectiveActivityMinimum(form);
+		const checkedOptions = fieldset.querySelectorAll(
+			'input[name="ticket_option_ids[]"]:checked'
+		);
+
+		const hint = fieldset.querySelector(
+			'.fair-events-ticket-options-min-hint'
+		);
+		if (hint) {
+			if (!hidden && effectiveMin > 0) {
+				hint.textContent = sprintf(
+					/* translators: %d: minimum number of activities required */
+					_n(
+						'Please select at least %d activity to sign up.',
+						'Please select at least %d activities to sign up.',
+						effectiveMin,
+						'fair-events'
+					),
+					effectiveMin
+				);
+				hint.style.display = '';
+			} else {
+				hint.style.display = 'none';
+			}
+		}
+
+		// Reveal the per-option "(+price)" add-on tag on unchecked options once
+		// the minimum is met (or there is none), so the checkbox list doesn't
+		// show a price twice.
+		const meetsMin =
+			effectiveMin === 0 || checkedOptions.length >= effectiveMin;
+		fieldset
+			.querySelectorAll('input[name="ticket_option_ids[]"]')
+			.forEach(function (input) {
+				const label = input.closest('label');
+				const addon = label
+					? label.querySelector('.fair-events-ticket-option-addon')
+					: null;
+				if (!addon) {
+					return;
+				}
+				addon.style.display = meetsMin && !input.checked ? '' : 'none';
+			});
+
+		const totalEl = fieldset.querySelector(
+			'.fair-events-ticket-options-total'
+		);
+		if (totalEl) {
+			const selectedTicketType = getSelectedTicketTypeOption(form);
+			const unitPrice = selectedTicketType
+				? parseFloat(selectedTicketType.dataset.ticketPrice || 0)
+				: 0;
+			const optionPrices = Array.from(checkedOptions).map((input) =>
+				parseFloat(input.dataset.optionPrice || 0)
+			);
+			const total = computeTicketTotal({
+				unitPrice,
+				count: 1,
+				optionPrices,
+			});
+			totalEl.textContent =
+				!hidden && checkedOptions.length > 0
+					? sprintf(
+							/* translators: %s: formatted total price */
+							__('Total: %s', 'fair-events'),
+							formatMoney(total, form.dataset.currency)
+					  )
+					: '';
+		}
+	}
+
+	/**
+	 * Wire the "add activities" section shown to a signed-up viewer (rendered
+	 * by fair-audience's SignupHookBridge, since only it can persist the
+	 * selection): keep the Add button's total in sync with the checked
+	 * options and submit on click. No-op when the section isn't present.
+	 * @param {HTMLFormElement} form The get-tickets form (used to reach the
+	 *                                shared currency/message container).
+	 */
+	function wireAddActivities(form) {
+		const block = form.closest('.fair-events-get-tickets');
+		const section = block
+			? block.querySelector('.fair-events-add-activities')
+			: null;
+		if (!section) {
+			return;
+		}
+		const button = section.querySelector(
+			'.fair-events-add-activities-button'
+		);
+		if (!button) {
+			return;
+		}
+		const checkboxes = section.querySelectorAll(
+			'input[name="add_option_ids[]"]'
+		);
+
+		const baseText = __('Add activities', 'fair-events');
+		const updateButton = function () {
+			const optionPrices = [];
+			let anyChecked = false;
+			checkboxes.forEach(function (cb) {
+				if (cb.checked) {
+					anyChecked = true;
+					optionPrices.push(parseFloat(cb.dataset.optionPrice || 0));
+				}
+			});
+			const total = computeTicketTotal({ unitPrice: 0, optionPrices });
+			button.disabled = !anyChecked;
+			button.textContent =
+				total > 0
+					? baseText +
+					  ' — ' +
+					  formatMoney(total, form.dataset.currency)
+					: baseText;
+		};
+
+		checkboxes.forEach(function (cb) {
+			cb.addEventListener('change', updateButton);
+		});
+		button.addEventListener('click', function () {
+			submitAddActivities(block, section, button);
+		});
+
+		updateButton();
+	}
+
+	/**
+	 * Submit the add-activities request to fair-audience's existing route.
+	 * Redirects to checkout when the added activities are priced; otherwise
+	 * reloads to reflect the updated list.
+	 * @param {HTMLElement} block   The .fair-events-get-tickets wrapper.
+	 * @param {HTMLElement} section The .fair-events-add-activities section.
+	 * @param {HTMLElement} button  The add-activities button.
+	 */
+	function submitAddActivities(block, section, button) {
+		const eventId = parseInt(section.dataset.eventId, 10);
+		const eventDateId = section.dataset.eventDateId
+			? parseInt(section.dataset.eventDateId, 10)
+			: null;
+		const token = section.dataset.participantToken || '';
+		const messageContainer = block.querySelector('.message-container');
+
+		const checked = section.querySelectorAll(
+			'input[name="add_option_ids[]"]:checked'
+		);
+		if (checked.length === 0) {
+			return;
+		}
+
+		const requestData = {
+			event_id: eventId,
+			ticket_option_ids: Array.from(checked).map((i) =>
+				parseInt(i.value, 10)
+			),
+		};
+		if (eventDateId) {
+			requestData.event_date_id = eventDateId;
+		}
+		if (token) {
+			requestData.participant_token = token;
+		}
+
+		const restoreButton = setButtonLoading(
+			button,
+			__('Adding…', 'fair-events')
+		);
+
+		apiFetch({
+			path: '/fair-audience/v1/event-signup/add-activities',
+			method: 'POST',
+			data: requestData,
+		})
+			.then(function (response) {
+				if (
+					response &&
+					response.status === 'payment_required' &&
+					response.checkout_url
+				) {
+					window.location = response.checkout_url;
+					return;
+				}
+				if (response && response.success) {
+					showMessage(
+						messageContainer,
+						response.message ||
+							__(
+								'Your activities have been added!',
+								'fair-events'
+							),
+						'success',
+						CSS_PREFIX
+					);
+					window.location.reload();
+					return;
+				}
+				restoreButton();
+			})
+			.catch(function (error) {
+				console.error('Add activities error:', error);
+				const errorMessage = extractErrorMessage(
+					error,
+					__(
+						'Failed to add activities. Please try again.',
+						'fair-events'
+					)
+				);
+				showMessage(
+					messageContainer,
+					errorMessage,
+					'error',
+					CSS_PREFIX
+				);
+				restoreButton();
+			});
+	}
+
 	function validateForm(form) {
 		const messageContainer = form
 			.closest('.fair-events-get-tickets')
@@ -473,6 +849,26 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 			}
 		}
 
+		if (!meetsActivityMinimum(form)) {
+			const effectiveMin = getEffectiveActivityMinimum(form);
+			showMessage(
+				messageContainer,
+				sprintf(
+					/* translators: %d: minimum number of activities required */
+					_n(
+						'Please select at least %d activity to sign up.',
+						'Please select at least %d activities to sign up.',
+						effectiveMin,
+						'fair-events'
+					),
+					effectiveMin
+				),
+				'error',
+				CSS_PREFIX
+			);
+			return false;
+		}
+
 		const questionError = validateQuestions(form);
 		if (questionError) {
 			showMessage(messageContainer, questionError, 'error', CSS_PREFIX);
@@ -534,6 +930,15 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 					Math.min(10, parseInt(quantityField.value, 10) || 1)
 				);
 			}
+		}
+
+		if (hasActivityOptions(form) && !isMultipleInstancesSelected(form)) {
+			const optionInputs = form.querySelectorAll(
+				'input[name="ticket_option_ids[]"]:checked'
+			);
+			data.ticket_option_ids = Array.from(optionInputs).map((i) =>
+				parseInt(i.value, 10)
+			);
 		}
 
 		const mailingField = form.querySelector('input[name="mailing_opt_in"]');

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -217,6 +217,42 @@ if ( class_exists( \FairEvents\Services\TicketPricing::class ) && class_exists( 
 	}
 }
 
+// Resolve activity options (ticket options) for this event date, if the
+// experimental catalogue is active. Options are displayed as checkboxes —
+// participants can select zero or more at signup. Gated on fair-audience
+// being active too: selections can only be persisted through its options
+// junction table, so a base-alone site must not render dead checkboxes.
+$ticket_options = array();
+if ( class_exists( \FairAudience\API\EventSignupController::class )
+	&& class_exists( \FairEventsExperimental\Models\TicketOption::class ) ) {
+	$raw_options = \FairEventsExperimental\Models\TicketOption::get_all_by_event_date_id( $pricing_event_date_id );
+	foreach ( $raw_options as $opt ) {
+		$resolved_base = class_exists( \FairEventsExperimental\Services\ActivityOptionPriceResolver::class )
+			? \FairEventsExperimental\Services\ActivityOptionPriceResolver::resolve( $opt )
+			: (float) $opt->price;
+		if ( null === $resolved_base ) {
+			// Derived mode with no active period / no row → option not purchasable; skip.
+			continue;
+		}
+		$ticket_options[] = array(
+			'id'         => (int) $opt->id,
+			'name'       => $opt->name,
+			'short_name' => $opt->short_name ?? null,
+			'price'      => (float) $resolved_base,
+			'is_full'    => false,
+		);
+	}
+}
+
+// Minimum number of activities the participant must select. Capped at the
+// number of options actually available so the requirement is never
+// impossible to satisfy, and only meaningful when at least one option exists.
+$minimum_activities = 0;
+if ( ! empty( $ticket_options ) && class_exists( \FairEvents\Models\EventDateSetting::class ) ) {
+	$minimum_activities = (int) \FairEvents\Models\EventDateSetting::get( $pricing_event_date_id, 'minimum_activities' );
+	$minimum_activities = max( 0, min( $minimum_activities, count( $ticket_options ) ) );
+}
+
 /**
  * Extension point for plugins (e.g. fair-audience) that want to enrich the
  * base signup form without owning a competing render — resolved viewer
@@ -226,6 +262,7 @@ if ( class_exists( \FairEvents\Services\TicketPricing::class ) && class_exists( 
  *
  * @param array    $context    Render context (event_date_id, pricing_event_date_id, ticket_types,
  *                              price_by_type_id, active_sale_period, occurrences_for_picker,
+ *                              ticket_options, minimum_activities,
  *                              callback_status, callback_tx_id, callback_token, callback_state,
  *                              callback_source, prefill_name, prefill_email, submit_button_text).
  * @param array    $attributes Block attributes.
@@ -242,6 +279,12 @@ $context = apply_filters(
 		'price_by_type_id'       => $price_by_type_id,
 		'active_sale_period'     => $active_sale_period,
 		'occurrences_for_picker' => $occurrences_for_picker,
+		// Activity add-ons and their minimum-selection requirement. A companion
+		// plugin (fair-audience) overrides 'price'/'is_full' with participant-
+		// aware resolution and adds 'addable_options'/'current_activity_names'
+		// for a recognised, already-signed-up viewer.
+		'ticket_options'         => $ticket_options,
+		'minimum_activities'     => $minimum_activities,
 		'callback_status'        => $callback_status,
 		'callback_tx_id'         => $callback_tx_id,
 		'callback_token'         => $callback_token,
@@ -267,6 +310,8 @@ $ticket_types           = $context['ticket_types'];
 $price_by_type_id       = $context['price_by_type_id'];
 $active_sale_period     = $context['active_sale_period'];
 $occurrences_for_picker = $context['occurrences_for_picker'];
+$ticket_options         = $context['ticket_options'];
+$minimum_activities     = $context['minimum_activities'];
 $callback_status        = $context['callback_status'];
 $signup_state           = $context['callback_state'];
 $prefill_name           = $context['prefill_name'];
@@ -282,6 +327,19 @@ foreach ( $ticket_types as $ticket_type ) {
 	}
 }
 $has_instance_picker = $has_multiple_instances_type && ! empty( $occurrences_for_picker );
+
+// A ticket type can raise the minimum-activities requirement above the
+// event-date global. Determine whether any selectable type carries a higher
+// requirement, and the effective minimum for the type that's pre-selected on
+// first paint (the first not-payment-blocked type, mirroring the radio
+// pre-selection below). frontend.js recomputes this live as the buyer
+// switches ticket type.
+$any_ticket_type_min = 0;
+if ( ! empty( $ticket_options ) ) {
+	foreach ( $ticket_types as $tt_for_min ) {
+		$any_ticket_type_min = max( $any_ticket_type_min, (int) $tt_for_min->minimum_activities );
+	}
+}
 
 // Single-occurrence dropdown: offered whenever the series has more than one
 // upcoming occurrence, regardless of which ticket scopes are configured.
@@ -448,6 +506,7 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 		data-currency="<?php echo esc_attr( \FairEventsShared\Money::site_currency() ); ?>"
 		data-event-date-id="<?php echo esc_attr( $event_date_id ); ?>"
 		data-fair-audience-active="<?php echo esc_attr( class_exists( \FairAudience\API\EventSignupController::class ) ? '1' : '0' ); ?>"
+		data-min-activities="<?php echo esc_attr( (string) $minimum_activities ); ?>"
 	>
 		<?php
 		/**
@@ -500,12 +559,111 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 								data-ticket-price="<?php echo esc_attr( null !== $type_price ? \FairEventsShared\Money::format_value( $type_price ) : '' ); ?>"
 								data-recurrence-scope="<?php echo esc_attr( $ticket_type->recurrence_scope ); ?>"
 								data-min-instances="<?php echo esc_attr( (string) $ticket_type->minimum_instances ); ?>"
+								data-min-activities="<?php echo esc_attr( (string) $ticket_type->minimum_activities ); ?>"
 								<?php echo $type_unavailable ? 'disabled' : ''; ?>
 								<?php echo $type_id === $first_enabled_type_id ? 'checked' : ''; ?>
 							/>
 							<?php echo esc_html( $label ); ?>
 						</label>
 					<?php endforeach; ?>
+				</fieldset>
+			</div>
+		<?php endif; ?>
+
+		<?php if ( ! empty( $ticket_options ) ) : ?>
+			<?php
+			// Effective minimum for the type pre-selected on first paint (the
+			// first not-payment-blocked type, mirroring the radio pre-selection
+			// above) — frontend.js recomputes this live as the buyer switches
+			// ticket type.
+			$preselected_type_min = 0;
+			if ( ! empty( $first_enabled_type_id ) ) {
+				foreach ( $ticket_types as $tt_preselected ) {
+					if ( (int) $tt_preselected->id === $first_enabled_type_id ) {
+						$preselected_type_min = (int) $tt_preselected->minimum_activities;
+						break;
+					}
+				}
+			}
+			// A minimum-activities requirement (global or ticket-type-raised)
+			// switches option prices from an always-on inline price to a hidden
+			// per-option "(+price)" add-on tag toggled by frontend.js once the
+			// minimum is met, so the requirement reads clearly.
+			$options_feature_active = ( $minimum_activities > 0 || $any_ticket_type_min > 0 );
+			$initial_min_activities = min( count( $ticket_options ), max( $minimum_activities, $preselected_type_min ) );
+			?>
+			<div class="form-row">
+				<fieldset class="fair-events-ticket-options">
+					<legend class="form-label"><?php esc_html_e( 'Select activities', 'fair-events' ); ?></legend>
+					<?php if ( $options_feature_active ) : ?>
+						<?php
+						$hint_text = $initial_min_activities > 0
+							? sprintf(
+								/* translators: %d: minimum number of activities required */
+								_n(
+									'Please select at least %d activity to sign up.',
+									'Please select at least %d activities to sign up.',
+									$initial_min_activities,
+									'fair-events'
+								),
+								$initial_min_activities
+							)
+							: '';
+						$hint_style = $initial_min_activities > 0 ? '' : ' style="display: none;"';
+						?>
+						<p class="fair-events-ticket-options-min-hint"<?php echo $hint_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static literal. ?>>
+							<?php echo esc_html( $hint_text ); ?>
+						</p>
+					<?php endif; ?>
+					<?php foreach ( $ticket_options as $opt ) : ?>
+						<?php
+						$opt_label = $opt['name'];
+						if ( ! $options_feature_active ) {
+							if ( $opt['price'] > 0 ) {
+								$opt_label .= ' — ' . \FairEventsShared\Money::format_inline( $opt['price'] );
+							} elseif ( $opt['price'] < 0 ) {
+								$opt_label .= ' — -' . \FairEventsShared\Money::format_inline( abs( $opt['price'] ) );
+							} else {
+								$opt_label .= ' — ' . __( 'free', 'fair-events' );
+							}
+						}
+						$opt_is_full = ! empty( $opt['is_full'] );
+						if ( $opt_is_full ) {
+							$opt_label .= ' — ' . __( 'full', 'fair-events' );
+						}
+						$opt_checkbox_id = $form_id . '-opt-' . (int) $opt['id'];
+						$opt_classes     = 'fair-events-ticket-option-item';
+						if ( $opt_is_full ) {
+							$opt_classes .= ' fair-events-ticket-option-full';
+						}
+						?>
+						<label class="<?php echo esc_attr( $opt_classes ); ?>" for="<?php echo esc_attr( $opt_checkbox_id ); ?>">
+							<input
+								type="checkbox"
+								name="ticket_option_ids[]"
+								id="<?php echo esc_attr( $opt_checkbox_id ); ?>"
+								value="<?php echo (int) $opt['id']; ?>"
+								class="form-checkbox"
+								data-option-price="<?php echo esc_attr( \FairEventsShared\Money::format_value( $opt['price'] ) ); ?>"
+								<?php echo $opt_is_full ? 'disabled' : ''; ?>
+							/>
+							<span class="fair-events-ticket-option-text">
+								<?php echo esc_html( $opt_label ); ?>
+								<?php if ( $options_feature_active && $opt['price'] > 0 ) : ?>
+									<span class="fair-events-ticket-option-addon" style="display: none;">
+										<?php
+										printf(
+											/* translators: %s: formatted add-on price */
+											esc_html__( '(+%s)', 'fair-events' ),
+											esc_html( \FairEventsShared\Money::format_inline( $opt['price'] ) )
+										);
+										?>
+									</span>
+								<?php endif; ?>
+							</span>
+						</label>
+					<?php endforeach; ?>
+					<p class="fair-events-ticket-options-total"></p>
 				</fieldset>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
## Summary

Ports fair-audience's legacy activities (ticket options) support into fair-events' unified signup form (`fair-events/event-signup` block + `fair-events/v1/get-tickets` route), following the pattern `d5ca5fa8` established for group pricing (#1242):

- fair-events' `render.php` resolves the activity catalogue (`ticket_options`) and the effective minimum-activities requirement into the render context, and renders the checkbox fieldset (with a live minimum hint, per-option `(+price)` add-on tags, and a total line) when both `fair-events-experimental`'s catalogue and fair-audience are active.
- `frontend.js` ports `getEffectiveMinimum()`, the hint/addon/total wiring, submit gating, and the quantity-pin-to-1 treatment (activities attach to a single `EventParticipant` row).
- Two new fair-events filters — `fair_events_signup_options_error` and `fair_events_signup_option_line_items` — run unconditionally in `GetTicketsController::create_signup()` (so a global minimum still applies to a signup with no ticket type). fair-audience's `SignupHookBridge` hooks both, delegating to a new `fair-audience/src/Services/SignupActivities.php` (mirroring `GroupSignupPricing.php`) for capacity/minimum validation and discounted pricing.
- A signed-up participant sees an "add activities" section (rendered by the bridge on the existing `fair_events_signup_render_after_form` hook), submitting through fair-audience's **existing, unchanged** `/fair-audience/v1/event-signup/add-activities` route — the base plugin reads the route from a data attribute rather than hardcoding it.
- `SignupHookBridge::link_participant()` now attaches selected activities via `EventParticipantRepository::add_options()` on both the free and pending_payment paths.

Closes #1243

## Acceptance criteria

- [x] **Activities render as priced checkboxes; full ones disabled and labelled.** `render.php`'s new fieldset + `SignupActivities::enrich_render_context()` (capacity → `is_full`).
- [x] **Minimum-activities requirement enforced with a live hint and total.** Server-side in `SignupActivities::validate_selection()` (400 `minimum_activities_not_met`); client-side hint/total/submit-gate in `frontend.js`.
- [x] **Signed-up participant can add not-yet-held activities via a dedicated section.** `SignupHookBridge::render_add_activities()` + `frontend.js`'s `wireAddActivities()`/`submitAddActivities()`, reusing the existing add-activities route.
- [x] **Events without activities are unchanged.** The fieldset only renders when `$ticket_options` is non-empty; no existing markup/behaviour is touched otherwise.
- [x] **API spec coverage for activity selection + minimum enforcement + add-activities; e2e coverage for the activity signup flow.** See Notes below — coverage was added but has a reachability caveat that predates this ticket.

## Notes

**Discovered architecture gap (not introduced by this PR, not fixed here — confirmed with the ticket author before proceeding).** `GetTicketsController::register_routes()` is only called when fair-audience is *absent* (`fair-events/src/Core/Plugin.php:230`), but `SignupHookBridge` — which implements the actual validation/pricing logic behind every `fair_events_signup_*` filter, including #1242's group-pricing filters and this PR's two new ones — only registers its hooks when fair-audience is *active*. Those two preconditions are mutually exclusive under the current pre-#1245 architecture, so none of this hook-based logic is reachable end-to-end in a live site yet (it was already true for #1242; nobody had hit it because `test:api` isn't wired into CI). This is presumably resolved once #1245 removes the render-delegation guard and this route registers unconditionally — flagging here rather than expanding this ticket's scope to fix it.

Given that, test coverage in this PR is split:
- `fair-audience/__tests__/Services/SignupActivitiesTest.php` — pure-logic PHPUnit coverage (effective minimum, capacity, discount pricing) that doesn't depend on the reachability gap. **Passing.**
- `fair-audience/src/API/__tests__/EventSignupActivities.api.spec.js` — written to the same standard as `EventSignupGroupPricing.api.spec.js`, but shares its (pre-existing, undiscovered) reachability gap. Not executable/verified in this session — see caveat above.
- `e2e/user-flows/unified-signup-activities.spec.js` — the one thing that *is* reachable today: a base-alone site (fair-audience inactive) with activities configured must never render dead checkboxes. Not executed in this session (no working local wp-env instance available — the running `localhost:8080` in this environment isn't wired for REST/Basic Auth per prior session notes).

I also extended `e2e/mu-plugins/{lib/event-factory.php,scripts/seed-event.php,scripts/signup-state.php}` with a `unified-with-options` seed flavour, an optional option `capacity` param, and `option_ids` in the signup-state report — generically useful infra for whoever picks up full fieldset e2e coverage once #1245 lands.

## Definition of Done

- `npm run build` (fair-events) — clean.
- `npm run format` (fair-events, fair-audience) — clean, no diff.
- `vendor/bin/phpcs` on all changed PHP files — clean (pre-existing unrelated warnings/errors elsewhere untouched).
- `test:js` (fair-events 175/175, fair-audience 27/27) and `test:php` (fair-audience, incl. new `SignupActivitiesTest` 11/11) — all passing. `test:api`/`test:e2e` not runnable in this session (see Notes).
- Changeset added for `fair-events` + `fair-audience`.
