### PR TITLE
Drop legacy signup block attributes the unified block discards

### DIFF
--- a/fair-audience/src/blocks/event-signup/block.json
+++ b/fair-audience/src/blocks/event-signup/block.json
@@ -22,26 +22,6 @@
 		"signupButtonText": {
 			"type": "string",
 			"default": "Sign Up"
-		},
-		"registerButtonText": {
-			"type": "string",
-			"default": "Register & Sign Up"
-		},
-		"requestLinkButtonText": {
-			"type": "string",
-			"default": "Send Signup Link"
-		},
-		"successMessage": {
-			"type": "string",
-			"default": "You have successfully signed up for the event!"
-		},
-		"showOptionPrices": {
-			"type": "boolean",
-			"default": true
-		},
-		"showTicketTypePrices": {
-			"type": "boolean",
-			"default": true
 		}
 	},
 	"editorScript": "file:./editor.js",

--- a/fair-audience/src/blocks/event-signup/editor.js
+++ b/fair-audience/src/blocks/event-signup/editor.js
@@ -8,13 +8,7 @@ import {
 	InspectorControls,
 	InnerBlocks,
 } from '@wordpress/block-editor';
-import {
-	PanelBody,
-	TextControl,
-	TextareaControl,
-	ToggleControl,
-	Notice,
-} from '@wordpress/components';
+import { PanelBody, TextControl, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const UNIFIED_NAME = 'fair-events/event-signup';
@@ -71,14 +65,7 @@ registerBlockType('fair-audience/event-signup', {
 		],
 	},
 	edit: ({ attributes, setAttributes }) => {
-		const {
-			signupButtonText,
-			registerButtonText,
-			requestLinkButtonText,
-			successMessage,
-			showOptionPrices,
-			showTicketTypePrices,
-		} = attributes;
+		const { signupButtonText } = attributes;
 
 		const blockProps = useBlockProps({
 			className: 'fair-audience-event-signup',
@@ -107,86 +94,6 @@ registerBlockType('fair-audience/event-signup', {
 								'Button text for authenticated users.',
 								'fair-audience'
 							)}
-						/>
-						<TextControl
-							label={__('Register Button Text', 'fair-audience')}
-							value={registerButtonText}
-							onChange={(value) =>
-								setAttributes({ registerButtonText: value })
-							}
-							placeholder={__(
-								'Register & Sign Up',
-								'fair-audience'
-							)}
-							help={__(
-								'Button text for new registrations.',
-								'fair-audience'
-							)}
-						/>
-						<TextControl
-							label={__(
-								'Request Link Button Text',
-								'fair-audience'
-							)}
-							value={requestLinkButtonText}
-							onChange={(value) =>
-								setAttributes({
-									requestLinkButtonText: value,
-								})
-							}
-							placeholder={__(
-								'Send Signup Link',
-								'fair-audience'
-							)}
-							help={__(
-								'Button text for existing participants.',
-								'fair-audience'
-							)}
-						/>
-						<TextareaControl
-							label={__('Success Message', 'fair-audience')}
-							value={successMessage}
-							onChange={(value) =>
-								setAttributes({ successMessage: value })
-							}
-							placeholder={__(
-								'You have successfully signed up for the event!',
-								'fair-audience'
-							)}
-							help={__(
-								'Message shown after successful signup.',
-								'fair-audience'
-							)}
-						/>
-						<ToggleControl
-							label={__(
-								'Show ticket type prices',
-								'fair-audience'
-							)}
-							help={__(
-								'Display the price of each ticket type next to its label.',
-								'fair-audience'
-							)}
-							checked={showTicketTypePrices}
-							onChange={(value) =>
-								setAttributes({
-									showTicketTypePrices: value,
-								})
-							}
-						/>
-						<ToggleControl
-							label={__(
-								'Show activity option prices',
-								'fair-audience'
-							)}
-							help={__(
-								'Display the price of each activity option next to its label. The running total in the button always updates regardless of this setting.',
-								'fair-audience'
-							)}
-							checked={showOptionPrices}
-							onChange={(value) =>
-								setAttributes({ showOptionPrices: value })
-							}
 						/>
 					</PanelBody>
 				</InspectorControls>
@@ -233,8 +140,7 @@ registerBlockType('fair-audience/event-signup', {
 								className="wp-block-button__link wp-element-button"
 								disabled
 							>
-								{registerButtonText ||
-									__('Register & Sign Up', 'fair-audience')}
+								{__('Register & Sign Up', 'fair-audience')}
 							</button>
 						</div>
 					</div>

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -57,10 +57,13 @@ if ( isset( $_GET['fair_payment_callback'] ) && 'true' === $_GET['fair_payment_c
 
 // Get block attributes — the defaults are the only literals that need
 // translating; a saved attribute value must never be run through __().
+// Only the signup button label stays configurable: the unified fair-events
+// block forwards that one attribute and nothing else, so every other label
+// and display toggle is a fixed default here.
 $signup_button_text       = $attributes['signupButtonText'] ?? __( 'Sign Up', 'fair-audience' );
-$register_button_text     = $attributes['registerButtonText'] ?? __( 'Register & Sign Up', 'fair-audience' );
-$request_link_button_text = $attributes['requestLinkButtonText'] ?? __( 'Send Signup Link', 'fair-audience' );
-$success_message          = $attributes['successMessage'] ?? __( 'You have successfully signed up for the event!', 'fair-audience' );
+$register_button_text     = __( 'Register & Sign Up', 'fair-audience' );
+$request_link_button_text = __( 'Send Signup Link', 'fair-audience' );
+$success_message          = __( 'You have successfully signed up for the event!', 'fair-audience' );
 
 // Get the current post ID (may be a direct event post or a linked page).
 $post_id = get_the_ID();
@@ -532,9 +535,6 @@ if ( $has_ticket_options && $has_ticket_types ) {
 }
 $initial_minimum_activities = min( $option_count, max( $minimum_activities, $preselected_type_min ) );
 
-// Read block attribute to control whether option prices are displayed.
-$show_option_prices = $attributes['showOptionPrices'] ?? true;
-
 // Detect whether any ticket option carries a non-zero price.  Used below to
 // decide whether data-base-price should be "0" (options-only pricing) vs ""
 // (truly free, no JS total updates needed).
@@ -682,10 +682,7 @@ if ( $best_discount_rule ) {
  * Render the ticket-type radio fieldset. No-op when the event date has no
  * ticket types configured. First enabled option is pre-selected.
  */
-// Read block attribute to control whether ticket type prices are displayed.
-$show_ticket_type_prices = $attributes['showTicketTypePrices'] ?? true;
-
-$render_ticket_types = static function () use ( $ticket_types_for_display, $has_ticket_types, $form_id, $show_ticket_type_prices ) {
+$render_ticket_types = static function () use ( $ticket_types_for_display, $has_ticket_types, $form_id ) {
 	if ( ! $has_ticket_types ) {
 		return;
 	}
@@ -696,7 +693,7 @@ $render_ticket_types = static function () use ( $ticket_types_for_display, $has_
 	foreach ( $ticket_types_for_display as $tt ) {
 		$tt_is_full = ! empty( $tt['is_full'] );
 		$tt_label   = $tt['name'];
-		if ( $show_ticket_type_prices && null !== $tt['price'] ) {
+		if ( null !== $tt['price'] ) {
 			if ( $tt['price'] > 0 ) {
 				$tt_label .= ' — ' . Money::format_inline( (float) $tt['price'] );
 			} elseif ( $tt['price'] < 0 ) {
@@ -731,7 +728,7 @@ $render_ticket_types = static function () use ( $ticket_types_for_display, $has_
 /**
  * Render the ticket options checkbox fieldset. No-op when no options configured.
  */
-$render_ticket_options = static function () use ( $ticket_options_for_display, $has_ticket_options, $form_id, $show_option_prices, $minimum_activities, $any_ticket_type_min, $initial_minimum_activities ) {
+$render_ticket_options = static function () use ( $ticket_options_for_display, $has_ticket_options, $form_id, $minimum_activities, $any_ticket_type_min, $initial_minimum_activities ) {
 	if ( ! $has_ticket_options ) {
 		return;
 	}
@@ -773,7 +770,7 @@ $render_ticket_options = static function () use ( $ticket_options_for_display, $
 		$opt_label = $opt['name'];
 		// Inline price only when the minimum-activities feature is inactive; the
 		// feature-active case uses the toggled "(+price)" tag emitted below.
-		if ( ! $feature_active && $show_option_prices ) {
+		if ( ! $feature_active ) {
 			if ( $opt['price'] > 0 ) {
 				$opt_label .= ' — ' . Money::format_inline( $opt['price'] );
 			} elseif ( $opt['price'] < 0 ) {
@@ -804,7 +801,7 @@ $render_ticket_options = static function () use ( $ticket_options_for_display, $
 		echo esc_html( $opt_label );
 		// Hidden add-on tag, revealed by frontend.js on unchecked options once
 		// the minimum is reached. Positive prices only (no "(+€0.00)").
-		if ( $feature_active && $show_option_prices && $opt['price'] > 0 ) {
+		if ( $feature_active && $opt['price'] > 0 ) {
 			printf(
 				'<span class="fair-audience-ticket-option-addon" style="display: none;"> %s</span>',
 				esc_html(
@@ -828,7 +825,7 @@ $render_ticket_options = static function () use ( $ticket_options_for_display, $
  * there's nothing left to add. The Add button total is kept in sync by the
  * frontend JS from the checked options' data-option-price.
  */
-$render_add_activities = static function () use ( $addable_options, $has_addable_options, $form_id, $show_option_prices ) {
+$render_add_activities = static function () use ( $addable_options, $has_addable_options, $form_id ) {
 	if ( ! $has_addable_options ) {
 		return;
 	}
@@ -836,14 +833,12 @@ $render_add_activities = static function () use ( $addable_options, $has_addable
 	echo '<legend>' . esc_html__( 'Add activities', 'fair-audience' ) . '</legend>';
 	foreach ( $addable_options as $opt ) {
 		$opt_label = $opt['name'];
-		if ( $show_option_prices ) {
-			if ( $opt['price'] > 0 ) {
-				$opt_label .= ' — ' . Money::format_inline( $opt['price'] );
-			} elseif ( $opt['price'] < 0 ) {
-				$opt_label .= ' — -' . Money::format_inline( abs( $opt['price'] ) );
-			} else {
-				$opt_label .= ' — ' . __( 'free', 'fair-audience' );
-			}
+		if ( $opt['price'] > 0 ) {
+			$opt_label .= ' — ' . Money::format_inline( $opt['price'] );
+		} elseif ( $opt['price'] < 0 ) {
+			$opt_label .= ' — -' . Money::format_inline( abs( $opt['price'] ) );
+		} else {
+			$opt_label .= ' — ' . __( 'free', 'fair-audience' );
 		}
 		$is_full = ! empty( $opt['is_full'] );
 		if ( $is_full ) {
@@ -972,7 +967,7 @@ $render_instance_picker = static function () use ( $occurrences_for_picker, $has
 
 // Base button labels (without price suffix) for dynamic JS price updates.
 $base_signup_button_text   = $attributes['signupButtonText'] ?? __( 'Sign Up', 'fair-audience' );
-$base_register_button_text = $attributes['registerButtonText'] ?? __( 'Register & Sign Up', 'fair-audience' );
+$base_register_button_text = __( 'Register & Sign Up', 'fair-audience' );
 
 // Get wrapper attributes.
 $wrapper_attributes = get_block_wrapper_attributes(


### PR DESCRIPTION
## Summary

Removes five attributes from the legacy fair-audience Event Signup block that could no longer take effect: the register button label, the request-link button label, the success message, and the two price-display toggles.

The unified fair-events signup block delegates to this block whenever fair-audience is active, and rebuilds the delegated attribute set from scratch carrying only the signup button label. Everything else an organizer configured was silently discarded before it reached the render — a custom success message or a disabled price display simply did nothing on the published page.

Rather than plumb five attributes through the delegation, this drops them. The former defaults become the fixed behaviour, which is what these blocks have actually been rendering all along. Only the signup button label stays configurable, because that is the one the unified block forwards.

## Notes

- **Behaviour change on paper only.** Sites that had customised those labels or hidden prices lose settings that were already being ignored at render time. Nothing that was visibly working stops working.
- Both price toggles defaulted to on, so the four conditionals they guarded now render unconditionally rather than being left as dead branches.
- The block is dynamic with an `InnerBlocks.Content` save, so stale attribute values still sitting in existing post markup are ignored — no block-validation errors and no migration step.
- No changeset added yet. Happy to add one if this should surface in the fair-audience release notes.
- This is a narrow fix. The wider question — that the unified block and its `get-tickets` route are both bypassed entirely whenever fair-audience is active, leaving most of the signup hook bridge dormant — is untouched here and worth its own ticket.

## Test plan

- [x] `npm run build` in fair-audience — compiles clean, translations regenerated
- [x] `npm run format` — clean
- [x] `npm run test:js` in fair-audience — 7 suites / 27 tests passing
- [x] `vendor/bin/phpcs` on the changed render — 12 errors / 1 warning, byte-identical to the count on the pre-change file (all pre-existing escaping sniffs on `$checkbox_id` / `$select_id`; none introduced, none fixed)
- [ ] `npm run test:php` in fair-audience — **not run**, `vendor/bin/phpunit` is not installed there. Its two suites cover signup activities and group pricing, neither of which touches these attributes.
- [ ] `npm run test:e2e` — **not run**, needs the wp-env stack up
- [ ] Manual: place the legacy block in the editor, confirm the Form Settings panel now shows only Signup Button Text
- [ ] Manual: view a published event signup form and confirm ticket-type and activity prices still render, and the success message after signup reads the default
