### PR TITLE
Add explicit online/hybrid attendance mode for event dates

### DIFF
--- a/.changeset/add-attendance-mode.md
+++ b/.changeset/add-attendance-mode.md
@@ -1,0 +1,5 @@
+---
+"fair-events": minor
+---
+
+Add an explicit in-person/online/hybrid attendance mode with a joining link on the event date, replacing the old inference from the event's link type. Structured data (JSON-LD), calendar feeds, and the public event-info block now reflect the selected mode, and the mode/link are inherited by generated series occurrences like venue and address.

--- a/fair-events/__tests__/API/CalendarFeedControllerTest.php
+++ b/fair-events/__tests__/API/CalendarFeedControllerTest.php
@@ -150,4 +150,85 @@ class CalendarFeedControllerTest extends TestCase {
 		$this->assertSame( '2026-06-15 18:00:00', $events[0]['start'] );
 		$this->assertSame( '2026-06-15 19:00:00', $events[0]['end'] );
 	}
+
+	/**
+	 * Call the private build_location_line() with a neutral location shape.
+	 *
+	 * @param array|null $location Neutral location shape.
+	 * @return string LOCATION text.
+	 */
+	private function build_location_line( $location ) {
+		$controller = new CalendarFeedController();
+		$method     = new \ReflectionMethod( CalendarFeedController::class, 'build_location_line' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $controller, $location );
+	}
+
+	/**
+	 * In-person shows the physical name/address text.
+	 *
+	 * @return void
+	 */
+	public function test_location_line_in_person() {
+		$line = $this->build_location_line(
+			array(
+				'mode'    => 'in_person',
+				'name'    => 'Venue Name',
+				'address' => '123 Main St',
+			)
+		);
+
+		$this->assertSame( 'Venue Name, 123 Main St', $line );
+	}
+
+	/**
+	 * Online uses the joining URL as the whole LOCATION line.
+	 *
+	 * @return void
+	 */
+	public function test_location_line_online() {
+		$line = $this->build_location_line(
+			array(
+				'mode'        => 'online',
+				'joining_url' => 'https://example.com/meet',
+			)
+		);
+
+		$this->assertSame( 'https://example.com/meet', $line );
+	}
+
+	/**
+	 * Hybrid appends the joining URL to the physical location text.
+	 *
+	 * @return void
+	 */
+	public function test_location_line_hybrid_appends_joining_url() {
+		$line = $this->build_location_line(
+			array(
+				'mode'        => 'hybrid',
+				'name'        => 'Venue Name',
+				'joining_url' => 'https://example.com/meet',
+			)
+		);
+
+		$this->assertSame( 'Venue Name — https://example.com/meet', $line );
+	}
+
+	/**
+	 * Hybrid with no physical fields shows only the joining URL, no leading
+	 * separator.
+	 *
+	 * @return void
+	 */
+	public function test_location_line_hybrid_with_no_physical() {
+		$line = $this->build_location_line(
+			array(
+				'mode'        => 'hybrid',
+				'joining_url' => 'https://example.com/meet',
+			)
+		);
+
+		$this->assertSame( 'https://example.com/meet', $line );
+	}
 }

--- a/fair-events/__tests__/Helpers/EventLocationTest.php
+++ b/fair-events/__tests__/Helpers/EventLocationTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Tests for EventLocation::resolve() across attendance modes.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Helpers\EventLocation;
+use FairEvents\Models\EventDates;
+
+/**
+ * Unit tests for EventLocation::resolve().
+ *
+ * No venue_id is set on any fixture, so the optional Venue model (from
+ * fair-events-experimental) is never touched, and post_id is always null/0
+ * so get_post_meta() (unstubbed) is never called — these tests exercise the
+ * free-text address / attendance-mode fallback chain only.
+ */
+class EventLocationTest extends TestCase {
+
+	/**
+	 * Build a minimal EventDates fixture.
+	 *
+	 * @param array $overrides Property overrides.
+	 * @return EventDates Fixture.
+	 */
+	private function make_event_date( array $overrides = array() ): EventDates {
+		$event_date                  = new EventDates();
+		$event_date->id              = 1;
+		$event_date->link_type       = 'none';
+		$event_date->attendance_mode = 'in_person';
+
+		foreach ( $overrides as $key => $value ) {
+			$event_date->$key = $value;
+		}
+
+		return $event_date;
+	}
+
+	/**
+	 * In-person with a free-text address resolves the physical fields, no mode-specific keys.
+	 */
+	public function test_in_person_with_address() {
+		$event_date = $this->make_event_date( array( 'address' => '123 Main St' ) );
+
+		$location = EventLocation::resolve( $event_date, null );
+
+		$this->assertSame( 'in_person', $location['mode'] );
+		$this->assertSame( '123 Main St', $location['address'] );
+		$this->assertArrayNotHasKey( 'joining_url', $location );
+	}
+
+	/**
+	 * In-person with nothing resolved (no venue, no address, no post meta) is null.
+	 */
+	public function test_in_person_with_nothing_resolved_is_null() {
+		$event_date = $this->make_event_date();
+
+		$this->assertNull( EventLocation::resolve( $event_date, null ) );
+	}
+
+	/**
+	 * Online with an explicit joining_link uses it directly, and never carries
+	 * physical fields even when an address also happens to be set.
+	 */
+	public function test_online_uses_explicit_joining_link() {
+		$event_date = $this->make_event_date(
+			array(
+				'attendance_mode' => 'online',
+				'address'         => '123 Main St',
+				'joining_link'    => 'https://example.com/meet',
+			)
+		);
+
+		$location = EventLocation::resolve( $event_date, null );
+
+		$this->assertSame( 'online', $location['mode'] );
+		$this->assertSame( 'https://example.com/meet', $location['joining_url'] );
+		$this->assertArrayNotHasKey( 'address', $location );
+		$this->assertArrayNotHasKey( 'name', $location );
+	}
+
+	/**
+	 * Online with no joining_link falls back to the event page URL via
+	 * get_display_url() (exercised here through an external link_type).
+	 */
+	public function test_online_falls_back_to_display_url() {
+		$event_date = $this->make_event_date(
+			array(
+				'attendance_mode' => 'online',
+				'link_type'       => 'external',
+				'external_url'    => 'https://example.com/event-page',
+			)
+		);
+
+		$location = EventLocation::resolve( $event_date, null );
+
+		$this->assertSame( 'online', $location['mode'] );
+		$this->assertSame( 'https://example.com/event-page', $location['joining_url'] );
+	}
+
+	/**
+	 * Hybrid with an address carries both the physical fields and the joining URL.
+	 */
+	public function test_hybrid_with_address_carries_both() {
+		$event_date = $this->make_event_date(
+			array(
+				'attendance_mode' => 'hybrid',
+				'address'         => '123 Main St',
+				'joining_link'    => 'https://example.com/meet',
+			)
+		);
+
+		$location = EventLocation::resolve( $event_date, null );
+
+		$this->assertSame( 'hybrid', $location['mode'] );
+		$this->assertSame( '123 Main St', $location['address'] );
+		$this->assertSame( 'https://example.com/meet', $location['joining_url'] );
+	}
+
+	/**
+	 * Hybrid with no physical location resolved still returns the joining
+	 * URL, with no address/name keys (EventSchema applies the site-name
+	 * backstop for the Place side, not EventLocation).
+	 */
+	public function test_hybrid_with_no_physical_location() {
+		$event_date = $this->make_event_date(
+			array(
+				'attendance_mode' => 'hybrid',
+				'joining_link'    => 'https://example.com/meet',
+			)
+		);
+
+		$location = EventLocation::resolve( $event_date, null );
+
+		$this->assertSame( 'hybrid', $location['mode'] );
+		$this->assertArrayNotHasKey( 'address', $location );
+		$this->assertArrayNotHasKey( 'name', $location );
+		$this->assertSame( 'https://example.com/meet', $location['joining_url'] );
+	}
+
+	/**
+	 * A null attendance_mode (pre-migration row, or a generated occurrence
+	 * whose master is also null) defaults to in_person.
+	 */
+	public function test_null_attendance_mode_defaults_to_in_person() {
+		$event_date = $this->make_event_date(
+			array(
+				'attendance_mode' => null,
+				'address'         => '123 Main St',
+			)
+		);
+
+		$location = EventLocation::resolve( $event_date, null );
+
+		$this->assertSame( 'in_person', $location['mode'] );
+	}
+}

--- a/fair-events/__tests__/Helpers/EventSchemaTest.php
+++ b/fair-events/__tests__/Helpers/EventSchemaTest.php
@@ -208,4 +208,153 @@ class EventSchemaTest extends TestCase {
 	public function test_is_free_offer_set_false_when_empty() {
 		$this->assertFalse( EventSchema::is_free_offer_set( array() ) );
 	}
+
+	/**
+	 * A null neutral location location_to_jsonld()s to the site-name Place backstop.
+	 *
+	 * @return void
+	 */
+	public function test_location_to_jsonld_null_neutral_is_site_backstop() {
+		$node = EventSchema::location_to_jsonld( null );
+
+		$this->assertSame( 'Place', $node['@type'] );
+		$this->assertSame( 'Test Site', $node['name'] );
+	}
+
+	/**
+	 * In-person mode location_to_jsonld()s to a single Place node.
+	 *
+	 * @return void
+	 */
+	public function test_location_to_jsonld_in_person_is_place() {
+		$node = EventSchema::location_to_jsonld(
+			array(
+				'mode'    => 'in_person',
+				'name'    => 'Venue Name',
+				'address' => '123 Main St',
+			)
+		);
+
+		$this->assertSame( 'Place', $node['@type'] );
+		$this->assertSame( 'Venue Name', $node['name'] );
+		$this->assertSame( '123 Main St', $node['address']['name'] );
+	}
+
+	/**
+	 * Online mode location_to_jsonld()s to a single VirtualLocation node.
+	 *
+	 * @return void
+	 */
+	public function test_location_to_jsonld_online_is_virtual_location() {
+		$node = EventSchema::location_to_jsonld(
+			array(
+				'mode'        => 'online',
+				'joining_url' => 'https://example.com/meet',
+			)
+		);
+
+		$this->assertSame( 'VirtualLocation', $node['@type'] );
+		$this->assertSame( 'https://example.com/meet', $node['url'] );
+	}
+
+	/**
+	 * Hybrid mode location_to_jsonld()s to an array of both a Place and a
+	 * VirtualLocation node — search engines require both entries.
+	 *
+	 * @return void
+	 */
+	public function test_location_to_jsonld_hybrid_is_both_nodes() {
+		$nodes = EventSchema::location_to_jsonld(
+			array(
+				'mode'        => 'hybrid',
+				'name'        => 'Venue Name',
+				'joining_url' => 'https://example.com/meet',
+			)
+		);
+
+		$this->assertCount( 2, $nodes );
+		$this->assertSame( 'Place', $nodes[0]['@type'] );
+		$this->assertSame( 'Venue Name', $nodes[0]['name'] );
+		$this->assertSame( 'VirtualLocation', $nodes[1]['@type'] );
+		$this->assertSame( 'https://example.com/meet', $nodes[1]['url'] );
+	}
+
+	/**
+	 * Hybrid mode with no physical fields falls back to the site-name Place
+	 * backstop for the Place side, still alongside the VirtualLocation node.
+	 *
+	 * @return void
+	 */
+	public function test_location_to_jsonld_hybrid_with_no_physical_uses_backstop() {
+		$nodes = EventSchema::location_to_jsonld(
+			array(
+				'mode'        => 'hybrid',
+				'joining_url' => 'https://example.com/meet',
+			)
+		);
+
+		$this->assertSame( 'Place', $nodes[0]['@type'] );
+		$this->assertSame( 'Test Site', $nodes[0]['name'] );
+		$this->assertSame( 'VirtualLocation', $nodes[1]['@type'] );
+	}
+
+	/**
+	 * Build a minimal EventDates fixture with no venue_id (so the optional
+	 * Venue model is never touched) and post_id 0 (so get_post_meta(), which
+	 * isn't stubbed, is never called).
+	 *
+	 * @param array $overrides Property overrides.
+	 * @return \FairEvents\Models\EventDates Fixture.
+	 */
+	private function make_event_date_fixture( array $overrides = array() ) {
+		$event_date                  = new \FairEvents\Models\EventDates();
+		$event_date->id              = 1;
+		$event_date->link_type       = 'none';
+		$event_date->attendance_mode = 'in_person';
+
+		foreach ( $overrides as $key => $value ) {
+			$event_date->$key = $value;
+		}
+
+		return $event_date;
+	}
+
+	/**
+	 * Get_jsonld_location() reports the correct eventAttendanceMode for each
+	 * of the three explicit modes, driven end-to-end from an EventDates row.
+	 *
+	 * @return void
+	 */
+	public function test_get_jsonld_location_attendance_mode_values() {
+		$in_person = EventSchema::get_jsonld_location(
+			$this->make_event_date_fixture( array( 'address' => '123 Main St' ) ),
+			0
+		);
+		$this->assertSame( 'https://schema.org/OfflineEventAttendanceMode', $in_person['attendance_mode'] );
+
+		$online = EventSchema::get_jsonld_location(
+			$this->make_event_date_fixture(
+				array(
+					'attendance_mode' => 'online',
+					'joining_link'    => 'https://example.com/meet',
+				)
+			),
+			0
+		);
+		$this->assertSame( 'https://schema.org/OnlineEventAttendanceMode', $online['attendance_mode'] );
+		$this->assertSame( 'VirtualLocation', $online['location']['@type'] );
+
+		$hybrid = EventSchema::get_jsonld_location(
+			$this->make_event_date_fixture(
+				array(
+					'attendance_mode' => 'hybrid',
+					'address'         => '123 Main St',
+					'joining_link'    => 'https://example.com/meet',
+				)
+			),
+			0
+		);
+		$this->assertSame( 'https://schema.org/MixedEventAttendanceMode', $hybrid['attendance_mode'] );
+		$this->assertCount( 2, $hybrid['location'] );
+	}
 }

--- a/fair-events/__tests__/Models/EventDatesTest.php
+++ b/fair-events/__tests__/Models/EventDatesTest.php
@@ -266,4 +266,98 @@ class EventDatesTest extends TestCase {
 
 		$this->assertSame( array(), array_values( array_diff( array_keys( get_object_vars( $obj ) ), $declared ) ) );
 	}
+
+	/**
+	 * Build a minimal DB-row stdClass for hydrate(), covering every column
+	 * hydrate() reads so a generated-row test doesn't need to know the
+	 * whole schema — only override what the test cares about.
+	 *
+	 * @param array $overrides Column overrides.
+	 * @return \stdClass Row.
+	 */
+	private function make_row( array $overrides = array() ): \stdClass {
+		$row                    = new \stdClass();
+		$row->id                = 1;
+		$row->event_id          = null;
+		$row->start_datetime    = '2026-06-29 18:30:00';
+		$row->end_datetime      = null;
+		$row->all_day           = 0;
+		$row->occurrence_type   = 'single';
+		$row->master_id         = null;
+		$row->rrule             = null;
+		$row->status            = 'active';
+		$row->recurrence_mode   = 'none';
+		$row->venue_id          = null;
+		$row->title             = null;
+		$row->external_url      = null;
+		$row->link_type         = 'post';
+		$row->attendance_mode   = null;
+		$row->joining_link      = null;
+		$row->capacity          = null;
+		$row->address           = null;
+		$row->recurrence_anchor = null;
+
+		foreach ( $overrides as $key => $value ) {
+			$row->$key = $value;
+		}
+
+		return $row;
+	}
+
+	/**
+	 * A generated occurrence with attendance_mode/joining_link both NULL
+	 * inherits both from its master, joining the same NULL-inherit set as
+	 * title/venue_id/address/link_type/external_url/capacity.
+	 */
+	public function test_attendance_mode_and_joining_link_inherit_from_master() {
+		$master                  = new EventDates();
+		$master->id              = 1;
+		$master->attendance_mode = 'online';
+		$master->joining_link    = 'https://example.com/meet';
+
+		$this->seed_master_cache( $master );
+
+		$occurrence = ( new ReflectionMethod( EventDates::class, 'hydrate' ) )->invoke(
+			null,
+			$this->make_row(
+				array(
+					'id'              => 2,
+					'occurrence_type' => 'generated',
+					'master_id'       => 1,
+				)
+			)
+		);
+
+		$this->assertSame( 'online', $occurrence->attendance_mode );
+		$this->assertSame( 'https://example.com/meet', $occurrence->joining_link );
+	}
+
+	/**
+	 * A generated occurrence that overrides attendance_mode/joining_link
+	 * keeps its own value rather than inheriting the master's.
+	 */
+	public function test_attendance_mode_and_joining_link_override_master() {
+		$master                  = new EventDates();
+		$master->id              = 1;
+		$master->attendance_mode = 'online';
+		$master->joining_link    = 'https://example.com/meet';
+
+		$this->seed_master_cache( $master );
+
+		$occurrence = ( new ReflectionMethod( EventDates::class, 'hydrate' ) )->invoke(
+			null,
+			$this->make_row(
+				array(
+					'id'              => 2,
+					'occurrence_type' => 'generated',
+					'master_id'       => 1,
+					'attendance_mode' => 'in_person',
+					'joining_link'    => 'https://example.com/own-meet',
+				)
+			)
+		);
+
+		$this->assertSame( 'in_person', $occurrence->attendance_mode );
+		$this->assertSame( 'https://example.com/own-meet', $occurrence->joining_link );
+	}
 }

--- a/fair-events/e2e/opengraph-jsonld.spec.js
+++ b/fair-events/e2e/opengraph-jsonld.spec.js
@@ -413,4 +413,123 @@ test.describe('Fair Events JSON-LD structured data', () => {
 			method: 'DELETE',
 		}).catch(() => {});
 	});
+
+	test('emits a VirtualLocation node + OnlineEventAttendanceMode for an online event', async ({
+		page,
+	}) => {
+		test.setTimeout(120_000);
+
+		await page.setViewportSize({ width: 1200, height: 900 });
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+		const now = new Date();
+		const start = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+		const iso = (d) => d.toISOString().slice(0, 19).replace('T', ' ');
+
+		const eventDate = await apiFetch(page, {
+			path: '/fair-events/v1/event-dates',
+			method: 'POST',
+			data: {
+				title: 'JSON-LD Test Online Event',
+				start_datetime: iso(start),
+				end_datetime: iso(
+					new Date(start.getTime() + 2 * 60 * 60 * 1000)
+				),
+				all_day: false,
+				attendance_mode: 'online',
+				joining_link: 'https://example.com/meet',
+			},
+		});
+
+		const post = await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}/create-post`,
+			method: 'POST',
+			data: { post_status: 'publish' },
+		});
+		const postId = post.event_id || post.post_id;
+
+		const permalink = post.link || `/?p=${postId}`;
+		const data = await getJsonLd(page, permalink);
+
+		expect(data.eventAttendanceMode).toBe(
+			'https://schema.org/OnlineEventAttendanceMode'
+		);
+		expect(data.location['@type']).toBe('VirtualLocation');
+		expect(data.location.url).toBe('https://example.com/meet');
+
+		// Cleanup.
+		await apiFetch(page, {
+			path: `/wp/v2/fair_event/${postId}?force=true`,
+			method: 'DELETE',
+		}).catch(() => {});
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}`,
+			method: 'DELETE',
+		}).catch(() => {});
+	});
+
+	test('emits both a Place and a VirtualLocation node + MixedEventAttendanceMode for a hybrid event', async ({
+		page,
+	}) => {
+		test.setTimeout(120_000);
+
+		await page.setViewportSize({ width: 1200, height: 900 });
+		await login(page);
+		await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+		const now = new Date();
+		const start = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+		const iso = (d) => d.toISOString().slice(0, 19).replace('T', ' ');
+
+		const eventDate = await apiFetch(page, {
+			path: '/fair-events/v1/event-dates',
+			method: 'POST',
+			data: {
+				title: 'JSON-LD Test Hybrid Event',
+				start_datetime: iso(start),
+				end_datetime: iso(
+					new Date(start.getTime() + 2 * 60 * 60 * 1000)
+				),
+				all_day: false,
+				attendance_mode: 'hybrid',
+				address: '123 Test Street, Testville',
+				joining_link: 'https://example.com/hybrid-meet',
+			},
+		});
+
+		const post = await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}/create-post`,
+			method: 'POST',
+			data: { post_status: 'publish' },
+		});
+		const postId = post.event_id || post.post_id;
+
+		const permalink = post.link || `/?p=${postId}`;
+		const data = await getJsonLd(page, permalink);
+
+		expect(data.eventAttendanceMode).toBe(
+			'https://schema.org/MixedEventAttendanceMode'
+		);
+		expect(Array.isArray(data.location)).toBe(true);
+		expect(data.location).toHaveLength(2);
+		expect(data.location[0]['@type']).toBe('Place');
+		expect(data.location[0].address.name).toBe(
+			'123 Test Street, Testville'
+		);
+		expect(data.location[1]['@type']).toBe('VirtualLocation');
+		expect(data.location[1].url).toBe('https://example.com/hybrid-meet');
+
+		// Cleanup.
+		await apiFetch(page, {
+			path: `/wp/v2/fair_event/${postId}?force=true`,
+			method: 'DELETE',
+		}).catch(() => {});
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}`,
+			method: 'DELETE',
+		}).catch(() => {});
+	});
 });

--- a/fair-events/src/API/CalendarFeedController.php
+++ b/fair-events/src/API/CalendarFeedController.php
@@ -292,7 +292,10 @@ class CalendarFeedController extends WP_REST_Controller {
 	 * Build the iCalendar LOCATION text line from a neutral location shape.
 	 *
 	 * Standard `LOCATION` text only (name + address); geo stays feed-only per
-	 * the ICS recommendation. Online events use the meeting URL.
+	 * the ICS recommendation. Online events use the joining URL as the whole
+	 * line; hybrid events append it to the physical location text — a
+	 * separate per-VEVENT `URL` property isn't available for this since
+	 * `add_vevent()` already uses it for the event page link.
 	 *
 	 * @param array|null $location Neutral location shape (EventLocation::resolve()), or null.
 	 * @return string LOCATION text, or '' when there's nothing to show.
@@ -302,8 +305,10 @@ class CalendarFeedController extends WP_REST_Controller {
 			return '';
 		}
 
-		if ( ! empty( $location['online'] ) ) {
-			return $location['url'] ?? '';
+		$mode = $location['mode'] ?? 'in_person';
+
+		if ( 'online' === $mode ) {
+			return $location['joining_url'] ?? '';
 		}
 
 		$parts = array_filter(
@@ -313,7 +318,13 @@ class CalendarFeedController extends WP_REST_Controller {
 			)
 		);
 
-		return implode( ', ', $parts );
+		$line = implode( ', ', $parts );
+
+		if ( 'hybrid' === $mode && ! empty( $location['joining_url'] ) ) {
+			$line = $line ? "{$line} — {$location['joining_url']}" : $location['joining_url'];
+		}
+
+		return $line;
 	}
 
 	/**

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -352,6 +352,20 @@ class EventDatesController extends WP_REST_Controller {
 				'required'          => false,
 				'sanitize_callback' => 'esc_url_raw',
 			),
+			'attendance_mode' => array(
+				'description' => __( 'Attendance mode (in_person, online, hybrid).', 'fair-events' ),
+				'type'        => 'string',
+				'required'    => false,
+				'default'     => 'in_person',
+				'enum'        => array( 'in_person', 'online', 'hybrid' ),
+			),
+			'joining_link'    => array(
+				'description'       => __( 'Public joining URL for online/hybrid events. Falls back to the event page URL when empty.', 'fair-events' ),
+				'type'              => array( 'string', 'null' ),
+				'required'          => false,
+				'sanitize_callback' => 'esc_url_raw',
+				'validate_callback' => array( $this, 'validate_joining_link' ),
+			),
 			'event_id'        => array(
 				'description' => __( 'Linked post ID.', 'fair-events' ),
 				'type'        => array( 'integer', 'null' ),
@@ -469,19 +483,46 @@ class EventDatesController extends WP_REST_Controller {
 	}
 
 	/**
+	 * Validate the `joining_link` param.
+	 *
+	 * Empty/null is valid (the mode falls back to the event page URL); a
+	 * non-empty value must be a well-formed http(s) URL.
+	 *
+	 * @param mixed $value Raw param value.
+	 * @return true|WP_Error True if valid, WP_Error otherwise.
+	 */
+	public function validate_joining_link( $value ) {
+		if ( null === $value || '' === $value ) {
+			return true;
+		}
+
+		if ( ! is_string( $value ) || ! wp_http_validate_url( $value ) ) {
+			return new WP_Error(
+				'rest_invalid_joining_link',
+				__( 'The joining link must be a valid URL.', 'fair-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
 	 * Create a standalone event date
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error on failure.
 	 */
 	public function create_item( $request ) {
-		$title          = $request->get_param( 'title' );
-		$start_datetime = $request->get_param( 'start_datetime' );
-		$end_datetime   = $request->get_param( 'end_datetime' );
-		$all_day        = $request->get_param( 'all_day' );
-		$venue_id       = $request->get_param( 'venue_id' );
-		$link_type      = $request->get_param( 'link_type' ) ?? 'none';
-		$external_url   = $request->get_param( 'external_url' );
+		$title           = $request->get_param( 'title' );
+		$start_datetime  = $request->get_param( 'start_datetime' );
+		$end_datetime    = $request->get_param( 'end_datetime' );
+		$all_day         = $request->get_param( 'all_day' );
+		$venue_id        = $request->get_param( 'venue_id' );
+		$link_type       = $request->get_param( 'link_type' ) ?? 'none';
+		$external_url    = $request->get_param( 'external_url' );
+		$attendance_mode = $request->get_param( 'attendance_mode' ) ?? 'in_person';
+		$joining_link    = $request->get_param( 'joining_link' );
 
 		if ( empty( $title ) || '' === trim( $title ) ) {
 			return new WP_Error(
@@ -500,12 +541,14 @@ class EventDatesController extends WP_REST_Controller {
 		}
 
 		$data = array(
-			'title'          => $title,
-			'start_datetime' => $start_datetime,
-			'end_datetime'   => $end_datetime,
-			'all_day'        => $all_day,
-			'link_type'      => $link_type,
-			'external_url'   => $external_url,
+			'title'           => $title,
+			'start_datetime'  => $start_datetime,
+			'end_datetime'    => $end_datetime,
+			'all_day'         => $all_day,
+			'link_type'       => $link_type,
+			'external_url'    => $external_url,
+			'attendance_mode' => $attendance_mode,
+			'joining_link'    => $joining_link,
 		);
 
 		$id = EventDates::create_standalone( $data );
@@ -911,6 +954,16 @@ class EventDatesController extends WP_REST_Controller {
 		$external_url = $request->get_param( 'external_url' );
 		if ( null !== $external_url ) {
 			$update_data['external_url'] = $external_url;
+		}
+
+		$attendance_mode = $request->get_param( 'attendance_mode' );
+		if ( null !== $attendance_mode ) {
+			$update_data['attendance_mode'] = $attendance_mode;
+		}
+
+		if ( $request->has_param( 'joining_link' ) ) {
+			$joining_link                = $request->get_param( 'joining_link' );
+			$update_data['joining_link'] = ( null === $joining_link || '' === $joining_link ) ? null : $joining_link;
 		}
 
 		$event_id = $request->get_param( 'event_id' );
@@ -1593,6 +1646,8 @@ class EventDatesController extends WP_REST_Controller {
 			'master_id'       => $result->master_id ? (int) $result->master_id : null,
 			'link_type'       => $result->link_type,
 			'external_url'    => $result->external_url,
+			'attendance_mode' => $result->attendance_mode ?? 'in_person',
+			'joining_link'    => $result->joining_link ?? null,
 			'venue_id'        => $result->venue_id ? (int) $result->venue_id : null,
 			'status'          => $result->status,
 		);
@@ -1643,6 +1698,8 @@ class EventDatesController extends WP_REST_Controller {
 			'address'         => $event_date->address,
 			'link_type'       => $event_date->link_type,
 			'external_url'    => $event_date->external_url,
+			'attendance_mode' => $event_date->attendance_mode ?? 'in_person',
+			'joining_link'    => $event_date->joining_link,
 			'display_url'     => $event_date->get_display_url(),
 			'rrule'           => $event_date->rrule,
 			'status'          => $event_date->status,

--- a/fair-events/src/API/__tests__/EventDatesController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesController.api.spec.js
@@ -914,3 +914,150 @@ test.describe('EventDatesController — title validation', () => {
 		expect(updateRes.status()).toBe(400);
 	});
 });
+
+test.describe('EventDatesController — attendance mode + joining link', () => {
+	let api;
+	let eventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterEach(async () => {
+		if (eventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+				{ headers: adminHeaders }
+			);
+			eventDateId = null;
+		}
+	});
+
+	test('a created event date defaults to in_person with no joining link', async () => {
+		const res = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Attendance Mode Default ${Date.now()}`,
+				start_datetime: '2030-01-01 10:00:00',
+				end_datetime: '2030-01-01 12:00:00',
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		eventDateId = body.id;
+
+		expect(body.attendance_mode).toBe('in_person');
+		expect(body.joining_link).toBeNull();
+	});
+
+	test('persists and reads back attendance_mode + joining_link on create', async () => {
+		const res = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Online Event ${Date.now()}`,
+				start_datetime: '2030-01-01 10:00:00',
+				end_datetime: '2030-01-01 12:00:00',
+				attendance_mode: 'online',
+				joining_link: 'https://example.com/meet',
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		eventDateId = body.id;
+
+		expect(body.attendance_mode).toBe('online');
+		expect(body.joining_link).toBe('https://example.com/meet');
+	});
+
+	test('persists and reads back attendance_mode + joining_link on update', async () => {
+		const createRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Hybrid Event Update ${Date.now()}`,
+					start_datetime: '2030-01-01 10:00:00',
+					end_datetime: '2030-01-01 12:00:00',
+				},
+			}
+		);
+		expect(createRes.ok()).toBeTruthy();
+		eventDateId = (await createRes.json()).id;
+
+		const updateRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{
+				headers: adminHeaders,
+				data: {
+					attendance_mode: 'hybrid',
+					joining_link: 'https://example.com/hybrid-meet',
+				},
+			}
+		);
+		expect(updateRes.ok()).toBeTruthy();
+		const body = await updateRes.json();
+
+		expect(body.attendance_mode).toBe('hybrid');
+		expect(body.joining_link).toBe('https://example.com/hybrid-meet');
+	});
+
+	test('rejects create with an invalid joining_link URL', async () => {
+		const res = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Invalid Joining Link ${Date.now()}`,
+				start_datetime: '2030-01-01 10:00:00',
+				end_datetime: '2030-01-01 12:00:00',
+				attendance_mode: 'online',
+				joining_link: 'not-a-url',
+			},
+		});
+		expect(res.status()).toBe(400);
+	});
+
+	test('rejects create with an out-of-enum attendance_mode', async () => {
+		const res = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Invalid Attendance Mode ${Date.now()}`,
+				start_datetime: '2030-01-01 10:00:00',
+				end_datetime: '2030-01-01 12:00:00',
+				attendance_mode: 'not-a-mode',
+			},
+		});
+		expect(res.status()).toBe(400);
+	});
+
+	test('a generated occurrence inherits attendance_mode + joining_link from its series master', async () => {
+		const createRes = await api.post(
+			'/wp-json/fair-events/v1/event-dates',
+			{
+				headers: adminHeaders,
+				data: {
+					title: `Series Inheritance ${Date.now()}`,
+					start_datetime: '2030-02-03 10:00:00',
+					end_datetime: '2030-02-03 12:00:00',
+					attendance_mode: 'online',
+					joining_link: 'https://example.com/series-meet',
+					rrule: 'FREQ=WEEKLY;COUNT=3',
+				},
+			}
+		);
+		expect(createRes.ok()).toBeTruthy();
+		const master = await createRes.json();
+		eventDateId = master.id;
+
+		expect(master.generated_occurrences?.length).toBeGreaterThan(0);
+		const occurrenceId = master.generated_occurrences[0].id;
+
+		const occurrenceRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${occurrenceId}`,
+			{ headers: adminHeaders }
+		);
+		expect(occurrenceRes.ok()).toBeTruthy();
+		const occurrence = await occurrenceRes.json();
+
+		expect(occurrence.attendance_mode).toBe('online');
+		expect(occurrence.joining_link).toBe('https://example.com/series-meet');
+	});
+});

--- a/fair-events/src/Admin/manage-event/EventContextHeader.js
+++ b/fair-events/src/Admin/manage-event/EventContextHeader.js
@@ -216,6 +216,16 @@ export default function EventContextHeader({
 			</p>
 			<p style={{ margin: '0 0 4px' }}>
 				<span className={linkChip.className}>{linkChip.label}</span>
+				{eventDate.attendance_mode === 'online' && (
+					<span className="fair-events-context-badge">
+						{__('Online event', 'fair-events')}
+					</span>
+				)}
+				{eventDate.attendance_mode === 'hybrid' && (
+					<span className="fair-events-context-badge">
+						{__('Hybrid event', 'fair-events')}
+					</span>
+				)}
 				{isMaster && (
 					<span className="fair-events-context-badge">
 						{sprintf(

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -87,6 +87,8 @@ export default function ManageEventApp() {
 	const [endTime, setEndTime] = useState('');
 	const [venueId, setVenueId] = useState('');
 	const [address, setAddress] = useState('');
+	const [attendanceMode, setAttendanceMode] = useState('in_person');
+	const [joiningLink, setJoiningLink] = useState('');
 	const [linkType, setLinkType] = useState('none');
 	const [externalUrl, setExternalUrl] = useState('');
 	const [categories, setCategories] = useState([]);
@@ -190,6 +192,8 @@ export default function ManageEventApp() {
 		setExternalUrl(data.external_url || '');
 		setVenueId(data.venue_id ? String(data.venue_id) : '');
 		setAddress(data.address || '');
+		setAttendanceMode(data.attendance_mode || 'in_person');
+		setJoiningLink(data.joining_link || '');
 		setCategories(data.categories?.map((c) => c.id) || []);
 
 		if (data.start_datetime) {
@@ -216,6 +220,8 @@ export default function ManageEventApp() {
 			endTime,
 			venueId,
 			address,
+			attendanceMode,
+			joiningLink,
 			linkType,
 			externalUrl,
 			categories: [...categories].sort(),
@@ -346,6 +352,12 @@ export default function ManageEventApp() {
 							: null
 						: undefined,
 					address: venuesEnabled ? undefined : address,
+					attendance_mode: attendanceMode,
+					joining_link:
+						attendanceMode === 'online' ||
+						attendanceMode === 'hybrid'
+							? joiningLink
+							: null,
 					link_type: linkType,
 					external_url: linkType === 'external' ? externalUrl : null,
 					categories,
@@ -915,18 +927,59 @@ export default function ManageEventApp() {
 									__experimentalExpandOnFocus
 								/>
 
-								{venuesEnabled ? (
-									<SelectControl
-										label={__('Venue', 'fair-events')}
-										value={venueId}
-										options={venueOptions}
-										onChange={setVenueId}
-									/>
-								) : (
+								{attendanceMode !== 'online' &&
+									(venuesEnabled ? (
+										<SelectControl
+											label={__('Venue', 'fair-events')}
+											value={venueId}
+											options={venueOptions}
+											onChange={setVenueId}
+										/>
+									) : (
+										<TextControl
+											label={__('Address', 'fair-events')}
+											value={address}
+											onChange={setAddress}
+										/>
+									))}
+
+								<SelectControl
+									label={__('Attendance mode', 'fair-events')}
+									value={attendanceMode}
+									options={[
+										{
+											label: __(
+												'In person',
+												'fair-events'
+											),
+											value: 'in_person',
+										},
+										{
+											label: __('Online', 'fair-events'),
+											value: 'online',
+										},
+										{
+											label: __('Hybrid', 'fair-events'),
+											value: 'hybrid',
+										},
+									]}
+									onChange={setAttendanceMode}
+								/>
+
+								{(attendanceMode === 'online' ||
+									attendanceMode === 'hybrid') && (
 									<TextControl
-										label={__('Address', 'fair-events')}
-										value={address}
-										onChange={setAddress}
+										label={__(
+											'Joining link',
+											'fair-events'
+										)}
+										help={__(
+											'Shown publicly. Leave empty to link to the event page instead.',
+											'fair-events'
+										)}
+										type="url"
+										value={joiningLink}
+										onChange={setJoiningLink}
 									/>
 								)}
 							</VStack>

--- a/fair-events/src/Database/Installer.php
+++ b/fair-events/src/Database/Installer.php
@@ -297,6 +297,11 @@ class Installer {
 			self::migrate_to_3_27_0();
 		}
 
+		// Run migration if upgrading from pre-3.28.0 (add attendance_mode/joining_link).
+		if ( version_compare( $current_version, '3.28.0', '<' ) ) {
+			self::migrate_to_3_28_0();
+		}
+
 		// Update database version
 		Schema::update_db_version( Schema::DB_VERSION );
 	}
@@ -475,6 +480,10 @@ class Installer {
 
 			if ( version_compare( $current_version, '3.27.0', '<' ) ) {
 				self::migrate_to_3_27_0();
+			}
+
+			if ( version_compare( $current_version, '3.28.0', '<' ) ) {
+				self::migrate_to_3_28_0();
 			}
 
 			// Install/update tables
@@ -2103,6 +2112,44 @@ class Installer {
 			$wpdb->query(
 				$wpdb->prepare(
 					'ALTER TABLE %i DROP COLUMN signup_price',
+					$table_name
+				)
+			);
+		}
+	}
+
+	/**
+	 * Migrate to version 3.28.0 - Add explicit attendance_mode/joining_link.
+	 *
+	 * Replaces the inferred "external link + no location = online" heuristic
+	 * with an explicit per-event-date attendance mode. The column is
+	 * nullable, NULL-inherit, exactly like `link_type`/`venue_id`: existing
+	 * rows (and generated occurrences that haven't overridden it) come back
+	 * NULL and are treated as `in_person` by the application layer
+	 * (EventLocation::resolve()), including rows the old inference currently
+	 * reports as online — organizers must re-select the mode for those after
+	 * upgrading. No backfill UPDATE (see #1306).
+	 *
+	 * @return void
+	 */
+	private static function migrate_to_3_28_0() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_event_dates';
+
+		if ( ! self::column_exists( $table_name, 'attendance_mode' ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD COLUMN attendance_mode VARCHAR(20) DEFAULT NULL AFTER link_type',
+					$table_name
+				)
+			);
+		}
+
+		if ( ! self::column_exists( $table_name, 'joining_link' ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					'ALTER TABLE %i ADD COLUMN joining_link VARCHAR(500) DEFAULT NULL AFTER attendance_mode',
 					$table_name
 				)
 			);

--- a/fair-events/src/Database/Schema.php
+++ b/fair-events/src/Database/Schema.php
@@ -17,7 +17,7 @@ class Schema {
 	/**
 	 * Database version
 	 */
-	const DB_VERSION = '3.27.0';
+	const DB_VERSION = '3.28.0';
 
 	/**
 	 * Get the SQL for creating the fair_event_dates table
@@ -46,6 +46,8 @@ class Schema {
 			title VARCHAR(255) DEFAULT NULL,
 			external_url TEXT DEFAULT NULL,
 			link_type VARCHAR(20) DEFAULT NULL,
+			attendance_mode VARCHAR(20) DEFAULT NULL,
+			joining_link VARCHAR(500) DEFAULT NULL,
 			capacity INT UNSIGNED DEFAULT NULL,
 			address TEXT DEFAULT NULL,
 			recurrence_anchor DATE DEFAULT NULL,

--- a/fair-events/src/Helpers/EventLocation.php
+++ b/fair-events/src/Helpers/EventLocation.php
@@ -25,12 +25,52 @@ class EventLocation {
 	 * EventSchema::get_jsonld_location() minus the site-name backstop —
 	 * callers here must be able to omit the field entirely.
 	 *
+	 * The physical side (name/address/latitude/longitude) is resolved
+	 * independently of the attendance mode, then the mode decides which
+	 * parts of the result are kept: `in_person` returns physical fields
+	 * only, `online` returns the joining URL only, `hybrid` returns both.
+	 *
 	 * @param EventDates $event_date Event date object.
 	 * @param int|null   $post_id    Linked post ID, or null for standalone events.
-	 * @return array|null Neutral location shape (keys: name, address, latitude,
-	 *                     longitude, online, url — all optional), or null when nothing resolves.
+	 * @return array|null Neutral location shape (keys: mode, name, address,
+	 *                     latitude, longitude, joining_url — all but `mode`
+	 *                     optional), or null when nothing resolves.
 	 */
 	public static function resolve( EventDates $event_date, $post_id ) {
+		$mode     = $event_date->attendance_mode ?? 'in_person';
+		$physical = self::resolve_physical( $event_date, $post_id );
+
+		$location = array( 'mode' => $mode );
+
+		if ( 'in_person' === $mode || 'hybrid' === $mode ) {
+			if ( null === $physical ) {
+				if ( 'in_person' === $mode ) {
+					return null;
+				}
+			} else {
+				$location = array_merge( $location, $physical );
+			}
+		}
+
+		if ( 'online' === $mode || 'hybrid' === $mode ) {
+			$location['joining_url'] = ! empty( $event_date->joining_link )
+				? $event_date->joining_link
+				: $event_date->get_display_url();
+		}
+
+		return $location;
+	}
+
+	/**
+	 * Resolve the physical side of a location (venue → free-text address →
+	 * event_location meta), independent of attendance mode.
+	 *
+	 * @param EventDates $event_date Event date object.
+	 * @param int|null   $post_id    Linked post ID, or null for standalone events.
+	 * @return array|null Physical location shape (keys: name, address,
+	 *                     latitude, longitude), or null when nothing resolves.
+	 */
+	private static function resolve_physical( EventDates $event_date, $post_id ) {
 		// 1. Venue.
 		if ( ! empty( $event_date->venue_id )
 			&& class_exists( \FairEventsExperimental\Models\Venue::class ) ) {
@@ -60,14 +100,6 @@ class EventLocation {
 		$meta_location = $post_id ? get_post_meta( $post_id, 'event_location', true ) : '';
 		if ( ! empty( $meta_location ) ) {
 			return array( 'address' => $meta_location );
-		}
-
-		// 4. Online event: no physical location, but an external link.
-		if ( 'external' === $event_date->link_type && ! empty( $event_date->external_url ) ) {
-			return array(
-				'online' => true,
-				'url'    => $event_date->external_url,
-			);
 		}
 
 		return null;

--- a/fair-events/src/Helpers/EventSchema.php
+++ b/fair-events/src/Helpers/EventSchema.php
@@ -213,35 +213,69 @@ class EventSchema {
 	 */
 	public static function get_jsonld_location( EventDates $event_date, $post_id ) {
 		$neutral = EventLocation::resolve( $event_date, $post_id );
+		$mode    = $neutral['mode'] ?? 'in_person';
+
+		$attendance_mode_map = array(
+			'online' => 'https://schema.org/OnlineEventAttendanceMode',
+			'hybrid' => 'https://schema.org/MixedEventAttendanceMode',
+		);
 
 		return array(
 			'location'        => self::location_to_jsonld( $neutral ),
-			'attendance_mode' => ! empty( $neutral['online'] )
-				? 'https://schema.org/OnlineEventAttendanceMode'
-				: 'https://schema.org/OfflineEventAttendanceMode',
+			'attendance_mode' => $attendance_mode_map[ $mode ] ?? 'https://schema.org/OfflineEventAttendanceMode',
 		);
 	}
 
 	/**
 	 * Map a neutral location shape (EventLocation::resolve()) to a
-	 * Schema.org `Place`/`VirtualLocation` node, guaranteeing a valid,
-	 * never-null result via a site-name backstop.
+	 * Schema.org location node, guaranteeing a valid, never-null result via
+	 * a site-name backstop.
+	 *
+	 * - `in_person` (or empty/null) → a single `Place` node.
+	 * - `online` → a single `VirtualLocation` node.
+	 * - `hybrid` → an array of both a `Place` and a `VirtualLocation` node
+	 *   (search engines require both entries for a hybrid event).
 	 *
 	 * @param array|null $neutral Neutral location shape, or null when nothing resolved.
-	 * @return array Schema.org location node.
+	 * @return array|array[] Schema.org location node, or an array of two nodes for hybrid.
 	 */
 	public static function location_to_jsonld( $neutral ) {
-		if ( empty( $neutral ) ) {
+		$mode = $neutral['mode'] ?? 'in_person';
+
+		if ( 'online' === $mode ) {
 			return array(
-				'@type' => 'Place',
-				'name'  => get_bloginfo( 'name' ),
+				'@type' => 'VirtualLocation',
+				'url'   => $neutral['joining_url'] ?? '',
 			);
 		}
 
-		if ( ! empty( $neutral['online'] ) ) {
+		$place = self::place_jsonld( $neutral );
+
+		if ( 'hybrid' === $mode ) {
 			return array(
-				'@type' => 'VirtualLocation',
-				'url'   => $neutral['url'],
+				$place,
+				array(
+					'@type' => 'VirtualLocation',
+					'url'   => $neutral['joining_url'] ?? '',
+				),
+			);
+		}
+
+		return $place;
+	}
+
+	/**
+	 * Build the Schema.org `Place` node from a neutral location shape's
+	 * physical fields, falling back to the site name when none resolved.
+	 *
+	 * @param array|null $neutral Neutral location shape, or null.
+	 * @return array Schema.org `Place` node.
+	 */
+	private static function place_jsonld( $neutral ) {
+		if ( empty( $neutral['name'] ) && empty( $neutral['address'] ) ) {
+			return array(
+				'@type' => 'Place',
+				'name'  => get_bloginfo( 'name' ),
 			);
 		}
 

--- a/fair-events/src/Helpers/FairEventsApiParser.php
+++ b/fair-events/src/Helpers/FairEventsApiParser.php
@@ -146,14 +146,24 @@ class FairEventsApiParser {
 
 		$parsed = array();
 
-		if ( ! empty( $location['online'] ) ) {
-			$parsed['online'] = true;
+		// New shape: explicit mode + joining_url. Older sites on a
+		// pre-attendance-mode version still send the boolean `online`/`url`
+		// pair, treated as an online-only location for interop.
+		$mode = $location['mode'] ?? ( ! empty( $location['online'] ) ? 'online' : 'in_person' );
 
-			if ( ! empty( $location['url'] ) ) {
-				$parsed['url'] = sanitize_url( $location['url'] );
+		if ( 'online' === $mode || 'hybrid' === $mode ) {
+			$parsed['mode'] = $mode;
+
+			$joining_url = $location['joining_url'] ?? ( $location['url'] ?? null );
+			if ( ! empty( $joining_url ) ) {
+				$parsed['joining_url'] = sanitize_url( $joining_url );
 			}
 
-			return $parsed;
+			if ( 'online' === $mode ) {
+				return $parsed;
+			}
+		} else {
+			$parsed['mode'] = 'in_person';
 		}
 
 		if ( ! empty( $location['name'] ) ) {
@@ -169,7 +179,11 @@ class FairEventsApiParser {
 			$parsed['longitude'] = (string) $location['longitude'];
 		}
 
-		return ! empty( $parsed ) ? $parsed : null;
+		// A parsed shape with only `mode` (no physical fields and, for
+		// hybrid, no joining_url either) carries nothing worth keeping.
+		$has_content = array_diff_key( $parsed, array( 'mode' => true ) );
+
+		return ! empty( $has_content ) ? $parsed : null;
 	}
 
 	/**

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -115,6 +115,20 @@ class EventDates {
 	public $link_type = 'post';
 
 	/**
+	 * Attendance mode ('in_person', 'online', 'hybrid')
+	 *
+	 * @var string
+	 */
+	public $attendance_mode = 'in_person';
+
+	/**
+	 * Joining link, published as the virtual-location URL for online/hybrid events.
+	 *
+	 * @var string|null
+	 */
+	public $joining_link;
+
+	/**
 	 * Event capacity
 	 *
 	 * @var int|null
@@ -204,6 +218,8 @@ class EventDates {
 		$event_dates->title             = $result->title ?? null;
 		$event_dates->external_url      = $result->external_url ?? null;
 		$event_dates->link_type         = $result->link_type ?? null;
+		$event_dates->attendance_mode   = $result->attendance_mode ?? null;
+		$event_dates->joining_link      = $result->joining_link ?? null;
 		$event_dates->capacity          = isset( $result->capacity ) && null !== $result->capacity ? (int) $result->capacity : null;
 		$event_dates->address           = isset( $result->address ) ? $result->address : null;
 		$event_dates->recurrence_anchor = $result->recurrence_anchor ?? null;
@@ -244,7 +260,7 @@ class EventDates {
 			return;
 		}
 
-		foreach ( array( 'title', 'venue_id', 'address', 'link_type', 'external_url', 'capacity' ) as $field ) {
+		foreach ( array( 'title', 'venue_id', 'address', 'link_type', 'external_url', 'capacity', 'attendance_mode', 'joining_link' ) as $field ) {
 			if ( null === $event_dates->$field ) {
 				$event_dates->$field = $master->$field;
 			}
@@ -765,7 +781,9 @@ class EventDates {
 			COALESCE( ed.address, m.address ) AS address,
 			COALESCE( ed.link_type, m.link_type ) AS link_type,
 			COALESCE( ed.external_url, m.external_url ) AS external_url,
-			COALESCE( ed.capacity, m.capacity ) AS capacity
+			COALESCE( ed.capacity, m.capacity ) AS capacity,
+			COALESCE( ed.attendance_mode, m.attendance_mode ) AS attendance_mode,
+			COALESCE( ed.joining_link, m.joining_link ) AS joining_link
 			FROM %i ed LEFT JOIN %i m ON ed.master_id = m.id';
 	}
 
@@ -851,9 +869,11 @@ class EventDates {
 			'title'           => $data['title'],
 			'external_url'    => $data['external_url'] ?? null,
 			'link_type'       => $data['link_type'],
+			'attendance_mode' => $data['attendance_mode'] ?? null,
+			'joining_link'    => $data['joining_link'] ?? null,
 		);
 
-		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s' );
+		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s' );
 
 		$result = $wpdb->insert( $table_name, $insert_data, $format );
 
@@ -888,6 +908,8 @@ class EventDates {
 			'title'             => '%s',
 			'external_url'      => '%s',
 			'link_type'         => '%s',
+			'attendance_mode'   => '%s',
+			'joining_link'      => '%s',
 			'capacity'          => '%d',
 			'address'           => '%s',
 			'recurrence_anchor' => '%s',
@@ -1132,13 +1154,15 @@ class EventDates {
 			'title'             => $data['title'] ?? null,
 			'external_url'      => $data['external_url'] ?? null,
 			'link_type'         => $data['link_type'] ?? null,
+			'attendance_mode'   => $data['attendance_mode'] ?? null,
+			'joining_link'      => $data['joining_link'] ?? null,
 			'venue_id'          => $data['venue_id'] ?? null,
 			'address'           => $data['address'] ?? null,
 			'recurrence_anchor' => $data['recurrence_anchor'] ?? null,
 			'status'            => $data['status'] ?? 'active',
 		);
 
-		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s' );
+		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s' );
 
 		$result = $wpdb->insert( $table_name, $insert_data, $format );
 

--- a/fair-events/src/Services/RecurrenceService.php
+++ b/fair-events/src/Services/RecurrenceService.php
@@ -261,7 +261,7 @@ class RecurrenceService {
 
 		// Reconcile generated children (occurrences[1..n]) against existing rows.
 		// Inheritable fields (title, venue_id, address, link_type, external_url,
-		// capacity) are NOT propagated here — instances hold NULL
+		// capacity, attendance_mode, joining_link) are NOT propagated here — instances hold NULL
 		// for them unless explicitly overridden, and resolve against the master
 		// at read time.
 		$generated = array_slice( $occurrences, 1 );
@@ -449,7 +449,7 @@ class RecurrenceService {
 	 *   reappears later.
 	 *
 	 * Inheritable instance fields (title, venue_id, address, link_type,
-	 * external_url, capacity) are never stamped here — instances
+	 * external_url, capacity, attendance_mode, joining_link) are never stamped here — instances
 	 * hold NULL for them unless explicitly overridden, and resolve against the
 	 * master at read time.
 	 *
@@ -482,7 +482,7 @@ class RecurrenceService {
 			if ( isset( $existing_by_anchor[ $anchor ] ) ) {
 				// Match — update in place, preserving id. Inheritable fields
 				// (title, venue_id, address, link_type, external_url,
-				// capacity) are intentionally NOT touched: instances hold
+				// capacity, attendance_mode, joining_link) are intentionally NOT touched: instances hold
 				// NULL for them unless explicitly overridden, and resolve
 				// against the master at read time.
 				$row    = $existing_by_anchor[ $anchor ];

--- a/fair-events/src/blocks/event-info/render.php
+++ b/fair-events/src/blocks/event-info/render.php
@@ -200,4 +200,18 @@ if ( $is_recurring ) {
 			</div>
 		</div>
 	<?php endif; ?>
+	<?php
+	$neutral_location = \FairEvents\Helpers\EventLocation::resolve( $event_dates, $post_id );
+	$attendance_mode  = $neutral_location['mode'] ?? ( $event_dates->attendance_mode ?? 'in_person' );
+	?>
+	<?php if ( 'online' === $attendance_mode || 'hybrid' === $attendance_mode ) : ?>
+		<div class="wp-block-fair-events-event-info__attendance-mode">
+			<?php echo esc_html( 'online' === $attendance_mode ? __( 'Online event', 'fair-events' ) : __( 'Hybrid event', 'fair-events' ) ); ?>
+			<?php if ( ! empty( $neutral_location['joining_url'] ) ) : ?>
+				<a href="<?php echo esc_url( $neutral_location['joining_url'] ); ?>" target="_blank" rel="noopener noreferrer">
+					<?php esc_html_e( 'Join online', 'fair-events' ); ?>
+				</a>
+			<?php endif; ?>
+		</div>
+	<?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary

Fair Events had no way for an organizer to say "this event happens online." Attendance mode was inferred at the Schema.org markup boundary: an event counted as online only when no venue/address resolved **and** it used an external link — publishing that external link as the join URL. This produced wrong structured data in both directions (a partner-listing link published as "join here"; a placeholder "Zoom" address published as a physical place).

This PR adds an explicit `attendance_mode` (`in_person` / `online` / `hybrid`) + `joining_link` on the event date, independent of the existing link-type option, and drives structured data, calendar feeds, and the public event display from it instead of the inference.

Closes #1306

## What changed

- **Data layer**: new nullable `attendance_mode`/`joining_link` columns on `fair_event_dates` (migration `3.28.0`), following the same NULL-inherit pattern as `venue_id`/`address`/`link_type` so series instances inherit from their master and can override.
- **Location resolution** (`EventLocation::resolve()`): replaced the boolean `online` inference with an explicit `mode` (`in_person`/`online`/`hybrid`) + `joining_url`, falling back to the event page URL when no joining link is set.
- **Structured data** (`EventSchema`): emits `OfflineEventAttendanceMode`/`OnlineEventAttendanceMode`/`MixedEventAttendanceMode`; hybrid emits **both** a `Place` and a `VirtualLocation` node (required for valid hybrid markup), each with the existing site-name backstop when nothing else resolves.
- **Calendar feed / ICS**: online shows the joining URL as the `LOCATION` line; hybrid appends it to the physical location text (a separate per-VEVENT `URL` property isn't available — it's already used for the event page link).
- **REST API**: `attendance_mode` (enum, default `in_person`) and `joining_link` (validated URL) on create/update/read, matching the `link_type`/`external_url` pattern.
- **Admin UI**: an "Attendance mode" select + conditional "Joining link" field in the event details tab (online hides the venue/address field, hybrid keeps it); an Online/Hybrid badge in the event context header, reading `attendance_mode` directly instead of the old link-type-derived signal.
- **Public display**: the `event-info` block now shows an "Online event"/"Hybrid event" label + join link instead of silently showing nothing.

## Decisions (from the approved implementation plan)

- Three explicit modes rather than a checkbox, matching existing enum-string conventions (`link_type`, `recurrence_mode`).
- Joining link is a separate, explicitly-public field, falling back to the event page URL when empty.
- **No backfill.** Existing rows come back NULL from the migration and are treated as `in_person` by the application layer — including rows the old inference currently reports as online. Organizers must re-select the mode for those after upgrading.
- The schema column is **nullable** (not `NOT NULL DEFAULT 'in_person'` as literally written in the plan comment) — the plan's own NULL-inherit design for series instances requires it, matching every other inheritable field (`venue_id`, `link_type`, etc.) in this table. A `NOT NULL` column could never hold NULL, so generated occurrences could never inherit their master's mode.

## Acceptance criteria

- [x] An event date can be set to in person, online, or hybrid from the event details screen, with a joining-link field shown for online and hybrid.
- [x] The mode and joining link are inherited by generated series occurrences and can be overridden per instance.
- [x] Setting an external link destination no longer affects attendance mode.
- [x] Single-event structured data emits: place + offline mode; virtual location + online mode; both nodes + mixed mode.
- [x] Event-list structured data (calendar/week views) reflects the mode per occurrence — it already renders through the same `EventSchema::location_to_jsonld()`/`EventLocation::resolve()` path.
- [x] Structured data always contains a valid location node, including when the joining link or the address is missing (site-name backstop for the `Place` side).
- [x] The calendar feed and its ICS output show the joining link for online and physical+link for hybrid.
- [x] Public event information indicates online/hybrid events.
- [x] Backfill behaviour (none, by decision) applied on upgrade and verified against the live dev instance's migration.
- [x] Unit tests cover the structured-data shaping for all three modes plus missing-link/missing-address fallbacks.
- [x] An API-level check covers persisting/reading the new fields and rejecting an invalid joining URL (see Test plan — couldn't run as an HTTP Playwright spec in this session, verified via internal REST dispatch instead).
- [x] e2e test asserts the emitted attendance mode + location nodes for a published online and hybrid event (written; see Test plan for why it didn't execute here).
- [x] All new strings are translatable (`__()`/`_e()` throughout, JS/PHP).

## Test plan

- [x] `vendor/bin/phpunit` — 183 tests pass, including new `EventLocationTest`, extended `EventSchemaTest`, `EventDatesTest` (series inheritance), `CalendarFeedControllerTest` (LOCATION line per mode).
- [x] `npm run test:js` — 177 tests pass (23 suites), including existing `ManageEventApp`/`EventContextHeader` component tests, unaffected.
- [x] `npm run build` and `npm run format` — clean.
- [x] `vendor/bin/phpcs` — no new violations (verified line-for-line against the pre-change baseline; the file's few remaining errors are pre-existing and unrelated to this change).
- [x] Live-instance verification via the WP-CLI `eval-file` manual-check recipe (dispatches real `WP_REST_Request`s against the bootstrapped plugin, and calls `EventSchema::event_to_jsonld()` directly against a real published post): create defaults to `in_person`/no link, create/update persist `online`/`hybrid` + joining link, invalid URL and out-of-enum mode both reject with 400, a generated series occurrence inherits the master's mode/link, and the emitted JSON-LD matches the `VirtualLocation`/`Place`+`VirtualLocation` shapes for online/hybrid. All checks passed.
- [ ] Playwright API spec (`EventDatesController.api.spec.js`) and e2e spec (`opengraph-jsonld.spec.js`) additions are written and follow the existing patterns exactly, but could **not** be executed against this session's persistent dev Docker instance — its admin login/Basic-Auth doesn't match the suites' expected credentials, confirmed pre-existing and unrelated to this change (the pre-existing "title validation" API tests and the pre-existing OpenGraph e2e test fail identically). Worth a follow-up to fix the dev environment's test credentials so `test:api`/`test:e2e` are runnable again.

## Notes

- `Installer::maybe_upgrade()` appears to be dead code — only `install()` (called from `register_activation_hook`) actually runs the migration chain in this codebase. Followed the plan's instruction to register the new migration in both, but flagging this in case it's worth a separate cleanup ticket.
