### PR TITLE
Extract event details from URL answers in Fair Form

### DIFF
--- a/.changeset/url-question-event-detail-extraction.md
+++ b/.changeset/url-question-event-detail-extraction.md
@@ -1,0 +1,5 @@
+---
+"fair-form": minor
+---
+
+Add an opt-in "read event details from the linked page" setting to the URL question, off by default. When enabled, the submitted address is fetched server-side at submission time and any structured event data it publishes (schema.org markup, falling back to social-sharing metadata or the page title) is captured and shown beneath the link in the form-answers and submission-detail admin views, marked as read from the page. Extraction never blocks submission — an unreachable page, a non-HTML response, or a page with no usable data still stores the plain address.

--- a/e2e/mu-plugins/scripts/seed-fair-form-url-extraction-page.php
+++ b/e2e/mu-plugins/scripts/seed-fair-form-url-extraction-page.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Seed a published page carrying a Fair Form block with an email question
+ * (for rate-limit/participant keying) and a URL question opted into "read
+ * event details from the linked page" (#1327).
+ *
+ * Mirrors seed-fair-form-questions-page.php's shape (a real Fair Form block
+ * the spec fills and submits through the browser), scoped to the one
+ * question type this suite needs.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-fair-form-url-extraction-page.php
+ *
+ * Prints a single `E2E_FAIR_FORM_URL_EXTRACTION_PAGE:{json}` line with the
+ * page id, permalink and the seeded question labels.
+ *
+ * Tear down with cleanup-fair-form-notification-page.php <pageId> (generic:
+ * page id -> submissions/answers).
+ *
+ * @package FairFormE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$questions = array(
+	'email'   => 'Your email',
+	'website' => 'Event page',
+);
+
+$content = implode(
+	'',
+	array(
+		'<!-- wp:fair-audience/fair-form -->',
+		'<!-- wp:fair-audience/fair-form-email ' . wp_json_encode(
+			array(
+				'questionKey'  => 'email',
+				'questionText' => $questions['email'],
+			)
+		) . ' /-->',
+		'<!-- wp:fair-audience/fair-form-url ' . wp_json_encode(
+			array(
+				'questionKey'         => 'website',
+				'questionText'        => $questions['website'],
+				'extractEventDetails' => true,
+			)
+		) . ' /-->',
+		'<!-- /wp:fair-audience/fair-form -->',
+	)
+);
+
+$page_id = wp_insert_post(
+	array(
+		'post_type'    => 'page',
+		'post_status'  => 'publish',
+		'post_title'   => 'E2E Fair Form URL Extraction ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ),
+		'post_content' => $content,
+	),
+	true
+);
+
+if ( is_wp_error( $page_id ) ) {
+	WP_CLI::error( 'Failed to create page: ' . $page_id->get_error_message() );
+}
+
+echo 'E2E_FAIR_FORM_URL_EXTRACTION_PAGE:' . wp_json_encode(
+	array(
+		'pageId'    => (int) $page_id,
+		'pageUrl'   => get_permalink( $page_id ),
+		'questions' => $questions,
+	)
+) . "\n";

--- a/e2e/user-flows/fair-form-url-extraction.spec.js
+++ b/e2e/user-flows/fair-form-url-extraction.spec.js
@@ -1,0 +1,175 @@
+/**
+ * E2E: a URL question opted into "read event details from the linked page"
+ * (#1327) fetches the submitted address server-side at submission time and
+ * shows the captured details on the submission-detail admin page, marked as
+ * read from the page rather than typed.
+ *
+ * The target page is https://example.com — a real, always-available address
+ * with no schema.org/OpenGraph markup, so it only yields a `<title>` fallback
+ * ("Example Domain"). That's enough to exercise the full
+ * frontend submit -> server-side fetch -> parse -> storage -> admin detail
+ * pipeline; the parser's schema.org/OpenGraph branches are already covered
+ * hermetically by fair-events/__tests__/Shared/PageMetadataParserTest.php.
+ */
+
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin, runScript, wpCli } from '../support/wp-cli.js';
+
+const DETAIL_PAGE = '/wp-admin/admin.php?page=fair-form-submission-detail';
+
+test.describe('Fair Form url question — read event details from the linked page', () => {
+	// The submit endpoint rate-limits 3 requests/hour, keyed on email.
+	test.beforeEach(() => {
+		wpCli('transient delete --all');
+	});
+
+	test('captures and displays details from a reachable page', async ({
+		page,
+	}) => {
+		const submitterEmail = `e2e.url-extract.${Date.now()}@example.test`;
+
+		const seed = runScript(
+			'seed-fair-form-url-extraction-page.php',
+			'E2E_FAIR_FORM_URL_EXTRACTION_PAGE'
+		);
+		let state = { found: false };
+
+		try {
+			await page.goto(seed.pageUrl);
+
+			await page.fill(
+				'[data-question-key="email"] input[type="email"]',
+				submitterEmail
+			);
+			await page.fill(
+				'[data-question-key="website"] input[type="text"]',
+				'https://example.com'
+			);
+
+			await page.click('.fair-form-submit-button');
+			await expect(page.locator('.fair-form-message')).toHaveText(
+				'Thank you for your submission!'
+			);
+
+			state = runScript(
+				'fair-form-submission-state.php',
+				'E2E_FAIR_FORM_SUBMISSION',
+				`${seed.pageId}`
+			);
+			expect(state.found).toBe(true);
+
+			await loginAsAdmin(page);
+			await page.goto(
+				`${DETAIL_PAGE}&submission_id=${state.submissionId}`
+			);
+
+			const answers = page.locator(
+				'.fair-form-submission-detail__answers-table'
+			);
+			await expect(
+				answers.getByText('https://example.com')
+			).toBeVisible();
+			await expect(
+				answers.getByText('Read from the linked page:')
+			).toBeVisible();
+			await expect(answers.getByText('Example Domain')).toBeVisible();
+		} finally {
+			if (!state.found) {
+				state = runScript(
+					'fair-form-submission-state.php',
+					'E2E_FAIR_FORM_SUBMISSION',
+					`${seed.pageId}`
+				);
+			}
+
+			runScript(
+				'cleanup-fair-form-notification-page.php',
+				'E2E_FAIR_FORM_NOTIFICATION_CLEANUP',
+				`${seed.pageId}`
+			);
+
+			if (state.participantId) {
+				runScript(
+					'cleanup-participant.php',
+					'E2E_PARTICIPANT_CLEANUP',
+					`${state.participantId}`
+				);
+			}
+		}
+	});
+
+	test('omits the "read from linked page" section when the toggle is off', async ({
+		page,
+	}) => {
+		const submitterEmail = `e2e.url-extract-off.${Date.now()}@example.test`;
+
+		// Reuse the standard (non-extraction) questions page — its url question
+		// has extractEventDetails left at its off-by-default value.
+		const seed = runScript(
+			'seed-fair-form-questions-page.php',
+			'E2E_FAIR_FORM_QUESTIONS_PAGE',
+			'e2e-url-extract-off e2e-url-extract-off'
+		);
+		let state = { found: false };
+
+		try {
+			await page.goto(seed.pageUrl);
+
+			await page.fill(
+				'[data-question-key="full_name"] input[type="text"]',
+				'No Extraction'
+			);
+			await page.fill(
+				'[data-question-key="email"] input[type="email"]',
+				submitterEmail
+			);
+			await page.selectOption(
+				'[data-question-key="how_heard"] select',
+				'A friend'
+			);
+
+			await page.click('.fair-form-submit-button');
+			await expect(page.locator('.fair-form-message')).toHaveText(
+				'Thank you for your submission!'
+			);
+
+			state = runScript(
+				'fair-form-submission-state.php',
+				'E2E_FAIR_FORM_SUBMISSION',
+				`${seed.pageId}`
+			);
+			expect(state.found).toBe(true);
+
+			await loginAsAdmin(page);
+			await page.goto(
+				`${DETAIL_PAGE}&submission_id=${state.submissionId}`
+			);
+
+			await expect(
+				page.locator('.fair-form-submission-detail__event-details')
+			).toHaveCount(0);
+		} finally {
+			if (!state.found) {
+				state = runScript(
+					'fair-form-submission-state.php',
+					'E2E_FAIR_FORM_SUBMISSION',
+					`${seed.pageId}`
+				);
+			}
+
+			runScript(
+				'cleanup-fair-form-notification-page.php',
+				'E2E_FAIR_FORM_NOTIFICATION_CLEANUP',
+				`${seed.pageId}`
+			);
+
+			if (state.participantId) {
+				runScript(
+					'cleanup-participant.php',
+					'E2E_PARTICIPANT_CLEANUP',
+					`${state.participantId}`
+				);
+			}
+		}
+	});
+});

--- a/fair-events-shared/php/composer.json
+++ b/fair-events-shared/php/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "fair-events/shared",
 	"description": "Shared PHP utilities for Fair Event plugins",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"type": "library",
 	"license": "GPL-3.0-or-later",
 	"autoload": {

--- a/fair-events-shared/php/src/Helpers/PageMetadataParser.php
+++ b/fair-events-shared/php/src/Helpers/PageMetadataParser.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Page Metadata Parser Helper for Fair Events
+ * Page Metadata Parser Helper for Fair Event Plugins
  *
  * Extracts event-ish metadata from an arbitrary HTML page: schema.org Event
  * (JSON-LD) first, falling back field-by-field to Open Graph, then <title>.
  *
- * @package FairEvents
+ * @package FairEventsShared
  */
 
-namespace FairEvents\Helpers;
+namespace FairEventsShared\Helpers;
 
 defined( 'WPINC' ) || die;
 
@@ -220,7 +220,7 @@ class PageMetadataParser {
 			);
 		}
 
-		$local = DateHelper::iso8601_to_local( $value );
+		$local = self::iso8601_to_local( $value );
 
 		if ( ! $local ) {
 			return null;
@@ -230,6 +230,24 @@ class PageMetadataParser {
 			'datetime' => $local,
 			'all_day'  => false,
 		);
+	}
+
+	/**
+	 * Convert an ISO 8601 date/datetime string to site-local 'Y-m-d H:i:s'.
+	 *
+	 * @param string $iso8601 ISO 8601 date/datetime string.
+	 * @return string|null Site-local 'Y-m-d H:i:s', or null if unparsable.
+	 */
+	private static function iso8601_to_local( $iso8601 ) {
+		try {
+			$dt = new \DateTime( $iso8601 );
+		} catch ( \Exception $e ) {
+			return null;
+		}
+
+		$dt->setTimezone( wp_timezone() );
+
+		return $dt->format( 'Y-m-d H:i:s' );
 	}
 
 	/**

--- a/fair-events-shared/php/src/Helpers/SafeUrlFetcher.php
+++ b/fair-events-shared/php/src/Helpers/SafeUrlFetcher.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Safe outbound HTTP fetch helper for Fair Event Plugins
+ *
+ * @package FairEventsShared
+ */
+
+namespace FairEventsShared\Helpers;
+
+defined( 'WPINC' ) || die;
+
+use WP_Error;
+
+/**
+ * Wraps wp_safe_remote_get() with the fetch/validation rules used to safely
+ * read a user-supplied page server-side: short timeout, capped redirects and
+ * response size, HTML-only, and rejection of private/internal targets via
+ * wp_safe_remote_get()'s own reject_unsafe_urls behaviour.
+ */
+class SafeUrlFetcher {
+
+	/**
+	 * Fetch the given URL and return its HTML body.
+	 *
+	 * @param string $url URL to fetch. Caller is responsible for validating
+	 *                    the scheme is http(s) before calling this.
+	 * @return string|WP_Error HTML body on success, WP_Error otherwise.
+	 */
+	public static function fetch( $url ) {
+		// wp_safe_remote_get() rejects redirects/targets that resolve to
+		// private/internal addresses (reject_unsafe_urls), unlike wp_remote_get().
+		$response = wp_safe_remote_get(
+			$url,
+			array(
+				'timeout'             => 5,
+				'redirection'         => 3,
+				'limit_response_size' => 2 * MB_IN_BYTES,
+				'headers'             => array(
+					'Accept' => 'text/html',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'rest_lookup_unreachable',
+				__( 'Could not reach that page.' ),
+				array( 'status' => 502 )
+			);
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( $status < 200 || $status >= 300 ) {
+			return new WP_Error(
+				'rest_lookup_bad_status',
+				__( 'That page could not be fetched.' ),
+				array( 'status' => 502 )
+			);
+		}
+
+		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+
+		if ( $content_type && false === stripos( $content_type, 'html' ) ) {
+			return new WP_Error(
+				'rest_lookup_not_html',
+				__( 'That URL did not return a web page.' ),
+				array( 'status' => 415 )
+			);
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+
+		if ( empty( $body ) ) {
+			return new WP_Error(
+				'rest_lookup_empty',
+				__( 'That page had no content to read.' ),
+				array( 'status' => 422 )
+			);
+		}
+
+		return $body;
+	}
+}

--- a/fair-events-shared/src/__tests__/questionnaire.test.js
+++ b/fair-events-shared/src/__tests__/questionnaire.test.js
@@ -533,17 +533,35 @@ describe('phone question type', () => {
 /**
  * Build a URL question as fair-form-url/render.php emits it.
  *
- * @param {string} value Field value.
+ * @param {string}  value               Field value.
+ * @param {boolean} extractEventDetails Whether `data-extract-event-details` is set.
  * @return {string} The question markup.
  */
-function urlQuestion(value) {
+function urlQuestion(value, extractEventDetails = false) {
 	return (
-		'<div data-fair-form-question data-question-key="website" data-question-text="Website" data-question-type="url" data-required="0">' +
-		`<input type="text" inputmode="url" value="${value}" /></div>`
+		`<div data-fair-form-question data-question-key="website" data-question-text="Website" data-question-type="url" data-required="0" data-extract-event-details="${
+			extractEventDetails ? '1' : '0'
+		}">` + `<input type="text" inputmode="url" value="${value}" /></div>`
 	);
 }
 
 describe('url question type', () => {
+	describe('collectQuestionAnswers', () => {
+		it('adds extract_event_details: true when the toggle is on', () => {
+			const form = buildForm(urlQuestion('https://example.com', true));
+			const answers = collectQuestionAnswers(form);
+			expect(answers).toHaveLength(1);
+			expect(answers[0].extract_event_details).toBe(true);
+		});
+
+		it('omits extract_event_details when the toggle is off', () => {
+			const form = buildForm(urlQuestion('https://example.com', false));
+			const answers = collectQuestionAnswers(form);
+			expect(answers).toHaveLength(1);
+			expect(answers[0]).not.toHaveProperty('extract_event_details');
+		});
+	});
+
 	describe('validateQuestions', () => {
 		it('passes a bare domain (accepted as shorthand for https://)', () => {
 			const form = buildForm(urlQuestion('example.com/my-event'));

--- a/fair-events-shared/src/questionnaire.js
+++ b/fair-events-shared/src/questionnaire.js
@@ -318,13 +318,19 @@ export function collectQuestionAnswers(form) {
 			answerValue = input.value;
 		}
 
-		answers.push({
+		const answer = {
 			question_key: el.dataset.questionKey,
 			question_text: el.dataset.questionText,
 			question_type: questionType,
 			answer_value: answerValue,
 			display_order: index,
-		});
+		};
+
+		if (questionType === 'url' && el.dataset.extractEventDetails === '1') {
+			answer.extract_event_details = true;
+		}
+
+		answers.push(answer);
 	});
 
 	return answers;

--- a/fair-events/__tests__/Shared/PageMetadataParserTest.php
+++ b/fair-events/__tests__/Shared/PageMetadataParserTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Tests for the vendored FairEventsShared\Helpers\PageMetadataParser.
+ *
+ * Lives in fair-events/__tests__/ per TESTING.md — this plugin already has
+ * phpunit.xml, a stub bootstrap, and `npm run test:php` wired into CI, and it
+ * tests exactly the vendored copy that ships in this plugin's build.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEventsShared\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEventsShared\Helpers\PageMetadataParser;
+
+/**
+ * Tests schema.org / OpenGraph / title extraction and the site-local date
+ * conversion, purely against fixture HTML strings (no network).
+ */
+class PageMetadataParserTest extends TestCase {
+
+	/**
+	 * Reset the stubbed site timezone before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$GLOBALS['_fair_test_timezone'] = 'UTC';
+	}
+
+	/**
+	 * A schema.org Event with a full datetime start/end wins over OpenGraph
+	 * and <title>, and dates convert to site-local 'Y-m-d H:i:s'.
+	 *
+	 * @return void
+	 */
+	public function test_parses_schema_event_with_datetime() {
+		$html = '<html><head>
+			<title>Fallback Title</title>
+			<meta property="og:title" content="OG Title">
+			<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "Event",
+				"name": "Community Picnic",
+				"startDate": "2026-09-12T18:00:00+00:00",
+				"endDate": "2026-09-12T20:00:00+00:00",
+				"location": { "@type": "Place", "name": "Central Park" }
+			}
+			</script>
+		</head><body></body></html>';
+
+		$result = PageMetadataParser::parse( $html );
+
+		$this->assertSame( 'Community Picnic', $result['title'] );
+		$this->assertSame( '2026-09-12 18:00:00', $result['start_datetime'] );
+		$this->assertSame( '2026-09-12 20:00:00', $result['end_datetime'] );
+		$this->assertFalse( $result['all_day'] );
+		$this->assertSame( 'Central Park', $result['location'] );
+		$this->assertSame( 'schema', $result['source'] );
+		$this->assertSame( array( 'title', 'start', 'end', 'location' ), $result['found'] );
+	}
+
+	/**
+	 * A date-only schema.org startDate (no time component) is treated as all-day.
+	 *
+	 * @return void
+	 */
+	public function test_date_only_schema_start_is_all_day() {
+		$html = '<script type="application/ld+json">
+			{ "@type": "Event", "name": "All Day Fair", "startDate": "2026-09-12" }
+		</script>';
+
+		$result = PageMetadataParser::parse( $html );
+
+		$this->assertSame( '2026-09-12 00:00:00', $result['start_datetime'] );
+		$this->assertTrue( $result['all_day'] );
+	}
+
+	/**
+	 * With no schema.org markup, Open Graph title is used and marked as the source.
+	 *
+	 * @return void
+	 */
+	public function test_falls_back_to_open_graph_title() {
+		$html = '<html><head>
+			<title>Fallback Title</title>
+			<meta property="og:title" content="OG Only Title">
+		</head></html>';
+
+		$result = PageMetadataParser::parse( $html );
+
+		$this->assertSame( 'OG Only Title', $result['title'] );
+		$this->assertSame( 'opengraph', $result['source'] );
+		$this->assertNull( $result['start_datetime'] );
+		$this->assertSame( array( 'title' ), $result['found'] );
+	}
+
+	/**
+	 * With no schema.org or Open Graph markup, the <title> tag is used.
+	 *
+	 * @return void
+	 */
+	public function test_falls_back_to_title_tag() {
+		$html = '<html><head><title>Just A Title</title></head></html>';
+
+		$result = PageMetadataParser::parse( $html );
+
+		$this->assertSame( 'Just A Title', $result['title'] );
+		$this->assertSame( 'title', $result['source'] );
+	}
+
+	/**
+	 * Malformed JSON-LD is skipped without fataling, still falling through to title.
+	 *
+	 * @return void
+	 */
+	public function test_malformed_json_ld_falls_through() {
+		$html = '<html><head>
+			<title>Recovered Title</title>
+			<script type="application/ld+json">{ not valid json </script>
+		</head></html>';
+
+		$result = PageMetadataParser::parse( $html );
+
+		$this->assertSame( 'Recovered Title', $result['title'] );
+		$this->assertSame( 'title', $result['source'] );
+	}
+
+	/**
+	 * A page with no usable data anywhere yields an entirely empty result.
+	 *
+	 * @return void
+	 */
+	public function test_no_usable_data_yields_empty_result() {
+		$html = '<html><head></head><body><p>Nothing here.</p></body></html>';
+
+		$result = PageMetadataParser::parse( $html );
+
+		$this->assertNull( $result['title'] );
+		$this->assertNull( $result['source'] );
+		$this->assertSame( array(), $result['found'] );
+	}
+}

--- a/fair-events/__tests__/Shared/SafeUrlFetcherTest.php
+++ b/fair-events/__tests__/Shared/SafeUrlFetcherTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Tests for the vendored FairEventsShared\Helpers\SafeUrlFetcher.
+ *
+ * Lives in fair-events/__tests__/ per TESTING.md — this plugin already has
+ * phpunit.xml, a stub bootstrap, and `npm run test:php` wired into CI, and it
+ * tests exactly the vendored copy that ships in this plugin's build.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEventsShared\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEventsShared\Helpers\SafeUrlFetcher;
+use WP_Error;
+
+/**
+ * Tests the fetch/validation rules against the bootstrap's wp_remote_get()
+ * stub, seeded per test via $GLOBALS['_fair_test_remote_responses'].
+ */
+class SafeUrlFetcherTest extends TestCase {
+
+	/**
+	 * Reset the stubbed remote-response registry before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$GLOBALS['_fair_test_remote_responses'] = array();
+	}
+
+	/**
+	 * A successful HTML response returns the raw body.
+	 *
+	 * @return void
+	 */
+	public function test_returns_body_on_success() {
+		$GLOBALS['_fair_test_remote_responses']['https://example.com/event'] = array(
+			'response' => array( 'code' => 200 ),
+			'headers'  => array( 'content-type' => 'text/html; charset=utf-8' ),
+			'body'     => '<html>ok</html>',
+		);
+
+		$result = SafeUrlFetcher::fetch( 'https://example.com/event' );
+
+		$this->assertSame( '<html>ok</html>', $result );
+	}
+
+	/**
+	 * A transport-level failure (e.g. unreachable host, private-IP rejection
+	 * by the real wp_safe_remote_get()) returns a WP_Error, never throws.
+	 *
+	 * @return void
+	 */
+	public function test_transport_error_returns_wp_error() {
+		$GLOBALS['_fair_test_remote_responses']['https://unreachable.example/'] = new WP_Error(
+			'http_request_failed',
+			'Could not resolve host.'
+		);
+
+		$result = SafeUrlFetcher::fetch( 'https://unreachable.example/' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_lookup_unreachable', $result->get_error_code() );
+	}
+
+	/**
+	 * A non-2xx status is rejected.
+	 *
+	 * @return void
+	 */
+	public function test_non_2xx_status_returns_wp_error() {
+		$GLOBALS['_fair_test_remote_responses']['https://example.com/missing'] = array(
+			'response' => array( 'code' => 404 ),
+			'body'     => 'Not found',
+		);
+
+		$result = SafeUrlFetcher::fetch( 'https://example.com/missing' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_lookup_bad_status', $result->get_error_code() );
+	}
+
+	/**
+	 * A non-HTML content type is rejected.
+	 *
+	 * @return void
+	 */
+	public function test_non_html_content_type_returns_wp_error() {
+		$GLOBALS['_fair_test_remote_responses']['https://example.com/data.json'] = array(
+			'response' => array( 'code' => 200 ),
+			'headers'  => array( 'content-type' => 'application/json' ),
+			'body'     => '{"a":1}',
+		);
+
+		$result = SafeUrlFetcher::fetch( 'https://example.com/data.json' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_lookup_not_html', $result->get_error_code() );
+	}
+
+	/**
+	 * An empty body is rejected.
+	 *
+	 * @return void
+	 */
+	public function test_empty_body_returns_wp_error() {
+		$GLOBALS['_fair_test_remote_responses']['https://example.com/blank'] = array(
+			'response' => array( 'code' => 200 ),
+			'headers'  => array( 'content-type' => 'text/html' ),
+			'body'     => '',
+		);
+
+		$result = SafeUrlFetcher::fetch( 'https://example.com/blank' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_lookup_empty', $result->get_error_code() );
+	}
+}

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -29,6 +29,10 @@ if ( ! defined( 'YEAR_IN_SECONDS' ) ) {
 	define( 'YEAR_IN_SECONDS', 365 * DAY_IN_SECONDS );
 }
 
+if ( ! defined( 'MB_IN_BYTES' ) ) {
+	define( 'MB_IN_BYTES', 1048576 );
+}
+
 // Minimal WordPress function stubs so pure settings logic can be unit tested
 // without a full WP bootstrap. Tests seed values via $GLOBALS['_fair_test_options'].
 if ( ! function_exists( 'sanitize_key' ) ) {
@@ -402,6 +406,36 @@ if ( ! function_exists( 'wp_remote_get' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_safe_remote_get' ) ) {
+	/**
+	 * Stub of WordPress wp_safe_remote_get() — delegates to the wp_remote_get()
+	 * stub above (this bootstrap has no notion of "unsafe" URL rejection;
+	 * seed $GLOBALS['_fair_test_remote_responses'][ $url ] with a WP_Error to
+	 * simulate that outcome).
+	 *
+	 * @param string $url  URL to fetch.
+	 * @param array  $args Request args (ignored by this stub).
+	 * @return array|WP_Error Raw response array, or a seeded WP_Error.
+	 */
+	function wp_safe_remote_get( $url, $args = array() ) {
+		return wp_remote_get( $url, $args );
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_header' ) ) {
+	/**
+	 * Stub of WordPress wp_remote_retrieve_header() backed by a response
+	 * array's 'headers' key (a plain associative array in test fixtures).
+	 *
+	 * @param array  $response Raw response array from wp_remote_get().
+	 * @param string $header   Header name to read.
+	 * @return string Header value, or empty string if absent.
+	 */
+	function wp_remote_retrieve_header( $response, $header ) {
+		return isset( $response['headers'][ $header ] ) ? $response['headers'][ $header ] : '';
+	}
+}
+
 if ( ! function_exists( 'is_wp_error' ) ) {
 	/**
 	 * Stub of WordPress is_wp_error() — no WP_Error stub class exists here, so
@@ -592,6 +626,7 @@ if ( ! function_exists( 'wp_mail' ) ) {
 }
 
 require_once __DIR__ . '/wp-class-stubs.php';
+require_once __DIR__ . '/wp-error-stub.php';
 require_once __DIR__ . '/Fair_Test_WPDB.php';
 
 // Global $wpdb double so model calls with a "not found" id (e.g. 0) resolve

--- a/fair-events/__tests__/wp-error-stub.php
+++ b/fair-events/__tests__/wp-error-stub.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Minimal WP_Error stub for PHPUnit, kept in its own file since a PHP file
+ * can only declare one class/interface/trait under phpcs's file-content sniff.
+ *
+ * @package FairEvents
+ */
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	/**
+	 * Minimal stub of WP_Error — enough for code under test to construct one
+	 * and for tests to assert its code/message/status.
+	 */
+	class WP_Error {
+
+		/**
+		 * Error code passed to the constructor.
+		 *
+		 * @var string
+		 */
+		private $code;
+
+		/**
+		 * Error message passed to the constructor.
+		 *
+		 * @var string
+		 */
+		private $message;
+
+		/**
+		 * Error data passed to the constructor.
+		 *
+		 * @var mixed
+		 */
+		private $data;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string $code    Error code.
+		 * @param string $message Error message.
+		 * @param mixed  $data    Optional error data (e.g. array( 'status' => 502 )).
+		 */
+		public function __construct( $code = '', $message = '', $data = null ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		/**
+		 * Get the error code.
+		 *
+		 * @return string
+		 */
+		public function get_error_code() {
+			return $this->code;
+		}
+
+		/**
+		 * Get the error message.
+		 *
+		 * @return string
+		 */
+		public function get_error_message() {
+			return $this->message;
+		}
+
+		/**
+		 * Get the error data.
+		 *
+		 * @return mixed
+		 */
+		public function get_error_data() {
+			return $this->data;
+		}
+	}
+}

--- a/fair-events/composer.lock
+++ b/fair-events/composer.lock
@@ -154,11 +154,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "113286293569fe13947bd9840c030cbfa68baff4"
+                "reference": "fd8e20b0d3fc7bc79506d1cc925a3e9fc044daca"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-events/src/API/EventLookupController.php
+++ b/fair-events/src/API/EventLookupController.php
@@ -9,7 +9,8 @@ namespace FairEvents\API;
 
 defined( 'WPINC' ) || die;
 
-use FairEvents\Helpers\PageMetadataParser;
+use FairEventsShared\Helpers\PageMetadataParser;
+use FairEventsShared\Helpers\SafeUrlFetcher;
 use WP_REST_Controller;
 use WP_REST_Server;
 use WP_REST_Request;
@@ -81,56 +82,10 @@ class EventLookupController extends WP_REST_Controller {
 	public function create_item( $request ) {
 		$url = $request->get_param( 'url' );
 
-		// wp_safe_remote_get() rejects redirects/targets that resolve to
-		// private/internal addresses (reject_unsafe_urls), unlike wp_remote_get().
-		$response = wp_safe_remote_get(
-			$url,
-			array(
-				'timeout'             => 5,
-				'redirection'         => 3,
-				'limit_response_size' => 2 * MB_IN_BYTES,
-				'headers'             => array(
-					'Accept' => 'text/html',
-				),
-			)
-		);
+		$body = SafeUrlFetcher::fetch( $url );
 
-		if ( is_wp_error( $response ) ) {
-			return new WP_Error(
-				'rest_lookup_unreachable',
-				__( 'Could not reach that page.', 'fair-events' ),
-				array( 'status' => 502 )
-			);
-		}
-
-		$status = (int) wp_remote_retrieve_response_code( $response );
-
-		if ( $status < 200 || $status >= 300 ) {
-			return new WP_Error(
-				'rest_lookup_bad_status',
-				__( 'That page could not be fetched.', 'fair-events' ),
-				array( 'status' => 502 )
-			);
-		}
-
-		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
-
-		if ( $content_type && false === stripos( $content_type, 'html' ) ) {
-			return new WP_Error(
-				'rest_lookup_not_html',
-				__( 'That URL did not return a web page.', 'fair-events' ),
-				array( 'status' => 415 )
-			);
-		}
-
-		$body = wp_remote_retrieve_body( $response );
-
-		if ( empty( $body ) ) {
-			return new WP_Error(
-				'rest_lookup_empty',
-				__( 'That page had no content to read.', 'fair-events' ),
-				array( 'status' => 422 )
-			);
+		if ( is_wp_error( $body ) ) {
+			return $body;
 		}
 
 		$metadata = PageMetadataParser::parse( $body );

--- a/fair-form/fair-form.php
+++ b/fair-form/fair-form.php
@@ -100,5 +100,19 @@ function fair_form_maybe_upgrade_db() {
 
 		update_option( 'fair_form_db_version', '0.3.0' );
 	}
+
+	if ( version_compare( $db_version, '0.4.0', '<' ) ) {
+		global $wpdb;
+
+		$answers_table = $wpdb->prefix . 'fair_audience_questionnaire_answers';
+
+		// Add answer_meta for captured details (e.g. url answers' extracted event data).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query(
+			$wpdb->prepare( 'ALTER TABLE %i ADD COLUMN answer_meta LONGTEXT NULL DEFAULT NULL AFTER answer_value', $answers_table )
+		);
+
+		update_option( 'fair_form_db_version', '0.4.0' );
+	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_form_maybe_upgrade_db' );

--- a/fair-form/src/API/FairFormController.php
+++ b/fair-form/src/API/FairFormController.php
@@ -228,6 +228,11 @@ class FairFormController extends WP_REST_Controller {
 		}
 		$questionnaire_answers = $file_result;
 
+		// Fetch linked pages for url answers opted into extraction and capture
+		// any event details they publish. Never blocks submission — see
+		// process_url_extractions() docblock.
+		$questionnaire_answers = $this->questionnaire_service->process_url_extractions( $questionnaire_answers );
+
 		// Save questionnaire answers (participant_id may be null for anonymous submissions).
 		$submission_id = $this->questionnaire_service->save_answers(
 			$participant_id,

--- a/fair-form/src/API/QuestionnaireResponsesController.php
+++ b/fair-form/src/API/QuestionnaireResponsesController.php
@@ -250,6 +250,10 @@ class QuestionnaireResponsesController extends WP_REST_Controller {
 					}
 				}
 
+				if ( 'url' === $answer->question_type && ! empty( $answer->answer_meta ) ) {
+					$answer_item['event_details'] = json_decode( $answer->answer_meta, true );
+				}
+
 				$answers_data[] = $answer_item;
 			}
 
@@ -469,6 +473,10 @@ class QuestionnaireResponsesController extends WP_REST_Controller {
 					$mime                    = get_post_mime_type( $attachment_id );
 					$answer_item['is_image'] = $mime && 0 === strpos( $mime, 'image/' );
 				}
+			}
+
+			if ( 'url' === $answer->question_type && ! empty( $answer->answer_meta ) ) {
+				$answer_item['event_details'] = json_decode( $answer->answer_meta, true );
 			}
 
 			$answers_data[] = $answer_item;

--- a/fair-form/src/API/__tests__/FairFormUrlExtraction.api.spec.js
+++ b/fair-form/src/API/__tests__/FairFormUrlExtraction.api.spec.js
@@ -1,0 +1,203 @@
+/**
+ * Playwright API tests for the url-question "read event details from the
+ * linked page" opt-in extraction (#1327): `QuestionnaireService::process_url_extractions()`
+ * is a post-sanitize processing step in `FairFormController::create_item()`
+ * that fetches a submitted url answer's address server-side (when the
+ * submission carries `extract_event_details: true` on that answer) and
+ * stores whatever event details it can read on `answer_meta`, surfaced back
+ * as `event_details` by `QuestionnaireResponsesController`.
+ *
+ * Success/failure targets are real, stable external addresses rather than a
+ * dedicated fixture page, mirroring `EventLookupController.api.spec.js`
+ * (which already relies on a live fetch of https://example.com) — this repo's
+ * existing convention for this kind of server-side-fetch integration test:
+ *   - https://example.com has only a `<title>` (no schema.org/OpenGraph), so
+ *     it exercises the full fetch → parse → persist → API pipeline via the
+ *     title fallback, while the parser's schema.org/OpenGraph branches are
+ *     already covered hermetically by
+ *     fair-events/__tests__/Shared/PageMetadataParserTest.php.
+ *   - example.test is an RFC 2606 reserved TLD guaranteed to never resolve,
+ *     for the "unreachable" case.
+ *   - 169.254.169.254 (the well-known cloud metadata address) is a private/
+ *     link-local target wp_safe_remote_get() must reject, for the SSRF case.
+ *   - https://api.github.com/zen returns a stable 200 text/plain response,
+ *     for the "non-HTML" case.
+ *
+ * Every case carries its own unique email answer so the FairFormController
+ * rate limiter (3/hour, keyed on email when present) keys per-submission.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}-${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+const emailQuestion = (value) => ({
+	question_key: 'email',
+	question_text: 'Email?',
+	question_type: 'email',
+	answer_value: value,
+	display_order: 0,
+});
+
+const urlQuestion = (value, extractEventDetails) => ({
+	question_key: 'website',
+	question_text: 'Event page?',
+	question_type: 'url',
+	answer_value: value,
+	display_order: 1,
+	...(extractEventDetails !== undefined && {
+		extract_event_details: extractEventDetails,
+	}),
+});
+
+test.describe('FairFormController — url extraction opt-in (#1327)', () => {
+	let api;
+	let fairAudienceActive = false;
+	const postId = Date.now();
+
+	async function findSubmissionByEmail(email) {
+		const res = await api.get(
+			'/wp-json/fair-form/v1/questionnaire-responses',
+			{
+				headers: adminHeaders,
+				params: { post_id: postId, title: 'Fair Form' },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const submissions = await res.json();
+		return submissions.find((s) =>
+			s.answers.some(
+				(a) => a.question_type === 'email' && a.answer_value === email
+			)
+		);
+	}
+
+	async function ensureParticipant(email) {
+		if (!fairAudienceActive) {
+			return;
+		}
+		await api.post('/wp-json/fair-audience/v1/participants', {
+			headers: adminHeaders,
+			data: { name: 'URL Extraction Test', email },
+		});
+	}
+
+	async function submitAndFindUrlAnswer(
+		email,
+		urlValue,
+		extractEventDetails
+	) {
+		await ensureParticipant(email);
+		const res = await api.post('/wp-json/fair-form/v1/fair-form-submit', {
+			data: {
+				post_id: postId,
+				questionnaire_answers: [
+					emailQuestion(email),
+					urlQuestion(urlValue, extractEventDetails),
+				],
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+
+		const submission = await findSubmissionByEmail(email);
+		expect(submission).toBeTruthy();
+		return submission.answers.find((a) => a.question_key === 'website');
+	}
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test('captures details when extract_event_details is true and the page is reachable', async () => {
+		const urlAnswer = await submitAndFindUrlAnswer(
+			uniqueEmail('extract-success'),
+			'https://example.com',
+			true
+		);
+
+		expect(urlAnswer.answer_value).toBe('https://example.com');
+		expect(urlAnswer.event_details).toBeTruthy();
+		expect(urlAnswer.event_details.title).toBeTruthy();
+	});
+
+	test('omits event_details when extract_event_details is false', async () => {
+		const urlAnswer = await submitAndFindUrlAnswer(
+			uniqueEmail('extract-off'),
+			'https://example.com',
+			false
+		);
+
+		expect(urlAnswer.answer_value).toBe('https://example.com');
+		expect(urlAnswer.event_details).toBeUndefined();
+	});
+
+	test('omits event_details when extract_event_details is not sent', async () => {
+		const urlAnswer = await submitAndFindUrlAnswer(
+			uniqueEmail('extract-unset'),
+			'https://example.com',
+			undefined
+		);
+
+		expect(urlAnswer.answer_value).toBe('https://example.com');
+		expect(urlAnswer.event_details).toBeUndefined();
+	});
+
+	test('submission still succeeds with no event_details for an unreachable domain', async () => {
+		const urlAnswer = await submitAndFindUrlAnswer(
+			uniqueEmail('extract-unreachable'),
+			'https://this-should-not-resolve.example.test',
+			true
+		);
+
+		expect(urlAnswer.event_details).toBeUndefined();
+	});
+
+	test('submission still succeeds with no event_details for a private/internal address', async () => {
+		const urlAnswer = await submitAndFindUrlAnswer(
+			uniqueEmail('extract-private-ip'),
+			'http://169.254.169.254/',
+			true
+		);
+
+		expect(urlAnswer.event_details).toBeUndefined();
+	});
+
+	test('submission still succeeds with no event_details for a non-HTML response', async () => {
+		const urlAnswer = await submitAndFindUrlAnswer(
+			uniqueEmail('extract-non-html'),
+			'https://api.github.com/zen',
+			true
+		);
+
+		expect(urlAnswer.event_details).toBeUndefined();
+	});
+});

--- a/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
+++ b/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
@@ -268,13 +268,27 @@ export default function QuestionnaireResponses() {
 						return value || '';
 					}
 					return (
-						<a
-							href={value}
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							{value}
-						</a>
+						<span>
+							<a
+								href={value}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{value}
+							</a>
+							{answer.event_details && (
+								<span
+									className="fair-form-questionnaire-responses__event-details-indicator"
+									title={__(
+										'Event details were read from the linked page.',
+										'fair-form'
+									)}
+								>
+									{' '}
+									★
+								</span>
+							)}
+						</span>
 					);
 				},
 			}),

--- a/fair-form/src/Admin/questionnaire-responses/__tests__/QuestionnaireResponses.test.jsx
+++ b/fair-form/src/Admin/questionnaire-responses/__tests__/QuestionnaireResponses.test.jsx
@@ -172,6 +172,59 @@ describe('QuestionnaireResponses — empty state', () => {
 	});
 });
 
+describe('QuestionnaireResponses — url answer with captured event details', () => {
+	const RESPONSES_WITH_EVENT_DETAILS = [
+		{
+			id: 3,
+			participant_id: 0,
+			participant_name: '',
+			participant_email: '',
+			participant_status: '',
+			participant_mailing: '',
+			participant_categories: [],
+			created_at: '2026-01-17 12:00:00',
+			answers: [
+				{
+					question_key: 'website',
+					question_text: 'Event page',
+					question_type: 'url',
+					answer_value: 'https://example.com/my-event',
+					event_details: {
+						title: 'Community Picnic',
+						source: 'schema',
+					},
+				},
+			],
+		},
+	];
+
+	it('shows an indicator next to the link when details were captured', async () => {
+		mockResponses(RESPONSES_WITH_EVENT_DETAILS);
+
+		render(<QuestionnaireResponses />);
+
+		const link = await screen.findByRole('link', {
+			name: 'https://example.com/my-event',
+		});
+		expect(link).toBeInTheDocument();
+		expect(
+			screen.getByTitle('Event details were read from the linked page.')
+		).toBeInTheDocument();
+	});
+
+	it('shows no indicator when a url answer has no captured details', async () => {
+		mockResponses(STANDALONE_RESPONSES);
+
+		render(<QuestionnaireResponses />);
+
+		await screen.findByText('Google');
+
+		expect(
+			screen.queryByTitle('Event details were read from the linked page.')
+		).not.toBeInTheDocument();
+	});
+});
+
 describe('QuestionnaireResponses — table containment', () => {
 	it('scopes the DataViews table in a scrollable CardBody so a wide table cannot drag the page sideways', async () => {
 		mockResponses(STANDALONE_RESPONSES);

--- a/fair-form/src/Admin/questionnaire-responses/style.css
+++ b/fair-form/src/Admin/questionnaire-responses/style.css
@@ -19,3 +19,8 @@
 	flex-wrap: wrap;
 	margin-bottom: 16px;
 }
+
+.fair-form-questionnaire-responses__event-details-indicator {
+	color: #996800;
+	cursor: help;
+}

--- a/fair-form/src/Admin/submission-detail/SubmissionDetail.js
+++ b/fair-form/src/Admin/submission-detail/SubmissionDetail.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import {
@@ -12,9 +12,41 @@ import {
 } from '@wordpress/components';
 import { submissionToMarkdown } from '../utils/submission-markdown.js';
 import { formatDate } from '../utils/format-date.js';
+import { formatSiteLocalDatetime, formatDateOnly } from 'fair-events-shared';
+
+function EventDetails({ details }) {
+	const { title, start_datetime, end_datetime, all_day, location } = details;
+
+	const formatWhen = (value) =>
+		all_day ? formatDateOnly(value) : formatSiteLocalDatetime(value);
+
+	return (
+		<div className="fair-form-submission-detail__event-details">
+			<span className="fair-form-submission-detail__event-details-label">
+				{__('Read from the linked page:', 'fair-form')}
+			</span>
+			<ul>
+				{title && <li>{title}</li>}
+				{start_datetime && (
+					<li>
+						{end_datetime
+							? sprintf(
+									/* translators: 1: start date/time, 2: end date/time */
+									__('%1$s – %2$s', 'fair-form'),
+									formatWhen(start_datetime),
+									formatWhen(end_datetime)
+							  )
+							: formatWhen(start_datetime)}
+					</li>
+				)}
+				{location && <li>{location}</li>}
+			</ul>
+		</div>
+	);
+}
 
 function AnswerDisplay({ answer }) {
-	const { question_type, answer_value, file_url } = answer;
+	const { question_type, answer_value, file_url, event_details } = answer;
 
 	if (question_type === 'file_upload' && file_url) {
 		return (
@@ -45,9 +77,16 @@ function AnswerDisplay({ answer }) {
 		/^https?:\/\//.test(answer_value)
 	) {
 		return (
-			<a href={answer_value} target="_blank" rel="noopener noreferrer">
-				{answer_value}
-			</a>
+			<div>
+				<a
+					href={answer_value}
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{answer_value}
+				</a>
+				{event_details && <EventDetails details={event_details} />}
+			</div>
 		);
 	}
 

--- a/fair-form/src/Admin/submission-detail/__tests__/SubmissionDetail.test.jsx
+++ b/fair-form/src/Admin/submission-detail/__tests__/SubmissionDetail.test.jsx
@@ -33,6 +33,26 @@ const SUBMISSION = {
 	],
 };
 
+const SUBMISSION_WITH_EVENT_DETAILS = {
+	...SUBMISSION,
+	answers: [
+		{
+			question_key: 'website',
+			question_text: 'Event page',
+			question_type: 'url',
+			answer_value: 'https://example.com/my-event',
+			event_details: {
+				title: 'Community Picnic',
+				start_datetime: '2026-09-12 18:00:00',
+				end_datetime: '2026-09-12 20:00:00',
+				all_day: false,
+				location: 'Central Park',
+				source: 'schema',
+			},
+		},
+	],
+};
+
 beforeEach(() => {
 	window.history.pushState(
 		{},
@@ -62,5 +82,31 @@ describe('SubmissionDetail', () => {
 			screen.getByRole('columnheader', { name: 'Question' })
 		).toBeInTheDocument();
 		expect(screen.getByText('Submitted by')).toBeInTheDocument();
+	});
+
+	it('renders captured event details beneath a url answer, marked as read from the page', async () => {
+		apiFetch.mockResolvedValue(SUBMISSION_WITH_EVENT_DETAILS);
+
+		render(<SubmissionDetail />);
+
+		await screen.findByText('https://example.com/my-event');
+
+		expect(
+			screen.getByText('Read from the linked page:')
+		).toBeInTheDocument();
+		expect(screen.getByText('Community Picnic')).toBeInTheDocument();
+		expect(screen.getByText('Central Park')).toBeInTheDocument();
+	});
+
+	it('renders a url answer with no captured details exactly as before', async () => {
+		const { container } = render(<SubmissionDetail />);
+
+		await screen.findByText('Google');
+
+		expect(
+			container.querySelector(
+				'.fair-form-submission-detail__event-details'
+			)
+		).not.toBeInTheDocument();
 	});
 });

--- a/fair-form/src/Admin/submission-detail/style.scss
+++ b/fair-form/src/Admin/submission-detail/style.scss
@@ -34,6 +34,21 @@
 		gap: 8px;
 	}
 
+	&__event-details {
+		margin-top: 6px;
+		font-size: 13px;
+		color: #50575e;
+
+		&-label {
+			font-style: italic;
+		}
+
+		ul {
+			margin: 2px 0 0 16px;
+			list-style: disc;
+		}
+	}
+
 	.fair-form-submission-detail__info-table th {
 		width: 200px;
 	}

--- a/fair-form/src/Database/Schema.php
+++ b/fair-form/src/Database/Schema.php
@@ -64,6 +64,7 @@ class Schema {
 			question_text VARCHAR(500) NOT NULL,
 			question_type ENUM('radio','checkbox','short_text','long_text','select','number','date','multiselect','file_upload','email','phone','url') NOT NULL DEFAULT 'short_text',
 			answer_value TEXT NOT NULL,
+			answer_meta LONGTEXT NULL DEFAULT NULL,
 			display_order INT DEFAULT 0,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY  (id),

--- a/fair-form/src/Models/QuestionnaireAnswer.php
+++ b/fair-form/src/Models/QuestionnaireAnswer.php
@@ -77,6 +77,13 @@ class QuestionnaireAnswer {
 	public $answer_value;
 
 	/**
+	 * Captured details JSON (e.g. url answers' extracted event data), or null.
+	 *
+	 * @var string|null
+	 */
+	public $answer_meta;
+
+	/**
 	 * Display order within submission.
 	 *
 	 * @var int
@@ -113,6 +120,7 @@ class QuestionnaireAnswer {
 		$this->question_text = isset( $data['question_text'] ) ? $data['question_text'] : '';
 		$this->question_type = isset( $data['question_type'] ) ? $data['question_type'] : 'short_text';
 		$this->answer_value  = isset( $data['answer_value'] ) ? $data['answer_value'] : '';
+		$this->answer_meta   = isset( $data['answer_meta'] ) ? $data['answer_meta'] : null;
 		$this->display_order = isset( $data['display_order'] ) ? (int) $data['display_order'] : 0;
 		$this->created_at    = isset( $data['created_at'] ) ? $data['created_at'] : '';
 	}
@@ -143,10 +151,11 @@ class QuestionnaireAnswer {
 			'question_text' => $this->question_text,
 			'question_type' => $this->question_type,
 			'answer_value'  => $this->answer_value,
+			'answer_meta'   => $this->answer_meta,
 			'display_order' => $this->display_order,
 		);
 
-		$format = array( '%d', '%s', '%s', '%s', '%s', '%d' );
+		$format = array( '%d', '%s', '%s', '%s', '%s', '%s', '%d' );
 
 		if ( $this->id ) {
 			// Update existing.

--- a/fair-form/src/Services/QuestionnaireService.php
+++ b/fair-form/src/Services/QuestionnaireService.php
@@ -15,6 +15,8 @@ namespace FairForm\Services;
 use FairForm\Database\QuestionnaireSubmissionRepository;
 use FairForm\Database\QuestionnaireAnswerRepository;
 use FairForm\Models\QuestionnaireSubmission;
+use FairEventsShared\Helpers\SafeUrlFetcher;
+use FairEventsShared\Helpers\PageMetadataParser;
 use WP_REST_Request;
 use WP_Error;
 
@@ -233,11 +235,12 @@ class QuestionnaireService {
 			}
 
 			$sanitized[] = array(
-				'question_key'  => sanitize_key( $answer['question_key'] ?? '' ),
-				'question_text' => $question_text,
-				'question_type' => $question_type,
-				'answer_value'  => $answer_value,
-				'display_order' => (int) ( $answer['display_order'] ?? 0 ),
+				'question_key'          => sanitize_key( $answer['question_key'] ?? '' ),
+				'question_text'         => $question_text,
+				'question_type'         => $question_type,
+				'answer_value'          => $answer_value,
+				'display_order'         => (int) ( $answer['display_order'] ?? 0 ),
+				'extract_event_details' => ! empty( $answer['extract_event_details'] ),
 			);
 		}
 
@@ -409,6 +412,54 @@ class QuestionnaireService {
 
 			// Store attachment ID as the answer value.
 			$answer['answer_value'] = (string) $attachment_id;
+		}
+
+		return $answers;
+	}
+
+	/**
+	 * For url answers opted into extraction, fetch the linked page server-side
+	 * and store whatever event details it publishes alongside the answer.
+	 *
+	 * Extraction never blocks submission: an unreachable page, a non-HTML
+	 * response, or a page with no usable data simply leaves the answer
+	 * without captured details — this method never returns a WP_Error.
+	 *
+	 * @param array $answers Sanitized questionnaire answers.
+	 * @return array Updated answers array (`extract_event_details` stripped,
+	 *               `answer_meta` set on url answers where extraction found data).
+	 */
+	public function process_url_extractions( $answers ) {
+		foreach ( $answers as &$answer ) {
+			$extract = ! empty( $answer['extract_event_details'] );
+			unset( $answer['extract_event_details'] );
+
+			if ( ! $extract
+				|| 'url' !== ( $answer['question_type'] ?? '' )
+				|| empty( $answer['answer_value'] ) ) {
+				continue;
+			}
+
+			$body = SafeUrlFetcher::fetch( $answer['answer_value'] );
+			if ( is_wp_error( $body ) ) {
+				continue;
+			}
+
+			$metadata = PageMetadataParser::parse( $body );
+			if ( empty( $metadata['found'] ) ) {
+				continue;
+			}
+
+			$captured = array( 'source' => $metadata['source'] );
+			foreach ( $metadata['found'] as $field ) {
+				$key              = 'start' === $field ? 'start_datetime' : ( 'end' === $field ? 'end_datetime' : $field );
+				$captured[ $key ] = $metadata[ $key ];
+			}
+			if ( in_array( 'start', $metadata['found'], true ) ) {
+				$captured['all_day'] = $metadata['all_day'];
+			}
+
+			$answer['answer_meta'] = wp_json_encode( $captured );
 		}
 
 		return $answers;

--- a/fair-form/src/blocks/fair-form-url/__tests__/editor.test.jsx
+++ b/fair-form/src/blocks/fair-form-url/__tests__/editor.test.jsx
@@ -65,6 +65,7 @@ describe('Fair Form URL Question Edit', () => {
 		questionKey: '',
 		required: false,
 		placeholder: '',
+		extractEventDetails: false,
 	};
 
 	const renderEdit = (attributes = {}, setAttributes = () => {}) =>
@@ -117,6 +118,29 @@ describe('Fair Form URL Question Edit', () => {
 		expect(screen.getByLabelText('Required')).toBeInTheDocument();
 		expect(screen.getByLabelText('Placeholder')).toBeInTheDocument();
 		expect(screen.getByLabelText('Question Key')).toBeInTheDocument();
+	});
+
+	it('renders the "Read event details from the linked page" toggle, off by default', () => {
+		renderEdit();
+
+		const toggle = screen.getByLabelText(
+			'Read event details from the linked page'
+		);
+		expect(toggle).toBeInTheDocument();
+		expect(toggle).not.toBeChecked();
+	});
+
+	it('toggles the extractEventDetails attribute', () => {
+		const setAttributes = jest.fn();
+		renderEdit({}, setAttributes);
+
+		fireEvent.click(
+			screen.getByLabelText('Read event details from the linked page')
+		);
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			extractEventDetails: true,
+		});
 	});
 
 	it('toggles the required attribute', () => {

--- a/fair-form/src/blocks/fair-form-url/block.json
+++ b/fair-form/src/blocks/fair-form-url/block.json
@@ -33,6 +33,10 @@
 		"placeholder": {
 			"type": "string",
 			"default": ""
+		},
+		"extractEventDetails": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"editorScript": "file:./editor.js",

--- a/fair-form/src/blocks/fair-form-url/editor.js
+++ b/fair-form/src/blocks/fair-form-url/editor.js
@@ -22,7 +22,13 @@ registerBlockType('fair-audience/fair-form-url', {
 		],
 	},
 	edit: ({ attributes, setAttributes }) => {
-		const { questionText, questionKey, required, placeholder } = attributes;
+		const {
+			questionText,
+			questionKey,
+			required,
+			placeholder,
+			extractEventDetails,
+		} = attributes;
 
 		const onQuestionTextChange = (value) => {
 			const updates = { questionText: value };
@@ -66,6 +72,20 @@ registerBlockType('fair-audience/fair-form-url', {
 							value={placeholder}
 							onChange={(value) =>
 								setAttributes({ placeholder: value })
+							}
+						/>
+						<ToggleControl
+							label={__(
+								'Read event details from the linked page',
+								'fair-audience'
+							)}
+							help={__(
+								'When submitted, the link is fetched and any event details it publishes (title, dates, location) are captured with the answer.',
+								'fair-audience'
+							)}
+							checked={extractEventDetails}
+							onChange={(value) =>
+								setAttributes({ extractEventDetails: value })
 							}
 						/>
 					</PanelBody>

--- a/fair-form/src/blocks/fair-form-url/render.php
+++ b/fair-form/src/blocks/fair-form-url/render.php
@@ -14,10 +14,11 @@
 
 defined( 'WPINC' ) || die;
 
-$question_text = $attributes['questionText'] ?? '';
-$question_key  = $attributes['questionKey'] ?? '';
-$required      = ! empty( $attributes['required'] );
-$placeholder   = $attributes['placeholder'] ?? '';
+$question_text         = $attributes['questionText'] ?? '';
+$question_key          = $attributes['questionKey'] ?? '';
+$required              = ! empty( $attributes['required'] );
+$placeholder           = $attributes['placeholder'] ?? '';
+$extract_event_details = ! empty( $attributes['extractEventDetails'] );
 
 // Skip rendering if no question text is set.
 if ( empty( $question_text ) ) {
@@ -29,12 +30,13 @@ $input_id = 'fair-form-q-' . sanitize_title( $question_key ) . '-' . wp_unique_i
 
 $wrapper_attributes = get_block_wrapper_attributes(
 	array(
-		'class'                   => 'fair-form-question fair-form-question-url',
-		'data-fair-form-question' => '',
-		'data-question-key'       => esc_attr( $question_key ),
-		'data-question-text'      => esc_attr( $question_text ),
-		'data-question-type'      => 'url',
-		'data-required'           => $required ? '1' : '0',
+		'class'                      => 'fair-form-question fair-form-question-url',
+		'data-fair-form-question'    => '',
+		'data-question-key'          => esc_attr( $question_key ),
+		'data-question-text'         => esc_attr( $question_text ),
+		'data-question-type'         => 'url',
+		'data-required'              => $required ? '1' : '0',
+		'data-extract-event-details' => $extract_event_details ? '1' : '0',
 	)
 );
 ?>


### PR DESCRIPTION
## Summary

- A URL question in Fair Form now has an opt-in "Read event details from the linked page" setting, off by default.
- When enabled, the submitted address is fetched server-side at submission time (reusing the existing safe-fetch protections: SSRF rejection, scheme restriction, redirect/size/time caps) and parsed for schema.org event markup, falling back to Open Graph, then the page `<title>`.
- Captured title, start/end, all-day flag, and location are stored with the answer and shown beneath the link in the form-answers and submission-detail admin views, clearly marked as read from the page.
- The fetch/parse logic (`SafeUrlFetcher`, `PageMetadataParser`) moved from `fair-events` into `fair-events-shared`, so `fair-events`' own event-lookup feature and this new Fair Form capability share one hardened implementation.

Closes #1327

## Acceptance criteria

- [x] A URL question has an opt-in "read event details from the linked page" setting, off by default. — `extractEventDetails` block attribute + `ToggleControl` in `fair-form-url/editor.js`.
- [x] With it on, submitting a link to a page publishing structured event markup stores the title, start, end, day-only flag, and location with the answer. — `QuestionnaireService::process_url_extractions()`.
- [x] A page with only social-sharing metadata or a plain title still yields whatever can be read from it. — `PageMetadataParser`'s existing OpenGraph/title fallback chain, unchanged, now shared.
- [x] An unreachable page, a non-HTML response, or a page with no usable data still produces a successful submission with the plain address stored. — `process_url_extractions()` never returns a `WP_Error`; covered by `FairFormUrlExtraction.api.spec.js`.
- [x] Addresses resolving to private/internal hosts and non-`http(s)` schemes are never fetched. — `SafeUrlFetcher::fetch()` uses `wp_safe_remote_get()`'s `reject_unsafe_urls`; scheme is already validated upstream in `sanitize_answers()`. Covered by the private-IP case in the API spec.
- [x] Repeated submissions cannot be used to drive unbounded outbound requests. — extraction runs inside `FairFormController::create_item()`'s existing transient-based rate limiter (3/hour), after the limit check.
- [x] The admin views show captured details under the link, marked as read from the page. — `SubmissionDetail.js`'s `EventDetails` component and the `QuestionnaireResponses.js` table indicator.
- [x] API spec covering the capture path including failure modes and private-address rejection, plus e2e coverage of a submission with the option enabled. — `FairFormUrlExtraction.api.spec.js` (6 cases) and `e2e/user-flows/fair-form-url-extraction.spec.js` (2 cases).

## Notes

- Extraction is wired into `FairFormController::create_item()` only (the standalone Fair Form submit endpoint) — not into `GetTicketsController`'s unified event-signup path, which processes questionnaire answers separately and doesn't share this endpoint's rate limiting. Out of scope per the approved plan; a follow-up ticket could extend it there.
- `fair-events-shared/php` bumped to 0.2.4 for the new `Helpers\SafeUrlFetcher`/`Helpers\PageMetadataParser` classes; `fair-events` and `fair-form` both ran `composer update fair-events/shared`. `fair-events/src/API/EventLookupController.php` was refactored to call the shared classes — behavior-preserving (existing `EventLookupController.api.spec.js` cases pass unchanged).
- New `answer_meta LONGTEXT NULL` column on `fair_audience_questionnaire_answers`, added via `dbDelta()` for fresh installs and a versioned `fair_form_maybe_upgrade_db()` step (`0.4.0`) for existing ones.

## Test plan

- [x] `fair-events` PHPUnit (`vendor/bin/phpunit`) — 194 tests pass, including new `PageMetadataParserTest` and `SafeUrlFetcherTest`.
- [x] `fair-events` `EventLookupController.api.spec.js` — 3/3 pass (refactor is behavior-preserving).
- [x] `fair-form` Jest (`npm run test:js`) — 35 tests pass, including new toggle/rendering coverage.
- [x] `fair-events-shared` Jest — 231 tests pass, including new `collectQuestionAnswers()` coverage.
- [x] `fair-events` / `fair-audience` Jest — unaffected (177 / 27 tests pass), sanity-checked since both consume the changed `collectQuestionAnswers()`.
- [x] `fair-form` API spec (`npm run test:api`) — 28/28 pass, including new `FairFormUrlExtraction.api.spec.js` (6 cases: success, opt-out via `false`/omitted, unreachable domain, private-IP rejection, non-HTML response).
- [x] E2E (`npm run test:e2e`) — new `fair-form-url-extraction.spec.js` (2 cases) plus the existing `fair-form-submission-detail.spec.js` and `unified-signup-url-question.spec.js` pass.
- [x] `vendor/bin/phpcs` clean on all changed PHP files.
