### PR TITLE
Add header background color to events-calendar/events-week

### DIFF
--- a/.changeset/events-nav-header-background-color.md
+++ b/.changeset/events-nav-header-background-color.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Add a "Header Background" color control to events-calendar and events-week, and rename events-calendar's ambiguous "Background"/"Text" color labels to "Event Background"/"Event Text" to match events-week.

--- a/fair-events/src/blocks/_navigation.scss
+++ b/fair-events/src/blocks/_navigation.scss
@@ -14,7 +14,7 @@ $fair-events-today-bg-color: #e7f5ff;
 		align-items: center;
 		margin-bottom: 1.5rem;
 		padding: 0.75rem 1rem;
-		background: #f9f9f9;
+		background: var(--fair-events-header-bg, #f9f9f9);
 		border-radius: 4px;
 
 		.navigation-title {

--- a/fair-events/src/blocks/events-calendar/block.json
+++ b/fair-events/src/blocks/events-calendar/block.json
@@ -45,6 +45,10 @@
 			"type": "string",
 			"default": "#ffffff"
 		},
+		"headerBackgroundColor": {
+			"type": "string",
+			"default": "#f9f9f9"
+		},
 		"eventSources": {
 			"type": "array",
 			"default": [],

--- a/fair-events/src/blocks/events-calendar/components/EditComponent.js
+++ b/fair-events/src/blocks/events-calendar/components/EditComponent.js
@@ -29,6 +29,7 @@ const EditComponent = ({ attributes, setAttributes }) => {
 		showDrafts,
 		backgroundColor,
 		textColor,
+		headerBackgroundColor,
 		eventSources,
 		showSubscribe,
 	} = attributes;
@@ -172,7 +173,7 @@ const EditComponent = ({ attributes, setAttributes }) => {
 								setAttributes({
 									backgroundColor: color || 'primary',
 								}),
-							label: __('Background', 'fair-events'),
+							label: __('Event Background', 'fair-events'),
 						},
 						{
 							value: textColor,
@@ -180,7 +181,15 @@ const EditComponent = ({ attributes, setAttributes }) => {
 								setAttributes({
 									textColor: color || '#ffffff',
 								}),
-							label: __('Text', 'fair-events'),
+							label: __('Event Text', 'fair-events'),
+						},
+						{
+							value: headerBackgroundColor,
+							onChange: (color) =>
+								setAttributes({
+									headerBackgroundColor: color || '#f9f9f9',
+								}),
+							label: __('Header Background', 'fair-events'),
 						},
 					]}
 				>

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -214,12 +214,14 @@ $categories      = $attributes['categories'] ?? array();
 $show_drafts     = $attributes['showDrafts'] ?? false;
 $bg_color        = $attributes['backgroundColor'] ?? 'primary';
 $text_color      = $attributes['textColor'] ?? '#ffffff';
+$header_bg_color = $attributes['headerBackgroundColor'] ?? '#f9f9f9';
 $event_sources   = $attributes['eventSources'] ?? array();
 $show_subscribe  = $attributes['showSubscribe'] ?? true;
 
 // Convert WordPress event colors to CSS values (used for post-linked/standalone events)
 $bg_color_value   = fair_events_convert_color_to_css( $bg_color );
 $text_color_value = fair_events_convert_color_to_css( $text_color );
+$header_bg_value  = fair_events_convert_color_to_css( $header_bg_color );
 
 // Get month/year from URL parameters or block attributes
 // URL params take precedence (for navigation), then block attributes, then current date
@@ -312,7 +314,7 @@ $subscribe_urls = fair_events_build_subscribe_urls( is_array( $categories ) ? $c
 ?>
 <div <?php echo wp_kses_post( get_block_wrapper_attributes( array( 'class' => 'wp-block-fair-events-events-calendar' ) ) ); ?>>
 	<?php if ( $show_navigation ) : ?>
-	<div class="fair-events-navigation">
+	<div class="fair-events-navigation" style="--fair-events-header-bg: <?php echo esc_attr( $header_bg_value ); ?>">
 		<div class="wp-block-button is-style-outline">
 			<a href="<?php echo esc_url( $prev_url ); ?>" class="nav-prev wp-block-button__link wp-element-button">
 				<?php esc_html_e( 'Previous', 'fair-events' ); ?>

--- a/fair-events/src/blocks/events-week/block.json
+++ b/fair-events/src/blocks/events-week/block.json
@@ -33,6 +33,10 @@
 			"type": "string",
 			"default": "#ffffff"
 		},
+		"headerBackgroundColor": {
+			"type": "string",
+			"default": "#f9f9f9"
+		},
 		"eventSources": {
 			"type": "array",
 			"default": [],

--- a/fair-events/src/blocks/events-week/components/EditComponent.js
+++ b/fair-events/src/blocks/events-week/components/EditComponent.js
@@ -27,6 +27,7 @@ const EditComponent = ({ attributes, setAttributes }) => {
 		showDrafts,
 		backgroundColor,
 		textColor,
+		headerBackgroundColor,
 		eventSources,
 		showCopySummary,
 	} = attributes;
@@ -143,6 +144,14 @@ const EditComponent = ({ attributes, setAttributes }) => {
 									textColor: color || '#ffffff',
 								}),
 							label: __('Event Text', 'fair-events'),
+						},
+						{
+							value: headerBackgroundColor,
+							onChange: (color) =>
+								setAttributes({
+									headerBackgroundColor: color || '#f9f9f9',
+								}),
+							label: __('Header Background', 'fair-events'),
 						},
 					]}
 				/>

--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -103,8 +103,9 @@ $show_drafts       = $attributes['showDrafts'] ?? false;
 $event_sources     = $attributes['eventSources'] ?? array();
 $show_copy_summary = $attributes['showCopySummary'] ?? false;
 
-$bg_color   = $attributes['backgroundColor'] ?? 'primary';
-$text_color = $attributes['textColor'] ?? '#ffffff';
+$bg_color        = $attributes['backgroundColor'] ?? 'primary';
+$text_color      = $attributes['textColor'] ?? '#ffffff';
+$header_bg_color = $attributes['headerBackgroundColor'] ?? '#f9f9f9';
 
 if ( preg_match( '/^#[0-9A-Fa-f]{3,6}$/', $bg_color ) ) {
 	$bg_color_value = $bg_color;
@@ -115,6 +116,11 @@ if ( preg_match( '/^#[0-9A-Fa-f]{3,6}$/', $text_color ) ) {
 	$text_color_value = $text_color;
 } else {
 	$text_color_value = 'var(--wp--preset--color--' . esc_attr( $text_color ) . ')';
+}
+if ( preg_match( '/^#[0-9A-Fa-f]{3,6}$/', $header_bg_color ) ) {
+	$header_bg_value = $header_bg_color;
+} else {
+	$header_bg_value = 'var(--wp--preset--color--' . esc_attr( $header_bg_color ) . ')';
 }
 
 // Week date range.
@@ -229,7 +235,7 @@ if ( $show_copy_summary ) {
 <div <?php echo wp_kses_post( get_block_wrapper_attributes( array( 'class' => 'wp-block-fair-events-events-week' ) ) ); ?>>
 
 	<?php if ( $show_navigation ) : ?>
-	<div class="fair-events-navigation">
+	<div class="fair-events-navigation" style="--fair-events-header-bg: <?php echo esc_attr( $header_bg_value ); ?>">
 		<div class="wp-block-button is-style-outline">
 			<a href="<?php echo esc_url( $prev_url ); ?>" class="nav-prev wp-block-button__link wp-element-button">
 				<?php esc_html_e( 'Previous', 'fair-events' ); ?>


### PR DESCRIPTION
## Summary

Implements "Step 4: Header background, event background & event text colors" from #1271: exposes a **Header Background** color control on `events-calendar` and `events-week`, and cleans up `events-calendar`'s ambiguous color labels.

- `_navigation.scss`: the shared `.fair-events-navigation` mixin's hardcoded `background: #f9f9f9` becomes `background: var(--fair-events-header-bg, #f9f9f9)`, so unset instances render identically to today.
- `block.json` (both blocks): new `headerBackgroundColor` attribute, default `#f9f9f9`.
- `render.php` (both blocks): resolves `headerBackgroundColor` through each block's existing hex-or-preset conversion (events-calendar's `fair_events_convert_color_to_css()`, events-week's inline regex check) and outputs it as `--fair-events-header-bg` on the nav wrapper.
- `EditComponent.js` (both blocks): adds a third `PanelColorSettings` entry, "Header Background".
- `events-calendar/components/EditComponent.js`: renames the existing "Background"/"Text" labels to "Event Background"/"Event Text", matching `events-week`, so they're not confused with the new header control.

Refs #1271

## Acceptance criteria (from the comment's plan)

- Header background exposed as a real control on both blocks, wired through attribute → render.php CSS custom property → sidebar `PanelColorSettings` — done.
- Unset instances keep rendering the current `#f9f9f9` gray — done (CSS `var()` fallback + attribute default both set to `#f9f9f9`).
- Event background/text colors untouched in behavior, only relabeled on `events-calendar` — done.
- Scope limited to the shared nav bar (`.fair-events-navigation`); the weekday-header row is explicitly out of scope per the plan's Decisions — untouched.

## Testing

- `npm run build` in `fair-events` — clean.
- `npm run test:js` — 23 suites / 177 tests pass.
- `vendor/bin/phpcs` on both changed `render.php` files — no new errors (diffed against pre-change versions; the pre-existing errors/warnings are identical, just shifted line numbers).
- Manual check against the running `docker compose` site (page "Próximos Eventos", which already has both blocks): confirmed the nav wrapper renders `style="--fair-events-header-bg: #f9f9f9"` by default, and temporarily setting `headerBackgroundColor` on each block's attributes produced the expected custom `--fair-events-header-bg` value on the frontend without affecting event chip colors. Reverted the test content back to its original state afterward.
