### PR TITLE
Chain PHP unit suites into every plugin's test script

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -189,8 +189,15 @@ the repo)
     (e.g. an `insert()` that returns success) rather than pulling in a DB
     library.
 -   Run via `npm run test:php` (→ `vendor/bin/phpunit`) or `composer test`.
-    `npm test` already chains `test:php` after `test:js`, so it runs in CI with
-    no dedicated workflow step.
+    **Every plugin's `test` script must chain `test:php` after `test:js`**
+    (e.g. `"test": "npm-run-all test:js test:php"`) — the root `npm test` runs
+    `npm run test --workspaces`, so CI only picks up a plugin's PHP suite if
+    its own `test` script includes it. There is no dedicated CI workflow step
+    for PHP unit tests; adding a suite to a plugin that doesn't chain it yet
+    means it silently never runs.
+-   A plugin with a `test:php` script but no `phpunit.xml`/`__tests__/*Test.php`
+    is stale — either add the suite or delete the command; don't leave a
+    script that references a suite that doesn't exist.
 
 **When to use**:
 
@@ -201,7 +208,7 @@ the repo)
 -   Pure PHP logic (settings parsing, formatting, recurrence math) that doesn't
     need a live WordPress instance — see `fair-events/__tests__/`.
 
-**Examples**: `fair-events`, `fair-payments-connector`,
+**Examples**: `fair-events`, `fair-payments-connector`, `fair-audience`,
 `fair-payments-connector-experimental`, `fair-events-experimental`,
 `fair-timetable`.
 
@@ -533,13 +540,19 @@ Each plugin should define these scripts:
 ```json
 {
 	"scripts": {
-		"test": "npm-run-all test:*",
+		"test": "npm-run-all test:js test:php",
 		"test:js": "jest",
+		"test:php": "vendor/bin/phpunit",
 		"test:e2e": "playwright test e2e/",
 		"test:api": "playwright test src/API/__tests__/"
 	}
 }
 ```
+
+`test` lists `test:js`/`test:php` explicitly rather than globbing `test:*` —
+`test:e2e` and `test:api` need a live WordPress instance and must stay opt-in,
+not swept into the plain `npm test` run. Omit `test:php` from the list (and
+the script) entirely on a plugin with no PHP suite.
 
 ## Notes and Best Practices
 

--- a/fair-events-experimental/__tests__/Models/VenueTest.php
+++ b/fair-events-experimental/__tests__/Models/VenueTest.php
@@ -20,7 +20,7 @@ class VenueTest extends TestCase {
 		$url = Venue::build_maps_url( '39.4878023', '-0.3613204', null );
 		$this->assertNotNull( $url );
 		$this->assertStringContainsString( 'query=39.4878023%2C-0.3613204', $url );
-		$this->assertStringContainsString( 'maps.google.com', $url );
+		$this->assertStringContainsString( 'google.com/maps', $url );
 	}
 
 	public function test_lat_lng_takes_priority_over_address() {

--- a/fair-events-experimental/package.json
+++ b/fair-events-experimental/package.json
@@ -20,8 +20,9 @@
 		"makejson": "wp i18n make-json languages ./build/languages --domain=fair-events-experimental --pretty-print --no-purge --use-map=build/map.json",
 		"makemo": "wp i18n make-mo languages/",
 		"updatepo": "wp i18n update-po languages/fair-events-experimental.pot languages/",
-		"test": "npm-run-all test:js",
+		"test": "npm-run-all test:js test:php",
 		"test:js": "jest --passWithNoTests",
+		"test:php": "vendor/bin/phpunit",
 		"test:api": "playwright test src/API/__tests__/"
 	},
 	"dependencies": {

--- a/fair-events/package.json
+++ b/fair-events/package.json
@@ -23,7 +23,7 @@
 		"updatepo": "wp i18n update-po languages/fair-events.pot languages/",
 		"svn:checkout": "svn co https://plugins.svn.wordpress.org/fair-events svn",
 		"svn:copy": "cp -r readme.txt fair-events.php src package* composer* languages CHANGELOG.md svn/trunk; cp assets/* svn/assets",
-		"test": "npm-run-all test:js",
+		"test": "npm-run-all test:js test:php",
 		"test:js": "jest",
 		"test:php": "vendor/bin/phpunit",
 		"test:api": "playwright test src/API/__tests__/",

--- a/fair-finance/package.json
+++ b/fair-finance/package.json
@@ -21,7 +21,6 @@
 		"updatepo": "wp i18n update-po languages/fair-finance.pot languages/",
 		"test": "jest",
 		"test:js": "jest",
-		"test:php": "vendor/bin/phpunit",
 		"svn:checkout": "svn co https://plugins.svn.wordpress.org/fair-finance svn",
 		"svn:copy": "cp -r readme.txt fair-finance.php composer* languages CHANGELOG.md svn/trunk"
 	},

--- a/fair-form/package.json
+++ b/fair-form/package.json
@@ -23,7 +23,6 @@
 		"test": "wp-scripts test-unit-js --config jest.config.js",
 		"test:js": "wp-scripts test-unit-js --config jest.config.js",
 		"test:api": "playwright test src/API/__tests__/",
-		"test:php": "vendor/bin/phpunit",
 		"svn:checkout": "svn co https://plugins.svn.wordpress.org/fair-form svn",
 		"svn:copy": "cp -r readme.txt fair-form.php composer* languages CHANGELOG.md svn/trunk"
 	},

--- a/fair-payments-connector-experimental/package.json
+++ b/fair-payments-connector-experimental/package.json
@@ -19,7 +19,7 @@
 		"makejson": "wp i18n make-json languages ./build/languages --domain=fair-payments-connector-experimental --pretty-print --no-purge --use-map=build/map.json",
 		"makemo": "wp i18n make-mo languages/",
 		"updatepo": "wp i18n update-po languages/fair-payments-connector-experimental.pot languages/",
-		"test": "wp-scripts test-unit-js --config jest.config.js",
+		"test": "npm-run-all test:js test:php",
 		"test:js": "wp-scripts test-unit-js --config jest.config.js",
 		"test:php": "vendor/bin/phpunit",
 		"svn:checkout": "svn co https://plugins.svn.wordpress.org/fair-payments-connector-experimental svn",

--- a/fair-platform/package.json
+++ b/fair-platform/package.json
@@ -22,7 +22,6 @@
 		"updatepo": "wp i18n update-po languages/fair-platform.pot languages/",
 		"test": "echo 'No tests yet'",
 		"test:js": "echo 'No JavaScript tests'",
-		"test:php": "vendor/bin/phpunit",
 		"svn:checkout": "svn co https://plugins.svn.wordpress.org/fair-platform svn",
 		"svn:copy": "cp -r readme.txt fair-platform.php composer* languages CHANGELOG.md svn/trunk"
 	},

--- a/fair-timetable/package.json
+++ b/fair-timetable/package.json
@@ -21,7 +21,7 @@
 		"composer:update": "composer update",
 		"composer:update:shared": "composer update fair-events/shared",
 		"composer:validate": "composer validate --strict",
-		"test": "npm-run-all test:*",
+		"test": "npm-run-all test:js test:php",
 		"test:js": "jest",
 		"test:php": "vendor/bin/phpunit",
 		"screenshots": "playwright test e2e/wordpress-org.spec.js",


### PR DESCRIPTION
## Summary

- The root `npm test` fans out to each workspace's own `test` script (`npm run test --workspaces`), not a dedicated CI step — a plugin's PHPUnit suite only ran in CI if its own `test` script chained `test:php`. Only `fair-payments-connector` and `fair-audience` did (`fair-timetable` also did, via a `test:*` glob).
- Chained `test:php` into `test` for the three plugins that have a real suite but weren't running it: `fair-events`, `fair-events-experimental`, `fair-payments-connector-experimental`.
- `fair-events-experimental`'s suite had one pre-existing failure (`VenueTest::test_lat_lng_produces_coordinate_query` asserted the maps URL contains `maps.google.com`, but `Venue::build_maps_url()` intentionally uses the keyless `www.google.com/maps/search/` scheme). Fixed the stale assertion so the newly-enabled check starts green.
- `fair-platform`, `fair-finance`, and `fair-form` each had a dangling `test:php: vendor/bin/phpunit` script with no `phpunit.xml`, no `__tests__/*Test.php`, and no `phpunit/phpunit` dev dependency behind it — it would fail if anyone ran it. Removed the stale command rather than backfilling a suite; none of these plugins currently has boundary-level pure-PHP logic worth locking down with PHPUnit (mostly thin repository/controller code, already covered by the API suites).
- Updated `TESTING.md`: removed the now-stale "only two plugins chain this" framing, added `fair-audience` to the PHP-unit-tests example list (it was missing), and fixed the `Required package.json Scripts` template — it showed `"test": "npm-run-all test:*"`, which would silently sweep `test:e2e`/`test:api` into a plain `npm test` run; replaced with the explicit `test:js test:php` convention actually used.

Closes #1316

## Acceptance criteria

- [x] The PHP unit suites run automatically on pull requests and a failing test fails the build — every plugin with a suite now chains `test:php` into its `test` script, which the existing `npm test` CI step already runs per-workspace (no new CI workflow step needed).
- [x] The check is green on the main branch at merge time — the one pre-existing failure (`fair-events-experimental`'s `VenueTest`) is fixed; full `npm test` run is green (exit 0) across all workspaces.
- [x] Every plugin with a PHP suite has a working command for it, and running a plugin's aggregate test command locally includes it — verified via `npm run test --workspace=<plugin>` for each of the three newly-wired plugins.
- [x] The testing docs match the actual behaviour — `TESTING.md` updated (see Summary).

Not applicable / deferred:
- The digest-rendering bootstrap stub the ticket's Risks section called out (`fair-audience`) was already fixed in an earlier commit — its suite is fully green with no skips.

## Test plan

- [x] `npm test` from repo root — all workspaces pass (exit 0).
- [x] `npm run test --workspace=fair-events` — PHP suite now runs (152 tests, 0 failures).
- [x] `npm run test --workspace=fair-events-experimental` — PHP suite now runs (18 tests, 0 failures, was 1 failure before the assertion fix).
- [x] `npm run test --workspace=fair-payments-connector-experimental` — PHP suite now runs (6 tests, 0 failures).
- [x] `npm run lint:docs` — passes.
- [x] `npm run format` — clean, no formatting noise staged.
