### PR TITLE
Add ticket-type condition source to Conditional Section

### DIFF
--- a/.changeset/conditional-ticket-type-source.md
+++ b/.changeset/conditional-ticket-type-source.md
@@ -1,0 +1,8 @@
+---
+"fair-form": minor
+"fair-events-shared": minor
+"fair-events": patch
+"fair-audience": patch
+---
+
+The Conditional Section block, when nested inside a signup form, can now show or hide its contents based on the visitor's selected ticket type (in addition to the existing question and event-option sources) — pick one or more ticket types and an "is selected" / "is not selected" operator, and the section reacts live as the visitor changes their selection. Also fixes the Conditional Section's "Event option" condition source, which failed to appear when nested inside the unified Event Signup block (it only recognized the older, hidden legacy block).

--- a/e2e/mu-plugins/scripts/seed-conditional-ticket-type.php
+++ b/e2e/mu-plugins/scripts/seed-conditional-ticket-type.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Seed a published free event whose Event Signup nests a Conditional Section
+ * keyed on the selected ticket type (issue #1349).
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-conditional-ticket-type.php
+ *
+ * Creates a fair_event post with two ticket types (Adult, Child). The
+ * event-signup block nests a fair-form-conditional (conditionSource=ticketType,
+ * referencing the Adult ticket type ID) that wraps a short-text question. The
+ * ticket types don't exist until after the event date is created, so the post
+ * content is built in a second pass, once their IDs are known. Prints a single
+ * `E2E_SEED:{json}` line the spec parses.
+ *
+ * @package FairEventsE2E
+ */
+
+use FairEvents\Models\EventDates;
+use FairEvents\Models\TicketSalePeriod;
+use FairEvents\Models\TicketType;
+use FairEvents\Models\TicketPrice;
+
+$event_id = wp_insert_post(
+	array(
+		'post_type'    => 'fair_event',
+		'post_status'  => 'publish',
+		'post_title'   => 'E2E Conditional Ticket Type ' . gmdate( 'YmdHis' ),
+		'post_content' => '',
+	),
+	true
+);
+
+if ( is_wp_error( $event_id ) ) {
+	WP_CLI::error( 'Failed to create event: ' . $event_id->get_error_message() );
+}
+
+$event_date_id = EventDates::save_occurrence(
+	$event_id,
+	gmdate( 'Y-m-d H:i:s', strtotime( '+7 days' ) ),
+	gmdate( 'Y-m-d H:i:s', strtotime( '+7 days +2 hours' ) ),
+	false,
+	'single'
+);
+
+if ( ! $event_date_id ) {
+	WP_CLI::error( 'Failed to create event date.' );
+}
+
+$sale_period_id = TicketSalePeriod::create(
+	$event_date_id,
+	'Standard',
+	gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) ),
+	gmdate( 'Y-m-d H:i:s', strtotime( '+30 days' ) ),
+	0
+);
+
+if ( ! $sale_period_id ) {
+	WP_CLI::error( 'Failed to create sale period.' );
+}
+
+$adult_type_id = TicketType::create( $event_date_id, 'Adult', null, 0 );
+$child_type_id = TicketType::create( $event_date_id, 'Child', null, 1 );
+
+if ( ! $adult_type_id || ! $child_type_id ) {
+	WP_CLI::error( 'Failed to create ticket types.' );
+}
+
+if ( ! TicketPrice::create( $adult_type_id, $sale_period_id, 0.0, null ) ) {
+	WP_CLI::error( 'Failed to create Adult ticket price.' );
+}
+
+if ( ! TicketPrice::create( $child_type_id, $sale_period_id, 0.0, null ) ) {
+	WP_CLI::error( 'Failed to create Child ticket price.' );
+}
+
+// The conditional reveals the "guardian" question only when the Adult
+// ticket type is selected.
+$content = implode(
+	"\n",
+	array(
+		'<!-- wp:fair-events/event-signup -->',
+		'<!-- wp:fair-audience/fair-form-conditional {"conditionSource":"ticketType","conditionTicketTypeIds":[' . $adult_type_id . '],"conditionOperator":"selected"} -->',
+		'<!-- wp:fair-audience/fair-form-short-text {"questionKey":"guardian","questionText":"Guardian contact"} /-->',
+		'<!-- /wp:fair-audience/fair-form-conditional -->',
+		'<!-- /wp:fair-events/event-signup -->',
+	)
+);
+
+$updated = wp_update_post(
+	array(
+		'ID'           => $event_id,
+		'post_content' => $content,
+	),
+	true
+);
+
+if ( is_wp_error( $updated ) ) {
+	WP_CLI::error( 'Failed to update event content: ' . $updated->get_error_message() );
+}
+
+echo 'E2E_SEED:' . wp_json_encode(
+	array(
+		'pageUrl'     => get_permalink( $event_id ),
+		'eventId'     => (int) $event_id,
+		'eventDateId' => (int) $event_date_id,
+		'adultTypeId' => (int) $adult_type_id,
+		'childTypeId' => (int) $child_type_id,
+	)
+) . "\n";

--- a/e2e/user-flows/conditional-ticket-type-fields.spec.js
+++ b/e2e/user-flows/conditional-ticket-type-fields.spec.js
@@ -1,0 +1,58 @@
+/**
+ * E2E: conditional signup fields keyed on the selected ticket type (#1349).
+ *
+ * Loads a public event whose Event Signup nests a Conditional Section
+ * (conditionSource=ticketType, referencing the Adult ticket type) wrapping a
+ * "Guardian contact" question. Asserts the real frontend show/hide logic in
+ * shared/questionnaire.js: the question is hidden until the Adult ticket
+ * type radio is selected, and hides again when a different type is picked.
+ *
+ * Everything here is production code — the block render callbacks emit the
+ * ticket_type_id radios / data-condition-* attributes and the bundled
+ * frontend.js evaluates them. See e2e/README.md for the harness mechanics.
+ */
+
+import { test, expect } from '@playwright/test';
+import { runScript } from '../support/wp-cli.js';
+
+let event;
+
+test.beforeAll(() => {
+	event = runScript('seed-conditional-ticket-type.php', 'E2E_SEED');
+});
+
+test.describe('conditional signup fields by ticket type', () => {
+	test('reveals the question only while the referenced ticket type is selected', async ({
+		page,
+	}) => {
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		const adultRadio = form.locator(
+			`input[name="ticket_type_id"][value="${event.adultTypeId}"]`
+		);
+		const childRadio = form.locator(
+			`input[name="ticket_type_id"][value="${event.childTypeId}"]`
+		);
+		await expect(adultRadio).toHaveCount(1);
+		await expect(childRadio).toHaveCount(1);
+
+		// The conditional wraps the "guardian" question; it is display:none
+		// until the Adult ticket type is selected.
+		const guardianQuestion = form.locator('[data-question-key="guardian"]');
+
+		// Selecting the Child type keeps it hidden.
+		await childRadio.check();
+		await expect(guardianQuestion).toBeHidden();
+
+		// Selecting the Adult type reveals it.
+		await adultRadio.check();
+		await expect(guardianQuestion).toBeVisible();
+
+		// Switching back to Child hides it again.
+		await childRadio.check();
+		await expect(guardianQuestion).toBeHidden();
+	});
+});

--- a/fair-events-shared/src/__tests__/questionnaire.test.js
+++ b/fair-events-shared/src/__tests__/questionnaire.test.js
@@ -199,6 +199,134 @@ describe('evaluateConditionals — eventOption source', () => {
 	});
 });
 
+/**
+ * Build a ticket type radio as the Event Signup render.php emits it.
+ *
+ * @param {Object}  opts         Radio config.
+ * @param {number}  opts.id      Ticket type ID (radio value).
+ * @param {boolean} opts.checked Whether it starts checked.
+ * @return {string} The input markup.
+ */
+function ticketTypeRadio({ id, checked }) {
+	return `<input type="radio" name="ticket_type_id" value="${id}"${
+		checked ? ' checked' : ''
+	} />`;
+}
+
+/**
+ * Build a conditional section keyed on the selected ticket type.
+ *
+ * @param {Object} opts           Section config.
+ * @param {Array}  opts.ids       conditionTicketTypeIds (as a JS array, JSON-encoded here).
+ * @param {string} opts.operator  selected | not_selected.
+ * @param {string} opts.inner     Inner HTML.
+ * @return {string} The section markup.
+ */
+function ticketTypeSection({ ids = [], operator = 'selected', inner = '' }) {
+	return `<div data-fair-form-conditional data-condition-source="ticketType" data-condition-operator="${operator}" data-condition-ticket-type-ids='${JSON.stringify(
+		ids
+	)}'>${inner}</div>`;
+}
+
+describe('evaluateConditionals — ticketType source', () => {
+	it('shows the section when the matching ticket type is selected', () => {
+		const form = buildForm(
+			ticketTypeRadio({ id: 1, checked: true }) +
+				ticketTypeRadio({ id: 2, checked: false }) +
+				ticketTypeSection({ ids: [1], operator: 'selected' })
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(true);
+	});
+
+	it('hides the section when a different ticket type is selected', () => {
+		const form = buildForm(
+			ticketTypeRadio({ id: 1, checked: false }) +
+				ticketTypeRadio({ id: 2, checked: true }) +
+				ticketTypeSection({ ids: [1], operator: 'selected' })
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(false);
+	});
+
+	it('inverts visibility for the not_selected operator', () => {
+		const form = buildForm(
+			ticketTypeRadio({ id: 1, checked: false }) +
+				ticketTypeRadio({ id: 2, checked: true }) +
+				ticketTypeSection({ ids: [1], operator: 'not_selected' })
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(true);
+	});
+
+	it('OR-matches when multiple ticket type IDs are referenced', () => {
+		const form = buildForm(
+			ticketTypeRadio({ id: 1, checked: false }) +
+				ticketTypeRadio({ id: 2, checked: true }) +
+				ticketTypeSection({ ids: [1, 2], operator: 'selected' })
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(true);
+	});
+
+	it('hides the section when no ticket types are referenced', () => {
+		const form = buildForm(
+			ticketTypeRadio({ id: 1, checked: true }) +
+				ticketTypeSection({ ids: [], operator: 'selected' })
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(false);
+	});
+
+	it('hides the section when no ticket type is selected at all', () => {
+		const form = buildForm(
+			ticketTypeRadio({ id: 1, checked: false }) +
+				ticketTypeSection({ ids: [1], operator: 'selected' })
+		);
+		const section = form.querySelector('[data-fair-form-conditional]');
+		expect(section.classList.contains(VISIBLE)).toBe(false);
+	});
+
+	it('keeps an inner section hidden when its parent conditional is hidden, even if its ticket type is selected', () => {
+		const form = buildForm(
+			ticketTypeRadio({ id: 1, checked: false }) +
+				ticketTypeRadio({ id: 2, checked: true }) +
+				ticketTypeSection({
+					ids: [1],
+					operator: 'selected',
+					inner: ticketTypeSection({
+						ids: [2],
+						operator: 'selected',
+					}),
+				})
+		);
+		const [outer, inner] = form.querySelectorAll(
+			'[data-fair-form-conditional]'
+		);
+		expect(outer.classList.contains(VISIBLE)).toBe(false);
+		expect(inner.classList.contains(VISIBLE)).toBe(false);
+	});
+
+	it('shows a nested section when both its ticket type and its ancestor are visible', () => {
+		const form = buildForm(
+			ticketTypeRadio({ id: 1, checked: true }) +
+				ticketTypeSection({
+					ids: [1],
+					operator: 'selected',
+					inner: ticketTypeSection({
+						ids: [1],
+						operator: 'selected',
+					}),
+				})
+		);
+		const [outer, inner] = form.querySelectorAll(
+			'[data-fair-form-conditional]'
+		);
+		expect(outer.classList.contains(VISIBLE)).toBe(true);
+		expect(inner.classList.contains(VISIBLE)).toBe(true);
+	});
+});
+
 describe('evaluateConditionals — question source (regression)', () => {
 	it('still shows a question-keyed section when its answer matches', () => {
 		const form = buildForm(

--- a/fair-events-shared/src/questionnaire.js
+++ b/fair-events-shared/src/questionnaire.js
@@ -137,9 +137,50 @@ function evaluateEventOptionCondition(form, section) {
 }
 
 /**
+ * Whether a ticket type (identified by ID) is the one currently selected via
+ * the `ticket_type_id` radio group.
+ *
+ * @param {HTMLElement} form         The form (or container) element.
+ * @param {number}      ticketTypeId The ticket type's ID.
+ * @return {boolean} Whether that ticket type is currently selected.
+ */
+function isTicketTypeSelected(form, ticketTypeId) {
+	const checked = form.querySelector('input[name="ticket_type_id"]:checked');
+	return !!checked && String(checked.value) === String(ticketTypeId);
+}
+
+/**
+ * Resolve whether a conditional section keyed on the selected ticket type
+ * should show, honoring the selected/not_selected operator and an empty
+ * reference list.
+ *
+ * @param {HTMLElement} form    The form (or container) element.
+ * @param {HTMLElement} section The conditional section element.
+ * @return {boolean} Whether the section's own condition is met.
+ */
+function evaluateTicketTypeCondition(form, section) {
+	let ticketTypeIds = [];
+	try {
+		ticketTypeIds = JSON.parse(
+			section.dataset.conditionTicketTypeIds || '[]'
+		);
+	} catch (e) {
+		ticketTypeIds = [];
+	}
+	if (!Array.isArray(ticketTypeIds) || ticketTypeIds.length === 0) {
+		return false;
+	}
+	const selected = ticketTypeIds.some((id) => isTicketTypeSelected(form, id));
+	return section.dataset.conditionOperator === 'not_selected'
+		? !selected
+		: selected;
+}
+
+/**
  * Show/hide conditional sections based on their controlling question's value
- * (the default "question" source) or whether an event option is selected (the
- * "eventOption" source).
+ * (the default "question" source), whether an event option is selected (the
+ * "eventOption" source), or whether a specific ticket type is selected (the
+ * "ticketType" source).
  *
  * @param {HTMLElement} form The form (or container) element.
  */
@@ -152,6 +193,16 @@ export function evaluateConditionals(form) {
 			const visible =
 				isQuestionVisible(section.parentElement) &&
 				evaluateEventOptionCondition(form, section);
+			section.classList.toggle('fair-form-conditional-visible', visible);
+			return;
+		}
+
+		if (section.dataset.conditionSource === 'ticketType') {
+			// A section nested inside a hidden conditional stays hidden
+			// regardless of its own condition.
+			const visible =
+				isQuestionVisible(section.parentElement) &&
+				evaluateTicketTypeCondition(form, section);
 			section.classList.toggle('fair-form-conditional-visible', visible);
 			return;
 		}

--- a/fair-form/src/blocks/fair-form-conditional/__tests__/editor.test.jsx
+++ b/fair-form/src/blocks/fair-form-conditional/__tests__/editor.test.jsx
@@ -1,0 +1,258 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const mockUseSelect = jest.fn();
+jest.mock('@wordpress/data', () => ({
+	useSelect: (...args) => mockUseSelect(...args),
+}));
+
+jest.mock('@wordpress/api-fetch', () => jest.fn());
+// eslint-disable-next-line import/first
+import apiFetch from '@wordpress/api-fetch';
+
+jest.mock('@wordpress/block-editor', () => ({
+	useBlockProps: (props) => props || {},
+	useInnerBlocksProps: (props) => props || {},
+	InspectorControls: ({ children }) => children,
+	InnerBlocks: Object.assign(() => null, {
+		Content: () => null,
+		ButtonBlockAppender: () => null,
+	}),
+}));
+
+jest.mock('@wordpress/components', () => ({
+	PanelBody: ({ children }) => children,
+	SelectControl: ({ label, value, options, onChange }) => (
+		<label>
+			{label}
+			<select value={value} onChange={(e) => onChange(e.target.value)}>
+				{options.map((opt) => (
+					<option key={opt.value} value={opt.value}>
+						{opt.label}
+					</option>
+				))}
+			</select>
+		</label>
+	),
+	TextControl: ({ label, value, onChange }) => (
+		<label>
+			{label}
+			<input value={value} onChange={(e) => onChange(e.target.value)} />
+		</label>
+	),
+	CheckboxControl: ({ label, checked, onChange }) => (
+		<label>
+			<input
+				type="checkbox"
+				checked={checked}
+				onChange={(e) => onChange(e.target.checked)}
+			/>
+			{label}
+		</label>
+	),
+	Notice: ({ children }) => <div role="alert">{children}</div>,
+}));
+
+let capturedSettings;
+jest.mock('@wordpress/blocks', () => ({
+	registerBlockType: (name, settings) => {
+		capturedSettings = settings;
+	},
+}));
+
+/**
+ * Wire up mockUseSelect so the real formParentId-resolution logic in
+ * editor.js runs against a small fake block tree: a Conditional Section
+ * (clientId) nested one level inside a form-like block.
+ *
+ * @param {Object|null} formBlock Fake parent block ({ name, attributes }), or
+ *                                null for a standalone Conditional Section.
+ */
+function mockFormParent(formBlock) {
+	mockUseSelect.mockImplementation((callback) =>
+		callback((store) => {
+			if (store !== 'core/block-editor') {
+				return {};
+			}
+			return {
+				getBlockParents: () => (formBlock ? ['form-1'] : []),
+				getBlock: (id) => (id === 'form-1' ? formBlock : undefined),
+				getBlocks: () => [],
+			};
+		})
+	);
+}
+
+describe('Fair Form Conditional Edit', () => {
+	let Edit;
+
+	beforeAll(() => {
+		require('../editor.js');
+		Edit = capturedSettings.edit;
+	});
+
+	beforeEach(() => {
+		apiFetch.mockReset();
+	});
+
+	afterEach(() => {
+		delete window.fairEventsSignupBlock;
+	});
+
+	const baseAttributes = {
+		conditionSource: 'question',
+		conditionQuestionKey: '',
+		conditionOperator: 'equals',
+		conditionValue: '',
+		conditionOptionShortName: '',
+		conditionTicketTypeIds: [],
+	};
+
+	const renderEdit = (attributes = {}, setAttributes = () => {}) =>
+		render(
+			<Edit
+				attributes={{ ...baseAttributes, ...attributes }}
+				setAttributes={setAttributes}
+				clientId="conditional-1"
+			/>
+		);
+
+	it('offers "Ticket type" as a condition source when nested in an Event Signup connected via the block attribute', async () => {
+		mockFormParent({
+			name: 'fair-events/event-signup',
+			attributes: { eventDateId: 42 },
+		});
+		apiFetch.mockResolvedValue({ ticket_types: [] });
+		renderEdit();
+
+		const select = screen.getByLabelText('Condition source');
+		expect(
+			Array.from(select.querySelectorAll('option')).map((o) => o.value)
+		).toEqual(['question', 'eventOption', 'ticketType']);
+
+		await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+	});
+
+	it('offers "Ticket type" resolving the event date from the post context global (the common case, since the block attribute itself is normally 0)', async () => {
+		window.fairEventsSignupBlock = { postEventDateId: 42 };
+		mockFormParent({
+			name: 'fair-events/event-signup',
+			attributes: { eventDateId: 0 },
+		});
+		apiFetch.mockResolvedValue({ ticket_types: [] });
+		renderEdit();
+
+		const select = screen.getByLabelText('Condition source');
+		expect(
+			Array.from(select.querySelectorAll('option')).map((o) => o.value)
+		).toEqual(['question', 'eventOption', 'ticketType']);
+
+		await waitFor(() =>
+			expect(apiFetch).toHaveBeenCalledWith({
+				path: '/fair-events/v1/event-dates/42/tickets',
+			})
+		);
+	});
+
+	it('does not offer "Ticket type" when standalone (not inside a signup form)', () => {
+		mockFormParent(null);
+		renderEdit();
+
+		expect(
+			screen.queryByLabelText('Condition source')
+		).not.toBeInTheDocument();
+	});
+
+	it('does not offer "Ticket type" when inside an unconnected Event Signup (no attribute, no resolved post event date)', () => {
+		mockFormParent({
+			name: 'fair-events/event-signup',
+			attributes: { eventDateId: 0 },
+		});
+		renderEdit();
+
+		const select = screen.getByLabelText('Condition source');
+		expect(
+			Array.from(select.querySelectorAll('option')).map((o) => o.value)
+		).toEqual(['question', 'eventOption']);
+	});
+
+	it('does not offer "Ticket type" when inside the legacy Event Signup', () => {
+		mockFormParent({
+			name: 'fair-audience/event-signup',
+			attributes: {},
+		});
+		renderEdit();
+
+		const select = screen.getByLabelText('Condition source');
+		expect(
+			Array.from(select.querySelectorAll('option')).map((o) => o.value)
+		).toEqual(['question', 'eventOption']);
+	});
+
+	it('renders fetched ticket types as checkboxes and toggles conditionTicketTypeIds', async () => {
+		mockFormParent({
+			name: 'fair-events/event-signup',
+			attributes: { eventDateId: 42 },
+		});
+		apiFetch.mockResolvedValue({
+			ticket_types: [
+				{ id: 1, name: 'Adult' },
+				{ id: 2, name: 'Child' },
+			],
+		});
+		const setAttributes = jest.fn();
+		renderEdit({ conditionSource: 'ticketType' }, setAttributes);
+
+		await waitFor(() =>
+			expect(apiFetch).toHaveBeenCalledWith({
+				path: '/fair-events/v1/event-dates/42/tickets',
+			})
+		);
+
+		const adultCheckbox = await screen.findByLabelText('Adult');
+		expect(adultCheckbox).not.toBeChecked();
+
+		adultCheckbox.click();
+		expect(setAttributes).toHaveBeenCalledWith({
+			conditionTicketTypeIds: [1],
+		});
+	});
+
+	it('shows a warning when a referenced ticket type no longer exists', async () => {
+		mockFormParent({
+			name: 'fair-events/event-signup',
+			attributes: { eventDateId: 42 },
+		});
+		apiFetch.mockResolvedValue({
+			ticket_types: [{ id: 1, name: 'Adult' }],
+		});
+		renderEdit({
+			conditionSource: 'ticketType',
+			conditionTicketTypeIds: [1, 999],
+		});
+
+		expect(await screen.findByRole('alert')).toHaveTextContent(
+			/no longer exist/
+		);
+	});
+
+	it('shows no warning while the referenced ticket types all still exist', async () => {
+		mockFormParent({
+			name: 'fair-events/event-signup',
+			attributes: { eventDateId: 42 },
+		});
+		apiFetch.mockResolvedValue({
+			ticket_types: [{ id: 1, name: 'Adult' }],
+		});
+		renderEdit({
+			conditionSource: 'ticketType',
+			conditionTicketTypeIds: [1],
+		});
+
+		await screen.findByLabelText('Adult');
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+});

--- a/fair-form/src/blocks/fair-form-conditional/block.json
+++ b/fair-form/src/blocks/fair-form-conditional/block.json
@@ -37,6 +37,13 @@
 		"conditionOptionShortName": {
 			"type": "string",
 			"default": ""
+		},
+		"conditionTicketTypeIds": {
+			"type": "array",
+			"items": {
+				"type": "integer"
+			},
+			"default": []
 		}
 	},
 	"editorScript": "file:./editor.js",

--- a/fair-form/src/blocks/fair-form-conditional/editor.js
+++ b/fair-form/src/blocks/fair-form-conditional/editor.js
@@ -8,9 +8,17 @@ import {
 	InspectorControls,
 	InnerBlocks,
 } from '@wordpress/block-editor';
-import { PanelBody, SelectControl, TextControl } from '@wordpress/components';
+import {
+	PanelBody,
+	SelectControl,
+	TextControl,
+	CheckboxControl,
+	Notice,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
 
 const ALLOWED_BLOCKS = [
 	'core/heading',
@@ -34,9 +42,10 @@ const OPERATOR_OPTIONS = [
 	{ label: __('is not empty', 'fair-audience'), value: 'not_empty' },
 ];
 
-// Event options are boolean per checkbox, so they get a dedicated
-// selected/not-selected operator pair rather than reusing equals/contains.
-const EVENT_OPTION_OPERATOR_OPTIONS = [
+// Event options and ticket types are boolean per checkbox/radio, so they
+// share a dedicated selected/not-selected operator pair rather than reusing
+// equals/contains.
+const SELECTED_OPERATOR_OPTIONS = [
 	{ label: __('is selected', 'fair-audience'), value: 'selected' },
 	{ label: __('is not selected', 'fair-audience'), value: 'not_selected' },
 ];
@@ -45,6 +54,11 @@ const SOURCE_OPTIONS = [
 	{ label: __('Question', 'fair-audience'), value: 'question' },
 	{ label: __('Event option', 'fair-audience'), value: 'eventOption' },
 ];
+
+const TICKET_TYPE_SOURCE_OPTION = {
+	label: __('Ticket type', 'fair-audience'),
+	value: 'ticketType',
+};
 
 const OPTION_BLOCK_PARENTS = [
 	'fair-audience/fair-form-multiselect',
@@ -89,41 +103,108 @@ registerBlockType('fair-audience/fair-form-conditional', {
 			conditionOperator,
 			conditionValue,
 			conditionOptionShortName,
+			conditionTicketTypeIds = [],
 		} = attributes;
 
-		const { questionOptions, isEventSignup } = useSelect(
+		const { questionOptions, isEventSignup, eventDateId } = useSelect(
 			(select) => {
 				const { getBlockParents, getBlocks, getBlock } =
 					select('core/block-editor');
 				const parents = getBlockParents(clientId);
 				// Find the nearest form-like parent: a Fair Form or an Event
 				// Signup (which accepts nested fair-form questions since #615).
+				// Both the legacy (fair-audience) and unified (fair-events)
+				// Event Signup blocks qualify.
 				const formParentId = parents.find((parentId) => {
 					const parentBlock = getBlock(parentId);
 					return (
 						parentBlock?.name === 'fair-audience/fair-form' ||
-						parentBlock?.name === 'fair-audience/event-signup'
+						parentBlock?.name === 'fair-audience/event-signup' ||
+						parentBlock?.name === 'fair-events/event-signup'
 					);
 				});
 				if (!formParentId) {
-					return { questionOptions: [], isEventSignup: false };
+					return {
+						questionOptions: [],
+						isEventSignup: false,
+						eventDateId: 0,
+					};
 				}
 				const formBlock = getBlock(formParentId);
 				const formBlocks = getBlocks(formParentId);
 				return {
 					questionOptions: findQuestionBlocks(formBlocks),
 					isEventSignup:
-						formBlock?.name === 'fair-audience/event-signup',
+						formBlock?.name === 'fair-audience/event-signup' ||
+						formBlock?.name === 'fair-events/event-signup',
+					// The unified block's own eventDateId attribute is only
+					// set in edge cases (e.g. the legacy get-tickets
+					// transform) — in normal usage editing a fair_event post
+					// it stays 0, since the block resolves its event date
+					// from post context at render time. The editor's actual
+					// source of truth for "which event date is this post" is
+					// the same localized global the block's own "Edit
+					// tickets" link uses (BlockHooks::localize_event_signup_editor_context).
+					eventDateId:
+						formBlock?.name === 'fair-events/event-signup'
+							? formBlock.attributes?.eventDateId ||
+							  window.fairEventsSignupBlock?.postEventDateId ||
+							  0
+							: 0,
 				};
 			},
 			[clientId]
 		);
+
+		// The ticket-type source additionally needs a resolved event date to
+		// fetch its ticket types from.
+		const canUseTicketType = isEventSignup && eventDateId > 0;
 
 		// The event-option source is only meaningful inside an Event Signup,
 		// whose runtime option checkboxes carry the short name. Outside one,
 		// keep the source on "question" regardless of the stored attribute.
 		const source = isEventSignup ? conditionSource : 'question';
 		const isEventOption = source === 'eventOption';
+		const isTicketType = source === 'ticketType' && canUseTicketType;
+
+		const sourceOptions = canUseTicketType
+			? [...SOURCE_OPTIONS, TICKET_TYPE_SOURCE_OPTION]
+			: SOURCE_OPTIONS;
+
+		// Ticket types for the active event date, fetched only while the
+		// ticket-type source is available. `null` means "not loaded yet".
+		const [ticketTypes, setTicketTypes] = useState(null);
+
+		useEffect(() => {
+			if (!canUseTicketType) {
+				setTicketTypes(null);
+				return;
+			}
+			let cancelled = false;
+			apiFetch({
+				path: `/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			})
+				.then((response) => {
+					if (!cancelled) {
+						setTicketTypes(response.ticket_types || []);
+					}
+				})
+				.catch(() => {
+					if (!cancelled) {
+						setTicketTypes([]);
+					}
+				});
+			return () => {
+				cancelled = true;
+			};
+		}, [canUseTicketType, eventDateId]);
+
+		const staleTicketTypeIds =
+			ticketTypes !== null
+				? conditionTicketTypeIds.filter(
+						(id) => !ticketTypes.some((tt) => tt.id === id)
+				  )
+				: [];
 
 		const questionSelectOptions = [
 			{
@@ -143,13 +224,15 @@ registerBlockType('fair-audience/fair-form-conditional', {
 			selectedQuestion?.options && selectedQuestion.options.length > 0;
 
 		// Keep the operator valid for the active source: the question
-		// operators (equals/…) and the event-option operators
-		// (selected/not_selected) are disjoint sets.
-		const eventOptionOperator =
+		// operators (equals/…) and the selected/not_selected operators
+		// (event option, ticket type) are disjoint sets.
+		const selectedOperator =
 			conditionOperator === 'not_selected' ? 'not_selected' : 'selected';
 
 		const isConfigured = isEventOption
 			? !!conditionOptionShortName
+			: isTicketType
+			? conditionTicketTypeIds.length > 0
 			: !!conditionQuestionKey;
 
 		let conditionLabel;
@@ -157,7 +240,20 @@ registerBlockType('fair-audience/fair-form-conditional', {
 			conditionLabel = __('No condition set', 'fair-audience');
 		} else if (isEventOption) {
 			conditionLabel = `${conditionOptionShortName} ${
-				eventOptionOperator === 'not_selected'
+				selectedOperator === 'not_selected'
+					? __('is not selected', 'fair-audience')
+					: __('is selected', 'fair-audience')
+			}`;
+		} else if (isTicketType) {
+			const names = conditionTicketTypeIds
+				.map((id) => ticketTypes?.find((tt) => tt.id === id)?.name)
+				.filter(Boolean);
+			conditionLabel = `${
+				names.length > 0
+					? names.join(', ')
+					: conditionTicketTypeIds.join(', ')
+			} ${
+				selectedOperator === 'not_selected'
 					? __('is not selected', 'fair-audience')
 					: __('is selected', 'fair-audience')
 			}`;
@@ -193,14 +289,15 @@ registerBlockType('fair-audience/fair-form-conditional', {
 							<SelectControl
 								label={__('Condition source', 'fair-audience')}
 								value={source}
-								options={SOURCE_OPTIONS}
+								options={sourceOptions}
 								onChange={(value) =>
 									setAttributes({
 										conditionSource: value,
 										// Reset the operator to one valid for the
 										// newly selected source.
 										conditionOperator:
-											value === 'eventOption'
+											value === 'eventOption' ||
+											value === 'ticketType'
 												? 'selected'
 												: 'equals',
 									})
@@ -227,14 +324,61 @@ registerBlockType('fair-audience/fair-form-conditional', {
 								/>
 								<SelectControl
 									label={__('Operator', 'fair-audience')}
-									value={eventOptionOperator}
-									options={EVENT_OPTION_OPERATOR_OPTIONS}
+									value={selectedOperator}
+									options={SELECTED_OPERATOR_OPTIONS}
 									onChange={(value) =>
 										setAttributes({
 											conditionOperator: value,
 										})
 									}
 								/>
+							</>
+						) : isTicketType ? (
+							<>
+								{(ticketTypes || []).map((ticketType) => (
+									<CheckboxControl
+										key={ticketType.id}
+										label={ticketType.name}
+										checked={conditionTicketTypeIds.includes(
+											ticketType.id
+										)}
+										onChange={(checked) => {
+											const next = checked
+												? [
+														...conditionTicketTypeIds,
+														ticketType.id,
+												  ]
+												: conditionTicketTypeIds.filter(
+														(id) =>
+															id !== ticketType.id
+												  );
+											setAttributes({
+												conditionTicketTypeIds: next,
+											});
+										}}
+									/>
+								))}
+								<SelectControl
+									label={__('Operator', 'fair-audience')}
+									value={selectedOperator}
+									options={SELECTED_OPERATOR_OPTIONS}
+									onChange={(value) =>
+										setAttributes({
+											conditionOperator: value,
+										})
+									}
+								/>
+								{staleTicketTypeIds.length > 0 && (
+									<Notice
+										status="warning"
+										isDismissible={false}
+									>
+										{__(
+											'One or more referenced ticket types no longer exist and will be ignored.',
+											'fair-audience'
+										)}
+									</Notice>
+								)}
 							</>
 						) : (
 							<>

--- a/fair-form/src/blocks/fair-form-conditional/render.php
+++ b/fair-form/src/blocks/fair-form-conditional/render.php
@@ -19,12 +19,18 @@ $condition_question_key      = $attributes['conditionQuestionKey'] ?? '';
 $condition_operator          = $attributes['conditionOperator'] ?? 'equals';
 $condition_value             = $attributes['conditionValue'] ?? '';
 $condition_option_short_name = $attributes['conditionOptionShortName'] ?? '';
+$condition_ticket_type_ids   = $attributes['conditionTicketTypeIds'] ?? array();
 
 // Don't render if the controlling reference is missing for the active source:
-// a question key for the question source, or an option short name for the
-// event-option source.
+// a question key for the question source, an option short name for the
+// event-option source, or at least one ticket type ID for the ticket-type
+// source.
 if ( 'eventOption' === $condition_source ) {
 	if ( empty( $condition_option_short_name ) ) {
+		return '';
+	}
+} elseif ( 'ticketType' === $condition_source ) {
+	if ( empty( $condition_ticket_type_ids ) ) {
 		return '';
 	}
 } elseif ( empty( $condition_question_key ) ) {
@@ -40,6 +46,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		'data-condition-operator'          => esc_attr( $condition_operator ),
 		'data-condition-value'             => esc_attr( $condition_value ),
 		'data-condition-option-short-name' => esc_attr( $condition_option_short_name ),
+		'data-condition-ticket-type-ids'   => esc_attr( wp_json_encode( $condition_ticket_type_ids ) ),
 	)
 );
 ?>


### PR DESCRIPTION
## Summary

- Conditional Section, nested inside a signup form, gains a **Ticket type** condition source alongside the existing Question and Event option sources: pick one or more of the event's ticket types and an "is selected" / "is not selected" operator, mirroring the event-option operator model.
- Fixes the existing "Event option" source (and now "Ticket type" too) not appearing when the Conditional Section is nested inside the unified `fair-events/event-signup` block — the availability check only recognized the older, inserter-hidden `fair-audience/event-signup` block.

Closes #1349

## Implementation notes / deviation from the plan

The approved plan (issue comment) assumed the `fair-events/event-signup` block's own `eventDateId` attribute could be read off the ancestor block to resolve which event date's ticket types to offer. Manual testing in the running editor showed that attribute is **always `0` in normal usage** — the block resolves its event date from post context at render time and never sets the attribute itself. The actual signal the editor needs (used identically by the block's own "Edit tickets" sidebar link) is the `window.fairEventsSignupBlock.postEventDateId` global, localized in `BlockHooks::localize_event_signup_editor_context()`. `editor.js` now reads the block attribute first (kept for forward-compatibility/edge cases) and falls back to that global. Without this fix, "Ticket type" would never have appeared for editors working the common way — editing a block automatically inserted into its own `fair_event` post.

## Acceptance criteria

- [x] Offers "Ticket type" when nested inside a signup form — verified via component tests and manually in the running editor (screenshot-equivalent: sidebar shows Condition source = "Ticket type" with per-type checkboxes).
- [x] Does not offer "Ticket type" when standalone (not inside a signup form), or inside an unconnected/legacy signup block.
- [x] Author can select one or more ticket types as the condition value (OR-matched, `selected` / `not_selected` operator).
- [x] Public signup form shows/hides live as the visitor changes ticket type, no reload — verified via the new E2E spec and manually against the dev site.
- [x] Editing/removing a referenced ticket type doesn't break the form; editor shows a warning `Notice` when a referenced ID is no longer in the fetched ticket-type list.
- [x] Component test added (`fair-form-conditional/__tests__/editor.test.jsx`, new file — the block had no component test before).
- [x] E2E test added (`e2e/user-flows/conditional-ticket-type-fields.spec.js` + seed script), passing against the isolated wp-env harness.

## Notes

- `fair-events-shared`'s `evaluateConditionals()` gains a `ticketType` branch (`isTicketTypeSelected`, `evaluateTicketTypeCondition`), following the same hidden-ancestor nesting-safety pattern as the `eventOption` source.
- `fair-events` and `fair-audience` are bumped patch in the changeset since their bundled `event-signup/frontend.js` reships the changed `fair-events-shared` logic, even though no source files in those plugins changed.

## Test plan

- [x] `fair-events-shared`: `npm test` — 221/221 passing (new `ticketType` describe block added).
- [x] `fair-form`: `npm run test:js` — 16/16 passing (new `editor.test.jsx`, 8 tests).
- [x] `fair-events`, `fair-audience`: `npm run test:js` — no regressions (176/176, 27/27).
- [x] `vendor/bin/phpcs` clean on changed PHP files.
- [x] `npm run build` in `fair-form`, `fair-events`, `fair-audience`.
- [x] New E2E spec passing against the isolated wp-env harness (`npm run test:e2e:setup` / `npx playwright test e2e/user-flows/conditional-ticket-type-fields.spec.js`), plus the existing `conditional-signup-fields.spec.js` re-run to confirm no regression from the `isEventSignup` fix.
- [x] Manually verified in the dev site (`docker compose`, `:8080`): seeded an event with Adult/Child ticket types and a conditional wrapping a question; confirmed the editor sidebar offers "Ticket type", shows fetched checkboxes, and the block label updates live; confirmed the public form shows/hides the wrapped question as the ticket type radio changes.
