### PR TITLE
Validate venue latitude/longitude on save and import

### DIFF
--- a/.changeset/venue-coordinate-validation.md
+++ b/.changeset/venue-coordinate-validation.md
@@ -1,0 +1,5 @@
+---
+"fair-events-experimental": minor
+---
+
+Validate venue latitude/longitude on save (form and API), accepting a decimal comma and auto-splitting a pasted "lat, lng" pair, and skip invalid coordinates (with a notice) instead of importing them unchecked.

--- a/fair-events-experimental/__tests__/Models/VenueTest.php
+++ b/fair-events-experimental/__tests__/Models/VenueTest.php
@@ -46,4 +46,80 @@ class VenueTest extends TestCase {
 		$this->assertNotNull( $url );
 		$this->assertStringContainsString( 'Fallback', rawurldecode( $url ) );
 	}
+
+	public function test_both_coordinates_empty_is_valid() {
+		$result = Venue::validate_coordinates( '', '' );
+		$this->assertTrue( $result['valid'] );
+		$this->assertNull( $result['latitude'] );
+		$this->assertNull( $result['longitude'] );
+
+		$result = Venue::validate_coordinates( null, null );
+		$this->assertTrue( $result['valid'] );
+	}
+
+	public function test_valid_coordinates_pass_through() {
+		$result = Venue::validate_coordinates( '39.4878023', '-0.3613204' );
+		$this->assertTrue( $result['valid'] );
+		$this->assertSame( '39.4878023', $result['latitude'] );
+		$this->assertSame( '-0.3613204', $result['longitude'] );
+	}
+
+	public function test_decimal_comma_is_normalized_to_dot() {
+		$result = Venue::validate_coordinates( '39,48', '-0,36' );
+		$this->assertTrue( $result['valid'] );
+		$this->assertSame( '39.48', $result['latitude'] );
+		$this->assertSame( '-0.36', $result['longitude'] );
+	}
+
+	public function test_pasted_pair_is_split_across_fields() {
+		$result = Venue::validate_coordinates( '39.4878023, -0.3613204', '' );
+		$this->assertTrue( $result['valid'] );
+		$this->assertSame( '39.4878023', $result['latitude'] );
+		$this->assertSame( '-0.3613204', $result['longitude'] );
+	}
+
+	public function test_only_one_coordinate_filled_is_rejected() {
+		$result = Venue::validate_coordinates( '39.4878023', '' );
+		$this->assertFalse( $result['valid'] );
+		$this->assertSame( 'coordinate_pair_incomplete', $result['code'] );
+
+		$result = Venue::validate_coordinates( '', '-0.3613204' );
+		$this->assertFalse( $result['valid'] );
+		$this->assertSame( 'coordinate_pair_incomplete', $result['code'] );
+	}
+
+	public function test_non_numeric_coordinates_are_rejected() {
+		$result = Venue::validate_coordinates( 'not-a-number', '-0.3613204' );
+		$this->assertFalse( $result['valid'] );
+		$this->assertSame( 'coordinate_not_numeric', $result['code'] );
+	}
+
+	public function test_out_of_range_latitude_is_rejected() {
+		$result = Venue::validate_coordinates( '90.0001', '0' );
+		$this->assertFalse( $result['valid'] );
+		$this->assertSame( 'coordinate_out_of_range', $result['code'] );
+
+		$valid = Venue::validate_coordinates( '90', '0' );
+		$this->assertTrue( $valid['valid'] );
+	}
+
+	public function test_out_of_range_longitude_is_rejected() {
+		$result = Venue::validate_coordinates( '0', '180.0001' );
+		$this->assertFalse( $result['valid'] );
+		$this->assertSame( 'coordinate_out_of_range', $result['code'] );
+
+		$valid = Venue::validate_coordinates( '0', '-180' );
+		$this->assertTrue( $valid['valid'] );
+	}
+
+	public function test_coordinates_exceeding_stored_length_are_rejected() {
+		// Long, but within range, so this exercises the length check specifically
+		// rather than being caught earlier by the range check.
+		$too_long = '0.1234567890123456789';
+		$this->assertGreaterThan( 20, strlen( $too_long ) );
+
+		$result = Venue::validate_coordinates( $too_long, '0' );
+		$this->assertFalse( $result['valid'] );
+		$this->assertSame( 'coordinate_too_long', $result['code'] );
+	}
 }

--- a/fair-events-experimental/__tests__/bootstrap.php
+++ b/fair-events-experimental/__tests__/bootstrap.php
@@ -12,3 +12,17 @@ require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 if ( ! defined( 'WPINC' ) ) {
 	define( 'WPINC', 'wp-includes' );
 }
+
+if ( ! function_exists( '__' ) ) {
+	/**
+	 * Stub for WordPress' translation function — returns the text unchanged.
+	 *
+	 * @param string $text   Text to translate.
+	 * @param string $domain Text domain (unused in the stub).
+	 * @return string Untranslated text.
+	 */
+	function __( $text, $domain = 'default' ) {
+		unset( $domain );
+		return $text;
+	}
+}

--- a/fair-events-experimental/src/API/VenueController.php
+++ b/fair-events-experimental/src/API/VenueController.php
@@ -208,6 +208,17 @@ class VenueController extends WP_REST_Controller {
 			);
 		}
 
+		$coordinates = Venue::validate_coordinates( $latitude, $longitude );
+		if ( ! $coordinates['valid'] ) {
+			return new WP_Error(
+				'rest_invalid_coordinates',
+				$coordinates['message'],
+				array( 'status' => 400 )
+			);
+		}
+		$latitude  = $coordinates['latitude'];
+		$longitude = $coordinates['longitude'];
+
 		$venue_id = Venue::create( $name, $address, $latitude, $longitude, $facebook_page_link, $instagram_handle, $website_url );
 
 		if ( ! $venue_id ) {
@@ -256,6 +267,17 @@ class VenueController extends WP_REST_Controller {
 				array( 'status' => 400 )
 			);
 		}
+
+		$coordinates = Venue::validate_coordinates( $latitude, $longitude );
+		if ( ! $coordinates['valid'] ) {
+			return new WP_Error(
+				'rest_invalid_coordinates',
+				$coordinates['message'],
+				array( 'status' => 400 )
+			);
+		}
+		$latitude  = $coordinates['latitude'];
+		$longitude = $coordinates['longitude'];
 
 		$success = Venue::update( $id, $name, $address, $latitude, $longitude, $facebook_page_link, $instagram_handle, $website_url );
 

--- a/fair-events-experimental/src/API/__tests__/VenueController.api.spec.js
+++ b/fair-events-experimental/src/API/__tests__/VenueController.api.spec.js
@@ -97,4 +97,100 @@ test.describe('VenueController', () => {
 		expect(body).not.toHaveProperty('google_maps_link');
 		expect(body.maps_url).toBeNull();
 	});
+
+	test('creates a venue with a decimal-comma pair and stores it normalized to dots', async () => {
+		const res = await api.post('/wp-json/fair-events/v1/venues', {
+			headers: authHeader,
+			data: {
+				name: `API Test Venue Comma ${Date.now()}`,
+				latitude: '39,48',
+				longitude: '-0,36',
+			},
+		});
+
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		await api.delete(`/wp-json/fair-events/v1/venues/${body.id}`, {
+			headers: authHeader,
+		});
+
+		expect(body.latitude).toBe('39.48');
+		expect(body.longitude).toBe('-0.36');
+	});
+
+	test.describe('rejected coordinates on POST', () => {
+		const invalidCases = [
+			{
+				label: 'out-of-range latitude',
+				data: { latitude: '200', longitude: '0' },
+			},
+			{
+				label: 'out-of-range longitude',
+				data: { latitude: '0', longitude: '200' },
+			},
+			{
+				label: 'only latitude filled',
+				data: { latitude: '39.4878023', longitude: '' },
+			},
+			{
+				label: 'only longitude filled',
+				data: { latitude: '', longitude: '-0.3613204' },
+			},
+			{
+				label: 'non-numeric latitude',
+				data: { latitude: 'not-a-number', longitude: '0' },
+			},
+			{
+				label: 'coordinate exceeding stored length',
+				data: { latitude: '0.1234567890123456789', longitude: '0' },
+			},
+		];
+
+		for (const { label, data } of invalidCases) {
+			test(`rejects ${label}`, async () => {
+				const res = await api.post('/wp-json/fair-events/v1/venues', {
+					headers: authHeader,
+					data: {
+						name: `API Test Venue Invalid ${Date.now()}`,
+						...data,
+					},
+				});
+
+				expect(res.status()).toBe(400);
+				const body = await res.json();
+				expect(body.code).toBe('rest_invalid_coordinates');
+			});
+		}
+	});
+
+	test('rejects invalid coordinates on PUT', async () => {
+		const createRes = await api.post('/wp-json/fair-events/v1/venues', {
+			headers: authHeader,
+			data: {
+				name: `API Test Venue Update ${Date.now()}`,
+			},
+		});
+		const created = await createRes.json();
+
+		const res = await api.put(
+			`/wp-json/fair-events/v1/venues/${created.id}`,
+			{
+				headers: authHeader,
+				data: {
+					name: created.name,
+					latitude: '39.4878023',
+					longitude: '',
+				},
+			}
+		);
+
+		expect(res.status()).toBe(400);
+		const body = await res.json();
+		expect(body.code).toBe('rest_invalid_coordinates');
+
+		await api.delete(`/wp-json/fair-events/v1/venues/${created.id}`, {
+			headers: authHeader,
+		});
+	});
 });

--- a/fair-events-experimental/src/Admin/venues/VenuesApp.js
+++ b/fair-events-experimental/src/Admin/venues/VenuesApp.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import {
 	Card,
@@ -28,6 +28,85 @@ const VENUE_FIELDS = [
 	'website_url',
 ];
 
+/**
+ * Replace a decimal-comma separator with a dot, unless the value already
+ * contains a dot (e.g. a pasted pair already split into its own field).
+ *
+ * @param {string} value Raw coordinate value.
+ * @return {string} Normalized value.
+ */
+export function normalizeDecimalSeparator(value) {
+	if (!value || value.includes('.') || !value.includes(',')) {
+		return value;
+	}
+	return value.replace(',', '.');
+}
+
+/**
+ * Split a pasted "lat, lng" pair into its two parts. Only matches when the
+ * comma is followed by whitespace (the shape mapping tools paste, e.g.
+ * "39.4878023, -0.3613204") so a plain decimal-comma value like "39,48"
+ * isn't misread as a pair.
+ *
+ * @param {string} value Raw latitude field value.
+ * @return {{latitude: string, longitude: string}|null} The split pair, or null.
+ */
+export function splitCoordinatePair(value) {
+	const match = value.match(/^(-?\d+(?:\.\d+)?)\s*,\s+(-?\d+(?:\.\d+)?)$/);
+	if (!match) {
+		return null;
+	}
+	return { latitude: match[1], longitude: match[2] };
+}
+
+/**
+ * Derive a coordinate validation error message from the current latitude/
+ * longitude form values, or null when they're valid (including both blank).
+ *
+ * @param {string} latitude  Raw latitude field value.
+ * @param {string} longitude Raw longitude field value.
+ * @return {string|null} Translated error message, or null when valid.
+ */
+export function getCoordinateError(latitude, longitude) {
+	const lat = normalizeDecimalSeparator((latitude || '').trim());
+	const lng = normalizeDecimalSeparator((longitude || '').trim());
+
+	if (!lat && !lng) {
+		return null;
+	}
+
+	if (!lat || !lng) {
+		return __(
+			'Enter both latitude and longitude, or leave both blank.',
+			'fair-events'
+		);
+	}
+
+	if (Number.isNaN(Number(lat)) || Number.isNaN(Number(lng))) {
+		return __(
+			'Latitude and longitude must be numbers, e.g. 39.4878023, -0.3613204.',
+			'fair-events'
+		);
+	}
+
+	if (Number(lat) < -90 || Number(lat) > 90) {
+		return __('Latitude must be between -90 and 90.', 'fair-events');
+	}
+
+	if (Number(lng) < -180 || Number(lng) > 180) {
+		return __('Longitude must be between -180 and 180.', 'fair-events');
+	}
+
+	if (lat.length > 20 || lng.length > 20) {
+		return __(
+			'Latitude and longitude must be 20 characters or fewer.',
+			'fair-events'
+		);
+	}
+
+	return null;
+}
+
 const VenuesApp = () => {
 	const [venues, setVenues] = useState([]);
 	const [loading, setLoading] = useState(true);
@@ -47,6 +126,11 @@ const VenuesApp = () => {
 	const [isSaving, setIsSaving] = useState(false);
 	const [selectedVenues, setSelectedVenues] = useState(new Set());
 	const [isImporting, setIsImporting] = useState(false);
+
+	const coordinateError = getCoordinateError(
+		formData.latitude,
+		formData.longitude
+	);
 
 	useEffect(() => {
 		loadVenues();
@@ -160,6 +244,21 @@ const VenuesApp = () => {
 		}
 	};
 
+	const handleLatitudeChange = (value) => {
+		if (!formData.longitude) {
+			const pair = splitCoordinatePair(value.trim());
+			if (pair) {
+				setFormData({
+					...formData,
+					latitude: pair.latitude,
+					longitude: pair.longitude,
+				});
+				return;
+			}
+		}
+		setFormData({ ...formData, latitude: value });
+	};
+
 	const handleFormCancel = () => {
 		setIsFormOpen(false);
 		setEditingVenue(null);
@@ -243,6 +342,7 @@ const VenuesApp = () => {
 			}
 
 			let created = 0;
+			const skippedCoordinates = [];
 			for (const venue of importedVenues) {
 				if (!venue.name) {
 					continue;
@@ -253,6 +353,13 @@ const VenuesApp = () => {
 						data[field] = venue[field];
 					}
 				});
+
+				if (getCoordinateError(data.latitude, data.longitude)) {
+					delete data.latitude;
+					delete data.longitude;
+					skippedCoordinates.push(venue.name);
+				}
+
 				await apiFetch({
 					path: '/fair-events/v1/venues',
 					method: 'POST',
@@ -261,13 +368,27 @@ const VenuesApp = () => {
 				created++;
 			}
 
-			setSuccess(
-				// translators: %d is the number of imported venues
-				__('%d venue(s) imported.', 'fair-events').replace(
-					'%d',
-					created
-				)
+			let message = sprintf(
+				/* translators: %d is the number of imported venues */
+				_n(
+					'%d venue imported.',
+					'%d venues imported.',
+					created,
+					'fair-events'
+				),
+				created
 			);
+			if (skippedCoordinates.length > 0) {
+				message += ` ${sprintf(
+					/* translators: %s is a comma-separated list of venue names */
+					__(
+						'Imported without coordinates (invalid): %s',
+						'fair-events'
+					),
+					skippedCoordinates.join(', ')
+				)}`;
+			}
+			setSuccess(message);
 			loadVenues();
 		} catch (err) {
 			setError(
@@ -490,16 +611,17 @@ const VenuesApp = () => {
 							<TextControl
 								label={__('Latitude', 'fair-events')}
 								value={formData.latitude}
-								onChange={(value) =>
-									setFormData({
-										...formData,
-										latitude: value,
-									})
+								onChange={handleLatitudeChange}
+								help={
+									coordinateError ||
+									__(
+										'Latitude coordinate (e.g., 39.4878023)',
+										'fair-events'
+									)
 								}
-								help={__(
-									'Latitude coordinate (e.g., 39.4878023)',
-									'fair-events'
-								)}
+								className={
+									coordinateError ? 'has-error' : undefined
+								}
 							/>
 							<TextControl
 								label={__('Longitude', 'fair-events')}
@@ -510,10 +632,16 @@ const VenuesApp = () => {
 										longitude: value,
 									})
 								}
-								help={__(
-									'Longitude coordinate (e.g., -0.3613204)',
-									'fair-events'
-								)}
+								help={
+									coordinateError ||
+									__(
+										'Longitude coordinate (e.g., -0.3613204)',
+										'fair-events'
+									)
+								}
+								className={
+									coordinateError ? 'has-error' : undefined
+								}
 							/>
 							<TextControl
 								label={__('Facebook Page Link', 'fair-events')}
@@ -568,7 +696,11 @@ const VenuesApp = () => {
 									variant="primary"
 									type="submit"
 									isBusy={isSaving}
-									disabled={isSaving || !formData.name}
+									disabled={
+										isSaving ||
+										!formData.name ||
+										!!coordinateError
+									}
 								>
 									{editingVenue
 										? __('Update Venue', 'fair-events')

--- a/fair-events-experimental/src/Admin/venues/__tests__/VenuesApp.test.jsx
+++ b/fair-events-experimental/src/Admin/venues/__tests__/VenuesApp.test.jsx
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import VenuesApp from '../VenuesApp.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const existingVenue = {
+	id: 1,
+	name: 'Existing Venue',
+	address: 'Gran Via 1, Valencia',
+	latitude: '200',
+	longitude: '-0.3613204',
+	facebook_page_link: '',
+	instagram_handle: '',
+	website_url: '',
+};
+
+beforeEach(() => {
+	apiFetch.mockResolvedValue([]);
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+const openCreateForm = async () => {
+	render(<VenuesApp />);
+	await waitFor(() =>
+		expect(
+			screen.getByRole('button', { name: /Add New Venue/i })
+		).toBeInTheDocument()
+	);
+	fireEvent.click(screen.getByRole('button', { name: /Add New Venue/i }));
+};
+
+const saveButton = () => screen.getByRole('button', { name: /Create Venue/i });
+
+test('both coordinates blank is valid and does not disable save', async () => {
+	await openCreateForm();
+
+	fireEvent.change(screen.getByLabelText('Name'), {
+		target: { value: 'New Venue' },
+	});
+
+	expect(saveButton()).not.toBeDisabled();
+});
+
+test('filling only latitude shows an inline error and disables save', async () => {
+	await openCreateForm();
+
+	fireEvent.change(screen.getByLabelText('Name'), {
+		target: { value: 'New Venue' },
+	});
+	fireEvent.change(screen.getByLabelText('Latitude'), {
+		target: { value: '39.4878023' },
+	});
+
+	expect(
+		screen.getAllByText(/Enter both latitude and longitude/i)
+	).toHaveLength(2);
+	expect(saveButton()).toBeDisabled();
+});
+
+test('an out-of-range latitude shows an inline error and disables save', async () => {
+	await openCreateForm();
+
+	fireEvent.change(screen.getByLabelText('Name'), {
+		target: { value: 'New Venue' },
+	});
+	fireEvent.change(screen.getByLabelText('Latitude'), {
+		target: { value: '200' },
+	});
+	fireEvent.change(screen.getByLabelText('Longitude'), {
+		target: { value: '0' },
+	});
+
+	expect(
+		screen.getAllByText(/Latitude must be between -90 and 90/i)
+	).toHaveLength(2);
+	expect(saveButton()).toBeDisabled();
+});
+
+test('a non-numeric coordinate shows an inline error and disables save', async () => {
+	await openCreateForm();
+
+	fireEvent.change(screen.getByLabelText('Name'), {
+		target: { value: 'New Venue' },
+	});
+	fireEvent.change(screen.getByLabelText('Latitude'), {
+		target: { value: 'not-a-number' },
+	});
+	fireEvent.change(screen.getByLabelText('Longitude'), {
+		target: { value: '0' },
+	});
+
+	expect(screen.getAllByText(/must be numbers/i)).toHaveLength(2);
+	expect(saveButton()).toBeDisabled();
+});
+
+test('pasting a "lat, lng" pair into latitude splits it across both fields', async () => {
+	await openCreateForm();
+
+	fireEvent.change(screen.getByLabelText('Latitude'), {
+		target: { value: '39.4878023, -0.3613204' },
+	});
+
+	expect(screen.getByLabelText('Latitude')).toHaveValue('39.4878023');
+	expect(screen.getByLabelText('Longitude')).toHaveValue('-0.3613204');
+});
+
+test('a decimal comma is accepted (no inline error)', async () => {
+	await openCreateForm();
+
+	fireEvent.change(screen.getByLabelText('Name'), {
+		target: { value: 'New Venue' },
+	});
+	fireEvent.change(screen.getByLabelText('Latitude'), {
+		target: { value: '39,48' },
+	});
+	fireEvent.change(screen.getByLabelText('Longitude'), {
+		target: { value: '-0,36' },
+	});
+
+	expect(
+		screen.queryByText(/must be between|must be numbers|Enter both/i)
+	).not.toBeInTheDocument();
+	expect(saveButton()).not.toBeDisabled();
+});
+
+test('opening a venue with pre-existing invalid coordinates shows the error immediately', async () => {
+	apiFetch.mockResolvedValue([existingVenue]);
+
+	render(<VenuesApp />);
+
+	await waitFor(() =>
+		expect(screen.getByText('Existing Venue')).toBeInTheDocument()
+	);
+	fireEvent.click(screen.getByRole('button', { name: /Edit/i }));
+
+	await waitFor(() =>
+		expect(
+			screen.getAllByText(/Latitude must be between -90 and 90/i)
+		).toHaveLength(2)
+	);
+	expect(
+		screen.getByRole('button', { name: /Update Venue/i })
+	).toBeDisabled();
+});

--- a/fair-events-experimental/src/Models/Venue.php
+++ b/fair-events-experimental/src/Models/Venue.php
@@ -332,6 +332,110 @@ class Venue {
 		return self::build_maps_url( $this->latitude, $this->longitude, $this->address );
 	}
 
+	/**
+	 * Replace a decimal-comma separator with a dot, but only when the value
+	 * doesn't already contain a dot (a pair-split result already uses dots).
+	 *
+	 * @param string $value Raw coordinate value.
+	 * @return string Normalized value.
+	 */
+	private static function normalize_decimal_separator( $value ) {
+		if ( '' === $value || false === strpos( $value, ',' ) || false !== strpos( $value, '.' ) ) {
+			return $value;
+		}
+
+		return str_replace( ',', '.', $value );
+	}
+
+	/**
+	 * Validate (and normalize) a latitude/longitude pair before it is stored.
+	 *
+	 * Both empty is valid (coordinates are optional). A decimal comma is
+	 * normalized to a dot. A "lat, lng" pair pasted into the latitude field
+	 * is split across both fields when longitude is empty — the split only
+	 * triggers when the comma is followed by whitespace (the shape mapping
+	 * tools paste, e.g. "39.4878023, -0.3613204"), so a plain decimal-comma
+	 * value like "39,48" (no space) is normalized instead of misread as a pair.
+	 *
+	 * @param string|null $latitude  Raw latitude input.
+	 * @param string|null $longitude Raw longitude input.
+	 * @return array {
+	 *     @type bool        $valid     Whether the pair is acceptable.
+	 *     @type string|null $latitude  Normalized latitude (only when valid).
+	 *     @type string|null $longitude Normalized longitude (only when valid).
+	 *     @type string      $code      Error code (only when invalid).
+	 *     @type string      $message   Translated error message (only when invalid).
+	 * }
+	 */
+	public static function validate_coordinates( $latitude, $longitude ) {
+		$latitude  = null === $latitude ? '' : trim( (string) $latitude );
+		$longitude = null === $longitude ? '' : trim( (string) $longitude );
+
+		if ( '' === $longitude && '' !== $latitude
+			&& preg_match( '/^(-?[0-9]+(?:\.[0-9]+)?)\s*,\s+(-?[0-9]+(?:\.[0-9]+)?)$/', $latitude, $matches )
+		) {
+			$latitude  = $matches[1];
+			$longitude = $matches[2];
+		}
+
+		$latitude  = self::normalize_decimal_separator( $latitude );
+		$longitude = self::normalize_decimal_separator( $longitude );
+
+		if ( '' === $latitude && '' === $longitude ) {
+			return array(
+				'valid'     => true,
+				'latitude'  => null,
+				'longitude' => null,
+			);
+		}
+
+		if ( '' === $latitude || '' === $longitude ) {
+			return array(
+				'valid'   => false,
+				'code'    => 'coordinate_pair_incomplete',
+				'message' => __( 'Enter both latitude and longitude, or leave both blank.', 'fair-events-experimental' ),
+			);
+		}
+
+		if ( ! is_numeric( $latitude ) || ! is_numeric( $longitude ) ) {
+			return array(
+				'valid'   => false,
+				'code'    => 'coordinate_not_numeric',
+				'message' => __( 'Latitude and longitude must be numbers, e.g. 39.4878023, -0.3613204.', 'fair-events-experimental' ),
+			);
+		}
+
+		if ( (float) $latitude < -90 || (float) $latitude > 90 ) {
+			return array(
+				'valid'   => false,
+				'code'    => 'coordinate_out_of_range',
+				'message' => __( 'Latitude must be between -90 and 90.', 'fair-events-experimental' ),
+			);
+		}
+
+		if ( (float) $longitude < -180 || (float) $longitude > 180 ) {
+			return array(
+				'valid'   => false,
+				'code'    => 'coordinate_out_of_range',
+				'message' => __( 'Longitude must be between -180 and 180.', 'fair-events-experimental' ),
+			);
+		}
+
+		if ( strlen( $latitude ) > 20 || strlen( $longitude ) > 20 ) {
+			return array(
+				'valid'   => false,
+				'code'    => 'coordinate_too_long',
+				'message' => __( 'Latitude and longitude must be 20 characters or fewer.', 'fair-events-experimental' ),
+			);
+		}
+
+		return array(
+			'valid'     => true,
+			'latitude'  => $latitude,
+			'longitude' => $longitude,
+		);
+	}
+
 	public function to_array() {
 		return array(
 			'id'                 => $this->id,


### PR DESCRIPTION
## Summary

- Adds `Venue::validate_coordinates()` — normalizes a decimal-comma value to a dot, auto-splits a pasted `"lat, lng"` pair into the latitude field when longitude is empty, treats both-empty as valid, and rejects non-numeric, out-of-range (-90..90 / -180..180), one-sided, or over-length (>20 chars) coordinates.
- `VenueController::create_item()` / `update_item()` call the helper and return `400 rest_invalid_coordinates` on failure, independently of the form's own check.
- `VenuesApp.js` derives the same validation from form state on every render, shows an inline error + `has-error` styling under the Latitude/Longitude fields, and disables Save while an error is present — including immediately when opening a venue that already holds invalid coordinates.
- The JSON import now validates each row client-side and imports a venue without its coordinates (listing the name in the success notice) instead of importing bad coordinates unchecked.

Closes #1289

## Acceptance criteria

- [x] Non-numeric/out-of-range latitude or longitude rejected on both form and endpoint.
- [x] Only one of the two filled is rejected, naming that both are needed.
- [x] Decimal comma accepted and stored in dot form.
- [x] Both coordinates empty saves successfully (existing address-fallback map link behaviour unchanged).
- [x] Inline errors under the offending field; Save disabled while any coordinate error is shown.
- [x] A venue with pre-existing invalid coordinates can be opened, corrected or cleared, and saved.
- [x] JSON import surfaces rows with invalid coordinates in the success notice instead of importing them unchecked.
- [x] API specs cover the rejected cases and the accepted comma normalization on POST and PUT.
- [x] Component tests cover inline errors, disabled Save, empty-coordinates, and pre-existing invalid coordinates.
- [x] All new messages are translatable (`__()`/`_n()`/`sprintf()`, no concatenation).

## Notes

- Swapped coordinates aren't specially detected beyond range validation, per the plan's decision.
- The pasted-pair split only triggers when the comma is followed by whitespace (the shape mapping tools paste, e.g. `39.4878023, -0.3613204`), so a plain decimal-comma value like `39,48` isn't misread as a pair.
- `__tests__/bootstrap.php` gained a minimal `__()` stub (untranslated passthrough) since the new PHPUnit tests exercise a code path that calls it.

## Test plan

- [x] `npx jest` (fair-events-experimental) — 20/20 passing, including new `VenuesApp.test.jsx` (7 tests) and `getCoordinateError`/paste-split coverage.
- [x] `vendor/bin/phpunit --filter VenueTest` — 13 new assertions passing (1 pre-existing, unrelated failure on `maps.google.com` string left untouched).
- [x] `npx playwright test src/API/__tests__/VenueController.api.spec.js` against the running dev site — 11/11 passing, including the new rejected-coordinate and comma-normalization cases on POST and PUT.
- [x] Manually verified in the browser (dev site, plugin temporarily activated then restored to its original inactive state): out-of-range coordinates show the inline error and disable Save; pasting `"39.4878023, -0.3613204"` into Latitude auto-splits into both fields.
