### PR TITLE
Fix long-text fields collapsing inside conditional sections

### DIFF
--- a/.changeset/long-text-autosize-fix.md
+++ b/.changeset/long-text-autosize-fix.md
@@ -1,0 +1,8 @@
+---
+"fair-events-shared": patch
+"fair-form": patch
+"fair-events": patch
+"fair-audience": patch
+---
+
+Fix long-answer question fields rendering collapsed to a single line instead of sizing to fit their content. A long-text question nested inside a Conditional Section stayed collapsed until the respondent typed in it, because the auto-grow behavior ran on hidden textareas (always 0 height) and never re-ran once the section was revealed. Long-text fields also had no styling at all outside the plain Fair Form block (e.g. in the Event Signup blocks), and could grow without limit; they now cap at roughly 12 lines and scroll internally beyond that.

--- a/e2e/mu-plugins/scripts/seed-conditional-signup.php
+++ b/e2e/mu-plugins/scripts/seed-conditional-signup.php
@@ -8,9 +8,12 @@
  *
  * Creates a fair_event post whose content is an event-signup block containing a
  * fair-form-conditional (conditionSource=eventOption, short name "dinner") that
- * wraps a short-text question. Adds one event date, an active sale period, a
- * free ticket type + price, and a "dinner" ticket option carrying the short
- * name. Prints a single `E2E_SEED:{json}` line the spec parses.
+ * wraps a short-text question and a long-text question (issue #1352 — verifies
+ * the long-text autosize re-triggers once the conditional section is revealed,
+ * instead of staying collapsed from the hidden-textarea autosize pass on load).
+ * Adds one event date, an active sale period, a free ticket type + price, and a
+ * "dinner" ticket option carrying the short name. Prints a single
+ * `E2E_SEED:{json}` line the spec parses.
  *
  * @package FairEventsE2E
  */
@@ -31,6 +34,7 @@ $content = implode(
 		'<!-- wp:fair-events/event-signup -->',
 		'<!-- wp:fair-audience/fair-form-conditional {"conditionSource":"eventOption","conditionOptionShortName":"dinner","conditionOperator":"selected"} -->',
 		'<!-- wp:fair-audience/fair-form-short-text {"questionKey":"diet","questionText":"Dietary restrictions"} /-->',
+		'<!-- wp:fair-audience/fair-form-long-text {"questionKey":"notes","questionText":"Anything else?"} /-->',
 		'<!-- /wp:fair-audience/fair-form-conditional -->',
 		'<!-- /wp:fair-events/event-signup -->',
 	)

--- a/e2e/user-flows/conditional-signup-fields.spec.js
+++ b/e2e/user-flows/conditional-signup-fields.spec.js
@@ -51,4 +51,29 @@ test.describe('conditional signup fields by event-option short name', () => {
 		await dinner.uncheck();
 		await expect(dietQuestion).toBeHidden();
 	});
+
+	test('sizes a revealed long-text question to fit its content instead of staying collapsed (#1352)', async ({
+		page,
+	}) => {
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		const dinner = form.locator(
+			'input[name="ticket_option_ids[]"][data-option-short-name="dinner"]'
+		);
+
+		// The long-text "notes" question shares the same hidden conditional as
+		// "diet". Its textarea gets autosized on load while still hidden
+		// (scrollHeight is always 0 for a display:none element), which used to
+		// bake in a collapsed height that never recovered once revealed.
+		const notesTextarea = form.locator(
+			'[data-question-key="notes"] textarea'
+		);
+
+		await dinner.check();
+		await expect(notesTextarea).toBeVisible();
+
+		const height = await notesTextarea.evaluate((el) => el.offsetHeight);
+		expect(height).toBeGreaterThan(40);
+	});
 });

--- a/fair-events-shared/src/__tests__/questionnaire.test.js
+++ b/fair-events-shared/src/__tests__/questionnaire.test.js
@@ -347,6 +347,51 @@ describe('evaluateConditionals — question source (regression)', () => {
 	});
 });
 
+/**
+ * Build a long-text question wrapped in a conditional section keyed on a
+ * short-text "color" question.
+ *
+ * @param {string} colorValue The color question's current value.
+ * @return {string} The markup.
+ */
+function conditionalLongTextQuestion(colorValue) {
+	return (
+		`<div data-fair-form-question data-question-key="color" data-question-type="short_text"><input type="text" value="${colorValue}" /></div>` +
+		`<div data-fair-form-conditional data-condition-source="question" data-condition-question-key="color" data-condition-operator="equals" data-condition-value="blue">` +
+		`<div data-fair-form-question data-question-key="details" data-question-type="long_text"><textarea></textarea></div>` +
+		`</div>`
+	);
+}
+
+describe('evaluateConditionals — long-text autosize on reveal', () => {
+	// jsdom performs no real layout, so scrollHeight is always 0 unless mocked.
+	it('autosizes a long-text textarea once its conditional section becomes visible', () => {
+		const form = buildForm(conditionalLongTextQuestion('blue'));
+		const textarea = form.querySelector('textarea');
+		Object.defineProperty(textarea, 'scrollHeight', {
+			configurable: true,
+			value: 120,
+		});
+
+		evaluateConditionals(form);
+
+		expect(textarea.style.height).toBe('120px');
+	});
+
+	it('leaves a long-text textarea unsized while its conditional section stays hidden', () => {
+		const form = buildForm(conditionalLongTextQuestion('red'));
+		const textarea = form.querySelector('textarea');
+		Object.defineProperty(textarea, 'scrollHeight', {
+			configurable: true,
+			value: 120,
+		});
+
+		evaluateConditionals(form);
+
+		expect(textarea.style.height).not.toBe('120px');
+	});
+});
+
 function consentQuestion({ checked = false, required = true } = {}) {
 	return (
 		`<div data-fair-form-question data-question-key="tos" data-question-text="I accept" data-question-type="checkbox" data-required="${

--- a/fair-events-shared/src/questionnaire.js
+++ b/fair-events-shared/src/questionnaire.js
@@ -234,6 +234,20 @@ export function evaluateConditionals(form) {
 		);
 		section.classList.toggle('fair-form-conditional-visible', visible);
 	});
+
+	// A hidden textarea always has a scrollHeight of 0, so an autosize run
+	// while it was still hidden collapsed it to a single line. Re-run
+	// autosize on every long-text textarea that just became visible so it
+	// grows to fit its content instead of staying collapsed.
+	form.querySelectorAll('[data-question-type="long_text"] textarea').forEach(
+		(textarea) => {
+			if (
+				isQuestionVisible(textarea.closest('[data-fair-form-question]'))
+			) {
+				autosizeTextarea(textarea);
+			}
+		}
+	);
 }
 
 /**

--- a/fair-form/src/blocks/fair-form-long-text/style.css
+++ b/fair-form/src/blocks/fair-form-long-text/style.css
@@ -24,7 +24,7 @@
 	border-bottom-color: #2271b1;
 }
 
-.fair-form-question-long-text textarea:disabled {
+.fair-form-question-long-text textarea {
 	box-sizing: border-box;
 	width: 100%;
 	padding: 8px 12px;
@@ -32,6 +32,12 @@
 	border-radius: 4px;
 	font-size: inherit;
 	line-height: 1.5;
+	resize: none;
+	overflow-y: auto;
+	max-height: calc(1.5em * 12 + 16px);
+}
+
+.fair-form-question-long-text textarea:disabled {
 	resize: vertical;
 	background: #f0f0f0;
 }

--- a/fair-form/src/blocks/fair-form/style.css
+++ b/fair-form/src/blocks/fair-form/style.css
@@ -15,7 +15,6 @@
 .fair-form-form input[type="text"],
 .fair-form-form input[type="email"],
 .fair-form-form input[type="tel"],
-.fair-form-form textarea,
 .fair-form-form select {
 	box-sizing: border-box;
 	width: 100%;
@@ -24,11 +23,6 @@
 	border-radius: 4px;
 	font-size: inherit;
 	line-height: 1.5;
-}
-
-.fair-form-form textarea {
-	resize: none;
-	overflow: hidden;
 }
 
 .fair-form-form input[type="text"]:focus,


### PR DESCRIPTION
## Summary

- Long-answer question fields no longer stay collapsed to a sliver when they live inside a Conditional Section: `evaluateConditionals()` re-runs autosize on every long-text textarea that just became visible, instead of relying solely on the initial (hidden, `scrollHeight === 0`) autosize pass and a later keystroke.
- Long-text fields now get their box styling (border, padding, radius, line-height, `resize: none`) from `.fair-form-question-long-text textarea` regardless of which block embeds them, so they're no longer unstyled inside the Event Signup blocks (`fair-audience`/`fair-events`), which had no textarea rule of their own. The plain Fair Form block's now-redundant textarea styling was removed.
- Growth is capped at ~12 lines (`calc(1.5em * 12 + 16px)`), then the field scrolls internally instead of growing without limit.

Closes #1352

## Acceptance criteria

- [x] A long-answer field shows multiple lines of visible height on initial load, even when empty — box styling is present unconditionally now (previously depended on being inside `.fair-form-form`), and the `rows` attribute plus the new default styling render several lines.
- [x] A long-answer field pre-filled with a multi-line saved answer displays at a height that fits that content on load — `applyQuestionAnswers()` already called `autosizeTextarea()` on restore; unaffected by this change.
- [x] Typing past the visible area grows the field — existing `input` listener from `setupAutosizeTextareas()`; unaffected.
- [x] Field growth stops at a maximum height, then scrolls internally — new `max-height` + `overflow-y: auto` in `fair-form-long-text/style.css`.
- [x] Behaviour verified in the form builder preview and on the live public form — Jest coverage in `fair-events-shared/src/__tests__/questionnaire.test.js` (mocked `scrollHeight`, since jsdom does no real layout) plus a real-browser Playwright assertion in `e2e/user-flows/conditional-signup-fields.spec.js` (extends the existing conditional-reveal seed with a long-text question and checks `offsetHeight` after the section is revealed).

## Notes

- Root cause was two-fold (see the [implementation plan](https://github.com/marcin-wosinek/fair-event-plugins/issues/1352#issuecomment-5156681095)): the reveal bug above, plus a missing CSS rule outside `fair-form/style.css` — the long-text answer textarea was only styled inside the plain Fair Form block, not the Event Signup blocks that also nest it.
- Verified the new e2e assertion actually catches the regression: reverted the JS fix locally, rebuilt, and confirmed the new test fails (`offsetHeight` 18 vs the expected >40); restored the fix and confirmed it passes again.
