### PR TITLE
Add price-visibility toggles to Event Signup block

### DIFF
--- a/.changeset/event-signup-price-toggles.md
+++ b/.changeset/event-signup-price-toggles.md
@@ -1,0 +1,5 @@
+---
+"fair-events": minor
+---
+
+Add "Show ticket price" and "Show option prices" toggles to the Event Signup block, so organizers can hide itemized pricing from the signup form when it's communicated elsewhere. When option prices are shown, they now consistently display as an addition to the base price (e.g. "+10.00€").

--- a/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
+++ b/fair-events/src/blocks/event-signup/__tests__/editor.test.jsx
@@ -14,7 +14,7 @@
  * one.
  */
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 // ServerSideRender hits the REST API for a live render; stub it to a marker
 // that also emits the questions slot render.php puts in preview markup, so
@@ -64,6 +64,16 @@ jest.mock('@wordpress/block-editor', () => ({
 jest.mock('@wordpress/components', () => ({
 	PanelBody: ({ children }) => children,
 	TextControl: () => null,
+	ToggleControl: ({ label, checked, onChange }) => (
+		<label>
+			<input
+				type="checkbox"
+				checked={checked}
+				onChange={(e) => onChange(e.target.checked)}
+			/>
+			{label}
+		</label>
+	),
 	ExternalLink: ({ href, children }) => <a href={href}>{children}</a>,
 }));
 
@@ -84,12 +94,21 @@ describe('Event Signup EditComponent', () => {
 		Edit = capturedSettings.edit;
 	});
 
-	const renderEdit = (isFairFormActive) => {
+	const renderEdit = (
+		isFairFormActive,
+		attributes = {},
+		setAttributes = () => {}
+	) => {
 		mockUseSelect.mockReturnValue(isFairFormActive);
 		return render(
 			<Edit
-				attributes={{ submitButtonText: 'Get Tickets' }}
-				setAttributes={() => {}}
+				attributes={{
+					submitButtonText: 'Get Tickets',
+					showTicketPrice: true,
+					showOptionPrices: true,
+					...attributes,
+				}}
+				setAttributes={setAttributes}
 			/>
 		);
 	};
@@ -159,6 +178,37 @@ describe('Event Signup EditComponent', () => {
 				'fair-audience/fair-form-conditional',
 			])
 		);
+	});
+
+	describe('price toggles', () => {
+		it('shows both toggles checked by default', () => {
+			renderEdit(false);
+
+			expect(screen.getByLabelText('Show ticket price')).toBeChecked();
+			expect(screen.getByLabelText('Show option prices')).toBeChecked();
+		});
+
+		it('toggles the showTicketPrice attribute', () => {
+			const setAttributes = jest.fn();
+			renderEdit(false, {}, setAttributes);
+
+			fireEvent.click(screen.getByLabelText('Show ticket price'));
+
+			expect(setAttributes).toHaveBeenCalledWith({
+				showTicketPrice: false,
+			});
+		});
+
+		it('toggles the showOptionPrices attribute', () => {
+			const setAttributes = jest.fn();
+			renderEdit(false, {}, setAttributes);
+
+			fireEvent.click(screen.getByLabelText('Show option prices'));
+
+			expect(setAttributes).toHaveBeenCalledWith({
+				showOptionPrices: false,
+			});
+		});
 	});
 
 	describe('ticket-editor link', () => {

--- a/fair-events/src/blocks/event-signup/block.json
+++ b/fair-events/src/blocks/event-signup/block.json
@@ -23,6 +23,14 @@
 			"type": "string",
 			"default": "Get Tickets"
 		},
+		"showTicketPrice": {
+			"type": "boolean",
+			"default": true
+		},
+		"showOptionPrices": {
+			"type": "boolean",
+			"default": true
+		},
 		"isEditorPreview": {
 			"type": "boolean",
 			"default": false

--- a/fair-events/src/blocks/event-signup/editor.js
+++ b/fair-events/src/blocks/event-signup/editor.js
@@ -21,7 +21,12 @@ import {
 	InspectorControls,
 	InnerBlocks,
 } from '@wordpress/block-editor';
-import { ExternalLink, PanelBody, TextControl } from '@wordpress/components';
+import {
+	ExternalLink,
+	PanelBody,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createPortal, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -151,6 +156,20 @@ registerBlockType(metadata.name, {
 							value={attributes.submitButtonText}
 							onChange={(value) =>
 								setAttributes({ submitButtonText: value })
+							}
+						/>
+						<ToggleControl
+							label={__('Show ticket price', 'fair-events')}
+							checked={attributes.showTicketPrice}
+							onChange={(value) =>
+								setAttributes({ showTicketPrice: value })
+							}
+						/>
+						<ToggleControl
+							label={__('Show option prices', 'fair-events')}
+							checked={attributes.showOptionPrices}
+							onChange={(value) =>
+								setAttributes({ showOptionPrices: value })
 							}
 						/>
 						{ticketingEnabled &&

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -17,6 +17,8 @@
 defined( 'WPINC' ) || die;
 
 $submit_button_text = $attributes['submitButtonText'] ?? __( 'Get Tickets', 'fair-events' );
+$show_ticket_price  = (bool) ( $attributes['showTicketPrice'] ?? true );
+$show_option_prices = (bool) ( $attributes['showOptionPrices'] ?? true );
 
 // Resolve event_date_id: query string (date, scoped to this post's series;
 // legacy numeric id kept for old links) → block attribute → current post's
@@ -256,7 +258,7 @@ if ( ! empty( $ticket_options ) && class_exists( \FairEvents\Models\EventDateSet
  *                              ticket_options, minimum_activities,
  *                              callback_status, callback_tx_id, callback_token, callback_state,
  *                              callback_source, prefill_name, prefill_email, submit_button_text,
- *                              suppress_form).
+ *                              show_ticket_price, show_option_prices, suppress_form).
  * @param array    $attributes Block attributes.
  * @param WP_Block $block      Block instance.
  */
@@ -292,6 +294,8 @@ $context = apply_filters(
 		'prefill_name'           => '',
 		'prefill_email'          => '',
 		'submit_button_text'     => $submit_button_text,
+		'show_ticket_price'      => $show_ticket_price,
+		'show_option_prices'     => $show_option_prices,
 		// When a companion plugin sets this true (e.g. a recognised viewer
 		// who already holds a signup), the base skips the <form> entirely and
 		// emits a plain wrapper div instead, still firing the render slots
@@ -314,6 +318,8 @@ $signup_state           = $context['callback_state'];
 $prefill_name           = $context['prefill_name'];
 $prefill_email          = $context['prefill_email'];
 $submit_button_text     = $context['submit_button_text'];
+$show_ticket_price      = (bool) $context['show_ticket_price'];
+$show_option_prices     = (bool) $context['show_option_prices'];
 $suppress_form          = ! empty( $context['suppress_form'] );
 
 // Recompute the multiple_instances flag from the (possibly filtered) ticket types.
@@ -579,7 +585,7 @@ if ( ! empty( $attributes['isEditorPreview'] ) ) {
 						$type_price       = $price_by_type_id[ $type_id ] ?? null;
 						$type_unavailable = $payments_unavailable && null !== $type_price && $type_price > 0;
 						$label            = esc_html( $ticket_type->name );
-						if ( null !== $type_price ) {
+						if ( $show_ticket_price && null !== $type_price ) {
 							$label .= ' — ' . esc_html( \FairEventsShared\Money::format_inline( $type_price ) );
 						} elseif ( null === $active_sale_period ) {
 							$label .= ' — ' . esc_html__( 'No active sale period', 'fair-events' );
@@ -624,10 +630,11 @@ if ( ! empty( $attributes['isEditorPreview'] ) ) {
 					}
 				}
 			}
-			// A minimum-activities requirement (global or ticket-type-raised)
-			// switches option prices from an always-on inline price to a hidden
-			// per-option "(+price)" add-on tag toggled by frontend.js once the
-			// minimum is met, so the requirement reads clearly.
+			// Whether a minimum-activities requirement (global or ticket-type-
+			// raised) applies, so the min-selection hint is only shown when
+			// relevant. Independent of $show_option_prices — the "+price"
+			// add-on tag is always emitted below when option prices are shown,
+			// with frontend.js toggling its visibility until the minimum is met.
 			$options_feature_active = ( $minimum_activities > 0 || $any_ticket_type_min > 0 );
 			$initial_min_activities = min( count( $ticket_options ), max( $minimum_activities, $preselected_type_min ) );
 			?>
@@ -656,16 +663,7 @@ if ( ! empty( $attributes['isEditorPreview'] ) ) {
 					<?php endif; ?>
 					<?php foreach ( $ticket_options as $opt ) : ?>
 						<?php
-						$opt_label = $opt['name'];
-						if ( ! $options_feature_active ) {
-							if ( $opt['price'] > 0 ) {
-								$opt_label .= ' — ' . \FairEventsShared\Money::format_inline( $opt['price'] );
-							} elseif ( $opt['price'] < 0 ) {
-								$opt_label .= ' — -' . \FairEventsShared\Money::format_inline( abs( $opt['price'] ) );
-							} else {
-								$opt_label .= ' — ' . __( 'free', 'fair-events' );
-							}
-						}
+						$opt_label   = $opt['name'];
 						$opt_is_full = ! empty( $opt['is_full'] );
 						if ( $opt_is_full ) {
 							$opt_label .= ' — ' . __( 'full', 'fair-events' );
@@ -689,15 +687,25 @@ if ( ! empty( $attributes['isEditorPreview'] ) ) {
 							/>
 							<span class="fair-events-ticket-option-text">
 								<?php echo esc_html( $opt_label ); ?>
-								<?php if ( $options_feature_active && $opt['price'] > 0 ) : ?>
+								<?php if ( $show_option_prices && 0.0 !== (float) $opt['price'] ) : ?>
 									<span class="fair-events-ticket-option-addon" style="display: none;">
-										<?php
-										printf(
-											/* translators: %s: formatted add-on price */
-											esc_html__( '(+%s)', 'fair-events' ),
-											esc_html( \FairEventsShared\Money::format_inline( $opt['price'] ) )
-										);
-										?>
+										<?php if ( $opt['price'] > 0 ) : ?>
+											<?php
+											printf(
+												/* translators: %s: formatted add-on price */
+												esc_html__( '+%s', 'fair-events' ),
+												esc_html( \FairEventsShared\Money::format_inline( $opt['price'] ) )
+											);
+											?>
+										<?php else : ?>
+											<?php
+											printf(
+												/* translators: %s: formatted add-on price */
+												esc_html__( '-%s', 'fair-events' ),
+												esc_html( \FairEventsShared\Money::format_inline( abs( $opt['price'] ) ) )
+											);
+											?>
+										<?php endif; ?>
 									</span>
 								<?php endif; ?>
 							</span>


### PR DESCRIPTION
## Summary

- Add two independent `ToggleControl`s ("Show ticket price" / "Show option prices") to the Event Signup block's Form Settings panel, both defaulting to the current shown behavior.
- Gate the ticket type radio label's price append on `showTicketPrice`; the "No active sale period" fallback and `data-ticket-price` attribute are untouched (the running total still needs the raw price).
- Collapse the option/add-on price logic to a single path: drop the old inline "— price"/"— free" label text, and always emit the `fair-events-ticket-option-addon` span (gated on `showOptionPrices` and a non-zero price), using "+10.00€" for positive prices and "-5.00€" for negative prices. `frontend.js`'s existing reveal logic needed no changes — it already degrades to "always visible" when there's no minimum-activities requirement.
- Implements the plan from [#1383 (comment)](https://github.com/marcin-wosinek/fair-event-plugins/issues/1383#issuecomment-5176561189); cross-plugin scope (fair-audience's `render_add_activities()`) is explicitly out of scope per that plan's Decisions section.

Closes #1383

## Acceptance criteria

- [x] Event Signup block editor has two independent settings — one for the ticket type price, one for option/add-on prices — both defaulting to "shown"
- [x] With the ticket price setting off, no ticket type price is rendered on the front-end signup form
- [x] With the option price setting off, no option/add-on price is rendered on the front-end signup form
- [x] Any running total/amount-due in the signup button or summary remains visible and accurate regardless of either setting — `data-ticket-price`/`data-option-price` stay populated either way, so `computeTicketTotal`/the button total are unaffected
- [x] With option prices shown, they always display as "+10.00€" style additions next to their label
- [x] Non-EUR currency formatting remains correct in the "+" display — verified with PLN (suffix symbol)
- [x] Existing signup functionality (ticket selection, option selection, submission) is unaffected — no JS changes, `frontend.js` reveal logic is untouched

## Test plan

- [x] `npm test` (Jest) — 182/182 passing, including new editor toggle tests
- [x] `vendor/bin/phpcs` clean on `render.php`
- [x] `npm run build` — production assets rebuilt
- [x] Manual WP-CLI `eval-file` check against a real event date (ticket price on/off, positive/negative/zero-price options, mixed toggle states, PLN currency) — all 16 assertions passed
- [x] Verified in the running site (`:8080`): both toggles appear in the block editor's Form Settings panel, default to checked, and the `ServerSideRender` preview updates live when toggled off
