### PR TITLE
Resolve ticket type name for signups table and CSV export

### DIFF
--- a/.changeset/signup-list-ticket-type-name.md
+++ b/.changeset/signup-list-ticket-type-name.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Show the ticket type name instead of its raw numeric ID in the Manage Event page's signups table and CSV export. A signup whose ticket type is missing or was later deleted now shows "—" instead of an ID or a blank field.

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -943,6 +943,35 @@ class GetTicketsController extends WP_REST_Controller {
 	public function get_items( $request ) {
 		$event_date_id = $request->get_param( 'event_date' );
 		$signups       = \FairEvents\Models\EventSignup::get_all_by_event_date_id( $event_date_id );
+
+		$ticket_type_names = array();
+		if ( class_exists( \FairEvents\Models\TicketType::class ) ) {
+			$ticket_types = \FairEvents\Models\TicketType::get_all_by_event_date_id( $event_date_id );
+
+			// A 'whole_series'/'multiple_instances' ticket type is configured
+			// on the series master, not the occurrence a signup was made
+			// against (see create_signup()'s $config_event_date_id pivot
+			// above) — pull those in too so a child-occurrence signup still
+			// resolves the name instead of falling back to null.
+			$master_event_date_id = $this->resolve_master_event_date_id( $event_date_id );
+			if ( $master_event_date_id && (int) $master_event_date_id !== (int) $event_date_id ) {
+				$ticket_types = array_merge(
+					$ticket_types,
+					\FairEvents\Models\TicketType::get_all_by_event_date_id( $master_event_date_id )
+				);
+			}
+
+			foreach ( $ticket_types as $ticket_type ) {
+				$ticket_type_names[ (int) $ticket_type->id ] = $ticket_type->name;
+			}
+		}
+
+		foreach ( $signups as $signup ) {
+			$signup->ticket_type_name = $signup->ticket_type_id && isset( $ticket_type_names[ (int) $signup->ticket_type_id ] )
+				? $ticket_type_names[ (int) $signup->ticket_type_id ]
+				: null;
+		}
+
 		return rest_ensure_response( $signups );
 	}
 

--- a/fair-events/src/API/__tests__/GetTicketsSignupsList.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsSignupsList.api.spec.js
@@ -1,0 +1,152 @@
+/**
+ * Playwright API tests for the get-tickets admin signups list (#1346):
+ * GetTicketsController::get_items() must embed a resolved ticket_type_name
+ * on each signup row, so the admin signups table/CSV export can show the
+ * name instead of a meaningless numeric ID.
+ *
+ * Covers:
+ *   - a signup with a valid ticket type gets its name attached.
+ *   - a signup whose ticket type has since been deleted gets ticket_type_name
+ *     null instead of an error or the stale ID.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('GetTicketsController — admin signups list ticket_type_name', () => {
+	let api;
+	let eventPostId;
+	let eventDateId;
+	let ticketTypeId;
+	let signupEmail;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Get-tickets signups list test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Get-tickets signups list test ${Date.now()}`,
+				link_type: 'post',
+				start_datetime: '2035-06-01 10:00:00',
+				end_datetime: '2035-06-01 12:00:00',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		eventDateId = (await edRes.json()).id;
+
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{ headers: adminHeaders, data: { event_id: eventPostId } }
+		);
+		expect(linkRes.ok()).toBeTruthy();
+
+		const ticketsRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'General Admission',
+							capacity: null,
+							minimum_activities: 0,
+							disable_at: null,
+							recurrence_scope: 'single_instance',
+							group_ids: [],
+						},
+					],
+					sale_periods: [],
+					prices: [],
+					settings: {},
+				},
+			}
+		);
+		expect(ticketsRes.ok()).toBeTruthy();
+		const ticketsBody = await ticketsRes.json();
+		ticketTypeId = ticketsBody.ticket_types?.[0]?.id;
+		expect(ticketTypeId).toBeTruthy();
+
+		signupEmail = `signups-list-${Date.now()}@example.test`;
+		const signupRes = await api.post(
+			'/wp-json/fair-events/v1/get-tickets',
+			{
+				data: {
+					event_date_id: eventDateId,
+					name: 'Signups List Tester',
+					email: signupEmail,
+					ticket_type_id: ticketTypeId,
+					quantity: 1,
+				},
+			}
+		);
+		expect(signupRes.ok()).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (eventPostId) {
+			await api.delete(
+				`/wp-json/wp/v2/fair_event/${eventPostId}?force=true`,
+				{ headers: adminHeaders }
+			);
+		}
+		await api.dispose();
+	});
+
+	test('a signup with a valid ticket type gets ticket_type_name resolved', async () => {
+		const res = await api.get('/wp-json/fair-events/v1/get-tickets', {
+			headers: adminHeaders,
+			params: { event_date: eventDateId },
+		});
+		expect(res.ok()).toBeTruthy();
+		const signups = await res.json();
+		const signup = signups.find((s) => s.email === signupEmail);
+		expect(signup).toBeTruthy();
+		expect(signup.ticket_type_name).toBe('General Admission');
+	});
+
+	test('a signup referencing a deleted ticket type gets ticket_type_name null', async () => {
+		const deleteRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [],
+					sale_periods: [],
+					prices: [],
+					settings: {},
+				},
+			}
+		);
+		expect(deleteRes.ok()).toBeTruthy();
+
+		const res = await api.get('/wp-json/fair-events/v1/get-tickets', {
+			headers: adminHeaders,
+			params: { event_date: eventDateId },
+		});
+		expect(res.ok()).toBeTruthy();
+		const signups = await res.json();
+		const signup = signups.find((s) => s.email === signupEmail);
+		expect(signup).toBeTruthy();
+		expect(signup.ticket_type_name).toBeNull();
+	});
+});

--- a/fair-events/src/Admin/manage-event/EventSignups.js
+++ b/fair-events/src/Admin/manage-event/EventSignups.js
@@ -59,7 +59,7 @@ function buildSignupsCsv(rows) {
 		const row = [
 			s.email,
 			s.name,
-			s.ticket_type_id || '',
+			s.ticket_type_name || '—',
 			s.quantity,
 			s.amount,
 			s.status,
@@ -220,7 +220,7 @@ export default function EventSignups({ eventDateId }) {
 											borderBottom: '1px solid #eee',
 										}}
 									>
-										{s.ticket_type_id || '—'}
+										{s.ticket_type_name || '—'}
 									</td>
 									<td
 										style={{

--- a/fair-events/src/Admin/manage-event/__tests__/EventSignups.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventSignups.test.jsx
@@ -22,7 +22,8 @@ const signups = [
 		id: 1,
 		name: 'Ada Lovelace',
 		email: 'ada@example.com',
-		ticket_type_id: 'General',
+		ticket_type_id: 3,
+		ticket_type_name: 'General',
 		quantity: 1,
 		amount: '20.00',
 		status: 'paid',
@@ -33,7 +34,8 @@ const signups = [
 		id: 2,
 		name: 'Bob, Jr.',
 		email: 'bob@example.com',
-		ticket_type_id: 'General',
+		ticket_type_id: 3,
+		ticket_type_name: 'General',
 		quantity: 2,
 		amount: '40.00',
 		status: 'paid',
@@ -41,6 +43,19 @@ const signups = [
 		created_at: '2026-07-21 10:00:00',
 	},
 ];
+
+const signupWithMissingTicketType = {
+	id: 3,
+	name: 'Carol Danvers',
+	email: 'carol@example.com',
+	ticket_type_id: 99,
+	ticket_type_name: null,
+	quantity: 1,
+	amount: '0.00',
+	status: 'confirmed',
+	mailing_opt_in: false,
+	created_at: '2026-07-22 10:00:00',
+};
 
 function mockObjectUrlAndClick() {
 	let clickedFilename = null;
@@ -151,6 +166,27 @@ describe('EventSignups — CSV export (#1171)', () => {
 		const button = screen.getByRole('button', { name: 'Download CSV' });
 		expect(button).toBeDisabled();
 		expect(screen.getByText('No signups yet.')).toBeInTheDocument();
+	});
+
+	it('shows the ticket type name, not its id, in the table and the CSV', async () => {
+		await renderSignups();
+		expect(screen.getAllByText('General')).toHaveLength(2);
+		expect(screen.queryByText('3')).not.toBeInTheDocument();
+
+		const mock = mockObjectUrlAndClick();
+		fireEvent.click(screen.getByRole('button', { name: 'Download CSV' }));
+		expect(mock.getText()).toContain(',General,');
+		mock.restore();
+	});
+
+	it('falls back to an em dash when the ticket type is missing or deleted', async () => {
+		await renderSignups([signupWithMissingTicketType]);
+		expect(screen.getByText('—')).toBeInTheDocument();
+
+		const mock = mockObjectUrlAndClick();
+		fireEvent.click(screen.getByRole('button', { name: 'Download CSV' }));
+		expect(mock.getText()).toContain(',—,');
+		mock.restore();
 	});
 
 	it('disables the button when the mailing filter matches nothing', async () => {


### PR DESCRIPTION
## Summary

- The Manage Event signups tab and its CSV export showed the raw `ticket_type_id` instead of the ticket type's name.
- `GetTicketsController::get_items()` now embeds a resolved `ticket_type_name` on each signup row (also checking the series master's ticket types, since a `whole_series`/`multiple_instances` type is configured there, not on the occurrence a signup was made against), keeping the raw `ticket_type_id` field.
- `EventSignups.js` now renders `ticket_type_name` (falling back to `—`) in both the on-screen table and the CSV export.

Closes #1346

## Acceptance criteria

- [x] CSV export's ticket type column shows the ticket type name, not the ID
- [x] On-screen signups table shows the ticket type name, not the ID
- [x] Signups with a missing/deleted ticket type show a fallback value (`—`), not a raw ID or error
- [x] Tests cover ticket type name resolution for the signups view — JS component test fixture fixed (it had used a string in place of a numeric ID, masking the bug) plus a new null-name case; new `GetTicketsSignupsList.api.spec.js` API test covers a valid ticket type and a deleted one

## Notes

- Also merges in ticket types configured on the series master when resolving names for a child-occurrence signup — the create-signup validation already allows a master-owned ticket type for an occurrence purchase (see `resolve_master_event_date_id()`), so the name lookup needed to match or a valid, non-deleted whole-series ticket type would incorrectly show the "—" fallback. Verified manually end-to-end against a recurring series.

## Test plan

- [x] `npm run test:js` (fair-events) — 23 suites / 179 tests pass
- [x] `npm run build` (fair-events)
- [x] `npm run format` (fair-events) — no stray diffs
- [x] New `GetTicketsSignupsList.api.spec.js` run against the local docker stack — both tests pass
- [x] Manually verified the master-pivot case (whole-series ticket type resolved for a child-occurrence signup) via direct REST calls against the dev stack
