### PR TITLE
Style calendar/week nav buttons with theme's button style

### DIFF
--- a/.changeset/nav-buttons-core-style.md
+++ b/.changeset/nav-buttons-core-style.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Render the Previous/Next navigation links in events-calendar and events-week as standard `core/button` outline buttons, so they follow the active theme's button styling instead of hardcoded colors.

--- a/fair-events/src/blocks/_navigation.scss
+++ b/fair-events/src/blocks/_navigation.scss
@@ -23,26 +23,8 @@ $fair-events-today-bg-color: #e7f5ff;
 			color: #1e1e1e;
 		}
 
-		.nav-prev,
-		.nav-next {
-			padding: 0.5rem 1rem;
-			background: #fff;
-			border: 1px solid #ddd;
-			border-radius: 4px;
-			text-decoration: none;
-			color: #1e1e1e;
-			transition: all 0.2s ease;
-
-			&:hover {
-				background: #2271b1;
-				color: #fff;
-				border-color: #2271b1;
-			}
-
-			&:focus {
-				outline: 2px solid #2271b1;
-				outline-offset: 2px;
-			}
+		.wp-block-button {
+			margin: 0;
 		}
 	}
 }

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -313,15 +313,19 @@ $subscribe_urls = fair_events_build_subscribe_urls( is_array( $categories ) ? $c
 <div <?php echo wp_kses_post( get_block_wrapper_attributes( array( 'class' => 'wp-block-fair-events-events-calendar' ) ) ); ?>>
 	<?php if ( $show_navigation ) : ?>
 	<div class="fair-events-navigation">
-		<a href="<?php echo esc_url( $prev_url ); ?>" class="nav-prev">
-			<?php esc_html_e( 'Previous', 'fair-events' ); ?>
-		</a>
+		<div class="wp-block-button is-style-outline">
+			<a href="<?php echo esc_url( $prev_url ); ?>" class="nav-prev wp-block-button__link wp-element-button">
+				<?php esc_html_e( 'Previous', 'fair-events' ); ?>
+			</a>
+		</div>
 		<h2 class="navigation-title">
 			<?php echo esc_html( date_i18n( 'F Y', $first_day_of_month_ts ) ); ?>
 		</h2>
-		<a href="<?php echo esc_url( $next_url ); ?>" class="nav-next">
-			<?php esc_html_e( 'Next', 'fair-events' ); ?>
-		</a>
+		<div class="wp-block-button is-style-outline">
+			<a href="<?php echo esc_url( $next_url ); ?>" class="nav-next wp-block-button__link wp-element-button">
+				<?php esc_html_e( 'Next', 'fair-events' ); ?>
+			</a>
+		</div>
 	</div>
 	<?php endif; ?>
 

--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -230,15 +230,19 @@ if ( $show_copy_summary ) {
 
 	<?php if ( $show_navigation ) : ?>
 	<div class="fair-events-navigation">
-		<a href="<?php echo esc_url( $prev_url ); ?>" class="nav-prev">
-			<?php esc_html_e( 'Previous', 'fair-events' ); ?>
-		</a>
+		<div class="wp-block-button is-style-outline">
+			<a href="<?php echo esc_url( $prev_url ); ?>" class="nav-prev wp-block-button__link wp-element-button">
+				<?php esc_html_e( 'Previous', 'fair-events' ); ?>
+			</a>
+		</div>
 		<h2 class="navigation-title">
 			<?php echo esc_html( $nav_title ); ?>
 		</h2>
-		<a href="<?php echo esc_url( $next_url ); ?>" class="nav-next">
-			<?php esc_html_e( 'Next', 'fair-events' ); ?>
-		</a>
+		<div class="wp-block-button is-style-outline">
+			<a href="<?php echo esc_url( $next_url ); ?>" class="nav-next wp-block-button__link wp-element-button">
+				<?php esc_html_e( 'Next', 'fair-events' ); ?>
+			</a>
+		</div>
 	</div>
 	<?php endif; ?>
 


### PR DESCRIPTION
## Summary

- Wrap the Previous/Next navigation links in `events-calendar` and `events-week` with the standard `core/button` outline markup (`wp-block-button is-style-outline` / `wp-block-button__link wp-element-button`), matching the pattern already used for the Subscribe/Copy-summary buttons in the same files.
- Trim `_navigation.scss`'s shared mixin: remove the now-redundant hardcoded `.nav-prev`/`.nav-next` background/border/hover/focus rules (supplied by the theme's button styles now), keeping only a `.wp-block-button { margin: 0; }` reset so the wrapper doesn't disturb the nav bar's `justify-content: space-between` row.

Refs #1271 (Step 3 of the comment thread — [implementation plan](https://github.com/marcin-wosinek/fair-event-plugins/issues/1271#issuecomment-5167503540))

## Acceptance criteria

From the linked comment's plan:

1. **`events-calendar/render.php` and `events-week/render.php` wrap `nav-prev`/`nav-next` in standard core-button markup** — done, both files updated identically to the Subscribe/Copy-summary pattern already in place.
2. **`_navigation.scss` custom button styling removed, keep only the flex-layout reset** — done; kept `.wp-block-button { margin: 0; }`, removed the old padding/background/border/hover/focus block.
3. **Dead tablet/mobile media-query selectors left as-is** (pre-existing bug, out of scope) — untouched, per the plan.

## Notes

- `is-style-outline` chosen to match the existing Subscribe/Copy-summary buttons in the same blocks, keeping the nav arrows visually secondary.
- `calendar-button` remains out of scope (confirmed in the Phase 0 comment — it's a `core/button` variation and already inherits everything).
- Padding/margin block supports (the ticket's step 2) are separate, deferred work.

## Test plan

- [x] `npm run build` in `fair-events`
- [x] `npm run format` — clean, no formatting noise
- [x] `vendor/bin/phpcs` on changed PHP files — 0 new findings (all pre-existing findings are outside the touched line ranges)
- [x] `npm run test:js` in `fair-events` — 23 suites / 177 tests pass
- [x] Manual check on the running dev site (`docker compose`, page with both blocks): Previous/Next now render as theme-styled pill buttons, matching "Subscribe to calendar", instead of the old hardcoded gray box
