### PR TITLE
Align nav bar & today-highlight styling in events-calendar/week

### DIFF
--- a/.changeset/align-calendar-week-navigation-styling.md
+++ b/.changeset/align-calendar-week-navigation-styling.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Align nav bar spacing and "today" highlight styling between the events-calendar and events-week blocks, which had visually diverged.

--- a/fair-events/src/blocks/_navigation.scss
+++ b/fair-events/src/blocks/_navigation.scss
@@ -1,0 +1,48 @@
+/**
+ * Shared navigation styling for events-calendar and events-week
+ *
+ * @package FairEvents
+ */
+
+$fair-events-today-border-color: #2271b1;
+$fair-events-today-bg-color: #e7f5ff;
+
+@mixin fair-events-navigation {
+	.fair-events-navigation {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 1.5rem;
+		padding: 0.75rem 1rem;
+		background: #f9f9f9;
+		border-radius: 4px;
+
+		.navigation-title {
+			margin: 0;
+			font-weight: 600;
+			color: #1e1e1e;
+		}
+
+		.nav-prev,
+		.nav-next {
+			padding: 0.5rem 1rem;
+			background: #fff;
+			border: 1px solid #ddd;
+			border-radius: 4px;
+			text-decoration: none;
+			color: #1e1e1e;
+			transition: all 0.2s ease;
+
+			&:hover {
+				background: #2271b1;
+				color: #fff;
+				border-color: #2271b1;
+			}
+
+			&:focus {
+				outline: 2px solid #2271b1;
+				outline-offset: 2px;
+			}
+		}
+	}
+}

--- a/fair-events/src/blocks/events-calendar/style.scss
+++ b/fair-events/src/blocks/events-calendar/style.scss
@@ -4,47 +4,16 @@
  * @package FairEvents
  */
 
+@use "../navigation" as nav;
+
 .wp-block-fair-events-events-calendar {
 	max-width: 100%;
 
-	// Navigation (shared with weekly-schedule)
-	.fair-events-navigation {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 1.5rem;
-		padding: 0.75rem 1rem;
-		background: #f9f9f9;
-		border-radius: 4px;
+	// Navigation (shared with events-week)
+	@include nav.fair-events-navigation;
 
-		.navigation-title {
-			margin: 0;
-			font-size: 1.25rem;
-			font-weight: 600;
-			color: #1e1e1e;
-		}
-
-		.nav-prev,
-		.nav-next {
-			padding: 0.5rem 1rem;
-			background: #fff;
-			border: 1px solid #ddd;
-			border-radius: 4px;
-			text-decoration: none;
-			color: #1e1e1e;
-			transition: all 0.2s ease;
-
-			&:hover {
-				background: #2271b1;
-				color: #fff;
-				border-color: #2271b1;
-			}
-
-			&:focus {
-				outline: 2px solid #2271b1;
-				outline-offset: 2px;
-			}
-		}
+	.fair-events-navigation .navigation-title {
+		font-size: 1.25rem;
 	}
 
 	// Calendar Grid
@@ -129,11 +98,11 @@
 
 		// Today
 		&.today {
-			background: #e7f5ff;
-			border: 2px solid #2271b1;
+			background: nav.$fair-events-today-bg-color;
+			border: 2px solid nav.$fair-events-today-border-color;
 
 			.day-number {
-				color: #2271b1;
+				color: nav.$fair-events-today-border-color;
 				font-weight: 700;
 			}
 		}

--- a/fair-events/src/blocks/events-week/style.scss
+++ b/fair-events/src/blocks/events-week/style.scss
@@ -4,40 +4,14 @@
  * @package FairEvents
  */
 
+@use "../navigation" as nav;
+
 .wp-block-fair-events-events-week {
-	// Navigation
-	.fair-events-navigation {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 1rem;
-		padding: 0.5rem 1rem;
-		background: #f9f9f9;
-		border-radius: 4px;
+	// Navigation (shared with events-calendar)
+	@include nav.fair-events-navigation;
 
-		.navigation-title {
-			margin: 0;
-			font-size: 1rem;
-			font-weight: 600;
-			color: #1e1e1e;
-		}
-
-		.nav-prev,
-		.nav-next {
-			padding: 0.375rem 0.75rem;
-			background: #fff;
-			border: 1px solid #ddd;
-			border-radius: 4px;
-			text-decoration: none;
-			color: #1e1e1e;
-			transition: all 0.2s ease;
-
-			&:hover {
-				background: #2271b1;
-				color: #fff;
-				border-color: #2271b1;
-			}
-		}
+	.fair-events-navigation .navigation-title {
+		font-size: 1rem;
 	}
 
 	// 7-column grid
@@ -67,13 +41,13 @@
 			border-right: none;
 		}
 
-		// Today: border + body background only, header stays neutral
+		// Today
 		&.is-today {
-			outline: 2px solid #2271b1;
-			outline-offset: -1px;
+			border: 2px solid nav.$fair-events-today-border-color;
 
+			.week-day-header,
 			.week-day-events {
-				background: #e7f5ff;
+				background: nav.$fair-events-today-bg-color;
 			}
 		}
 


### PR DESCRIPTION
## Summary

- `events-calendar` and `events-week` had visually diverged despite being conceptually the same navigation pattern: different nav bar padding/margin, different nav button padding, and `events-week` used an outline-only "today" highlight while `events-calendar` used a filled background.
- Extracted the shared nav bar/button and "today" color values into a new `fair-events/src/blocks/_navigation.scss` partial (mixin + variables), included by both blocks' `style.scss`, so the two can't drift apart again.
- `events-week`'s nav bar padding/margin and nav button padding are raised to match `events-calendar`'s (larger) values — calendar is the more prominent, already-shipped view, so shrinking it risked a visible regression on live sites.
- `events-week`'s "today" highlight now fully matches `events-calendar`'s: solid border + filled background on both the day header and events area (previously outline-only with a neutral header).
- Pure CSS-value alignment — no `block.json`/attribute/markup changes. That's a separate follow-up step ("Add padding & margin to calendar & week view").

Refs #1271

## Acceptance criteria

This implements "Step 1: Align calendar's & week's views' basic styling" from the [approved implementation plan](https://github.com/marcin-wosinek/fair-event-plugins/issues/1271#issuecomment-5165397414):

- [x] Nav bar padding/margin unified — `events-week` raised to `events-calendar`'s values (`0.75rem 1rem` padding, `1.5rem` bottom margin).
- [x] Nav button padding unified — `events-week` raised to `events-calendar`'s `0.5rem 1rem`.
- [x] "Today" highlight unified — `events-week` switched from outline-only/header-neutral to `events-calendar`'s solid-border + full-cell background fill.
- [x] Nav title font-size left as-is per the plan's decision (calendar `1.25rem`, week `1rem` — out of scope, suits week's denser layout).
- [x] Shared values extracted into a `_navigation.scss` mixin partial rather than duplicated inline.

## Test plan

- [x] `npm run build` in `fair-events`; verified compiled CSS output for both blocks.
- [x] Visually compared both blocks side by side on the "Próximos Eventos" page in the local WordPress environment — nav bar spacing, nav button padding, and "today" cell now match between the two blocks.
- [x] `npm run format` — no formatting noise.
- Added a changeset (`fair-events` patch) per RELEASES.md.
