### PR TITLE
Allow question fields in the unified Event Signup block's Form content

### DIFF
--- a/.changeset/form-content-question-fields-insertable.md
+++ b/.changeset/form-content-question-fields-insertable.md
@@ -1,0 +1,5 @@
+---
+"fair-form": patch
+---
+
+Fix question fields (short text, phone, consent, conditional section, etc.) not being insertable into the Event Signup block's Form content area.

--- a/e2e/user-flows/event-signup-editor-form-content.spec.js
+++ b/e2e/user-flows/event-signup-editor-form-content.spec.js
@@ -73,4 +73,51 @@ test.describe('Event Signup block "Form content" area in the editor', () => {
 		await paragraph.type('Extra instructions');
 		await expect(paragraph).toHaveText('Extra instructions');
 	});
+
+	test('question fields can be found and inserted from the appender (#1347)', async ({
+		page,
+		seedEvent,
+	}) => {
+		// A bare unified block — no pre-existing question — to prove insertion
+		// itself works, not just rendering of already-nested questions.
+		const event = seedEvent('free');
+
+		await loginAsAdmin(page);
+		await page.goto(`/wp-admin/post.php?post=${event.eventId}&action=edit`);
+
+		const editorFrame = page.frameLocator('[name="editor-canvas"]');
+		await editorFrame.locator('.block-editor-iframe__body').waitFor();
+
+		const welcomeGuide = page.locator('.components-guide');
+		if (await welcomeGuide.isVisible().catch(() => false)) {
+			await page.getByRole('button', { name: 'Close' }).first().click();
+		}
+
+		const signupBlock = editorFrame.locator(
+			'.wp-block-fair-events-event-signup'
+		);
+		await signupBlock.waitFor();
+
+		const questionsArea = signupBlock.locator(
+			'.fair-events-event-signup-questions'
+		);
+		const appender = questionsArea.locator('.block-list-appender button');
+		await appender.click();
+
+		await page.fill(
+			'.block-editor-inserter__search input',
+			'Conditional Section'
+		);
+		await page.click(
+			'.block-editor-block-types-list__item:has-text("Conditional Section")'
+		);
+
+		// The inserted question block lands inside the Form content area, not
+		// somewhere else in the block tree, and remains selectable/configurable.
+		const question = questionsArea.locator(
+			'.wp-block-fair-audience-fair-form-conditional'
+		);
+		await question.waitFor();
+		await expect(question).toHaveClass(/is-selected/);
+	});
 });

--- a/fair-form/src/blocks/fair-form-conditional/block.json
+++ b/fair-form/src/blocks/fair-form-conditional/block.json
@@ -9,7 +9,11 @@
 	"description": "Show or hide a group of fields based on an answer to a previous question",
 	"keywords": ["conditional", "show", "hide", "section", "logic"],
 	"textdomain": "fair-audience",
-	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
+	"ancestor": [
+		"fair-audience/fair-form",
+		"fair-audience/event-signup",
+		"fair-events/event-signup"
+	],
 	"supports": {
 		"html": false
 	},

--- a/fair-form/src/blocks/fair-form-consent/block.json
+++ b/fair-form/src/blocks/fair-form-consent/block.json
@@ -9,7 +9,11 @@
 	"description": "A single consent checkbox question for Fair Form (e.g. terms and conditions)",
 	"keywords": ["question", "checkbox", "consent", "terms"],
 	"textdomain": "fair-audience",
-	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
+	"ancestor": [
+		"fair-audience/fair-form",
+		"fair-audience/event-signup",
+		"fair-events/event-signup"
+	],
 	"supports": {
 		"html": false
 	},

--- a/fair-form/src/blocks/fair-form-long-text/block.json
+++ b/fair-form/src/blocks/fair-form-long-text/block.json
@@ -9,7 +9,11 @@
 	"description": "A long text (textarea) question for Fair Form",
 	"keywords": ["question", "textarea", "long text"],
 	"textdomain": "fair-audience",
-	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
+	"ancestor": [
+		"fair-audience/fair-form",
+		"fair-audience/event-signup",
+		"fair-events/event-signup"
+	],
 	"supports": {
 		"html": false
 	},

--- a/fair-form/src/blocks/fair-form-multiselect/block.json
+++ b/fair-form/src/blocks/fair-form-multiselect/block.json
@@ -9,7 +9,11 @@
 	"description": "A multiple-choice checkbox question for Fair Form",
 	"keywords": ["question", "checkbox", "multiselect", "multiple"],
 	"textdomain": "fair-audience",
-	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
+	"ancestor": [
+		"fair-audience/fair-form",
+		"fair-audience/event-signup",
+		"fair-events/event-signup"
+	],
 	"supports": {
 		"html": false
 	},

--- a/fair-form/src/blocks/fair-form-phone/block.json
+++ b/fair-form/src/blocks/fair-form-phone/block.json
@@ -9,7 +9,11 @@
 	"description": "A phone number input question with enforced country code for Fair Form",
 	"keywords": ["question", "phone", "tel"],
 	"textdomain": "fair-audience",
-	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
+	"ancestor": [
+		"fair-audience/fair-form",
+		"fair-audience/event-signup",
+		"fair-events/event-signup"
+	],
 	"supports": {
 		"html": false
 	},

--- a/fair-form/src/blocks/fair-form-radio/block.json
+++ b/fair-form/src/blocks/fair-form-radio/block.json
@@ -9,7 +9,11 @@
 	"description": "A single-choice radio button question for Fair Form",
 	"keywords": ["question", "radio", "choice", "button"],
 	"textdomain": "fair-audience",
-	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
+	"ancestor": [
+		"fair-audience/fair-form",
+		"fair-audience/event-signup",
+		"fair-events/event-signup"
+	],
 	"supports": {
 		"html": false
 	},

--- a/fair-form/src/blocks/fair-form-select-one/block.json
+++ b/fair-form/src/blocks/fair-form-select-one/block.json
@@ -9,7 +9,11 @@
 	"description": "A single-choice question (select or radio) for Fair Form",
 	"keywords": ["question", "select", "radio", "choice"],
 	"textdomain": "fair-audience",
-	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
+	"ancestor": [
+		"fair-audience/fair-form",
+		"fair-audience/event-signup",
+		"fair-events/event-signup"
+	],
 	"supports": {
 		"html": false
 	},

--- a/fair-form/src/blocks/fair-form-short-text/block.json
+++ b/fair-form/src/blocks/fair-form-short-text/block.json
@@ -9,7 +9,11 @@
 	"description": "A short text input question for Fair Form",
 	"keywords": ["question", "text", "input"],
 	"textdomain": "fair-audience",
-	"ancestor": ["fair-audience/fair-form", "fair-audience/event-signup"],
+	"ancestor": [
+		"fair-audience/fair-form",
+		"fair-audience/event-signup",
+		"fair-events/event-signup"
+	],
 	"supports": {
 		"html": false
 	},


### PR DESCRIPTION
## Summary

Implements the approved plan from [#1347 comment](https://github.com/marcin-wosinek/fair-event-plugins/issues/1347#issuecomment-5152307320).

Question field blocks (short text, phone, consent, conditional section, etc.) each restrict where they can be inserted via `block.json`'s `ancestor` field, listing only the legacy `fair-audience/fair-form` and `fair-audience/event-signup` containers — never `fair-events/event-signup`, the unified block's actual name. WordPress enforces `ancestor` at the inserter level independently of `allowedBlocks`, so even though the unified block's `editor.js` already lists the right block names in `FAIR_FORM_ALLOWED_BLOCKS`, the inserter filtered every one of them out. Editors building a new signup form from scratch had no way to add a question field.

Fix: add `"fair-events/event-signup"` to the `ancestor` array of each of the 8 affected `fair-form` block.json files (`fair-form-short-text`, `fair-form-long-text`, `fair-form-phone`, `fair-form-select-one`, `fair-form-radio`, `fair-form-multiselect`, `fair-form-consent`, `fair-form-conditional`). No JS changes needed. Adding Email and Mailing-signup to the unified block's allowed set is deferred to a follow-up ticket, per the plan's decision.

Refs #1347

## Acceptance criteria coverage

- **Insertable via inserter (incl. conditional)** — met: `ancestor` fix on all 8 blocks; new e2e test opens the Form content inserter on a bare unified block, searches "Conditional Section", and confirms it lands inside `.fair-events-event-signup-questions` and is selected.
- **Configurable once inserted** — met: no new code needed, existing editor behavior handles this; verified in the new e2e test (block is selected/configurable after insertion).
- **Works with fair-audience active/inactive** — met: `ancestor` only depends on `fair-form`'s own registration (gated by the existing `isFairFormActive` check), not on fair-audience's activation state.
- **Pre-existing nested questions keep rendering/selectable** — met, no regression: `ancestor` only gates the inserter, not rendering of already-serialized content. Verified by re-running the existing test in the same spec file (pre-existing nested question stays selectable) — still passes.
- **Live preview stays non-interactive (#1344 non-regression)** — met: no changes near that code path; existing assertion in the same spec still passes.

## Test plan

- [x] `npm run build` in `fair-form` — built `block.json` output confirmed to carry the new `ancestor` entry.
- [x] `npm run format` (via commit hook) — clean, no formatting noise staged.
- [x] No PHP changed — phpcs not applicable.
- [x] `npm run test:js` in `fair-events` (176 tests) and `fair-form` (9 tests) — all pass.
- [x] `npm run test:e2e` against `e2e/user-flows/event-signup-editor-form-content.spec.js` on a live wp-env instance (`:8889`) — both the pre-existing test and the new regression test pass.
- [x] Changeset added (`fair-form`, patch).
