### PR TITLE
Reject empty block_id and fix secure-context UUID gaps

### DIFF
--- a/.changeset/fair-events-shared-uuid-helper.md
+++ b/.changeset/fair-events-shared-uuid-helper.md
@@ -1,0 +1,5 @@
+---
+"fair-events-shared": patch
+---
+
+Add a `generateUuid()` helper that falls back to `crypto.getRandomValues()` when `crypto.randomUUID()` is unavailable (plain-HTTP sites are not a secure context), for blocks that need to mint a stable id in the editor.

--- a/.changeset/fair-form-secure-context-uuid.md
+++ b/.changeset/fair-form-secure-context-uuid.md
@@ -1,0 +1,5 @@
+---
+"fair-form": patch
+---
+
+Fix the Fair Form block failing to assign a form id on plain-HTTP sites (common for self-hosted staging), where `crypto.randomUUID()` is unavailable outside a secure context. The block now falls back to `crypto.getRandomValues()` when generating its id.

--- a/.changeset/fix-simple-payment-block-id.md
+++ b/.changeset/fix-simple-payment-block-id.md
@@ -1,0 +1,5 @@
+---
+"fair-payments-connector": patch
+---
+
+Reject a payment request whose `block_id` is empty instead of matching it against any legacy simple-payment block with the same blank saved id — closes a mischarge risk on pages with more than one such block. The block editor also now warns with a save prompt when a simple-payment block is missing its id, since the id is only fixed in the published post once it's re-saved.

--- a/e2e/mu-plugins/scripts/seed-payment-page.php
+++ b/e2e/mu-plugins/scripts/seed-payment-page.php
@@ -18,9 +18,10 @@ $description = isset( $args[1] ) && '' !== $args[1] ? (string) $args[1] : 'E2E s
 // The editor assigns every simple-payment block a UUID blockId attribute;
 // the payment endpoint derives the authoritative amount by matching it, so
 // the seeded block must carry one too.
+$block_id    = wp_generate_uuid4();
 $block_attrs = wp_json_encode(
 	array(
-		'blockId'     => wp_generate_uuid4(),
+		'blockId'     => $block_id,
 		'amount'      => $amount,
 		'description' => $description,
 	)
@@ -46,5 +47,6 @@ echo 'E2E_PAYMENT_PAGE:' . wp_json_encode(
 		'pageUrl'     => get_permalink( $page_id ),
 		'amount'      => (float) $amount,
 		'description' => $description,
+		'blockId'     => $block_id,
 	)
 ) . "\n";

--- a/e2e/user-flows/simple-payment-purchase.spec.js
+++ b/e2e/user-flows/simple-payment-purchase.spec.js
@@ -93,4 +93,77 @@ test.describe('simple-payment block purchase', () => {
 		expect(tx.status).toBe('paid');
 		expect(tx.testmode).toBe(true);
 	});
+
+	test('rejects a submitted amount below the block-configured amount with 422', async ({
+		page,
+	}) => {
+		const nonceRes = await page.request.get(
+			'/wp-json/fair-payments-connector/v1/nonce'
+		);
+		const { nonce } = await nonceRes.json();
+
+		const res = await page.request.post(
+			'/wp-json/fair-payments-connector/v1/payments',
+			{
+				data: {
+					amount: '1.00',
+					currency: 'EUR',
+					post_id: seed.pageId,
+					block_id: seed.blockId,
+					nonce,
+				},
+			}
+		);
+
+		expect(res.status()).toBe(422);
+		const body = await res.json();
+		expect(body.code).toBe('amount_too_low');
+	});
+
+	test('rejects an empty block_id with 403 (regression guard)', async ({
+		page,
+	}) => {
+		const nonceRes = await page.request.get(
+			'/wp-json/fair-payments-connector/v1/nonce'
+		);
+		const { nonce } = await nonceRes.json();
+
+		const res = await page.request.post(
+			'/wp-json/fair-payments-connector/v1/payments',
+			{
+				data: {
+					amount: String(seed.amount),
+					currency: 'EUR',
+					post_id: seed.pageId,
+					block_id: '',
+					nonce,
+				},
+			}
+		);
+
+		expect(res.status()).toBe(403);
+		const body = await res.json();
+		expect(body.code).toBe('invalid_block');
+	});
+
+	test('rejects a client-tampered amount and does not reach Mollie checkout', async ({
+		page,
+	}) => {
+		await page.goto(seed.pageUrl);
+
+		const payButton = page.locator('.fair-payments-connector-button');
+		await expect(payButton).toBeVisible();
+
+		// The server derives the authoritative amount from the saved block, so a
+		// tampered data-amount must be rejected rather than trusted.
+		await payButton.evaluate((button) =>
+			button.setAttribute('data-amount', '0.01')
+		);
+		await payButton.click();
+
+		await expect(
+			page.locator('.fair-payments-connector-error')
+		).toBeVisible({ timeout: 15000 });
+		await expect(page).not.toHaveURL(/fair_payment_callback=true/);
+	});
 });

--- a/fair-events-shared/src/__tests__/uuid.test.js
+++ b/fair-events-shared/src/__tests__/uuid.test.js
@@ -1,0 +1,33 @@
+import { generateUuid } from '../uuid.js';
+
+const UUID_V4_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('generateUuid', () => {
+	const originalRandomUUID = crypto.randomUUID;
+
+	afterEach(() => {
+		crypto.randomUUID = originalRandomUUID;
+	});
+
+	it('uses crypto.randomUUID() when available', () => {
+		crypto.randomUUID = jest.fn(
+			() => '11111111-1111-4111-8111-111111111111'
+		);
+		expect(generateUuid()).toBe('11111111-1111-4111-8111-111111111111');
+		expect(crypto.randomUUID).toHaveBeenCalled();
+	});
+
+	it('falls back to crypto.getRandomValues() when randomUUID is unavailable', () => {
+		crypto.randomUUID = undefined;
+		const uuid = generateUuid();
+		expect(uuid).toMatch(UUID_V4_PATTERN);
+	});
+
+	it('generates unique values on repeated calls', () => {
+		crypto.randomUUID = undefined;
+		const first = generateUuid();
+		const second = generateUuid();
+		expect(first).not.toBe(second);
+	});
+});

--- a/fair-events-shared/src/index.js
+++ b/fair-events-shared/src/index.js
@@ -23,3 +23,4 @@ export * from './question-utils.js';
 export * from './payment-flow.js';
 export * from './event-utils.js';
 export * from './ticket-pricing.js';
+export * from './uuid.js';

--- a/fair-events-shared/src/uuid.js
+++ b/fair-events-shared/src/uuid.js
@@ -1,0 +1,35 @@
+/**
+ * `crypto.randomUUID()` is only exposed in secure contexts (HTTPS or
+ * localhost). On a plain-HTTP install — common for self-hosted staging —
+ * it is `undefined`, so block editors that call it directly throw and never
+ * assign an id. Fall back to `crypto.getRandomValues()`, which is available
+ * more broadly, to build a UUIDv4 by hand.
+ */
+
+/**
+ * Generate a UUIDv4 string, preferring the native `crypto.randomUUID()` and
+ * falling back to `crypto.getRandomValues()` when it isn't available.
+ *
+ * @return {string} A UUIDv4 string.
+ */
+export function generateUuid() {
+	if (typeof crypto.randomUUID === 'function') {
+		return crypto.randomUUID();
+	}
+
+	const bytes = crypto.getRandomValues(new Uint8Array(16));
+	bytes[6] = (bytes[6] & 0x0f) | 0x40;
+	bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+	const hex = Array.from(bytes, (byte) =>
+		byte.toString(16).padStart(2, '0')
+	).join('');
+
+	return [
+		hex.slice(0, 8),
+		hex.slice(8, 12),
+		hex.slice(12, 16),
+		hex.slice(16, 20),
+		hex.slice(20, 32),
+	].join('-');
+}

--- a/fair-form/src/blocks/fair-form/editor.js
+++ b/fair-form/src/blocks/fair-form/editor.js
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
+import { generateUuid } from 'fair-events-shared';
 
 const ALLOWED_BLOCKS = [
 	'core/heading',
@@ -136,7 +137,7 @@ registerBlockType('fair-audience/fair-form', {
 				);
 
 			if (!formId || isDuplicate) {
-				setAttributes({ formId: crypto.randomUUID() });
+				setAttributes({ formId: generateUuid() });
 			}
 		}, [formId, clientId, allBlocks, setAttributes]);
 

--- a/fair-payments-connector/src/API/PaymentEndpoint.php
+++ b/fair-payments-connector/src/API/PaymentEndpoint.php
@@ -192,6 +192,17 @@ class PaymentEndpoint extends WP_REST_Controller {
 		$post_id     = $request->get_param( 'post_id' );
 		$block_id    = $request->get_param( 'block_id' );
 
+		// WordPress' `required` check on args passes on ''. An empty block_id would
+		// otherwise match any legacy block whose saved blockId is also '', so reject
+		// it outright rather than resolving an ambiguous match.
+		if ( '' === $block_id ) {
+			return new WP_Error(
+				'invalid_block',
+				__( 'Block not found.', 'fair-payments-connector' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		// Derive authoritative amount from saved block content.
 		$post = $post_id ? get_post( $post_id ) : null;
 		if ( ! $post ) {

--- a/fair-payments-connector/src/blocks/simple-payment/index.js
+++ b/fair-payments-connector/src/blocks/simple-payment/index.js
@@ -3,9 +3,14 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
-import { TextControl } from '@wordpress/components';
+import { Notice, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { generateUuid } from 'fair-events-shared';
 
 /**
  * Block metadata
@@ -28,9 +33,14 @@ registerBlockType(metadata.name, {
 		const blockProps = useBlockProps();
 		const { blockId, amount, currency, description } = attributes;
 
+		// The blockId assigned here only takes effect on the frontend once the post is
+		// saved, so a legacy block (blockId missing before this mount) keeps warning
+		// even after the id is generated in-memory — until the user actually saves.
+		const [wasMissingBlockId] = useState(() => !blockId);
+
 		useEffect(() => {
 			if (!blockId) {
-				setAttributes({ blockId: crypto.randomUUID() });
+				setAttributes({ blockId: generateUuid() });
 			}
 			if (!currency) {
 				setAttributes({
@@ -45,6 +55,14 @@ registerBlockType(metadata.name, {
 					<h3>
 						{__('Simple Payment Block', 'fair-payments-connector')}
 					</h3>
+					{wasMissingBlockId && (
+						<Notice status="warning" isDismissible={false}>
+							{__(
+								'This block is missing an identifier and payments will fail until the post is saved. Save or update the post now.',
+								'fair-payments-connector'
+							)}
+						</Notice>
+					)}
 					<TextControl
 						label={__('Amount', 'fair-payments-connector')}
 						value={amount}


### PR DESCRIPTION
## Summary

The headline `block_id` clobbering from the ticket body was already fixed and shipped in `ce4566c6` (see plan comment for details) and is e2e-covered by the existing happy-path spec. This PR implements the remainder of the approved [implementation plan](https://github.com/marcin-wosinek/fair-event-plugins/issues/857#issuecomment-5106938859):

- **Backend**: `PaymentEndpoint::create_payment()` now rejects an empty `block_id` with `403 invalid_block` before the tree walk. WordPress' `required` arg check passes on `''`, so an empty submitted id would otherwise match any legacy block whose saved `blockId` is also `''` — on a page with two such blocks, the first always won, silently mischarging the buyer of the second.
- **Shared**: added `generateUuid()` to `fair-events-shared` (falls back to `crypto.getRandomValues()` when `crypto.randomUUID()` is unavailable outside a secure context — a real gap on plain-HTTP self-hosted installs that would otherwise throw in the editor and leave every simple-payment/fair-form block without an id). Consumed by both `fair-payments-connector`'s simple-payment block and `fair-form`'s block.
- **Editor**: the simple-payment block now shows a non-dismissible warning `Notice` when it mounts with a missing `blockId`, since the in-memory fix only reaches the frontend once the post is saved.
- **Tests**: added three e2e cases to `e2e/user-flows/simple-payment-purchase.spec.js` (the root wp-env harness — the only suite wired into CI): low-amount rejection (`422 amount_too_low`), empty `block_id` rejection (`403 invalid_block`), and a client-tampered `data-amount` that must not reach Mollie checkout. `e2e/mu-plugins/scripts/seed-payment-page.php` now also emits the seeded `blockId` so specs can POST with it directly.

Closes #857

## Acceptance criteria

- [x] A payment from a saved simple-payment block reaches Mollie checkout — already fixed pre-PR (`ce4566c6`), proven by the existing happy-path e2e case (still passing).
- [x] Submitting an amount below the block's configured amount is rejected with `422` — code already existed; now covered by a new e2e case (previously zero test coverage).
- [x] e2e test covering the happy path + low-amount rejection — both covered, plus two additional regression cases (empty `block_id`, tampered client amount) found while grounding the plan.

## Notes

- Duplicated `blockId` on block duplication (mentioned in the plan's Decisions) is explicitly out of scope — tracked as a separate follow-up ticket per the plan.
- I did not visually verify the new editor `Notice` in a running browser: this worktree's `docker compose` dev stack has never been provisioned (fresh DB, no WordPress install) and its OAuth-proxy port collided with another running project's stack. The actual bug (payment flow, amount-floor rejection, empty `block_id`, tampered amount) is exercised end-to-end against a live WordPress instance via the wp-env e2e harness, which all pass. The `Notice` itself follows an existing in-repo pattern (`fair-events/src/blocks/events-calendar/components/EditComponent.js`) verbatim.

## Test plan

- [x] `npm run build` — `fair-payments-connector`, `fair-form`
- [x] `npm run format` — `fair-payments-connector`, `fair-form`
- [x] `vendor/bin/phpcs` clean for `PaymentEndpoint.php` (one pre-existing, unrelated Yoda-condition error elsewhere in the file, untouched by this change)
- [x] `npm run test:js` — `fair-events-shared` (213 tests incl. new `uuid.test.js`), `fair-payments-connector` (9 tests), `fair-form` (9 tests)
- [x] `npm run test:php` — `fair-payments-connector` (37 tests)
- [x] Root `npm run test:e2e` — full suite, 75/75 passing, including the 4 simple-payment-purchase cases (1 pre-existing + 3 new)
- [x] Changesets added: `fair-payments-connector`, `fair-form`, `fair-events-shared`
