### PR TITLE
Share question-block allow-list; fix Conditional Section gap

### DIFF
--- a/FAIR_FORM_QUESTION_BLOCKS.md
+++ b/FAIR_FORM_QUESTION_BLOCKS.md
@@ -36,16 +36,24 @@ Mirror the closest existing sibling under `fair-form/src/blocks/fair-form-{type}
 `ancestor` in `block.json` is necessary but **not sufficient** — each parent
 block also keeps its own hardcoded allow-list passed to
 `useInnerBlocksProps`/`InnerBlocks`, and the inserter only offers a question
-block where it appears in **both** places:
+block where it appears in **both** places. There are four such gates:
 
 -   `fair-form/src/blocks/fair-form/editor.js` — `ALLOWED_BLOCKS`
+-   `fair-form/src/blocks/fair-form-conditional/editor.js` — `ALLOWED_BLOCKS`
 -   `fair-audience/src/blocks/event-signup/editor.js` — `ALLOWED_BLOCKS`
 -   `fair-events/src/blocks/event-signup/editor.js` — `FAIR_FORM_ALLOWED_BLOCKS`
 
-Add `'fair-audience/fair-form-{type}'` to every array named in the new
-block's `ancestor` list. A block with a correct `ancestor` array and no entry
-here will register cleanly, pass review, and simply never show up in the
-inserter.
+The first two source from `FAIR_FORM_QUESTION_BLOCK_NAMES`
+(`fair-events-shared/src/question-utils.js`), since a fair-form and a
+conditional section inside it are supposed to accept the exact same set of
+question types — add the new block's name there and both arrays pick it up.
+The two `event-signup` arrays are genuine, deliberately smaller subsets (e.g.
+file-upload and mailing-signup are excluded) and stay hardcoded — add
+`'fair-audience/fair-form-{type}'` to each one directly, if the new type
+belongs there.
+
+A block with a correct `ancestor` array and no entry in these arrays will
+register cleanly, pass review, and simply never show up in the inserter.
 
 ## 4. Answer validation (shared across every submission path)
 

--- a/fair-events-shared/src/question-utils.js
+++ b/fair-events-shared/src/question-utils.js
@@ -1,4 +1,29 @@
 /**
+ * Every `fair-audience/fair-form-*` question block name.
+ *
+ * Shared source of truth for the two parent blocks whose allow-lists are
+ * supposed to contain the full set (`fair-form` and `fair-form-conditional`).
+ * The `event-signup` parents keep their own hardcoded, deliberately smaller
+ * subsets — see FAIR_FORM_QUESTION_BLOCKS.md.
+ *
+ * @type {string[]}
+ */
+export const FAIR_FORM_QUESTION_BLOCK_NAMES = [
+	'fair-audience/fair-form-short-text',
+	'fair-audience/fair-form-long-text',
+	'fair-audience/fair-form-email',
+	'fair-audience/fair-form-phone',
+	'fair-audience/fair-form-url',
+	'fair-audience/fair-form-select-one',
+	'fair-audience/fair-form-multiselect',
+	'fair-audience/fair-form-radio',
+	'fair-audience/fair-form-file-upload',
+	'fair-audience/fair-form-consent',
+	'fair-audience/fair-form-conditional',
+	'fair-audience/fair-form-mailing-signup',
+];
+
+/**
  * Generate a question key from question text.
  *
  * Converts text to a lowercase snake_case key suitable for use as a

--- a/fair-form/src/blocks/fair-form-conditional/editor.js
+++ b/fair-form/src/blocks/fair-form-conditional/editor.js
@@ -19,20 +19,13 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { FAIR_FORM_QUESTION_BLOCK_NAMES } from 'fair-events-shared';
 
 const ALLOWED_BLOCKS = [
 	'core/heading',
 	'core/paragraph',
 	'core/list',
-	'fair-audience/fair-form-short-text',
-	'fair-audience/fair-form-long-text',
-	'fair-audience/fair-form-select-one',
-	'fair-audience/fair-form-multiselect',
-	'fair-audience/fair-form-radio',
-	'fair-audience/fair-form-file-upload',
-	'fair-audience/fair-form-consent',
-	'fair-audience/fair-form-conditional',
-	'fair-audience/fair-form-mailing-signup',
+	...FAIR_FORM_QUESTION_BLOCK_NAMES,
 ];
 
 const OPERATOR_OPTIONS = [

--- a/fair-form/src/blocks/fair-form-short-text/__tests__/editor.test.jsx
+++ b/fair-form/src/blocks/fair-form-short-text/__tests__/editor.test.jsx
@@ -36,6 +36,7 @@ jest.mock('@wordpress/components', () => ({
 }));
 
 jest.mock('fair-events-shared', () => ({
+	autosizeTextarea: () => {},
 	generateQuestionKey: (text) =>
 		text
 			.toLowerCase()
@@ -52,7 +53,7 @@ jest.mock('@wordpress/blocks', () => ({
 	createBlock: (name, attributes) => ({ name, attributes }),
 }));
 
-describe('Fair Form URL Question Edit', () => {
+describe('Fair Form Short Text Question Edit', () => {
 	let Edit;
 
 	beforeAll(() => {
@@ -83,19 +84,19 @@ describe('Fair Form URL Question Edit', () => {
 			'Enter your question...'
 		);
 		fireEvent.change(questionTextInput, {
-			target: { value: 'Portfolio website' },
+			target: { value: 'Favorite color' },
 		});
 
 		expect(setAttributes).toHaveBeenCalledWith({
-			questionText: 'Portfolio website',
-			questionKey: 'portfolio_website',
+			questionText: 'Favorite color',
+			questionKey: 'favorite_color',
 		});
 	});
 
 	it('does not override a manually-edited question key', () => {
 		const setAttributes = jest.fn();
 		renderEdit(
-			{ questionText: 'Website', questionKey: 'custom_key' },
+			{ questionText: 'Color', questionKey: 'custom_key' },
 			setAttributes
 		);
 
@@ -103,11 +104,11 @@ describe('Fair Form URL Question Edit', () => {
 			'Enter your question...'
 		);
 		fireEvent.change(questionTextInput, {
-			target: { value: 'Website updated' },
+			target: { value: 'Color updated' },
 		});
 
 		expect(setAttributes).toHaveBeenCalledWith({
-			questionText: 'Website updated',
+			questionText: 'Color updated',
 		});
 	});
 
@@ -133,29 +134,40 @@ describe('Fair Form URL Question Edit', () => {
 		renderEdit({}, setAttributes);
 
 		fireEvent.change(screen.getByLabelText('Placeholder'), {
-			target: { value: 'https://example.com' },
+			target: { value: 'Type your answer...' },
 		});
 
 		expect(setAttributes).toHaveBeenCalledWith({
-			placeholder: 'https://example.com',
+			placeholder: 'Type your answer...',
 		});
 	});
 
-	it('transforms to short-text, preserving attributes', () => {
-		const transform = capturedSettings.transforms.to.find((t) =>
-			t.blocks.includes('fair-audience/fair-form-short-text')
-		);
-
+	describe('transforms.to', () => {
 		const attributes = {
 			questionText: 'Website',
 			questionKey: 'website',
 			required: true,
-			placeholder: 'https://example.com',
+			placeholder: '',
 		};
 
-		expect(transform.transform(attributes)).toEqual({
-			name: 'fair-audience/fair-form-short-text',
-			attributes,
+		it('includes long-text, phone, and url, preserving attributes', () => {
+			const targets = [
+				'fair-audience/fair-form-long-text',
+				'fair-audience/fair-form-phone',
+				'fair-audience/fair-form-url',
+			];
+
+			for (const target of targets) {
+				const transform = capturedSettings.transforms.to.find((t) =>
+					t.blocks.includes(target)
+				);
+
+				expect(transform).toBeDefined();
+				expect(transform.transform(attributes)).toEqual({
+					name: target,
+					attributes,
+				});
+			}
 		});
 	});
 });

--- a/fair-form/src/blocks/fair-form-short-text/editor.js
+++ b/fair-form/src/blocks/fair-form-short-text/editor.js
@@ -29,6 +29,16 @@ registerBlockType('fair-audience/fair-form-short-text', {
 					);
 				},
 			},
+			{
+				type: 'block',
+				blocks: ['fair-audience/fair-form-url'],
+				transform: (attributes) => {
+					return createBlock(
+						'fair-audience/fair-form-url',
+						attributes
+					);
+				},
+			},
 		],
 	},
 	edit: ({ attributes, setAttributes }) => {

--- a/fair-form/src/blocks/fair-form-url/editor.js
+++ b/fair-form/src/blocks/fair-form-url/editor.js
@@ -1,12 +1,26 @@
 import './style.css';
 
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockType, createBlock } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { generateQuestionKey } from 'fair-events-shared';
 
 registerBlockType('fair-audience/fair-form-url', {
+	transforms: {
+		to: [
+			{
+				type: 'block',
+				blocks: ['fair-audience/fair-form-short-text'],
+				transform: (attributes) => {
+					return createBlock(
+						'fair-audience/fair-form-short-text',
+						attributes
+					);
+				},
+			},
+		],
+	},
 	edit: ({ attributes, setAttributes }) => {
 		const { questionText, questionKey, required, placeholder } = attributes;
 

--- a/fair-form/src/blocks/fair-form/editor.js
+++ b/fair-form/src/blocks/fair-form/editor.js
@@ -20,24 +20,16 @@ import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
-import { generateUuid } from 'fair-events-shared';
+import {
+	generateUuid,
+	FAIR_FORM_QUESTION_BLOCK_NAMES,
+} from 'fair-events-shared';
 
 const ALLOWED_BLOCKS = [
 	'core/heading',
 	'core/paragraph',
 	'core/list',
-	'fair-audience/fair-form-short-text',
-	'fair-audience/fair-form-long-text',
-	'fair-audience/fair-form-email',
-	'fair-audience/fair-form-phone',
-	'fair-audience/fair-form-url',
-	'fair-audience/fair-form-select-one',
-	'fair-audience/fair-form-multiselect',
-	'fair-audience/fair-form-radio',
-	'fair-audience/fair-form-file-upload',
-	'fair-audience/fair-form-consent',
-	'fair-audience/fair-form-conditional',
-	'fair-audience/fair-form-mailing-signup',
+	...FAIR_FORM_QUESTION_BLOCK_NAMES,
 ];
 
 function EventDateSelect({ eventDateId, onChange }) {


### PR DESCRIPTION
## Summary

Follow-up to the URL question feature (#1326 comment): extracts a shared
`FAIR_FORM_QUESTION_BLOCK_NAMES` constant and closes a 4th hardcoded
inserter-allow-list gate that silently excluded email/phone/url questions
from Conditional Sections, plus adds the short-text ⇄ url block transform.

- `fair-events-shared/src/question-utils.js`: new
  `FAIR_FORM_QUESTION_BLOCK_NAMES` export listing all 12
  `fair-audience/fair-form-*` question block names.
- `fair-form/src/blocks/fair-form/editor.js` and
  `fair-form-conditional/editor.js`: both `ALLOWED_BLOCKS` now spread
  `FAIR_FORM_QUESTION_BLOCK_NAMES` instead of duplicating the list — the
  conditional block's array was missing email/phone/url, so those question
  types could never be inserted inside a Conditional Section even though
  they were allowed everywhere else.
- `fair-form-short-text/editor.js` / `fair-form-url/editor.js`: added the
  reciprocal `transforms.to` entries (short-text → url, url → short-text),
  mirroring the existing short-text ↔ phone pair.
- `FAIR_FORM_QUESTION_BLOCKS.md`: documents the 4th allow-list gate and
  that `fair-form`/`fair-form-conditional` now source from the shared
  constant, while the two `event-signup` arrays stay hardcoded subsets.

Closes #1326

## Acceptance criteria (from the comment)

1. **Shared question-block-name constant** — done:
   `FAIR_FORM_QUESTION_BLOCK_NAMES` added to
   `fair-events-shared/src/question-utils.js`, consumed by both
   `fair-form/editor.js` and `fair-form-conditional/editor.js`. The two
   `event-signup` allow-lists were left hardcoded as decided (genuine
   subsets).
2. **Allow URL/email/phone inside a Conditional Section** — done: switching
   the conditional block's `ALLOWED_BLOCKS` to the shared constant closes
   the gap for all three at once; verified live in the block editor (URL
   Question now appears in the inserter inside a Conditional Section nested
   in a Fair Form block).
3. **Document the 4th gate** — done: `FAIR_FORM_QUESTION_BLOCKS.md` step 3
   now names all four allow-list arrays and explains which two are sourced
   from the shared constant vs. hardcoded subsets.
4. **Short Text ⇄ URL transform** — done: reciprocal `transforms.to` entries
   added to both blocks; verified live (URL Question block's "Transform to"
   menu offers Short Text Question).
5. **Tests** — done: new `fair-form-short-text/__tests__/editor.test.jsx`
   (question-key/required/placeholder coverage plus transform assertions
   for long-text/phone/url), and `fair-form-url/__tests__/editor.test.jsx`
   extended with a reciprocal-transform test. Full `npm run test:js` suite
   passes (29/29) in fair-form, and fair-events-shared's suite passes
   (229/229).

## Verification

- `npm run build` in `fair-form` — clean.
- `npm run format` — clean, no formatting noise.
- `npm run test:js` (fair-form) and `npx jest` (fair-events-shared) — all
  passing.
- Manually verified in the running WP editor (docker compose, `:8080`):
  inserted Fair Form → Conditional Section → URL Question (previously
  impossible), and confirmed the URL block's block-switcher offers
  "Short Text Question".
- No PHP changed; `vendor/bin/phpcs` not applicable.
- No new changeset: this fixes an unreleased feature (the
  `add-url-question-block.md` changeset for fair-form is still pending),
  matching the precedent set by the prior inserter-gap fix (f7692bce),
  which also shipped without its own changeset.
