### PR TITLE
Make Mollie OAuth tokens write-only over REST

### DIFF
--- a/.changeset/mollie-oauth-tokens-write-only.md
+++ b/.changeset/mollie-oauth-tokens-write-only.md
@@ -1,0 +1,5 @@
+---
+"fair-payments-connector": patch
+---
+
+Security: Mollie OAuth access and refresh tokens are no longer readable or writable through `/wp/v2/settings` (they were previously returned in full to any `manage_options` user despite a REST context scope that had no effect). Disconnecting from Mollie now goes through a dedicated `oauth/disconnect` endpoint instead of clearing the tokens via the settings REST route.

--- a/fair-payments-connector/src/API/OAuthCallbackController.php
+++ b/fair-payments-connector/src/API/OAuthCallbackController.php
@@ -83,6 +83,18 @@ class OAuthCallbackController extends \WP_REST_Controller {
 				),
 			)
 		);
+
+		register_rest_route(
+			'fair-payments-connector/v1',
+			'/oauth/disconnect',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'handle_disconnect' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
 	}
 
 	/**
@@ -124,6 +136,26 @@ class OAuthCallbackController extends \WP_REST_Controller {
 		update_option( 'fair_payment_mollie_profile_id', $request->get_param( 'profile_id' ) );
 		update_option( 'fair_payment_mollie_connected', true );
 		update_option( 'fair_payment_mode', $request->get_param( 'test_mode' ) ? 'test' : 'live' );
+
+		return new \WP_REST_Response( array( 'success' => true ), 200 );
+	}
+
+	/**
+	 * Remove the stored Mollie OAuth credentials and connection state.
+	 *
+	 * The tokens have no show_in_rest entry (see Settings::register_settings()),
+	 * so /wp/v2/settings can no longer clear them — this is the only write
+	 * path for disconnecting.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function handle_disconnect() {
+		delete_option( 'fair_payment_mollie_access_token' );
+		delete_option( 'fair_payment_mollie_refresh_token' );
+		update_option( 'fair_payment_mollie_token_expires', 0 );
+		update_option( 'fair_payment_mollie_connected', false );
+		delete_transient( 'fair_payment_connection_overview_test' );
+		delete_transient( 'fair_payment_connection_overview_live' );
 
 		return new \WP_REST_Response( array( 'success' => true ), 200 );
 	}

--- a/fair-payments-connector/src/API/__tests__/OAuthCallbackController.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/OAuthCallbackController.api.spec.js
@@ -3,6 +3,9 @@ import { test, expect, request } from '@playwright/test';
 const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
 const STATE_ENDPOINT = '/wp-json/fair-payments-connector/v1/oauth/state';
 const CALLBACK_ENDPOINT = '/wp-json/fair-payments-connector/v1/oauth/callback';
+const DISCONNECT_ENDPOINT =
+	'/wp-json/fair-payments-connector/v1/oauth/disconnect';
+const SETTINGS_ENDPOINT = '/wp-json/wp/v2/settings';
 
 const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
 const ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
@@ -121,6 +124,79 @@ test.describe('OAuthCallbackController', () => {
 			expect(second.status()).toBe(403);
 			const body = await second.json();
 			expect(body.code).toBe('invalid_oauth_state');
+		});
+	});
+
+	test.describe('GET/POST /wp/v2/settings — token write-only (#859)', () => {
+		test('GET does not include the OAuth token values', async () => {
+			// Ensure tokens are populated first, via a normal callback.
+			const stateRes = await api.post(STATE_ENDPOINT, {
+				headers: adminAuth(),
+			});
+			const { state } = await stateRes.json();
+			const callbackRes = await api.post(CALLBACK_ENDPOINT, {
+				headers: adminAuth(),
+				data: { state, ...VALID_TOKENS },
+			});
+			expect(callbackRes.status()).toBe(200);
+
+			const res = await api.get(SETTINGS_ENDPOINT, {
+				headers: adminAuth(),
+			});
+			expect(res.status()).toBe(200);
+			const body = await res.json();
+			expect(body).not.toHaveProperty('fair_payment_mollie_access_token');
+			expect(body).not.toHaveProperty(
+				'fair_payment_mollie_refresh_token'
+			);
+		});
+
+		test('POST carrying token keys is accepted but ignores them', async () => {
+			const res = await api.post(SETTINGS_ENDPOINT, {
+				headers: adminAuth(),
+				data: {
+					fair_payment_mollie_access_token: 'attacker_supplied',
+					fair_payment_mollie_refresh_token: 'attacker_supplied',
+				},
+			});
+			expect(res.status()).toBe(200);
+			const body = await res.json();
+			expect(body).not.toHaveProperty('fair_payment_mollie_access_token');
+			expect(body).not.toHaveProperty(
+				'fair_payment_mollie_refresh_token'
+			);
+		});
+	});
+
+	test.describe('POST /oauth/disconnect', () => {
+		test('returns 401 for unauthenticated requests', async () => {
+			const res = await api.post(DISCONNECT_ENDPOINT);
+			expect(res.status()).toBe(401);
+		});
+
+		test('clears the connection and returns 200 for an admin', async () => {
+			// Connect first so there is something to disconnect.
+			const stateRes = await api.post(STATE_ENDPOINT, {
+				headers: adminAuth(),
+			});
+			const { state } = await stateRes.json();
+			await api.post(CALLBACK_ENDPOINT, {
+				headers: adminAuth(),
+				data: { state, ...VALID_TOKENS },
+			});
+
+			const res = await api.post(DISCONNECT_ENDPOINT, {
+				headers: adminAuth(),
+			});
+			expect(res.status()).toBe(200);
+			const body = await res.json();
+			expect(body.success).toBe(true);
+
+			const settingsRes = await api.get(SETTINGS_ENDPOINT, {
+				headers: adminAuth(),
+			});
+			const settings = await settingsRes.json();
+			expect(settings.fair_payment_mollie_connected).toBe(false);
 		});
 	});
 });

--- a/fair-payments-connector/src/Admin/settings/ConnectionTab.js
+++ b/fair-payments-connector/src/Admin/settings/ConnectionTab.js
@@ -22,6 +22,7 @@ import {
 	testConnection,
 	createTestPayment,
 	fetchOAuthState,
+	disconnectOAuth,
 } from './settings-api';
 
 /**
@@ -190,12 +191,7 @@ export default function ConnectionTab({ onNotice, shouldReload }) {
 
 		setIsSaving(true);
 
-		saveSettings({
-			fair_payment_mollie_access_token: '',
-			fair_payment_mollie_refresh_token: '',
-			fair_payment_mollie_token_expires: 0,
-			fair_payment_mollie_connected: false,
-		})
+		disconnectOAuth()
 			.then(() => {
 				loadSettings();
 				onNotice({

--- a/fair-payments-connector/src/Admin/settings/__tests__/ConnectionTab.test.jsx
+++ b/fair-payments-connector/src/Admin/settings/__tests__/ConnectionTab.test.jsx
@@ -8,7 +8,7 @@
  *     connected controls (mode switch, disconnect) still render.
  */
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import ConnectionTab from '../ConnectionTab.js';
 
@@ -117,6 +117,39 @@ describe('ConnectionTab — connection overview', () => {
 			screen.getByRole('button', { name: 'Disconnect' })
 		).toBeInTheDocument();
 
+		expect(console).toHaveLogged();
+	});
+});
+
+describe('ConnectionTab — disconnect', () => {
+	it('calls the oauth/disconnect endpoint, not /wp/v2/settings, on confirm', async () => {
+		mockApiFetchFor({ connected: true, overview: OVERVIEW });
+		jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+		render(<ConnectionTab onNotice={() => {}} shouldReload={false} />);
+
+		const disconnectButton = await screen.findByRole('button', {
+			name: 'Disconnect',
+		});
+		fireEvent.click(disconnectButton);
+
+		await waitFor(() => {
+			expect(apiFetch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: '/fair-payments-connector/v1/oauth/disconnect',
+					method: 'POST',
+				})
+			);
+		});
+
+		expect(apiFetch).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				path: '/wp/v2/settings',
+				method: 'POST',
+			})
+		);
+
+		window.confirm.mockRestore();
 		expect(console).toHaveLogged();
 	});
 });

--- a/fair-payments-connector/src/Admin/settings/settings-api.js
+++ b/fair-payments-connector/src/Admin/settings/settings-api.js
@@ -72,6 +72,18 @@ export function saveOAuthCallback(data) {
 }
 
 /**
+ * Disconnect from Mollie: server clears the stored OAuth credentials.
+ *
+ * @return {Promise<Object>} Promise resolving to the API response
+ */
+export function disconnectOAuth() {
+	return apiFetch({
+		path: '/fair-payments-connector/v1/oauth/disconnect',
+		method: 'POST',
+	});
+}
+
+/**
  * Load the connected Mollie profile name and enabled payment methods.
  *
  * @return {Promise<Object>} Promise resolving to the connection overview

--- a/fair-payments-connector/src/Settings/Settings.php
+++ b/fair-payments-connector/src/Settings/Settings.php
@@ -98,7 +98,10 @@ class Settings {
 			)
 		);
 
-		// OAuth Access Token.
+		// OAuth Access Token. No show_in_rest: write-only credential,
+		// written server-side only via OAuthCallbackController. Omitting the
+		// key (rather than scoping context) is what actually hides it from
+		// /wp/v2/settings — see #859.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_mollie_access_token',
@@ -106,17 +109,11 @@ class Settings {
 				'type'              => 'string',
 				'description'       => __( 'Mollie OAuth Access Token', 'fair-payments-connector' ),
 				'sanitize_callback' => 'sanitize_text_field',
-				'show_in_rest'      => array(
-					'schema' => array(
-						'type'    => 'string',
-						'context' => array( 'edit' ),
-					),
-				),
 				'default'           => '',
 			)
 		);
 
-		// OAuth Refresh Token.
+		// OAuth Refresh Token. No show_in_rest — see access token above.
 		register_setting(
 			'fair_payment_settings',
 			'fair_payment_mollie_refresh_token',
@@ -124,12 +121,6 @@ class Settings {
 				'type'              => 'string',
 				'description'       => __( 'Mollie OAuth Refresh Token', 'fair-payments-connector' ),
 				'sanitize_callback' => 'sanitize_text_field',
-				'show_in_rest'      => array(
-					'schema' => array(
-						'type'    => 'string',
-						'context' => array( 'edit' ),
-					),
-				),
 				'default'           => '',
 			)
 		);


### PR DESCRIPTION
## Summary

- `context => ['edit']` did nothing for `/wp/v2/settings` — `WP_REST_Settings_Controller` never filters by context, so `fair_payment_mollie_access_token` / `fair_payment_mollie_refresh_token` were still returned in full to any `manage_options` user despite the "recent hardening" the ticket referenced.
- Dropped `show_in_rest` entirely from both token settings in `Settings.php` — they are now neither readable nor writable through `/wp/v2/settings`.
- Added `POST /fair-payments-connector/v1/oauth/disconnect` (same `manage_options` permission pattern as the existing OAuth routes) as the replacement write path: it clears both tokens, zeroes the expiry, flips `connected` to false, and deletes the cached connection-overview transients (`fair_payment_connection_overview_test` / `_live`).
- `ConnectionTab.js`'s Disconnect button now calls the new endpoint instead of POSTing empty strings for the tokens through `/wp/v2/settings` — without this, removing `show_in_rest` alone would have left Disconnect silently stranding live tokens in the database.

Closes #859

## Acceptance criteria

- [x] `GET /wp/v2/settings` as an admin does not include the OAuth token values — verified by API test and manual `wp eval-file` check.
- [x] OAuth connect flow still works end to end — the callback still writes the tokens directly via `update_option()` (unaffected by dropping `show_in_rest`, which only governs the REST settings controller), verified manually.

## Notes

- The legacy Mollie API keys (`fair_payment_test_api_key` / `fair_payment_live_api_key`) and encryption-at-rest are out of scope per the approved plan — tracked separately in #1317 and #1318.
- The repo's `docker compose` dev environment doesn't have pretty permalinks enabled (Apache `AllowOverride` isn't configured for `.htaccess` rewrites), so the new Playwright API tests couldn't be run live against it in this session — same limitation applies to the pre-existing tests in this spec file. I verified the full flow (state → callback → settings read/write → disconnect → transient cleanup → unauthenticated rejection) instead via a throwaway `wp eval-file` script dispatching through `WP_REST_Server` directly; all checks passed. The new `.api.spec.js` assertions are in place for whenever `test:api` runs against a properly configured instance.

## Test plan

- [x] `npm run test:js` (fair-payments-connector) — 4 suites / 9 tests pass, including the new disconnect-endpoint assertion in `ConnectionTab.test.jsx`.
- [x] `vendor/bin/phpcs` clean on `Settings.php` and `OAuthCallbackController.php`.
- [x] `npm run build` (fair-payments-connector) succeeds.
- [x] Manual `wp eval-file` verification against the docker WordPress instance: state → callback → `GET /wp/v2/settings` omits tokens → `POST /wp/v2/settings` with token keys is accepted but ignored (value unchanged) → `oauth/disconnect` clears tokens, `connected`, `token_expires`, and both overview transients → unauthenticated disconnect returns 401.
- [ ] `test:api` Playwright spec — added but not runnable in this session's docker environment (see Notes); should be exercised in CI/a properly configured instance.
