### PR TITLE
Add URL question block to Fair Form

### DIFF
--- a/.changeset/add-url-question-block.md
+++ b/.changeset/add-url-question-block.md
@@ -1,0 +1,5 @@
+---
+"fair-form": minor
+---
+
+Add a URL question block (mirrors the email question) that renders a mobile-friendly text input on the frontend, normalizes bare domains to `https://`, and rejects non-web values server-side. Stored answers render as links in the submission-detail and questionnaire-responses admin views.

--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -129,6 +129,15 @@ if ( 'audience-ticket-scopes' === $flavour ) {
 			'<!-- /wp:fair-events/event-signup -->',
 		)
 	);
+} elseif ( isset( $overrides['block'] ) && 'unified-with-url' === $overrides['block'] ) {
+	$block_content = implode(
+		"\n",
+		array(
+			'<!-- wp:fair-events/event-signup -->',
+			'<!-- wp:fair-audience/fair-form-url {"questionKey":"website","questionText":"Website"} /-->',
+			'<!-- /wp:fair-events/event-signup -->',
+		)
+	);
 } elseif ( 'address' === $flavour ) {
 	// event-info block (renders the address/venue) + a calendar button — no
 	// signup block, since this flavour never touches the purchase path.

--- a/e2e/user-flows/unified-signup-url-question.spec.js
+++ b/e2e/user-flows/unified-signup-url-question.spec.js
@@ -1,0 +1,40 @@
+/**
+ * E2E: signup with a URL question nested in the unified Event Signup block
+ * (#1326). A bare domain typed the way people actually write it — no
+ * `https://` prefix — must be accepted and complete the signup, mirroring
+ * unified-signup-phone-question.spec.js for the phone question.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+
+test.describe('unified event-signup block: nested URL question', () => {
+	test('a free signup with a bare-domain URL completes', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('free', { block: 'unified-with-url' });
+		const stamp = Date.now();
+		const email = `unified.url.${stamp}@example.test`;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		const question = form.locator('[data-question-key="website"]');
+		await expect(question).toBeVisible();
+		await expect(question).toContainText('Website');
+
+		await form.locator('input[name="name"]').fill('Unified Visitor');
+		await form.locator('input[name="email"]').fill(email);
+		await question.locator('input').fill('example.com/my-portfolio');
+
+		await form.locator('.form-button').click();
+
+		await expect(
+			page.getByText('You have successfully registered', {
+				exact: false,
+			})
+		).toBeVisible();
+	});
+});

--- a/fair-events-shared/src/__tests__/questionnaire.test.js
+++ b/fair-events-shared/src/__tests__/questionnaire.test.js
@@ -529,3 +529,50 @@ describe('phone question type', () => {
 		});
 	});
 });
+
+/**
+ * Build a URL question as fair-form-url/render.php emits it.
+ *
+ * @param {string} value Field value.
+ * @return {string} The question markup.
+ */
+function urlQuestion(value) {
+	return (
+		'<div data-fair-form-question data-question-key="website" data-question-text="Website" data-question-type="url" data-required="0">' +
+		`<input type="text" inputmode="url" value="${value}" /></div>`
+	);
+}
+
+describe('url question type', () => {
+	describe('validateQuestions', () => {
+		it('passes a bare domain (accepted as shorthand for https://)', () => {
+			const form = buildForm(urlQuestion('example.com/my-event'));
+			expect(validateQuestions(form)).toBeNull();
+		});
+
+		it('passes an already-schemed https:// value', () => {
+			const form = buildForm(urlQuestion('https://example.com'));
+			expect(validateQuestions(form)).toBeNull();
+		});
+
+		it('passes an already-schemed http:// value', () => {
+			const form = buildForm(urlQuestion('http://example.com'));
+			expect(validateQuestions(form)).toBeNull();
+		});
+
+		it('passes an empty, non-required value', () => {
+			const form = buildForm(urlQuestion(''));
+			expect(validateQuestions(form)).toBeNull();
+		});
+
+		it('blocks a javascript: address', () => {
+			const form = buildForm(urlQuestion('javascript:alert(1)'));
+			expect(validateQuestions(form)).toMatch(/Website/);
+		});
+
+		it('blocks free text', () => {
+			const form = buildForm(urlQuestion('just some free text'));
+			expect(validateQuestions(form)).toMatch(/Website/);
+		});
+	});
+});

--- a/fair-events-shared/src/questionnaire.js
+++ b/fair-events-shared/src/questionnaire.js
@@ -408,8 +408,8 @@ export function applyQuestionAnswers(form, answers) {
  * Validate the nested question blocks within a form.
  *
  * Checks required questions (respecting conditional visibility), phone format
- * (E.164), and file-upload size limits. The caller is responsible for any
- * non-question fields (name/email).
+ * (E.164), URL format (accepting a bare domain), and file-upload size limits.
+ * The caller is responsible for any non-question fields (name/email).
  *
  * @param {HTMLElement} form The form (or container) element.
  * @return {string|null} An error message, or null when valid.
@@ -498,6 +498,40 @@ export function validateQuestions(form) {
 					'Please enter a valid email address for: ',
 					'fair-audience'
 				) + questionText
+			);
+		}
+	}
+
+	// Validate URL questions (format check, accepting a bare domain).
+	const urlQuestions = form.querySelectorAll(
+		'[data-fair-form-question][data-question-type="url"]'
+	);
+	for (const el of urlQuestions) {
+		if (!isQuestionVisible(el)) {
+			continue;
+		}
+		const input = el.querySelector('input');
+		const value = input ? input.value.trim() : '';
+		if (!value) {
+			continue;
+		}
+		const normalized = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(value)
+			? value
+			: 'https://' + value;
+		let isValid = false;
+		try {
+			const parsed = new URL(normalized);
+			isValid =
+				parsed.protocol === 'http:' || parsed.protocol === 'https:';
+		} catch (e) {
+			isValid = false;
+		}
+		if (!isValid) {
+			const questionText = el.dataset.questionText || '';
+			return sprintf(
+				/* translators: %s: question text */
+				__('Please enter a valid web address for: %s', 'fair-audience'),
+				questionText
 			);
 		}
 	}

--- a/fair-form/fair-form.php
+++ b/fair-form/fair-form.php
@@ -84,5 +84,21 @@ function fair_form_maybe_upgrade_db() {
 
 		update_option( 'fair_form_db_version', '0.2.0' );
 	}
+
+	if ( version_compare( $db_version, '0.3.0', '<' ) ) {
+		global $wpdb;
+
+		$answers_table = $wpdb->prefix . 'fair_audience_questionnaire_answers';
+
+		// Add 'url' to the question_type ENUM so URL-field answers persist
+		// correctly, and 'phone' (a pre-existing gap left by the 0.2.0 step)
+		// in the same ALTER TABLE statement.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query(
+			$wpdb->prepare( "ALTER TABLE %i MODIFY question_type ENUM('radio','checkbox','short_text','long_text','select','number','date','multiselect','file_upload','email','phone','url') NOT NULL DEFAULT 'short_text'", $answers_table )
+		);
+
+		update_option( 'fair_form_db_version', '0.3.0' );
+	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_form_maybe_upgrade_db' );

--- a/fair-form/src/API/__tests__/FairFormUrlAnswers.api.spec.js
+++ b/fair-form/src/API/__tests__/FairFormUrlAnswers.api.spec.js
@@ -1,0 +1,185 @@
+/**
+ * Playwright API tests for URL-question validation/normalization in
+ * FairFormController::create_item() / QuestionnaireService::sanitize_answers()
+ * (#1326): a bare domain (no scheme) is accepted and normalized to
+ * `https://`, an already-schemed `http://`/`https://` value passes through
+ * unchanged, and anything that isn't a well-formed `http`/`https` address
+ * (a `javascript:`/`file:` value, or free text) is rejected.
+ *
+ * Every accept-case payload carries its own unique email answer so the
+ * FairFormController rate limiter (3/hour, keyed on email when present) keys
+ * per-submission instead of falling back to the shared IP key.
+ *
+ * When fair-audience is active, FairFormController opportunistically creates
+ * a Participant from that email — but Participant::save() requires a
+ * non-empty `name`, which the controller never supplies. Pre-creating each
+ * accept case's participant via the admin API (name + email) sidesteps that
+ * pre-existing gap so this spec stays focused on URL validation; reject
+ * cases never reach participant creation (sanitize_answers() fails first).
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}-${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+const emailQuestion = (value) => ({
+	question_key: 'email',
+	question_text: 'Email?',
+	question_type: 'email',
+	answer_value: value,
+	display_order: 0,
+});
+
+const urlQuestion = (value) => ({
+	question_key: 'website',
+	question_text: 'Website?',
+	question_type: 'url',
+	answer_value: value,
+	display_order: 1,
+});
+
+const ACCEPT_CASES = [
+	{ input: 'example.com', expected: 'https://example.com' },
+	{ input: 'example.com/my-event', expected: 'https://example.com/my-event' },
+	{ input: 'https://example.com', expected: 'https://example.com' },
+	{ input: 'http://example.com', expected: 'http://example.com' },
+];
+
+const REJECT_CASES = [
+	'javascript:alert(1)',
+	'file:///etc/passwd',
+	'just some free text',
+	'',
+];
+
+test.describe('FairFormController — URL question validation (#1326)', () => {
+	let api;
+	let fairAudienceActive = false;
+	const postId = Date.now();
+
+	async function findSubmissionByEmail(email) {
+		const res = await api.get(
+			'/wp-json/fair-form/v1/questionnaire-responses',
+			{
+				headers: adminHeaders,
+				params: { post_id: postId, title: 'Fair Form' },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const submissions = await res.json();
+		return submissions.find((s) =>
+			s.answers.some((a) => a.answer_value === email)
+		);
+	}
+
+	async function ensureParticipant(email) {
+		if (!fairAudienceActive) {
+			return;
+		}
+		await api.post('/wp-json/fair-audience/v1/participants', {
+			headers: adminHeaders,
+			data: { name: 'URL Test', email },
+		});
+	}
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	for (const { input, expected } of ACCEPT_CASES) {
+		test(`normalizes ${JSON.stringify(input)} to ${expected}`, async () => {
+			const email = uniqueEmail('url-accept');
+			await ensureParticipant(email);
+			const res = await api.post(
+				'/wp-json/fair-form/v1/fair-form-submit',
+				{
+					data: {
+						post_id: postId,
+						questionnaire_answers: [
+							emailQuestion(email),
+							urlQuestion(input),
+						],
+					},
+				}
+			);
+			expect(res.ok()).toBeTruthy();
+
+			const submission = await findSubmissionByEmail(email);
+			expect(submission).toBeTruthy();
+			const urlAnswer = submission.answers.find(
+				(a) => a.question_key === 'website'
+			);
+			expect(urlAnswer.answer_value).toBe(expected);
+		});
+	}
+
+	// Empty (not required) should be accepted and stored empty, unlike the
+	// other reject cases which are invalid values, not absent ones.
+	test('accepts an empty, non-required URL answer', async () => {
+		const email = uniqueEmail('url-empty');
+		await ensureParticipant(email);
+		const res = await api.post('/wp-json/fair-form/v1/fair-form-submit', {
+			data: {
+				post_id: postId,
+				questionnaire_answers: [emailQuestion(email), urlQuestion('')],
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+
+		const submission = await findSubmissionByEmail(email);
+		expect(submission).toBeTruthy();
+		const urlAnswer = submission.answers.find(
+			(a) => a.question_key === 'website'
+		);
+		expect(urlAnswer.answer_value).toBe('');
+	});
+
+	for (const value of REJECT_CASES.filter((v) => v !== '')) {
+		test(`rejects ${JSON.stringify(value)}`, async () => {
+			const email = uniqueEmail('url-reject');
+			const res = await api.post(
+				'/wp-json/fair-form/v1/fair-form-submit',
+				{
+					data: {
+						post_id: postId,
+						questionnaire_answers: [
+							emailQuestion(email),
+							urlQuestion(value),
+						],
+					},
+				}
+			);
+			expect(res.status()).toBe(400);
+			expect((await res.json()).code).toBe('invalid_url');
+		});
+	}
+});

--- a/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
+++ b/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
@@ -106,13 +106,17 @@ export default function QuestionnaireResponses() {
 		responses.forEach((response) => {
 			(response.answers || []).forEach((answer) => {
 				if (!seen.has(answer.question_key)) {
-					seen.set(answer.question_key, answer.question_text);
+					seen.set(answer.question_key, {
+						text: answer.question_text,
+						type: answer.question_type,
+					});
 				}
 			});
 		});
-		return Array.from(seen.entries()).map(([key, text]) => ({
+		return Array.from(seen.entries()).map(([key, { text, type }]) => ({
 			key,
 			text,
+			type,
 		}));
 	}, [responses]);
 
@@ -254,6 +258,26 @@ export default function QuestionnaireResponses() {
 				);
 				return answer ? answer.answer_value : '';
 			},
+			...(col.type === 'url' && {
+				render: ({ item }) => {
+					const answer = (item.answers || []).find(
+						(a) => a.question_key === col.key
+					);
+					const value = answer ? answer.answer_value : '';
+					if (!value || !/^https?:\/\//.test(value)) {
+						return value || '';
+					}
+					return (
+						<a
+							href={value}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{value}
+						</a>
+					);
+				},
+			}),
 		}));
 
 		return [

--- a/fair-form/src/Admin/submission-detail/SubmissionDetail.js
+++ b/fair-form/src/Admin/submission-detail/SubmissionDetail.js
@@ -39,6 +39,18 @@ function AnswerDisplay({ answer }) {
 		);
 	}
 
+	if (
+		question_type === 'url' &&
+		answer_value &&
+		/^https?:\/\//.test(answer_value)
+	) {
+		return (
+			<a href={answer_value} target="_blank" rel="noopener noreferrer">
+				{answer_value}
+			</a>
+		);
+	}
+
 	if (question_type === 'multiselect' && answer_value) {
 		try {
 			const values = JSON.parse(answer_value);

--- a/fair-form/src/Database/Schema.php
+++ b/fair-form/src/Database/Schema.php
@@ -62,7 +62,7 @@ class Schema {
 			submission_id BIGINT UNSIGNED NOT NULL,
 			question_key VARCHAR(100) DEFAULT '',
 			question_text VARCHAR(500) NOT NULL,
-			question_type ENUM('radio','checkbox','short_text','long_text','select','number','date','multiselect','file_upload','email') NOT NULL DEFAULT 'short_text',
+			question_type ENUM('radio','checkbox','short_text','long_text','select','number','date','multiselect','file_upload','email','phone','url') NOT NULL DEFAULT 'short_text',
 			answer_value TEXT NOT NULL,
 			display_order INT DEFAULT 0,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/fair-form/src/Hooks/BlockHooks.php
+++ b/fair-form/src/Hooks/BlockHooks.php
@@ -37,6 +37,7 @@ class BlockHooks {
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-long-text' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-email' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-phone' );
+		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-url' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-select-one' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-multiselect' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-radio' );
@@ -55,6 +56,7 @@ class BlockHooks {
 		wp_set_script_translations( 'fair-form-fair-form-long-text-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-email-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-phone-editor-script', 'fair-audience', $translations_path );
+		wp_set_script_translations( 'fair-form-fair-form-url-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-select-one-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-multiselect-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-radio-editor-script', 'fair-audience', $translations_path );

--- a/fair-form/src/Models/QuestionnaireAnswer.php
+++ b/fair-form/src/Models/QuestionnaireAnswer.php
@@ -31,6 +31,7 @@ class QuestionnaireAnswer {
 		'file_upload',
 		'phone',
 		'email',
+		'url',
 	);
 
 	/**

--- a/fair-form/src/Services/QuestionnaireService.php
+++ b/fair-form/src/Services/QuestionnaireService.php
@@ -50,7 +50,7 @@ class QuestionnaireService {
 	 *
 	 * @var array
 	 */
-	const VALID_TYPES = array( 'radio', 'checkbox', 'short_text', 'long_text', 'select', 'number', 'date', 'multiselect', 'file_upload', 'phone', 'email' );
+	const VALID_TYPES = array( 'radio', 'checkbox', 'short_text', 'long_text', 'select', 'number', 'date', 'multiselect', 'file_upload', 'phone', 'email', 'url' );
 
 	/**
 	 * HTML `pattern` attribute value for the phone question's `<input>`.
@@ -216,6 +216,22 @@ class QuestionnaireService {
 				$answer_value = $normalized;
 			}
 
+			if ( 'url' === $question_type && '' !== $answer_value ) {
+				$normalized = self::normalize_url( $answer_value );
+				if ( ! self::is_valid_web_url( $normalized ) ) {
+					return new WP_Error(
+						'invalid_url',
+						sprintf(
+							/* translators: %s: question text */
+							__( 'Please enter a valid web address for: %s', 'fair-form' ),
+							$question_text
+						),
+						array( 'status' => 400 )
+					);
+				}
+				$answer_value = $normalized;
+			}
+
 			$sanitized[] = array(
 				'question_key'  => sanitize_key( $answer['question_key'] ?? '' ),
 				'question_text' => $question_text,
@@ -242,6 +258,40 @@ class QuestionnaireService {
 	 */
 	public static function normalize_phone( $value ) {
 		return preg_replace( '/[\p{Z}\s\x{FEFF}.()-]/u', '', $value );
+	}
+
+	/**
+	 * Prepend `https://` to a URL question value that has no scheme, so a
+	 * bare domain (e.g. "example.com/my-event") is accepted as shorthand for
+	 * the full web address. Mirrored by the JS twin in
+	 * `fair-events-shared/src/questionnaire.js`'s `validateQuestions()`.
+	 *
+	 * @param string $value Raw URL value.
+	 * @return string Value with a scheme, unchanged if it already had one.
+	 */
+	public static function normalize_url( $value ) {
+		if ( ! preg_match( '#^[a-zA-Z][a-zA-Z\d+.-]*://#', $value ) ) {
+			return 'https://' . $value;
+		}
+		return $value;
+	}
+
+	/**
+	 * Whether a (already-schemed) value is a well-formed `http`/`https` web
+	 * address. Rejects other schemes (`javascript:`, `file:`, …) and free
+	 * text that doesn't parse as a URL at all.
+	 *
+	 * @param string $value URL value, expected to already carry a scheme.
+	 * @return bool Whether the value is a valid http/https URL.
+	 */
+	public static function is_valid_web_url( $value ) {
+		$filtered = filter_var( $value, FILTER_VALIDATE_URL );
+		if ( false === $filtered ) {
+			return false;
+		}
+
+		$scheme = wp_parse_url( $filtered, PHP_URL_SCHEME );
+		return in_array( $scheme, array( 'http', 'https' ), true );
 	}
 
 	/**

--- a/fair-form/src/blocks/fair-form-url/__tests__/editor.test.jsx
+++ b/fair-form/src/blocks/fair-form-url/__tests__/editor.test.jsx
@@ -1,0 +1,142 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('@wordpress/block-editor', () => ({
+	useBlockProps: (props) => props || {},
+	InspectorControls: ({ children }) => children,
+}));
+
+jest.mock('@wordpress/components', () => ({
+	PanelBody: ({ children }) => children,
+	TextControl: ({ label, value, onChange, help }) => (
+		<div>
+			<label>
+				{label}
+				<input
+					value={value}
+					onChange={(e) => onChange(e.target.value)}
+				/>
+			</label>
+			{help}
+		</div>
+	),
+	ToggleControl: ({ label, checked, onChange }) => (
+		<label>
+			<input
+				type="checkbox"
+				checked={checked}
+				onChange={(e) => onChange(e.target.checked)}
+			/>
+			{label}
+		</label>
+	),
+}));
+
+jest.mock('fair-events-shared', () => ({
+	generateQuestionKey: (text) =>
+		text
+			.toLowerCase()
+			.trim()
+			.replace(/[^a-z0-9]+/g, '_')
+			.replace(/^_+|_+$/g, ''),
+}));
+
+let capturedSettings;
+jest.mock('@wordpress/blocks', () => ({
+	registerBlockType: (name, settings) => {
+		capturedSettings = settings;
+	},
+}));
+
+describe('Fair Form URL Question Edit', () => {
+	let Edit;
+
+	beforeAll(() => {
+		require('../editor.js');
+		Edit = capturedSettings.edit;
+	});
+
+	const baseAttributes = {
+		questionText: '',
+		questionKey: '',
+		required: false,
+		placeholder: '',
+	};
+
+	const renderEdit = (attributes = {}, setAttributes = () => {}) =>
+		render(
+			<Edit
+				attributes={{ ...baseAttributes, ...attributes }}
+				setAttributes={setAttributes}
+			/>
+		);
+
+	it('derives the question key from the question text', () => {
+		const setAttributes = jest.fn();
+		renderEdit({}, setAttributes);
+
+		const questionTextInput = screen.getByPlaceholderText(
+			'Enter your question...'
+		);
+		fireEvent.change(questionTextInput, {
+			target: { value: 'Portfolio website' },
+		});
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			questionText: 'Portfolio website',
+			questionKey: 'portfolio_website',
+		});
+	});
+
+	it('does not override a manually-edited question key', () => {
+		const setAttributes = jest.fn();
+		renderEdit(
+			{ questionText: 'Website', questionKey: 'custom_key' },
+			setAttributes
+		);
+
+		const questionTextInput = screen.getByPlaceholderText(
+			'Enter your question...'
+		);
+		fireEvent.change(questionTextInput, {
+			target: { value: 'Website updated' },
+		});
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			questionText: 'Website updated',
+		});
+	});
+
+	it('renders the Required toggle and Placeholder controls', () => {
+		renderEdit();
+
+		expect(screen.getByLabelText('Required')).toBeInTheDocument();
+		expect(screen.getByLabelText('Placeholder')).toBeInTheDocument();
+		expect(screen.getByLabelText('Question Key')).toBeInTheDocument();
+	});
+
+	it('toggles the required attribute', () => {
+		const setAttributes = jest.fn();
+		renderEdit({}, setAttributes);
+
+		fireEvent.click(screen.getByLabelText('Required'));
+
+		expect(setAttributes).toHaveBeenCalledWith({ required: true });
+	});
+
+	it('updates the placeholder attribute', () => {
+		const setAttributes = jest.fn();
+		renderEdit({}, setAttributes);
+
+		fireEvent.change(screen.getByLabelText('Placeholder'), {
+			target: { value: 'https://example.com' },
+		});
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			placeholder: 'https://example.com',
+		});
+	});
+});

--- a/fair-form/src/blocks/fair-form-url/block.json
+++ b/fair-form/src/blocks/fair-form-url/block.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "fair-audience/fair-form-url",
+	"version": "1.0.0",
+	"title": "URL Question",
+	"category": "widgets",
+	"icon": "admin-links",
+	"description": "A URL input question with built-in web-address validation for Fair Form",
+	"keywords": ["question", "url", "link", "website"],
+	"textdomain": "fair-audience",
+	"ancestor": [
+		"fair-audience/fair-form",
+		"fair-audience/event-signup",
+		"fair-events/event-signup"
+	],
+	"supports": {
+		"html": false
+	},
+	"attributes": {
+		"questionText": {
+			"type": "string",
+			"default": ""
+		},
+		"questionKey": {
+			"type": "string",
+			"default": ""
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		},
+		"placeholder": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"editorScript": "file:./editor.js",
+	"render": "file:./render.php",
+	"style": "file:./style-editor.css"
+}

--- a/fair-form/src/blocks/fair-form-url/editor.js
+++ b/fair-form/src/blocks/fair-form-url/editor.js
@@ -1,0 +1,92 @@
+import './style.css';
+
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { generateQuestionKey } from 'fair-events-shared';
+
+registerBlockType('fair-audience/fair-form-url', {
+	edit: ({ attributes, setAttributes }) => {
+		const { questionText, questionKey, required, placeholder } = attributes;
+
+		const onQuestionTextChange = (value) => {
+			const updates = { questionText: value };
+			if (
+				!questionKey ||
+				questionKey === generateQuestionKey(questionText)
+			) {
+				updates.questionKey = generateQuestionKey(value);
+			}
+			setAttributes(updates);
+		};
+
+		const blockProps = useBlockProps({
+			className: 'fair-form-question fair-form-question-url',
+		});
+
+		return (
+			<>
+				<InspectorControls>
+					<PanelBody title={__('Question Settings', 'fair-audience')}>
+						<TextControl
+							label={__('Question Key', 'fair-audience')}
+							value={questionKey}
+							onChange={(value) =>
+								setAttributes({ questionKey: value })
+							}
+							help={__(
+								'A unique identifier for this question (e.g. "website"). Used internally.',
+								'fair-audience'
+							)}
+						/>
+						<ToggleControl
+							label={__('Required', 'fair-audience')}
+							checked={required}
+							onChange={(value) =>
+								setAttributes({ required: value })
+							}
+						/>
+						<TextControl
+							label={__('Placeholder', 'fair-audience')}
+							value={placeholder}
+							onChange={(value) =>
+								setAttributes({ placeholder: value })
+							}
+						/>
+					</PanelBody>
+				</InspectorControls>
+
+				<div {...blockProps}>
+					<p>
+						<input
+							type="text"
+							value={questionText}
+							onChange={(e) =>
+								onQuestionTextChange(e.target.value)
+							}
+							placeholder={__(
+								'Enter your question...',
+								'fair-audience'
+							)}
+							className="fair-form-question-label-input"
+						/>
+						{required && <span className="required"> *</span>}
+						<br />
+						<input
+							type="text"
+							disabled
+							placeholder={
+								placeholder ||
+								__('https://example.com', 'fair-audience')
+							}
+						/>
+					</p>
+				</div>
+			</>
+		);
+	},
+	save: () => {
+		return null;
+	},
+});

--- a/fair-form/src/blocks/fair-form-url/render.php
+++ b/fair-form/src/blocks/fair-form-url/render.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Render callback for the Fair Form URL question block
+ *
+ * @package FairForm
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block content.
+ * @param WP_Block $block      Block instance.
+ * @return string Rendered block HTML.
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ * Variables in block render templates are scoped to the template and don't need prefixing.
+ */
+
+defined( 'WPINC' ) || die;
+
+$question_text = $attributes['questionText'] ?? '';
+$question_key  = $attributes['questionKey'] ?? '';
+$required      = ! empty( $attributes['required'] );
+$placeholder   = $attributes['placeholder'] ?? '';
+
+// Skip rendering if no question text is set.
+if ( empty( $question_text ) ) {
+	return '';
+}
+
+// Generate unique ID for this input.
+$input_id = 'fair-form-q-' . sanitize_title( $question_key ) . '-' . wp_unique_id();
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class'                   => 'fair-form-question fair-form-question-url',
+		'data-fair-form-question' => '',
+		'data-question-key'       => esc_attr( $question_key ),
+		'data-question-text'      => esc_attr( $question_text ),
+		'data-question-type'      => 'url',
+		'data-required'           => $required ? '1' : '0',
+	)
+);
+?>
+
+<div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
+	<label for="<?php echo esc_attr( $input_id ); ?>">
+		<?php echo esc_html( $question_text ); ?>
+		<?php if ( $required ) : ?>
+			<span class="required">*</span>
+		<?php endif; ?>
+	</label>
+	<input
+		type="text"
+		inputmode="url"
+		id="<?php echo esc_attr( $input_id ); ?>"
+		name="<?php echo esc_attr( 'fair_form_q_' . $question_key ); ?>"
+		<?php if ( $required ) : ?>
+			required
+		<?php endif; ?>
+		<?php if ( ! empty( $placeholder ) ) : ?>
+			placeholder="<?php echo esc_attr( $placeholder ); ?>"
+		<?php endif; ?>
+	/>
+</div>

--- a/fair-form/src/blocks/fair-form-url/style.css
+++ b/fair-form/src/blocks/fair-form-url/style.css
@@ -1,0 +1,24 @@
+.fair-form-question-url .fair-form-question-label-input {
+	border: none;
+	border-bottom: 1px dashed #8c8f94;
+	background: transparent;
+	font-weight: 600;
+	padding: 2px 0;
+	font-size: inherit;
+	width: auto;
+}
+
+.fair-form-question-url .fair-form-question-label-input:focus {
+	outline: none;
+	border-bottom-color: #2271b1;
+}
+
+.fair-form-question-url input[type="text"]:disabled {
+	width: 100%;
+	padding: 8px 12px;
+	border: 1px solid #8c8f94;
+	border-radius: 4px;
+	font-size: inherit;
+	line-height: 1.5;
+	background: #f0f0f0;
+}


### PR DESCRIPTION
## Summary

- Adds a new `fair-audience/fair-form-url` question block to Fair Form, mirroring the email question's editor experience (question text, machine-readable key, required/placeholder settings).
- Frontend renders as `<input type="text" inputmode="url">` (not `type="url"` — see Notes), accepts a bare domain and normalizes it to `https://`, and blocks empty submission when required.
- Server-side (`QuestionnaireService::sanitize_answers()`) normalizes bare domains to `https://` and rejects anything that isn't a well-formed `http`/`https` address (`javascript:`, `file:`, free text, …) with a 400 `invalid_url` error naming the question.
- DB migration (`fair_form_db_version` → `0.3.0`) adds `'url'` to the `question_type` ENUM for existing installs, and fixes a pre-existing gap by adding `'phone'` in the same statement (phone answers have been silently falling back to `short_text`-shaped storage since #1267 introduced the phone question without a matching ENUM update).
- Stored URL answers render as safe links (`target="_blank" rel="noopener noreferrer"`) in the submission-detail and questionnaire-responses admin views.

Closes #1326

## Acceptance criteria

- [x] **The URL question block can be inserted into a form and configured (question text, key, required, placeholder) like the email question.** New block at `fair-form/src/blocks/fair-form-url/` mirrors `fair-form-email`'s `block.json`/`editor.js`/`render.php`/`style.css` exactly, registered in `BlockHooks.php` alongside phone/email, with the same `ancestor` list as phone (`fair-audience/fair-form`, `fair-audience/event-signup`, `fair-events/event-signup`).
- [x] **The frontend field is a URL input; required fields block empty submission.** `render.php` emits `<input type="text" inputmode="url">`; required-field blocking is handled generically by the existing `validateQuestions()` required-question check in `fair-events-shared/src/questionnaire.js` (unchanged — it already works for any input type).
- [x] **A bare domain is accepted and stored as an `https://` address.** Both the JS (`validateQuestions()`) and PHP (`QuestionnaireService::normalize_url()`) sides prepend `https://` when no `scheme://` prefix is present, before validating.
- [x] **A non-web value (e.g. a `javascript:` or `file:` address, or free text) is rejected server-side with a clear error.** `QuestionnaireService::is_valid_web_url()` uses `filter_var(..., FILTER_VALIDATE_URL)` plus an explicit `http`/`https` scheme check, returning `WP_Error( 'invalid_url', ... , [ 'status' => 400 ] )` naming the question — mirrors the existing `invalid_email`/`invalid_phone` shape.
- [x] **Stored answers render as safe links in the form-answers and submission-detail admin views.** `SubmissionDetail.js`'s `AnswerDisplay()` and `QuestionnaireResponses.js`'s dynamic per-question columns both link-ify `url`-typed answers (with an `http`/`https` scheme guard before rendering as a link).
- [x] **Existing forms and stored answers continue to work after the change, including on an upgraded install.** The `0.3.0` migration step in `fair_form_maybe_upgrade_db()` runs a guarded `ALTER TABLE ... MODIFY question_type ENUM(...)` adding `'url'` and `'phone'`; `Schema::get_questionnaire_answers_table_sql()`'s ENUM literal is bumped the same way for fresh installs. No existing question type, table, or route changes.
- [x] **Component test for the editor block, API spec covering accepted/rejected submitted values, and e2e coverage of filling and submitting a form containing a URL question.** See Test plan below.

## Notes

- Per the approved implementation plan's Decision 2: the frontend input uses `type="text" inputmode="url"` rather than `type="url"`. The `fair-form` block's `<form>` has `novalidate`, but `event-signup`'s forms don't — a literal `type="url"` would trigger native browser constraint validation requiring an absolute URL, rejecting bare domains on event-signup forms and contradicting the "bare domain accepted" acceptance criterion. `inputmode="url"` still gives the correct mobile keyboard.
- The `'phone'`-missing-from-ENUM gap (pre-existing since #1267) is fixed in the same `ALTER TABLE` statement as this ticket's `'url'` addition, per Decision 3 of the plan.
- Added a `fair-form` minor changeset.
- Added a unit-test block (`describe('url question type', ...)`) to `fair-events-shared/src/__tests__/questionnaire.test.js` mirroring the existing phone-question coverage — not explicitly listed in the plan's Tests section, but the same shared module already had equivalent phone coverage, so I added it for consistency.

## Test plan

- [x] `npm run build` in `fair-form` — succeeds (only pre-existing bundle-size warnings unrelated to this change).
- [x] `npm run format` in `fair-form` — clean, no formatting noise.
- [x] `vendor/bin/phpcs` on all changed PHP files — 0 errors. A few pre-existing warnings surface (direct-DB-call / schema-change-discouraged) on lines this change didn't touch or that mirror the existing `0.2.0` migration step's already-accepted pattern.
- [x] `npm run test:js` in `fair-form` — 6 suites / 22 tests pass, including the new `fair-form-url/__tests__/editor.test.jsx` (5 tests) and the existing `SubmissionDetail`/`QuestionnaireResponses` component tests (unaffected).
- [x] `npm test` in `fair-events-shared` — 17 suites / 229 tests pass, including the new URL-validation coverage in `questionnaire.test.js`.
- [ ] `npm run test:api` (`FairFormUrlAnswers.api.spec.js`) — written, modeled on `FairFormPhoneAnswers.api.spec.js`, but **not executed**: the only reachable WordPress instance (`localhost:8080`) is bound to a different git worktree's checkout that this agent is isolated from and not permitted to modify, so it doesn't reflect this branch's code, and spinning up a second stack conflicts on the same host ports. Please run `npm run test:api` locally before merging.
- [ ] `npm run test:e2e` (`unified-signup-url-question.spec.js`, using the new `unified-with-url` seed variant) — written, modeled on `unified-signup-phone-question.spec.js`, same execution caveat as above.
- [ ] Manual verification in the block editor / a live form submission — not performed, same environment constraint.
