### PR TITLE
Send fair-events' own signup confirmation email

### DIFF
--- a/.changeset/send-signup-confirmation-email.md
+++ b/.changeset/send-signup-confirmation-email.md
@@ -1,0 +1,5 @@
+---
+"fair-events": minor
+---
+
+Send a baseline signup confirmation email (event name, date, and registration reference) when fair-audience isn't active, so the "check your email" promise in the event-signup block is always fulfilled. The free-signup success message now mentions the confirmation email too, matching the paid path.

--- a/e2e/mu-plugins/scripts/get-tickets-state.php
+++ b/e2e/mu-plugins/scripts/get-tickets-state.php
@@ -6,9 +6,11 @@
  *   wp eval-file wp-content/mu-plugins/scripts/get-tickets-state.php <event_date_id>
  *
  * Prints a single `E2E_GT_STATE:{json}` line with one entry per
- * fair_events_signups row: name, email, quantity, amount, status, and — when a
- * transaction is attached — its status, testmode flag, and Mollie payment id
- * from fair_payment_transactions.
+ * fair_events_signups row: name, email, quantity, amount, status, mail
+ * (captured mail addressed to the row's email — fair-events' own baseline
+ * confirmation, since this script targets the fair-audience-inactive path),
+ * and — when a transaction is attached — its status, testmode flag, and
+ * Mollie payment id from fair_payment_transactions.
  *
  * @package FairEventsE2E
  */
@@ -24,6 +26,7 @@ if ( ! $event_date_id ) {
 
 $signups_table      = $wpdb->prefix . 'fair_events_signups';
 $transactions_table = $wpdb->prefix . 'fair_payment_transactions';
+$captured_mail      = get_option( 'fair_e2e_captured_mail', array() );
 
 // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off state dump for the spec, no cache to honour.
 $rows = $wpdb->get_results(
@@ -32,6 +35,18 @@ $rows = $wpdb->get_results(
 
 $signups = array();
 foreach ( $rows as $row ) {
+	$mail = array();
+	foreach ( $captured_mail as $captured ) {
+		$recipients = (array) ( $captured['to'] ?? array() );
+		if ( in_array( $row->email, $recipients, true ) ) {
+			$mail[] = array(
+				'to'      => $captured['to'] ?? '',
+				'subject' => $captured['subject'] ?? '',
+				'body'    => $captured['body'] ?? '',
+			);
+		}
+	}
+
 	$entry = array(
 		'id'             => (int) $row->id,
 		'name'           => (string) $row->name,
@@ -40,6 +55,7 @@ foreach ( $rows as $row ) {
 		'amount'         => (float) $row->amount,
 		'status'         => (string) $row->status,
 		'transaction_id' => $row->transaction_id ? (int) $row->transaction_id : null,
+		'mail'           => $mail,
 	);
 
 	if ( $row->transaction_id ) {

--- a/e2e/user-flows/get-tickets-purchase.spec.js
+++ b/e2e/user-flows/get-tickets-purchase.spec.js
@@ -22,6 +22,12 @@
  *     to paid from there, fair_payment_paid → FairEvents PaymentHooks
  *     confirms the signup, and the block's poller swaps in the confirmed card.
  *
+ * Both scenarios also assert fair-events' own baseline confirmation email
+ * (FairEvents\Services\EmailService, wired via SignupEmailHooks) is captured —
+ * with fair-audience inactive there is no other mailer to send it, so a site
+ * running fair-events standalone must not leave the "check your email"
+ * promise in the UI unfulfilled (#1360).
+ *
  */
 
 import { test, expect } from '../support/fixtures.js';
@@ -97,6 +103,7 @@ test.describe('get-tickets block purchase (fair-audience inactive)', () => {
 		expect(state.signups[0].status).toBe('pending_payment');
 		expect(state.signups[0].amount).toBe(event.price);
 		expect(state.signups[0].mollie_payment_id).toBeTruthy();
+		expect(state.signups[0].mail).toHaveLength(0);
 
 		// The buyer's bank has now confirmed the payment. Simulate Mollie's
 		// webhook call (production path): the handler fetches the payment
@@ -125,6 +132,12 @@ test.describe('get-tickets block purchase (fair-audience inactive)', () => {
 		expect(state.signups[0].status).toBe('confirmed');
 		expect(state.signups[0].transaction_status).toBe('paid');
 		expect(state.signups[0].transaction_testmode).toBe(true);
+
+		// fair-events' own confirmation email goes out once payment is
+		// confirmed — not before (the earlier pending_payment read above
+		// carried no mail yet).
+		expect(state.signups[0].mail).toHaveLength(1);
+		expect(state.signups[0].mail[0].subject).toContain('registration');
 	});
 
 	test('free ticket: immediate confirmation without any transaction', async ({
@@ -169,5 +182,7 @@ test.describe('get-tickets block purchase (fair-audience inactive)', () => {
 		expect(state.signups[0].status).toBe('confirmed');
 		expect(state.signups[0].amount).toBe(0);
 		expect(state.signups[0].transaction_id).toBeNull();
+		expect(state.signups[0].mail).toHaveLength(1);
+		expect(state.signups[0].mail[0].subject).toContain('registration');
 	});
 });

--- a/e2e/user-flows/ticket-purchase-confirmation.spec.js
+++ b/e2e/user-flows/ticket-purchase-confirmation.spec.js
@@ -122,6 +122,18 @@ test.describe('ticket purchase confirmation', () => {
 				).toBeFalsy();
 			}
 
+			// fair-events' own baseline confirmation (SignupEmailHooks) must not
+			// also fire here — fair-audience is active, so it already sent the
+			// richer "Signup confirmed" email above; a duplicate would show up
+			// as extra captured mail beyond the two subjects asserted here.
+			const ownBaselineConfirmation = state.mail.find((m) =>
+				m.subject.includes('registration')
+			);
+			expect(
+				ownBaselineConfirmation,
+				'fair-events must not send its own confirmation when fair-audience is active'
+			).toBeFalsy();
+
 			// Organizer-facing: the buyer's name is on the per-event participants
 			// page. Drive the real admin UI (React app fetching the participants
 			// REST endpoint), not a DB read.

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -446,7 +446,7 @@ class GetTicketsController extends WP_REST_Controller {
 			return rest_ensure_response(
 				array(
 					'status'  => 'confirmed',
-					'message' => __( 'You have successfully registered!', 'fair-events' ),
+					'message' => __( 'You have successfully registered! A confirmation email is on its way.', 'fair-events' ),
 				)
 			);
 		}
@@ -803,7 +803,7 @@ class GetTicketsController extends WP_REST_Controller {
 			return rest_ensure_response(
 				array(
 					'status'  => 'confirmed',
-					'message' => __( 'You have successfully registered!', 'fair-events' ),
+					'message' => __( 'You have successfully registered! A confirmation email is on its way.', 'fair-events' ),
 				)
 			);
 		}

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -119,6 +119,7 @@ class Plugin {
 		new \FairEvents\Hooks\OrganizationHooks();
 		new \FairEvents\Hooks\AdminBarHooks();
 		\FairEvents\Hooks\PaymentHooks::init();
+		\FairEvents\Hooks\SignupEmailHooks::init();
 	}
 
 	/**

--- a/fair-events/src/Hooks/SignupEmailHooks.php
+++ b/fair-events/src/Hooks/SignupEmailHooks.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Signup confirmation email hooks for Fair Events
+ *
+ * Sends fair-events' own baseline confirmation email on the free and paid
+ * signup lifecycle actions, but only on sites where fair-audience isn't
+ * active to send its own (richer) confirmation instead — see #1360.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Hooks;
+
+use FairEvents\Services\EmailService;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Hooks into the base signup lifecycle actions to send a confirmation email.
+ */
+class SignupEmailHooks {
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'fair_events_signup_created', array( static::class, 'handle_signup_created' ), 10, 6 );
+		add_action( 'fair_events_signup_confirmed', array( static::class, 'handle_signup_confirmed' ), 10, 2 );
+	}
+
+	/**
+	 * Free-path signup: send the confirmation email immediately, since a free
+	 * signup is confirmed on creation. Paid-but-unconfirmed signups
+	 * (`$transaction_id` not null) must not get a premature email — those are
+	 * handled by handle_signup_confirmed() once payment clears.
+	 *
+	 * @param int      $signup_id        The fair_events_signups row just created.
+	 * @param int      $event_date_id    Event-date ID the signup targets.
+	 * @param string   $name             Buyer name.
+	 * @param string   $email            Buyer email.
+	 * @param array    $ticket_selection Ticket selection details (unused here).
+	 * @param int|null $transaction_id   fair-payments-connector transaction ID, or null on the free path.
+	 * @return void
+	 */
+	public static function handle_signup_created( $signup_id, $event_date_id, $name, $email, $ticket_selection, $transaction_id ) {
+		if ( null !== $transaction_id ) {
+			return;
+		}
+
+		self::maybe_send_confirmation( $signup_id, $event_date_id, $name, $email );
+	}
+
+	/**
+	 * Paid-path signup: send the confirmation email once payment is confirmed.
+	 *
+	 * @param object $signup      The fair_events_signups row (status already 'confirmed').
+	 * @param object $transaction Transaction object from fair-payments-connector (unused here).
+	 * @return void
+	 */
+	public static function handle_signup_confirmed( $signup, $transaction ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- required by the fair_events_signup_confirmed hook signature.
+		self::maybe_send_confirmation( (int) $signup->id, (int) $signup->event_date_id, $signup->name, $signup->email );
+	}
+
+	/**
+	 * Send fair-events' own confirmation email, unless fair-audience is
+	 * active — it already sends a richer confirmation via the same hooks, so
+	 * sending here too would double-mail the buyer.
+	 *
+	 * @param int    $signup_id     The fair_events_signups row ID.
+	 * @param int    $event_date_id Event-date ID the signup targets.
+	 * @param string $name          Buyer name.
+	 * @param string $email         Buyer email.
+	 * @return void
+	 */
+	private static function maybe_send_confirmation( $signup_id, $event_date_id, $name, $email ) {
+		if ( class_exists( \FairAudience\Hooks\SignupHookBridge::class ) ) {
+			return;
+		}
+
+		( new EmailService() )->send_signup_confirmation( $signup_id, $event_date_id, $name, $email );
+	}
+}

--- a/fair-events/src/Services/EmailService.php
+++ b/fair-events/src/Services/EmailService.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Baseline signup confirmation email for standalone fair-events sites
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Sends fair-events' own minimal signup confirmation email. Only used when no
+ * companion plugin (fair-audience) is active to send a richer one instead —
+ * see FairEvents\Hooks\SignupEmailHooks.
+ */
+class EmailService {
+
+	/**
+	 * Send a signup confirmation email to the buyer.
+	 *
+	 * @param int    $signup_id     The fair_events_signups row ID, used as the registration reference.
+	 * @param int    $event_date_id Event date ID the signup targets.
+	 * @param string $name          Buyer name.
+	 * @param string $email         Buyer email.
+	 * @return bool True on send success.
+	 */
+	public function send_signup_confirmation( $signup_id, $event_date_id, $name, $email ) {
+		$event_title        = __( 'the event', 'fair-events' );
+		$event_date_display = '';
+
+		$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+		if ( $event_date ) {
+			$event = get_post( $event_date->event_id );
+			if ( $event ) {
+				$event_title = $event->post_title;
+			}
+
+			$timestamp = strtotime( $event_date->start_datetime );
+			if ( false !== $timestamp ) {
+				$event_date_display = wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
+			}
+		}
+
+		$site_name = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+		$subject = sprintf(
+			/* translators: %s: event title */
+			__( 'Your registration for %s is confirmed', 'fair-events' ),
+			$event_title
+		);
+
+		$message = sprintf(
+			/* translators: 1: buyer name, 2: event title, 3: event date, 4: registration reference, 5: site name */
+			__(
+				"Hi %1\$s,\n\nYour registration for %2\$s on %3\$s is confirmed.\n\nRegistration reference: #%4\$s\n\nThanks,\nThe %5\$s Team",
+				'fair-events'
+			),
+			$name,
+			$event_title,
+			$event_date_display,
+			$signup_id,
+			$site_name
+		);
+
+		return $this->deliver( $email, $subject, $message );
+	}
+
+	/**
+	 * Send an email — the only wp_mail() call site in fair-events.
+	 *
+	 * @param string $to      Recipient email address.
+	 * @param string $subject Email subject.
+	 * @param string $message Plain-text body.
+	 * @return bool True on success.
+	 */
+	private function deliver( $to, $subject, $message ) {
+		return wp_mail( $to, $subject, $message );
+	}
+}

--- a/fair-events/src/Services/__tests__/no-direct-wp-mail.test.js
+++ b/fair-events/src/Services/__tests__/no-direct-wp-mail.test.js
@@ -1,0 +1,63 @@
+/**
+ * Guards EmailService::deliver() as the sole wp_mail() call site in
+ * fair-events/src. A new send path that calls wp_mail() directly bypasses the
+ * fair-audience-presence guard centralized in SignupEmailHooks — see #1360.
+ */
+
+import { readFileSync, readdirSync } from 'fs';
+import { join, resolve } from 'path';
+
+const srcDir = resolve(__dirname, '..', '..');
+const FUNCTION_PATTERN = /function\s+&?(\w+)\s*\(/;
+
+function collectPhpFiles(dir) {
+	const files = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (
+			entry.name === 'build' ||
+			entry.name === 'vendor' ||
+			entry.name === 'node_modules'
+		) {
+			continue;
+		}
+
+		const entryPath = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...collectPhpFiles(entryPath));
+		} else if (entry.name.endsWith('.php')) {
+			files.push(entryPath);
+		}
+	}
+	return files;
+}
+
+function enclosingFunctionName(lines, lineIndex) {
+	for (let i = lineIndex; i >= 0; i--) {
+		const match = lines[i].match(FUNCTION_PATTERN);
+		if (match) {
+			return match[1];
+		}
+	}
+	return null;
+}
+
+test('wp_mail() is only called inside EmailService::deliver()', () => {
+	const callSites = [];
+
+	for (const filePath of collectPhpFiles(srcDir)) {
+		const lines = readFileSync(filePath, 'utf8').split('\n');
+		lines.forEach((line, index) => {
+			if (/\bwp_mail\(\s*[^)\s]/.test(line)) {
+				callSites.push({
+					location: `${filePath}:${index + 1}`,
+					enclosingFunction: enclosingFunctionName(lines, index),
+					isEmailService: filePath.endsWith('EmailService.php'),
+				});
+			}
+		});
+	}
+
+	expect(callSites).toHaveLength(1);
+	expect(callSites[0].isEmailService).toBe(true);
+	expect(callSites[0].enclosingFunction).toBe('deliver');
+});

--- a/fair-events/src/blocks/event-signup/frontend.js
+++ b/fair-events/src/blocks/event-signup/frontend.js
@@ -1088,7 +1088,10 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 				showMessage(
 					messageContainer,
 					response.message ||
-						__('You have successfully registered!', 'fair-events'),
+						__(
+							'You have successfully registered! A confirmation email is on its way.',
+							'fair-events'
+						),
 					'success',
 					CSS_PREFIX
 				);


### PR DESCRIPTION
## Summary

- Adds `FairEvents\Services\EmailService`, fair-events' own minimal signup
  confirmation email (event name, date, and the signup ID as a registration
  reference).
- Wires it via a new `FairEvents\Hooks\SignupEmailHooks`, listening on the
  existing `fair_events_signup_created` (free path) and
  `fair_events_signup_confirmed` (paid path) actions, guarded by
  `class_exists( \FairAudience\Hooks\SignupHookBridge::class )` so a site with
  fair-audience active still gets exactly one (fair-audience's richer) email.
- The free-signup success message now also mentions the confirmation email,
  matching the paid path's existing "confirmation email is on its way" copy.

Closes #1360

## Acceptance criteria

- [x] Completing a free signup on a site running fair-events alone (no
      fair-audience) results in a confirmation email to the buyer — covered by
      `e2e/user-flows/get-tickets-purchase.spec.js`'s free-ticket test.
- [x] Completing a paid signup on a site running fair-events alone results in
      a confirmation email to the buyer — covered by the same spec's paid-ticket
      test (asserts the email is captured only after the webhook confirms
      payment, not before).
- [x] On a site with fair-audience active, buyers receive exactly one
      confirmation email (no duplicate) — enforced structurally by the
      `class_exists()` guard, and asserted in
      `e2e/user-flows/ticket-purchase-confirmation.spec.js` (no fair-events
      "…registration…" email alongside fair-audience's "Signup confirmed").
- [x] Automated test coverage — e2e coverage as above (no PHPUnit/API-spec mail
      capture exists in this repo; real `wp_mail()` interception is e2e-only,
      see `e2e/README.md`), plus a static guard test
      (`fair-events/src/Services/__tests__/no-direct-wp-mail.test.js`, mirroring
      fair-audience's) asserting `wp_mail()` is only ever called inside
      `EmailService::deliver()`.

## Notes

- Email content is intentionally minimal per the ticket — event title, date,
  and the signup ID as the registration reference. No ticket-option/
  questionnaire enrichment; that richness stays fair-audience's differentiator.
- Deliverability (SMTP/spam) is outside this change's control; `wp_mail()`'s
  own return value is what `EmailService::send_signup_confirmation()` reports,
  same as every other mailer in this repo.

## Test plan

- [x] `npm run test:js` (fair-events) — 23 suites / 177 tests pass, including
      the new `no-direct-wp-mail.test.js` guard.
- [x] `vendor/bin/phpcs` clean on all changed PHP files.
- [x] `npm run build` (fair-events).
- [x] `npx playwright test e2e/user-flows/get-tickets-purchase.spec.js
      e2e/user-flows/ticket-purchase-confirmation.spec.js` — 4/4 pass against
      the wp-env test instance, covering: free signup email (fair-audience
      inactive), paid signup email fires only after payment confirmation
      (fair-audience inactive), and no duplicate fair-events email when
      fair-audience is active.
- [x] Changeset added (`fair-events`: minor).
