### PR TITLE
Fix events-calendar/events-week colors ignored for non-hex values

### DIFF
--- a/.changeset/fix-events-color-oklch.md
+++ b/.changeset/fix-events-color-oklch.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix events-calendar/events-week block colors being silently ignored when the color picker returns a non-hex CSS value (e.g. `oklch(...)`, `rgb(...)`) instead of a preset slug or hex code — such values were wrongly treated as WordPress preset-color slugs, producing invalid CSS that browsers dropped.

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -108,17 +108,20 @@ if ( ! function_exists( 'fair_events_render_subscribe_icon' ) ) {
 /**
  * Convert color value to CSS value
  *
- * Converts either a hex color or a WordPress color preset name to a CSS value.
+ * Converts either a WordPress color preset slug or a literal CSS color to a
+ * CSS value. Preset slugs are always kebab-case identifiers (e.g. 'primary',
+ * 'vivid-green-cyan'), so anything else — hex, rgb()/hsl()/oklch(), etc. — is
+ * passed through as a literal color instead of being mistaken for a slug.
  *
- * @param string $color Color value (hex like '#4caf50' or preset name like 'primary').
+ * @param string $color Color value (preset slug like 'primary' or a literal CSS color).
  * @return string CSS color value.
  */
 if ( ! function_exists( 'fair_events_convert_color_to_css' ) ) {
 	function fair_events_convert_color_to_css( $color ) {
-		if ( preg_match( '/^#[0-9A-Fa-f]{3,6}$/', $color ) ) {
-			return $color;
+		if ( preg_match( '/^[a-z0-9]+(-[a-z0-9]+)*$/', $color ) ) {
+			return 'var(--wp--preset--color--' . esc_attr( $color ) . ')';
 		}
-		return 'var(--wp--preset--color--' . esc_attr( $color ) . ')';
+		return $color;
 	}
 }
 

--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -81,6 +81,25 @@ if ( ! function_exists( 'fair_events_offset_week' ) ) {
 	}
 }
 
+if ( ! function_exists( 'fair_events_convert_color_to_css' ) ) {
+	/**
+	 * Convert a block color attribute to a CSS value.
+	 *
+	 * Preset slugs are always kebab-case identifiers (e.g. 'primary'), so
+	 * anything else — hex, rgb()/hsl()/oklch(), etc. — is passed through as a
+	 * literal color instead of being mistaken for a slug.
+	 *
+	 * @param string $color Color value (preset slug like 'primary' or a literal CSS color).
+	 * @return string CSS color value.
+	 */
+	function fair_events_convert_color_to_css( $color ) {
+		if ( preg_match( '/^[a-z0-9]+(-[a-z0-9]+)*$/', $color ) ) {
+			return 'var(--wp--preset--color--' . esc_attr( $color ) . ')';
+		}
+		return $color;
+	}
+}
+
 // Resolve which week to show — URL param takes precedence over current week.
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $url_week_param = isset( $_GET['week_view'] ) ? sanitize_text_field( wp_unslash( $_GET['week_view'] ) ) : '';
@@ -107,21 +126,9 @@ $bg_color        = $attributes['backgroundColor'] ?? 'primary';
 $text_color      = $attributes['textColor'] ?? '#ffffff';
 $header_bg_color = $attributes['headerBackgroundColor'] ?? '#f9f9f9';
 
-if ( preg_match( '/^#[0-9A-Fa-f]{3,6}$/', $bg_color ) ) {
-	$bg_color_value = $bg_color;
-} else {
-	$bg_color_value = 'var(--wp--preset--color--' . esc_attr( $bg_color ) . ')';
-}
-if ( preg_match( '/^#[0-9A-Fa-f]{3,6}$/', $text_color ) ) {
-	$text_color_value = $text_color;
-} else {
-	$text_color_value = 'var(--wp--preset--color--' . esc_attr( $text_color ) . ')';
-}
-if ( preg_match( '/^#[0-9A-Fa-f]{3,6}$/', $header_bg_color ) ) {
-	$header_bg_value = $header_bg_color;
-} else {
-	$header_bg_value = 'var(--wp--preset--color--' . esc_attr( $header_bg_color ) . ')';
-}
+$bg_color_value   = fair_events_convert_color_to_css( $bg_color );
+$text_color_value = fair_events_convert_color_to_css( $text_color );
+$header_bg_value  = fair_events_convert_color_to_css( $header_bg_color );
 
 // Week date range.
 $boundaries = fair_events_get_week_boundaries( $year, $week, $start_of_week );


### PR DESCRIPTION
## Summary
- `fair_events_convert_color_to_css()` (used by both events-calendar and events-week) only recognized `#rrggbb` hex as a literal color value; any other value — e.g. `oklch(78% 0.14 150)` from a color picker — was treated as a WordPress preset-color slug and wrapped in `var(--wp--preset--color--oklch(78% 0.14 150))`, which is invalid CSS and gets silently dropped by the browser.
- Result: any custom "Event Background"/"Event Text"/"Header Background" color that wasn't a plain hex code was silently ignored, falling back to the hardcoded defaults, in both the editor preview and the frontend.
- Fixed by detecting preset slugs by their kebab-case shape (`primary`, `vivid-green-cyan`, …) instead of assuming "anything non-hex is a slug" — everything else now passes through as a literal CSS color (hex, `rgb()`, `hsl()`, `oklch()`, etc.).
- Also de-duplicated events-week's three inline copies of this logic into a shared guarded helper, matching the pattern events-calendar already used.

## Test plan
- [x] Rebuilt `fair-events` and rendered a real page via WP-CLI/docker with `backgroundColor`/`textColor`/`headerBackgroundColor` set to `oklch(...)` values (the exact values from the reported bug) — confirmed the inline `--event-bg-color`/`--event-text-color`/`--fair-events-header-bg` styles now come through as the literal `oklch()` value instead of broken `var()` syntax.
- [x] Verified default values (`primary` slug, `#f9f9f9` hex) still resolve correctly — no regression.
- [x] `vendor/bin/phpcs` on both changed files: identical warning count before/after (no new issues introduced).
- [x] Added a changeset (`fix-events-color-oklch.md`).