### PR TITLE
Send a payment-failed email from fair-events' Event Signup block

### DIFF
--- a/.changeset/send-payment-failed-email.md
+++ b/.changeset/send-payment-failed-email.md
@@ -1,0 +1,6 @@
+---
+"fair-events-shared": minor
+"fair-events": minor
+---
+
+Send a payment-failed email (event name, plain link back to the event page) from the standalone Event Signup block when a payment fails, is rejected, cancelled, or expires — mirroring fair-audience's own failed-payment email so buyers on fair-audience-free sites get the same notice. The shared `SignupConfirmationEmail` formatter gains an optional plain action link, reused for this new email.

--- a/fair-audience-experimental/composer.lock
+++ b/fair-audience-experimental/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "fair-events/shared",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "7282e0b97cc1b1abfad91e89704b49098f6400b5"
+                "reference": "113286293569fe13947bd9840c030cbfa68baff4"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-audience/composer.lock
+++ b/fair-audience/composer.lock
@@ -87,11 +87,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "7282e0b97cc1b1abfad91e89704b49098f6400b5"
+                "reference": "113286293569fe13947bd9840c030cbfa68baff4"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-events-shared/php/composer.json
+++ b/fair-events-shared/php/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "fair-events/shared",
 	"description": "Shared PHP utilities for Fair Event plugins",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"type": "library",
 	"license": "GPL-3.0-or-later",
 	"autoload": {

--- a/fair-events-shared/php/src/Notifications/SignupConfirmationEmail.php
+++ b/fair-events-shared/php/src/Notifications/SignupConfirmationEmail.php
@@ -33,13 +33,15 @@ class SignupConfirmationEmail {
 	 * `$args` keys — data: event_title, participant_name, site_name,
 	 * event_date_display, registration_reference, ticket_type_name,
 	 * payment_amount_display, option_names (array), answers_html
-	 * (pre-rendered `<tr>` fragment). Copy (already translated/escaped):
-	 * greeting_template, confirmation_sentence, event_date_label,
-	 * registration_reference_label, ticket_type_label, amount_paid_label,
-	 * selected_options_label, your_answers_label, sign_off_template.
+	 * (pre-rendered `<tr>` fragment), action_url (pre-escaped, e.g. via
+	 * esc_url()). Copy (already translated/escaped): greeting_template,
+	 * confirmation_sentence, event_date_label, registration_reference_label,
+	 * ticket_type_label, amount_paid_label, selected_options_label,
+	 * your_answers_label, sign_off_template, action_label.
 	 *
 	 * Each optional data/label pair renders only when the data value is
-	 * non-empty.
+	 * non-empty. The action link (action_url + action_label) is a plain text
+	 * link — not a resume/token URL — so it renders only when both are set.
 	 *
 	 * @param array $args See above.
 	 * @return string Full HTML document.
@@ -54,6 +56,7 @@ class SignupConfirmationEmail {
 		$payment_amount_display = $args['payment_amount_display'] ?? '';
 		$option_names           = $args['option_names'] ?? array();
 		$answers_html           = $args['answers_html'] ?? '';
+		$action_url             = $args['action_url'] ?? '';
 
 		$greeting_template            = $args['greeting_template'] ?? '';
 		$confirmation_sentence        = $args['confirmation_sentence'] ?? '';
@@ -64,6 +67,7 @@ class SignupConfirmationEmail {
 		$selected_options_label       = $args['selected_options_label'] ?? '';
 		$your_answers_label           = $args['your_answers_label'] ?? '';
 		$sign_off_template            = $args['sign_off_template'] ?? '';
+		$action_label                 = $args['action_label'] ?? '';
 
 		$details_rows = '';
 		foreach (
@@ -108,6 +112,14 @@ class SignupConfirmationEmail {
 							<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0 0 20px 0; border: 1px solid #eeeeee; border-radius: 4px;">' . $answers_html . '</table>';
 		}
 
+		$action_html = '';
+		if ( '' !== $action_url && '' !== $action_label ) {
+			$action_html = '
+							<p style="margin: 0 0 20px 0; font-size: 16px;">
+								<a href="' . $action_url . '" style="color: #0073aa;">' . $action_label . '</a>
+							</p>';
+		}
+
 		return '<!DOCTYPE html>
 <html>
 <head>
@@ -140,6 +152,8 @@ class SignupConfirmationEmail {
 							' . $options_html . '
 
 							' . $answers_section . '
+
+							' . $action_html . '
 
 							<p style="margin: 20px 0 0 0; font-size: 14px; color: #666666;">
 								' . sprintf( $sign_off_template, '<br>', $site_name ) . '

--- a/fair-events/__tests__/Hooks/SignupEmailHooksTest.php
+++ b/fair-events/__tests__/Hooks/SignupEmailHooksTest.php
@@ -14,18 +14,21 @@ use FairEvents\Hooks\SignupEmailHooks;
  * Verifies SignupEmailHooks reads the fair_events_signups row and threads its
  * ticket_type_id/amount through to EmailService::send_signup_confirmation()
  * for both the free-path (handle_signup_created) and paid-path
- * (handle_signup_confirmed) hooks. FairAudience\Hooks\SignupHookBridge is
+ * (handle_signup_confirmed) hooks, and through to
+ * EmailService::send_signup_payment_failed() for the failed-path hook
+ * (handle_signup_payment_failed). FairAudience\Hooks\SignupHookBridge is
  * never loaded in fair-events' own test process, so the
  * "fair-audience active" suppression guard never trips here.
  */
 class SignupEmailHooksTest extends TestCase {
 
 	/**
-	 * Reset recorded test emails and seeded rows before each test.
+	 * Reset recorded test emails/transients and seeded rows before each test.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 		$GLOBALS['_fair_test_sent_emails'] = array();
+		$GLOBALS['_fair_test_transients']  = array();
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.
 		$GLOBALS['wpdb'] = new \Fair_Test_WPDB();
 	}
@@ -112,5 +115,66 @@ class SignupEmailHooksTest extends TestCase {
 		$sent = $GLOBALS['_fair_test_sent_emails'][0];
 		$this->assertStringContainsString( 'Amount paid:', $sent['message'] );
 		$this->assertStringContainsString( '25.50 EUR', $sent['message'] );
+	}
+
+	/**
+	 * The failed-path hook sends a payment-failed email once, threading the
+	 * signup's name/email through.
+	 */
+	public function test_handle_signup_payment_failed_sends_email(): void {
+		$signup = (object) array(
+			'id'             => 13,
+			'event_date_id'  => 0,
+			'name'           => 'Jane Doe',
+			'email'          => 'jane@example.test',
+			'ticket_type_id' => 0,
+			'amount'         => 0.0,
+		);
+
+		SignupEmailHooks::handle_signup_payment_failed( $signup, (object) array( 'id' => 501 ) );
+
+		$this->assertCount( 1, $GLOBALS['_fair_test_sent_emails'] );
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertSame( 'jane@example.test', $sent['to'] );
+	}
+
+	/**
+	 * A retry of the same failed transaction (e.g. a webhook retry) must not
+	 * send a second email.
+	 */
+	public function test_handle_signup_payment_failed_dedupes_by_transaction(): void {
+		$signup      = (object) array(
+			'id'             => 14,
+			'event_date_id'  => 0,
+			'name'           => 'Jane Doe',
+			'email'          => 'jane@example.test',
+			'ticket_type_id' => 0,
+			'amount'         => 0.0,
+		);
+		$transaction = (object) array( 'id' => 502 );
+
+		SignupEmailHooks::handle_signup_payment_failed( $signup, $transaction );
+		SignupEmailHooks::handle_signup_payment_failed( $signup, $transaction );
+
+		$this->assertCount( 1, $GLOBALS['_fair_test_sent_emails'] );
+	}
+
+	/**
+	 * A separate failed attempt (its own transaction ID) gets its own email.
+	 */
+	public function test_handle_signup_payment_failed_sends_again_for_new_transaction(): void {
+		$signup = (object) array(
+			'id'             => 15,
+			'event_date_id'  => 0,
+			'name'           => 'Jane Doe',
+			'email'          => 'jane@example.test',
+			'ticket_type_id' => 0,
+			'amount'         => 0.0,
+		);
+
+		SignupEmailHooks::handle_signup_payment_failed( $signup, (object) array( 'id' => 601 ) );
+		SignupEmailHooks::handle_signup_payment_failed( $signup, (object) array( 'id' => 602 ) );
+
+		$this->assertCount( 2, $GLOBALS['_fair_test_sent_emails'] );
 	}
 }

--- a/fair-events/__tests__/Services/EmailServiceTest.php
+++ b/fair-events/__tests__/Services/EmailServiceTest.php
@@ -83,4 +83,36 @@ class EmailServiceTest extends TestCase {
 		$sent = $GLOBALS['_fair_test_sent_emails'][0];
 		$this->assertStringContainsString( '<!DOCTYPE html>', $sent['message'] );
 	}
+
+	/**
+	 * A payment-failed email links back to the site's home URL (event_date_id
+	 * 0 means EventDates::get_by_id() finds no row, so the fallback link
+	 * applies) with a plain, non-token link.
+	 */
+	public function test_payment_failed_links_back_to_event(): void {
+		$email_service = new EmailService();
+
+		$result = $email_service->send_signup_payment_failed( 42, 0, 'Jane Doe', 'jane@example.test' );
+
+		$this->assertTrue( $result );
+		$this->assertCount( 1, $GLOBALS['_fair_test_sent_emails'] );
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertSame( 'jane@example.test', $sent['to'] );
+		$this->assertStringContainsString( 'href="https://example.com/"', $sent['message'] );
+		$this->assertStringContainsString( 'Return to the event page to try again', $sent['message'] );
+	}
+
+	/**
+	 * The failed-payment email's subject calls out that the payment didn't
+	 * go through, distinguishing it from the paid confirmation email.
+	 */
+	public function test_payment_failed_subject_mentions_payment(): void {
+		$email_service = new EmailService();
+
+		$email_service->send_signup_payment_failed( 42, 0, 'Jane Doe', 'jane@example.test' );
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( 'Payment', $sent['subject'] );
+	}
 }

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -215,6 +215,18 @@ if ( ! function_exists( 'current_time' ) ) {
 	}
 }
 
+if ( ! function_exists( 'esc_url' ) ) {
+	/**
+	 * Stub of WordPress esc_url() — a no-op pass-through for test input.
+	 *
+	 * @param string $url URL to sanitize.
+	 * @return string Unmodified URL.
+	 */
+	function esc_url( $url ) {
+		return (string) $url;
+	}
+}
+
 if ( ! function_exists( 'esc_url_raw' ) ) {
 	/**
 	 * Stub of WordPress esc_url_raw() — a no-op pass-through for test input.
@@ -520,6 +532,39 @@ if ( ! function_exists( 'number_format_i18n' ) ) {
 	 */
 	function number_format_i18n( $number, $decimals = 0 ) {
 		return number_format( (float) $number, $decimals );
+	}
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+	/**
+	 * Stub of WordPress get_transient() backed by $GLOBALS['_fair_test_transients'].
+	 *
+	 * @param string $key Transient key.
+	 * @return mixed Stored value, or false when unset.
+	 */
+	function get_transient( $key ) {
+		$transients = isset( $GLOBALS['_fair_test_transients'] ) ? $GLOBALS['_fair_test_transients'] : array();
+		return array_key_exists( $key, $transients ) ? $transients[ $key ] : false;
+	}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	/**
+	 * Stub of WordPress set_transient() backed by $GLOBALS['_fair_test_transients'].
+	 * Expiration is ignored — tests that need expiry semantics unset the key
+	 * directly on $GLOBALS['_fair_test_transients'].
+	 *
+	 * @param string $key        Transient key.
+	 * @param mixed  $value      Value to store.
+	 * @param int    $expiration Expiration in seconds (ignored by the stub).
+	 * @return bool Always true.
+	 */
+	function set_transient( $key, $value, $expiration = 0 ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- stub ignores expiry.
+		if ( ! isset( $GLOBALS['_fair_test_transients'] ) ) {
+			$GLOBALS['_fair_test_transients'] = array();
+		}
+		$GLOBALS['_fair_test_transients'][ $key ] = $value;
+		return true;
 	}
 }
 

--- a/fair-events/composer.lock
+++ b/fair-events/composer.lock
@@ -154,11 +154,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "7282e0b97cc1b1abfad91e89704b49098f6400b5"
+                "reference": "113286293569fe13947bd9840c030cbfa68baff4"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-events/src/Hooks/SignupEmailHooks.php
+++ b/fair-events/src/Hooks/SignupEmailHooks.php
@@ -3,8 +3,9 @@
  * Signup confirmation email hooks for Fair Events
  *
  * Sends fair-events' own baseline confirmation email on the free and paid
- * signup lifecycle actions, but only on sites where fair-audience isn't
- * active to send its own (richer) confirmation instead — see #1360.
+ * signup lifecycle actions, and a payment-failed email on the failed one, but
+ * only on sites where fair-audience isn't active to send its own (richer)
+ * versions instead — see #1360 and #1373.
  *
  * @package FairEvents
  */
@@ -29,6 +30,7 @@ class SignupEmailHooks {
 	public static function init() {
 		add_action( 'fair_events_signup_created', array( static::class, 'handle_signup_created' ), 10, 6 );
 		add_action( 'fair_events_signup_confirmed', array( static::class, 'handle_signup_confirmed' ), 10, 2 );
+		add_action( 'fair_events_signup_payment_failed', array( static::class, 'handle_signup_payment_failed' ), 10, 2 );
 	}
 
 	/**
@@ -62,6 +64,38 @@ class SignupEmailHooks {
 	 */
 	public static function handle_signup_confirmed( $signup, $transaction ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- required by the fair_events_signup_confirmed hook signature.
 		self::maybe_send_confirmation( (int) $signup->id, (int) $signup->event_date_id, $signup->name, $signup->email );
+	}
+
+	/**
+	 * Failed-path signup: send a payment-failed email once, unless
+	 * fair-audience is active — it already sends its own failed-payment
+	 * email via the same hook (see FairAudience\Hooks\SignupHookBridge).
+	 * Dedupes per transaction via a transient so payment-webhook retries for
+	 * the same failed attempt don't double-mail the buyer; a later, separate
+	 * failed attempt gets its own transaction ID and so its own email.
+	 *
+	 * @param object $signup      The fair_events_signups row (status already 'failed').
+	 * @param object $transaction Transaction object from fair-payments-connector.
+	 * @return void
+	 */
+	public static function handle_signup_payment_failed( $signup, $transaction ) {
+		if ( class_exists( \FairAudience\Hooks\SignupHookBridge::class ) ) {
+			return;
+		}
+
+		$transaction_id = isset( $transaction->id ) ? (int) $transaction->id : 0;
+		if ( $transaction_id > 0 ) {
+			$transient_key = 'fair_events_payment_failed_email_' . $transaction_id;
+			if ( get_transient( $transient_key ) ) {
+				return;
+			}
+			set_transient( $transient_key, 1, HOUR_IN_SECONDS );
+		}
+
+		$ticket_type_id = isset( $signup->ticket_type_id ) ? (int) $signup->ticket_type_id : 0;
+		$amount         = isset( $signup->amount ) ? (float) $signup->amount : 0.0;
+
+		( new EmailService() )->send_signup_payment_failed( (int) $signup->id, (int) $signup->event_date_id, $signup->name, $signup->email, $ticket_type_id, $amount );
 	}
 
 	/**

--- a/fair-events/src/Services/EmailService.php
+++ b/fair-events/src/Services/EmailService.php
@@ -98,6 +98,95 @@ class EmailService {
 	}
 
 	/**
+	 * Send a payment-failed email to the buyer, built on the same shared
+	 * formatter as send_signup_confirmation(). Links back to the event page
+	 * with a plain link — not a token-based resume link — since the
+	 * fair-events signup flow already shows an in-page retry state when the
+	 * buyer returns to a page with a failed attempt (see #1373).
+	 *
+	 * @param int    $signup_id      The fair_events_signups row ID.
+	 * @param int    $event_date_id  Event date ID the signup targeted.
+	 * @param string $name           Buyer name.
+	 * @param string $email          Buyer email.
+	 * @param int    $ticket_type_id Ticket type ID shown in the email. Pass 0 to omit.
+	 * @param float  $amount         Amount attempted, shown when known. Pass 0 to omit.
+	 * @return bool True on send success.
+	 */
+	public function send_signup_payment_failed( $signup_id, $event_date_id, $name, $email, $ticket_type_id = 0, $amount = 0.0 ) {
+		$event_title        = __( 'the event', 'fair-events' );
+		$event_date_display = '';
+		$event_url          = home_url( '/' );
+
+		$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+		if ( $event_date ) {
+			$event = get_post( $event_date->get_resolved_event_id() );
+			if ( $event ) {
+				$event_title = $event->post_title;
+			}
+
+			$display_url = $event_date->get_display_url();
+			if ( $display_url ) {
+				$event_url = $display_url;
+			}
+
+			$timestamp = strtotime( $event_date->start_datetime );
+			if ( false !== $timestamp ) {
+				$event_date_display = wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
+			}
+		}
+
+		$ticket_type_name = '';
+		if ( $ticket_type_id > 0 && class_exists( \FairEvents\Models\TicketType::class ) ) {
+			$ticket_type = \FairEvents\Models\TicketType::get_by_id( $ticket_type_id );
+			if ( $ticket_type ) {
+				$ticket_type_name = $ticket_type->name;
+			}
+		}
+
+		$payment_amount_display = $amount > 0 ? Money::format_display( (float) $amount ) : '';
+
+		$site_name = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+		$subject_template =
+			/* translators: %s: event title */
+			__( 'Payment didn’t go through — %s', 'fair-events' );
+
+		$subject = SignupConfirmationEmail::subject( $subject_template, $event_title );
+		$message = SignupConfirmationEmail::html(
+			array(
+				'event_title'                  => esc_html( $event_title ),
+				'participant_name'             => esc_html( $name ),
+				'site_name'                    => esc_html( $site_name ),
+				'event_date_display'           => esc_html( $event_date_display ),
+				'registration_reference'       => '#' . $signup_id,
+				'ticket_type_name'             => esc_html( $ticket_type_name ),
+				'payment_amount_display'       => esc_html( $payment_amount_display ),
+				'option_names'                 => array(),
+				'answers_html'                 => '',
+				'action_url'                   => esc_url( $event_url ),
+				/* translators: %s: buyer first name */
+				'greeting_template'            => esc_html__( 'Hi %s,', 'fair-events' ),
+				'confirmation_sentence'        => sprintf(
+					/* translators: %s: event title */
+					esc_html__( 'Your payment for %s didn’t go through, so the registration wasn’t completed.', 'fair-events' ),
+					'<strong>' . esc_html( $event_title ) . '</strong>'
+				),
+				'event_date_label'             => esc_html__( 'Event date:', 'fair-events' ),
+				'registration_reference_label' => esc_html__( 'Registration reference:', 'fair-events' ),
+				'ticket_type_label'            => esc_html__( 'Ticket type:', 'fair-events' ),
+				'amount_paid_label'            => esc_html__( 'Amount:', 'fair-events' ),
+				'selected_options_label'       => esc_html__( 'Selected options:', 'fair-events' ),
+				'your_answers_label'           => esc_html__( 'Your answers:', 'fair-events' ),
+				'action_label'                 => esc_html__( 'Return to the event page to try again', 'fair-events' ),
+				/* translators: 1: line break, 2: site name */
+				'sign_off_template'            => esc_html__( 'Thanks,%1$sThe %2$s Team', 'fair-events' ),
+			)
+		);
+
+		return $this->deliver( $email, $subject, $message );
+	}
+
+	/**
 	 * Send an email — the only wp_mail() call site in fair-events.
 	 *
 	 * @param string $to      Recipient email address.

--- a/fair-payments-connector/composer.lock
+++ b/fair-payments-connector/composer.lock
@@ -80,11 +80,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "7282e0b97cc1b1abfad91e89704b49098f6400b5"
+                "reference": "113286293569fe13947bd9840c030cbfa68baff4"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-timetable/composer.lock
+++ b/fair-timetable/composer.lock
@@ -154,11 +154,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "7282e0b97cc1b1abfad91e89704b49098f6400b5"
+                "reference": "113286293569fe13947bd9840c030cbfa68baff4"
             },
             "require": {
                 "php": ">=7.4 <9.0"


### PR DESCRIPTION
## Summary

- fair-audience already emails buyers when a payment through its Event Signup block fails, is rejected, cancelled, or expires. The unified Event Signup block that ships with fair-events (used on sites where fair-audience isn't active) did the equivalent status bookkeeping but never sent that email — this adds it.
- Per the ticket's open question, the email links back to the event page with a **plain link**, not a token-based one-click resume link — the fair-events signup flow already shows an in-page retry state when the buyer returns to a page with a failed attempt.
- Reuses the shared `FairEventsShared\Notifications\SignupConfirmationEmail` formatter (same branded layout as the existing paid confirmation email), now extended with an optional plain action link.

Closes #1373

## Acceptance criteria

- [x] A buyer whose payment fails/is rejected/is cancelled/expires on a fair-events event-signup receives an email about it — `SignupEmailHooks::handle_signup_payment_failed()` listens on the existing `fair_events_signup_payment_failed` action and sends via `EmailService::send_signup_payment_failed()`.
- [x] The email is not duplicated by webhook retries for the same failed attempt — deduped via a transient keyed on the transaction ID (`fair_events_payment_failed_email_{id}`, 1 hour), mirroring fair-audience's own dedupe pattern.
- [x] A subsequent, separate failed attempt by the same buyer sends its own email — dedupe is keyed per transaction ID, so a new failed attempt (new transaction) always sends.
- [x] Sites with fair-audience active still see only fair-audience's failed-payment email, not an additional one from fair-events — guarded by the same `class_exists( FairAudience\Hooks\SignupHookBridge::class )` check used by the existing confirmation-email hooks (fair-audience's own listener on this hook is an intentional no-op).
- [x] Free signups and successful paid signups are unaffected — this only hooks the existing `fair_events_signup_payment_failed` action, which only fires from `PaymentHooks::handle_payment_failed()`.
- [x] Test coverage: added PHPUnit unit tests for `EmailService::send_signup_payment_failed()` and `SignupEmailHooks::handle_signup_payment_failed()` (send, dedupe-by-transaction, and new-transaction-sends-again cases). Per existing project convention (see `SignupPaymentStateTest`/`EmailServiceTest` docblocks), the webhook path itself isn't exercised via an API/Playwright spec since seeding a real failed transaction requires routing through the payment gateway — instead verified manually against a live WordPress bootstrap via the WP-CLI `eval-file` recipe (email renders with a plain event link and correct subject; suppressed when fair-audience is active), matching this codebase's existing testing pattern for payment-webhook behavior.

## Other changes

- `fair-events-shared/php/src/Notifications/SignupConfirmationEmail.php` gains an optional `action_url`/`action_label` pair, additively (no existing signature changed) — renders a plain link paragraph only when both are set. Shared package version bumped to 0.2.3 and `npm run composer:update:shared` run across all consumers.

## Test plan

- [x] `vendor/bin/phpunit` in `fair-events` (164 tests) and `fair-audience` (78 tests) — all pass.
- [x] `vendor/bin/phpcs` clean on all changed PHP files.
- [x] Manual WP-CLI `eval-file` check against the running `docker compose` WordPress instance (fair-audience active): confirmed `EmailService::send_signup_payment_failed()` renders the correct subject and a plain event link, and confirmed `SignupEmailHooks::handle_signup_payment_failed()` is a no-op while fair-audience is active.
