### PR TITLE
Fix missing structured data for online-mode events

### DIFF
--- a/fair-events/__tests__/Fair_Test_WPDB.php
+++ b/fair-events/__tests__/Fair_Test_WPDB.php
@@ -32,6 +32,13 @@ class Fair_Test_WPDB {
 	private $rows = array();
 
 	/**
+	 * Seeded column lists, keyed by table name then id — backs get_col().
+	 *
+	 * @var array<string, array<int, array<int>>>
+	 */
+	private $cols = array();
+
+	/**
 	 * Seed a row so get_row() resolves it for the given table + id.
 	 *
 	 * @param string $table Table name, including prefix (e.g. 'wp_fair_events_signups').
@@ -41,6 +48,19 @@ class Fair_Test_WPDB {
 	 */
 	public function seed_row( $table, $id, $row ) {
 		$this->rows[ $table ][ $id ] = $row;
+	}
+
+	/**
+	 * Seed a column list so get_col() resolves it for the given table + id
+	 * (e.g. junction-table post ids for `wp_fair_event_date_posts`).
+	 *
+	 * @param string $table Table name, including prefix.
+	 * @param int    $id    Lookup id.
+	 * @param array  $values Column values to return.
+	 * @return void
+	 */
+	public function seed_col( $table, $id, array $values ) {
+		$this->cols[ $table ][ $id ] = $values;
 	}
 
 	/**
@@ -71,5 +91,19 @@ class Fair_Test_WPDB {
 			return null;
 		}
 		return $this->rows[ $prepared['table'] ][ $prepared['id'] ] ?? null;
+	}
+
+	/**
+	 * Stub of wpdb::get_col() — resolves a prepare()d table/id lookup against
+	 * values seeded via seed_col(), or an empty array when nothing was seeded.
+	 *
+	 * @param array{table: string|null, id: int|null}|mixed $prepared Value returned by prepare().
+	 * @return array Seeded column values, or an empty array.
+	 */
+	public function get_col( $prepared ) {
+		if ( ! is_array( $prepared ) ) {
+			return array();
+		}
+		return $this->cols[ $prepared['table'] ][ $prepared['id'] ] ?? array();
 	}
 }

--- a/fair-events/__tests__/Helpers/EventLocationTest.php
+++ b/fair-events/__tests__/Helpers/EventLocationTest.php
@@ -22,6 +22,16 @@ use FairEvents\Models\EventDates;
 class EventLocationTest extends TestCase {
 
 	/**
+	 * Reset the fake $wpdb before each test so junction-table seeding
+	 * (get_primary_linked_post_id()'s get_col() lookup) never leaks between tests.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.
+		$GLOBALS['wpdb'] = new \Fair_Test_WPDB();
+	}
+
+	/**
 	 * Build a minimal EventDates fixture.
 	 *
 	 * @param array $overrides Property overrides.
@@ -84,22 +94,50 @@ class EventLocationTest extends TestCase {
 	}
 
 	/**
-	 * Online with no joining_link falls back to the event page URL via
-	 * get_display_url() (exercised here through an external link_type).
+	 * Online with no joining_link falls back to the event's own page URL
+	 * (get_event_page_url()), never the external_url configured for
+	 * `link_type = 'external'` — that's an unrelated calendar/RSVP target,
+	 * not the event's own page.
 	 */
-	public function test_online_falls_back_to_display_url() {
+	public function test_online_falls_back_to_event_page_url() {
 		$event_date = $this->make_event_date(
 			array(
+				'id'              => 7,
 				'attendance_mode' => 'online',
 				'link_type'       => 'external',
-				'external_url'    => 'https://example.com/event-page',
+				'external_url'    => 'https://example.com/unrelated-listing',
 			)
 		);
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.
+		$GLOBALS['wpdb']->seed_col( 'wp_fair_event_date_posts', 7, array( 42 ) );
 
 		$location = EventLocation::resolve( $event_date, null );
 
 		$this->assertSame( 'online', $location['mode'] );
-		$this->assertSame( 'https://example.com/event-page', $location['joining_url'] );
+		// Falls back to the event's own page permalink, ignoring the unrelated external_url.
+		$this->assertSame( 'https://example.com/?p=42', $location['joining_url'] );
+	}
+
+	/**
+	 * A blank external_url (empty-string regression) still falls back to the
+	 * event's own page permalink rather than producing an empty joining URL.
+	 */
+	public function test_online_falls_back_to_event_page_url_with_blank_external_url() {
+		$event_date = $this->make_event_date(
+			array(
+				'id'              => 8,
+				'attendance_mode' => 'online',
+				'link_type'       => 'external',
+				'external_url'    => '',
+			)
+		);
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.
+		$GLOBALS['wpdb']->seed_col( 'wp_fair_event_date_posts', 8, array( 43 ) );
+
+		$location = EventLocation::resolve( $event_date, null );
+
+		$this->assertSame( 'online', $location['mode'] );
+		$this->assertSame( 'https://example.com/?p=43', $location['joining_url'] );
 	}
 
 	/**

--- a/fair-events/__tests__/Models/EventDatesTest.php
+++ b/fair-events/__tests__/Models/EventDatesTest.php
@@ -360,4 +360,76 @@ class EventDatesTest extends TestCase {
 		$this->assertSame( 'in_person', $occurrence->attendance_mode );
 		$this->assertSame( 'https://example.com/own-meet', $occurrence->joining_link );
 	}
+
+	/**
+	 * Resolves the junction-table-linked post's permalink regardless of
+	 * link_type — including 'external', where get_display_url() would
+	 * return the unrelated external_url instead.
+	 *
+	 * @dataProvider linkTypeProvider
+	 * @param string $link_type link_type value under test.
+	 */
+	public function test_event_page_url_resolves_regardless_of_link_type( $link_type ) {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.
+		$GLOBALS['wpdb'] = new \Fair_Test_WPDB();
+		$GLOBALS['wpdb']->seed_col( 'wp_fair_event_date_posts', 5, array( 99 ) );
+
+		$occurrence                  = new EventDates();
+		$occurrence->id              = 5;
+		$occurrence->master_id       = null;
+		$occurrence->occurrence_type = 'single';
+		$occurrence->link_type       = $link_type;
+		$occurrence->external_url    = 'https://example.org/unrelated-listing';
+
+		$this->assertSame( 'https://example.com/?p=99', $occurrence->get_event_page_url() );
+	}
+
+	/**
+	 * Data provider for test_event_page_url_resolves_regardless_of_link_type().
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function linkTypeProvider(): array {
+		return array(
+			'none'     => array( 'none' ),
+			'post'     => array( 'post' ),
+			'external' => array( 'external' ),
+		);
+	}
+
+	/**
+	 * Decorates the permalink with `?event_date=` for a generated
+	 * occurrence, resolving the junction-table link via the master's id
+	 * (links are stored on the master row).
+	 */
+	public function test_event_page_url_decorates_generated_occurrence() {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.
+		$GLOBALS['wpdb'] = new \Fair_Test_WPDB();
+		$GLOBALS['wpdb']->seed_col( 'wp_fair_event_date_posts', 1, array( 42 ) );
+
+		$occurrence                  = new EventDates();
+		$occurrence->id              = 2;
+		$occurrence->master_id       = 1;
+		$occurrence->occurrence_type = 'generated';
+		$occurrence->link_type       = 'none';
+		$occurrence->start_datetime  = '2026-06-29 18:30:00';
+
+		$this->assertSame( 'https://example.com/?p=42&event_date=2026-06-29', $occurrence->get_event_page_url() );
+	}
+
+	/**
+	 * Returns null when no post is linked at all.
+	 */
+	public function test_event_page_url_returns_null_when_unlinked() {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- test-only fake, no real $wpdb exists here.
+		$GLOBALS['wpdb'] = new \Fair_Test_WPDB();
+
+		$occurrence                  = new EventDates();
+		$occurrence->id              = 5;
+		$occurrence->master_id       = null;
+		$occurrence->occurrence_type = 'single';
+		$occurrence->link_type       = 'none';
+
+		$this->assertNull( $occurrence->get_event_page_url() );
+	}
 }

--- a/fair-events/src/Helpers/EventLocation.php
+++ b/fair-events/src/Helpers/EventLocation.php
@@ -55,7 +55,7 @@ class EventLocation {
 		if ( 'online' === $mode || 'hybrid' === $mode ) {
 			$location['joining_url'] = ! empty( $event_date->joining_link )
 				? $event_date->joining_link
-				: $event_date->get_display_url();
+				: $event_date->get_event_page_url();
 		}
 
 		return $location;

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -652,6 +652,25 @@ class EventDates {
 	}
 
 	/**
+	 * Get this event's own page URL, independent of `link_type`.
+	 *
+	 * Unlike get_display_url() (which points wherever the calendar/RSVP link
+	 * is configured to go — an external partner page for `link_type =
+	 * 'external'`), this always resolves the permalink of the post linked via
+	 * the junction table (see get_primary_linked_post_id()), regardless of
+	 * how the link/calendar entry is configured. Used as the joining-link
+	 * fallback for online/hybrid events, so the fallback is never an
+	 * unrelated external URL (see EventLocation::resolve()).
+	 *
+	 * @return string|null The event's own page URL, or null if no post is linked.
+	 */
+	public function get_event_page_url() {
+		$linked_post_id = $this->get_primary_linked_post_id();
+
+		return $linked_post_id ? $this->with_occurrence_arg( get_permalink( $linked_post_id ) ) : null;
+	}
+
+	/**
 	 * Append `?event_date={Y-m-d}` to a URL for generated occurrences only.
 	 *
 	 * @param string|false $url Permalink to decorate.


### PR DESCRIPTION
## Summary

`EventLocation::resolve()`'s joining-link fallback called
`EventDates::get_display_url()`, which is `link_type`-aware: for
`link_type = 'external'` it returns the external URL verbatim (a partner
listing page in the reported case), not the event's own page — and an
empty `external_url` produced an empty joining URL. Google's Rich Results
treats an empty `VirtualLocation` URL as invalid, so a published `online`
event lost its structured data entirely. `hybrid` events kept a valid
`Place` node alongside the broken `VirtualLocation`, which is why the bug
only showed up for `online` mode.

Fix: add `EventDates::get_event_page_url()`, which resolves the event's
own page permalink via the junction-table link (`get_primary_linked_post_id()`)
independent of `link_type`, and use it as the joining-link fallback
instead of `get_display_url()`. This single fix propagates to JSON-LD
(`EventSchema`), the ICS feed (`CalendarFeedController`), and the public
`event-info` block, since all three already consume
`EventLocation::resolve()`'s `joining_url`.

Refs #1306

## Acceptance criteria (from the fix-plan comment)

1. **New `EventDates::get_event_page_url()`** — same logic as the
   `'none'`/default branch of `get_display_url()`
   (`get_primary_linked_post_id()` → `get_permalink()` →
   `with_occurrence_arg()`), independent of `link_type`. ✅
2. **`EventLocation::resolve()`'s joining-link fallback** now calls
   `get_event_page_url()` instead of `get_display_url()`. ✅
3. **`EventLocationTest.php`** — renamed
   `test_online_falls_back_to_display_url` →
   `test_online_falls_back_to_event_page_url`; fixture keeps
   `link_type = 'external'` + a real `external_url` to prove the fallback
   ignores it, asserting `joining_url` equals the linked post's permalink.
   Added a case for `link_type = 'external'` with a **blank**
   `external_url`, proving the empty-string regression is gone. ✅
4. **`EventDatesTest.php`** — new tests for `get_event_page_url()`
   directly: resolves regardless of `link_type` (`none`/`post`/`external`),
   decorates generated occurrences with `?event_date=`, and returns `null`
   when no post is linked at all. ✅
5. **No changes needed** in `EventSchema.php`, `CalendarFeedController.php`,
   or `render.php` — confirmed all three consume
   `EventLocation::resolve()`'s `joining_url`, so this single fix
   propagates automatically. ✅

Test-infra note: `get_primary_linked_post_id()` reaches `$wpdb->get_col()`
via the `'none'`/junction-table path, which the PHPUnit test double
(`Fair_Test_WPDB`) didn't support yet. Added `seed_col()`/`get_col()` to
`Fair_Test_WPDB`, mirroring the existing `seed_row()`/`get_row()` pattern.

## Test plan

- [x] `vendor/bin/phpunit` — 200/200 passing (fair-events)
- [x] `vendor/bin/phpcs` clean on all changed files
- [x] No JS/CSS changed — no build/i18n/screenshot steps apply
