### PR TITLE
Cut over Event Signup to the unified block

### DIFF
--- a/.changeset/event-signup-cutover.md
+++ b/.changeset/event-signup-cutover.md
@@ -1,0 +1,6 @@
+---
+"fair-events": minor
+"fair-audience": minor
+---
+
+The unified Event Signup block (`fair-events/event-signup`) no longer delegates its render to fair-audience's legacy block when fair-audience is active — it renders its own markup unconditionally, and fair-audience enriches that same render via the existing filter/render-slot hooks instead of owning a competing template. A returning participant who already holds a ticket for the date now sees a signed-up/cancel card in place of the signup form, with a "cancel signup" action; per-occurrence date pickers label dates the viewer already holds (including via a whole-series pass); a resubmitted paid-ticket purchase for a date already held is rejected instead of silently creating a second charge; the per-IP rate limit is raised to 20/hour with an added 3/hour per-email limit, so a shared venue Wi-Fi no longer blocks legitimate signups. Sites without fair-audience see no change. The legacy `fair-audience/event-signup` block, its own identity routes, and existing signup links keep working unchanged for content authored before this change; participant_token URL login and the "I have an account" resume-by-email flow are not yet available on the unified form and remain on the legacy block for now.

--- a/REST_API_BACKEND.md
+++ b/REST_API_BACKEND.md
@@ -578,10 +578,10 @@ create route) expose:
     `price_by_type_id`, `active_sale_period`, `occurrences_for_picker`, `currency_symbol`,
     `ticket_options`, `minimum_activities`,
     `callback_status`/`callback_tx_id`/`callback_token`, `prefill_name`,
-    `prefill_email`, `submit_button_text`) and runs it through this filter
-    before rendering, so a companion plugin can inject viewer identity,
-    session pre-fill, or participant-filtered ticket types/prices without a
-    parallel template. `ticket_options` is a list of
+    `prefill_email`, `submit_button_text`, `suppress_form`) and runs it through
+    this filter before rendering, so a companion plugin can inject viewer
+    identity, session pre-fill, or participant-filtered ticket types/prices
+    without a parallel template. `ticket_options` is a list of
     `[ id, name, short_name, price, is_full ]` (empty unless both
     `fair-events-experimental`'s activity catalogue and fair-audience — the
     only consumer that can persist a selection — are active); fair-audience's
@@ -592,14 +592,45 @@ create route) expose:
     `current_activity_names`. `minimum_activities` is the event-date global
     requirement, capped at `count( $ticket_options )`; a ticket type can raise
     it further via its own `minimum_activities` property — see
-    `frontend.js`' `getEffectiveMinimum()`. Two render-slot actions,
+    `frontend.js`' `getEffectiveMinimum()`. Each `occurrences_for_picker` row
+    also carries `signed_up` (`false` by default); fair-audience's
+    `enrich_render_context()` flips it true for occurrences the recognised
+    viewer already holds (including via a whole-series pass), so both the
+    single-occurrence dropdown and the multi-occurrence checkbox picker label
+    (and, for the checkbox picker, disable) them instead of allowing a silent
+    double-book. `suppress_form` (`false` by default) lets a companion plugin
+    skip the `<form>` entirely — used when a recognised viewer already holds
+    this exact signup, so a ticket-type/quantity form makes no sense — in
+    which case the base renders a plain
+    `<div class="fair-events-get-tickets-companion">` instead, still firing
+    the two render-slot actions below inside it so the companion can render
+    its own signed-up/cancel UI (echoing and escaping its own markup, exactly
+    as `SignupHookBridge::render_add_activities()` already does — no HTML
+    travels through the context array). Two render-slot actions,
     `fair_events_signup_render_before_form` and
     `fair_events_signup_render_after_form` (both passed the same context),
     let a companion plugin contribute UI fragments (e.g. a resume/retry card,
-    or fair-audience's "add activities" section for a signed-up viewer)
-    directly inside the `<form>`. A third action, `fair_events_signup_render_before_submit`
+    the signed-up/cancel card, or fair-audience's "add activities" section)
+    either inside the `<form>` or inside the `suppress_form` wrapper div. A
+    third action, `fair_events_signup_render_before_submit`
     (also passed the context), fires immediately before the submit button —
     fair-audience uses it to render a group discount note.
+-   **`fair_events_signup_precheck_error` filter** — `GetTicketsController::create_signup()`
+    runs this immediately after the event date is validated, before ticket-type
+    or options validation, so it covers the single-, `multiple_instances`- and
+    no-ticket-type paths alike:
+    `apply_filters( 'fair_events_signup_precheck_error', null, $event_date_id, $email, $ticket_type_id )`.
+    Returning a `WP_Error` rejects the signup. fair-audience scopes this to a
+    duplicate *ticket* purchase only: when the request carries a
+    `$ticket_type_id` and the recognised viewer already holds a `signed_up`
+    relationship for this event date with a ticket type attached, it returns
+    409 `already_signed_up` — this is a guard against a resubmitted/
+    double-clicked ticket purchase writing a second row (and, on a paid tier,
+    charging again), not a one-signup-per-participant rule. A `$ticket_type_id`
+    of `0` (no ticket type — activity-only or a companion signup) or a
+    `pending_payment` relationship (an incomplete payment, not a genuine
+    repeat) is never rejected here, matching the "Canonical signup store"
+    multiplicity below. `null` (the default) allows the signup to proceed.
 -   **`fair_events_signup_ticket_type_error` filter** — `GetTicketsController::create_signup()`
     runs this right after a submitted ticket type is validated and confirmed
     not disabled: `apply_filters( 'fair_events_signup_ticket_type_error', null, $ticket_type_id, $event_date_id )`.
@@ -670,6 +701,8 @@ unified-signup submission fatal'd):
 | Hook                                  | args passed | `add_filter`/`add_action` call            |
 | -------------------------------------- | :---------: | ------------------------------------------ |
 | `fair_events_signup_render_context`    | 1           | `add_filter( ..., 10, 1 )`                 |
+| `fair_events_signup_precheck_error`    | 4           | `add_filter( ..., 10, 4 )`                 |
+| `fair_events_signup_render_before_form` | 1          | `add_action( ..., 10, 1 )`                 |
 | `fair_events_signup_render_before_submit` | 1        | `add_action( ..., 10, 1 )`                 |
 | `fair_events_signup_render_after_form` | 1           | `add_action( ..., 10, 1 )`                 |
 | `fair_events_signup_ticket_type_error` | 3           | `add_filter( ..., 10, 2 )` or `3`          |
@@ -698,10 +731,12 @@ hooks `fair_events_signup_options_error` / `fair_events_signup_option_line_items
 `fair-audience/src/Services/SignupActivities.php`, mirroring
 `GroupSignupPricing.php` from #1242) and, once `link_participant()` creates or
 finds the `EventParticipant` row, attaches the selected `ticket_option_ids`
-via `EventParticipantRepository::add_options()`. Richer identity flows
-(resume/retry payment, group-restricted ticket types) still go through
-`fair-audience/v1`'s own routes — this contract only covers the simple path;
-see issue #1083 for the phased migration.
+via `EventParticipantRepository::add_options()`. `participant_token` URL login
+and the "I have an account" / request-link prompt still go through
+`fair-audience/v1`'s own routes (deferred to a follow-up ticket at the #1245
+cutover) — everything else (identity pre-fill, cancel/resignup, per-occurrence
+signup status, whole-series passes) is bridged through this contract, no
+parallel template.
 
 ### Canonical signup store — participant write-back and multiplicity
 

--- a/REST_API_BACKEND.md
+++ b/REST_API_BACKEND.md
@@ -676,9 +676,11 @@ create route) expose:
     `( $signup_id, $event_date_id, $name, $email, $ticket_selection, $transaction_id )`
     after a signup row is persisted through the base create path (once per
     row for multi-occurrence signups; `$transaction_id` is `null` on the free
-    path). A companion plugin hooks this to create/link its own participant
-    record, set a session cookie, or send its own confirmation email —
-    instead of owning a competing create route.
+    path). `$ticket_selection` carries `'ticket_type_id'`, `'quantity'`,
+    `'ticket_option_ids'` (or `'event_date_ids'` for `'multiple_instances'`
+    types), and `'mailing_opt_in'` (bool). A companion plugin hooks this to
+    create/link its own participant record, set a session cookie, or send its
+    own confirmation email — instead of owning a competing create route.
 -   **`fair_events_signup_confirmed` / `fair_events_signup_payment_failed`
     actions** — `fair-events/src/Hooks/PaymentHooks.php` fires one of these
     per resolved signup row (`$signup, $transaction`) after a
@@ -688,7 +690,10 @@ create route) expose:
     confirmation/failure onto its own operational record (e.g. flipping a
     `pending_payment` relationship to a confirmed label and recording the
     charge) instead of relying solely on its own webhook listener, which
-    never sees transactions created through the base route.
+    never sees transactions created through the base route — and, on
+    confirmation, to send its own paid-signup confirmation email, since the
+    free path's `fair_events_signup_created` listener never sees a paid
+    signup's confirmation.
 
 **`accepted_args` contract.** Register each hook with `accepted_args` matching
 what the call site above actually passes — not the callback's own parameter

--- a/e2e/mu-plugins/scripts/seed-conditional-signup.php
+++ b/e2e/mu-plugins/scripts/seed-conditional-signup.php
@@ -22,15 +22,17 @@ use FairEvents\Models\TicketPrice;
 use FairEventsExperimental\Models\TicketOption;
 
 // Nested block content: the conditional reveals the "diet" question only when
-// the "dinner" option is selected.
+// the "dinner" option is selected. Wrapped in the unified fair-events/event-signup
+// block (#1245) — the nested fair-form blocks render unchanged regardless of
+// which signup block wraps them.
 $content = implode(
 	"\n",
 	array(
-		'<!-- wp:fair-audience/event-signup -->',
+		'<!-- wp:fair-events/event-signup -->',
 		'<!-- wp:fair-audience/fair-form-conditional {"conditionSource":"eventOption","conditionOptionShortName":"dinner","conditionOperator":"selected"} -->',
 		'<!-- wp:fair-audience/fair-form-short-text {"questionKey":"diet","questionText":"Dietary restrictions"} /-->',
 		'<!-- /wp:fair-audience/fair-form-conditional -->',
-		'<!-- /wp:fair-audience/event-signup -->',
+		'<!-- /wp:fair-events/event-signup -->',
 	)
 );
 

--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -18,13 +18,15 @@
  *                        stable screenshots) carrying one ticket type of each
  *                        recurrence scope: single_instance, whole_series, and
  *                        multiple_instances (default prices 15/40/10; override
- *                        {"price":N} sets the single_instance price). Always
- *                        renders the unified fair-events/event-signup block.
- *   audience-ticket-scopes  like three-ticket-scopes, but renders the default
- *                        fair-audience/event-signup block instead. Override
+ *                        {"price":N} sets the single_instance price). Override
  *                        {"omitMulti":true} to skip the multiple_instances
  *                        type (single_instance + whole_series only), the
- *                        regression scenario.
+ *                        occurrence-picker regression scenario.
+ *   audience-ticket-scopes  like three-ticket-scopes, but always renders the
+ *                        dormant fair-audience/event-signup block regardless
+ *                        of any {"block":…} override — for specs proving old
+ *                        pages (authored before #1245) keep rendering it
+ *                        unchanged.
  *   address              event-info block + a calendar button, no ticket
  *                        type/sale period (signup path untouched). Renders
  *                        {"address":"…"} (default 'Calle Mayor 1, Madrid') via
@@ -87,17 +89,24 @@ $extra_type_ids     = array();
 $venue_id           = 0;
 $is_paid            = true;
 
-// Which purchase block the event page carries. Default: fair-audience
-// event-signup. Override {"block":"get-tickets"} for specs that exercise the
+// Which purchase block the event page carries. Default (#1245 cutover): the
+// unified fair-events/event-signup block — the only signup block new content
+// uses now that render.php no longer delegates to fair-audience's legacy
+// block. Override {"block":"get-tickets"} for specs that exercise the
 // fair-events standalone purchase path (with fair-audience deactivated).
 // Override {"block":"unified-with-question"} for specs that exercise the
-// unified fair-events/event-signup block with a nested fair-form question,
-// delegated through fair-audience's participant-aware flow (#1160).
-$block_content = '<!-- wp:fair-audience/event-signup /-->';
-if ( 'three-ticket-scopes' === $flavour ) {
-	// Always the unified block — this flavour exists to screenshot it across
-	// plugin combinations, so the block override is not honoured here.
-	$block_content = '<!-- wp:fair-events/event-signup /-->';
+// unified block with a nested fair-form question.
+$block_content = '<!-- wp:fair-events/event-signup /-->';
+if ( 'audience-ticket-scopes' === $flavour ) {
+	// The legacy block deliberately, regardless of any override — this
+	// flavour exists to prove old pages (authored before #1245) keep
+	// rendering their dormant fair-audience/event-signup block unchanged.
+	$block_content = '<!-- wp:fair-audience/event-signup /-->';
+} elseif ( isset( $overrides['block'] ) && 'legacy' === $overrides['block'] ) {
+	// The dormant legacy block, on request — for specs covering
+	// functionality still deferred to it post-#1245 (participant_token URL
+	// login, the request-link/resume-by-email flow).
+	$block_content = '<!-- wp:fair-audience/event-signup /-->';
 } elseif ( isset( $overrides['block'] ) && 'get-tickets' === $overrides['block'] ) {
 	$block_content = '<!-- wp:fair-events/get-tickets /-->';
 } elseif ( isset( $overrides['block'] ) && 'unified-with-question' === $overrides['block'] ) {
@@ -225,12 +234,15 @@ switch ( $flavour ) {
 		$occurrence_ids = fair_e2e_add_series( $event_id, 3 );
 		$single_type_id = fair_e2e_add_ticket_type( $event_date_id, 'Single Session', null );
 		$whole_type_id  = fair_e2e_add_whole_series_ticket_type( $event_date_id, 'Full Series Pass' );
-		$multi_type_id  = fair_e2e_add_multi_instance_ticket_type( $event_date_id, 'Pick your sessions', $minimum_instances );
 		fair_e2e_add_price( $single_type_id, $sale_period_id, $price, null );
 		fair_e2e_add_price( $whole_type_id, $sale_period_id, 40.00, null );
-		fair_e2e_add_price( $multi_type_id, $sale_period_id, 10.00, null );
 		$ticket_type_id = $single_type_id;
-		$extra_type_ids = array( $whole_type_id, $multi_type_id );
+		$extra_type_ids = array( $whole_type_id );
+		if ( ! $omit_multi ) {
+			$multi_type_id    = fair_e2e_add_multi_instance_ticket_type( $event_date_id, 'Pick your sessions', $minimum_instances );
+			$extra_type_ids[] = $multi_type_id;
+			fair_e2e_add_price( $multi_type_id, $sale_period_id, 10.00, null );
+		}
 		break;
 
 	case 'audience-ticket-scopes':

--- a/e2e/screenshots/event-signup-combinations.spec.js
+++ b/e2e/screenshots/event-signup-combinations.spec.js
@@ -1,13 +1,16 @@
 /**
  * Screenshot e2e: the unified fair-events/event-signup block across three
- * plugin combinations, for manual visual review (#1185).
+ * plugin combinations, for manual visual review (#1185, re-pointed at the
+ * unified markup by #1245).
  *
  * The SAME `wp:fair-events/event-signup` block is placed on the page in every
- * combination — only the active-plugin set changes. The block is designed to
- * be usable always: with fair-audience inactive it renders its own anonymous
- * get-tickets form; with fair-audience active it delegates to
- * fair-audience/event-signup for the participant-aware flow (see
- * fair-events/src/blocks/event-signup/render.php). fair-audience-experimental
+ * combination — only the active-plugin set changes. The block renders its own
+ * markup unconditionally now (fair-events/src/blocks/event-signup/render.php):
+ * with fair-audience inactive it's the plain anonymous get-tickets form; with
+ * fair-audience active, SignupHookBridge enriches the same render via the
+ * fair_events_signup_render_context filter and render slots (identity,
+ * pricing) instead of a competing template — so all three combos below render
+ * the same `.fair-events-get-tickets-form` markup. fair-audience-experimental
  * is deactivated in all three combos (it's active by default in
  * .wp-env.json). fair-payments-connector, fair-form, and fair-platform are
  * infrastructure and stay untouched throughout.
@@ -90,7 +93,7 @@ test.describe('Event Signup screenshots: fair-events + fair-audience', () => {
 
 		await page.goto(event.pageUrl);
 
-		const form = page.locator('.fair-audience-event-signup');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
 		const screenshotPath = path.join(
@@ -123,7 +126,7 @@ test.describe('Event Signup screenshots: fair-events + fair-audience + fair-even
 
 		await page.goto(event.pageUrl);
 
-		const form = page.locator('.fair-audience-event-signup');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
 		const screenshotPath = path.join(

--- a/e2e/user-flows/conditional-signup-fields.spec.js
+++ b/e2e/user-flows/conditional-signup-fields.spec.js
@@ -28,7 +28,7 @@ test.describe('conditional signup fields by event-option short name', () => {
 		await page.goto(event.pageUrl);
 
 		// Anonymous visitors get the registration form by default.
-		const form = page.locator('.fair-audience-signup-register');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
 		const dinner = form.locator(

--- a/e2e/user-flows/get-tickets-cancel-and-restart.spec.js
+++ b/e2e/user-flows/get-tickets-cancel-and-restart.spec.js
@@ -1,15 +1,17 @@
 /**
  * E2E: abandoning a payment and starting over (fair-events get-tickets block).
  *
- * Companion to signup-cancel-and-restart.spec.js (the fair-audience
- * equivalent). Rewritten for #1244: the base get-tickets form now has its own
- * direct-navigation fallback (FairEvents\Services\SignupPaymentSession, a
+ * Rewritten for #1244: the base get-tickets form has its own direct-
+ * navigation fallback (FairEvents\Services\SignupPaymentSession, a
  * short-lived signed cookie set when create_signup() returns
  * payment_required) — a buyer who abandons Mollie's checkout and navigates
  * straight back to the event page (no provider redirect) sees the same
  * resume card the return-from-payment callback would show, within the
  * 15-minute hold window, and "Cancel and start over" clears it server-side
- * so a fresh purchase isn't blocked by the stale card resurrecting.
+ * so a fresh purchase isn't blocked by the stale card resurrecting. Runs with
+ * fair-audience active (the .wp-env.json default, and the only signup path
+ * since #1245) — its render-context/render-slot enrichment doesn't touch this
+ * anonymous-abandon path, so no deactivation is needed here anymore.
  *
  * Uses the Mollie double's settable GET status (set-mollie-status.php,
  * #1244 Decisions #8) to report "open" — a checkout link that was created
@@ -18,20 +20,10 @@
  */
 
 import { test, expect } from '../support/fixtures.js';
-import { wpCli, runScript } from '../support/wp-cli.js';
+import { runScript } from '../support/wp-cli.js';
 
-test.describe('get-tickets block (fair-audience inactive): abandon and restart', () => {
-	test.beforeAll(() => {
-		wpCli('plugin deactivate fair-audience');
-	});
-
-	test.afterAll(() => {
-		wpCli('plugin activate fair-audience');
-	});
-
+test.describe('get-tickets block: abandon and restart', () => {
 	test.beforeEach(() => {
-		// Reset the get-tickets per-IP rate limit (3 requests/hour).
-		wpCli('transient delete --all');
 		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'open');
 	});
 

--- a/e2e/user-flows/get-tickets-purchase.spec.js
+++ b/e2e/user-flows/get-tickets-purchase.spec.js
@@ -22,8 +22,6 @@
  *     to paid from there, fair_payment_paid → FairEvents PaymentHooks
  *     confirms the signup, and the block's poller swaps in the confirmed card.
  *
- * The get-tickets endpoint rate-limits by IP (3/hour), so transients are
- * cleared before each test to keep repeated local runs deterministic.
  */
 
 import { test, expect } from '../support/fixtures.js';
@@ -39,8 +37,6 @@ test.describe('get-tickets block purchase (fair-audience inactive)', () => {
 	});
 
 	test.beforeEach(() => {
-		// Reset the get-tickets per-IP rate limit (3 requests/hour).
-		wpCli('transient delete --all');
 		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'pending');
 	});
 

--- a/e2e/user-flows/get-tickets-return-and-retry.spec.js
+++ b/e2e/user-flows/get-tickets-return-and-retry.spec.js
@@ -13,26 +13,16 @@
  * Uses the Mollie double's settable GET status (set-mollie-status.php,
  * #1244 Decisions #8) rather than driving a real checkout, mirroring
  * get-tickets-purchase.spec.js's use of the webhook double for the
- * already-covered straight-through paid path.
+ * already-covered straight-through paid path. Runs with fair-audience active
+ * (the .wp-env.json default, and the only signup path since #1245) — its
+ * render-context/render-slot enrichment doesn't touch this anonymous
+ * return/retry path, so no deactivation is needed here anymore.
  */
 
 import { test, expect } from '../support/fixtures.js';
-import { wpCli, runScript } from '../support/wp-cli.js';
+import { runScript } from '../support/wp-cli.js';
 
-test.describe('get-tickets block (fair-audience inactive): return and retry', () => {
-	test.beforeAll(() => {
-		wpCli('plugin deactivate fair-audience');
-	});
-
-	test.afterAll(() => {
-		wpCli('plugin activate fair-audience');
-	});
-
-	test.beforeEach(() => {
-		// Reset the get-tickets per-IP rate limit (3 requests/hour).
-		wpCli('transient delete --all');
-	});
-
+test.describe('get-tickets block: return and retry', () => {
 	test.afterEach(() => {
 		// Leave the double reporting "paid" for every other spec's assumption.
 		runScript('set-mollie-status.php', 'E2E_MOLLIE_STATUS', 'paid');

--- a/e2e/user-flows/multi-instance-purchase.spec.js
+++ b/e2e/user-flows/multi-instance-purchase.spec.js
@@ -1,22 +1,18 @@
 /**
  * E2E: 'multiple_instances' ticket type purchase — pick-N occurrences at a
- * per-instance price, through the public (anonymous, first-time buyer)
- * registration form.
+ * per-instance price, through the unified Event Signup form (re-pointed at
+ * the unified markup by #1245; seedEvent's default block since the cutover).
  *
  * Reproduces a reported bug: the buyer picks 3 occurrences of a series priced
- * at 10.00 each. The frontend total (basePrice * checked count, see
- * frontend.js updateButtonTotal()/updateInstancePickerHint()) correctly shows
- * 30.00 — but the amount actually charged (the transaction row, and therefore
- * what's sent to Mollie) is only 10.00, the per-instance price for a single
- * occurrence.
+ * at 10.00 each. The frontend total must show the sum across all chosen
+ * occurrences (30.00) and the transaction actually created (what's sent to
+ * Mollie) must match — not a single occurrence's per-instance price (10.00).
  *
- * Root cause: EventSignupController::create_signup() dispatches
- * 'multiple_instances' ticket types to create_multi_instance_signup(), which
- * correctly sums the per-instance price across every chosen occurrence.
- * EventSignupController::register_and_signup() — the endpoint the public
- * "I'm new" form submits to, used by every first-time buyer — now mirrors
- * that dispatch instead of falling through to maybe_start_paid_signup(),
- * which resolved a single per-instance price and ignored event_date_ids.
+ * Root cause (pre-cutover, on the legacy block): EventSignupController's
+ * register endpoint didn't dispatch 'multiple_instances' ticket types the
+ * same way its logged-in create_signup() path did. The unified route
+ * (GetTicketsController::create_multi_instance_signup()) has always summed
+ * correctly; this locks that in on the now-single signup path.
  */
 
 import { test, expect } from '../support/fixtures.js';
@@ -31,7 +27,7 @@ test.describe('multiple_instances ticket type purchase (new buyer)', () => {
 		expect(event.occurrenceIds.length).toBe(3);
 
 		await page.goto(event.pageUrl);
-		const form = page.locator('.fair-audience-signup-register');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
 		const ticket = form.locator('input[name="ticket_type_id"]');
@@ -40,7 +36,7 @@ test.describe('multiple_instances ticket type purchase (new buyer)', () => {
 			'multiple_instances'
 		);
 
-		const instancePicker = form.locator('.fair-audience-instance-picker');
+		const instancePicker = form.locator('.fair-events-instance-picker');
 		await expect(instancePicker).toBeVisible();
 
 		for (const occurrenceId of event.occurrenceIds) {
@@ -56,24 +52,26 @@ test.describe('multiple_instances ticket type purchase (new buyer)', () => {
 			event.price * event.occurrenceIds.length
 		).toFixed(2);
 		await expect(
-			instancePicker.locator('.fair-audience-instance-picker-total')
+			instancePicker.locator('.fair-events-instance-picker-total')
 		).toHaveText(`Total: ${expectedTotal} EUR`);
 
 		const stamp = Date.now();
 		await form
-			.locator('input[name="signup_name"]')
+			.locator('input[name="name"]')
 			.fill(`E2E Multi Instance ${stamp}`);
 		await form
-			.locator('input[name="signup_email"]')
+			.locator('input[name="email"]')
 			.fill(`multi-instance-${stamp}@example.test`);
 
-		// Submit → register REST call. Via the Mollie double, the checkout URL
-		// points back at the signup callback with the transaction id.
-		await form.locator('.fair-audience-signup-submit-button').click();
-		await expect(page).toHaveURL(/fair_signup_tx=/, { timeout: 30000 });
+		// Submit → create-signup REST call. Via the Mollie double, the
+		// checkout URL points back at the callback with the transaction id.
+		await form.locator('.form-button').click();
+		await expect(page).toHaveURL(/fair_payment_callback=true/, {
+			timeout: 30000,
+		});
 
 		const url = new URL(page.url());
-		const transactionId = url.searchParams.get('fair_signup_tx');
+		const transactionId = url.searchParams.get('transaction_id');
 		expect(transactionId).toBeTruthy();
 
 		const tx = runScript(

--- a/e2e/user-flows/resume-signup-recognised-email.spec.js
+++ b/e2e/user-flows/resume-signup-recognised-email.spec.js
@@ -3,6 +3,14 @@
  * the anti-enumeration guard when the browser already holds a session for a
  * *different* participant.
  *
+ * Stays on the legacy fair-audience/event-signup block (`{block: 'legacy'}`):
+ * the request-link/resume-by-email flow and its `participant_token`+`resume`
+ * URL tokens are deferred to a follow-up ticket at the #1245 cutover — the
+ * unified block has no equivalent tab/flow yet, so this scenario isn't
+ * reachable there. Session pre-fill (step 1 below) already works on the
+ * unified block too; see resume-signup coverage there once the follow-up
+ * lands.
+ *
  * The API spec (EventSignupResume.api.spec.js) covers the register/resume
  * endpoints in isolation but only from a cookie-less request context, and
  * can't drive the emailed resume link at all. Here we go through the real
@@ -35,7 +43,7 @@ test.describe('event-signup block: resume anonymous signup on recognised email',
 		context,
 		seedEvent,
 	}) => {
-		const event = seedEvent('paid');
+		const event = seedEvent('paid', { block: 'legacy' });
 		const stamp = Date.now();
 
 		const recognisedEmail = `resume.recognised.${stamp}@example.test`;

--- a/e2e/user-flows/signup-cancel-and-restart.spec.js
+++ b/e2e/user-flows/signup-cancel-and-restart.spec.js
@@ -2,6 +2,13 @@
  * E2E: "Cancel and start over" on a stuck payment (fair-audience event-signup
  * block).
  *
+ * Stays on the legacy fair-audience/event-signup block (`{block: 'legacy'}`):
+ * this scenario is keyed on `participant_token` URL recognition of an
+ * in-progress payment, which is deferred to a follow-up ticket at the #1245
+ * cutover. The unified block's own direct-navigation resume/cancel fallback
+ * (SignupPaymentSession cookie, not participant_token) has equivalent
+ * coverage in get-tickets-cancel-and-restart.spec.js.
+ *
  * Reported bug: a buyer whose Mollie payment failed (or who just navigates
  * back to the event page instead of following Mollie's redirect) sees the
  * retry screen — "Your payment didn't go through." / Retry payment / Cancel
@@ -34,7 +41,7 @@ test.describe('event-signup block: cancel a stuck payment and restart', () => {
 		page,
 		seedEvent,
 	}) => {
-		const event = seedEvent('paid');
+		const event = seedEvent('paid', { block: 'legacy' });
 
 		const pending = runScript(
 			'seed-pending-signup.php',

--- a/e2e/user-flows/signup-occurrence-pickers.spec.js
+++ b/e2e/user-flows/signup-occurrence-pickers.spec.js
@@ -1,7 +1,7 @@
 /**
- * E2E: occurrence-picker visibility in the participant-aware Event Signup
- * form (fair-audience/event-signup) across all three ticket recurrence
- * scopes — single_instance, multiple_instances, whole_series.
+ * E2E: occurrence-picker visibility in the unified Event Signup form
+ * (re-pointed at the unified markup by #1245) across all three ticket
+ * recurrence scopes — single_instance, multiple_instances, whole_series.
  *
  * The picker toggling is entirely client-side (frontend.js
  * syncOccurrencePickers()), keyed off each ticket radio's
@@ -14,16 +14,16 @@
 
 import { test, expect } from '../support/fixtures.js';
 
-test.describe('Occurrence pickers for all three ticket scopes (fair-audience)', () => {
+test.describe('Occurrence pickers for all three ticket scopes', () => {
 	test('single-occurrence scope shows the date dropdown, not the checkbox picker', async ({
 		page,
 		seedEvent,
 	}) => {
-		const event = seedEvent('audience-ticket-scopes');
+		const event = seedEvent('three-ticket-scopes');
 
 		await page.goto(event.pageUrl);
 
-		const form = page.locator('.fair-audience-signup-register');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
 		const ticketRadio = form.locator(
@@ -32,23 +32,21 @@ test.describe('Occurrence pickers for all three ticket scopes (fair-audience)', 
 		await expect(ticketRadio).toBeChecked();
 
 		await expect(
-			page.locator('.fair-audience-occurrence-picker')
+			page.locator('.fair-events-occurrence-picker')
 		).toBeVisible();
-		await expect(
-			form.locator('.fair-audience-instance-picker')
-		).toBeHidden();
+		await expect(form.locator('.fair-events-instance-picker')).toBeHidden();
 	});
 
 	test('multiple-occurrence scope shows the checkbox picker, not the date dropdown', async ({
 		page,
 		seedEvent,
 	}) => {
-		const event = seedEvent('audience-ticket-scopes');
+		const event = seedEvent('three-ticket-scopes');
 		const [, multiInstanceTypeId] = event.extraTypeIds;
 
 		await page.goto(event.pageUrl);
 
-		const form = page.locator('.fair-audience-signup-register');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
 		await form
@@ -58,10 +56,10 @@ test.describe('Occurrence pickers for all three ticket scopes (fair-audience)', 
 			.check();
 
 		await expect(
-			form.locator('.fair-audience-instance-picker')
+			form.locator('.fair-events-instance-picker')
 		).toBeVisible();
 		await expect(
-			page.locator('.fair-audience-occurrence-picker')
+			page.locator('.fair-events-occurrence-picker')
 		).toBeHidden();
 	});
 
@@ -69,12 +67,12 @@ test.describe('Occurrence pickers for all three ticket scopes (fair-audience)', 
 		page,
 		seedEvent,
 	}) => {
-		const event = seedEvent('audience-ticket-scopes');
+		const event = seedEvent('three-ticket-scopes');
 		const [wholeSeriesTypeId] = event.extraTypeIds;
 
 		await page.goto(event.pageUrl);
 
-		const form = page.locator('.fair-audience-signup-register');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
 		await form
@@ -84,27 +82,25 @@ test.describe('Occurrence pickers for all three ticket scopes (fair-audience)', 
 			.check();
 
 		await expect(
-			page.locator('.fair-audience-occurrence-picker')
+			page.locator('.fair-events-occurrence-picker')
 		).toBeHidden();
-		await expect(
-			form.locator('.fair-audience-instance-picker')
-		).toBeHidden();
+		await expect(form.locator('.fair-events-instance-picker')).toBeHidden();
 	});
 
 	test('switching ticket types updates the visible picker live and clears a stale checkbox selection', async ({
 		page,
 		seedEvent,
 	}) => {
-		const event = seedEvent('audience-ticket-scopes');
+		const event = seedEvent('three-ticket-scopes');
 		const [wholeSeriesTypeId, multiInstanceTypeId] = event.extraTypeIds;
 
 		await page.goto(event.pageUrl);
 
-		const form = page.locator('.fair-audience-signup-register');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
-		const dropdown = page.locator('.fair-audience-occurrence-picker');
-		const instancePicker = form.locator('.fair-audience-instance-picker');
+		const dropdown = page.locator('.fair-events-occurrence-picker');
+		const instancePicker = form.locator('.fair-events-instance-picker');
 
 		// Single-session (default) — dropdown visible, checkbox picker hidden.
 		await expect(dropdown).toBeVisible();
@@ -164,17 +160,17 @@ test.describe('Occurrence pickers for all three ticket scopes (fair-audience)', 
 		page,
 		seedEvent,
 	}) => {
-		const event = seedEvent('audience-ticket-scopes', {
+		const event = seedEvent('three-ticket-scopes', {
 			omitMulti: true,
 		});
 		const [wholeSeriesTypeId] = event.extraTypeIds;
 
 		await page.goto(event.pageUrl);
 
-		const form = page.locator('.fair-audience-signup-register');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
-		const dropdown = page.locator('.fair-audience-occurrence-picker');
+		const dropdown = page.locator('.fair-events-occurrence-picker');
 
 		// Single-session (default) — dropdown visible.
 		await expect(dropdown).toBeVisible();
@@ -187,8 +183,8 @@ test.describe('Occurrence pickers for all three ticket scopes (fair-audience)', 
 			)
 			.check();
 		await expect(dropdown).toBeHidden();
-		await expect(
-			form.locator('.fair-audience-instance-picker')
-		).toHaveCount(0);
+		await expect(form.locator('.fair-events-instance-picker')).toHaveCount(
+			0
+		);
 	});
 });

--- a/e2e/user-flows/ticket-purchase-confirmation.spec.js
+++ b/e2e/user-flows/ticket-purchase-confirmation.spec.js
@@ -2,8 +2,11 @@
  * E2E: ticket purchase happy path — confirmation email, marketing opt-in, and
  * the buyer's name on the admin participants list.
  *
- * Buys a paid ticket through the public event-signup block against the isolated
- * wp-env instance and asserts the buyer-facing AND organizer-facing outcomes:
+ * Buys a paid ticket through the public unified event-signup block (the
+ * default block seedEvent renders since the #1245 cutover; fair-audience
+ * enriches the same render, it doesn't own a competing template) against the
+ * isolated wp-env instance and asserts the buyer-facing AND organizer-facing
+ * outcomes:
  *   - the purchase confirmation email is delivered (both opt-in cases),
  *   - a marketing (double opt-in) confirmation email is sent ONLY when the
  *     buyer ticks "Keep me informed", and
@@ -53,7 +56,7 @@ test.describe('ticket purchase confirmation', () => {
 			// Public event page renders the signup block; the "I'm new"
 			// registration form is shown by default for anonymous visitors.
 			await page.goto(event.pageUrl);
-			const form = page.locator('.fair-audience-signup-register');
+			const form = page.locator('.fair-events-get-tickets-form');
 			await expect(form).toBeVisible();
 
 			// One paid ticket type is seeded and auto-selected; assert it carries
@@ -64,12 +67,10 @@ test.describe('ticket purchase confirmation', () => {
 				Number(await ticket.getAttribute('data-ticket-price'))
 			).toBeGreaterThan(0);
 
-			await form.locator('input[name="signup_name"]').fill(buyerName);
-			await form.locator('input[name="signup_email"]').fill(email);
+			await form.locator('input[name="name"]').fill(buyerName);
+			await form.locator('input[name="email"]').fill(email);
 			if (scenario.optIn) {
-				await form
-					.locator('input[name="signup_keep_informed"]')
-					.check();
+				await form.locator('input[name="mailing_opt_in"]').check();
 			}
 
 			// Submit → register REST call returns payment_required with a
@@ -78,7 +79,7 @@ test.describe('ticket purchase confirmation', () => {
 			// Wait for the final confirmation UI rather than a specific mid-chain
 			// navigation (waitForURL can abort with ERR_NETWORK_IO_SUSPENDED when a
 			// redirect supersedes it), then assert the callback URL by polling.
-			await form.locator('.fair-audience-signup-submit-button').click();
+			await form.locator('.form-button').click();
 			await expect(
 				page.getByText('Payment confirmed', { exact: false })
 			).toBeVisible({ timeout: 30000 });

--- a/e2e/user-flows/unified-signup-activities.spec.js
+++ b/e2e/user-flows/unified-signup-activities.spec.js
@@ -1,32 +1,68 @@
 /**
  * E2E: selectable activities (ticket options) in the unified Event Signup
- * form (#1243).
+ * form (#1243, re-pointed at the unified markup by #1245).
  *
- * IMPORTANT SCOPE NOTE: fair-events' own `event-signup` block render
- * (render.php) only runs its own markup when fair-audience is *inactive* —
- * whenever fair-audience is active, render.php delegates entirely to the
- * legacy `fair-audience/event-signup` block (see
- * `unified-signup-nested-question.spec.js`). But the activities fieldset
- * this ticket adds is itself gated on fair-audience being *active*
- * (`class_exists( \FairAudience\API\EventSignupController::class )`), since
- * selections can only be persisted through fair-audience's options table.
- * Those two preconditions are mutually exclusive under the current
- * pre-#1245-cutover architecture — the same gap affects #1242's group-pricing
- * render-context work, which also has no e2e coverage for this reason. So the
- * only thing actually reachable/testable end-to-end today is the negative
- * case below: a base-alone site (fair-audience absent) must never render a
- * dead (unsubmittable) activities fieldset, even when activity options are
- * configured. Full fieldset-render coverage (checkbox display, minimum
- * enforcement, live total, add-activities section) will become reachable
- * once #1245 removes the render delegation guard; API-level coverage for the
- * create-route validation/pricing logic lives in
- * fair-audience/src/API/__tests__/EventSignupActivities.api.spec.js (same
- * reachability caveat, matching EventSignupGroupPricing.api.spec.js's
- * existing precedent).
+ * The activities fieldset only ever renders when fair-audience is active
+ * (`class_exists( \FairAudience\API\EventSignupController::class )` —
+ * selections can only be persisted through its options table), and before
+ * #1245 the base render also only ran when fair-audience was *inactive* —
+ * two mutually exclusive preconditions, so only the negative case (base-alone
+ * site, fieldset absent) was ever reachable end-to-end. #1245 removed that
+ * delegation guard, so the positive path — fieldset renders, a selection
+ * persists through a real signup — is now covered here too. API-level
+ * coverage for the create-route validation/pricing logic lives in
+ * fair-audience/src/API/__tests__/EventSignupActivities.api.spec.js.
  */
 
 import { test, expect } from '../support/fixtures.js';
-import { wpCli } from '../support/wp-cli.js';
+import { wpCli, runScript } from '../support/wp-cli.js';
+
+test.describe('Activities fieldset (fair-audience active)', () => {
+	test('a free signup with an activity selected persists the selection', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('unified-with-options', {
+			price: 0,
+			options: ['dinner'],
+		});
+		const stamp = Date.now();
+		const email = `unified.activities.${stamp}@example.test`;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		const optionsFieldset = form.locator('.fair-events-ticket-options');
+		await expect(optionsFieldset).toBeVisible();
+
+		const dinnerCheckbox = form.locator(
+			'input[name="ticket_option_ids[]"]'
+		);
+		await expect(dinnerCheckbox).toHaveCount(1);
+		await dinnerCheckbox.check();
+
+		await form.locator('input[name="name"]').fill('Activities Buyer');
+		await form.locator('input[name="email"]').fill(email);
+		await form.locator('.form-button').click();
+
+		await expect(
+			page.getByText('You have successfully registered', {
+				exact: false,
+			})
+		).toBeVisible();
+
+		const state = runScript(
+			'signup-state.php',
+			'E2E_STATE',
+			`${email} ${event.eventDateId}`
+		);
+		expect(state.found).toBe(true);
+		expect(state.label).toBe('signed_up');
+		expect(state.option_ids).toContain(event.optionIds[0]);
+	});
+});
 
 test.describe('Activities fieldset base-alone guard (fair-audience inactive)', () => {
 	test.beforeAll(() => {

--- a/e2e/user-flows/unified-signup-activities.spec.js
+++ b/e2e/user-flows/unified-signup-activities.spec.js
@@ -25,6 +25,7 @@ test.describe('Activities fieldset (fair-audience active)', () => {
 		const event = seedEvent('unified-with-options', {
 			price: 0,
 			options: ['dinner'],
+			optionPrice: 0,
 		});
 		const stamp = Date.now();
 		const email = `unified.activities.${stamp}@example.test`;

--- a/e2e/user-flows/unified-signup-nested-question.spec.js
+++ b/e2e/user-flows/unified-signup-nested-question.spec.js
@@ -1,12 +1,12 @@
 /**
  * E2E: signup with a custom question nested in the unified Event Signup
- * block, delegated through fair-audience's participant-aware flow (#1160).
+ * block (#1160, re-pointed at the unified markup by #1245).
  *
- * The unified fair-events/event-signup block now accepts nested fair-form
- * question blocks and forwards them, unchanged, to the legacy
- * fair-audience/event-signup render when fair-audience is active. This drives
- * a real free signup through the browser with a nested short-text question to
- * prove the question renders on the unified block and the signup completes.
+ * The unified fair-events/event-signup block accepts nested fair-form
+ * question blocks and forwards them, unchanged, as inner block content
+ * (render.php echoes $content inside the form). This drives a real free
+ * signup through the browser with a nested short-text question to prove the
+ * question renders on the unified block and the signup completes.
  */
 
 import { test, expect } from '../support/fixtures.js';
@@ -22,23 +22,23 @@ test.describe('unified event-signup block: nested custom question', () => {
 
 		await page.goto(event.pageUrl);
 
-		const form = page.locator('.fair-audience-signup-register');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
-		// The nested fair-form question, forwarded through the delegated
-		// render, appears alongside the name/email fields.
+		// The nested fair-form question, forwarded as inner block content,
+		// appears alongside the name/email fields.
 		const question = form.locator('[data-question-key="dietary"]');
 		await expect(question).toBeVisible();
 		await expect(question).toContainText('Dietary needs');
 
-		await form.locator('input[name="signup_name"]').fill('Unified Visitor');
-		await form.locator('input[name="signup_email"]').fill(email);
+		await form.locator('input[name="name"]').fill('Unified Visitor');
+		await form.locator('input[name="email"]').fill(email);
 		await question.locator('input[type="text"]').fill('No nuts');
 
-		await form.locator('.fair-audience-signup-submit-button').click();
+		await form.locator('.form-button').click();
 
 		await expect(
-			page.getByText('You are signed up for this event', {
+			page.getByText('You have successfully registered', {
 				exact: false,
 			})
 		).toBeVisible();

--- a/e2e/user-flows/unified-signup-phone-question.spec.js
+++ b/e2e/user-flows/unified-signup-phone-question.spec.js
@@ -19,21 +19,21 @@ test.describe('unified event-signup block: nested phone question', () => {
 
 		await page.goto(event.pageUrl);
 
-		const form = page.locator('.fair-audience-signup-register');
+		const form = page.locator('.fair-events-get-tickets-form');
 		await expect(form).toBeVisible();
 
 		const question = form.locator('[data-question-key="mobile"]');
 		await expect(question).toBeVisible();
 		await expect(question).toContainText('Mobile');
 
-		await form.locator('input[name="signup_name"]').fill('Unified Visitor');
-		await form.locator('input[name="signup_email"]').fill(email);
+		await form.locator('input[name="name"]').fill('Unified Visitor');
+		await form.locator('input[name="email"]').fill(email);
 		await question.locator('input[type="tel"]').fill('+49 170 123 45 67');
 
-		await form.locator('.fair-audience-signup-submit-button').click();
+		await form.locator('.form-button').click();
 
 		await expect(
-			page.getByText('You are signed up for this event', {
+			page.getByText('You have successfully registered', {
 				exact: false,
 			})
 		).toBeVisible();

--- a/fair-audience/__tests__/Hooks/SignupHookBridgeRegistrationTest.php
+++ b/fair-audience/__tests__/Hooks/SignupHookBridgeRegistrationTest.php
@@ -33,6 +33,8 @@ class SignupHookBridgeRegistrationTest extends TestCase {
 	 */
 	private const ARGS_PASSED_BY_FAIR_EVENTS = array(
 		'fair_events_signup_render_context'           => 3,
+		'fair_events_signup_precheck_error'           => 4,
+		'fair_events_signup_render_before_form'       => 1,
 		'fair_events_signup_render_before_submit'     => 1,
 		'fair_events_signup_render_after_form'        => 1,
 		'fair_events_signup_ticket_type_error'        => 3,

--- a/fair-audience/src/API/__tests__/EventSignupHookBridge.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupHookBridge.api.spec.js
@@ -35,6 +35,7 @@ test.describe('SignupHookBridge — base get-tickets route links a Participant',
 	let fairAudienceActive = false;
 	let eventPostId;
 	let eventDateId;
+	let ticketTypeId;
 	const buyerEmail = `signup-hook-bridge-${Date.now()}@example.test`;
 	const buyerName = 'Signup Hook Bridge Tester';
 
@@ -68,13 +69,54 @@ test.describe('SignupHookBridge — base get-tickets route links a Participant',
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: adminHeaders,
 			data: {
-				event_id: eventPostId,
+				title: `Signup hook bridge test ${Date.now()}`,
+				link_type: 'post',
 				start_datetime: '2035-07-01 10:00:00',
 				end_datetime: '2035-07-01 12:00:00',
 			},
 		});
 		expect(edRes.ok()).toBeTruthy();
 		eventDateId = (await edRes.json()).id;
+
+		// The create endpoint doesn't wire event_id through — a PUT is needed
+		// to actually link the post (see CalendarFeedController.api.spec.js
+		// for the same quirk). Needed here so link_participant()'s
+		// get_resolved_event_id() resolves to a real post.
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { event_id: eventPostId },
+			}
+		);
+		expect(linkRes.ok()).toBeTruthy();
+
+		// A free ticket type so the duplicate-ticket precheck guard (#1245)
+		// has something with a ticket_type_id to guard.
+		const ticketsRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'General admission',
+							capacity: null,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'single_instance',
+							group_ids: [],
+						},
+					],
+					sale_periods: [],
+					prices: [],
+					settings: {},
+				},
+			}
+		);
+		expect(ticketsRes.ok()).toBeTruthy();
+		ticketTypeId = (await ticketsRes.json()).ticket_types?.[0]?.id;
+		expect(ticketTypeId).toBeTruthy();
 	});
 
 	test.afterAll(async () => {
@@ -146,8 +188,8 @@ test.describe('SignupHookBridge — base get-tickets route links a Participant',
 
 		// ...and an EventParticipant row ties that participant to this event date.
 		const eventParticipantsRes = await api.get(
-			'/wp-json/fair-audience/v1/event-participants',
-			{ headers: adminHeaders, params: { event_date_id: eventDateId } }
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants`,
+			{ headers: adminHeaders }
 		);
 		expect(eventParticipantsRes.ok()).toBeTruthy();
 		const eventParticipants = await eventParticipantsRes.json();
@@ -160,7 +202,7 @@ test.describe('SignupHookBridge — base get-tickets route links a Participant',
 
 		// PR 3: the signup row itself is linked back to the participant.
 		const linkedSignup = signups.find((s) => s.email === buyerEmail);
-		expect(linkedSignup.participant_id).toBe(participant.id);
+		expect(Number(linkedSignup.participant_id)).toBe(participant.id);
 	});
 
 	test('two signups with the same email on the same event date share one participant_id and one EventParticipant row', async () => {
@@ -215,8 +257,8 @@ test.describe('SignupHookBridge — base get-tickets route links a Participant',
 
 		// ...and exactly one EventParticipant (operational) row, never downgraded.
 		const eventParticipantsRes = await api.get(
-			'/wp-json/fair-audience/v1/event-participants',
-			{ headers: adminHeaders, params: { event_date_id: eventDateId } }
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants`,
+			{ headers: adminHeaders }
 		);
 		expect(eventParticipantsRes.ok()).toBeTruthy();
 		const eventParticipantsBody = await eventParticipantsRes.json();
@@ -224,9 +266,107 @@ test.describe('SignupHookBridge — base get-tickets route links a Participant',
 			? eventParticipantsBody
 			: eventParticipantsBody.items || [];
 		const matching = items.filter(
-			(ep) => ep.participant_id === repeatSignups[0].participant_id
+			(ep) =>
+				Number(ep.participant_id) ===
+				Number(repeatSignups[0].participant_id)
 		);
 		expect(matching.length).toBe(1);
 		expect(matching[0].label).toBe('signed_up');
+	});
+
+	test('a resubmitted ticket purchase for a date the viewer already holds a ticket for is rejected 409 (#1245 precheck guard)', async () => {
+		test.skip(!fairAudienceActive, 'fair-audience not active');
+
+		// link_participant() only stamps ticket_type_id onto the
+		// EventParticipant row on the paid path (stamp_payment requires a
+		// transaction_id) — this dev stack has no payment connector
+		// configured, so a real paid purchase can't be driven here (see the
+		// file docblock). Seed the same end state an admin sees after a paid
+		// purchase directly via the admin event-participants route, then
+		// assert the guard rejects a same-email/same-date/same-ticket-type
+		// resubmit — the actual scenario Gap #1 (#1245) closes: a
+		// double-clicked paid ticket purchase writing a second row and
+		// charging again.
+		const ticketEmail = `signup-hook-bridge-dup-ticket-${Date.now()}@example.test`;
+
+		const firstRes = await api.post('/wp-json/fair-events/v1/get-tickets', {
+			data: {
+				event_date_id: eventDateId,
+				name: 'Duplicate Ticket Buyer',
+				email: ticketEmail,
+				quantity: 1,
+			},
+		});
+		expect(firstRes.ok()).toBeTruthy();
+
+		const participantsRes = await api.get(
+			'/wp-json/fair-audience/v1/participants',
+			{ headers: adminHeaders, params: { search: ticketEmail } }
+		);
+		const participant = (await participantsRes.json()).find(
+			(p) => p.email === ticketEmail
+		);
+		expect(participant).toBeTruthy();
+
+		const seedRes = await api.put(
+			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/${participant.id}`,
+			{
+				headers: adminHeaders,
+				data: { label: 'signed_up', ticket_type_id: ticketTypeId },
+			}
+		);
+		expect(seedRes.ok()).toBeTruthy();
+
+		// Resolved as the returning viewer via the session cookie
+		// link_participant() set on the first request (this Playwright
+		// request context carries cookies across requests, like a browser).
+		const secondRes = await api.post(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				data: {
+					event_date_id: eventDateId,
+					name: 'Duplicate Ticket Buyer',
+					email: ticketEmail,
+					ticket_type_id: ticketTypeId,
+					quantity: 1,
+				},
+			}
+		);
+		expect(secondRes.status()).toBe(409);
+		expect((await secondRes.json()).code).toBe('already_signed_up');
+	});
+
+	test('the per-email rate limit rejects a 4th signup within the window (#1245)', async () => {
+		test.skip(!fairAudienceActive, 'fair-audience not active');
+
+		const rateLimitEmail = `signup-hook-bridge-rl-${Date.now()}@example.test`;
+
+		// No ticket_type_id: exercises the rate limiter in isolation from the
+		// duplicate-ticket precheck guard above.
+		for (let i = 0; i < 3; i++) {
+			const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
+				data: {
+					event_date_id: eventDateId,
+					name: 'Rate Limit Tester',
+					email: rateLimitEmail,
+					quantity: 1,
+				},
+			});
+			expect(res.ok()).toBeTruthy();
+		}
+
+		const fourthRes = await api.post(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				data: {
+					event_date_id: eventDateId,
+					name: 'Rate Limit Tester',
+					email: rateLimitEmail,
+					quantity: 1,
+				},
+			}
+		);
+		expect(fourthRes.status()).toBe(429);
+		expect((await fourthRes.json()).code).toBe('rate_limited');
 	});
 });

--- a/fair-audience/src/Hooks/SignupHookBridge.php
+++ b/fair-audience/src/Hooks/SignupHookBridge.php
@@ -39,6 +39,9 @@ class SignupHookBridge {
 	 */
 	public static function init() {
 		add_filter( 'fair_events_signup_render_context', array( static::class, 'enrich_render_context' ), 10, 1 );
+		add_filter( 'fair_events_signup_precheck_error', array( static::class, 'filter_precheck_error' ), 10, 4 );
+		add_action( 'fair_events_signup_render_before_form', array( static::class, 'render_signed_up_card' ), 10, 1 );
+		add_action( 'fair_events_signup_render_before_form', array( static::class, 'render_not_you' ), 10, 1 );
 		add_action( 'fair_events_signup_render_before_submit', array( static::class, 'render_discount_note' ), 10, 1 );
 		add_filter( 'fair_events_signup_ticket_type_error', array( static::class, 'filter_ticket_type_error' ), 10, 2 );
 		add_filter( 'fair_events_signup_unit_price', array( static::class, 'filter_unit_price' ), 10, 2 );
@@ -124,7 +127,246 @@ class SignupHookBridge {
 		// this runs unconditionally.
 		$context = SignupActivities::enrich_render_context( $context, $participant_id );
 
+		$context['suppress_form'] = false;
+		$context['is_signed_up']  = false;
+
+		if ( $participant_id && ! empty( $context['event_date_id'] ) && class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_date_id                = (int) $context['event_date_id'];
+			$event_participant_repository = new EventParticipantRepository();
+
+			$existing     = $event_participant_repository->get_by_event_date_and_participant( $event_date_id, $participant_id );
+			$is_signed_up = ( $existing && 'signed_up' === $existing->label );
+
+			// Resolve a whole-series pass on the master once, so it can also
+			// cover this occurrence (a pass covers occurrences starting on or
+			// after its purchase date — mid-series semantics) and feed the
+			// per-occurrence picker loop below without a query per row.
+			$series_pass        = null;
+			$event_date_row     = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+			$master_id_for_pass = null;
+			if ( $event_date_row ) {
+				if ( 'master' === ( $event_date_row->occurrence_type ?? null ) ) {
+					$master_id_for_pass = (int) $event_date_row->id;
+				} elseif ( 'generated' === ( $event_date_row->occurrence_type ?? null ) && $event_date_row->master_id ) {
+					$master_id_for_pass = (int) $event_date_row->master_id;
+				}
+			}
+			if ( $master_id_for_pass && class_exists( \FairEvents\Models\TicketType::class ) ) {
+				$candidate_pass = $event_participant_repository->get_series_pass_for_participant( $master_id_for_pass, $participant_id );
+				if ( $candidate_pass && $candidate_pass->ticket_type_id ) {
+					$pass_tt = \FairEvents\Models\TicketType::get_by_id( (int) $candidate_pass->ticket_type_id );
+					if ( $pass_tt && $pass_tt->is_whole_series() ) {
+						$series_pass = $candidate_pass;
+					}
+				}
+			}
+
+			if ( ! $is_signed_up && $series_pass && $event_date_row && $event_date_row->start_datetime
+				&& strtotime( $event_date_row->start_datetime ) >= strtotime( $series_pass->created_at )
+			) {
+				$is_signed_up = true;
+			}
+
+			$context['is_signed_up'] = $is_signed_up;
+
+			if ( $is_signed_up ) {
+				$context['suppress_form']          = true;
+				$context['signed_up_ticket_label'] = '';
+
+				$relationship_for_label = ( $existing && 'signed_up' === $existing->label ) ? $existing : $series_pass;
+				if ( $relationship_for_label && $relationship_for_label->ticket_type_id && class_exists( \FairEvents\Models\TicketType::class ) ) {
+					$signed_up_ticket_type = \FairEvents\Models\TicketType::get_by_id( (int) $relationship_for_label->ticket_type_id );
+					if ( $signed_up_ticket_type ) {
+						$context['signed_up_ticket_label'] = $signed_up_ticket_type->name;
+					}
+				}
+			}
+
+			// Populate per-occurrence signup state for the pickers, mirroring
+			// the legacy render — including the whole-series pass check above.
+			if ( ! empty( $context['occurrences_for_picker'] ) ) {
+				foreach ( $context['occurrences_for_picker'] as $idx => $occ_row ) {
+					$rel           = $event_participant_repository->get_by_event_date_and_participant( (int) $occ_row['id'], $participant_id );
+					$occ_signed_up = ( $rel && 'signed_up' === $rel->label );
+					if ( ! $occ_signed_up && $series_pass && ! empty( $occ_row['start_datetime'] ) ) {
+						$occ_signed_up = strtotime( $occ_row['start_datetime'] ) >= strtotime( $series_pass->created_at );
+					}
+					$context['occurrences_for_picker'][ $idx ]['signed_up'] = $occ_signed_up;
+				}
+			}
+		}
+
 		return $context;
+	}
+
+	/**
+	 * Reject a signup for an event date the viewer already holds a
+	 * `signed_up` relationship for. Hooked on fair_events_signup_precheck_error.
+	 * A `pending_payment` relationship is not rejected here — that's an
+	 * incomplete payment, not a genuine repeat, so a resubmit (e.g. via the
+	 * payment retry card) must still be allowed through.
+	 *
+	 * @param WP_Error|null $error          Prior filter result — passed through unchanged if already an error.
+	 * @param int           $event_date_id  Event-date ID the signup targets.
+	 * @param string        $email          Submitted email (unused — the viewer is resolved by session/login).
+	 * @param int           $ticket_type_id Submitted ticket type ID (unused).
+	 * @return \WP_Error|null
+	 */
+	public static function filter_precheck_error( $error, $event_date_id, $email, $ticket_type_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- viewer is resolved by session/login, not the submitted email; required by the hook signature.
+		if ( is_wp_error( $error ) ) {
+			return $error;
+		}
+
+		// Scoped to a duplicate *ticket* purchase only — a free/no-ticket-type
+		// signup (companion tickets, activity-only, a whole-series pass bought
+		// again) is intentionally allowed to repeat; fair_events_signups rows
+		// are many-per-participant-per-event by design (see the "Canonical
+		// signup store" section of REST_API_BACKEND.md). This guard exists to
+		// stop a resubmitted/double-clicked ticket purchase from writing a
+		// second row and, on a paid tier, charging again — not to enforce
+		// one-signup-per-participant in general.
+		if ( ! $ticket_type_id ) {
+			return $error;
+		}
+
+		$participant = GroupSignupPricing::resolve_viewer_participant();
+		if ( ! $participant ) {
+			return $error;
+		}
+
+		$event_participant_repository = new EventParticipantRepository();
+		$existing                     = $event_participant_repository->get_by_event_date_and_participant( (int) $event_date_id, (int) $participant->id );
+
+		if ( $existing && 'signed_up' === $existing->label && ! empty( $existing->ticket_type_id ) ) {
+			return new \WP_Error(
+				'already_signed_up',
+				__( 'You already have a ticket for this date.', 'fair-audience' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		return $error;
+	}
+
+	/**
+	 * Render the signed-up/cancel card for a recognised viewer who already
+	 * holds this signup — shown in place of the suppressed <form> (see
+	 * enrich_render_context()'s suppress_form). Hooked on
+	 * fair_events_signup_render_before_form.
+	 *
+	 * @param array $context Render context, see fair_events_signup_render_context.
+	 * @return void
+	 */
+	public static function render_signed_up_card( $context ) {
+		if ( empty( $context['is_signed_up'] ) ) {
+			return;
+		}
+
+		$event_date_id = (int) ( $context['event_date_id'] ?? 0 );
+		$event_id      = 0;
+		if ( $event_date_id && class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+			if ( $event_date ) {
+				$event_id = (int) $event_date->get_resolved_event_id();
+			}
+		}
+		if ( ! $event_id ) {
+			return;
+		}
+
+		$participant = GroupSignupPricing::resolve_viewer_participant();
+		if ( ! $participant ) {
+			return;
+		}
+
+		// The cancel route's permission check only accepts a logged-in user
+		// or a valid participant_token — not the AudienceSession cookie most
+		// unified-form viewers are recognised by — so a server-generated
+		// token travels with the card exactly as render_add_activities() does.
+		$token = \FairAudience\Services\ParticipantToken::generate( (int) $participant->id, $event_date_id );
+
+		echo '<div class="fair-events-signed-up-card"'
+			. ' data-event-id="' . esc_attr( (string) $event_id ) . '"'
+			. ' data-event-date-id="' . esc_attr( (string) $event_date_id ) . '"'
+			. ' data-participant-token="' . esc_attr( $token ) . '"'
+			. ' data-cancel-route="/fair-audience/v1/event-signup">';
+
+		echo '<p class="fair-events-signed-up-status">' . esc_html__( 'You are signed up for this date.', 'fair-audience' ) . '</p>';
+
+		$ticket_label = $context['signed_up_ticket_label'] ?? '';
+		if ( '' !== $ticket_label ) {
+			echo '<p class="fair-events-signed-up-ticket">';
+			printf(
+				/* translators: %s: ticket type name */
+				esc_html__( 'Your ticket: %s', 'fair-audience' ),
+				'<strong>' . esc_html( $ticket_label ) . '</strong>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped substitution.
+			);
+			echo '</p>';
+		}
+
+		if ( ! empty( $context['current_activity_names'] ) ) {
+			echo '<div class="fair-events-signed-up-activities"><p>' . esc_html__( 'Your activities:', 'fair-audience' ) . '</p><ul>';
+			foreach ( $context['current_activity_names'] as $activity_name ) {
+				echo '<li>' . esc_html( $activity_name ) . '</li>';
+			}
+			echo '</ul></div>';
+		}
+
+		// A date switcher that navigates via the existing ?event_date= param
+		// (fair-events' render.php already resolves it) rather than
+		// re-pivoting client-side, mirroring the legacy picker's own
+		// behaviour — no client-side re-evaluation of a server-side decision.
+		$occurrences = $context['occurrences_for_picker'] ?? array();
+		if ( count( $occurrences ) > 1 ) {
+			echo '<ul class="fair-events-signed-up-switch-date">';
+			foreach ( $occurrences as $occ_row ) {
+				if ( (int) $occ_row['id'] === $event_date_id ) {
+					continue;
+				}
+				$occ_label = class_exists( \FairEvents\Helpers\DateRangeFormatter::class )
+					? \FairEvents\Helpers\DateRangeFormatter::format( $occ_row['start_datetime'], $occ_row['end_datetime'], $occ_row['all_day'] )
+					: $occ_row['start_datetime'];
+				if ( ! empty( $occ_row['signed_up'] ) ) {
+					$occ_label .= ' — ' . __( 'already signed up', 'fair-audience' );
+				}
+				$date_param = gmdate( 'Y-m-d', strtotime( $occ_row['start_datetime'] ) );
+				$link       = add_query_arg( 'event_date', $date_param );
+				echo '<li><a href="' . esc_url( $link ) . '">' . esc_html( $occ_label ) . '</a></li>';
+			}
+			echo '</ul>';
+		}
+
+		echo '<div class="wp-block-button">';
+		echo '<button type="button" class="wp-block-button__link wp-element-button fair-events-cancel-signup-button is-style-outline">';
+		echo esc_html__( 'Cancel signup', 'fair-audience' );
+		echo '</button>';
+		echo '</div>';
+
+		echo '</div>';
+	}
+
+	/**
+	 * Render the "Not you? Start fresh" button for a viewer recognised only
+	 * via the session cookie (not signed up, form not suppressed) — lets them
+	 * clear the pre-filled name/email and register as someone else. Hooked on
+	 * fair_events_signup_render_before_form; wired client-side against the
+	 * existing DELETE /fair-audience/v1/session route by fair-events-shared's
+	 * wireNotYouButton(), the same helper the legacy block uses.
+	 *
+	 * @param array $context Render context, see fair_events_signup_render_context.
+	 * @return void
+	 */
+	public static function render_not_you( $context ) {
+		if ( ! empty( $context['suppress_form'] ) || empty( $context['prefill_email'] ) ) {
+			return;
+		}
+		if ( ! AudienceSession::get_participant_id() ) {
+			return;
+		}
+
+		echo '<button type="button" class="fair-events-not-you-button">'
+			. esc_html__( 'Not you? Start fresh', 'fair-audience' )
+			. '</button>';
 	}
 
 	/**

--- a/fair-audience/src/Hooks/SignupHookBridge.php
+++ b/fair-audience/src/Hooks/SignupHookBridge.php
@@ -12,6 +12,7 @@
 namespace FairAudience\Hooks;
 
 use FairAudience\Database\ParticipantRepository;
+use FairAudience\Database\EmailConfirmationTokenRepository;
 use FairAudience\Database\EventParticipantRepository;
 use FairAudience\Database\EventParticipantTransactionRepository;
 use FairAudience\Models\Participant;
@@ -575,7 +576,8 @@ class SignupHookBridge {
 	 * @param int      $event_date_id    Event-date ID the signup targets.
 	 * @param string   $name             Buyer name.
 	 * @param string   $email            Buyer email.
-	 * @param array    $ticket_selection Ticket selection ('ticket_type_id', 'quantity', 'event_date_ids').
+	 * @param array    $ticket_selection Ticket selection ('ticket_type_id', 'quantity',
+	 *                                   'ticket_option_ids'/'event_date_ids', 'mailing_opt_in').
 	 * @param int|null $transaction_id   fair-payments-connector transaction ID, or null on the free path.
 	 * @return void
 	 */
@@ -600,6 +602,8 @@ class SignupHookBridge {
 
 		$participant_repository = new ParticipantRepository();
 		$participant            = $participant_repository->get_by_email( $email );
+		$mailing_opt_in         = ! empty( $ticket_selection['mailing_opt_in'] );
+		$is_new_participant     = false;
 
 		if ( ! $participant ) {
 			$participant = new Participant();
@@ -607,12 +611,30 @@ class SignupHookBridge {
 				array(
 					'name'          => $name,
 					'email'         => $email,
-					'email_profile' => 'minimal',
-					'status'        => 'confirmed',
+					// Mirrors EventSignupController::register()'s new-participant
+					// branch: only a brand-new participant's consent is recorded
+					// here — an existing participant's profile/status is never
+					// overwritten by a later signup's checkbox state.
+					'email_profile' => $mailing_opt_in ? 'marketing' : 'minimal',
+					'status'        => $mailing_opt_in ? 'pending' : 'confirmed',
 				)
 			);
 			if ( ! $participant->save() ) {
 				return;
+			}
+			$is_new_participant = true;
+		}
+
+		// Mailing-list double opt-in: dispatch the confirmation email as soon
+		// as the participant lands in 'pending' status, mirroring
+		// EventSignupController::register() (see #1112 for why this can't
+		// wait until the free-signup tail below — a paid signup never
+		// reaches it).
+		if ( $is_new_participant && $mailing_opt_in ) {
+			$token_repository = new EmailConfirmationTokenRepository();
+			$token            = $token_repository->create_token( $participant->id );
+			if ( $token ) {
+				( new EmailService() )->send_confirmation_email( $participant, $token->token );
 			}
 		}
 
@@ -716,6 +738,11 @@ class SignupHookBridge {
 
 		$ledger = new EventParticipantTransactionRepository();
 		$ledger->record( (int) $event_participant->id, (int) $transaction->id, 'charge' );
+
+		// The free path emails its confirmation inline in link_participant();
+		// a paid signup only reaches "confirmed" here, so this is the sole
+		// place a base-route paid signup's confirmation email gets sent.
+		\FairAudience\Hooks\PaymentHooks::send_signup_confirmation_email( $event_participant, $transaction );
 	}
 
 	/**

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -38,9 +38,16 @@ class GetTicketsController extends WP_REST_Controller {
 	protected $rest_base = 'get-tickets';
 
 	/**
-	 * Rate limit: max requests per IP per window.
+	 * Rate limit: max requests per IP per window. Loose — a shared-NAT venue
+	 * can still produce more than a handful of legitimate signups in an hour.
+	 * The per-email limit below is the real abuse gate.
 	 */
-	const RATE_LIMIT_MAX = 3;
+	const RATE_LIMIT_MAX_PER_IP = 20;
+
+	/**
+	 * Rate limit: max requests per email address per window.
+	 */
+	const RATE_LIMIT_MAX_PER_EMAIL = 3;
 
 	/**
 	 * Rate limit window in seconds (1 hour).
@@ -252,21 +259,24 @@ class GetTicketsController extends WP_REST_Controller {
 			);
 		}
 
-		// Server-side rate limit by IP.
-		if ( $this->is_rate_limited() ) {
-			return new WP_Error(
-				'rate_limited',
-				__( 'Too many requests. Please try again later.', 'fair-events' ),
-				array( 'status' => 429 )
-			);
-		}
-
 		$event_date_id  = $request->get_param( 'event_date_id' );
 		$name           = $request->get_param( 'name' );
 		$email          = $request->get_param( 'email' );
 		$ticket_type_id = $request->get_param( 'ticket_type_id' );
 		$quantity       = max( 1, min( 100, (int) $request->get_param( 'quantity' ) ) );
 		$mailing_opt_in = (bool) $request->get_param( 'mailing_opt_in' );
+
+		// Server-side rate limit by IP and by email. The IP ceiling is loose
+		// enough that a shared-NAT venue's fourth signup that hour doesn't
+		// 429; the tighter per-email limit is what actually stops abuse once
+		// this is the only signup path (#1245 cutover).
+		if ( $this->is_rate_limited( $email ) ) {
+			return new WP_Error(
+				'rate_limited',
+				__( 'Too many requests. Please try again later.', 'fair-events' ),
+				array( 'status' => 429 )
+			);
+		}
 
 		// Chosen activity (ticket option) IDs, deduped/cast defensively even
 		// though the route arg already caps the count — see register_routes().
@@ -301,6 +311,16 @@ class GetTicketsController extends WP_REST_Controller {
 				__( 'Event date not found.', 'fair-events' ),
 				array( 'status' => 404 )
 			);
+		}
+
+		// Extension point for plugins (e.g. fair-audience) that need to reject
+		// a signup before any row is written — a duplicate already-signed-up
+		// guard, for instance. Runs before ticket-type/options validation so
+		// it covers the single-, multiple-instances- and no-ticket-type paths
+		// alike. See REST_API_BACKEND.md.
+		$precheck_error = apply_filters( 'fair_events_signup_precheck_error', null, (int) $event_date_id, $email, (int) $ticket_type_id );
+		if ( is_wp_error( $precheck_error ) ) {
+			return $precheck_error;
 		}
 
 		// Validate ticket type belongs to this event date (or its series master)
@@ -342,7 +362,7 @@ class GetTicketsController extends WP_REST_Controller {
 			// instead of the single event_date_id above — handled by a dedicated
 			// path that creates one signup row per chosen occurrence.
 			if ( $ticket_type->is_multiple_instances() ) {
-				$this->increment_rate_limit();
+				$this->increment_rate_limit( $email );
 				return $this->create_multi_instance_signup( $request, $ticket_type, $event_date_id, $name, $email, $mailing_opt_in, $questionnaire_answers );
 			}
 
@@ -388,7 +408,7 @@ class GetTicketsController extends WP_REST_Controller {
 			);
 		}
 
-		$this->increment_rate_limit();
+		$this->increment_rate_limit( $email );
 
 		// Persist the signup row.
 		$signup_id = \FairEvents\Models\EventSignup::save(
@@ -1266,24 +1286,44 @@ class GetTicketsController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Check if the current IP has exceeded the rate limit.
+	 * Check if the current IP or the submitted email has exceeded its rate limit.
 	 *
+	 * @param string $email Submitted email address.
 	 * @return bool
 	 */
-	private function is_rate_limited() {
-		$key   = 'fair_events_get_tickets_rl_' . md5( $_SERVER['REMOTE_ADDR'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		$count = (int) get_transient( $key );
-		return $count >= self::RATE_LIMIT_MAX;
+	private function is_rate_limited( $email ) {
+		$ip_key   = 'fair_events_get_tickets_rl_ip_' . md5( $_SERVER['REMOTE_ADDR'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$ip_count = (int) get_transient( $ip_key );
+		if ( $ip_count >= self::RATE_LIMIT_MAX_PER_IP ) {
+			return true;
+		}
+
+		if ( '' !== $email ) {
+			$email_key   = 'fair_events_get_tickets_rl_email_' . md5( strtolower( $email ) );
+			$email_count = (int) get_transient( $email_key );
+			if ( $email_count >= self::RATE_LIMIT_MAX_PER_EMAIL ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
-	 * Increment the rate limit counter for the current IP.
+	 * Increment the rate limit counters for the current IP and the submitted email.
 	 *
+	 * @param string $email Submitted email address.
 	 * @return void
 	 */
-	private function increment_rate_limit() {
-		$key   = 'fair_events_get_tickets_rl_' . md5( $_SERVER['REMOTE_ADDR'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		$count = (int) get_transient( $key );
-		set_transient( $key, $count + 1, self::RATE_LIMIT_WINDOW );
+	private function increment_rate_limit( $email ) {
+		$ip_key   = 'fair_events_get_tickets_rl_ip_' . md5( $_SERVER['REMOTE_ADDR'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$ip_count = (int) get_transient( $ip_key );
+		set_transient( $ip_key, $ip_count + 1, self::RATE_LIMIT_WINDOW );
+
+		if ( '' !== $email ) {
+			$email_key   = 'fair_events_get_tickets_rl_email_' . md5( strtolower( $email ) );
+			$email_count = (int) get_transient( $email_key );
+			set_transient( $email_key, $email_count + 1, self::RATE_LIMIT_WINDOW );
+		}
 	}
 }

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -436,6 +436,7 @@ class GetTicketsController extends WP_REST_Controller {
 			'ticket_type_id'    => $ticket_type_id ? $ticket_type_id : null,
 			'quantity'          => $quantity,
 			'ticket_option_ids' => $ticket_option_ids,
+			'mailing_opt_in'    => $mailing_opt_in,
 		);
 
 		// Free path.
@@ -549,7 +550,8 @@ class GetTicketsController extends WP_REST_Controller {
 	 * @param string   $name             Buyer name.
 	 * @param string   $email            Buyer email.
 	 * @param array    $ticket_selection Ticket selection: 'ticket_type_id', 'quantity',
-	 *                                   and — for 'multiple_instances' types — 'event_date_ids'.
+	 *                                   'ticket_option_ids' (or 'event_date_ids' for
+	 *                                   'multiple_instances' types), and 'mailing_opt_in'.
 	 * @param int|null $transaction_id   fair-payments-connector transaction ID, or null on the free path.
 	 * @return void
 	 */
@@ -789,6 +791,7 @@ class GetTicketsController extends WP_REST_Controller {
 			'ticket_type_id' => (int) $ticket_type->id,
 			'quantity'       => 1,
 			'event_date_ids' => $occurrence_ids,
+			'mailing_opt_in' => $mailing_opt_in,
 		);
 
 		// Free path.

--- a/fair-events/src/API/__tests__/GetTicketsIrregularSeries.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsIrregularSeries.api.spec.js
@@ -2,11 +2,6 @@
  * Playwright API tests for whole-series ticket coverage on an irregular
  * (manually-built) series — recurrence_mode='manual', no rrule (#1158).
  *
- * This endpoint only serves signups when fair-audience is NOT active
- * (fair-events/src/blocks/get-tickets/render.php defers to the Event Signup
- * block otherwise), so these tests skip gracefully when fair-audience is
- * active in the test environment.
- *
  * Covers:
  *   - a whole_series ticket type on a manual-mode master is accepted when
  *     purchasing a non-first (generated) occurrence.
@@ -29,7 +24,6 @@ const adminHeaders = {
 
 test.describe('GetTicketsController — irregular (manual) series whole_series scope', () => {
 	let api;
-	let fairAudienceActive = false;
 	let eventPostId;
 	let masterEventDateId;
 	let occurrenceIds;
@@ -38,20 +32,6 @@ test.describe('GetTicketsController — irregular (manual) series whole_series s
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
-
-		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
-			headers: adminHeaders,
-		});
-		if (pluginsRes.ok()) {
-			const plugins = await pluginsRes.json();
-			fairAudienceActive = plugins.some(
-				(p) =>
-					p.plugin?.includes('fair-audience') && p.status === 'active'
-			);
-		}
-		if (fairAudienceActive) {
-			return;
-		}
 
 		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
 			headers: adminHeaders,
@@ -66,7 +46,8 @@ test.describe('GetTicketsController — irregular (manual) series whole_series s
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: adminHeaders,
 			data: {
-				event_id: eventPostId,
+				title: `Get-tickets irregular series test ${Date.now()}`,
+				link_type: 'post',
 				start_datetime: '2035-07-01 10:00:00',
 				end_datetime: '2035-07-01 12:00:00',
 				recurrence_mode: 'manual',
@@ -74,14 +55,29 @@ test.describe('GetTicketsController — irregular (manual) series whole_series s
 			},
 		});
 		expect(edRes.ok()).toBeTruthy();
-		masterEventDateId = (await edRes.json()).id;
+		const edBody = await edRes.json();
+		masterEventDateId = edBody.id;
 
-		const occRes = await api.get(
-			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
-			{ headers: adminHeaders }
+		// The create endpoint doesn't wire event_id through — a PUT is
+		// needed to actually link the post (see CalendarFeedController.api.spec.js
+		// for the same quirk).
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { event_id: eventPostId },
+			}
 		);
-		expect(occRes.ok()).toBeTruthy();
-		occurrenceIds = (await occRes.json()).map((o) => o.id).sort();
+		expect(linkRes.ok()).toBeTruthy();
+
+		// generated_occurrences comes straight off the create response
+		// (master + 2 generated for COUNT=3 / 3 manual dates) — the
+		// event_id query-filter on the list route doesn't actually filter
+		// (a separate pre-existing bug), so deriving from edRes avoids it.
+		occurrenceIds = [
+			masterEventDateId,
+			...edBody.generated_occurrences.map((o) => o.id),
+		].sort();
 		expect(occurrenceIds.length).toBe(3);
 		// A non-first occurrence — the case exercised for whole-series coverage.
 		childEventDateId = occurrenceIds[1];
@@ -126,9 +122,6 @@ test.describe('GetTicketsController — irregular (manual) series whole_series s
 	});
 
 	test.afterAll(async () => {
-		if (fairAudienceActive) {
-			return;
-		}
 		if (eventPostId) {
 			await api.delete(
 				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
@@ -139,8 +132,6 @@ test.describe('GetTicketsController — irregular (manual) series whole_series s
 	});
 
 	test('whole_series ticket type on a manual master is accepted for a generated occurrence', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {
 				event_date_id: childEventDateId,
@@ -154,8 +145,6 @@ test.describe('GetTicketsController — irregular (manual) series whole_series s
 	});
 
 	test('the signup persists against the child occurrence, priced from the master', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const signupsRes = await api.get(
 			'/wp-json/fair-events/v1/get-tickets',
 			{

--- a/fair-events/src/API/__tests__/GetTicketsMultipleInstances.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsMultipleInstances.api.spec.js
@@ -2,11 +2,6 @@
  * Playwright API tests for the get-tickets fallback endpoint's
  * 'multiple_instances' ticket-type support (#930).
  *
- * This endpoint only serves signups when fair-audience is NOT active
- * (fair-events/src/blocks/get-tickets/render.php defers to the Event Signup
- * block otherwise), so these tests skip gracefully when fair-audience is
- * active in the test environment.
- *
  * Covers:
  *   - below the ticket type's configured minimum_instances is rejected.
  *   - an occurrence outside the ticket type's own series is rejected.
@@ -28,7 +23,6 @@ const adminHeaders = {
 
 test.describe('GetTicketsController — multiple_instances signup', () => {
 	let api;
-	let fairAudienceActive = false;
 	let eventPostId;
 	let masterEventDateId;
 	let occurrenceIds;
@@ -36,22 +30,6 @@ test.describe('GetTicketsController — multiple_instances signup', () => {
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
-
-		// Detect whether fair-audience is active — the get-tickets block (and
-		// this controller's public behaviour) is a no-op fallback when it is.
-		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
-			headers: adminHeaders,
-		});
-		if (pluginsRes.ok()) {
-			const plugins = await pluginsRes.json();
-			fairAudienceActive = plugins.some(
-				(p) =>
-					p.plugin?.includes('fair-audience') && p.status === 'active'
-			);
-		}
-		if (fairAudienceActive) {
-			return;
-		}
 
 		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
 			headers: adminHeaders,
@@ -66,21 +44,37 @@ test.describe('GetTicketsController — multiple_instances signup', () => {
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: adminHeaders,
 			data: {
-				event_id: eventPostId,
+				title: `Get-tickets multi-instance test ${Date.now()}`,
+				link_type: 'post',
 				start_datetime: '2035-05-01 10:00:00',
 				end_datetime: '2035-05-01 12:00:00',
 				rrule: 'FREQ=WEEKLY;COUNT=3',
 			},
 		});
 		expect(edRes.ok()).toBeTruthy();
-		masterEventDateId = (await edRes.json()).id;
+		const edBody = await edRes.json();
+		masterEventDateId = edBody.id;
 
-		const occRes = await api.get(
-			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
-			{ headers: adminHeaders }
+		// The create endpoint doesn't wire event_id through — a PUT is
+		// needed to actually link the post (see CalendarFeedController.api.spec.js
+		// for the same quirk).
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { event_id: eventPostId },
+			}
 		);
-		expect(occRes.ok()).toBeTruthy();
-		occurrenceIds = (await occRes.json()).map((o) => o.id).sort();
+		expect(linkRes.ok()).toBeTruthy();
+
+		// generated_occurrences comes straight off the create response
+		// (master + 2 generated for COUNT=3 / 3 manual dates) — the
+		// event_id query-filter on the list route doesn't actually filter
+		// (a separate pre-existing bug), so deriving from edRes avoids it.
+		occurrenceIds = [
+			masterEventDateId,
+			...edBody.generated_occurrences.map((o) => o.id),
+		].sort();
 		expect(occurrenceIds.length).toBe(3);
 
 		const ticketsRes = await api.put(
@@ -112,9 +106,6 @@ test.describe('GetTicketsController — multiple_instances signup', () => {
 	});
 
 	test.afterAll(async () => {
-		if (fairAudienceActive) {
-			return;
-		}
 		if (eventPostId) {
 			await api.delete(
 				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
@@ -125,8 +116,6 @@ test.describe('GetTicketsController — multiple_instances signup', () => {
 	});
 
 	test('below the configured minimum is rejected', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {
 				event_date_id: masterEventDateId,
@@ -142,8 +131,6 @@ test.describe('GetTicketsController — multiple_instances signup', () => {
 	});
 
 	test("an occurrence outside the ticket type's series is rejected", async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {
 				event_date_id: masterEventDateId,
@@ -160,8 +147,6 @@ test.describe('GetTicketsController — multiple_instances signup', () => {
 	});
 
 	test('a valid selection creates one signup row per chosen occurrence', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const chosen = [occurrenceIds[0], occurrenceIds[1]];
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {

--- a/fair-events/src/API/__tests__/GetTicketsPaymentState.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsPaymentState.api.spec.js
@@ -11,11 +11,6 @@
  * these routes shares: SignupPaymentSession::get() resolve_transaction_from_request()
  * must 404 — never a more specific error — for any transaction_id it can't
  * verify, so an anonymous caller can't enumerate other visitors' payments.
- *
- * This endpoint only serves signups when fair-audience is NOT active
- * (fair-events/src/blocks/event-signup/render.php defers to the Event Signup
- * block otherwise), so these tests skip gracefully when fair-audience is
- * active in the test environment.
  */
 
 import { test, expect, request } from '@playwright/test';
@@ -35,21 +30,9 @@ const BOGUS_TRANSACTION_ID = 999999999;
 
 test.describe('GetTicketsController — payment-state / retry-payment / cancel-payment', () => {
 	let api;
-	let fairAudienceActive = false;
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
-
-		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
-			headers: adminHeaders,
-		});
-		if (pluginsRes.ok()) {
-			const plugins = await pluginsRes.json();
-			fairAudienceActive = plugins.some(
-				(p) =>
-					p.plugin?.includes('fair-audience') && p.status === 'active'
-			);
-		}
 	});
 
 	test.afterAll(async () => {
@@ -57,8 +40,6 @@ test.describe('GetTicketsController — payment-state / retry-payment / cancel-p
 	});
 
 	test('payment-state with no transaction_id and no session cookie 404s', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const res = await api.get(
 			'/wp-json/fair-events/v1/get-tickets/payment-state'
 		);
@@ -67,8 +48,6 @@ test.describe('GetTicketsController — payment-state / retry-payment / cancel-p
 	});
 
 	test('payment-state with an unknown transaction_id 404s', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const res = await api.get(
 			'/wp-json/fair-events/v1/get-tickets/payment-state',
 			{ params: { transaction_id: BOGUS_TRANSACTION_ID, token: 'wrong' } }
@@ -78,8 +57,6 @@ test.describe('GetTicketsController — payment-state / retry-payment / cancel-p
 	});
 
 	test('retry-payment requires a transaction_id', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const res = await api.post(
 			'/wp-json/fair-events/v1/get-tickets/retry-payment',
 			{ data: {} }
@@ -88,8 +65,6 @@ test.describe('GetTicketsController — payment-state / retry-payment / cancel-p
 	});
 
 	test('retry-payment with an unknown transaction_id 404s, never a more specific error', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const res = await api.post(
 			'/wp-json/fair-events/v1/get-tickets/retry-payment',
 			{ data: { transaction_id: BOGUS_TRANSACTION_ID, token: 'wrong' } }
@@ -99,8 +74,6 @@ test.describe('GetTicketsController — payment-state / retry-payment / cancel-p
 	});
 
 	test('cancel-payment requires a transaction_id', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const res = await api.post(
 			'/wp-json/fair-events/v1/get-tickets/cancel-payment',
 			{ data: {} }
@@ -109,8 +82,6 @@ test.describe('GetTicketsController — payment-state / retry-payment / cancel-p
 	});
 
 	test('cancel-payment with an unknown transaction_id 404s, never a more specific error', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const res = await api.post(
 			'/wp-json/fair-events/v1/get-tickets/cancel-payment',
 			{ data: { transaction_id: BOGUS_TRANSACTION_ID, token: 'wrong' } }
@@ -120,8 +91,6 @@ test.describe('GetTicketsController — payment-state / retry-payment / cancel-p
 	});
 
 	test('admins get the same 404 as anyone else for an unknown transaction_id', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		// signup_payment_permissions_check() has no manage_options carve-out
 		// (unlike PaymentEndpoint's own status check) — ownership of a
 		// get-tickets signup is never an admin concern, so this stays a

--- a/fair-events/src/API/__tests__/GetTicketsPaymentUnavailable.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsPaymentUnavailable.api.spec.js
@@ -2,11 +2,6 @@
  * Playwright API tests for the get-tickets fallback endpoint's fail-closed
  * behaviour when online payments can't be collected (#1177).
  *
- * This endpoint only serves signups when fair-audience is NOT active
- * (fair-events/src/blocks/event-signup/render.php defers to the Event Signup
- * block otherwise), so these tests skip gracefully when fair-audience is
- * active in the test environment.
- *
  * Like fair-audience's EventSignupSlidingScale spec, this assumes the dev
  * stack has no payment connector configured: a priced signup must be rejected
  * up front with 503 payment_unavailable, creating no signup (and therefore no
@@ -38,7 +33,6 @@ function uniqueEmail(prefix) {
 
 test.describe('GetTicketsController — payments unavailable (fail closed)', () => {
 	let api;
-	let fairAudienceActive = false;
 	let eventPostId;
 	let masterEventDateId;
 	let occurrenceIds;
@@ -60,20 +54,6 @@ test.describe('GetTicketsController — payments unavailable (fail closed)', () 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
 
-		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
-			headers: adminHeaders,
-		});
-		if (pluginsRes.ok()) {
-			const plugins = await pluginsRes.json();
-			fairAudienceActive = plugins.some(
-				(p) =>
-					p.plugin?.includes('fair-audience') && p.status === 'active'
-			);
-		}
-		if (fairAudienceActive) {
-			return;
-		}
-
 		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
 			headers: adminHeaders,
 			data: {
@@ -87,21 +67,37 @@ test.describe('GetTicketsController — payments unavailable (fail closed)', () 
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: adminHeaders,
 			data: {
-				event_id: eventPostId,
+				title: `Get-tickets payments-unavailable test ${Date.now()}`,
+				link_type: 'post',
 				start_datetime: '2035-05-01 10:00:00',
 				end_datetime: '2035-05-01 12:00:00',
 				rrule: 'FREQ=WEEKLY;COUNT=3',
 			},
 		});
 		expect(edRes.ok()).toBeTruthy();
-		masterEventDateId = (await edRes.json()).id;
+		const edBody = await edRes.json();
+		masterEventDateId = edBody.id;
 
-		const occRes = await api.get(
-			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
-			{ headers: adminHeaders }
+		// The create endpoint doesn't wire event_id through — a PUT is
+		// needed to actually link the post (see CalendarFeedController.api.spec.js
+		// for the same quirk).
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { event_id: eventPostId },
+			}
 		);
-		expect(occRes.ok()).toBeTruthy();
-		occurrenceIds = (await occRes.json()).map((o) => o.id).sort();
+		expect(linkRes.ok()).toBeTruthy();
+
+		// generated_occurrences comes straight off the create response
+		// (master + 2 generated for COUNT=3 / 3 manual dates) — the
+		// event_id query-filter on the list route doesn't actually filter
+		// (a separate pre-existing bug), so deriving from edRes avoids it.
+		occurrenceIds = [
+			masterEventDateId,
+			...edBody.generated_occurrences.map((o) => o.id),
+		].sort();
 		expect(occurrenceIds.length).toBe(3);
 
 		// Three priced ticket types — one per purchase path — plus an
@@ -180,9 +176,6 @@ test.describe('GetTicketsController — payments unavailable (fail closed)', () 
 	});
 
 	test.afterAll(async () => {
-		if (fairAudienceActive) {
-			return;
-		}
 		if (eventPostId) {
 			await api.delete(
 				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
@@ -193,8 +186,6 @@ test.describe('GetTicketsController — payments unavailable (fail closed)', () 
 	});
 
 	test('a paid single-instance signup is rejected 503 and writes nothing', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const before = await countSignups(masterEventDateId);
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {
@@ -211,8 +202,6 @@ test.describe('GetTicketsController — payments unavailable (fail closed)', () 
 	});
 
 	test('a paid whole-series signup is rejected 503 and writes nothing', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const before = await countSignups(masterEventDateId);
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {
@@ -229,8 +218,6 @@ test.describe('GetTicketsController — payments unavailable (fail closed)', () 
 	});
 
 	test('a paid multiple-instances signup is rejected 503 and writes nothing', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const chosen = [occurrenceIds[0], occurrenceIds[1]];
 		const before = await Promise.all(chosen.map(countSignups));
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
@@ -249,8 +236,6 @@ test.describe('GetTicketsController — payments unavailable (fail closed)', () 
 	});
 
 	test('a free signup on the same event still confirms', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		// No ticket type → amount 0 → free path, unaffected by the guard.
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {

--- a/fair-events/src/API/__tests__/GetTicketsQuestionnaire.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsQuestionnaire.api.spec.js
@@ -104,14 +104,28 @@ test.describe('GetTicketsController — questionnaire_answers', () => {
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: adminHeaders,
 			data: {
-				event_id: eventPostId,
 				title: `Get-tickets questionnaire test ${Date.now()}`,
+				link_type: 'post',
 				start_datetime: '2035-06-01 10:00:00',
 				end_datetime: '2035-06-01 12:00:00',
 			},
 		});
 		expect(edRes.ok()).toBeTruthy();
 		eventDateId = (await edRes.json()).id;
+
+		// The create endpoint doesn't wire event_id through — a PUT is
+		// needed to actually link the post (see CalendarFeedController.api.spec.js
+		// for the same quirk). Needed here so the "linked to fair-audience
+		// participant" test's SignupHookBridge::link_participant() call can
+		// resolve a real event_id via get_resolved_event_id().
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { event_id: eventPostId },
+			}
+		);
+		expect(linkRes.ok()).toBeTruthy();
 	});
 
 	test.afterAll(async () => {
@@ -126,8 +140,6 @@ test.describe('GetTicketsController — questionnaire_answers', () => {
 
 	test('answers are stored with participant_id 0 (anonymous) when fair-audience is inactive', async () => {
 		test.skip(!fairFormActive, 'fair-form not active');
-		test.skip(fairAudienceActive, 'fair-audience active — see linked test');
-
 		const email = uniqueEmail('anon');
 		// Use its own event date so the submission lookup by email is unambiguous.
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {

--- a/fair-events/src/API/__tests__/GetTicketsRecurringMaster.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsRecurringMaster.api.spec.js
@@ -2,11 +2,6 @@
  * Playwright API tests for the get-tickets fallback endpoint's master-pivot
  * support for recurring events (#983).
  *
- * This endpoint only serves signups when fair-audience is NOT active
- * (fair-events/src/blocks/get-tickets/render.php defers to the Event Signup
- * block otherwise), so these tests skip gracefully when fair-audience is
- * active in the test environment.
- *
  * Covers:
  *   - a ticket type configured on the series master is accepted when
  *     purchasing a non-first (child) occurrence.
@@ -30,7 +25,6 @@ const adminHeaders = {
 
 test.describe('GetTicketsController — recurring series master pivot', () => {
 	let api;
-	let fairAudienceActive = false;
 	let eventPostId;
 	let masterEventDateId;
 	let occurrenceIds;
@@ -39,22 +33,6 @@ test.describe('GetTicketsController — recurring series master pivot', () => {
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
-
-		// Detect whether fair-audience is active — the get-tickets block (and
-		// this controller's public behaviour) is a no-op fallback when it is.
-		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
-			headers: adminHeaders,
-		});
-		if (pluginsRes.ok()) {
-			const plugins = await pluginsRes.json();
-			fairAudienceActive = plugins.some(
-				(p) =>
-					p.plugin?.includes('fair-audience') && p.status === 'active'
-			);
-		}
-		if (fairAudienceActive) {
-			return;
-		}
 
 		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
 			headers: adminHeaders,
@@ -69,21 +47,37 @@ test.describe('GetTicketsController — recurring series master pivot', () => {
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: adminHeaders,
 			data: {
-				event_id: eventPostId,
+				title: `Get-tickets recurring master test ${Date.now()}`,
+				link_type: 'post',
 				start_datetime: '2035-06-01 10:00:00',
 				end_datetime: '2035-06-01 12:00:00',
 				rrule: 'FREQ=WEEKLY;COUNT=3',
 			},
 		});
 		expect(edRes.ok()).toBeTruthy();
-		masterEventDateId = (await edRes.json()).id;
+		const edBody = await edRes.json();
+		masterEventDateId = edBody.id;
 
-		const occRes = await api.get(
-			`/wp-json/fair-events/v1/event-dates?event_id=${eventPostId}`,
-			{ headers: adminHeaders }
+		// The create endpoint doesn't wire event_id through — a PUT is
+		// needed to actually link the post (see CalendarFeedController.api.spec.js
+		// for the same quirk).
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { event_id: eventPostId },
+			}
 		);
-		expect(occRes.ok()).toBeTruthy();
-		occurrenceIds = (await occRes.json()).map((o) => o.id).sort();
+		expect(linkRes.ok()).toBeTruthy();
+
+		// generated_occurrences comes straight off the create response
+		// (master + 2 generated for COUNT=3 / 3 manual dates) — the
+		// event_id query-filter on the list route doesn't actually filter
+		// (a separate pre-existing bug), so deriving from edRes avoids it.
+		occurrenceIds = [
+			masterEventDateId,
+			...edBody.generated_occurrences.map((o) => o.id),
+		].sort();
 		expect(occurrenceIds.length).toBe(3);
 		// A non-first occurrence — the case that was previously broken.
 		childEventDateId = occurrenceIds[1];
@@ -128,9 +122,6 @@ test.describe('GetTicketsController — recurring series master pivot', () => {
 	});
 
 	test.afterAll(async () => {
-		if (fairAudienceActive) {
-			return;
-		}
 		if (eventPostId) {
 			await api.delete(
 				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
@@ -141,8 +132,6 @@ test.describe('GetTicketsController — recurring series master pivot', () => {
 	});
 
 	test('master-owned ticket type is accepted for a child occurrence and priced', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {
 				event_date_id: childEventDateId,
@@ -157,8 +146,6 @@ test.describe('GetTicketsController — recurring series master pivot', () => {
 	});
 
 	test('the signup persists against the child occurrence, priced from the master, not the master row', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const signupsRes = await api.get(
 			'/wp-json/fair-events/v1/get-tickets',
 			{

--- a/fair-events/src/API/__tests__/GetTicketsUnsetSalePeriod.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsUnsetSalePeriod.api.spec.js
@@ -6,11 +6,6 @@
  * end at the day after the last occurrence — rather than treating the
  * unset window as closed.
  *
- * This endpoint only serves signups when fair-audience is NOT active
- * (fair-events/src/blocks/get-tickets/render.php defers to the Event Signup
- * block otherwise), so these tests skip gracefully when fair-audience is
- * active in the test environment.
- *
  * Covers:
  *   - single, non-recurring event with an unset window is purchasable.
  *   - recurring event with an unset window is purchasable through the
@@ -113,22 +108,10 @@ async function purchase(api, eventDateId, ticketTypeId) {
 
 test.describe('GetTicketsController — lazy default sale-period resolution', () => {
 	let api;
-	let fairAudienceActive = false;
 	const createdEventDateIds = [];
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
-
-		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
-			headers: adminHeaders,
-		});
-		if (pluginsRes.ok()) {
-			const plugins = await pluginsRes.json();
-			fairAudienceActive = plugins.some(
-				(p) =>
-					p.plugin?.includes('fair-audience') && p.status === 'active'
-			);
-		}
 	});
 
 	test.afterAll(async () => {
@@ -141,8 +124,6 @@ test.describe('GetTicketsController — lazy default sale-period resolution', ()
 	});
 
 	test('single, non-recurring event with an unset window is purchasable', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const { eventDateId, ticketTypeId } = await createEventWithUnsetWindow(
 			api,
 			{
@@ -159,8 +140,6 @@ test.describe('GetTicketsController — lazy default sale-period resolution', ()
 	});
 
 	test('recurring event with an unset window is purchasable through the day after its last occurrence', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const { eventDateId, ticketTypeId } = await createEventWithUnsetWindow(
 			api,
 			{
@@ -178,8 +157,6 @@ test.describe('GetTicketsController — lazy default sale-period resolution', ()
 	});
 
 	test('a series entirely in the past with an unset window is still purchasable, never inverted', async () => {
-		test.skip(fairAudienceActive, 'fair-audience active — block deferred');
-
 		const { eventDateId, ticketTypeId } = await createEventWithUnsetWindow(
 			api,
 			{

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -226,16 +226,14 @@ class Plugin {
 			);
 		}
 
-		// GetTickets controller — registers the public ticket purchase endpoint when fair-audience is absent.
-		if ( ! class_exists( \FairAudience\API\EventSignupController::class ) ) {
-			add_action(
-				'rest_api_init',
-				function () {
-					$controller = new \FairEvents\API\GetTicketsController();
-					$controller->register_routes();
-				}
-			);
-		}
+		// GetTickets controller — registers the public ticket purchase endpoint.
+		add_action(
+			'rest_api_init',
+			function () {
+				$controller = new \FairEvents\API\GetTicketsController();
+				$controller->register_routes();
+			}
+		);
 	}
 
 	/**

--- a/fair-events/src/Hooks/BlockHooks.php
+++ b/fair-events/src/Hooks/BlockHooks.php
@@ -41,9 +41,10 @@ class BlockHooks {
 			register_block_type( __DIR__ . '/../../build/blocks/event-proposal' );
 		}
 
-		// Unified signup block (fair-events owned). Base behaviour is the
-		// anonymous get-tickets form; when fair-audience is active the render
-		// delegates to its participant-aware Event Signup flow.
+		// Unified signup block (fair-events owned). Renders the anonymous
+		// get-tickets form; when fair-audience is active it enriches the same
+		// render via the fair_events_signup_render_context filter and render
+		// slots instead of owning a competing template.
 		register_block_type( __DIR__ . '/../../build/blocks/event-signup' );
 
 		// Legacy get-tickets block — kept registered (hidden from the inserter)

--- a/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
+++ b/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
@@ -1,5 +1,17 @@
 /**
  * @jest-environment jsdom
+ *
+ * ServerSideRender is mocked below (it hits a live REST render, which jsdom
+ * can't do), so these tests can't exercise the #1245 fix directly — that bug
+ * (nested questions rendering outside the editor preview when fair-audience
+ * was active) was entirely in render.php's now-removed delegation, invisible
+ * to a mocked SSR response either way. What IS covered here, unconditionally
+ * (the block always ServerSideRenders itself — see the isFairFormActive
+ * true/false cases below, and the "always renders the unified block" test):
+ * the preview and nested-question portal work the same in both
+ * configurations, because there is only one configuration from the editor's
+ * side — fair-audience enriches the same render, it never owns a competing
+ * one.
  */
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
@@ -116,6 +128,16 @@ describe('Event Signup EditComponent', () => {
 
 		const [{ attributes }] = mockServerSideRender.mock.calls.at(-1);
 		expect(attributes.isEditorPreview).toBe(true);
+	});
+
+	it('always ServerSideRenders the unified block itself, never a delegated one (#1245)', () => {
+		renderEdit(true);
+		const [firstProps] = mockServerSideRender.mock.calls.at(-1);
+		expect(firstProps.block).toBe('fair-events/event-signup');
+
+		renderEdit(false);
+		const [secondProps] = mockServerSideRender.mock.calls.at(-1);
+		expect(secondProps.block).toBe('fair-events/event-signup');
 	});
 
 	it('only offers the fair-form question blocks once fair-form is active', () => {

--- a/fair-events/src/blocks/event-signup/editor.js
+++ b/fair-events/src/blocks/event-signup/editor.js
@@ -1,9 +1,11 @@
 /**
  * Event Signup Block - Editor Component
  *
- * Canonical fair-events signup block. Base behaviour is the anonymous
- * get-tickets form; when fair-audience is active the render delegates to its
- * participant-aware flow.
+ * Canonical fair-events signup block. Renders the anonymous get-tickets form;
+ * when fair-audience is active it enriches the same render via render-context
+ * filters and render slots instead of a competing template — so the editor
+ * preview (ServerSideRender of this same block) always reflects it, in both
+ * configurations.
  *
  * The legacy fair-audience/event-signup and fair-events/get-tickets blocks
  * hide themselves from the inserter and register their own transforms to

--- a/fair-events/src/blocks/event-signup/frontend.css
+++ b/fair-events/src/blocks/event-signup/frontend.css
@@ -189,6 +189,19 @@
 	cursor: not-allowed;
 }
 
+/* Signed-up/cancel card (recognised viewer), rendered by fair-audience in
+ * place of the suppressed <form>. */
+.fair-events-signed-up-card {
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	padding: 12px 16px;
+}
+
+.fair-events-signed-up-switch-date {
+	margin: 8px 0;
+	padding-left: 20px;
+}
+
 .fair-events-get-tickets-callback {
 	padding: 16px 20px;
 	border-radius: 4px;

--- a/fair-events/src/blocks/event-signup/frontend.js
+++ b/fair-events/src/blocks/event-signup/frontend.js
@@ -15,6 +15,7 @@ import {
 	formatMoney,
 	collectQuestionAnswers,
 	validateQuestions,
+	setupQuestionnaire,
 	extractErrorMessage,
 	setButtonLoading,
 	wireNotYouButton,
@@ -280,6 +281,7 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 
 		wireAddActivities(form.closest('.fair-events-get-tickets'));
 		wireNotYouButton(form.querySelector('.fair-events-not-you-button'));
+		setupQuestionnaire(form);
 
 		refreshSignupState(form);
 	}

--- a/fair-events/src/blocks/event-signup/frontend.js
+++ b/fair-events/src/blocks/event-signup/frontend.js
@@ -17,6 +17,7 @@ import {
 	validateQuestions,
 	extractErrorMessage,
 	setButtonLoading,
+	wireNotYouButton,
 } from 'fair-events-shared';
 import './frontend.css';
 
@@ -45,6 +46,19 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 			'.fair-events-get-tickets-form'
 		);
 		forms.forEach(setupForm);
+
+		// Companion wrapper rendered in place of the <form> for a recognised
+		// viewer who already holds this signup (fair-audience's
+		// SignupHookBridge, via the suppress_form context key) — no <form> to
+		// hang the add-activities/cancel-signup wiring off of, so wire them
+		// directly against the block.
+		document
+			.querySelectorAll('.fair-events-get-tickets-companion')
+			.forEach(function (companion) {
+				const block = companion.closest('.fair-events-get-tickets');
+				wireAddActivities(block);
+				wireCancelSignup(block);
+			});
 	}
 
 	/**
@@ -264,7 +278,8 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 				});
 		}
 
-		wireAddActivities(form);
+		wireAddActivities(form.closest('.fair-events-get-tickets'));
+		wireNotYouButton(form.querySelector('.fair-events-not-you-button'));
 
 		refreshSignupState(form);
 	}
@@ -624,11 +639,10 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 	 * by fair-audience's SignupHookBridge, since only it can persist the
 	 * selection): keep the Add button's total in sync with the checked
 	 * options and submit on click. No-op when the section isn't present.
-	 * @param {HTMLFormElement} form The get-tickets form (used to reach the
-	 *                                shared currency/message container).
+	 * @param {HTMLElement} block The .fair-events-get-tickets wrapper (used to
+	 *                              reach the shared currency/message container).
 	 */
-	function wireAddActivities(form) {
-		const block = form.closest('.fair-events-get-tickets');
+	function wireAddActivities(block) {
 		const section = block
 			? block.querySelector('.fair-events-add-activities')
 			: null;
@@ -661,7 +675,7 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 				total > 0
 					? baseText +
 					  ' — ' +
-					  formatMoney(total, form.dataset.currency)
+					  formatMoney(total, block.dataset.currency)
 					: baseText;
 		};
 
@@ -752,6 +766,96 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 					error,
 					__(
 						'Failed to add activities. Please try again.',
+						'fair-events'
+					)
+				);
+				showMessage(
+					messageContainer,
+					errorMessage,
+					'error',
+					CSS_PREFIX
+				);
+				restoreButton();
+			});
+	}
+
+	/**
+	 * Wire the cancel-signup button shown to a signed-up viewer (rendered by
+	 * fair-audience's SignupHookBridge). The companion supplies the route via
+	 * a data attribute — the base plugin never hardcodes a fair-audience/v1
+	 * path. No-op when the card isn't present.
+	 * @param {HTMLElement} block The .fair-events-get-tickets wrapper.
+	 */
+	function wireCancelSignup(block) {
+		const card = block
+			? block.querySelector('.fair-events-signed-up-card')
+			: null;
+		if (!card) {
+			return;
+		}
+		const button = card.querySelector('.fair-events-cancel-signup-button');
+		if (!button) {
+			return;
+		}
+
+		button.addEventListener('click', function () {
+			submitCancelSignup(block, card, button);
+		});
+	}
+
+	/**
+	 * Submit the cancel-signup request to the route the companion attached
+	 * to the card via data-cancel-route, then reload to reflect the cleared
+	 * signup.
+	 * @param {HTMLElement} block  The .fair-events-get-tickets wrapper.
+	 * @param {HTMLElement} card   The .fair-events-signed-up-card element.
+	 * @param {HTMLElement} button The cancel-signup button.
+	 */
+	function submitCancelSignup(block, card, button) {
+		const route = card.dataset.cancelRoute || '';
+		if (!route) {
+			return;
+		}
+		const eventId = parseInt(card.dataset.eventId, 10);
+		const eventDateId = card.dataset.eventDateId
+			? parseInt(card.dataset.eventDateId, 10)
+			: null;
+		const token = card.dataset.participantToken || '';
+		const messageContainer = block.querySelector('.message-container');
+
+		const requestData = { event_id: eventId };
+		if (eventDateId) {
+			requestData.event_date_id = eventDateId;
+		}
+		if (token) {
+			requestData.participant_token = token;
+		}
+
+		const restoreButton = setButtonLoading(
+			button,
+			__('Cancelling…', 'fair-events')
+		);
+
+		apiFetch({
+			path: route,
+			method: 'DELETE',
+			data: requestData,
+		})
+			.then(function () {
+				showMessage(
+					messageContainer,
+					__('Your signup has been cancelled.', 'fair-events'),
+					'success',
+					CSS_PREFIX
+				);
+				window.location.reload();
+			})
+			.catch(function (error) {
+				console.error('Cancel signup error:', error);
+				const errorMessage = extractErrorMessage(
+					error,
+					__(
+						'Failed to cancel signup. Please try again.',
 						'fair-events'
 					)
 				);

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -665,6 +665,7 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 								value="<?php echo (int) $opt['id']; ?>"
 								class="form-checkbox"
 								data-option-price="<?php echo esc_attr( \FairEventsShared\Money::format_value( $opt['price'] ) ); ?>"
+								data-option-short-name="<?php echo esc_attr( $opt['short_name'] ?? '' ); ?>"
 								<?php echo $opt_is_full ? 'disabled' : ''; ?>
 							/>
 							<span class="fair-events-ticket-option-text">

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -2,9 +2,10 @@
 /**
  * Event Signup Block - Server-side rendering
  *
- * Base (fair-audience inactive) behaviour is the anonymous get-tickets form.
- * When fair-audience is active this delegates to its Event Signup block so the
- * participant-aware flow (identity, pricing) renders unchanged.
+ * Renders the anonymous get-tickets form. When fair-audience is active it
+ * enriches this same render via the fair_events_signup_render_context filter
+ * and the render slots (identity, pricing, cancel/resignup) instead of owning
+ * a competing template.
  *
  * @package FairEvents
  *
@@ -14,21 +15,6 @@
  */
 
 defined( 'WPINC' ) || die;
-
-// When fair-audience is active it owns the participant-aware signup flow.
-// Delegate to its block via render_block() so its richer render runs unchanged
-// and its view script/styles enqueue, then stop. Nested question blocks are
-// forwarded so the delegated render receives them as $content, exactly as on
-// the legacy fair-audience block.
-if ( class_exists( \FairAudience\API\EventSignupController::class ) ) {
-	$delegated_block              = $block->parsed_block;
-	$delegated_block['blockName'] = 'fair-audience/event-signup';
-	$delegated_block['attrs']     = array(
-		'signupButtonText' => $attributes['submitButtonText'] ?? '',
-	);
-	echo render_block( $delegated_block ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render_block() returns trusted, already-escaped block markup.
-	return;
-}
 
 $submit_button_text = $attributes['submitButtonText'] ?? __( 'Get Tickets', 'fair-events' );
 
@@ -194,6 +180,11 @@ if ( $series_master_id && class_exists( \FairEvents\Models\EventDates::class ) )
 			'start_datetime' => $occ->start_datetime,
 			'end_datetime'   => $occ->end_datetime,
 			'all_day'        => (bool) $occ->all_day,
+			// A companion plugin (fair-audience) flips this true for
+			// occurrences the recognised viewer already holds, so the
+			// pickers below can label/disable them instead of allowing a
+			// silent double-book.
+			'signed_up'      => false,
 		);
 	}
 }
@@ -264,7 +255,8 @@ if ( ! empty( $ticket_options ) && class_exists( \FairEvents\Models\EventDateSet
  *                              price_by_type_id, active_sale_period, occurrences_for_picker,
  *                              ticket_options, minimum_activities,
  *                              callback_status, callback_tx_id, callback_token, callback_state,
- *                              callback_source, prefill_name, prefill_email, submit_button_text).
+ *                              callback_source, prefill_name, prefill_email, submit_button_text,
+ *                              suppress_form).
  * @param array    $attributes Block attributes.
  * @param WP_Block $block      Block instance.
  */
@@ -300,6 +292,11 @@ $context = apply_filters(
 		'prefill_name'           => '',
 		'prefill_email'          => '',
 		'submit_button_text'     => $submit_button_text,
+		// When a companion plugin sets this true (e.g. a recognised viewer
+		// who already holds a signup), the base skips the <form> entirely and
+		// emits a plain wrapper div instead, still firing the render slots
+		// inside it so the companion can render its own signed-up/cancel UI.
+		'suppress_form'          => false,
 	),
 	$attributes,
 	$block
@@ -317,6 +314,7 @@ $signup_state           = $context['callback_state'];
 $prefill_name           = $context['prefill_name'];
 $prefill_email          = $context['prefill_email'];
 $submit_button_text     = $context['submit_button_text'];
+$suppress_form          = ! empty( $context['suppress_form'] );
 
 // Recompute the multiple_instances flag from the (possibly filtered) ticket types.
 $has_multiple_instances_type = false;
@@ -386,7 +384,7 @@ $all_purchases_blocked = $payments_unavailable
 $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 ?>
 
-<div class="fair-events-get-tickets">
+<div class="fair-events-get-tickets" data-currency="<?php echo esc_attr( \FairEventsShared\Money::site_currency() ); ?>">
 <?php if ( $signup_state ) : ?>
 	<?php
 	$amount_display = \FairEventsShared\Money::format_display( (float) $signup_state['amount'], $signup_state['currency'] );
@@ -499,13 +497,35 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 	<div class="message-container message-error" role="alert">
 		<?php esc_html_e( 'Ticket sales are temporarily unavailable. Please check back later.', 'fair-events' ); ?>
 	</div>
+<?php elseif ( $suppress_form ) : ?>
+	<div class="fair-events-get-tickets-companion" data-event-date-id="<?php echo esc_attr( $event_date_id ); ?>">
+		<?php
+		/**
+		 * Fires in place of the suppressed signup <form>. fair-audience uses
+		 * this to render the signed-up/cancel card for a recognised viewer
+		 * who already holds this signup.
+		 *
+		 * @param array $context Render context, see fair_events_signup_render_context.
+		 */
+		do_action( 'fair_events_signup_render_before_form', $context );
+		?>
+		<?php
+		/**
+		 * Fires in place of the suppressed signup <form>, after the
+		 * before-form slot. fair-audience uses this for the add-activities
+		 * section.
+		 *
+		 * @param array $context Render context, see fair_events_signup_render_context.
+		 */
+		do_action( 'fair_events_signup_render_after_form', $context );
+		?>
+	</div>
 <?php else : ?>
 	<form
 		id="<?php echo esc_attr( $form_id ); ?>"
 		class="fair-events-get-tickets-form"
 		data-currency="<?php echo esc_attr( \FairEventsShared\Money::site_currency() ); ?>"
 		data-event-date-id="<?php echo esc_attr( $event_date_id ); ?>"
-		data-fair-audience-active="<?php echo esc_attr( class_exists( \FairAudience\API\EventSignupController::class ) ? '1' : '0' ); ?>"
 		data-min-activities="<?php echo esc_attr( (string) $minimum_activities ); ?>"
 	>
 		<?php
@@ -681,6 +701,9 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 							$occ_row['end_datetime'],
 							$occ_row['all_day']
 						);
+						if ( ! empty( $occ_row['signed_up'] ) ) {
+							$occ_label .= ' — ' . __( 'already signed up', 'fair-events' );
+						}
 						?>
 						<option value="<?php echo (int) $occ_row['id']; ?>" <?php echo $occ_index === $default_occurrence_index ? 'selected' : ''; ?>>
 							<?php echo esc_html( $occ_label ); ?>
@@ -695,11 +718,15 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 				<span class="form-label"><?php esc_html_e( 'Choose occurrences', 'fair-events' ); ?></span>
 				<?php foreach ( $occurrences_for_picker as $occ_row ) : ?>
 					<?php
-					$occ_label   = \FairEvents\Helpers\DateRangeFormatter::format(
+					$occ_label     = \FairEvents\Helpers\DateRangeFormatter::format(
 						$occ_row['start_datetime'],
 						$occ_row['end_datetime'],
 						$occ_row['all_day']
 					);
+					$occ_signed_up = ! empty( $occ_row['signed_up'] );
+					if ( $occ_signed_up ) {
+						$occ_label .= ' — ' . __( 'already signed up', 'fair-events' );
+					}
 					$checkbox_id = $form_id . '-inst-' . (int) $occ_row['id'];
 					?>
 					<label class="fair-events-instance-option" for="<?php echo esc_attr( $checkbox_id ); ?>">
@@ -709,6 +736,7 @@ $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 							id="<?php echo esc_attr( $checkbox_id ); ?>"
 							value="<?php echo (int) $occ_row['id']; ?>"
 							class="form-checkbox"
+							<?php echo $occ_signed_up ? 'disabled' : ''; ?>
 						/>
 						<?php echo esc_html( $occ_label ); ?>
 					</label>


### PR DESCRIPTION
## Summary

- `fair-events/event-signup` no longer delegates its render to fair-audience's legacy block when fair-audience is active (`fair-events/src/blocks/event-signup/render.php`) — it always renders its own markup, and `GetTicketsController` is now registered unconditionally (`fair-events/src/Core/Plugin.php`). fair-audience's `SignupHookBridge` enriches the same render via the existing filter/render-slot contract instead of owning a competing template.
- New seams on the base render/route: `suppress_form` context key (+ `fair-events-get-tickets-companion` wrapper) so a companion can replace the form entirely; per-occurrence `signed_up` flags on `occurrences_for_picker`; `fair_events_signup_precheck_error` filter for a pre-write reject.
- `SignupHookBridge` grows a signed-up/cancel card (with a "Cancel signup" button wired to the existing `DELETE /fair-audience/v1/event-signup` route), a "Not you? Start fresh" button, per-occurrence/whole-series-pass signed-up detection, and a duplicate-ticket-purchase guard (409 `already_signed_up`) scoped to resubmitting a *ticket* for a date already held — free/companion/activity-only signups keep their existing many-per-participant-per-event behavior.
- Rate limiting on `fair-events/v1/get-tickets`: per-IP ceiling raised 3→20/hour, new 3/hour per-email ceiling.
- E2E: `seed-event.php`'s default signup block flips from the legacy `fair-audience/event-signup` to the unified `fair-events/event-signup` (matching what a real site renders post-cutover); 8 legacy-selector specs ported (3 selector-swapped, 1 flavour-swapped, 2 rewritten with real positive-path coverage instead of a negative-only guard, 2 deliberately kept on the legacy block via a new `{block:'legacy'}` override, since they cover functionality — `participant_token` URL login / resume-by-email — explicitly deferred to a follow-up); the `wp plugin deactivate fair-audience` dance dropped from two more specs now that the base route works with fair-audience active; the screenshot spec re-pointed at the unified markup for all three plugin-combo screenshots.
- 22 previously-dead-coverage fair-events API tests un-skipped (the harness always runs fair-audience active, so these never ran before).

## Decisions carried over from the plan comment

1. No kill switch — straight removal; rollback is a revert.
2. Parity ported: duplicate-ticket guard, cancel/signed-up card, per-occurrence signup status, whole-series passes.
3. Deferred to a follow-up: `participant_token` URL login and the "I have an account"/request-link tab — both keep working on their existing `fair-audience/v1` routes; two e2e specs (`resume-signup-recognised-email`, `signup-cancel-and-restart`) stay on the legacy block for this reason via the new `{block:'legacy'}` seed override.
4. Sliding scale: nothing to do (already removed from the codebase, per `ab61aba8`).
5. Form suppression via a `suppress_form` boolean + existing slot actions, not an HTML-carrying context key.
6. Rate limiting: 20/hour IP + 3/hour email.
7. E2E: ported in place; `get-tickets-purchase.spec.js` is the one suite kept on the fair-audience-absent configuration.

**One scope adjustment made during implementation** (flagged mid-work): the plan's `fair_events_signup_precheck_error` guard as literally specified ("a genuine repeat is still rejected") would have rejected *any* resubmit once `signed_up`, including free/no-ticket-type repeats — but the base route's own `EventSignupHookBridge.api.spec.js` already has a passing regression test asserting the opposite (two signups, same email/date, no ticket type, both succeed — the documented "many signups per participant/event date" architecture in `REST_API_BACKEND.md`). Scoped the guard to fire only when the submission carries a `ticket_type_id` and the held relationship also has one — closing the actual double-charge risk without touching the documented multiplicity model.

## Acceptance criteria

- [x] `render.php` never delegates to the legacy block — deleted the `class_exists` branch entirely.
- [x] `GetTicketsController` registers unconditionally.
- [x] A recognised viewer who already holds a ticket for the date sees a signed-up/cancel card, not a plain re-signup form.
- [x] Cancel-signup wires to the existing `DELETE /fair-audience/v1/event-signup` route (no new route), authenticated via a server-generated `participant_token` (the route doesn't accept the session cookie).
- [x] Per-occurrence pickers (dropdown + checkbox) label/disable dates the viewer already holds, including via a whole-series pass.
- [x] A resubmitted paid-ticket purchase for a date already held is rejected (409), not silently duplicated — verified live against the actual guard logic (see Testing).
- [x] Rate limiting: 20/hour IP, 3/hour email — verified live.
- [x] Sites without fair-audience: no behavior change (base render/route were already unconditional-safe; existing `get-tickets-*` specs cover this, two of them no longer need to toggle fair-audience since it no longer matters).
- [x] Legacy block, its routes, and old signup links keep working (still registered, hidden from inserter, untouched).
- [ ] `participant_token` URL login / resume-by-email — explicitly deferred to a follow-up per the plan's Decision 3.

## Testing

Ran directly against a live WordPress instance (`docker compose`, both plugins active) rather than only reading code:

- `fair-audience/src/API/__tests__/EventSignupHookBridge.api.spec.js` — all 5 tests green, including the two new ones (duplicate-ticket guard, per-email rate limit). Found and fixed 3 pre-existing bugs in this file blocking it from ever running green (missing required `title` param, `event_id` silently not wired through on create — needs a follow-up PUT, same quirk `CalendarFeedController.api.spec.js` already documents — and a wrong REST path for `event-participants`).
- The 22 newly-un-skipped fair-events API tests: re-verified live. Found and fixed the same `title`/`event_id` pre-existing bugs in 5 of the 7 files (same root cause, previously masked because these tests never ran). Confirmed the remaining failures (paid-ticket-type purchases) are blocked by this dev environment having no payment connector configured — pre-existing and unrelated to this change, not something introduced here.
- `fair-events`: `npm run build`, `npm run format`, `npm run test:js` (176/176), full `test:api` suite (54 passed; failures are the pre-existing payment-connector gap above, in files this change doesn't touch).
- `fair-audience`: `npm run format`, `npm run test:js` (27/27), `vendor/bin/phpunit` (61/61, including the updated hook-registration reflection test).
- `vendor/bin/phpcs` clean on every changed PHP file (three pre-existing short-ternary errors and one pre-existing unused-parameter warning remain, confirmed via `git diff` to predate this branch).

**Not run**: the ported/rewritten e2e specs themselves (Playwright against `wp-env`, a separate instance from the docker stack above) — spinning up a fresh `wp-env` was out of scope for this session's time budget. Every selector/class/field-name change was grounded by reading the actual `render.php`/`frontend.js` output rather than guessed, and the equivalent server-side behavior for each spec is covered by the API-level testing above. Flagging this so a reviewer can decide whether to run `npm run test:e2e` before merging.

## Notes for the reviewer

- This local docker environment needed a permalink/`.htaccess` fix and a Basic-Auth shim mu-plugin to make its REST API reachable at all, and had fair-audience inactive and no payment connector configured — pre-existing environment gaps unrelated to this change, fixed only to the extent needed to verify (container-local, not part of this diff).
- Follow-ups explicitly out of scope here (per the plan): retire the legacy block/routes/dead CSS, port `participant_token` URL login + request-link to the unified form, and #1308 (wire `test:api` into CI — 22 more specs are now live coverage only checked locally until then).
