### PR TITLE
Move signup confirmation email formatting to fair-events-shared

### DIFF
--- a/.changeset/shared-signup-confirmation-email.md
+++ b/.changeset/shared-signup-confirmation-email.md
@@ -1,0 +1,7 @@
+---
+"fair-events-shared": minor
+"fair-audience": minor
+"fair-events": minor
+---
+
+Move fair-audience's signup confirmation email formatting into a shared `FairEventsShared\Notifications\SignupConfirmationEmail` formatter, and use it for both plugins' confirmation emails. fair-audience's confirmation email now also shows the event date, a registration reference, and the ticket type. fair-events' standalone confirmation email (sent when fair-audience isn't active) is now built from the same branded HTML template instead of a plain-text message, and includes the ticket type and — on paid signups — the amount paid.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,10 @@ Before declaring a task finished (and before any commit), all of these hold:
    when a wording pass touched them.
 6. For PRs on `responsive-ui` tickets: before/after screenshots at all three
    viewports ([COMMIT_GUIDE.md](./COMMIT_GUIDE.md)).
+7. If `fair-events-shared/php/src/**` changed: version bumped in its
+   `composer.json` and `npm run composer:update:shared` ran (see
+   [PHP_PATTERNS.md § Shared Package](./PHP_PATTERNS.md#shared-package-fair-events-shared)) —
+   otherwise consumers' vendor copies silently keep the old code.
 
 ## Critical Rules
 

--- a/PHP_PATTERNS.md
+++ b/PHP_PATTERNS.md
@@ -479,6 +479,20 @@ through to whichever plugin ships the new copy. A changed signature fatals
 whenever an older copy of the class wins the autoload race and gets called
 with the new call shape.
 
+**After editing anything under `fair-events-shared/php/src/`, bump the
+`version` in `fair-events-shared/php/composer.json` and run `npm run
+composer:update:shared`** (runs `composer update fair-events/shared` in every
+consumer workspace) before committing. `composer install` only re-mirrors a
+`path`-type dependency when the lock file's version/reference for that
+package changes — if the version isn't bumped, consumers' vendor copies
+(including CI's restored vendor cache) silently keep the *old* shared code
+even though the source changed, with no install error to flag it. This broke
+CI once already (class-not-found on a plugin whose cached vendor still had
+the pre-edit copy). If you scaffold a new plugin that consumes the shared
+package, make sure its `package.json` gets a `composer:update:shared` script
+too (see [ADDING_NEW_PLUGIN.md](./ADDING_NEW_PLUGIN.md)) — two plugins were
+found missing it.
+
 ## Code Quality Standards
 
 Formatting is automatic — see [CLAUDE.md § Formatting & Build](./CLAUDE.md#formatting--build)

--- a/e2e/user-flows/ticket-purchase-confirmation.spec.js
+++ b/e2e/user-flows/ticket-purchase-confirmation.spec.js
@@ -106,6 +106,14 @@ test.describe('ticket purchase confirmation', () => {
 				'a "Signup confirmed" email should be captured for the buyer'
 			).toBeTruthy();
 
+			// Shared formatter fields (#1369): event date, registration
+			// reference, ticket type, and (paid path) amount paid.
+			expect(confirmation.body).toContain('Event date:');
+			expect(confirmation.body).toContain('Registration reference:');
+			expect(confirmation.body).toContain('Ticket type:');
+			expect(confirmation.body).toContain('General Admission');
+			expect(confirmation.body).toContain('Amount paid:');
+
 			// The marketing (double opt-in) email is sent ONLY when opting in.
 			const marketing = state.mail.find((m) =>
 				m.subject.includes('Confirm your subscription')

--- a/fair-audience-experimental/composer.lock
+++ b/fair-audience-experimental/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "fair-events/shared",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "a510a98d90c0da800c1e05bb2c497b17e51e6206"
+                "reference": "7282e0b97cc1b1abfad91e89704b49098f6400b5"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-audience-experimental/package.json
+++ b/fair-audience-experimental/package.json
@@ -15,6 +15,7 @@
 		"composer:install": "composer install",
 		"composer:install:prod": "composer install --no-dev",
 		"composer:update": "composer update",
+		"composer:update:shared": "composer update fair-events/shared",
 		"composer:validate": "composer validate --strict",
 		"makepot": "wp i18n make-pot . languages/fair-audience-experimental.pot --exclude=node_modules,vendor,tests,build,svn && node ../scripts/translation/merge-shared-strings.js --plugin=fair-audience-experimental",
 		"makejson": "wp i18n make-json languages ./build/languages --domain=fair-audience-experimental --pretty-print --no-purge --use-map=build/map.json",

--- a/fair-audience/__tests__/Services/EmailServiceTest.php
+++ b/fair-audience/__tests__/Services/EmailServiceTest.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * EmailService::send_signup_payment_confirmation() tests
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairAudience\Services\EmailService;
+use FairAudience\Models\Participant;
+
+/**
+ * Verifies the new registration-reference and ticket-type fields reach the
+ * rendered email for both the free and paid signup paths. FairEvents\Models
+ * classes are never loaded in fair-audience's test process, so the
+ * event-date/ticket-type lookups inside EmailService no-op via their
+ * class_exists() guards — these tests exercise everything reachable without
+ * them (participant name, transaction amount, options, registration reference).
+ */
+class EmailServiceTest extends TestCase {
+
+	/**
+	 * Reset recorded test emails before each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['_fair_test_sent_emails'] = array();
+	}
+
+	/**
+	 * Build a valid-email participant.
+	 *
+	 * @param string $name Participant name.
+	 * @return Participant
+	 */
+	private function participant( $name = 'Jane Doe' ) {
+		$participant        = new Participant();
+		$participant->id    = 7;
+		$participant->name  = $name;
+		$participant->email = 'jane@example.test';
+		return $participant;
+	}
+
+	/**
+	 * Build a fake event post object.
+	 *
+	 * @return object
+	 */
+	private function event() {
+		return (object) array(
+			'post_title' => 'Community Meetup',
+		);
+	}
+
+	/**
+	 * The free-signup path includes the registration reference and omits the
+	 * amount-paid row (no transaction).
+	 */
+	public function test_free_signup_includes_registration_reference(): void {
+		$email_service = new EmailService();
+
+		$result = $email_service->send_signup_payment_confirmation(
+			$this->participant(),
+			$this->event(),
+			null,
+			array(),
+			0,
+			0,
+			42
+		);
+
+		$this->assertTrue( $result );
+		$this->assertCount( 1, $GLOBALS['_fair_test_sent_emails'] );
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertSame( 'jane@example.test', $sent['to'] );
+		$this->assertStringContainsString( 'Community Meetup', $sent['subject'] );
+		$this->assertStringContainsString( '#42', $sent['message'] );
+		$this->assertStringNotContainsString( 'Amount paid:', $sent['message'] );
+		$this->assertStringContainsString( 'has been confirmed.', $sent['message'] );
+	}
+
+	/**
+	 * The paid-signup path includes the amount-paid row and the
+	 * payment-received confirmation sentence.
+	 */
+	public function test_paid_signup_includes_amount_paid(): void {
+		$email_service = new EmailService();
+
+		$transaction = (object) array(
+			'amount'   => 25.5,
+			'currency' => 'EUR',
+		);
+
+		$email_service->send_signup_payment_confirmation(
+			$this->participant(),
+			$this->event(),
+			$transaction,
+			array(),
+			0,
+			0,
+			99
+		);
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( 'Amount paid:', $sent['message'] );
+		$this->assertStringContainsString( '25.50 EUR', $sent['message'] );
+		$this->assertStringContainsString( 'payment has been received', $sent['message'] );
+	}
+
+	/**
+	 * Selected ticket-activity option names render as a list.
+	 */
+	public function test_includes_selected_option_names(): void {
+		$email_service = new EmailService();
+
+		$email_service->send_signup_payment_confirmation(
+			$this->participant(),
+			$this->event(),
+			null,
+			array( 'Workshop A', 'Workshop B' ),
+			0,
+			0,
+			1
+		);
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( 'Selected options:', $sent['message'] );
+		$this->assertStringContainsString( 'Workshop A', $sent['message'] );
+		$this->assertStringContainsString( 'Workshop B', $sent['message'] );
+	}
+
+	/**
+	 * A registration reference of 0 (not yet known) omits the row entirely.
+	 */
+	public function test_omits_registration_reference_when_zero(): void {
+		$email_service = new EmailService();
+
+		$email_service->send_signup_payment_confirmation(
+			$this->participant(),
+			$this->event(),
+			null,
+			array(),
+			0,
+			0,
+			0
+		);
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringNotContainsString( 'Registration reference:', $sent['message'] );
+	}
+
+	/**
+	 * An invalid (empty) participant email skips the send entirely.
+	 */
+	public function test_skips_send_for_invalid_email(): void {
+		$email_service = new EmailService();
+
+		$participant        = new Participant();
+		$participant->name  = 'No Email';
+		$participant->email = '';
+
+		$result = $email_service->send_signup_payment_confirmation( $participant, $this->event(), null, array(), 0, 0, 1 );
+
+		$this->assertFalse( $result );
+		$this->assertCount( 0, $GLOBALS['_fair_test_sent_emails'] );
+	}
+}

--- a/fair-audience/__tests__/Shared/SignupConfirmationEmailTest.php
+++ b/fair-audience/__tests__/Shared/SignupConfirmationEmailTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * FairEventsShared\Notifications\SignupConfirmationEmail formatting tests.
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Tests\Shared;
+
+use PHPUnit\Framework\TestCase;
+use FairEventsShared\Notifications\SignupConfirmationEmail;
+
+/**
+ * Unit tests for the shared signup confirmation email formatter — subject
+ * assembly and each optional detail section's shown/hidden behavior.
+ */
+class SignupConfirmationEmailTest extends TestCase {
+
+	/**
+	 * Minimal required args for html() — every optional field defaults to
+	 * empty/omitted unless a test overrides it.
+	 *
+	 * @param array $overrides Args to merge over the defaults.
+	 * @return array Complete args array for html().
+	 */
+	private function args( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'event_title'                  => 'Test Event',
+				'participant_name'             => 'Jane Doe',
+				'site_name'                    => 'Test Site',
+				'event_date_display'           => '',
+				'registration_reference'       => '',
+				'ticket_type_name'             => '',
+				'payment_amount_display'       => '',
+				'option_names'                 => array(),
+				'answers_html'                 => '',
+				'greeting_template'            => 'Hi %s,',
+				'confirmation_sentence'        => 'Your signup is confirmed.',
+				'event_date_label'             => 'Event date:',
+				'registration_reference_label' => 'Registration reference:',
+				'ticket_type_label'            => 'Ticket type:',
+				'amount_paid_label'            => 'Amount paid:',
+				'selected_options_label'       => 'Selected options:',
+				'your_answers_label'           => 'Your answers:',
+				'sign_off_template'            => 'Thanks,%1$sThe %2$s Team',
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Subject() interpolates the event title into the translated template.
+	 */
+	public function test_subject_interpolates_event_title(): void {
+		$this->assertSame(
+			'Signup confirmed — Test Event',
+			SignupConfirmationEmail::subject( 'Signup confirmed — %s', 'Test Event' )
+		);
+	}
+
+	/**
+	 * Html() greets the participant by name and includes the event title as the header.
+	 */
+	public function test_html_includes_greeting_and_header(): void {
+		$html = SignupConfirmationEmail::html( $this->args() );
+
+		$this->assertStringContainsString( '<h1 style="margin: 0; font-size: 24px; font-weight: bold;">Test Event</h1>', $html );
+		$this->assertStringContainsString( 'Hi <strong>Jane Doe</strong>,', $html );
+		$this->assertStringContainsString( 'Your signup is confirmed.', $html );
+	}
+
+	/**
+	 * Every optional detail row (event date, registration reference, ticket
+	 * type, amount paid) is omitted when its data value is empty.
+	 */
+	public function test_html_omits_all_detail_rows_when_empty(): void {
+		$html = SignupConfirmationEmail::html( $this->args() );
+
+		$this->assertStringNotContainsString( 'Event date:', $html );
+		$this->assertStringNotContainsString( 'Registration reference:', $html );
+		$this->assertStringNotContainsString( 'Ticket type:', $html );
+		$this->assertStringNotContainsString( 'Amount paid:', $html );
+	}
+
+	/**
+	 * The event date row renders only when event_date_display is non-empty.
+	 */
+	public function test_html_shows_event_date_row_when_present(): void {
+		$html = SignupConfirmationEmail::html( $this->args( array( 'event_date_display' => 'January 1, 2026 10:00 am' ) ) );
+
+		$this->assertStringContainsString( 'Event date:', $html );
+		$this->assertStringContainsString( 'January 1, 2026 10:00 am', $html );
+	}
+
+	/**
+	 * The registration reference row renders only when non-empty.
+	 */
+	public function test_html_shows_registration_reference_row_when_present(): void {
+		$html = SignupConfirmationEmail::html( $this->args( array( 'registration_reference' => '#42' ) ) );
+
+		$this->assertStringContainsString( 'Registration reference:', $html );
+		$this->assertStringContainsString( '#42', $html );
+	}
+
+	/**
+	 * The ticket type row renders only when non-empty.
+	 */
+	public function test_html_shows_ticket_type_row_when_present(): void {
+		$html = SignupConfirmationEmail::html( $this->args( array( 'ticket_type_name' => 'VIP' ) ) );
+
+		$this->assertStringContainsString( 'Ticket type:', $html );
+		$this->assertStringContainsString( 'VIP', $html );
+	}
+
+	/**
+	 * The amount paid row renders only when non-empty.
+	 */
+	public function test_html_shows_amount_paid_row_when_present(): void {
+		$html = SignupConfirmationEmail::html( $this->args( array( 'payment_amount_display' => '12.50 EUR' ) ) );
+
+		$this->assertStringContainsString( 'Amount paid:', $html );
+		$this->assertStringContainsString( '12.50 EUR', $html );
+	}
+
+	/**
+	 * The selected-options list is omitted when option_names is empty.
+	 */
+	public function test_html_omits_options_list_when_empty(): void {
+		$html = SignupConfirmationEmail::html( $this->args() );
+
+		$this->assertStringNotContainsString( 'Selected options:', $html );
+	}
+
+	/**
+	 * The selected-options list renders each name as an <li> when present.
+	 */
+	public function test_html_shows_options_list_when_present(): void {
+		$html = SignupConfirmationEmail::html( $this->args( array( 'option_names' => array( 'Workshop A', 'Workshop B' ) ) ) );
+
+		$this->assertStringContainsString( 'Selected options:', $html );
+		$this->assertStringContainsString( '<li style="padding: 4px 0;">Workshop A</li>', $html );
+		$this->assertStringContainsString( '<li style="padding: 4px 0;">Workshop B</li>', $html );
+	}
+
+	/**
+	 * The answers section is omitted when answers_html is empty.
+	 */
+	public function test_html_omits_answers_section_when_empty(): void {
+		$html = SignupConfirmationEmail::html( $this->args() );
+
+		$this->assertStringNotContainsString( 'Your answers:', $html );
+	}
+
+	/**
+	 * The answers section wraps the pre-rendered fragment in a table when present.
+	 */
+	public function test_html_shows_answers_section_when_present(): void {
+		$html = SignupConfirmationEmail::html( $this->args( array( 'answers_html' => '<tr><td>Question</td><td>Answer</td></tr>' ) ) );
+
+		$this->assertStringContainsString( 'Your answers:', $html );
+		$this->assertStringContainsString( '<tr><td>Question</td><td>Answer</td></tr>', $html );
+	}
+
+	/**
+	 * The sign-off and footer both include the site name.
+	 */
+	public function test_html_includes_site_name_in_sign_off_and_footer(): void {
+		$html = SignupConfirmationEmail::html( $this->args() );
+
+		$this->assertStringContainsString( 'Thanks,<br>The Test Site Team', $html );
+		// Footer repeats the site name in its own <p>.
+		$this->assertSame( 2, substr_count( $html, 'Test Site' ) );
+	}
+}

--- a/fair-audience/__tests__/bootstrap.php
+++ b/fair-audience/__tests__/bootstrap.php
@@ -96,6 +96,90 @@ if ( ! function_exists( 'add_action' ) ) {
 	}
 }
 
+if ( ! function_exists( 'remove_filter' ) ) {
+	/**
+	 * Stub of WordPress remove_filter() — a no-op for test purposes; the
+	 * add_filter() stub never wires callbacks into a real apply_filters().
+	 *
+	 * @param string   $hook_name Hook name.
+	 * @param callable $callback  Callback.
+	 * @param int      $priority  Priority (unused by the stub).
+	 * @return true
+	 */
+	function remove_filter( $hook_name, $callback, $priority = 10 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- no-op stub, kept param-compatible with the real signature.
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_mail' ) ) {
+	/**
+	 * Stub of WordPress wp_mail() recording each send into
+	 * $GLOBALS['_fair_test_sent_emails'] so tests can assert on subject/message.
+	 *
+	 * @param string $to      Recipient email address.
+	 * @param string $subject Email subject.
+	 * @param string $message Email body.
+	 * @return bool Always true.
+	 */
+	function wp_mail( $to, $subject, $message ) {
+		if ( ! isset( $GLOBALS['_fair_test_sent_emails'] ) ) {
+			$GLOBALS['_fair_test_sent_emails'] = array();
+		}
+		$GLOBALS['_fair_test_sent_emails'][] = array(
+			'to'      => $to,
+			'subject' => $subject,
+			'message' => $message,
+		);
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_post' ) ) {
+	/**
+	 * Stub of WordPress get_post() backed by $GLOBALS['_fair_test_posts'] (a
+	 * map of post ID => object). Also passes through an already-object $post.
+	 *
+	 * @param int|object $post Post ID, or an already-built post-like object.
+	 * @return object|null Stored post object, the passed object, or null.
+	 */
+	function get_post( $post ) {
+		if ( is_object( $post ) ) {
+			return $post;
+		}
+		$posts = isset( $GLOBALS['_fair_test_posts'] ) ? $GLOBALS['_fair_test_posts'] : array();
+		return isset( $posts[ $post ] ) ? $posts[ $post ] : null;
+	}
+}
+
+if ( ! function_exists( 'wp_specialchars_decode' ) ) {
+	/**
+	 * Stub of WordPress wp_specialchars_decode() — delegates to htmlspecialchars_decode().
+	 *
+	 * @param string $text  Text to decode.
+	 * @param mixed  $quote_style Quote style (ignored by the stub).
+	 * @return string Decoded text.
+	 */
+	function wp_specialchars_decode( $text, $quote_style = ENT_NOQUOTES ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- stub always decodes with ENT_QUOTES.
+		return htmlspecialchars_decode( (string) $text, ENT_QUOTES );
+	}
+}
+
+if ( ! function_exists( 'wp_date' ) ) {
+	/**
+	 * Stub of WordPress wp_date() — formats a timestamp in UTC, no locale/i18n handling.
+	 *
+	 * @param string   $format    date() format string.
+	 * @param int|null $timestamp Unix timestamp; defaults to now.
+	 * @return string Formatted date.
+	 */
+	function wp_date( $format, $timestamp = null ) {
+		if ( null === $timestamp ) {
+			$timestamp = time();
+		}
+		return gmdate( $format, $timestamp );
+	}
+}
+
 if ( ! function_exists( 'current_time' ) ) {
 	/**
 	 * Stub of WordPress current_time(). Always returns UTC 'mysql' format.

--- a/fair-audience/composer.lock
+++ b/fair-audience/composer.lock
@@ -87,11 +87,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "a510a98d90c0da800c1e05bb2c497b17e51e6206"
+                "reference": "7282e0b97cc1b1abfad91e89704b49098f6400b5"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-audience/languages/fair-audience.pot
+++ b/fair-audience/languages/fair-audience.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-3.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Fair Audience 1.11.0\n"
+"Project-Id-Version: Fair Audience 1.12.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/fair-audience\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-02T09:52:40+00:00\n"
+"POT-Creation-Date: 2026-08-03T15:42:59+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fair-audience\n"
@@ -68,16 +68,16 @@ msgstr ""
 
 #: src/API/AudienceSignupController.php:204
 #: src/API/EventInterestController.php:156
-#: src/API/EventSignupController.php:2146
-#: src/API/EventSignupController.php:2678
+#: src/API/EventSignupController.php:2147
+#: src/API/EventSignupController.php:2679
 #: src/API/MailingSignupController.php:172
 msgid "Please enter a valid email address."
 msgstr ""
 
 #: src/API/AudienceSignupController.php:223
 #: src/API/EventInterestController.php:182
-#: src/API/EventSignupController.php:2155
-#: src/API/EventSignupController.php:2717
+#: src/API/EventSignupController.php:2156
+#: src/API/EventSignupController.php:2718
 #: src/API/MailingSignupController.php:192
 msgid "Too many requests. Please try again later."
 msgstr ""
@@ -147,22 +147,22 @@ msgstr ""
 #: src/API/EventParticipantsController.php:1468
 #: src/API/EventSignupController.php:468
 #: src/API/EventSignupController.php:613
-#: src/API/EventSignupController.php:1080
-#: src/API/EventSignupController.php:2137
-#: src/API/EventSignupController.php:2340
-#: src/API/EventSignupController.php:2532
-#: src/API/EventSignupController.php:2660
-#: src/API/EventSignupController.php:2960
-#: src/Services/EmailService.php:336
-#: src/Services/EmailService.php:560
-#: src/Services/EmailService.php:1400
-#: src/Services/EmailService.php:2816
+#: src/API/EventSignupController.php:1081
+#: src/API/EventSignupController.php:2138
+#: src/API/EventSignupController.php:2341
+#: src/API/EventSignupController.php:2533
+#: src/API/EventSignupController.php:2661
+#: src/API/EventSignupController.php:2962
+#: src/Services/EmailService.php:337
+#: src/Services/EmailService.php:561
+#: src/Services/EmailService.php:1401
+#: src/Services/EmailService.php:2771
 msgid "Event not found."
 msgstr ""
 
 #: src/API/EventParticipantsController.php:582
-#: src/API/EventSignupController.php:1751
-#: src/Services/EmailService.php:2294
+#: src/API/EventSignupController.php:1752
+#: src/Services/EmailService.php:2293
 #: src/blocks/event-signup/editor.js:110
 msgid "Event Signup"
 msgstr ""
@@ -175,11 +175,11 @@ msgstr ""
 #: src/API/ParticipantsController.php:729
 #: src/API/ParticipantsController.php:762
 #: src/API/ParticipantsController.php:789
-#: src/Services/EmailService.php:360
-#: src/Services/EmailService.php:583
-#: src/Services/EmailService.php:1439
-#: src/Services/EmailService.php:1829
-#: src/Services/EmailService.php:2891
+#: src/Services/EmailService.php:361
+#: src/Services/EmailService.php:584
+#: src/Services/EmailService.php:1440
+#: src/Services/EmailService.php:1830
+#: src/Services/EmailService.php:2846
 #: src/Admin/participant-detail/ParticipantDetail.js:86
 msgid "Participant not found."
 msgstr ""
@@ -304,40 +304,40 @@ msgid "This registration link has expired. Please fill in the form again."
 msgstr ""
 
 #: src/API/EventSignupController.php:642
-#: src/API/EventSignupController.php:1108
-#: src/API/EventSignupController.php:2989
+#: src/API/EventSignupController.php:1109
+#: src/API/EventSignupController.php:2991
 msgid "Could not find your participant profile."
 msgstr ""
 
 #: src/API/EventSignupController.php:726
-#: src/API/EventSignupController.php:2368
-#: src/API/EventSignupController.php:2794
+#: src/API/EventSignupController.php:2369
+#: src/API/EventSignupController.php:2795
 msgid "You are already signed up for this event."
 msgstr ""
 
-#: src/API/EventSignupController.php:776
-#: src/API/EventSignupController.php:918
+#: src/API/EventSignupController.php:777
+#: src/API/EventSignupController.php:919
 #: src/blocks/event-signup/render.php:66
 #: src/blocks/event-signup/frontend.js:961
 #: src/blocks/event-signup/frontend.js:1271
 msgid "You have successfully signed up for the event!"
 msgstr ""
 
-#: src/API/EventSignupController.php:805
+#: src/API/EventSignupController.php:806
 msgid "Please select at least one occurrence."
 msgstr ""
 
-#: src/API/EventSignupController.php:813
-#: src/API/EventSignupController.php:824
+#: src/API/EventSignupController.php:814
+#: src/API/EventSignupController.php:825
 msgid "Invalid ticket type."
 msgstr ""
 
-#: src/API/EventSignupController.php:835
+#: src/API/EventSignupController.php:836
 msgid "One of the selected occurrences is not valid for this ticket."
 msgstr ""
 
 #. translators: %d: minimum number of occurrences required
-#: src/API/EventSignupController.php:848
+#: src/API/EventSignupController.php:849
 #: src/blocks/event-signup/frontend.js:311
 #, php-format,js-format
 msgid "Please select at least %d occurrence."
@@ -345,79 +345,79 @@ msgid_plural "Please select at least %d occurrences."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/API/EventSignupController.php:875
+#: src/API/EventSignupController.php:876
 msgid "You are already signed up for these occurrences."
 msgstr ""
 
-#: src/API/EventSignupController.php:928
-#: src/API/EventSignupController.php:1816
-#: src/API/EventSignupController.php:1828
-#: src/API/EventSignupController.php:2039
+#: src/API/EventSignupController.php:929
+#: src/API/EventSignupController.php:1817
+#: src/API/EventSignupController.php:1829
+#: src/API/EventSignupController.php:2040
 msgid "Paid signup is not available because the payment plugin is not configured."
 msgstr ""
 
-#: src/API/EventSignupController.php:945
+#: src/API/EventSignupController.php:946
 msgid "One of the selected occurrences is fully booked."
 msgstr ""
 
 #. translators: %s: event title or occurrence date/time label
-#: src/API/EventSignupController.php:984
-#: src/API/EventSignupController.php:998
-#: src/API/EventSignupController.php:1873
+#: src/API/EventSignupController.php:985
+#: src/API/EventSignupController.php:999
+#: src/API/EventSignupController.php:1874
 #, php-format
 msgid "Signup for %s"
 msgstr ""
 
-#: src/API/EventSignupController.php:1051
-#: src/API/EventSignupController.php:1317
-#: src/API/EventSignupController.php:1965
-#: src/API/EventSignupController.php:2112
-#: src/API/EventSignupController.php:2489
-#: src/API/EventSignupController.php:2630
+#: src/API/EventSignupController.php:1052
+#: src/API/EventSignupController.php:1318
+#: src/API/EventSignupController.php:1966
+#: src/API/EventSignupController.php:2113
+#: src/API/EventSignupController.php:2490
+#: src/API/EventSignupController.php:2631
 #: src/blocks/event-signup/frontend.js:1080
 #: src/blocks/event-signup/frontend.js:1362
 msgid "Redirecting to payment…"
 msgstr ""
 
-#: src/API/EventSignupController.php:1130
+#: src/API/EventSignupController.php:1131
 msgid "You need an active signup before you can add activities."
 msgstr ""
 
-#: src/API/EventSignupController.php:1152
+#: src/API/EventSignupController.php:1153
 msgid "No new activities to add."
 msgstr ""
 
-#: src/API/EventSignupController.php:1177
+#: src/API/EventSignupController.php:1178
 #: src/blocks/event-signup/frontend.js:1556
 msgid "Your activities have been added!"
 msgstr ""
 
-#: src/API/EventSignupController.php:1239
-#: src/API/EventSignupController.php:1251
+#: src/API/EventSignupController.php:1240
+#: src/API/EventSignupController.php:1252
 msgid "Paid activities are not available because the payment plugin is not configured."
 msgstr ""
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:1258
+#: src/API/EventSignupController.php:1259
 #, php-format
 msgid "Added activities for %s"
 msgstr ""
 
-#: src/API/EventSignupController.php:1355
+#: src/API/EventSignupController.php:1356
 #: src/Services/GroupSignupPricing.php:113
 msgid "This ticket type is not available for your account."
 msgstr ""
 
-#: src/API/EventSignupController.php:1458
+#: src/API/EventSignupController.php:1459
 msgid "This ticket type is sold out. Please pick another option."
 msgstr ""
 
-#: src/API/EventSignupController.php:1485
+#: src/API/EventSignupController.php:1486
 msgid "This ticket type is no longer available. Please pick another option."
 msgstr ""
 
 #. translators: %d: minimum number of activities required
-#: src/API/EventSignupController.php:1598
+#: src/API/EventSignupController.php:1599
 #: src/blocks/event-signup/render.php:753
 #: src/Services/SignupActivities.php:187
 #: src/blocks/event-signup/frontend.js:391
@@ -427,99 +427,99 @@ msgid_plural "Please select at least %d activities to sign up."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/API/EventSignupController.php:1841
+#: src/API/EventSignupController.php:1842
 msgid "This event is fully booked."
 msgstr ""
 
-#: src/API/EventSignupController.php:2030
+#: src/API/EventSignupController.php:2031
 msgid "Your series pass is now active!"
 msgstr ""
 
 #. translators: %s: ticket type name
-#: src/API/EventSignupController.php:2048
+#: src/API/EventSignupController.php:2049
 #, php-format
 msgid "Upgrade to series pass: %s"
 msgstr ""
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:2062
+#: src/API/EventSignupController.php:2063
 #, php-format
 msgid "Series pass upgrade for %s"
 msgstr ""
 
-#: src/API/EventSignupController.php:2187
+#: src/API/EventSignupController.php:2188
 msgid "If your email is in our system, you will receive a signup link shortly. Please check your inbox."
 msgstr ""
 
-#: src/API/EventSignupController.php:2206
+#: src/API/EventSignupController.php:2207
 msgid "Invalid transaction."
 msgstr ""
 
-#: src/API/EventSignupController.php:2214
+#: src/API/EventSignupController.php:2215
 msgid "Payment plugin is missing."
 msgstr ""
 
-#: src/API/EventSignupController.php:2223
-#: src/API/EventSignupController.php:2288
+#: src/API/EventSignupController.php:2224
+#: src/API/EventSignupController.php:2289
 msgid "Transaction not found."
 msgstr ""
 
-#: src/API/EventSignupController.php:2264
+#: src/API/EventSignupController.php:2265
 msgid "You are not authorized to retry this payment."
 msgstr ""
 
-#: src/API/EventSignupController.php:2300
+#: src/API/EventSignupController.php:2301
 msgid "This payment cannot be retried."
 msgstr ""
 
-#: src/API/EventSignupController.php:2318
+#: src/API/EventSignupController.php:2319
 msgid "This payment is not retriable from this endpoint."
 msgstr ""
 
-#: src/API/EventSignupController.php:2331
-#: src/API/EventSignupController.php:2523
+#: src/API/EventSignupController.php:2332
+#: src/API/EventSignupController.php:2524
 msgid "This payment is missing context needed to retry."
 msgstr ""
 
-#: src/API/EventSignupController.php:2379
-#: src/API/EventSignupController.php:2566
+#: src/API/EventSignupController.php:2380
+#: src/API/EventSignupController.php:2567
 msgid "Original line items could not be loaded."
 msgstr ""
 
-#: src/API/EventSignupController.php:2541
+#: src/API/EventSignupController.php:2542
 msgid "Your signup is no longer active."
 msgstr ""
 
-#: src/API/EventSignupController.php:2555
+#: src/API/EventSignupController.php:2556
 msgid "These activities are already on your signup."
 msgstr ""
 
-#: src/API/EventSignupController.php:2687
+#: src/API/EventSignupController.php:2688
 msgid "Please enter your name."
 msgstr ""
 
-#: src/API/EventSignupController.php:2769
+#: src/API/EventSignupController.php:2770
 #: src/blocks/event-signup/frontend.js:1096
 msgid "We recognise this email — check your inbox to continue."
 msgstr ""
 
-#: src/API/EventSignupController.php:2821
+#: src/API/EventSignupController.php:2822
 msgid "Failed to process registration. Please try again."
 msgstr ""
 
-#: src/API/EventSignupController.php:2929
+#: src/API/EventSignupController.php:2931
 msgid "You have been signed up for the event! Please check your email to confirm your subscription."
 msgstr ""
 
-#: src/API/EventSignupController.php:2938
+#: src/API/EventSignupController.php:2940
 msgid "You have successfully registered and signed up for the event!"
 msgstr ""
 
-#: src/API/EventSignupController.php:3010
+#: src/API/EventSignupController.php:3012
 msgid "You are not signed up for this event."
 msgstr ""
 
-#: src/API/EventSignupController.php:3026
+#: src/API/EventSignupController.php:3028
 #: src/blocks/event-signup/frontend.js:1640
 msgid "You have been removed from this event."
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 #: src/blocks/event-signup/render.php:1265
 #: src/blocks/event-signup/render.php:1320
 #: src/blocks/mailing-signup/render.php:125
-#: src/Services/EmailService.php:1920
+#: src/Services/EmailService.php:1921
 #: src/Admin/all-participants/AllParticipants.js:108
 #: src/Admin/components/ParticipantEditModal.js:177
 #: src/Admin/participant-detail/ParticipantDetail.js:190
@@ -708,7 +708,7 @@ msgid "This block can only be used on event pages."
 msgstr ""
 
 #: src/blocks/event-interest/render.php:135
-#: src/Services/EmailService.php:1916
+#: src/Services/EmailService.php:1917
 #: src/Admin/all-participants/AllParticipants.js:93
 #: src/Admin/event-participants/EventParticipants.js:629
 #: src/Admin/manage-event-audience-tab/EventAudience.js:892
@@ -1057,12 +1057,12 @@ msgstr ""
 msgid "Every 5 minutes (fair-audience)"
 msgstr ""
 
-#: src/Hooks/PaymentHooks.php:819
+#: src/Hooks/PaymentHooks.php:827
 msgid "Paid online via Mollie"
 msgstr ""
 
 #. translators: %1$s: Mollie status, %2$d: transaction ID
-#: src/Hooks/PaymentHooks.php:863
+#: src/Hooks/PaymentHooks.php:871
 #, php-format
 msgid "Online payment %1$s (transaction #%2$d)"
 msgstr ""
@@ -1105,322 +1105,322 @@ msgstr ""
 msgid "Powered by %s"
 msgstr ""
 
-#: src/Services/EmailService.php:153
+#: src/Services/EmailService.php:154
 msgid "Participant has not yet confirmed their marketing subscription."
 msgstr ""
 
-#: src/Services/EmailService.php:161
+#: src/Services/EmailService.php:162
 msgid "Opted out of the weekly summary."
 msgstr ""
 
-#: src/Services/EmailService.php:164
+#: src/Services/EmailService.php:165
 msgid "Participant opted out of marketing emails."
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:210
+#: src/Services/EmailService.php:211
 #, php-format
 msgid "Quick question about %s"
 msgstr ""
 
 #. translators: %s: participant first name
-#: src/Services/EmailService.php:239
-#: src/Services/EmailService.php:446
-#: src/Services/EmailService.php:666
-#: src/Services/EmailService.php:774
-#: src/Services/EmailService.php:875
-#: src/Services/EmailService.php:997
-#: src/Services/EmailService.php:1159
-#: src/Services/EmailService.php:1334
-#: src/Services/EmailService.php:1604
-#: src/Services/EmailService.php:1709
-#: src/Services/EmailService.php:2193
-#: src/Services/EmailService.php:2335
-#: src/Services/EmailService.php:2460
-#: src/Services/EmailService.php:2572
-#: src/Services/EmailService.php:2709
-#: src/Services/EmailService.php:2998
-#: src/Services/EmailService.php:3091
+#: src/Services/EmailService.php:240
+#: src/Services/EmailService.php:447
+#: src/Services/EmailService.php:667
+#: src/Services/EmailService.php:775
+#: src/Services/EmailService.php:876
+#: src/Services/EmailService.php:998
+#: src/Services/EmailService.php:1160
+#: src/Services/EmailService.php:1335
+#: src/Services/EmailService.php:1605
+#: src/Services/EmailService.php:1710
+#: src/Services/EmailService.php:2194
+#: src/Services/EmailService.php:2325
+#: src/Services/EmailService.php:2415
+#: src/Services/EmailService.php:2527
+#: src/Services/EmailService.php:2664
+#: src/Services/EmailService.php:2953
+#: src/Services/EmailService.php:3046
 #: src/Admin/event-participants/EventParticipants.js:1192
 #, php-format,js-format
 msgid "Hi %s,"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:247
+#: src/Services/EmailService.php:248
 #, php-format
 msgid "We'd love to hear from you about %s!"
 msgstr ""
 
-#: src/Services/EmailService.php:261
+#: src/Services/EmailService.php:262
 msgid "Please take a moment to answer our quick poll:"
 msgstr ""
 
-#: src/Services/EmailService.php:266
+#: src/Services/EmailService.php:267
 msgid "Answer Poll"
 msgstr ""
 
 #. translators: 1: line break, 2: site name
-#: src/Services/EmailService.php:273
-#: src/Services/EmailService.php:498
-#: src/Services/EmailService.php:692
-#: src/Services/EmailService.php:796
-#: src/Services/EmailService.php:905
-#: src/Services/EmailService.php:1027
-#: src/Services/EmailService.php:1169
-#: src/Services/EmailService.php:1346
-#: src/Services/EmailService.php:1616
-#: src/Services/EmailService.php:1754
-#: src/Services/EmailService.php:2209
+#: src/Services/EmailService.php:274
+#: src/Services/EmailService.php:499
+#: src/Services/EmailService.php:693
+#: src/Services/EmailService.php:797
+#: src/Services/EmailService.php:906
+#: src/Services/EmailService.php:1028
+#: src/Services/EmailService.php:1170
+#: src/Services/EmailService.php:1347
+#: src/Services/EmailService.php:1617
+#: src/Services/EmailService.php:1755
+#: src/Services/EmailService.php:2210
 #, php-format
 msgid "Thanks,%1$sThe %2$s Team"
 msgstr ""
 
-#: src/Services/EmailService.php:285
-#: src/Services/EmailService.php:510
-#: src/Services/EmailService.php:704
-#: src/Services/EmailService.php:808
-#: src/Services/EmailService.php:917
-#: src/Services/EmailService.php:1039
-#: src/Services/EmailService.php:1769
-#: src/Services/EmailService.php:2755
+#: src/Services/EmailService.php:286
+#: src/Services/EmailService.php:511
+#: src/Services/EmailService.php:705
+#: src/Services/EmailService.php:809
+#: src/Services/EmailService.php:918
+#: src/Services/EmailService.php:1040
+#: src/Services/EmailService.php:1770
+#: src/Services/EmailService.php:2710
 msgid "If the button above doesn't work, copy and paste this link:"
 msgstr ""
 
-#: src/Services/EmailService.php:325
+#: src/Services/EmailService.php:326
 msgid "Poll not found."
 msgstr ""
 
-#: src/Services/EmailService.php:369
-#: src/Services/EmailService.php:592
-#: src/Services/EmailService.php:1448
-#: src/Services/EmailService.php:1525
-#: src/Services/EmailService.php:1838
-#: src/Services/EmailService.php:2900
+#: src/Services/EmailService.php:370
+#: src/Services/EmailService.php:593
+#: src/Services/EmailService.php:1449
+#: src/Services/EmailService.php:1526
+#: src/Services/EmailService.php:1839
+#: src/Services/EmailService.php:2855
 msgid "Participant has no email address."
 msgstr ""
 
-#: src/Services/EmailService.php:387
-#: src/Services/EmailService.php:609
-#: src/Services/EmailService.php:1472
-#: src/Services/EmailService.php:1549
-#: src/Services/EmailService.php:1864
-#: src/Services/EmailService.php:2927
+#: src/Services/EmailService.php:388
+#: src/Services/EmailService.php:610
+#: src/Services/EmailService.php:1473
+#: src/Services/EmailService.php:1550
+#: src/Services/EmailService.php:1865
+#: src/Services/EmailService.php:2882
 msgid "wp_mail() failed to send."
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:417
+#: src/Services/EmailService.php:418
 #, php-format
 msgid "Photos from %s are ready!"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:454
+#: src/Services/EmailService.php:455
 #: src/Admin/event-participants/EventParticipants.js:1204
 #, php-format,js-format
 msgid "The photos from %s are now available for you to view and like!"
 msgstr ""
 
-#: src/Services/EmailService.php:468
+#: src/Services/EmailService.php:469
 #: src/Admin/event-participants/EventParticipants.js:1217
 msgid "Click the button below to browse the gallery and let us know which photos you like best:"
 msgstr ""
 
-#: src/Services/EmailService.php:473
+#: src/Services/EmailService.php:474
 #: src/Admin/event-participants/EventParticipants.js:1239
 msgid "View Gallery"
 msgstr ""
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:637
+#: src/Services/EmailService.php:638
 #, php-format
 msgid "Confirm your subscription to %s"
 msgstr ""
 
-#: src/Services/EmailService.php:672
+#: src/Services/EmailService.php:673
 msgid "Thank you for signing up for our mailing list! Please confirm your email address by clicking the button below."
 msgstr ""
 
-#: src/Services/EmailService.php:677
+#: src/Services/EmailService.php:678
 msgid "Confirm Email"
 msgstr ""
 
-#: src/Services/EmailService.php:682
+#: src/Services/EmailService.php:683
 msgid "This link will expire in 48 hours."
 msgstr ""
 
-#: src/Services/EmailService.php:686
+#: src/Services/EmailService.php:687
 msgid "If you didn't sign up for this mailing list, you can safely ignore this email."
 msgstr ""
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:743
+#: src/Services/EmailService.php:744
 #, php-format
 msgid "Your signup answers — %s"
 msgstr ""
 
-#: src/Services/EmailService.php:780
+#: src/Services/EmailService.php:781
 msgid "Thank you for signing up! Here are the answers you submitted:"
 msgstr ""
 
-#: src/Services/EmailService.php:789
+#: src/Services/EmailService.php:790
 msgid "Edit Your Answers"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:846
+#: src/Services/EmailService.php:847
 #, php-format
 msgid "Sign up for %s"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:883
+#: src/Services/EmailService.php:884
 #, php-format
 msgid "You requested a signup link for %s."
 msgstr ""
 
-#: src/Services/EmailService.php:889
+#: src/Services/EmailService.php:890
 msgid "Click the button below to sign up for the event:"
 msgstr ""
 
-#: src/Services/EmailService.php:894
-#: src/Services/EmailService.php:2736
+#: src/Services/EmailService.php:895
+#: src/Services/EmailService.php:2691
 msgid "Sign Up Now"
 msgstr ""
 
-#: src/Services/EmailService.php:899
+#: src/Services/EmailService.php:900
 msgid "If you didn't request this link, you can safely ignore this email."
-msgstr ""
-
-#: src/Services/EmailService.php:923
-#: src/Services/EmailService.php:1045
-#: src/Services/EmailService.php:2761
-msgid "Don't want to receive event invitations?"
 msgstr ""
 
 #: src/Services/EmailService.php:924
 #: src/Services/EmailService.php:1046
-#: src/Services/EmailService.php:1180
-#: src/Services/EmailService.php:1359
-#: src/Services/EmailService.php:1629
-#: src/Services/EmailService.php:2762
+#: src/Services/EmailService.php:2716
+msgid "Don't want to receive event invitations?"
+msgstr ""
+
+#: src/Services/EmailService.php:925
+#: src/Services/EmailService.php:1047
+#: src/Services/EmailService.php:1181
+#: src/Services/EmailService.php:1360
+#: src/Services/EmailService.php:1630
+#: src/Services/EmailService.php:2717
 msgid "Manage your preferences"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:964
+#: src/Services/EmailService.php:965
 #, php-format
 msgid "Continue registering for %s"
 msgstr ""
 
-#: src/Services/EmailService.php:969
+#: src/Services/EmailService.php:970
 msgid "Continue to payment"
 msgstr ""
 
-#: src/Services/EmailService.php:970
+#: src/Services/EmailService.php:971
 msgid "Continue to sign up"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:1005
+#: src/Services/EmailService.php:1006
 #, php-format
 msgid "You're registering for %s."
 msgstr ""
 
-#: src/Services/EmailService.php:1011
+#: src/Services/EmailService.php:1012
 msgid "We've saved your answers — click below to continue where you left off:"
 msgstr ""
 
-#: src/Services/EmailService.php:1021
+#: src/Services/EmailService.php:1022
 msgid "If you didn't try to register, you can safely ignore this email."
 msgstr ""
 
-#: src/Services/EmailService.php:1179
-#: src/Services/EmailService.php:1358
-#: src/Services/EmailService.php:1628
+#: src/Services/EmailService.php:1180
+#: src/Services/EmailService.php:1359
+#: src/Services/EmailService.php:1629
 msgid "Don't want to receive these emails?"
 msgstr ""
 
-#: src/Services/EmailService.php:1428
-#: src/Services/EmailService.php:1516
+#: src/Services/EmailService.php:1429
+#: src/Services/EmailService.php:1517
 msgid "Manually skipped."
 msgstr ""
 
 #. translators: %s: fee name
-#: src/Services/EmailService.php:1680
+#: src/Services/EmailService.php:1681
 #, php-format
 msgid "Payment reminder: %s"
 msgstr ""
 
-#: src/Services/EmailService.php:1715
+#: src/Services/EmailService.php:1716
 msgid "This is a friendly reminder about a pending payment:"
 msgstr ""
 
-#: src/Services/EmailService.php:1720
+#: src/Services/EmailService.php:1721
 msgid "Fee:"
 msgstr ""
 
-#: src/Services/EmailService.php:1724
-#: src/Services/EmailService.php:2544
+#: src/Services/EmailService.php:1725
+#: src/Services/EmailService.php:2499
 msgid "Amount:"
 msgstr ""
 
-#: src/Services/EmailService.php:1731
+#: src/Services/EmailService.php:1732
 msgid "Due Date:"
 msgstr ""
 
-#: src/Services/EmailService.php:1745
+#: src/Services/EmailService.php:1746
 msgid "Pay Now"
 msgstr ""
 
-#: src/Services/EmailService.php:1815
+#: src/Services/EmailService.php:1816
 msgid "Fee not found."
 msgstr ""
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:1910
+#: src/Services/EmailService.php:1911
 #, php-format
 msgid "New form submission — %s"
 msgstr ""
 
 #. translators: %s: page title
-#: src/Services/EmailService.php:1931
+#: src/Services/EmailService.php:1932
 #, php-format
 msgid "Page: %s"
 msgstr ""
 
-#: src/Services/EmailService.php:1959
+#: src/Services/EmailService.php:1960
 msgid "A new form submission has been received."
 msgstr ""
 
-#: src/Services/EmailService.php:2041
+#: src/Services/EmailService.php:2042
 msgid "[Test email — real sends to subscribers include a \"Manage your preferences\" unsubscribe link here.]"
 msgstr ""
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:2140
+#: src/Services/EmailService.php:2141
 #, php-format
 msgid "Your submission — %s"
 msgstr ""
 
 #. translators: %s: page title
-#: src/Services/EmailService.php:2151
+#: src/Services/EmailService.php:2152
 #, php-format
 msgid "Form: %s"
 msgstr ""
 
-#: src/Services/EmailService.php:2161
+#: src/Services/EmailService.php:2162
 msgid "Here are the answers you submitted:"
 msgstr ""
 
-#: src/Services/EmailService.php:2199
+#: src/Services/EmailService.php:2200
 msgid "Thank you for your submission! We have received your response."
 msgstr ""
 
-#: src/Services/EmailService.php:2253
-#: src/Services/EmailService.php:2403
-#: src/Services/EmailService.php:2525
+#: src/Services/EmailService.php:2256
+#: src/Services/EmailService.php:2358
+#: src/Services/EmailService.php:2480
 #: src/Admin/events-list/EventsList.js:37
 #: src/Admin/manage-event-audience-tab/EventAudience.js:778
 #: src/Admin/participant-detail/ParticipantDetail.js:271
@@ -1429,160 +1429,172 @@ msgid "Event"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2257
+#: src/Services/EmailService.php:2260
 #, php-format
 msgid "Signup confirmed — %s"
 msgstr ""
 
-#: src/Services/EmailService.php:2269
-#: src/Services/EmailService.php:2419
-#: src/blocks/event-signup/frontend.js:1816
-#: src/blocks/event-signup/frontend.js:1938
-msgid "Amount paid:"
-msgstr ""
-
-#: src/Services/EmailService.php:2282
-msgid "Selected options:"
-msgstr ""
-
-#: src/Services/EmailService.php:2303
-msgid "Your answers:"
-msgstr ""
-
 #. translators: %s: event title
-#: src/Services/EmailService.php:2344
+#: src/Services/EmailService.php:2306
 #, php-format
 msgid "Your signup for %s has been confirmed and your payment has been received."
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2346
+#: src/Services/EmailService.php:2308
 #, php-format
 msgid "Your signup for %s has been confirmed."
 msgstr ""
 
+#: src/Services/EmailService.php:2327
+msgid "Event date:"
+msgstr ""
+
+#: src/Services/EmailService.php:2328
+msgid "Registration reference:"
+msgstr ""
+
+#: src/Services/EmailService.php:2329
+msgid "Ticket type:"
+msgstr ""
+
+#: src/Services/EmailService.php:2330
+#: src/Services/EmailService.php:2374
+#: src/blocks/event-signup/frontend.js:1816
+#: src/blocks/event-signup/frontend.js:1938
+msgid "Amount paid:"
+msgstr ""
+
+#: src/Services/EmailService.php:2331
+msgid "Selected options:"
+msgstr ""
+
+#: src/Services/EmailService.php:2332
+msgid "Your answers:"
+msgstr ""
+
 #. translators: 1: line break, 2: site name
-#: src/Services/EmailService.php:2360
-#: src/Services/EmailService.php:2480
-#: src/Services/EmailService.php:2743
+#: src/Services/EmailService.php:2334
+#: src/Services/EmailService.php:2435
+#: src/Services/EmailService.php:2698
 #, php-format
 msgid "See you there!%1$sThe %2$s Team"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2407
+#: src/Services/EmailService.php:2362
 #, php-format
 msgid "Activities added — %s"
 msgstr ""
 
-#: src/Services/EmailService.php:2432
+#: src/Services/EmailService.php:2387
 msgid "Activities added:"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2468
+#: src/Services/EmailService.php:2423
 #, php-format
 msgid "The following activities have been added to your signup for %s."
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2532
+#: src/Services/EmailService.php:2487
 #, php-format
 msgid "Payment didn’t go through — %s"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2580
+#: src/Services/EmailService.php:2535
 #, php-format
 msgid "Your payment for %s didn’t go through. Your spot is still held for a short while — pick up where you left off using the link below."
 msgstr ""
 
-#: src/Services/EmailService.php:2589
+#: src/Services/EmailService.php:2544
 msgid "Resume payment"
 msgstr ""
 
-#: src/Services/EmailService.php:2594
+#: src/Services/EmailService.php:2549
 msgid "If the button doesn’t work, copy and paste this link into your browser:"
 msgstr ""
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:2601
+#: src/Services/EmailService.php:2556
 #, php-format
 msgid "See you soon,%1$sThe %2$s Team"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2680
+#: src/Services/EmailService.php:2635
 #, php-format
 msgid "You're invited: %s"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2717
+#: src/Services/EmailService.php:2672
 #, php-format
 msgid "We have a new event coming up: %s."
 msgstr ""
 
-#: src/Services/EmailService.php:2731
+#: src/Services/EmailService.php:2686
 msgid "Would you like to join? Click the button below to sign up:"
 msgstr ""
 
-#: src/Services/EmailService.php:2879
+#: src/Services/EmailService.php:2834
 msgid "Already signed up"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2972
+#: src/Services/EmailService.php:2927
 #, php-format
 msgid "Thanks for your interest in %s"
 msgstr ""
 
-#: src/Services/EmailService.php:2976
-#: src/Services/EmailService.php:3054
+#: src/Services/EmailService.php:2931
+#: src/Services/EmailService.php:3009
 msgid "there"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:3003
+#: src/Services/EmailService.php:2958
 #, php-format
 msgid "Thanks for registering your interest in %s. We will let you know when there are updates."
 msgstr ""
 
-#: src/Services/EmailService.php:3006
+#: src/Services/EmailService.php:2961
 msgid "If you didn't register your interest, you can safely ignore this email."
 msgstr ""
 
-#: src/Services/EmailService.php:3011
+#: src/Services/EmailService.php:2966
 msgid "No longer interested?"
 msgstr ""
 
-#: src/Services/EmailService.php:3012
+#: src/Services/EmailService.php:2967
 msgid "Unsubscribe from updates about this event"
 msgstr ""
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3050
+#: src/Services/EmailService.php:3005
 #, php-format
 msgid "Welcome to the %s mailing list"
 msgstr ""
 
 #. translators: 1: site name, 2: event title
-#: src/Services/EmailService.php:3059
+#: src/Services/EmailService.php:3014
 #, php-format
 msgid "You've been added to the %1$s mailing list following the consent you gave at %2$s. We'll keep you posted about upcoming events and news."
 msgstr ""
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3066
+#: src/Services/EmailService.php:3021
 #, php-format
 msgid "You've been added to the %s mailing list following the consent you gave. We'll keep you posted about upcoming events and news."
 msgstr ""
 
-#: src/Services/EmailService.php:3099
+#: src/Services/EmailService.php:3054
 msgid "Changed your mind?"
 msgstr ""
 
-#: src/Services/EmailService.php:3100
+#: src/Services/EmailService.php:3055
 msgid "Manage your subscription or unsubscribe"
 msgstr ""
 
@@ -3748,7 +3760,11 @@ msgstr ""
 msgid "Please enter a valid email address for: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:527
+#: ../fair-events-shared/src/questionnaire.js:533
+msgid "Please enter a valid web address for: %s"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:561
 msgid "File is too large. Maximum size is "
 msgstr ""
 

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -758,15 +758,16 @@ class EventSignupController extends WP_REST_Controller {
 			} else {
 				$this->event_participant_repository->update_label( $event_id, $participant->id, 'signed_up' );
 			}
+			$event_participant_id = (int) $existing->id;
 		} else {
-			$this->event_participant_repository->add_participant_to_event( $event_id, $participant->id, 'signed_up', $event_date_id );
+			$event_participant_id = (int) $this->event_participant_repository->add_participant_to_event( $event_id, $participant->id, 'signed_up', $event_date_id );
 		}
 
 		$this->snapshot_ticket_type_on_signup( $event_date_id, $participant->id, $ticket_type_id );
 		$this->snapshot_options_on_signup( $event_date_id, $participant->id, $option_items );
 
 		$option_names = array_map( fn( $o ) => $o->name, $option_items );
-		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names, (int) $event_date_id );
+		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names, (int) $event_date_id, (int) $ticket_type_id, $event_participant_id );
 
 		AudienceSession::set( (int) $participant->id );
 
@@ -2905,15 +2906,16 @@ class EventSignupController extends WP_REST_Controller {
 			} else {
 				$this->event_participant_repository->update_label( $event_id, $participant->id, 'signed_up' );
 			}
+			$event_participant_id = (int) $existing->id;
 		} else {
-			$this->event_participant_repository->add_participant_to_event( $event_id, $participant->id, 'signed_up', $event_date_id );
+			$event_participant_id = (int) $this->event_participant_repository->add_participant_to_event( $event_id, $participant->id, 'signed_up', $event_date_id );
 		}
 
 		$this->snapshot_ticket_type_on_signup( $event_date_id, $participant->id, $ticket_type_id );
 		$this->snapshot_options_on_signup( $event_date_id, $participant->id, $option_items );
 
 		$option_names = array_map( fn( $o ) => $o->name, $option_items );
-		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names, (int) $event_date_id );
+		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names, (int) $event_date_id, (int) $ticket_type_id, $event_participant_id );
 
 		if ( $is_new_participant ) {
 			AudienceSession::set( (int) $participant->id );

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -700,7 +700,15 @@ class PaymentHooks {
 		);
 
 		$email_service = new EmailService();
-		$email_service->send_signup_payment_confirmation( $participant, $event, $transaction, $option_names, (int) $event_participant->event_date_id );
+		$email_service->send_signup_payment_confirmation(
+			$participant,
+			$event,
+			$transaction,
+			$option_names,
+			(int) $event_participant->event_date_id,
+			(int) $event_participant->ticket_type_id,
+			(int) $event_participant->id
+		);
 	}
 
 	/**

--- a/fair-audience/src/Hooks/SignupHookBridge.php
+++ b/fair-audience/src/Hooks/SignupHookBridge.php
@@ -646,8 +646,9 @@ class SignupHookBridge {
 		$label                        = $transaction_id ? 'pending_payment' : 'signed_up';
 		$ticket_type_id               = ! empty( $ticket_selection['ticket_type_id'] ) ? (int) $ticket_selection['ticket_type_id'] : null;
 
-		$existing      = $event_participant_repository->get_by_event_date_and_participant( $event_date_id, $participant->id );
-		$stamp_payment = false;
+		$existing             = $event_participant_repository->get_by_event_date_and_participant( $event_date_id, $participant->id );
+		$stamp_payment        = false;
+		$event_participant_id = $existing ? (int) $existing->id : 0;
 
 		if ( $existing ) {
 			if ( 'signed_up' !== $existing->label ) {
@@ -655,8 +656,8 @@ class SignupHookBridge {
 				$stamp_payment = (bool) $transaction_id;
 			}
 		} else {
-			$event_participant_repository->add_participant_to_event( $event_id, $participant->id, $label, $event_date_id );
-			$stamp_payment = (bool) $transaction_id;
+			$event_participant_id = (int) $event_participant_repository->add_participant_to_event( $event_id, $participant->id, $label, $event_date_id );
+			$stamp_payment        = (bool) $transaction_id;
 		}
 
 		// Only stamp payment metadata when this call created the junction row
@@ -703,7 +704,7 @@ class SignupHookBridge {
 		if ( ! $transaction_id ) {
 			$email_service = new EmailService();
 			$event         = get_post( $event_id );
-			$email_service->send_signup_payment_confirmation( $participant, $event, null, array(), (int) $event_date_id );
+			$email_service->send_signup_payment_confirmation( $participant, $event, null, array(), (int) $event_date_id, (int) $ticket_type_id, $event_participant_id );
 		}
 	}
 

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -25,6 +25,7 @@ use FairAudience\Services\ParticipantToken;
 use FairAudienceExperimental\Services\FeePaymentToken;
 use FairAudience\Services\RecipientResolver;
 use FairEventsShared\Money;
+use FairEventsShared\Notifications\SignupConfirmationEmail;
 
 defined( 'WPINC' ) || die;
 
@@ -2235,16 +2236,18 @@ class EmailService {
 	/**
 	 * Send signup confirmation email to the participant.
 	 *
-	 * @param Participant   $participant   Participant who signed up.
-	 * @param \WP_Post|null $event         Event post object (nullable).
-	 * @param object|null   $transaction   Transaction row from fair-payments-connector (null for free signups).
-	 * @param array         $option_names  Names of the selected ticket-activity options.
-	 * @param int           $event_date_id Event date ID — used to load the signup
-	 *                                     questionnaire answers so they can be
-	 *                                     included in the email. Pass 0 to skip.
+	 * @param Participant   $participant             Participant who signed up.
+	 * @param \WP_Post|null $event                   Event post object (nullable).
+	 * @param object|null   $transaction             Transaction row from fair-payments-connector (null for free signups).
+	 * @param array         $option_names            Names of the selected ticket-activity options.
+	 * @param int           $event_date_id           Event date ID — used to load the event date
+	 *                                                and the signup questionnaire answers. Pass 0 to skip both.
+	 * @param int           $ticket_type_id           Ticket type ID shown in the email. Pass 0 to omit.
+	 * @param int           $registration_reference  EventParticipant row ID shown as the registration
+	 *                                                reference. Pass 0 to omit.
 	 * @return bool Success.
 	 */
-	public function send_signup_payment_confirmation( Participant $participant, $event, $transaction = null, $option_names = array(), int $event_date_id = 0 ): bool {
+	public function send_signup_payment_confirmation( Participant $participant, $event, $transaction = null, $option_names = array(), int $event_date_id = 0, int $ticket_type_id = 0, int $registration_reference = 0 ): bool {
 		if ( ! $this->has_valid_email( $participant ) ) {
 			return false;
 		}
@@ -2252,36 +2255,32 @@ class EmailService {
 		$site_name   = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
 		$event_title = $event ? $event->post_title : __( 'Event', 'fair-audience' );
 
-		$subject = sprintf(
+		$subject_template =
 			/* translators: %s: event title */
-			__( 'Signup confirmed — %s', 'fair-audience' ),
-			$event_title
-		);
+			__( 'Signup confirmed — %s', 'fair-audience' );
 
-		$amount   = isset( $transaction->amount ) ? (float) $transaction->amount : 0;
-		$currency = ! empty( $transaction->currency ) ? $transaction->currency : 'EUR';
-
-		$payment_html = '';
-		if ( $amount > 0 ) {
-			$payment_html = '
-							<table style="width: 100%; border-collapse: collapse; margin: 0 0 20px 0;">
-								<tr>
-									<td style="padding: 8px 0; border-bottom: 1px solid #eee; font-weight: bold;">' . esc_html__( 'Amount paid:', 'fair-audience' ) . '</td>
-									<td style="padding: 8px 0; border-bottom: 1px solid #eee;">' . esc_html( Money::format_display( $amount, $currency ) ) . '</td>
-								</tr>
-							</table>';
-		}
-
-		$options_html = '';
-		if ( ! empty( $option_names ) ) {
-			$options_list = '';
-			foreach ( $option_names as $name ) {
-				$options_list .= '<li style="padding: 4px 0;">' . esc_html( $name ) . '</li>';
+		$event_date_display = '';
+		if ( $event_date_id > 0 && class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+			if ( $event_date ) {
+				$timestamp = strtotime( $event_date->start_datetime );
+				if ( false !== $timestamp ) {
+					$event_date_display = wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
+				}
 			}
-			$options_html = '
-							<p style="margin: 0 0 8px 0; font-size: 16px; font-weight: bold;">' . esc_html__( 'Selected options:', 'fair-audience' ) . '</p>
-							<ul style="margin: 0 0 20px 20px; padding: 0;">' . $options_list . '</ul>';
 		}
+
+		$ticket_type_name = '';
+		if ( $ticket_type_id > 0 && class_exists( \FairEvents\Models\TicketType::class ) ) {
+			$ticket_type = \FairEvents\Models\TicketType::get_by_id( $ticket_type_id );
+			if ( $ticket_type ) {
+				$ticket_type_name = $ticket_type->name;
+			}
+		}
+
+		$amount                 = isset( $transaction->amount ) ? (float) $transaction->amount : 0;
+		$currency               = ! empty( $transaction->currency ) ? $transaction->currency : 'EUR';
+		$payment_amount_display = $amount > 0 ? Money::format_display( $amount, $currency ) : '';
 
 		// Custom signup question answers (Event Signup questionnaire submission).
 		$answers_html = '';
@@ -2296,89 +2295,45 @@ class EmailService {
 			);
 
 			if ( ! empty( $submissions ) ) {
-				$answer_repo = new \FairForm\Database\QuestionnaireAnswerRepository();
-				$rows_html   = $this->render_answer_rows( $answer_repo->get_by_submission( $submissions[0]->id ) );
-				if ( '' !== $rows_html ) {
-					$answers_html = '
-							<p style="margin: 0 0 8px 0; font-size: 16px; font-weight: bold;">' . esc_html__( 'Your answers:', 'fair-audience' ) . '</p>
-							<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0 0 20px 0; border: 1px solid #eeeeee; border-radius: 4px;">'
-						. $rows_html
-						. '</table>';
-				}
+				$answer_repo  = new \FairForm\Database\QuestionnaireAnswerRepository();
+				$answers_html = $this->render_answer_rows( $answer_repo->get_by_submission( $submissions[0]->id ) );
 			}
 		}
 
-		$message = '<!DOCTYPE html>
-<html>
-<head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-</head>
-<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #333333; background-color: #f4f4f4;">
-	<table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f4;">
-		<tr>
-			<td align="center" style="padding: 20px 0;">
-				<table width="600" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
-					<!-- Header -->
-					<tr>
-						<td style="background-color: #0073aa; color: #ffffff; padding: 30px; border-radius: 8px 8px 0 0; text-align: center;">
-							<h1 style="margin: 0; font-size: 24px; font-weight: bold;">' . esc_html( $event_title ) . '</h1>
-						</td>
-					</tr>
+		$confirmation_sentence = sprintf(
+			$transaction
+				/* translators: %s: event title */
+				? esc_html__( 'Your signup for %s has been confirmed and your payment has been received.', 'fair-audience' )
+				/* translators: %s: event title */
+				: esc_html__( 'Your signup for %s has been confirmed.', 'fair-audience' ),
+			'<strong>' . esc_html( $event_title ) . '</strong>'
+		);
 
-					<!-- Content -->
-					<tr>
-						<td style="padding: 40px 30px;">
-							<p style="margin: 0 0 20px 0; font-size: 16px;">
-								' . sprintf(
-									/* translators: %s: participant first name */
-								esc_html__( 'Hi %s,', 'fair-audience' ),
-								'<strong>' . esc_html( $participant->name ) . '</strong>'
-							) . '
-							</p>
-
-							<p style="margin: 0 0 20px 0; font-size: 16px;">
-								' . sprintf(
-								$transaction
-									/* translators: %s: event title */
-									? esc_html__( 'Your signup for %s has been confirmed and your payment has been received.', 'fair-audience' )
-									/* translators: %s: event title */
-									: esc_html__( 'Your signup for %s has been confirmed.', 'fair-audience' ),
-								'<strong>' . esc_html( $event_title ) . '</strong>'
-							) . '
-							</p>
-
-							' . $payment_html . '
-
-							' . $options_html . '
-
-							' . $answers_html . '
-
-							<p style="margin: 20px 0 0 0; font-size: 14px; color: #666666;">
-								' . sprintf(
-									/* translators: 1: line break, 2: site name */
-								esc_html__( 'See you there!%1$sThe %2$s Team', 'fair-audience' ),
-								'<br>',
-								esc_html( $site_name )
-							) . '
-							</p>
-						</td>
-					</tr>
-
-					<!-- Footer -->
-					<tr>
-						<td style="background-color: #f8f8f8; padding: 20px 30px; border-radius: 0 0 8px 8px; text-align: center; font-size: 12px; color: #666666;">
-							<p style="margin: 0;">
-								' . esc_html( $site_name ) . '
-							</p>
-						</td>
-					</tr>
-				</table>
-			</td>
-		</tr>
-	</table>
-</body>
-</html>';
+		$subject = SignupConfirmationEmail::subject( $subject_template, $event_title );
+		$message = SignupConfirmationEmail::html(
+			array(
+				'event_title'                  => esc_html( $event_title ),
+				'participant_name'             => esc_html( $participant->name ),
+				'site_name'                    => esc_html( $site_name ),
+				'event_date_display'           => esc_html( $event_date_display ),
+				'registration_reference'       => $registration_reference > 0 ? '#' . $registration_reference : '',
+				'ticket_type_name'             => esc_html( $ticket_type_name ),
+				'payment_amount_display'       => esc_html( $payment_amount_display ),
+				'option_names'                 => array_map( 'esc_html', $option_names ),
+				'answers_html'                 => $answers_html,
+				/* translators: %s: participant first name */
+				'greeting_template'            => esc_html__( 'Hi %s,', 'fair-audience' ),
+				'confirmation_sentence'        => $confirmation_sentence,
+				'event_date_label'             => esc_html__( 'Event date:', 'fair-audience' ),
+				'registration_reference_label' => esc_html__( 'Registration reference:', 'fair-audience' ),
+				'ticket_type_label'            => esc_html__( 'Ticket type:', 'fair-audience' ),
+				'amount_paid_label'            => esc_html__( 'Amount paid:', 'fair-audience' ),
+				'selected_options_label'       => esc_html__( 'Selected options:', 'fair-audience' ),
+				'your_answers_label'           => esc_html__( 'Your answers:', 'fair-audience' ),
+				/* translators: 1: line break, 2: site name */
+				'sign_off_template'            => esc_html__( 'See you there!%1$sThe %2$s Team', 'fair-audience' ),
+			)
+		);
 
 		return 'sent' === $this->deliver( $participant, $subject, $message, EmailType::MINIMAL );
 	}

--- a/fair-events-shared/php/composer.json
+++ b/fair-events-shared/php/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "fair-events/shared",
 	"description": "Shared PHP utilities for Fair Event plugins",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"type": "library",
 	"license": "GPL-3.0-or-later",
 	"autoload": {

--- a/fair-events-shared/php/src/Notifications/SignupConfirmationEmail.php
+++ b/fair-events-shared/php/src/Notifications/SignupConfirmationEmail.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Shared signup confirmation email formatter.
+ *
+ * @package FairEventsShared
+ */
+
+namespace FairEventsShared\Notifications;
+
+/**
+ * Renders the branded signup confirmation email shared by fair-audience and
+ * standalone fair-events. Takes only pre-translated, pre-escaped strings —
+ * it never calls translation functions itself, so each plugin keeps its own
+ * literal calls against its own text domain and this class stays free of any
+ * plugin-specific dependency.
+ */
+class SignupConfirmationEmail {
+
+	/**
+	 * Build the email subject line.
+	 *
+	 * @param string $subject_template Translated subject with one `%s` placeholder for the event title.
+	 * @param string $event_title      Event title.
+	 * @return string Finished subject line.
+	 */
+	public static function subject( string $subject_template, string $event_title ): string {
+		return sprintf( $subject_template, $event_title );
+	}
+
+	/**
+	 * Build the full HTML email body.
+	 *
+	 * `$args` keys — data: event_title, participant_name, site_name,
+	 * event_date_display, registration_reference, ticket_type_name,
+	 * payment_amount_display, option_names (array), answers_html
+	 * (pre-rendered `<tr>` fragment). Copy (already translated/escaped):
+	 * greeting_template, confirmation_sentence, event_date_label,
+	 * registration_reference_label, ticket_type_label, amount_paid_label,
+	 * selected_options_label, your_answers_label, sign_off_template.
+	 *
+	 * Each optional data/label pair renders only when the data value is
+	 * non-empty.
+	 *
+	 * @param array $args See above.
+	 * @return string Full HTML document.
+	 */
+	public static function html( array $args ): string {
+		$event_title            = $args['event_title'] ?? '';
+		$participant_name       = $args['participant_name'] ?? '';
+		$site_name              = $args['site_name'] ?? '';
+		$event_date_display     = $args['event_date_display'] ?? '';
+		$registration_reference = $args['registration_reference'] ?? '';
+		$ticket_type_name       = $args['ticket_type_name'] ?? '';
+		$payment_amount_display = $args['payment_amount_display'] ?? '';
+		$option_names           = $args['option_names'] ?? array();
+		$answers_html           = $args['answers_html'] ?? '';
+
+		$greeting_template            = $args['greeting_template'] ?? '';
+		$confirmation_sentence        = $args['confirmation_sentence'] ?? '';
+		$event_date_label             = $args['event_date_label'] ?? '';
+		$registration_reference_label = $args['registration_reference_label'] ?? '';
+		$ticket_type_label            = $args['ticket_type_label'] ?? '';
+		$amount_paid_label            = $args['amount_paid_label'] ?? '';
+		$selected_options_label       = $args['selected_options_label'] ?? '';
+		$your_answers_label           = $args['your_answers_label'] ?? '';
+		$sign_off_template            = $args['sign_off_template'] ?? '';
+
+		$details_rows = '';
+		foreach (
+			array(
+				array( $event_date_label, $event_date_display ),
+				array( $registration_reference_label, $registration_reference ),
+				array( $ticket_type_label, $ticket_type_name ),
+				array( $amount_paid_label, $payment_amount_display ),
+			) as list( $label, $value )
+		) {
+			if ( '' === (string) $value ) {
+				continue;
+			}
+
+			$details_rows .= '<tr>
+					<td style="padding: 8px 0; border-bottom: 1px solid #eee; font-weight: bold;">' . $label . '</td>
+					<td style="padding: 8px 0; border-bottom: 1px solid #eee;">' . $value . '</td>
+				</tr>';
+		}
+
+		$details_html = '';
+		if ( '' !== $details_rows ) {
+			$details_html = '
+							<table style="width: 100%; border-collapse: collapse; margin: 0 0 20px 0;">' . $details_rows . '</table>';
+		}
+
+		$options_html = '';
+		if ( ! empty( $option_names ) ) {
+			$options_list = '';
+			foreach ( $option_names as $name ) {
+				$options_list .= '<li style="padding: 4px 0;">' . $name . '</li>';
+			}
+			$options_html = '
+							<p style="margin: 0 0 8px 0; font-size: 16px; font-weight: bold;">' . $selected_options_label . '</p>
+							<ul style="margin: 0 0 20px 20px; padding: 0;">' . $options_list . '</ul>';
+		}
+
+		$answers_section = '';
+		if ( '' !== $answers_html ) {
+			$answers_section = '
+							<p style="margin: 0 0 8px 0; font-size: 16px; font-weight: bold;">' . $your_answers_label . '</p>
+							<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0 0 20px 0; border: 1px solid #eeeeee; border-radius: 4px;">' . $answers_html . '</table>';
+		}
+
+		return '<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #333333; background-color: #f4f4f4;">
+	<table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f4;">
+		<tr>
+			<td align="center" style="padding: 20px 0;">
+				<table width="600" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+					<tr>
+						<td style="background-color: #0073aa; color: #ffffff; padding: 30px; border-radius: 8px 8px 0 0; text-align: center;">
+							<h1 style="margin: 0; font-size: 24px; font-weight: bold;">' . $event_title . '</h1>
+						</td>
+					</tr>
+
+					<tr>
+						<td style="padding: 40px 30px;">
+							<p style="margin: 0 0 20px 0; font-size: 16px;">
+								' . sprintf( $greeting_template, '<strong>' . $participant_name . '</strong>' ) . '
+							</p>
+
+							<p style="margin: 0 0 20px 0; font-size: 16px;">
+								' . $confirmation_sentence . '
+							</p>
+
+							' . $details_html . '
+
+							' . $options_html . '
+
+							' . $answers_section . '
+
+							<p style="margin: 20px 0 0 0; font-size: 14px; color: #666666;">
+								' . sprintf( $sign_off_template, '<br>', $site_name ) . '
+							</p>
+						</td>
+					</tr>
+
+					<tr>
+						<td style="background-color: #f8f8f8; padding: 20px 30px; border-radius: 0 0 8px 8px; text-align: center; font-size: 12px; color: #666666;">
+							<p style="margin: 0;">
+								' . $site_name . '
+							</p>
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+</body>
+</html>';
+	}
+}

--- a/fair-events/__tests__/Fair_Test_WPDB.php
+++ b/fair-events/__tests__/Fair_Test_WPDB.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Minimal fake $wpdb for PHPUnit bootstrap.
+ *
+ * @package FairEvents
+ */
+
+/**
+ * Minimal $wpdb double: get_row() resolves to "not found" unless a row was
+ * seeded for the exact table + id via seed_row(). Enough for code paths that
+ * guard on a null model lookup (e.g. an event_date_id/ticket_type_id of 0)
+ * without pulling in a DB library, and for models whose get_by_id() returns
+ * the raw row with no hydrate() column contract (e.g. EventSignup). Models
+ * with a hydrate() that reads many required columns (EventDates, TicketType)
+ * are left unseeded on purpose — see SignupPaymentStateTest's documented
+ * convention of keeping those paths out of unit tests.
+ */
+class Fair_Test_WPDB {
+
+	/**
+	 * Table prefix, matching WordPress's default.
+	 *
+	 * @var string
+	 */
+	public $prefix = 'wp_';
+
+	/**
+	 * Seeded rows, keyed by table name then id.
+	 *
+	 * @var array<string, array<int, object>>
+	 */
+	private $rows = array();
+
+	/**
+	 * Seed a row so get_row() resolves it for the given table + id.
+	 *
+	 * @param string $table Table name, including prefix (e.g. 'wp_fair_events_signups').
+	 * @param int    $id    Row id.
+	 * @param object $row   Row to return.
+	 * @return void
+	 */
+	public function seed_row( $table, $id, $row ) {
+		$this->rows[ $table ][ $id ] = $row;
+	}
+
+	/**
+	 * Stub of wpdb::prepare() — captures the table + id args this codebase's
+	 * `SELECT * FROM %i WHERE id = %d` queries always pass in that order, so
+	 * get_row() can resolve them against seeded rows.
+	 *
+	 * @param string $query   Query with placeholders (ignored).
+	 * @param mixed  ...$args Values for the placeholders — [0] table, [1] id.
+	 * @return array{table: string|null, id: int|null} Captured lookup key.
+	 */
+	public function prepare( $query, ...$args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- query text is irrelevant, only the table/id args matter.
+		return array(
+			'table' => $args[0] ?? null,
+			'id'    => isset( $args[1] ) ? (int) $args[1] : null,
+		);
+	}
+
+	/**
+	 * Stub of wpdb::get_row() — resolves a prepare()d table/id lookup against
+	 * seeded rows, or null when nothing was seeded for it.
+	 *
+	 * @param array{table: string|null, id: int|null}|mixed $prepared Value returned by prepare().
+	 * @return object|null Seeded row, or null.
+	 */
+	public function get_row( $prepared ) {
+		if ( ! is_array( $prepared ) ) {
+			return null;
+		}
+		return $this->rows[ $prepared['table'] ][ $prepared['id'] ] ?? null;
+	}
+}

--- a/fair-events/__tests__/Hooks/SignupEmailHooksTest.php
+++ b/fair-events/__tests__/Hooks/SignupEmailHooksTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * SignupEmailHooks tests
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Hooks;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Hooks\SignupEmailHooks;
+
+/**
+ * Verifies SignupEmailHooks reads the fair_events_signups row and threads its
+ * ticket_type_id/amount through to EmailService::send_signup_confirmation()
+ * for both the free-path (handle_signup_created) and paid-path
+ * (handle_signup_confirmed) hooks. FairAudience\Hooks\SignupHookBridge is
+ * never loaded in fair-events' own test process, so the
+ * "fair-audience active" suppression guard never trips here.
+ */
+class SignupEmailHooksTest extends TestCase {
+
+	/**
+	 * Reset recorded test emails and seeded rows before each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['_fair_test_sent_emails'] = array();
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.
+		$GLOBALS['wpdb'] = new \Fair_Test_WPDB();
+	}
+
+	/**
+	 * Seed a fair_events_signups row for EventSignup::get_by_id().
+	 *
+	 * @param int   $signup_id Row id.
+	 * @param array $overrides Column overrides.
+	 * @return void
+	 */
+	private function seed_signup( $signup_id, array $overrides = array() ): void {
+		$row = (object) array_merge(
+			array(
+				'id'             => $signup_id,
+				'event_date_id'  => 0,
+				'ticket_type_id' => 0,
+				'name'           => 'Jane Doe',
+				'email'          => 'jane@example.test',
+				'amount'         => 0.0,
+			),
+			$overrides
+		);
+
+		$GLOBALS['wpdb']->seed_row( 'wp_fair_events_signups', $signup_id, $row );
+	}
+
+	/**
+	 * The free-path hook (transaction_id null) sends immediately, with the
+	 * signup row's ticket_type_id/amount threaded through.
+	 */
+	public function test_handle_signup_created_free_path_sends_with_signup_fields(): void {
+		$this->seed_signup(
+			10,
+			array(
+				'ticket_type_id' => 3,
+				'amount'         => 0.0,
+			)
+		);
+
+		SignupEmailHooks::handle_signup_created( 10, 0, 'Jane Doe', 'jane@example.test', array(), null );
+
+		$this->assertCount( 1, $GLOBALS['_fair_test_sent_emails'] );
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertSame( 'jane@example.test', $sent['to'] );
+		$this->assertStringContainsString( '#10', $sent['message'] );
+	}
+
+	/**
+	 * The free-path hook does not send when a transaction_id is present — a
+	 * paid-but-unconfirmed signup waits for handle_signup_confirmed().
+	 */
+	public function test_handle_signup_created_paid_path_does_not_send(): void {
+		$this->seed_signup( 11 );
+
+		SignupEmailHooks::handle_signup_created( 11, 0, 'Jane Doe', 'jane@example.test', array(), 55 );
+
+		$this->assertCount( 0, $GLOBALS['_fair_test_sent_emails'] );
+	}
+
+	/**
+	 * The paid-path hook sends once payment is confirmed, with the amount
+	 * paid from the signup row surfaced in the email.
+	 */
+	public function test_handle_signup_confirmed_sends_with_amount_paid(): void {
+		$this->seed_signup(
+			12,
+			array(
+				'ticket_type_id' => 0,
+				'amount'         => 25.5,
+			)
+		);
+
+		$signup = (object) array(
+			'id'            => 12,
+			'event_date_id' => 0,
+			'name'          => 'Jane Doe',
+			'email'         => 'jane@example.test',
+		);
+
+		SignupEmailHooks::handle_signup_confirmed( $signup, (object) array() );
+
+		$this->assertCount( 1, $GLOBALS['_fair_test_sent_emails'] );
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( 'Amount paid:', $sent['message'] );
+		$this->assertStringContainsString( '25.50 EUR', $sent['message'] );
+	}
+}

--- a/fair-events/__tests__/Services/EmailServiceTest.php
+++ b/fair-events/__tests__/Services/EmailServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * EmailService::send_signup_confirmation() tests
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Services\EmailService;
+
+/**
+ * Verifies fair-events' standalone confirmation email renders through the
+ * shared formatter with the registration reference and (on paid signups) the
+ * amount paid. event_date_id and ticket_type_id are left at 0 throughout —
+ * passing a non-zero value would make EmailService reach for
+ * FairEvents\Models\EventDates / TicketType, which need a live $wpdb (see
+ * SignupPaymentStateTest's same convention).
+ */
+class EmailServiceTest extends TestCase {
+
+	/**
+	 * Reset recorded test emails before each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['_fair_test_sent_emails'] = array();
+	}
+
+	/**
+	 * A free signup's email includes the registration reference and omits
+	 * the amount-paid row.
+	 */
+	public function test_free_signup_includes_registration_reference(): void {
+		$email_service = new EmailService();
+
+		$result = $email_service->send_signup_confirmation( 42, 0, 'Jane Doe', 'jane@example.test' );
+
+		$this->assertTrue( $result );
+		$this->assertCount( 1, $GLOBALS['_fair_test_sent_emails'] );
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertSame( 'jane@example.test', $sent['to'] );
+		$this->assertStringContainsString( '#42', $sent['message'] );
+		$this->assertStringContainsString( 'Jane Doe', $sent['message'] );
+		$this->assertStringNotContainsString( 'Amount paid:', $sent['message'] );
+	}
+
+	/**
+	 * A paid signup's email includes the amount-paid row.
+	 */
+	public function test_paid_signup_includes_amount_paid(): void {
+		$email_service = new EmailService();
+
+		$email_service->send_signup_confirmation( 7, 0, 'Jane Doe', 'jane@example.test', 0, 25.5 );
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( 'Amount paid:', $sent['message'] );
+		$this->assertStringContainsString( '25.50 EUR', $sent['message'] );
+	}
+
+	/**
+	 * A zero amount omits the amount-paid row entirely.
+	 */
+	public function test_zero_amount_omits_amount_paid_row(): void {
+		$email_service = new EmailService();
+
+		$email_service->send_signup_confirmation( 7, 0, 'Jane Doe', 'jane@example.test', 0, 0 );
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringNotContainsString( 'Amount paid:', $sent['message'] );
+	}
+
+	/**
+	 * The email is sent as HTML (wp_mail_content_type filtered to text/html).
+	 */
+	public function test_sends_as_html(): void {
+		$email_service = new EmailService();
+
+		$email_service->send_signup_confirmation( 7, 0, 'Jane Doe', 'jane@example.test' );
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( '<!DOCTYPE html>', $sent['message'] );
+	}
+}

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -428,4 +428,128 @@ if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
 	}
 }
 
+if ( ! function_exists( '__' ) ) {
+	/**
+	 * Stub of WordPress __() — returns the string untranslated.
+	 *
+	 * @param string $text   Text to translate.
+	 * @param string $domain Text domain (unused).
+	 * @return string
+	 */
+	function __( $text, $domain = 'default' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'esc_html__' ) ) {
+	/**
+	 * Stub of WordPress esc_html__().
+	 *
+	 * @param string $text   Text to translate/escape.
+	 * @param string $domain Text domain (unused).
+	 * @return string HTML-escaped text.
+	 */
+	function esc_html__( $text, $domain = 'default' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return esc_html( $text );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	/**
+	 * Stub of WordPress esc_html().
+	 *
+	 * @param string $text Text to escape.
+	 * @return string HTML-escaped text.
+	 */
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES );
+	}
+}
+
+if ( ! function_exists( 'wp_specialchars_decode' ) ) {
+	/**
+	 * Stub of WordPress wp_specialchars_decode() — delegates to htmlspecialchars_decode().
+	 *
+	 * @param string $text        Text to decode.
+	 * @param mixed  $quote_style Quote style (ignored by the stub).
+	 * @return string Decoded text.
+	 */
+	function wp_specialchars_decode( $text, $quote_style = ENT_NOQUOTES ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- stub always decodes with ENT_QUOTES.
+		return htmlspecialchars_decode( (string) $text, ENT_QUOTES );
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	/**
+	 * Stub of WordPress add_filter() — a no-op for test purposes; nothing in
+	 * this bootstrap calls a real apply_filters() against registered filters.
+	 *
+	 * @param string   $hook_name     Hook name.
+	 * @param callable $callback      Callback.
+	 * @param int      $priority      Priority (unused by the stub).
+	 * @param int      $accepted_args Number of accepted args (unused by the stub).
+	 * @return true
+	 */
+	function add_filter( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- no-op stub.
+		return true;
+	}
+}
+
+if ( ! function_exists( 'remove_filter' ) ) {
+	/**
+	 * Stub of WordPress remove_filter() — a no-op for test purposes.
+	 *
+	 * @param string   $hook_name Hook name.
+	 * @param callable $callback  Callback.
+	 * @param int      $priority  Priority (unused by the stub).
+	 * @return true
+	 */
+	function remove_filter( $hook_name, $callback, $priority = 10 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- no-op stub.
+		return true;
+	}
+}
+
+if ( ! function_exists( 'number_format_i18n' ) ) {
+	/**
+	 * Stub of WordPress number_format_i18n() — delegates to PHP's number_format()
+	 * without locale-specific separators, sufficient for deterministic tests.
+	 *
+	 * @param float $number   Number to format.
+	 * @param int   $decimals Number of decimal points.
+	 * @return string Formatted number.
+	 */
+	function number_format_i18n( $number, $decimals = 0 ) {
+		return number_format( (float) $number, $decimals );
+	}
+}
+
+if ( ! function_exists( 'wp_mail' ) ) {
+	/**
+	 * Stub of WordPress wp_mail() recording each send into
+	 * $GLOBALS['_fair_test_sent_emails'] so tests can assert on subject/message.
+	 *
+	 * @param string $to      Recipient email address.
+	 * @param string $subject Email subject.
+	 * @param string $message Email body.
+	 * @return bool Always true.
+	 */
+	function wp_mail( $to, $subject, $message ) {
+		if ( ! isset( $GLOBALS['_fair_test_sent_emails'] ) ) {
+			$GLOBALS['_fair_test_sent_emails'] = array();
+		}
+		$GLOBALS['_fair_test_sent_emails'][] = array(
+			'to'      => $to,
+			'subject' => $subject,
+			'message' => $message,
+		);
+		return true;
+	}
+}
+
 require_once __DIR__ . '/wp-class-stubs.php';
+require_once __DIR__ . '/Fair_Test_WPDB.php';
+
+// Global $wpdb double so model calls with a "not found" id (e.g. 0) resolve
+// safely instead of fataling on a null global. See Fair_Test_WPDB's docblock.
+// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.
+$GLOBALS['wpdb'] = new Fair_Test_WPDB();

--- a/fair-events/composer.lock
+++ b/fair-events/composer.lock
@@ -154,11 +154,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "a510a98d90c0da800c1e05bb2c497b17e51e6206"
+                "reference": "7282e0b97cc1b1abfad91e89704b49098f6400b5"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-events/languages/fair-events.pot
+++ b/fair-events/languages/fair-events.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv3 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Fair Events 1.11.0\n"
+"Project-Id-Version: Fair Events 1.12.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/fair-events\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-02T09:52:39+00:00\n"
+"POT-Creation-Date: 2026-08-03T15:43:18+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fair-events\n"
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Manage Event"
 msgstr ""
 
-#: src/Admin/AdminPages.php:544
+#: src/Admin/AdminPages.php:542
 msgid "Upcoming"
 msgstr ""
 
@@ -388,7 +388,7 @@ msgstr ""
 #: src/API/GetTicketsController.php:449
 #: src/API/GetTicketsController.php:806
 #: src/blocks/event-signup/frontend.js:1091
-msgid "You have successfully registered!"
+msgid "You have successfully registered! A confirmation email is on its way."
 msgstr ""
 
 #. translators: %d: event date ID
@@ -577,12 +577,12 @@ msgid "4 hours"
 msgstr ""
 
 #: src/blocks/event-proposal/render.php:58
-#: src/blocks/event-signup/render.php:752
+#: src/blocks/event-signup/render.php:771
 msgid "Your Name"
 msgstr ""
 
 #: src/blocks/event-proposal/render.php:73
-#: src/blocks/event-signup/render.php:769
+#: src/blocks/event-signup/render.php:788
 msgid "Your Email"
 msgstr ""
 
@@ -628,97 +628,97 @@ msgstr ""
 msgid "Event Signup: could not resolve an event date for this page."
 msgstr ""
 
-#: src/blocks/event-signup/render.php:395
+#: src/blocks/event-signup/render.php:414
 #: src/blocks/event-signup/frontend.js:130
 msgid "Payment confirmed"
 msgstr ""
 
 #. translators: %s: event title
-#: src/blocks/event-signup/render.php:401
+#: src/blocks/event-signup/render.php:420
 #, php-format
 msgid "You're signed up for %s."
 msgstr ""
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:411
+#: src/blocks/event-signup/render.php:430
 #, php-format
 msgid "Amount paid: %s"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:417
+#: src/blocks/event-signup/render.php:436
 #: src/blocks/event-signup/frontend.js:145
 msgid "A confirmation email is on its way. You can close this page."
 msgstr ""
 
-#: src/blocks/event-signup/render.php:425
+#: src/blocks/event-signup/render.php:444
 msgid "Thank you for your payment!"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:427
+#: src/blocks/event-signup/render.php:446
 msgid "We're confirming with your bank. This usually takes a few seconds — the page will update as soon as it's done."
 msgstr ""
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:433
+#: src/blocks/event-signup/render.php:452
 #, php-format
 msgid "Amount: %s"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:443
+#: src/blocks/event-signup/render.php:462
 msgid "Your payment is waiting."
 msgstr ""
 
-#: src/blocks/event-signup/render.php:445
+#: src/blocks/event-signup/render.php:464
 msgid "You can pick up where you left off on the secure payment page."
 msgstr ""
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:451
-#: src/blocks/event-signup/render.php:474
+#: src/blocks/event-signup/render.php:470
+#: src/blocks/event-signup/render.php:493
 #, php-format
 msgid "Amount due: %s"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:458
+#: src/blocks/event-signup/render.php:477
 msgid "Continue payment"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:462
-#: src/blocks/event-signup/render.php:491
+#: src/blocks/event-signup/render.php:481
+#: src/blocks/event-signup/render.php:510
 msgid "Cancel and start over"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:469
+#: src/blocks/event-signup/render.php:488
 msgid "Your payment didn't go through."
 msgstr ""
 
-#: src/blocks/event-signup/render.php:481
-#: src/blocks/event-signup/render.php:498
+#: src/blocks/event-signup/render.php:500
+#: src/blocks/event-signup/render.php:517
 msgid "Ticket sales are temporarily unavailable. Please check back later."
 msgstr ""
 
-#: src/blocks/event-signup/render.php:486
+#: src/blocks/event-signup/render.php:505
 msgid "Retry payment"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:556
+#: src/blocks/event-signup/render.php:575
 msgid "Choose ticket type"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:566
+#: src/blocks/event-signup/render.php:585
 msgid "No active sale period"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:569
+#: src/blocks/event-signup/render.php:588
 msgid "ticket sales temporarily unavailable"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:617
+#: src/blocks/event-signup/render.php:636
 msgid "Select activities"
 msgstr ""
 
 #. translators: %d: minimum number of activities required
-#: src/blocks/event-signup/render.php:623
+#: src/blocks/event-signup/render.php:642
 #: src/blocks/event-signup/frontend.js:580
 #: src/blocks/event-signup/frontend.js:964
 #, php-format,js-format
@@ -727,74 +727,74 @@ msgid_plural "Please select at least %d activities to sign up."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/blocks/event-signup/render.php:647
+#: src/blocks/event-signup/render.php:666
 msgid "free"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:652
+#: src/blocks/event-signup/render.php:671
 msgid "full"
 msgstr ""
 
 #. translators: %s: formatted add-on price
-#: src/blocks/event-signup/render.php:678
+#: src/blocks/event-signup/render.php:697
 #, php-format
 msgid "(+%s)"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:695
+#: src/blocks/event-signup/render.php:714
 msgid "Choose a date"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:706
-#: src/blocks/event-signup/render.php:729
+#: src/blocks/event-signup/render.php:725
+#: src/blocks/event-signup/render.php:748
 msgid "already signed up"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:719
+#: src/blocks/event-signup/render.php:738
 msgid "Choose occurrences"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:786
+#: src/blocks/event-signup/render.php:805
 msgid "Quantity"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:807
+#: src/blocks/event-signup/render.php:826
 msgid "Keep me informed about future events"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:317
-#: src/blocks/events-week/render.php:234
+#: src/blocks/events-calendar/render.php:318
+#: src/blocks/events-week/render.php:235
 #: src/Admin/calendar/components/CalendarHeader.js:27
 msgid "Previous"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:323
-#: src/blocks/events-week/render.php:240
+#: src/blocks/events-calendar/render.php:326
+#: src/blocks/events-week/render.php:243
 #: src/Admin/calendar/components/CalendarHeader.js:33
 msgid "Next"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:462
+#: src/blocks/events-calendar/render.php:466
 msgid "Copy feed URL"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:478
+#: src/blocks/events-calendar/render.php:482
 msgid "Subscribe to calendar"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:496
+#: src/blocks/events-calendar/render.php:500
 msgid "Google Calendar"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:507
+#: src/blocks/events-calendar/render.php:511
 msgid "Outlook"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:516
+#: src/blocks/events-calendar/render.php:520
 msgid "Apple Calendar"
 msgstr ""
 
-#: src/blocks/events-calendar/render.php:529
+#: src/blocks/events-calendar/render.php:533
 msgid "Subscribed calendars refresh on your calendar app's own schedule (often hours, not instant)."
 msgstr ""
 
@@ -802,7 +802,7 @@ msgstr ""
 msgid "No events found. Please select a valid display pattern."
 msgstr ""
 
-#: src/blocks/events-week/render.php:311
+#: src/blocks/events-week/render.php:315
 msgid "Copy summary"
 msgstr ""
 
@@ -1047,6 +1047,59 @@ msgstr ""
 #: src/Services/Branding.php:57
 #, php-format
 msgid "Powered by %s"
+msgstr ""
+
+#: src/Services/EmailService.php:35
+msgid "the event"
+msgstr ""
+
+#. translators: %s: event title
+#: src/Services/EmailService.php:65
+#, php-format
+msgid "Your registration for %s is confirmed"
+msgstr ""
+
+#. translators: %s: buyer first name
+#: src/Services/EmailService.php:80
+#, php-format
+msgid "Hi %s,"
+msgstr ""
+
+#. translators: %s: event title
+#: src/Services/EmailService.php:83
+#, php-format
+msgid "Your registration for %s is confirmed."
+msgstr ""
+
+#: src/Services/EmailService.php:86
+msgid "Event date:"
+msgstr ""
+
+#: src/Services/EmailService.php:87
+msgid "Registration reference:"
+msgstr ""
+
+#: src/Services/EmailService.php:88
+msgid "Ticket type:"
+msgstr ""
+
+#: src/Services/EmailService.php:89
+#: src/blocks/event-signup/frontend.js:136
+msgid "Amount paid:"
+msgstr ""
+
+#: src/Services/EmailService.php:90
+msgid "Selected options:"
+msgstr ""
+
+#: src/Services/EmailService.php:91
+msgid "Your answers:"
+msgstr ""
+
+#. translators: 1: line break, 2: site name
+#: src/Services/EmailService.php:93
+#, php-format
+msgid "Thanks,%1$sThe %2$s Team"
 msgstr ""
 
 #: src/Services/WeeklyEventsProvider.php:42
@@ -2934,10 +2987,6 @@ msgstr ""
 
 #: src/blocks/event-signup/editor.js:164
 msgid "Connect this block to an event date to edit its tickets."
-msgstr ""
-
-#: src/blocks/event-signup/frontend.js:136
-msgid "Amount paid:"
 msgstr ""
 
 #: src/blocks/event-signup/frontend.js:180

--- a/fair-events/src/Hooks/SignupEmailHooks.php
+++ b/fair-events/src/Hooks/SignupEmailHooks.php
@@ -11,6 +11,7 @@
 
 namespace FairEvents\Hooks;
 
+use FairEvents\Models\EventSignup;
 use FairEvents\Services\EmailService;
 
 defined( 'WPINC' ) || die;
@@ -79,6 +80,10 @@ class SignupEmailHooks {
 			return;
 		}
 
-		( new EmailService() )->send_signup_confirmation( $signup_id, $event_date_id, $name, $email );
+		$signup         = EventSignup::get_by_id( $signup_id );
+		$ticket_type_id = $signup ? (int) $signup->ticket_type_id : 0;
+		$amount         = $signup ? (float) $signup->amount : 0.0;
+
+		( new EmailService() )->send_signup_confirmation( $signup_id, $event_date_id, $name, $email, $ticket_type_id, $amount );
 	}
 }

--- a/fair-events/src/Services/EmailService.php
+++ b/fair-events/src/Services/EmailService.php
@@ -7,25 +7,31 @@
 
 namespace FairEvents\Services;
 
+use FairEventsShared\Money;
+use FairEventsShared\Notifications\SignupConfirmationEmail;
+
 defined( 'WPINC' ) || die;
 
 /**
- * Sends fair-events' own minimal signup confirmation email. Only used when no
- * companion plugin (fair-audience) is active to send a richer one instead —
- * see FairEvents\Hooks\SignupEmailHooks.
+ * Sends fair-events' own baseline signup confirmation email, built on the
+ * same shared formatter fair-audience uses. Only used when no companion
+ * plugin (fair-audience) is active to send a richer one instead — see
+ * FairEvents\Hooks\SignupEmailHooks.
  */
 class EmailService {
 
 	/**
 	 * Send a signup confirmation email to the buyer.
 	 *
-	 * @param int    $signup_id     The fair_events_signups row ID, used as the registration reference.
-	 * @param int    $event_date_id Event date ID the signup targets.
-	 * @param string $name          Buyer name.
-	 * @param string $email         Buyer email.
+	 * @param int    $signup_id      The fair_events_signups row ID, used as the registration reference.
+	 * @param int    $event_date_id  Event date ID the signup targets.
+	 * @param string $name           Buyer name.
+	 * @param string $email          Buyer email.
+	 * @param int    $ticket_type_id Ticket type ID shown in the email. Pass 0 to omit.
+	 * @param float  $amount         Amount paid, shown on paid signups. Pass 0 to omit.
 	 * @return bool True on send success.
 	 */
-	public function send_signup_confirmation( $signup_id, $event_date_id, $name, $email ) {
+	public function send_signup_confirmation( $signup_id, $event_date_id, $name, $email, $ticket_type_id = 0, $amount = 0.0 ) {
 		$event_title        = __( 'the event', 'fair-events' );
 		$event_date_display = '';
 
@@ -42,25 +48,50 @@ class EmailService {
 			}
 		}
 
+		$ticket_type_name = '';
+		if ( $ticket_type_id > 0 && class_exists( \FairEvents\Models\TicketType::class ) ) {
+			$ticket_type = \FairEvents\Models\TicketType::get_by_id( $ticket_type_id );
+			if ( $ticket_type ) {
+				$ticket_type_name = $ticket_type->name;
+			}
+		}
+
+		$payment_amount_display = $amount > 0 ? Money::format_display( (float) $amount ) : '';
+
 		$site_name = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
 
-		$subject = sprintf(
+		$subject_template =
 			/* translators: %s: event title */
-			__( 'Your registration for %s is confirmed', 'fair-events' ),
-			$event_title
-		);
+			__( 'Your registration for %s is confirmed', 'fair-events' );
 
-		$message = sprintf(
-			/* translators: 1: buyer name, 2: event title, 3: event date, 4: registration reference, 5: site name */
-			__(
-				"Hi %1\$s,\n\nYour registration for %2\$s on %3\$s is confirmed.\n\nRegistration reference: #%4\$s\n\nThanks,\nThe %5\$s Team",
-				'fair-events'
-			),
-			$name,
-			$event_title,
-			$event_date_display,
-			$signup_id,
-			$site_name
+		$subject = SignupConfirmationEmail::subject( $subject_template, $event_title );
+		$message = SignupConfirmationEmail::html(
+			array(
+				'event_title'                  => esc_html( $event_title ),
+				'participant_name'             => esc_html( $name ),
+				'site_name'                    => esc_html( $site_name ),
+				'event_date_display'           => esc_html( $event_date_display ),
+				'registration_reference'       => '#' . $signup_id,
+				'ticket_type_name'             => esc_html( $ticket_type_name ),
+				'payment_amount_display'       => esc_html( $payment_amount_display ),
+				'option_names'                 => array(),
+				'answers_html'                 => '',
+				/* translators: %s: buyer first name */
+				'greeting_template'            => esc_html__( 'Hi %s,', 'fair-events' ),
+				'confirmation_sentence'        => sprintf(
+					/* translators: %s: event title */
+					esc_html__( 'Your registration for %s is confirmed.', 'fair-events' ),
+					'<strong>' . esc_html( $event_title ) . '</strong>'
+				),
+				'event_date_label'             => esc_html__( 'Event date:', 'fair-events' ),
+				'registration_reference_label' => esc_html__( 'Registration reference:', 'fair-events' ),
+				'ticket_type_label'            => esc_html__( 'Ticket type:', 'fair-events' ),
+				'amount_paid_label'            => esc_html__( 'Amount paid:', 'fair-events' ),
+				'selected_options_label'       => esc_html__( 'Selected options:', 'fair-events' ),
+				'your_answers_label'           => esc_html__( 'Your answers:', 'fair-events' ),
+				/* translators: 1: line break, 2: site name */
+				'sign_off_template'            => esc_html__( 'Thanks,%1$sThe %2$s Team', 'fair-events' ),
+			)
 		);
 
 		return $this->deliver( $email, $subject, $message );
@@ -71,10 +102,18 @@ class EmailService {
 	 *
 	 * @param string $to      Recipient email address.
 	 * @param string $subject Email subject.
-	 * @param string $message Plain-text body.
+	 * @param string $message Full HTML body.
 	 * @return bool True on success.
 	 */
 	private function deliver( $to, $subject, $message ) {
-		return wp_mail( $to, $subject, $message );
+		$content_type = static function () {
+			return 'text/html';
+		};
+
+		add_filter( 'wp_mail_content_type', $content_type );
+		$result = wp_mail( $to, $subject, $message );
+		remove_filter( 'wp_mail_content_type', $content_type );
+
+		return $result;
 	}
 }

--- a/fair-payments-connector-experimental/package.json
+++ b/fair-payments-connector-experimental/package.json
@@ -14,6 +14,7 @@
 		"composer:install": "composer install",
 		"composer:install:prod": "composer install --no-dev",
 		"composer:update": "composer update",
+		"composer:update:shared": "composer update fair-events/shared",
 		"composer:validate": "composer validate --strict",
 		"makepot": "wp i18n make-pot . languages/fair-payments-connector-experimental.pot --exclude=node_modules,vendor,tests,build,svn",
 		"makejson": "wp i18n make-json languages ./build/languages --domain=fair-payments-connector-experimental --pretty-print --no-purge --use-map=build/map.json",

--- a/fair-payments-connector/composer.lock
+++ b/fair-payments-connector/composer.lock
@@ -80,11 +80,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "a510a98d90c0da800c1e05bb2c497b17e51e6206"
+                "reference": "7282e0b97cc1b1abfad91e89704b49098f6400b5"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-timetable/composer.lock
+++ b/fair-timetable/composer.lock
@@ -154,11 +154,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "a510a98d90c0da800c1e05bb2c497b17e51e6206"
+                "reference": "7282e0b97cc1b1abfad91e89704b49098f6400b5"
             },
             "require": {
                 "php": ">=7.4 <9.0"


### PR DESCRIPTION
## Summary

- Adds `FairEventsShared\Notifications\SignupConfirmationEmail`, a shared formatter (`subject()` / `html()`) that renders the branded HTML confirmation email from plain, pre-translated/pre-escaped data — no plugin-specific dependency, no translation calls of its own.
- fair-audience's `EmailService::send_signup_payment_confirmation()` now builds its email through the shared formatter, and additionally shows the **event date**, a **registration reference**, and the **ticket type** (all 4 call sites updated to pass them through).
- fair-events' standalone `EmailService::send_signup_confirmation()` (used only when fair-audience isn't active) now builds through the same shared formatter instead of a plain-text message, and shows the ticket type plus the **amount paid** on paid signups.

Closes #1369

## Acceptance criteria

- [x] fair-events-shared exposes the email-formatting logic previously specific to fair-audience's signup confirmation email — `fair-events-shared/php/src/Notifications/SignupConfirmationEmail.php`.
- [x] fair-audience's confirmation email (free and paid signup) is generated via the shared formatter, and additionally shows the event date, a registration reference, and the ticket type (per the planning comment's amended scope).
- [x] fair-events' standalone confirmation email is generated via the same shared formatter, replacing its plain-text email, and includes the payment amount on paid signups.
- [x] Automated test coverage: unit tests for the shared formatter (12 cases covering subject assembly and each optional section shown/hidden), plus new/updated PHPUnit coverage in both plugins' `EmailService` and fair-events' `SignupEmailHooks`, and updated e2e assertions.

## Notes

- The shared formatter takes only pre-translated, pre-escaped strings (Decision 1 in the planning comment) — each plugin keeps its own literal `__()` calls against its own text domain, so both catalogs stay extractable via `wp i18n make-pot`. Both `.pot` files were regenerated in this PR.
- fair-events' unit tests keep `event_date_id`/`ticket_type_id` at 0 to stay DB-free, following `SignupPaymentStateTest`'s existing documented convention; a manual WP-CLI `eval-file` check (see Test plan) exercised the real `EventDates`/`TicketType` DB lookups end-to-end instead.

## Test plan

- [x] `vendor/bin/phpcs` clean on all changed PHP files (pre-existing errors elsewhere in touched files confirmed unrelated via `git stash`).
- [x] `fair-audience`: `vendor/bin/phpunit` (78 tests) and `npm run test:js` (27 tests) pass.
- [x] `fair-events`: `vendor/bin/phpunit` (159 tests) and `npm run test:js` (177 tests) pass.
- [x] Manual WP-CLI `eval-file` check against the running dev stack: created a real event/date/ticket type, called `FairEvents\Services\EmailService::send_signup_confirmation()` directly, and captured the mail via `pre_wp_mail` — confirmed HTML output, subject, buyer name, event date, registration reference, ticket type name, and amount paid all render correctly.
- [x] Regenerated `fair-audience.pot` / `fair-events.pot` — diff shows only the new label/sentence strings.
- [ ] `e2e/user-flows/ticket-purchase-confirmation.spec.js` — updated assertions for the new email fields (event date, registration reference, ticket type, amount paid); not run in this session (requires the isolated wp-env `e2e` harness, not the dev `docker compose` stack used for the manual check above).
