### PR TITLE
Cover Fair Form submit through the detail page in e2e

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -160,6 +160,20 @@ Each prints a single `MARKER:{json}` line (`E2E_SEED`, `E2E_STATE`,
   are posted directly to REST). Pass `1` as `noBlock` to omit the block
   entirely. Cleanup also removes any questionnaire submissions/answers
   created against the page.
+- **`seed-fair-form-questions-page.php [formId] [formTitle]`** — creates a
+  published page carrying a `fair-audience/fair-form` block with **real inner
+  question blocks** (short text, email, and a select-one built from option
+  blocks), so a spec can fill and submit the form through the browser instead
+  of posting to REST. Emits the page id + permalink and the seeded question
+  texts/choices. Tear down with `cleanup-fair-form-notification-page.php`,
+  which is generic (page id → submissions/answers) and serves both fair-form
+  seeds; the participant the email answer auto-creates needs
+  `cleanup-participant.php` on top.
+- **`fair-form-submission-state.php <postId>`** — reports the most recent
+  questionnaire submission stored for a page (`submissionId`,
+  `participantId`, `title`, `formId`/`formTitle`, answer count). The public
+  submit endpoint returns only `{success, message}`, so specs resolve the
+  submission id server-side rather than reading it off the response.
 - **`fair-form-notification-state.php [email]`** — reports mail captured for
   the given recipient (or everything captured, unfiltered, when called with
   no address — used by the "nothing should be sent" scenarios).

--- a/e2e/mu-plugins/scripts/fair-form-submission-state.php
+++ b/e2e/mu-plugins/scripts/fair-form-submission-state.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Report the questionnaire submission stored for a seeded Fair Form page.
+ *
+ * The public submit endpoint answers with `{success, message}` only — by
+ * design, so an anonymous submitter never learns an internal row id — so the
+ * spec cannot read the submission id off the response. This script resolves it
+ * server-side instead, keeping #619 test-only.
+ *
+ * Returns the most recent submission for the page, so a spec that submits more
+ * than once still gets the one it just created.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/fair-form-submission-state.php <postId>
+ *
+ * Prints a single `E2E_FAIR_FORM_SUBMISSION:{json}` line.
+ *
+ * @package FairFormE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+global $wpdb;
+
+$page_id = isset( $args[0] ) ? (int) $args[0] : 0;
+if ( ! $page_id ) {
+	WP_CLI::error( 'Usage: fair-form-submission-state.php <postId>' );
+}
+
+$submissions_table = $wpdb->prefix . 'fair_audience_questionnaire_submissions';
+$answers_table     = $wpdb->prefix . 'fair_audience_questionnaire_answers';
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off state dump for the spec, no cache to honour.
+$submission = $wpdb->get_row(
+	$wpdb->prepare(
+		'SELECT * FROM %i WHERE post_id = %d ORDER BY id DESC LIMIT 1',
+		$submissions_table,
+		$page_id
+	)
+);
+
+if ( ! $submission ) {
+	echo 'E2E_FAIR_FORM_SUBMISSION:' . wp_json_encode( array( 'found' => false ) ) . "\n";
+	return;
+}
+
+$answer_count = (int) $wpdb->get_var(
+	$wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE submission_id = %d', $answers_table, $submission->id )
+);
+// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+echo 'E2E_FAIR_FORM_SUBMISSION:' . wp_json_encode(
+	array(
+		'found'         => true,
+		'submissionId'  => (int) $submission->id,
+		'participantId' => $submission->participant_id ? (int) $submission->participant_id : null,
+		'title'         => (string) $submission->title,
+		'formId'        => (string) $submission->form_id,
+		'formTitle'     => (string) $submission->form_title,
+		'answerCount'   => $answer_count,
+	)
+) . "\n";

--- a/e2e/mu-plugins/scripts/seed-fair-form-questions-page.php
+++ b/e2e/mu-plugins/scripts/seed-fair-form-questions-page.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Seed a published page carrying a Fair Form block with real question blocks
+ * for the submission-detail E2E suite (#619).
+ *
+ * Unlike seed-fair-form-notification-page.php — which deliberately carries no
+ * inner blocks, because that suite posts answers straight to REST — this seed
+ * needs the questions to actually render, so the spec can fill and submit the
+ * form through the browser and exercise the full
+ * frontend submit -> storage -> admin detail view path.
+ *
+ * Covers the three question shapes the detail page renders differently:
+ * short text, email (which also drives participant auto-creation), and a
+ * single-choice select built from inner option blocks.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-fair-form-questions-page.php [formId] [formTitle]
+ *
+ * Prints a single `E2E_FAIR_FORM_QUESTIONS_PAGE:{json}` line with the page id,
+ * permalink, form id/title and the seeded question definitions.
+ *
+ * Tear down with `cleanup-fair-form-notification-page.php <pageId>`, which is
+ * generic (page id -> submissions/answers) and serves both fair-form seeds.
+ *
+ * @package FairFormE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$form_id    = isset( $args[0] ) && '' !== $args[0] ? (string) $args[0] : 'e2e-detail';
+$form_title = isset( $args[1] ) && '' !== $args[1] ? (string) $args[1] : 'E2E Detail Form';
+
+$questions = array(
+	'full_name' => 'Your name',
+	'email'     => 'Your email',
+	'how_heard' => 'How did you hear about us?',
+);
+
+$choices = array( 'A friend', 'Social media' );
+
+$option_blocks = '';
+foreach ( $choices as $choice ) {
+	$option_blocks .= '<!-- wp:fair-audience/fair-form-option ' . wp_json_encode( array( 'value' => $choice ) ) . ' /-->';
+}
+
+$content = implode(
+	'',
+	array(
+		'<!-- wp:fair-audience/fair-form ' . wp_json_encode(
+			array(
+				'formId'    => $form_id,
+				'formTitle' => $form_title,
+			)
+		) . ' -->',
+		'<!-- wp:fair-audience/fair-form-short-text ' . wp_json_encode(
+			array(
+				'questionKey'  => 'full_name',
+				'questionText' => $questions['full_name'],
+			)
+		) . ' /-->',
+		'<!-- wp:fair-audience/fair-form-email ' . wp_json_encode(
+			array(
+				'questionKey'  => 'email',
+				'questionText' => $questions['email'],
+			)
+		) . ' /-->',
+		'<!-- wp:fair-audience/fair-form-select-one ' . wp_json_encode(
+			array(
+				'questionKey'  => 'how_heard',
+				'questionText' => $questions['how_heard'],
+			)
+		) . ' -->',
+		$option_blocks,
+		'<!-- /wp:fair-audience/fair-form-select-one -->',
+		'<!-- /wp:fair-audience/fair-form -->',
+	)
+);
+
+$page_id = wp_insert_post(
+	array(
+		'post_type'    => 'page',
+		'post_status'  => 'publish',
+		'post_title'   => 'E2E Fair Form Questions ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ),
+		'post_content' => $content,
+	),
+	true
+);
+
+if ( is_wp_error( $page_id ) ) {
+	WP_CLI::error( 'Failed to create page: ' . $page_id->get_error_message() );
+}
+
+echo 'E2E_FAIR_FORM_QUESTIONS_PAGE:' . wp_json_encode(
+	array(
+		'pageId'    => (int) $page_id,
+		'pageUrl'   => get_permalink( $page_id ),
+		'formId'    => $form_id,
+		'formTitle' => $form_title,
+		'questions' => $questions,
+		'choices'   => $choices,
+	)
+) . "\n";

--- a/e2e/user-flows/fair-form-submission-detail.spec.js
+++ b/e2e/user-flows/fair-form-submission-detail.spec.js
@@ -1,0 +1,168 @@
+/**
+ * E2E: a Fair Form submitted from the frontend must render faithfully on the
+ * submission-detail admin page (#619).
+ *
+ * This is the cross-plugin seam nothing else covers: the existing
+ * `fair-form-standalone-responses.spec.js` opens the same page, but from a
+ * DB-seeded submission. Here the data travels the whole way — rendered block
+ * -> public REST submit -> questionnaire storage -> participant auto-creation
+ * -> `GET /fair-form/v1/questionnaire-responses/{id}` -> the React detail view
+ * — so a break anywhere along it fails the test.
+ *
+ * The submission id is resolved server-side via WP-CLI: the submit endpoint
+ * deliberately returns only `{success, message}`.
+ */
+
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin, runScript, wpCli } from '../support/wp-cli.js';
+
+const DETAIL_PAGE = '/wp-admin/admin.php?page=fair-form-submission-detail';
+
+test.describe('Fair Form submission detail', () => {
+	// The submit endpoint rate-limits 3 requests/hour. The email below is
+	// unique per run, but the IP-keyed fallback and CI retries are not, so
+	// clear transients the same way the notification suite does.
+	test.beforeEach(() => {
+		wpCli('transient delete --all');
+	});
+
+	test('renders every submitted answer and the submission metadata', async ({
+		page,
+	}) => {
+		const submitterEmail = `e2e.detail.${Date.now()}@example.test`;
+		const submitterName = 'Detail Tester';
+		const choice = 'Social media';
+
+		const seed = runScript(
+			'seed-fair-form-questions-page.php',
+			'E2E_FAIR_FORM_QUESTIONS_PAGE'
+		);
+		let state = { found: false };
+
+		try {
+			await page.goto(seed.pageUrl);
+
+			await page.fill(
+				'[data-question-key="full_name"] input[type="text"]',
+				submitterName
+			);
+			await page.fill(
+				'[data-question-key="email"] input[type="email"]',
+				submitterEmail
+			);
+			await page.selectOption(
+				'[data-question-key="how_heard"] select',
+				choice
+			);
+
+			await page.click('.fair-form-submit-button');
+			await expect(page.locator('.fair-form-message')).toHaveText(
+				'Thank you for your submission!'
+			);
+
+			state = runScript(
+				'fair-form-submission-state.php',
+				'E2E_FAIR_FORM_SUBMISSION',
+				`${seed.pageId}`
+			);
+			expect(state.found).toBe(true);
+			expect(state.answerCount).toBe(3);
+			expect(state.participantId).toBeGreaterThan(0);
+
+			await loginAsAdmin(page);
+			await page.goto(
+				`${DETAIL_PAGE}&submission_id=${state.submissionId}`
+			);
+
+			const answers = page.locator(
+				'.fair-form-submission-detail__answers-table'
+			);
+			await expect(
+				answers.getByText(seed.questions.full_name)
+			).toBeVisible();
+			await expect(answers.getByText(submitterName)).toBeVisible();
+			await expect(answers.getByText(seed.questions.email)).toBeVisible();
+			await expect(answers.getByText(submitterEmail)).toBeVisible();
+			await expect(
+				answers.getByText(seed.questions.how_heard)
+			).toBeVisible();
+			await expect(answers.getByText(choice)).toBeVisible();
+
+			// Submission Info: the email answer auto-creates a participant, and
+			// "Submitted by" must link to it.
+			const info = page.locator(
+				'.fair-form-submission-detail__info-table'
+			);
+			const submittedBy = info.locator('tr', {
+				hasText: 'Submitted by',
+			});
+			await expect(
+				submittedBy.locator(
+					`a[href*="participant_id=${state.participantId}"]`
+				)
+			).toBeVisible();
+
+			await expect(
+				info.locator('tr', { hasText: 'Email' }).locator('td')
+			).toHaveText(submitterEmail);
+
+			// formatDate() goes through toLocaleString(), so the exact text is
+			// locale/timezone dependent — assert only that a date rendered.
+			const dateCell = info
+				.locator('tr', { hasText: 'Date' })
+				.locator('td');
+			await expect(dateCell).not.toHaveText('');
+			await expect(dateCell).not.toHaveText('—');
+		} finally {
+			// A failure before the state read still leaves rows behind — look
+			// the submission up again so teardown stays complete.
+			if (!state.found) {
+				state = runScript(
+					'fair-form-submission-state.php',
+					'E2E_FAIR_FORM_SUBMISSION',
+					`${seed.pageId}`
+				);
+			}
+
+			// Generic in the page id -> submissions/answers direction, so it
+			// serves this seed too; the auto-created participant is not tied to
+			// the page and needs its own teardown.
+			runScript(
+				'cleanup-fair-form-notification-page.php',
+				'E2E_FAIR_FORM_NOTIFICATION_CLEANUP',
+				`${seed.pageId}`
+			);
+
+			if (state.participantId) {
+				runScript(
+					'cleanup-participant.php',
+					'E2E_PARTICIPANT_CLEANUP',
+					`${state.participantId}`
+				);
+			}
+		}
+	});
+
+	test('shows a not-found notice for an unknown submission id', async ({
+		page,
+	}) => {
+		const pageErrors = [];
+		page.on('pageerror', (err) => pageErrors.push(err.message));
+
+		await loginAsAdmin(page);
+		await page.goto(`${DETAIL_PAGE}&submission_id=999999`);
+
+		// Scoped to the notice: @wordpress/a11y mirrors the same string into the
+		// off-screen speak region, which makes an unscoped getByText ambiguous.
+		await expect(
+			page.locator(
+				'.fair-form-submission-detail .components-notice__content'
+			)
+		).toHaveText('Submission not found.');
+
+		const body = await page.locator('body').innerText();
+		expect(body).not.toContain('Fatal error');
+		expect(body).not.toContain('Warning:');
+		expect(pageErrors).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

Adds E2E coverage for the cross-plugin seam nothing tested before: a Fair Form
filled in and submitted **from the browser** must land in questionnaire storage
and render faithfully on the submission-detail admin page.

`fair-form-standalone-responses.spec.js` already opens that page, but from a
DB-seeded submission — it never exercises the frontend block, the public REST
submit, or the participant auto-creation in between. The new spec drives the
whole path: rendered block → `POST /fair-form/v1/fair-form-submit` →
`QuestionnaireService::save_answers()` → participant auto-creation →
`GET /fair-form/v1/questionnaire-responses/{id}` → the React detail view.

Test-only: no plugin code changes, so no changeset.

Closes #619

## What's here

- **`e2e/mu-plugins/scripts/seed-fair-form-questions-page.php`** — seeds a page
  with a `fair-audience/fair-form` block carrying **real inner question
  blocks**: short text, email, and a select-one built from option blocks. The
  existing `seed-fair-form-notification-page.php` deliberately has no inner
  blocks (that suite posts to REST directly) and stays that way.
- **`e2e/mu-plugins/scripts/fair-form-submission-state.php`** — resolves the
  stored submission for a page (`submissionId`, `participantId`, `formId`,
  answer count). The submit endpoint returns only `{success, message}`, so the
  id is read back server-side rather than leaked to anonymous submitters.
- **`e2e/user-flows/fair-form-submission-detail.spec.js`** — the two scenarios
  below.
- **`e2e/README.md`** — both scripts documented in the WP-CLI helper list,
  noting that `cleanup-fair-form-notification-page.php` now serves both
  fair-form seeds.

## Acceptance criteria

| Criterion | How it's met |
| --- | --- |
| `npm run test:e2e` passes locally and on CI with the new spec | Passes locally against wp-env `:8889` (ran the new spec 3×, plus the full suite). No CI change needed — `.github/workflows/e2e.yml` already triggers on `e2e/**` and `fair-form/**`. |
| Self-contained: creates its own form + submission | The spec seeds its own page with question blocks and submits through the rendered DOM; it relies on no pre-existing data. |
| Test cleans up | `finally` runs `cleanup-fair-form-notification-page.php` (page + submissions + answers) and `cleanup-participant.php` for the participant the email answer auto-creates. Verified: after repeat runs, zero `e2e.detail%` participants and zero submissions for the seeded pages remain. |
| Submit the seeded form with known values from the frontend | Fills `[data-question-key="…"]` inputs and the select on the public page, clicks `.fair-form-submit-button`, asserts the success message in `.fair-form-message`. |
| Log in as admin, navigate to the detail page | `loginAsAdmin(page)` then `admin.php?page=fair-form-submission-detail&submission_id=<id>`. |
| Assert each submitted field label + value | All three question texts and their submitted values asserted in the answers table (text, email, choice). |
| Assert submission metadata is present | **Email** row shows the submitted address; **Submitted by** links to the auto-created participant; **Date** row asserted non-empty and not `—` (loose, because `formatDate()` uses `toLocaleString()` — exact text is locale/timezone dependent). |
| Snapshot/visual check out of scope | Text-content assertions only. |
| Negative case: unknown `submission_id` degrades gracefully | Second test loads `?submission_id=999999` and asserts the "Submission not found." notice, no `Fatal error` / `Warning:` in the body, and no uncaught page errors. |

### Deferred

**"source form" in submission metadata.** The detail page cannot show it today:
`QuestionnaireResponsesController::get_item()` omits `form_id`/`form_title`, and
the submission `title` is the hardcoded `'Fair Form'` set in
`QuestionnaireService::save_answers()`. Asserting it would mean changing plugin
code, which takes this ticket out of test-only scope. The spec asserts the
metadata that does render. Worth a follow-up ticket to surface the source form
(title + link to the page it lives on) on the detail view.

## Notes

- The ticket names `e2e/fair-audience/submission-detail.spec.js` and the
  `fair-audience-submission-detail` slug. Both are stale: the page moved to
  **fair-form** (`page=fair-form-submission-detail`), and all functional specs
  live in `e2e/user-flows/` — the repo has no per-plugin e2e subdirectories.
- The not-found assertion is scoped to `.components-notice__content`;
  `@wordpress/a11y` mirrors the same string into the off-screen speak region,
  which makes an unscoped `getByText` ambiguous.
