### PR TITLE
Fix event-proposal/event-signup block wrapper markup

### DIFF
--- a/.changeset/fix-event-block-wrapper-attributes.md
+++ b/.changeset/fix-event-block-wrapper-attributes.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix event-proposal and event-signup blocks to use the standard block wrapper markup, so their padding/margin sidebar controls now actually apply on the frontend.

--- a/fair-events/src/blocks/event-proposal/render.php
+++ b/fair-events/src/blocks/event-proposal/render.php
@@ -46,7 +46,7 @@ $duration_options = array(
 );
 ?>
 
-<div class="fair-events-proposal-form">
+<div <?php echo wp_kses_post( get_block_wrapper_attributes( array( 'class' => 'fair-events-proposal-form' ) ) ); ?>>
 	<form
 		id="<?php echo esc_attr( $form_id ); ?>"
 		class="proposal-form"

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -382,9 +382,16 @@ $all_purchases_blocked = $payments_unavailable
 
 // Generate unique form ID.
 $form_id = 'fair-events-get-tickets-' . wp_unique_id();
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class'         => 'fair-events-get-tickets',
+		'data-currency' => \FairEventsShared\Money::site_currency(),
+	)
+);
 ?>
 
-<div class="fair-events-get-tickets" data-currency="<?php echo esc_attr( \FairEventsShared\Money::site_currency() ); ?>">
+<div <?php echo wp_kses_post( $wrapper_attributes ); ?>>
 <?php if ( $signup_state ) : ?>
 	<?php
 	$amount_display = \FairEventsShared\Money::format_display( (float) $signup_state['amount'], $signup_state['currency'] );

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -383,12 +383,24 @@ $all_purchases_blocked = $payments_unavailable
 // Generate unique form ID.
 $form_id = 'fair-events-get-tickets-' . wp_unique_id();
 
-$wrapper_attributes = get_block_wrapper_attributes(
-	array(
-		'class'         => 'fair-events-get-tickets',
-		'data-currency' => \FairEventsShared\Money::site_currency(),
-	)
-);
+// The editor's live preview nests this render inside its own block wrapper
+// (editor.js's useBlockProps() div), which already carries the
+// wp-block-fair-events-event-signup class and any spacing support styles. Adding
+// get_block_wrapper_attributes() here too would duplicate both — a second
+// element matching the block's wrapper class, and doubled-up padding/margin.
+if ( ! empty( $attributes['isEditorPreview'] ) ) {
+	$wrapper_attributes = sprintf(
+		'class="fair-events-get-tickets" data-currency="%s"',
+		esc_attr( \FairEventsShared\Money::site_currency() )
+	);
+} else {
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array(
+			'class'         => 'fair-events-get-tickets',
+			'data-currency' => \FairEventsShared\Money::site_currency(),
+		)
+	);
+}
 ?>
 
 <div <?php echo wp_kses_post( $wrapper_attributes ); ?>>


### PR DESCRIPTION
## Summary

Phase 0 of #1271: `event-proposal` and `event-signup` (fair-events) built their outer `<div>` by hand instead of calling `get_block_wrapper_attributes()`, unlike `event-dates` or `time-slot`. `event-signup`'s `block.json` already declares `spacing.padding`/`margin` support, so its sidebar controls existed but had no effect on the frontend — this fix makes them work. `event-proposal` gets the same treatment for consistency (and so it picks up standard supports like `className`/align going forward).

`calendar-button` is confirmed out of scope — it's a `core/button` variation and already inherits all of `core/button`'s styling supports. Full per-block styling supports across all three plugins, and the events-week/events-calendar visual alignment, are deferred to a later phase per the approved plan.

Refs #1271

## Changes

- `fair-events/src/blocks/event-proposal/render.php`: wrap output in `get_block_wrapper_attributes()`.
- `fair-events/src/blocks/event-signup/render.php`: same, preserving the existing `data-currency` attribute.
- Changeset (patch) for `fair-events`.

## Acceptance criteria (scoped to this Phase 0 PR)

- [x] `event-signup`'s existing spacing (padding/margin) sidebar controls now visibly apply on the frontend, verified via a `wp eval-file` render check (custom `className`, block class, and a `style.spacing.padding` value all showed up in the rendered wrapper).
- [x] `event-proposal`'s wrapper now also carries block-name class + custom `className`, matching the `event-dates`/`time-slot` pattern.
- [ ] Broader styling-supports rollout (color/typography/border across all blocks), calendar/week color migration, and events-week/events-calendar visual alignment — deferred to a later phase per the plan's Decisions section.

## Test plan

- [x] `npm run build` (fair-events)
- [x] `npm run format` (fair-events)
- [x] `vendor/bin/phpcs` on both changed files — clean (5 pre-existing unrelated errors in `event-proposal/render.php` confirmed present on `main` before this change)
- [x] `npm run test:js` (fair-events) — 22 suites / 176 tests pass
- [x] Manual `wp eval-file` check against the running docker WordPress: rendered both blocks with a custom `className` and (for event-signup) a `style.spacing.padding` value, confirmed the wrapper now includes the block class, custom class, and the spacing style alongside the existing markup/`data-currency` attribute
