### PR TITLE
Consolidate organizer settings' duplicated fallback/sanitize logic

### DIFF
--- a/fair-events/src/Admin/AdminPages.php
+++ b/fair-events/src/Admin/AdminPages.php
@@ -370,38 +370,36 @@ class AdminPages {
 
 		$asset_file = include FAIR_EVENTS_PLUGIN_DIR . 'build/admin/settings/index.asset.php';
 
-		if ( 'fair-events-settings' === $slug ) {
-			wp_enqueue_media();
+		wp_enqueue_media();
 
-			wp_enqueue_script(
-				'fair-events-settings',
-				FAIR_EVENTS_PLUGIN_URL . 'build/admin/settings/index.js',
-				$asset_file['dependencies'],
-				$asset_file['version'],
-				true
-			);
+		wp_enqueue_script(
+			'fair-events-settings',
+			FAIR_EVENTS_PLUGIN_URL . 'build/admin/settings/index.js',
+			$asset_file['dependencies'],
+			$asset_file['version'],
+			true
+		);
 
-			wp_localize_script(
-				'fair-events-settings',
-				'fairEventsSettingsData',
-				array(
-					'eventsApiUrl' => rest_url( 'fair-events/v1/events' ),
-					// Feature registry (labels/descriptions/forced state) for the
-					// Features tab; resolved enabled state comes via the stored
-					// option once toggles are saved, but the registry itself is
-					// PHP-owned.
-					'features'     => \FairEvents\Core\Features::all(),
-				)
-			);
+		wp_localize_script(
+			'fair-events-settings',
+			'fairEventsSettingsData',
+			array(
+				'eventsApiUrl' => rest_url( 'fair-events/v1/events' ),
+				// Feature registry (labels/descriptions/forced state) for the
+				// Features tab; resolved enabled state comes via the stored
+				// option once toggles are saved, but the registry itself is
+				// PHP-owned.
+				'features'     => \FairEvents\Core\Features::all(),
+			)
+		);
 
-			wp_set_script_translations(
-				'fair-events-settings',
-				'fair-events',
-				\FairEvents\Core\Features::script_translations_path()
-			);
+		wp_set_script_translations(
+			'fair-events-settings',
+			'fair-events',
+			\FairEvents\Core\Features::script_translations_path()
+		);
 
-			wp_enqueue_style( 'wp-components' );
-		}
+		wp_enqueue_style( 'wp-components' );
 	}
 
 	/**

--- a/fair-events/src/Helpers/OrganizationSchema.php
+++ b/fair-events/src/Helpers/OrganizationSchema.php
@@ -41,12 +41,7 @@ class OrganizationSchema {
 			return null;
 		}
 
-		$data = array(
-			'@type' => $organizer['type'],
-			'@id'   => self::node_id(),
-			'name'  => $organizer['name'],
-			'url'   => '' !== $organizer['website'] ? $organizer['website'] : home_url(),
-		);
+		$data = self::build_identity_node( $organizer );
 
 		$address = self::build_address( $organizer );
 		if ( ! empty( $address ) ) {
@@ -90,6 +85,17 @@ class OrganizationSchema {
 			);
 		}
 
+		return self::build_identity_node( $organizer );
+	}
+
+	/**
+	 * Build the shared `@type`/`@id`/`name`/`url` identity block used by both
+	 * the sitewide Organization object and the per-event organizer reference.
+	 *
+	 * @param array $organizer Normalized organizer identity, as returned by Organizer::get().
+	 * @return array{'@type': string, '@id': string, name: string, url: string} Identity node.
+	 */
+	private static function build_identity_node( array $organizer ): array {
 		return array(
 			'@type' => $organizer['type'],
 			'@id'   => self::node_id(),

--- a/fair-events/src/Settings/Organizer.php
+++ b/fair-events/src/Settings/Organizer.php
@@ -104,34 +104,72 @@ class Organizer {
 		}
 		$out['same_as'] = array_values( array_unique( $same_as ) );
 
-		if ( ! empty( $value['logo_id'] ) ) {
-			$logo_id = absint( $value['logo_id'] );
-			if ( $logo_id && wp_attachment_is_image( $logo_id ) ) {
-				$out['logo_id'] = $logo_id;
+		foreach (
+			array(
+				'logo_id'       => array( self::class, 'sanitize_logo_id' ),
+				'website'       => array( self::class, 'sanitize_website' ),
+				'contact_email' => array( self::class, 'sanitize_contact_email' ),
+				'contact_phone' => array( self::class, 'sanitize_contact_phone' ),
+			) as $key => $sanitizer
+		) {
+			if ( empty( $value[ $key ] ) ) {
+				continue;
 			}
-		}
 
-		if ( ! empty( $value['website'] ) ) {
-			$website = esc_url_raw( (string) $value['website'] );
-			if ( '' !== $website && filter_var( $website, FILTER_VALIDATE_URL ) ) {
-				$out['website'] = $website;
-			}
-		}
-
-		if ( ! empty( $value['contact_email'] ) ) {
-			$email = sanitize_email( (string) $value['contact_email'] );
-			if ( '' !== $email && is_email( $email ) ) {
-				$out['contact_email'] = $email;
-			}
-		}
-
-		if ( ! empty( $value['contact_phone'] ) ) {
-			$phone = trim( sanitize_text_field( $value['contact_phone'] ) );
-			if ( '' !== $phone ) {
-				$out['contact_phone'] = $phone;
+			$sanitized = call_user_func( $sanitizer, $value[ $key ] );
+			if ( null !== $sanitized ) {
+				$out[ $key ] = $sanitized;
 			}
 		}
 
 		return $out;
+	}
+
+	/**
+	 * Sanitize+validate a raw `logo_id` value.
+	 *
+	 * @param mixed $raw_value Raw attachment ID.
+	 * @return int|null Sanitized attachment ID, or null when invalid.
+	 */
+	private static function sanitize_logo_id( $raw_value ) {
+		$logo_id = absint( $raw_value );
+
+		return ( $logo_id && wp_attachment_is_image( $logo_id ) ) ? $logo_id : null;
+	}
+
+	/**
+	 * Sanitize+validate a raw `website` value.
+	 *
+	 * @param mixed $raw_value Raw website URL.
+	 * @return string|null Sanitized URL, or null when invalid.
+	 */
+	private static function sanitize_website( $raw_value ) {
+		$website = esc_url_raw( (string) $raw_value );
+
+		return ( '' !== $website && filter_var( $website, FILTER_VALIDATE_URL ) ) ? $website : null;
+	}
+
+	/**
+	 * Sanitize+validate a raw `contact_email` value.
+	 *
+	 * @param mixed $raw_value Raw email address.
+	 * @return string|null Sanitized email, or null when invalid.
+	 */
+	private static function sanitize_contact_email( $raw_value ) {
+		$email = sanitize_email( (string) $raw_value );
+
+		return ( '' !== $email && is_email( $email ) ) ? $email : null;
+	}
+
+	/**
+	 * Sanitize+validate a raw `contact_phone` value.
+	 *
+	 * @param mixed $raw_value Raw phone number.
+	 * @return string|null Sanitized phone number, or null when empty.
+	 */
+	private static function sanitize_contact_phone( $raw_value ) {
+		$phone = trim( sanitize_text_field( $raw_value ) );
+
+		return ( '' !== $phone ) ? $phone : null;
 	}
 }


### PR DESCRIPTION
## Summary

Consolidates three duplicated blocks in the organizer settings, per the [approved plan](https://github.com/marcin-wosinek/fair-event-plugins/issues/1302#issuecomment-5164944215):

- `OrganizationSchema::organization_to_jsonld()` and `organizer_ref()` each independently built the same `@type`/`@id`/`name`/`url` identity block (including a byte-identical website→`home_url()` fallback ternary). Extracted into a shared private `build_identity_node()`.
- `Organizer::sanitize_option()` had one bespoke sanitize/validate block per optional field (`logo_id`, `website`, `contact_email`, `contact_phone`). Replaced with a `field => sanitizer` map driving a single loop, mirroring the registry+loop pattern already used in `Features::sanitize_option()`. Each sanitizer is now an independent private static method returning the sanitized value or `null`.
- `AdminPages::enqueue_admin_scripts()` had a redundant `if ( 'fair-events-settings' === $slug )` check whose condition the method's earlier early-return guard already guaranteed. Removed the dead conditional and de-indented its body.

This is internal cleanup only — no user-visible behavior change.

Closes #1302

## Acceptance criteria

- [x] Fallback-resolution logic for structured organization data consolidated into one shared implementation (`build_identity_node()`) instead of duplicated per call site.
- [x] Settings sanitization for optional organizer profile fields consolidated into a single shared mechanism (registry + loop) instead of one bespoke block per field.
- [x] Redundant leftover conditional on the settings page removed.
- [x] No user-visible behaviour change — existing test coverage (`OrganizerTest.php`, `OrganizationSchemaTest.php`, `OrganizerSettings.api.spec.js`, `OrganizerTab.test.jsx`, `e2e/organizer-jsonld.spec.js`) pins down current behavior and passes unchanged; manual WP-CLI checks below confirm identical output.

## Notes

- Scope matches the plan's **Decisions**: only the literally-duplicated identity block was extracted (address/`sameAs`/logo/`contactPoint` stay put since they're not duplicated); `same_as` URL validation was left out of scope (candidate for a follow-up ticket).
- No JS/CSS changed, so no `npm run build` was needed.

## Test plan

- [x] `npm run test:php` in `fair-events` — 152 tests, 263 assertions, same pass count before/after the refactor.
- [x] `vendor/bin/phpcs` on the three changed files — clean (pre-existing unrelated findings in `AdminPages.php` are unchanged from `main`).
- [x] Manual WP-CLI `eval-file` check against the running dev site: confirmed the consolidated sanitizers keep valid/invalid behavior identical for all 4 optional fields, `organization_to_jsonld()`/`organizer_ref()` produce matching `@id`s and the same `home_url()` website fallback, and the de-duplicated settings-page enqueue still registers the script/style with no fatal.
