### PR TITLE
fair-events: show occurrence dropdown for a series' last remaining date

### DIFF
--- a/.changeset/fix-single-occurrence-dropdown.md
+++ b/.changeset/fix-single-occurrence-dropdown.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix the Event Signup block's "Choose a date" picker disappearing once a recurring series ages down to its last upcoming occurrence, leaving no confirmation of which date a per-occurrence ticket was signing up for.

--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -21,7 +21,10 @@
  *                        {"price":N} sets the single_instance price). Override
  *                        {"omitMulti":true} to skip the multiple_instances
  *                        type (single_instance + whole_series only), the
- *                        occurrence-picker regression scenario.
+ *                        occurrence-picker regression scenario. Override
+ *                        {"seriesCount":N} to change the number of occurrences
+ *                        (default 3); {"seriesCount":1} seeds a series with
+ *                        exactly one upcoming occurrence.
  *   audience-ticket-scopes  like three-ticket-scopes, but always renders the
  *                        dormant fair-audience/event-signup block regardless
  *                        of any {"block":…} override — for specs proving old
@@ -75,6 +78,7 @@ $price              = isset( $overrides['price'] ) ? (float) $overrides['price']
 $option_names       = isset( $overrides['options'] ) ? (array) $overrides['options'] : array( 'dinner', 'tshirt' );
 $option_price       = isset( $overrides['optionPrice'] ) ? (float) $overrides['optionPrice'] : 10.00;
 $minimum_instances  = isset( $overrides['minimumInstances'] ) ? (int) $overrides['minimumInstances'] : 2;
+$series_count       = isset( $overrides['seriesCount'] ) ? (int) $overrides['seriesCount'] : 3;
 $minimum_activities = isset( $overrides['minimumActivities'] ) ? (int) $overrides['minimumActivities'] : 0;
 $omit_multi         = isset( $overrides['omitMulti'] ) && $overrides['omitMulti'];
 $address            = isset( $overrides['address'] ) ? (string) $overrides['address'] : 'Calle Mayor 1, Madrid';
@@ -239,8 +243,10 @@ switch ( $flavour ) {
 	case 'three-ticket-scopes':
 		$price = isset( $overrides['price'] ) ? (float) $overrides['price'] : 15.00;
 		// Turns the single occurrence already created above into the series
-		// master (same event_date_id/sale_period_id) plus 2 generated siblings.
-		$occurrence_ids = fair_e2e_add_series( $event_id, 3 );
+		// master (same event_date_id/sale_period_id) plus generated siblings
+		// (default 2, for 3 total; override {"seriesCount":1} for the
+		// last-occurrence-remaining scenario).
+		$occurrence_ids = fair_e2e_add_series( $event_id, $series_count );
 		$single_type_id = fair_e2e_add_ticket_type( $event_date_id, 'Single Session', null );
 		$whole_type_id  = fair_e2e_add_whole_series_ticket_type( $event_date_id, 'Full Series Pass' );
 		fair_e2e_add_price( $single_type_id, $sale_period_id, $price, null );

--- a/e2e/user-flows/get-tickets-occurrence-dropdown.spec.js
+++ b/e2e/user-flows/get-tickets-occurrence-dropdown.spec.js
@@ -130,6 +130,55 @@ test.describe('Occurrence dropdown for single-occurrence tickets (fair-events al
 		await expect(instancePicker).toBeHidden();
 	});
 
+	test('single remaining occurrence: dropdown still shows with one pre-selected option', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('three-ticket-scopes', {
+			price: 0,
+			seriesCount: 1,
+		});
+		const [onlyOccurrenceId] = event.occurrenceIds;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		// Single-session ticket is the first enabled type, preselected by default.
+		const ticketRadio = form.locator(
+			`input[name="ticket_type_id"][value="${event.ticketTypeId}"]`
+		);
+		await expect(ticketRadio).toBeChecked();
+
+		const dropdown = form.locator('.fair-events-occurrence-picker');
+		await expect(dropdown).toBeVisible();
+
+		const select = dropdown.locator('select[name="event_date_id_single"]');
+		await expect(select.locator('option')).toHaveCount(1);
+		await expect(select).toHaveValue(String(onlyOccurrenceId));
+
+		const stamp = Date.now();
+		const email = `occurrence-dropdown-single.${stamp}@example.test`;
+		await form
+			.locator('input[name="name"]')
+			.fill(`E2E Occurrence Dropdown Single ${stamp}`);
+		await form.locator('input[name="email"]').fill(email);
+
+		await form.locator('button[type="submit"]').click();
+		await expect(
+			page.getByText('You have successfully registered', { exact: false })
+		).toBeVisible({ timeout: 15000 });
+
+		const chosenState = runScript(
+			'get-tickets-state.php',
+			'E2E_GT_STATE',
+			String(onlyOccurrenceId)
+		);
+		expect(chosenState.signups).toHaveLength(1);
+		expect(chosenState.signups[0].email).toBe(email);
+	});
+
 	test('non-recurring event renders no occurrence dropdown', async ({
 		page,
 		seedEvent,

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -339,10 +339,10 @@ if ( ! empty( $ticket_options ) ) {
 	}
 }
 
-// Single-occurrence dropdown: offered whenever the series has more than one
+// Single-occurrence dropdown: offered whenever the series has at least one
 // upcoming occurrence, regardless of which ticket scopes are configured.
 // frontend.js shows/hides it based on the selected ticket type's scope.
-$has_occurrence_dropdown  = count( $occurrences_for_picker ) > 1;
+$has_occurrence_dropdown  = ! empty( $occurrences_for_picker );
 $default_occurrence_index = 0;
 if ( $has_occurrence_dropdown ) {
 	foreach ( $occurrences_for_picker as $occ_index => $occ_row ) {


### PR DESCRIPTION
## Summary

- The Event Signup block's "Choose a date" dropdown only rendered when a recurring series had two or more upcoming occurrences (`count( $occurrences_for_picker ) > 1`). Once a series aged down to its last remaining date, the picker vanished and a `single_instance` ticket silently fell back to whatever occurrence the page resolved, with no confirmation shown.
- Loosens the gate to `! empty( $occurrences_for_picker )`, matching the sibling checkbox picker's own visibility flag — the dropdown now renders whenever at least one upcoming occurrence exists, showing it as the sole, pre-selected `<option>`.
- No `frontend.js` change: its show/hide toggle is driven by the selected ticket type's `recurrence-scope`, not by occurrence count.
- Extends the `three-ticket-scopes` e2e seed flavour with a `seriesCount` override (default 3, unchanged for every existing caller) and adds a new e2e case covering the single-remaining-occurrence scenario.

Closes #1379

## Acceptance criteria

- [x] Date picker renders whenever at least one upcoming occurrence exists (not only when two or more do), for ticket types that require picking a specific occurrence.
- [x] With exactly one upcoming occurrence, the picker shows that date as the only, pre-selected option.
- [x] With zero upcoming occurrences, current behaviour (no picker) is unchanged — `! empty()` on an empty array is still `false`.
- [x] A signup submitted via the single-option picker records the correct occurrence date.
- [x] e2e coverage added for the single-remaining-occurrence case, alongside existing picker coverage (`e2e/user-flows/get-tickets-occurrence-dropdown.spec.js`).

fair-audience's legacy Event Signup block is intentionally left unchanged, per the ticket's own recommendation.

## Test plan

- [x] `vendor/bin/phpcs` clean on changed PHP files.
- [x] `npx playwright test e2e/user-flows/get-tickets-occurrence-dropdown.spec.js` — all 4 tests pass (including the new single-occurrence case), run against a local wp-env instance.
- [x] Added a patch changeset for `fair-events`.
