### PR TITLE
Make Event Signup form safe under full-page caching

### DIFF
--- a/.changeset/cache-safe-event-signup-viewer-context.md
+++ b/.changeset/cache-safe-event-signup-viewer-context.md
@@ -1,0 +1,6 @@
+---
+"fair-events": patch
+"fair-audience": patch
+---
+
+Fix the Event Signup form leaking one visitor's group-restricted ticket tiers, discounted prices, and name/email pre-fill to another visitor under full-page caching. The form now server-renders the same unrestricted, undiscounted, unfilled markup for every viewer, and fetches the actual viewer's personalization (restricted tiers, discounts, pre-fill, signed-up state) client-side after load.

--- a/REST_API_BACKEND.md
+++ b/REST_API_BACKEND.md
@@ -568,20 +568,75 @@ truth and lets experimental features stay additive.
 
 ### Example: `fair-events` unified signup
 
-`fair-events/src/blocks/event-signup/render.php` (base render, used when no
-companion plugin renders a richer flow) and
-`fair-events/src/API/GetTicketsController.php` (the `fair-events/v1/get-tickets`
-create route) expose:
+`fair-events/src/blocks/event-signup/render.php` (base render — the
+cache-safe baseline every viewer gets, see below),
+`fair-events/src/Services/SignupFieldsetRenderer.php` (the ticket-type/
+ticket-options fieldset markup, shared between the base render and the
+viewer-context endpoint), and `fair-events/src/API/GetTicketsController.php`
+(the `fair-events/v1/get-tickets` create route, plus its `viewer-context`
+sub-route) expose:
 
 -   **`fair_events_signup_render_context` filter** — the base render builds a
     context array (`event_date_id`, `pricing_event_date_id`, `ticket_types`,
-    `price_by_type_id`, `active_sale_period`, `occurrences_for_picker`, `currency_symbol`,
+    `price_by_type_id`, `active_sale_period`, `occurrences_for_picker`,
     `ticket_options`, `minimum_activities`,
     `callback_status`/`callback_tx_id`/`callback_token`, `prefill_name`,
-    `prefill_email`, `submit_button_text`, `suppress_form`) and runs it through
-    this filter before rendering, so a companion plugin can inject viewer
-    identity, session pre-fill, or participant-filtered ticket types/prices
-    without a parallel template. `ticket_options` is a list of
+    `prefill_email`, `submit_button_text`, `suppress_form`) and runs it
+    through this filter before rendering. Since a full-page cache stores and
+    replays this render for every viewer (#1300), `ticket_types` here already
+    excludes any group-restricted tier, and `prefill_name`/`prefill_email`/
+    `suppress_form`/every occurrence's `signed_up` are always their
+    viewer-independent defaults (`''`/`''`/`false`/`false`) — **no consumer
+    may set viewer-dependent state through this filter.** It exists only for
+    a future genuinely viewer-independent extension; fair-audience does not
+    hook it. Per-viewer personalization is resolved by the
+    `fair_events_signup_viewer_context` filter below instead.
+-   **`fair_events_signup_viewer_context` filter** — resolved at request time
+    by `GetTicketsController::get_viewer_context()`
+    (`GET fair-events/v1/get-tickets/viewer-context?event_date_id=…`,
+    `permission_callback: __return_true` — safe because the route carries no
+    identity parameter; the viewer is resolved purely server-side from the
+    session cookie/login, same as the public
+    `/fair-audience/v1/event-signup/status` endpoint), never by the render a
+    full-page cache stores. frontend.js calls this endpoint after load for
+    every page view — cached or not — and patches the response into the DOM,
+    so the visible result never depends on who the page happened to be
+    rendered for. The endpoint rebuilds the same-shaped context as
+    `fair_events_signup_render_context` above, but *unfiltered* (including
+    group-restricted tiers), plus a `viewer_resolved` key (`false` by
+    default). A companion plugin sets `viewer_resolved = true` whenever it
+    recognises the viewer (fair-audience's
+    `SignupHookBridge::enrich_render_context()` — the same method, now
+    hooked to this filter instead) and overrides `ticket_types`/
+    `price_by_type_id` (participant-filtered/discounted), `prefill_name`/
+    `prefill_email`, `suppress_form`, and each `occurrences_for_picker`
+    row's `signed_up`, exactly as it used to for the base render. When
+    `viewer_resolved` is true the endpoint renders the personalized
+    fragments below and returns them as HTML (reusing
+    `SignupFieldsetRenderer` and the same render-slot actions the base
+    render fires — no templating logic duplicated in JavaScript); an
+    unrecognised viewer (the common case) gets an empty/no-op response, so
+    no rendering work happens for the anonymous majority. Response shape:
+    `viewer_resolved`, `suppress_form`, `ticket_type_fieldset_html` /
+    `ticket_options_fieldset_html` (the two fieldsets, HTML or `null`),
+    `before_form_html` / `before_submit_html` / `after_form_html` (the three
+    render-slot actions' captured output, HTML or `null`),
+    `occurrences_signed_up` (event_date_ids), `prefill_name`, `prefill_email`.
+    frontend.js swaps the `<form>` for a `fair-events-get-tickets-companion`
+    wrapper client-side when `suppress_form` is true (mirroring what the base
+    render used to do server-side), instead of patching the fieldsets.
+-   **Three render-slot actions**, all passed the context from whichever
+    filter above ran (so they no-op on the base render's un-enriched
+    context, and produce fragments on the viewer-context endpoint's enriched
+    one): `fair_events_signup_render_before_form` and
+    `fair_events_signup_render_after_form` let a companion plugin contribute
+    UI fragments (e.g. a resume/retry card, the signed-up/cancel card, or
+    fair-audience's "add activities" section) either inside the `<form>` (or
+    its client-side companion swap) or inside the base render's (now
+    effectively unreachable, kept for future use) `suppress_form` wrapper
+    div. A third action, `fair_events_signup_render_before_submit`, fires
+    immediately before the submit button — fair-audience uses it to render a
+    group discount note. `ticket_options` is a list of
     `[ id, name, short_name, price, is_full ]` (empty unless both
     `fair-events-experimental`'s activity catalogue and fair-audience — the
     only consumer that can persist a selection — are active); fair-audience's
@@ -592,29 +647,7 @@ create route) expose:
     `current_activity_names`. `minimum_activities` is the event-date global
     requirement, capped at `count( $ticket_options )`; a ticket type can raise
     it further via its own `minimum_activities` property — see
-    `frontend.js`' `getEffectiveMinimum()`. Each `occurrences_for_picker` row
-    also carries `signed_up` (`false` by default); fair-audience's
-    `enrich_render_context()` flips it true for occurrences the recognised
-    viewer already holds (including via a whole-series pass), so both the
-    single-occurrence dropdown and the multi-occurrence checkbox picker label
-    (and, for the checkbox picker, disable) them instead of allowing a silent
-    double-book. `suppress_form` (`false` by default) lets a companion plugin
-    skip the `<form>` entirely — used when a recognised viewer already holds
-    this exact signup, so a ticket-type/quantity form makes no sense — in
-    which case the base renders a plain
-    `<div class="fair-events-get-tickets-companion">` instead, still firing
-    the two render-slot actions below inside it so the companion can render
-    its own signed-up/cancel UI (echoing and escaping its own markup, exactly
-    as `SignupHookBridge::render_add_activities()` already does — no HTML
-    travels through the context array). Two render-slot actions,
-    `fair_events_signup_render_before_form` and
-    `fair_events_signup_render_after_form` (both passed the same context),
-    let a companion plugin contribute UI fragments (e.g. a resume/retry card,
-    the signed-up/cancel card, or fair-audience's "add activities" section)
-    either inside the `<form>` or inside the `suppress_form` wrapper div. A
-    third action, `fair_events_signup_render_before_submit`
-    (also passed the context), fires immediately before the submit button —
-    fair-audience uses it to render a group discount note.
+    `frontend.js`' `getEffectiveActivityMinimum()`.
 -   **`fair_events_signup_precheck_error` filter** — `GetTicketsController::create_signup()`
     runs this immediately after the event date is validated, before ticket-type
     or options validation, so it covers the single-, `multiple_instances`- and
@@ -705,7 +738,7 @@ unified-signup submission fatal'd):
 
 | Hook                                  | args passed | `add_filter`/`add_action` call            |
 | -------------------------------------- | :---------: | ------------------------------------------ |
-| `fair_events_signup_render_context`    | 1           | `add_filter( ..., 10, 1 )`                 |
+| `fair_events_signup_viewer_context`    | 1           | `add_filter( ..., 10, 1 )`                 |
 | `fair_events_signup_precheck_error`    | 4           | `add_filter( ..., 10, 4 )`                 |
 | `fair_events_signup_render_before_form` | 1          | `add_action( ..., 10, 1 )`                 |
 | `fair_events_signup_render_before_submit` | 1        | `add_action( ..., 10, 1 )`                 |

--- a/fair-audience/__tests__/Hooks/SignupHookBridgeRegistrationTest.php
+++ b/fair-audience/__tests__/Hooks/SignupHookBridgeRegistrationTest.php
@@ -32,7 +32,7 @@ class SignupHookBridgeRegistrationTest extends TestCase {
 	 * @var array<string, int>
 	 */
 	private const ARGS_PASSED_BY_FAIR_EVENTS = array(
-		'fair_events_signup_render_context'           => 3,
+		'fair_events_signup_viewer_context'           => 1,
 		'fair_events_signup_precheck_error'           => 4,
 		'fair_events_signup_render_before_form'       => 1,
 		'fair_events_signup_render_before_submit'     => 1,

--- a/fair-audience/src/Hooks/SignupHookBridge.php
+++ b/fair-audience/src/Hooks/SignupHookBridge.php
@@ -39,7 +39,7 @@ class SignupHookBridge {
 	 * @return void
 	 */
 	public static function init() {
-		add_filter( 'fair_events_signup_render_context', array( static::class, 'enrich_render_context' ), 10, 1 );
+		add_filter( 'fair_events_signup_viewer_context', array( static::class, 'enrich_render_context' ), 10, 1 );
 		add_filter( 'fair_events_signup_precheck_error', array( static::class, 'filter_precheck_error' ), 10, 4 );
 		add_action( 'fair_events_signup_render_before_form', array( static::class, 'render_signed_up_card' ), 10, 1 );
 		add_action( 'fair_events_signup_render_before_form', array( static::class, 'render_not_you' ), 10, 1 );
@@ -56,17 +56,26 @@ class SignupHookBridge {
 	}
 
 	/**
-	 * Inject the signed-in/known viewer's name and email into the base
-	 * form's pre-fill so returning participants don't retype them, filter out
+	 * Inject the signed-in/known viewer's name and email into the form's
+	 * pre-fill so returning participants don't retype them, filter out
 	 * group-restricted ticket types the viewer can't buy, and re-resolve
 	 * prices through the viewer's group discounts.
 	 *
-	 * @param array $context Render context from fair-events' base render.
+	 * Hooked on fair_events_signup_viewer_context — resolved at request time
+	 * by GetTicketsController::get_viewer_context(), never by the base
+	 * render.php a full-page cache stores and replays (#1300).
+	 *
+	 * @param array $context Context from fair-events' viewer-context endpoint.
 	 * @return array Filtered context.
 	 */
 	public static function enrich_render_context( $context ) {
 		$participant    = GroupSignupPricing::resolve_viewer_participant();
 		$participant_id = $participant ? (int) $participant->id : null;
+
+		// Signals the endpoint that a viewer was actually recognised, so it
+		// renders the personalized fragments — true whenever prefill applies,
+		// even when nothing else about ticket types/pricing changed.
+		$context['viewer_resolved'] = (bool) $participant;
 
 		if ( $participant ) {
 			$context['prefill_name']  = trim( $participant->name . ' ' . $participant->surname );
@@ -255,7 +264,8 @@ class SignupHookBridge {
 	 * enrich_render_context()'s suppress_form). Hooked on
 	 * fair_events_signup_render_before_form.
 	 *
-	 * @param array $context Render context, see fair_events_signup_render_context.
+	 * @param array $context Context, see fair_events_signup_viewer_context /
+	 *                       enrich_render_context() above.
 	 * @return void
 	 */
 	public static function render_signed_up_card( $context ) {
@@ -354,7 +364,8 @@ class SignupHookBridge {
 	 * existing DELETE /fair-audience/v1/session route by fair-events-shared's
 	 * wireNotYouButton(), the same helper the legacy block uses.
 	 *
-	 * @param array $context Render context, see fair_events_signup_render_context.
+	 * @param array $context Context, see fair_events_signup_viewer_context /
+	 *                       enrich_render_context() above.
 	 * @return void
 	 */
 	public static function render_not_you( $context ) {
@@ -375,7 +386,8 @@ class SignupHookBridge {
 	 * viewer's best-matching group discount rule was stashed onto the context
 	 * by enrich_render_context().
 	 *
-	 * @param array $context Render context, see fair_events_signup_render_context.
+	 * @param array $context Context, see fair_events_signup_viewer_context /
+	 *                       enrich_render_context() above.
 	 * @return void
 	 */
 	public static function render_discount_note( $context ) {
@@ -491,7 +503,8 @@ class SignupHookBridge {
 	 * companion plugin owns is read from a data attribute so the base plugin
 	 * never hardcodes it.
 	 *
-	 * @param array $context Render context, see fair_events_signup_render_context.
+	 * @param array $context Context, see fair_events_signup_viewer_context /
+	 *                       enrich_render_context() above.
 	 * @return void
 	 */
 	public static function render_add_activities( $context ) {

--- a/fair-events/e2e/event-signup-viewer-context.spec.js
+++ b/fair-events/e2e/event-signup-viewer-context.spec.js
@@ -1,0 +1,215 @@
+import { test, expect } from '@playwright/test';
+
+const WP_ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const WP_ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * E2E coverage for #1300: the Event Signup form's cache-safe baseline must
+ * render identically for every viewer, with per-viewer personalization
+ * (here: name/email pre-fill and signed-up state) hydrated client-side
+ * after load — so a page a full-page cache stores for one viewer never
+ * leaks another viewer's details, and the same browser gets its own state
+ * back once it holds one.
+ *
+ * fair-events-experimental isn't assumed active, so the group-restricted-
+ * tier/discount half of the ticket isn't exercised here — only the
+ * prefill/signed-up-state half the ticket explicitly calls out as sharing
+ * the same leak. A free ticket type is used so the flow completes without a
+ * configured payment connector.
+ */
+
+async function apiFetch(page, options) {
+	const result = await page.evaluate(async (opts) => {
+		try {
+			// eslint-disable-next-line no-undef
+			const res = await wp.apiFetch(opts);
+			return { ok: true, data: res };
+		} catch (err) {
+			return {
+				ok: false,
+				error: {
+					message: err && err.message,
+					code: err && err.code,
+					data: err && err.data,
+				},
+			};
+		}
+	}, options);
+	if (!result.ok) {
+		throw new Error(
+			`apiFetch ${options.method || 'GET'} ${
+				options.path
+			} failed: ${JSON.stringify(result.error)}`
+		);
+	}
+	return result.data;
+}
+
+async function login(page) {
+	await page.goto('/wp-admin');
+	if (page.url().includes('wp-login.php')) {
+		await page.fill('#user_login', WP_ADMIN_USER);
+		await page.fill('#user_pass', WP_ADMIN_PASS);
+		await page.click('#wp-submit');
+	}
+	await page.waitForSelector('#wpadminbar');
+}
+
+test.describe('Event Signup — cache-safe baseline + viewer-context hydration', () => {
+	test('a viewer who signs up sees their own state on reload; a fresh viewer on the same page never does', async ({
+		browser,
+	}) => {
+		const adminContext = await browser.newContext();
+		const adminPage = await adminContext.newPage();
+		await login(adminPage);
+		await adminPage.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await adminPage.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+		const eventPost = await apiFetch(adminPage, {
+			path: '/wp/v2/fair_event',
+			method: 'POST',
+			data: {
+				title: `Viewer-context e2e ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+
+		const eventDate = await apiFetch(adminPage, {
+			path: '/fair-events/v1/event-dates',
+			method: 'POST',
+			data: {
+				title: 'Viewer-context e2e',
+				link_type: 'post',
+				start_datetime: '2036-01-01 10:00:00',
+				end_datetime: '2036-01-01 12:00:00',
+			},
+		});
+
+		try {
+			await apiFetch(adminPage, {
+				path: `/fair-events/v1/event-dates/${eventDate.id}`,
+				method: 'PUT',
+				data: { event_id: eventPost.id },
+			});
+
+			await apiFetch(adminPage, {
+				path: `/fair-events/v1/event-dates/${eventDate.id}/tickets`,
+				method: 'PUT',
+				data: {
+					ticket_types: [
+						{
+							name: 'Free entry',
+							recurrence_scope: 'single_instance',
+							capacity: null,
+							minimum_activities: 0,
+							disable_at: null,
+							group_ids: [],
+						},
+					],
+					sale_periods: [
+						{
+							name: 'Always on',
+							sale_start: '2020-01-01 00:00:00',
+							sale_end: '2099-01-01 00:00:00',
+						},
+					],
+					prices: [
+						{
+							ticket_type_index: 0,
+							sale_period_index: 0,
+							price: 0,
+						},
+					],
+					settings: {},
+				},
+			});
+
+			const signupPage = await apiFetch(adminPage, {
+				path: '/wp/v2/pages',
+				method: 'POST',
+				data: {
+					title: `Viewer-context e2e page ${Date.now()}`,
+					status: 'publish',
+					content: `<!-- wp:fair-events/event-signup {"eventDateId":${eventDate.id}} /-->`,
+				},
+			});
+
+			// Context B: the visitor who will sign up.
+			const visitorContext = await browser.newContext();
+			const visitorPage = await visitorContext.newPage();
+			await visitorPage.goto(`/?page_id=${signupPage.id}`);
+
+			const form = visitorPage.locator('.fair-events-get-tickets-form');
+			await expect(form).toBeVisible();
+			// Baseline: no signed-up card, no pre-filled identity.
+			await expect(
+				visitorPage.locator('.fair-events-signed-up-card')
+			).toHaveCount(0);
+			await expect(form.locator('input[name="name"]')).toHaveValue('');
+			await expect(form.locator('input[name="email"]')).toHaveValue('');
+
+			await form.locator('input[name="name"]').fill('Ada Lovelace');
+			await form
+				.locator('input[name="email"]')
+				.fill(`ada-e2e-${Date.now()}@example.test`);
+			await form.locator('button[type="submit"]').click();
+			await expect(
+				visitorPage.locator('.fair-events-get-tickets-message-success')
+			).toBeVisible();
+
+			// Reload as the same browser (same AudienceSession cookie): the
+			// server-rendered baseline is identical, but frontend.js's
+			// viewer-context hydration must recognise this viewer already
+			// holds the signup and swap in the signed-up card.
+			await visitorPage.reload();
+			await expect(
+				visitorPage.locator('.fair-events-get-tickets-form')
+			).toHaveCount(0);
+			await expect(
+				visitorPage.locator('.fair-events-signed-up-card')
+			).toBeVisible();
+			await expect(
+				visitorPage.locator('.fair-events-signed-up-card')
+			).toContainText('You are signed up for this date.');
+
+			// Context C: a second, unrelated visitor loading the exact same
+			// page (same cached markup) must never see the first visitor's
+			// signed-up state or identity — the core of #1300's guarantee.
+			const strangerContext = await browser.newContext();
+			const strangerPage = await strangerContext.newPage();
+			await strangerPage.goto(`/?page_id=${signupPage.id}`);
+
+			await expect(
+				strangerPage.locator('.fair-events-get-tickets-form')
+			).toBeVisible();
+			await expect(
+				strangerPage.locator('.fair-events-signed-up-card')
+			).toHaveCount(0);
+			await expect(
+				strangerPage.locator('input[name="name"]')
+			).toHaveValue('');
+			await expect(
+				strangerPage.locator('input[name="email"]')
+			).toHaveValue('');
+
+			await strangerContext.close();
+			await visitorContext.close();
+			await apiFetch(adminPage, {
+				path: `/wp/v2/pages/${signupPage.id}`,
+				method: 'DELETE',
+				data: { force: true },
+			}).catch(() => {});
+		} finally {
+			await apiFetch(adminPage, {
+				path: `/wp/v2/fair_event/${eventPost.id}`,
+				method: 'DELETE',
+				data: { force: true },
+			}).catch(() => {});
+			await apiFetch(adminPage, {
+				path: `/fair-events/v1/event-dates/${eventDate.id}`,
+				method: 'DELETE',
+			}).catch(() => {});
+			await adminContext.close();
+		}
+	});
+});

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -161,6 +161,47 @@ class GetTicketsController extends WP_REST_Controller {
 			)
 		);
 
+		// GET /fair-events/v1/get-tickets/viewer-context — request-time-only
+		// per-viewer personalization (restricted tiers, discounted prices,
+		// prefill, signed-up state) for the cache-safe baseline render's
+		// occurrence, resolved outside the base render so a full-page cache
+		// never stores another viewer's tiers, prices, or details (#1300).
+		// permission_callback: __return_true is safe here — the route takes
+		// no identity parameter at all; the viewer is resolved purely
+		// server-side from the session cookie/login, exactly like the
+		// existing public /fair-audience/v1/event-signup/status endpoint.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/viewer-context',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_viewer_context' ),
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'event_date_id'      => array(
+						'type'              => 'integer',
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					),
+					// Block-author display choices, viewer-independent — read
+					// from the baseline render's data attributes by
+					// frontend.js so the personalized fragments match it.
+					'show_ticket_price'  => array(
+						'type'              => 'boolean',
+						'required'          => false,
+						'default'           => true,
+						'sanitize_callback' => 'rest_sanitize_boolean',
+					),
+					'show_option_prices' => array(
+						'type'              => 'boolean',
+						'required'          => false,
+						'default'           => true,
+						'sanitize_callback' => 'rest_sanitize_boolean',
+					),
+				),
+			)
+		);
+
 		// GET /fair-events/v1/get-tickets/payment-state — resolved
 		// confirmed/processing/resume/retry state + card payload. Consumed by
 		// the return-from-payment callback card and the direct-navigation
@@ -537,6 +578,233 @@ class GetTicketsController extends WP_REST_Controller {
 				'currency'       => $currency,
 			)
 		);
+	}
+
+	/**
+	 * Resolve request-time per-viewer personalization for the Event Signup
+	 * block's cache-safe baseline render: restricted tiers becoming visible,
+	 * discounted prices, name/email pre-fill, and signed-up state — none of
+	 * which the base render (render.php) may compute, since a full-page
+	 * cache stores and replays it (#1300). frontend.js hydrates this after
+	 * load for every viewer, cached page or not, so the visible result never
+	 * depends on who the page happened to be rendered for.
+	 *
+	 * Rebuilds the full (unfiltered, including group-restricted) ticket
+	 * type/options/occurrences context render.php itself builds, runs it
+	 * through the fair_events_signup_viewer_context filter (fair-audience's
+	 * SignupHookBridge::enrich_render_context() is the intended consumer),
+	 * and — only when that filter actually recognised a viewer — renders the
+	 * two selection fieldsets and captures whatever the three render-slot
+	 * actions echo, via output buffering, exactly as render.php fires them.
+	 * An anonymous caller (the common case) does none of that rendering
+	 * work: the response is an empty/no-op payload.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_viewer_context( $request ) {
+		$event_date_id = (int) $request->get_param( 'event_date_id' );
+
+		if ( ! class_exists( \FairEvents\Models\EventDates::class ) ) {
+			return new WP_Error(
+				'invalid_event_date',
+				__( 'Event date not found.', 'fair-events' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+		if ( ! $event_date ) {
+			return new WP_Error(
+				'invalid_event_date',
+				__( 'Event date not found.', 'fair-events' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Pivot config/pricing lookups to the series master for generated
+		// occurrences, mirroring render.php.
+		$pricing_event_date_id = $event_date_id;
+		if ( 'generated' === ( $event_date->occurrence_type ?? null ) && ! empty( $event_date->master_id ) ) {
+			$pricing_event_date_id = (int) $event_date->master_id;
+		}
+
+		$ticket_types = array();
+		if ( class_exists( \FairEvents\Models\TicketType::class ) ) {
+			$ticket_types = \FairEvents\Models\TicketType::get_all_by_event_date_id( $pricing_event_date_id );
+		}
+
+		$series_master_id = null;
+		if ( 'master' === ( $event_date->occurrence_type ?? null ) ) {
+			$series_master_id = (int) $event_date->id;
+		} elseif ( 'generated' === ( $event_date->occurrence_type ?? null ) && ! empty( $event_date->master_id ) ) {
+			$series_master_id = (int) $event_date->master_id;
+		}
+
+		$occurrences_for_picker = array();
+		if ( $series_master_id ) {
+			$upcoming = \FairEvents\Models\EventDates::get_upcoming_by_master_id( $series_master_id );
+			foreach ( $upcoming as $occ ) {
+				$occurrences_for_picker[] = array(
+					'id'             => (int) $occ->id,
+					'start_datetime' => $occ->start_datetime,
+					'end_datetime'   => $occ->end_datetime,
+					'all_day'        => (bool) $occ->all_day,
+					'signed_up'      => false,
+				);
+			}
+		}
+
+		$price_by_type_id   = array();
+		$active_sale_period = null;
+		if ( class_exists( \FairEvents\Services\TicketPricing::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
+			$active_sale_period = \FairEvents\Services\TicketPricing::resolve_active_sale_period( $pricing_event_date_id );
+			if ( $active_sale_period ) {
+				$prices = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id );
+				foreach ( $prices as $price ) {
+					if ( (int) $price->sale_period_id === (int) $active_sale_period->id ) {
+						$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
+					}
+				}
+			}
+		}
+
+		$ticket_options = array();
+		if ( class_exists( \FairAudience\API\EventSignupController::class )
+			&& class_exists( \FairEventsExperimental\Models\TicketOption::class ) ) {
+			$raw_options = \FairEventsExperimental\Models\TicketOption::get_all_by_event_date_id( $pricing_event_date_id );
+			foreach ( $raw_options as $opt ) {
+				$resolved_base = class_exists( \FairEventsExperimental\Services\ActivityOptionPriceResolver::class )
+					? \FairEventsExperimental\Services\ActivityOptionPriceResolver::resolve( $opt )
+					: (float) $opt->price;
+				if ( null === $resolved_base ) {
+					continue;
+				}
+				$ticket_options[] = array(
+					'id'         => (int) $opt->id,
+					'name'       => $opt->name,
+					'short_name' => $opt->short_name ?? null,
+					'price'      => (float) $resolved_base,
+					'is_full'    => false,
+				);
+			}
+		}
+
+		$minimum_activities = 0;
+		if ( ! empty( $ticket_options ) && class_exists( \FairEvents\Models\EventDateSetting::class ) ) {
+			$minimum_activities = (int) \FairEvents\Models\EventDateSetting::get( $pricing_event_date_id, 'minimum_activities' );
+			$minimum_activities = max( 0, min( $minimum_activities, count( $ticket_options ) ) );
+		}
+
+		$show_ticket_price    = (bool) $request->get_param( 'show_ticket_price' );
+		$show_option_prices   = (bool) $request->get_param( 'show_option_prices' );
+		$payments_unavailable = ! class_exists( \FairPaymentsConnector\API\TransactionAPI::class )
+			|| ! \FairPaymentsConnector\API\TransactionAPI::is_configured();
+
+		/**
+		 * Extension point for plugins (e.g. fair-audience) that resolve
+		 * per-viewer personalization at request time. Safe to compute here —
+		 * unlike fair_events_signup_render_context, this runs inside an
+		 * uncached REST request, never inside the page a full-page cache
+		 * stores. See REST_API_BACKEND.md.
+		 *
+		 * @param array $context Context array, the same shape
+		 *                       fair_events_signup_render_context builds,
+		 *                       plus 'viewer_resolved' (bool, default
+		 *                       false) — a companion plugin sets this true
+		 *                       whenever it recognises the viewer, signalling
+		 *                       this endpoint to render the personalized
+		 *                       fragments below.
+		 */
+		$context = apply_filters(
+			'fair_events_signup_viewer_context',
+			array(
+				'event_date_id'          => $event_date_id,
+				'pricing_event_date_id'  => $pricing_event_date_id,
+				'ticket_types'           => $ticket_types,
+				'price_by_type_id'       => $price_by_type_id,
+				'active_sale_period'     => $active_sale_period,
+				'occurrences_for_picker' => $occurrences_for_picker,
+				'ticket_options'         => $ticket_options,
+				'minimum_activities'     => $minimum_activities,
+				'prefill_name'           => '',
+				'prefill_email'          => '',
+				'suppress_form'          => false,
+				'viewer_resolved'        => false,
+			)
+		);
+
+		$viewer_resolved = ! empty( $context['viewer_resolved'] );
+		$suppress_form   = ! empty( $context['suppress_form'] );
+
+		$occurrences_signed_up = array();
+		foreach ( (array) ( $context['occurrences_for_picker'] ?? array() ) as $occ_row ) {
+			if ( ! empty( $occ_row['signed_up'] ) ) {
+				$occurrences_signed_up[] = (int) $occ_row['id'];
+			}
+		}
+
+		$response = array(
+			'viewer_resolved'              => $viewer_resolved,
+			'suppress_form'                => $suppress_form,
+			'ticket_type_fieldset_html'    => null,
+			'ticket_options_fieldset_html' => null,
+			'before_form_html'             => null,
+			'before_submit_html'           => null,
+			'after_form_html'              => null,
+			'occurrences_signed_up'        => $occurrences_signed_up,
+			'prefill_name'                 => (string) ( $context['prefill_name'] ?? '' ),
+			'prefill_email'                => (string) ( $context['prefill_email'] ?? '' ),
+		);
+
+		// Anonymous majority case: no viewer was recognised, so there is
+		// nothing to personalize — skip all rendering work below.
+		if ( ! $viewer_resolved ) {
+			return rest_ensure_response( $response );
+		}
+
+		// Deterministic and namespaced away from render.php's own
+		// wp_unique_id()-based $form_id (a bare per-request counter) so IDs
+		// generated by this separate REST request can never collide with the
+		// IDs already present in the page's DOM.
+		$form_id = 'fair-events-get-tickets-viewer-' . $event_date_id;
+
+		if ( ! $suppress_form ) {
+			$response['ticket_type_fieldset_html']    = \FairEvents\Services\SignupFieldsetRenderer::ticket_type_fieldset(
+				$context['ticket_types'],
+				$context['price_by_type_id'],
+				$context['active_sale_period'],
+				$show_ticket_price,
+				$payments_unavailable,
+				$form_id
+			);
+			$response['ticket_options_fieldset_html'] = \FairEvents\Services\SignupFieldsetRenderer::ticket_options_fieldset(
+				$context['ticket_options'],
+				$context['ticket_types'],
+				$context['price_by_type_id'],
+				(int) $context['minimum_activities'],
+				$show_option_prices,
+				$payments_unavailable,
+				$form_id
+			);
+
+			ob_start();
+			do_action( 'fair_events_signup_render_before_submit', $context );
+			$response['before_submit_html'] = ob_get_clean();
+		}
+
+		// Fired regardless of suppress_form — inside the <form> when not
+		// suppressed, inside the client-swapped companion wrapper otherwise,
+		// mirroring render.php's two call sites for these same actions.
+		ob_start();
+		do_action( 'fair_events_signup_render_before_form', $context );
+		$response['before_form_html'] = ob_get_clean();
+
+		ob_start();
+		do_action( 'fair_events_signup_render_after_form', $context );
+		$response['after_form_html'] = ob_get_clean();
+
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/fair-events/src/API/__tests__/GetTicketsViewerContext.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsViewerContext.api.spec.js
@@ -1,0 +1,167 @@
+/**
+ * Playwright API tests for the get-tickets viewer-context endpoint (#1300):
+ * the request-time personalization the Event Signup block's cache-safe
+ * baseline render can no longer compute itself, since a full-page cache
+ * stores and replays it.
+ *
+ * These assertions hold whether or not fair-audience (the only current
+ * consumer of fair_events_signup_viewer_context) is active on the stack
+ * this suite runs against: an anonymous caller — and an authenticated admin
+ * who isn't linked to any fair-audience participant — both resolve to no
+ * viewer, so `viewer_resolved` is false and the response is the same
+ * no-op payload either way. That is also exactly the guarantee the ticket's
+ * "discloses nothing about a participant other than the current viewer"
+ * acceptance criterion needs: nothing here can be used to enumerate or infer
+ * another visitor's identity.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+const VIEWER_CONTEXT_PATH =
+	'/wp-json/fair-events/v1/get-tickets/viewer-context';
+
+test.describe('GetTicketsController — viewer-context', () => {
+	let api;
+	let eventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Get-tickets viewer-context test ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		const eventPostId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Get-tickets viewer-context test ${Date.now()}`,
+				link_type: 'post',
+				start_datetime: '2035-06-01 10:00:00',
+				end_datetime: '2035-06-01 12:00:00',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		eventDateId = (await edRes.json()).id;
+
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{
+				headers: adminHeaders,
+				data: { event_id: eventPostId },
+			}
+		);
+		expect(linkRes.ok()).toBeTruthy();
+
+		const ticketsRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+			{
+				headers: adminHeaders,
+				data: {
+					ticket_types: [
+						{
+							name: 'General',
+							recurrence_scope: 'single_instance',
+							capacity: null,
+							minimum_activities: 0,
+							disable_at: null,
+							group_ids: [],
+						},
+					],
+					sale_periods: [
+						{
+							name: 'Always on',
+							sale_start: '2020-01-01 00:00:00',
+							sale_end: '2099-01-01 00:00:00',
+						},
+					],
+					prices: [
+						{
+							ticket_type_index: 0,
+							sale_period_index: 0,
+							price: 15,
+						},
+					],
+					settings: {},
+				},
+			}
+		);
+		expect(ticketsRes.ok()).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	test('requires event_date_id', async () => {
+		const res = await api.get(VIEWER_CONTEXT_PATH);
+		expect(res.status()).toBe(400);
+	});
+
+	test('an unknown event_date_id 404s', async () => {
+		const res = await api.get(VIEWER_CONTEXT_PATH, {
+			params: { event_date_id: 999999999 },
+		});
+		expect(res.status()).toBe(404);
+		expect((await res.json()).code).toBe('invalid_event_date');
+	});
+
+	test('an anonymous caller gets a no-op payload — no fieldsets, no prefill, not signed up', async () => {
+		const res = await api.get(VIEWER_CONTEXT_PATH, {
+			params: { event_date_id: eventDateId },
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		expect(body.viewer_resolved).toBe(false);
+		expect(body.suppress_form).toBe(false);
+		expect(body.ticket_type_fieldset_html).toBeNull();
+		expect(body.ticket_options_fieldset_html).toBeNull();
+		expect(body.before_form_html).toBeNull();
+		expect(body.before_submit_html).toBeNull();
+		expect(body.after_form_html).toBeNull();
+		expect(body.occurrences_signed_up).toEqual([]);
+		expect(body.prefill_name).toBe('');
+		expect(body.prefill_email).toBe('');
+	});
+
+	test('an authenticated admin with no linked participant gets the same no-op payload as an anonymous caller — no enumeration', async () => {
+		const res = await api.get(VIEWER_CONTEXT_PATH, {
+			headers: adminHeaders,
+			params: { event_date_id: eventDateId },
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		expect(body.viewer_resolved).toBe(false);
+		expect(body.prefill_name).toBe('');
+		expect(body.prefill_email).toBe('');
+	});
+
+	test('display flags round-trip without affecting viewer_resolved', async () => {
+		const res = await api.get(VIEWER_CONTEXT_PATH, {
+			params: {
+				event_date_id: eventDateId,
+				show_ticket_price: '0',
+				show_option_prices: '0',
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		expect((await res.json()).viewer_resolved).toBe(false);
+	});
+});

--- a/fair-events/src/Services/SignupFieldsetRenderer.php
+++ b/fair-events/src/Services/SignupFieldsetRenderer.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Signup ticket-type / ticket-options fieldset renderer.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Renders the Event Signup form's two ticket-selection fieldsets as
+ * self-contained HTML fragments, shared between the block's base render
+ * (render.php, cache-safe baseline) and the viewer-context REST endpoint
+ * (GetTicketsController::get_viewer_context(), personalized fragments) so
+ * both produce identical markup for a given ticket-type/options set instead
+ * of maintaining the templating logic twice.
+ */
+class SignupFieldsetRenderer {
+
+	/**
+	 * Resolve the first ticket type not blocked by a payments-unavailable
+	 * price, matching the radio pre-selection shown on first paint.
+	 *
+	 * @param object[] $ticket_types         Ticket type objects.
+	 * @param float[]  $price_by_type_id     Ticket-type ID => resolved price.
+	 * @param bool     $payments_unavailable Whether online payments can't be collected right now.
+	 * @return int|null
+	 */
+	public static function resolve_first_enabled_type_id( array $ticket_types, array $price_by_type_id, $payments_unavailable ) {
+		foreach ( $ticket_types as $ticket_type ) {
+			$type_id    = (int) $ticket_type->id;
+			$type_price = $price_by_type_id[ $type_id ] ?? null;
+			if ( ! ( $payments_unavailable && null !== $type_price && $type_price > 0 ) ) {
+				return $type_id;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Render the "Choose ticket type" fieldset.
+	 *
+	 * @param object[]    $ticket_types         Ticket type objects for this event date.
+	 * @param float[]     $price_by_type_id     Ticket-type ID => resolved price.
+	 * @param object|null $active_sale_period   Active sale period row, or null.
+	 * @param bool        $show_ticket_price    Whether to show the price in each option's label.
+	 * @param bool        $payments_unavailable Whether online payments can't be collected right now.
+	 * @param string      $form_id              Unique prefix for input/label IDs.
+	 * @return string HTML, or '' when there are no ticket types.
+	 */
+	public static function ticket_type_fieldset( array $ticket_types, array $price_by_type_id, $active_sale_period, $show_ticket_price, $payments_unavailable, $form_id ) {
+		if ( empty( $ticket_types ) ) {
+			return '';
+		}
+
+		$first_enabled_type_id = self::resolve_first_enabled_type_id( $ticket_types, $price_by_type_id, $payments_unavailable );
+
+		ob_start();
+		?>
+		<div class="form-row">
+			<fieldset class="fair-events-ticket-fieldset">
+				<legend class="form-label"><?php esc_html_e( 'Choose ticket type', 'fair-events' ); ?></legend>
+				<?php foreach ( $ticket_types as $ticket_type ) : ?>
+					<?php
+					$type_id          = (int) $ticket_type->id;
+					$type_price       = $price_by_type_id[ $type_id ] ?? null;
+					$type_unavailable = $payments_unavailable && null !== $type_price && $type_price > 0;
+					$label            = esc_html( $ticket_type->name );
+					if ( $show_ticket_price && null !== $type_price ) {
+						$label .= ' — ' . esc_html( \FairEventsShared\Money::format_inline( $type_price ) );
+					} elseif ( null === $active_sale_period ) {
+						$label .= ' — ' . esc_html__( 'No active sale period', 'fair-events' );
+					}
+					if ( $type_unavailable ) {
+						$label .= ' — ' . esc_html__( 'ticket sales temporarily unavailable', 'fair-events' );
+					}
+					$radio_id = $form_id . '-ticket-type-' . $type_id;
+					?>
+					<label class="fair-events-ticket-option" for="<?php echo esc_attr( $radio_id ); ?>">
+						<input
+							type="radio"
+							id="<?php echo esc_attr( $radio_id ); ?>"
+							name="ticket_type_id"
+							value="<?php echo esc_attr( $type_id ); ?>"
+							data-ticket-price="<?php echo esc_attr( null !== $type_price ? \FairEventsShared\Money::format_value( $type_price ) : '' ); ?>"
+							data-recurrence-scope="<?php echo esc_attr( $ticket_type->recurrence_scope ); ?>"
+							data-min-instances="<?php echo esc_attr( (string) $ticket_type->minimum_instances ); ?>"
+							data-min-activities="<?php echo esc_attr( (string) $ticket_type->minimum_activities ); ?>"
+							<?php echo $type_unavailable ? 'disabled' : ''; ?>
+							<?php echo $type_id === $first_enabled_type_id ? 'checked' : ''; ?>
+						/>
+						<?php echo esc_html( $label ); ?>
+					</label>
+				<?php endforeach; ?>
+			</fieldset>
+		</div>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Render the "Select activities" fieldset.
+	 *
+	 * @param array    $ticket_options       Activity option rows ([ id, name, short_name, price, is_full ]).
+	 * @param object[] $ticket_types         Ticket type objects, used to resolve the preselected type's own minimum-activities.
+	 * @param float[]  $price_by_type_id     Ticket-type ID => resolved price.
+	 * @param int      $minimum_activities   Event-date global minimum-activities requirement.
+	 * @param bool     $show_option_prices   Whether to show each option's add-on price tag.
+	 * @param bool     $payments_unavailable Whether online payments can't be collected right now.
+	 * @param string   $form_id              Unique prefix for input/label IDs.
+	 * @return string HTML, or '' when there are no activity options.
+	 */
+	public static function ticket_options_fieldset( array $ticket_options, array $ticket_types, array $price_by_type_id, $minimum_activities, $show_option_prices, $payments_unavailable, $form_id ) {
+		if ( empty( $ticket_options ) ) {
+			return '';
+		}
+
+		$first_enabled_type_id = self::resolve_first_enabled_type_id( $ticket_types, $price_by_type_id, $payments_unavailable );
+
+		$any_ticket_type_min = 0;
+		foreach ( $ticket_types as $tt_for_min ) {
+			$any_ticket_type_min = max( $any_ticket_type_min, (int) $tt_for_min->minimum_activities );
+		}
+
+		$preselected_type_min = 0;
+		if ( ! empty( $first_enabled_type_id ) ) {
+			foreach ( $ticket_types as $tt_preselected ) {
+				if ( (int) $tt_preselected->id === $first_enabled_type_id ) {
+					$preselected_type_min = (int) $tt_preselected->minimum_activities;
+					break;
+				}
+			}
+		}
+
+		$options_feature_active = ( $minimum_activities > 0 || $any_ticket_type_min > 0 );
+		$initial_min_activities = min( count( $ticket_options ), max( $minimum_activities, $preselected_type_min ) );
+
+		ob_start();
+		?>
+		<div class="form-row">
+			<fieldset class="fair-events-ticket-options">
+				<legend class="form-label"><?php esc_html_e( 'Select activities', 'fair-events' ); ?></legend>
+				<?php if ( $options_feature_active ) : ?>
+					<?php
+					$hint_text = $initial_min_activities > 0
+						? sprintf(
+							/* translators: %d: minimum number of activities required */
+							_n(
+								'Please select at least %d activity to sign up.',
+								'Please select at least %d activities to sign up.',
+								$initial_min_activities,
+								'fair-events'
+							),
+							$initial_min_activities
+						)
+						: '';
+					$hint_style = $initial_min_activities > 0 ? '' : ' style="display: none;"';
+					?>
+					<p class="fair-events-ticket-options-min-hint"<?php echo $hint_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static literal. ?>>
+						<?php echo esc_html( $hint_text ); ?>
+					</p>
+				<?php endif; ?>
+				<?php foreach ( $ticket_options as $opt ) : ?>
+					<?php
+					$opt_label   = $opt['name'];
+					$opt_is_full = ! empty( $opt['is_full'] );
+					if ( $opt_is_full ) {
+						$opt_label .= ' — ' . __( 'full', 'fair-events' );
+					}
+					$opt_checkbox_id = $form_id . '-opt-' . (int) $opt['id'];
+					$opt_classes     = 'fair-events-ticket-option-item';
+					if ( $opt_is_full ) {
+						$opt_classes .= ' fair-events-ticket-option-full';
+					}
+					?>
+					<label class="<?php echo esc_attr( $opt_classes ); ?>" for="<?php echo esc_attr( $opt_checkbox_id ); ?>">
+						<input
+							type="checkbox"
+							name="ticket_option_ids[]"
+							id="<?php echo esc_attr( $opt_checkbox_id ); ?>"
+							value="<?php echo (int) $opt['id']; ?>"
+							class="form-checkbox"
+							data-option-price="<?php echo esc_attr( \FairEventsShared\Money::format_value( $opt['price'] ) ); ?>"
+							data-option-short-name="<?php echo esc_attr( $opt['short_name'] ?? '' ); ?>"
+							<?php echo $opt_is_full ? 'disabled' : ''; ?>
+						/>
+						<span class="fair-events-ticket-option-text">
+							<?php echo esc_html( $opt_label ); ?>
+							<?php if ( $show_option_prices && 0.0 !== (float) $opt['price'] ) : ?>
+								<span class="fair-events-ticket-option-addon" style="display: none;">
+									<?php if ( $opt['price'] > 0 ) : ?>
+										<?php
+										printf(
+											/* translators: %s: formatted add-on price */
+											esc_html__( '+%s', 'fair-events' ),
+											esc_html( \FairEventsShared\Money::format_inline( $opt['price'] ) )
+										);
+										?>
+									<?php else : ?>
+										<?php
+										printf(
+											/* translators: %s: formatted add-on price */
+											esc_html__( '-%s', 'fair-events' ),
+											esc_html( \FairEventsShared\Money::format_inline( abs( $opt['price'] ) ) )
+										);
+										?>
+									<?php endif; ?>
+								</span>
+							<?php endif; ?>
+						</span>
+					</label>
+				<?php endforeach; ?>
+				<p class="fair-events-ticket-options-total"></p>
+			</fieldset>
+		</div>
+		<?php
+		return ob_get_clean();
+	}
+}

--- a/fair-events/src/blocks/event-signup/__tests__/frontend.test.js
+++ b/fair-events/src/blocks/event-signup/__tests__/frontend.test.js
@@ -1,0 +1,276 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Covers frontend.js's viewer-context hydration (#1300): the cache-safe
+ * baseline markup is patched in place for the actual viewer after load,
+ * regardless of who the page happened to be rendered for. fair-events-shared
+ * and @wordpress/api-fetch are mocked so these tests exercise only
+ * frontend.js's own DOM-patching logic, not a real fetch or the shared
+ * helpers' own behavior (covered by their own unit tests).
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { wireNotYouButton } from 'fair-events-shared';
+
+jest.mock('@wordpress/api-fetch', () => jest.fn());
+jest.mock('fair-events-shared', () => ({
+	showMessage: jest.fn(),
+	onDomReady: (cb) => {
+		global.__fairEventsSignupInitialize = cb;
+	},
+	initiatePayment: jest.fn(() => Promise.resolve({})),
+	pollPaymentStatus: jest.fn(),
+	computeTicketTotal: jest.fn(() => 0),
+	formatMoney: jest.fn((amount) => String(amount)),
+	collectQuestionAnswers: jest.fn(() => ({})),
+	validateQuestions: jest.fn(() => null),
+	setupQuestionnaire: jest.fn(),
+	extractErrorMessage: jest.fn((_error, fallback) => fallback),
+	setButtonLoading: jest.fn(() => jest.fn()),
+	wireNotYouButton: jest.fn(),
+}));
+
+// The module registers its DOM-ready callback (captured by the onDomReady
+// mock above) once, at import time — reused across every test below.
+require('../frontend.js');
+const initialize = global.__fairEventsSignupInitialize;
+
+function buildBlock({ eventDateId = 42 } = {}) {
+	document.body.innerHTML = `
+		<div class="fair-events-get-tickets" data-event-date-id="${eventDateId}" data-show-ticket-price="1" data-show-option-prices="1" data-currency="EUR">
+			<form class="fair-events-get-tickets-form" data-event-date-id="${eventDateId}" data-min-activities="0" data-currency="EUR">
+				<div class="form-row">
+					<fieldset class="fair-events-ticket-fieldset">
+						<legend>Choose ticket type</legend>
+						<label class="fair-events-ticket-option">
+							<input type="radio" name="ticket_type_id" value="1" checked />
+							General
+						</label>
+					</fieldset>
+				</div>
+				<div class="form-row">
+					<label>Your Name</label>
+					<input type="text" name="name" />
+				</div>
+				<div class="form-row">
+					<label>Your Email</label>
+					<input type="email" name="email" />
+				</div>
+				<div class="form-row form-submit">
+					<button type="submit">Get Tickets</button>
+				</div>
+			</form>
+			<div class="message-container"></div>
+		</div>
+	`;
+	return document.querySelector('.fair-events-get-tickets');
+}
+
+function noopResponse() {
+	return {
+		viewer_resolved: false,
+		suppress_form: false,
+		ticket_type_fieldset_html: null,
+		ticket_options_fieldset_html: null,
+		before_form_html: null,
+		before_submit_html: null,
+		after_form_html: null,
+		occurrences_signed_up: [],
+		prefill_name: '',
+		prefill_email: '',
+	};
+}
+
+beforeEach(() => {
+	apiFetch.mockReset();
+	wireNotYouButton.mockClear();
+});
+
+describe('Event Signup frontend.js — viewer-context hydration', () => {
+	test('fetches viewer-context with the event date and display flags, disabling submit until it resolves', async () => {
+		const block = buildBlock({ eventDateId: 42 });
+		const submitButton = block.querySelector('button[type="submit"]');
+		let resolveFetch;
+		apiFetch.mockReturnValue(
+			new Promise((resolve) => {
+				resolveFetch = resolve;
+			})
+		);
+
+		initialize();
+
+		expect(submitButton.disabled).toBe(true);
+		expect(apiFetch).toHaveBeenCalledTimes(1);
+		const { path } = apiFetch.mock.calls[0][0];
+		expect(path).toContain('/fair-events/v1/get-tickets/viewer-context');
+		expect(path).toContain('event_date_id=42');
+		expect(path).toContain('show_ticket_price=1');
+		expect(path).toContain('show_option_prices=1');
+
+		resolveFetch(noopResponse());
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(submitButton.disabled).toBe(false);
+	});
+
+	test('anonymous (viewer_resolved: false) response leaves the baseline markup untouched', async () => {
+		const block = buildBlock();
+		const nameField = block.querySelector('input[name="name"]');
+		apiFetch.mockResolvedValue(noopResponse());
+
+		initialize();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(nameField.value).toBe('');
+		expect(
+			block.querySelector('.fair-events-get-tickets-viewer-slot')
+		).toBeNull();
+		expect(
+			block.querySelector('.fair-events-get-tickets-form')
+		).not.toBeNull();
+	});
+
+	test('a recognised viewer: patches the ticket-type fieldset, prefill, and render-slot fragments', async () => {
+		const block = buildBlock();
+		const form = block.querySelector('.fair-events-get-tickets-form');
+
+		apiFetch.mockResolvedValue({
+			viewer_resolved: true,
+			suppress_form: false,
+			ticket_type_fieldset_html:
+				'<div class="form-row"><fieldset class="fair-events-ticket-fieldset">' +
+				'<legend>Choose ticket type</legend>' +
+				'<label class="fair-events-ticket-option"><input type="radio" name="ticket_type_id" value="2" data-recurrence-scope="single_instance" checked /> Member</label>' +
+				'</fieldset></div>',
+			ticket_options_fieldset_html: null,
+			before_form_html:
+				'<p class="fair-events-not-you-marker">not you</p>',
+			before_submit_html:
+				'<p class="fair-events-get-tickets-discount-note">10% off</p>',
+			after_form_html: '<div class="fair-events-add-activities"></div>',
+			occurrences_signed_up: [],
+			prefill_name: 'Ada Lovelace',
+			prefill_email: 'ada@example.com',
+		});
+
+		initialize();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// Fieldset swapped to the personalized markup.
+		expect(form.querySelector('input[name="ticket_type_id"]').value).toBe(
+			'2'
+		);
+		expect(
+			form.querySelector('.fair-events-ticket-option').textContent
+		).toContain('Member');
+
+		// Prefill applied.
+		expect(form.querySelector('input[name="name"]').value).toBe(
+			'Ada Lovelace'
+		);
+		expect(form.querySelector('input[name="email"]').value).toBe(
+			'ada@example.com'
+		);
+
+		// Render-slot fragments injected: before_form at the top, before_submit
+		// just ahead of the submit row, after_form at the end.
+		expect(
+			form.querySelector('.fair-events-not-you-marker')
+		).not.toBeNull();
+		expect(
+			form.querySelector('.fair-events-get-tickets-discount-note')
+		).not.toBeNull();
+		expect(
+			form.querySelector('.fair-events-add-activities')
+		).not.toBeNull();
+
+		const submitRow = form.querySelector('.form-submit');
+		const discountSlot = form
+			.querySelector('.fair-events-get-tickets-discount-note')
+			.closest('.fair-events-get-tickets-viewer-slot');
+		expect(discountSlot.nextElementSibling).toBe(submitRow);
+
+		// The swapped-in radio was re-wired: changing it must not throw, and
+		// the submit gate recomputes without error.
+		const submitButton = form.querySelector('button[type="submit"]');
+		form.querySelector('input[name="ticket_type_id"]').dispatchEvent(
+			new window.Event('change', { bubbles: true })
+		);
+		expect(submitButton.disabled).toBe(false);
+	});
+
+	test('marks a signed-up occurrence in the single-occurrence dropdown', async () => {
+		const block = buildBlock();
+		const form = block.querySelector('.fair-events-get-tickets-form');
+		const select = document.createElement('select');
+		select.name = 'event_date_id_single';
+		const option = document.createElement('option');
+		option.value = '99';
+		option.textContent = 'Sat, 1 Jan';
+		select.appendChild(option);
+		form.insertBefore(select, form.querySelector('.form-submit'));
+
+		apiFetch.mockResolvedValue({
+			...noopResponse(),
+			viewer_resolved: true,
+			occurrences_signed_up: [99],
+		});
+
+		initialize();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(option.textContent).toContain('already signed up');
+	});
+
+	test('suppress_form: true swaps the <form> for the companion wrapper', async () => {
+		const block = buildBlock();
+
+		apiFetch.mockResolvedValue({
+			...noopResponse(),
+			viewer_resolved: true,
+			suppress_form: true,
+			before_form_html:
+				'<div class="fair-events-signed-up-card">You are signed up</div>',
+			after_form_html: '',
+		});
+
+		initialize();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(block.querySelector('.fair-events-get-tickets-form')).toBeNull();
+		const companion = block.querySelector(
+			'.fair-events-get-tickets-companion'
+		);
+		expect(companion).not.toBeNull();
+		expect(
+			companion.querySelector('.fair-events-signed-up-card')
+		).not.toBeNull();
+	});
+
+	test('re-enables the submit button after a timeout even if the fetch never resolves', () => {
+		jest.useFakeTimers();
+		const block = buildBlock();
+		const submitButton = block.querySelector('button[type="submit"]');
+		apiFetch.mockReturnValue(new Promise(() => {}));
+
+		initialize();
+		expect(submitButton.disabled).toBe(true);
+
+		jest.advanceTimersByTime(3000);
+
+		expect(submitButton.disabled).toBe(false);
+		jest.useRealTimers();
+	});
+
+	test('a block with no data-event-date-id is left alone (no fetch)', () => {
+		document.body.innerHTML = '<div class="fair-events-get-tickets"></div>';
+
+		initialize();
+
+		expect(apiFetch).not.toHaveBeenCalled();
+	});
+});

--- a/fair-events/src/blocks/event-signup/frontend.js
+++ b/fair-events/src/blocks/event-signup/frontend.js
@@ -24,6 +24,11 @@ import './frontend.css';
 
 const CSS_PREFIX = 'fair-events-get-tickets';
 const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
+const VIEWER_CONTEXT_PATH = '/fair-events/v1/get-tickets/viewer-context';
+// A member's discount/eligibility must be applied before the submit button
+// is usable, but a slow/failed fetch must never strand the visitor with a
+// permanently disabled form — release the gate after this either way.
+const VIEWER_CONTEXT_TIMEOUT = 3000;
 
 (function () {
 	'use strict';
@@ -60,6 +65,281 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 				wireAddActivities(block);
 				wireCancelSignup(block);
 			});
+
+		// Per-viewer personalization (#1300): the markup above is the
+		// cache-safe baseline, identical for every viewer. Hydrate the
+		// actual viewer's restricted tiers, discounted prices, prefill, and
+		// signed-up state after load, for every page load — cached or not —
+		// so the visible result never depends on who the page was rendered
+		// for.
+		document
+			.querySelectorAll('.fair-events-get-tickets')
+			.forEach(hydrateViewerContext);
+	}
+
+	/**
+	 * Fetch and apply the request-time viewer-context personalization for a
+	 * single Event Signup block.
+	 * @param {HTMLElement} block The .fair-events-get-tickets wrapper.
+	 */
+	function hydrateViewerContext(block) {
+		const eventDateId = parseInt(block.dataset.eventDateId || '0', 10);
+		if (!eventDateId) {
+			return;
+		}
+
+		const form = block.querySelector('.fair-events-get-tickets-form');
+		const submitButton = form
+			? form.querySelector('button[type="submit"]')
+			: null;
+		if (submitButton) {
+			submitButton.disabled = true;
+			submitButton.classList.add('is-disabled');
+		}
+
+		let settled = false;
+		const release = function () {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			if (form) {
+				updateSubmitGate(form);
+			}
+		};
+		const timeoutId = setTimeout(release, VIEWER_CONTEXT_TIMEOUT);
+
+		const params = new URLSearchParams({ event_date_id: eventDateId });
+		if (block.dataset.showTicketPrice !== undefined) {
+			params.set('show_ticket_price', block.dataset.showTicketPrice);
+		}
+		if (block.dataset.showOptionPrices !== undefined) {
+			params.set('show_option_prices', block.dataset.showOptionPrices);
+		}
+
+		apiFetch({ path: `${VIEWER_CONTEXT_PATH}?${params.toString()}` })
+			.then(function (response) {
+				clearTimeout(timeoutId);
+				applyViewerContext(block, form, response);
+				release();
+			})
+			.catch(function (error) {
+				console.error('Viewer-context fetch error:', error);
+				clearTimeout(timeoutId);
+				release();
+			});
+	}
+
+	/**
+	 * Apply a viewer-context response to a block: swap to the companion
+	 * markup for a signed-up viewer, or patch the selection fieldsets,
+	 * prefill, signed-up occurrences, and render-slot fragments into the
+	 * existing form.
+	 * @param {HTMLElement}          block    The .fair-events-get-tickets wrapper.
+	 * @param {HTMLFormElement|null} form     The block's signup form, if present.
+	 * @param {Object}               response viewer-context response.
+	 */
+	function applyViewerContext(block, form, response) {
+		if (!response || !response.viewer_resolved) {
+			return;
+		}
+
+		if (response.suppress_form) {
+			swapToCompanion(block, form, response);
+			return;
+		}
+
+		if (!form) {
+			return;
+		}
+
+		if (response.ticket_type_fieldset_html) {
+			replaceFieldset(
+				form,
+				'.fair-events-ticket-fieldset',
+				response.ticket_type_fieldset_html
+			);
+			wireTicketTypeInputs(form);
+		}
+		if (response.ticket_options_fieldset_html) {
+			replaceFieldset(
+				form,
+				'.fair-events-ticket-options',
+				response.ticket_options_fieldset_html
+			);
+			wireTicketOptionInputs(form);
+		}
+
+		const nameField = form.querySelector('input[name="name"]');
+		if (nameField && response.prefill_name) {
+			nameField.value = response.prefill_name;
+		}
+		const emailField = form.querySelector('input[name="email"]');
+		if (emailField && response.prefill_email) {
+			emailField.value = response.prefill_email;
+		}
+
+		markSignedUpOccurrences(form, response.occurrences_signed_up || []);
+
+		prependSlotFragment(form, response.before_form_html);
+		insertBeforeSubmitFragment(form, response.before_submit_html);
+		appendSlotFragment(form, response.after_form_html);
+
+		wireNotYouButton(form.querySelector('.fair-events-not-you-button'));
+		wireAddActivities(block);
+		wireCancelSignup(block);
+
+		refreshSignupState(form);
+	}
+
+	/**
+	 * Replace a fieldset's enclosing .form-row with freshly rendered markup
+	 * for the same fieldset (identified by its own class), matching what
+	 * FairEvents\Services\SignupFieldsetRenderer produces server-side.
+	 * @param {HTMLFormElement} form          The get-tickets form.
+	 * @param {string}          fieldsetClass CSS class identifying the fieldset (e.g. '.fair-events-ticket-fieldset').
+	 * @param {string}          html          Replacement HTML, including the enclosing .form-row.
+	 */
+	function replaceFieldset(form, fieldsetClass, html) {
+		const existing = form.querySelector(fieldsetClass);
+		const row = existing ? existing.closest('.form-row') : null;
+		if (!row) {
+			return;
+		}
+		const template = document.createElement('template');
+		template.innerHTML = html.trim();
+		const replacement = template.content.firstElementChild;
+		if (!replacement) {
+			return;
+		}
+		row.replaceWith(replacement);
+	}
+
+	/**
+	 * Label (and disable, for the checkbox picker) occurrences the viewer
+	 * already holds a signup for, mirroring the server-rendered "already
+	 * signed up" treatment the baseline render can no longer bake in.
+	 * @param {HTMLFormElement} form          The get-tickets form.
+	 * @param {number[]}        signedUpIds   event_date_ids the viewer already holds.
+	 */
+	function markSignedUpOccurrences(form, signedUpIds) {
+		if (!signedUpIds.length) {
+			return;
+		}
+		const idSet = new Set(signedUpIds.map(Number));
+		const suffix = ' — ' + __('already signed up', 'fair-events');
+
+		const select = form.querySelector(
+			'select[name="event_date_id_single"]'
+		);
+		if (select) {
+			Array.from(select.options).forEach(function (option) {
+				if (
+					idSet.has(parseInt(option.value, 10)) &&
+					option.textContent.indexOf(suffix) === -1
+				) {
+					option.textContent += suffix;
+				}
+			});
+		}
+
+		form.querySelectorAll('input[name="event_date_ids[]"]').forEach(
+			function (checkbox) {
+				if (!idSet.has(parseInt(checkbox.value, 10))) {
+					return;
+				}
+				checkbox.checked = false;
+				checkbox.disabled = true;
+				const label = checkbox.closest('label');
+				if (label && label.textContent.indexOf(suffix) === -1) {
+					label.append(suffix);
+				}
+			}
+		);
+	}
+
+	/**
+	 * Insert a render-slot HTML fragment as the form's first child.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 * @param {string|null}     html Fragment HTML, or null/empty for nothing to insert.
+	 */
+	function prependSlotFragment(form, html) {
+		if (!html) {
+			return;
+		}
+		const wrapper = document.createElement('div');
+		wrapper.className = 'fair-events-get-tickets-viewer-slot';
+		wrapper.innerHTML = html;
+		form.insertBefore(wrapper, form.firstChild);
+	}
+
+	/**
+	 * Append a render-slot HTML fragment as the form's last child.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 * @param {string|null}     html Fragment HTML, or null/empty for nothing to insert.
+	 */
+	function appendSlotFragment(form, html) {
+		if (!html) {
+			return;
+		}
+		const wrapper = document.createElement('div');
+		wrapper.className = 'fair-events-get-tickets-viewer-slot';
+		wrapper.innerHTML = html;
+		form.appendChild(wrapper);
+	}
+
+	/**
+	 * Insert a render-slot HTML fragment immediately before the submit
+	 * button's row, mirroring render.php's fair_events_signup_render_before_submit
+	 * call site (inside the <form>, just before the submit button).
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 * @param {string|null}     html Fragment HTML, or null/empty for nothing to insert.
+	 */
+	function insertBeforeSubmitFragment(form, html) {
+		if (!html) {
+			return;
+		}
+		const submitRow = form.querySelector('.form-submit');
+		if (!submitRow || !submitRow.parentNode) {
+			return;
+		}
+		const wrapper = document.createElement('div');
+		wrapper.className = 'fair-events-get-tickets-viewer-slot';
+		wrapper.innerHTML = html;
+		submitRow.parentNode.insertBefore(wrapper, submitRow);
+	}
+
+	/**
+	 * Replace the <form> with the companion wrapper for a viewer who already
+	 * holds this signup, mirroring render.php's suppress_form branch —
+	 * done client-side here since the viewer isn't known until after load.
+	 * @param {HTMLElement}          block    The .fair-events-get-tickets wrapper.
+	 * @param {HTMLFormElement|null} form     The form being replaced.
+	 * @param {Object}               response viewer-context response.
+	 */
+	function swapToCompanion(block, form, response) {
+		if (!form) {
+			return;
+		}
+		const companion = document.createElement('div');
+		companion.className = 'fair-events-get-tickets-companion';
+		companion.setAttribute(
+			'data-event-date-id',
+			block.dataset.eventDateId || ''
+		);
+		if (response.before_form_html) {
+			companion.insertAdjacentHTML(
+				'beforeend',
+				response.before_form_html
+			);
+		}
+		if (response.after_form_html) {
+			companion.insertAdjacentHTML('beforeend', response.after_form_html);
+		}
+		form.replaceWith(companion);
+
+		wireAddActivities(block);
+		wireCancelSignup(block);
 	}
 
 	/**
@@ -246,44 +526,70 @@ const PAYMENT_STATE_PATH = '/fair-events/v1/get-tickets/payment-state';
 			submitForm(form, data);
 		});
 
-		const ticketTypeFields = form.querySelectorAll(
-			'input[name="ticket_type_id"]'
-		);
-		ticketTypeFields.forEach(function (field) {
-			field.addEventListener('change', function () {
-				refreshSignupState(form);
-			});
-		});
-
-		const instancePicker = form.querySelector(
-			'.fair-events-instance-picker'
-		);
-		if (instancePicker) {
-			instancePicker
-				.querySelectorAll('input[name="event_date_ids[]"]')
-				.forEach(function (checkbox) {
-					checkbox.addEventListener('change', function () {
-						refreshSignupState(form);
-					});
-				});
-		}
-
-		const ticketOptions = form.querySelector('.fair-events-ticket-options');
-		if (ticketOptions) {
-			ticketOptions
-				.querySelectorAll('input[name="ticket_option_ids[]"]')
-				.forEach(function (checkbox) {
-					checkbox.addEventListener('change', function () {
-						refreshSignupState(form);
-					});
-				});
-		}
+		wireTicketTypeInputs(form);
+		wireInstancePickerInputs(form);
+		wireTicketOptionInputs(form);
 
 		wireAddActivities(form.closest('.fair-events-get-tickets'));
 		wireNotYouButton(form.querySelector('.fair-events-not-you-button'));
 		setupQuestionnaire(form);
 
 		refreshSignupState(form);
+	}
+
+	/**
+	 * Wire the ticket-type radios' change listener. Reusable both at initial
+	 * setup and after a viewer-context swap replaces the fieldset (#1300).
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 */
+	function wireTicketTypeInputs(form) {
+		form.querySelectorAll('input[name="ticket_type_id"]').forEach(function (
+			field
+		) {
+			field.addEventListener('change', function () {
+				refreshSignupState(form);
+			});
+		});
+	}
+
+	/**
+	 * Wire the multi-occurrence checkbox picker's change listener, if present.
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 */
+	function wireInstancePickerInputs(form) {
+		const instancePicker = form.querySelector(
+			'.fair-events-instance-picker'
+		);
+		if (!instancePicker) {
+			return;
+		}
+		instancePicker
+			.querySelectorAll('input[name="event_date_ids[]"]')
+			.forEach(function (checkbox) {
+				checkbox.addEventListener('change', function () {
+					refreshSignupState(form);
+				});
+			});
+	}
+
+	/**
+	 * Wire the activities (ticket options) checkboxes' change listener, if
+	 * present. Reusable both at initial setup and after a viewer-context
+	 * swap replaces the fieldset (#1300).
+	 * @param {HTMLFormElement} form The get-tickets form.
+	 */
+	function wireTicketOptionInputs(form) {
+		const ticketOptions = form.querySelector('.fair-events-ticket-options');
+		if (!ticketOptions) {
+			return;
+		}
+		ticketOptions
+			.querySelectorAll('input[name="ticket_option_ids[]"]')
+			.forEach(function (checkbox) {
+				checkbox.addEventListener('change', function () {
+					refreshSignupState(form);
+				});
+			});
 	}
 
 	/**

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -2,10 +2,19 @@
 /**
  * Event Signup Block - Server-side rendering
  *
- * Renders the anonymous get-tickets form. When fair-audience is active it
- * enriches this same render via the fair_events_signup_render_context filter
- * and the render slots (identity, pricing, cancel/resignup) instead of owning
- * a competing template.
+ * Renders the cache-safe baseline get-tickets form: unrestricted ticket
+ * types at their undiscounted prices, no prefill, no signed-up state —
+ * identical for every viewer, since a full-page cache stores and replays
+ * this markup (#1300). frontend.js hydrates per-viewer personalization
+ * (restricted tiers, discounts, prefill, signed-up state) after load via
+ * GET fair-events/v1/get-tickets/viewer-context, which runs the
+ * fair_events_signup_viewer_context filter fair-audience hooks — the render
+ * slots below (identity, pricing, cancel/resignup) are fired from both this
+ * base render (with the un-enriched baseline context, so they no-op) and
+ * that endpoint (with the enriched context, so they produce the fragments
+ * frontend.js injects), instead of owning a competing template.
+ * fair_events_signup_render_context still fires here too, for any future
+ * genuinely viewer-independent extension.
  *
  * @package FairEvents
  *
@@ -148,6 +157,26 @@ if ( $event_date
 $ticket_types = array();
 if ( class_exists( \FairEvents\Models\TicketType::class ) ) {
 	$ticket_types = \FairEvents\Models\TicketType::get_all_by_event_date_id( $pricing_event_date_id );
+}
+
+// Baseline excludes any group-restricted tier outright, independent of the
+// viewer — this is the "unrestricted tiers at undiscounted prices" a
+// full-page cache is allowed to store (#1300). A recognised viewer's
+// restricted tiers are re-added at request time by the
+// fair_events_signup_viewer_context filter, resolved by the
+// GET .../viewer-context endpoint frontend.js hydrates after load.
+if ( ! empty( $ticket_types ) && class_exists( \FairEventsExperimental\Models\TicketTypeGroupRestriction::class ) ) {
+	$restrictions_map = \FairEventsExperimental\Models\TicketTypeGroupRestriction::get_all_by_event_date_id( $pricing_event_date_id );
+	if ( ! empty( $restrictions_map ) ) {
+		$ticket_types = array_values(
+			array_filter(
+				$ticket_types,
+				function ( $type ) use ( $restrictions_map ) {
+					return empty( $restrictions_map[ (int) $type->id ] ?? array() );
+				}
+			)
+		);
+	}
 }
 
 // Resolve the series master (if any) so 'multiple_instances' ticket types can
@@ -332,19 +361,6 @@ foreach ( $ticket_types as $ticket_type ) {
 }
 $has_instance_picker = $has_multiple_instances_type && ! empty( $occurrences_for_picker );
 
-// A ticket type can raise the minimum-activities requirement above the
-// event-date global. Determine whether any selectable type carries a higher
-// requirement, and the effective minimum for the type that's pre-selected on
-// first paint (the first not-payment-blocked type, mirroring the radio
-// pre-selection below). frontend.js recomputes this live as the buyer
-// switches ticket type.
-$any_ticket_type_min = 0;
-if ( ! empty( $ticket_options ) ) {
-	foreach ( $ticket_types as $tt_for_min ) {
-		$any_ticket_type_min = max( $any_ticket_type_min, (int) $tt_for_min->minimum_activities );
-	}
-}
-
 // Single-occurrence dropdown: offered whenever the series has at least one
 // upcoming occurrence, regardless of which ticket scopes are configured.
 // frontend.js shows/hides it based on the selected ticket type's scope.
@@ -402,8 +418,16 @@ if ( ! empty( $attributes['isEditorPreview'] ) ) {
 } else {
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'class'         => 'fair-events-get-tickets',
-			'data-currency' => \FairEventsShared\Money::site_currency(),
+			'class'                   => 'fair-events-get-tickets',
+			'data-currency'           => \FairEventsShared\Money::site_currency(),
+			// Read by frontend.js to fetch the request-time
+			// fair-events/v1/get-tickets/viewer-context personalization for
+			// this occurrence (#1300) — present on every branch below
+			// (form, companion, blocked, callback card) so hydration always
+			// has somewhere to attach.
+			'data-event-date-id'      => $event_date_id,
+			'data-show-ticket-price'  => $show_ticket_price ? '1' : '0',
+			'data-show-option-prices' => $show_option_prices ? '1' : '0',
 		)
 	);
 }
@@ -564,157 +588,31 @@ if ( ! empty( $attributes['isEditorPreview'] ) ) {
 		do_action( 'fair_events_signup_render_before_form', $context );
 		?>
 
-		<?php if ( ! empty( $ticket_types ) ) : ?>
-			<?php
-			$first_enabled_type_id = null;
-			foreach ( $ticket_types as $ticket_type ) {
-				$type_id    = (int) $ticket_type->id;
-				$type_price = $price_by_type_id[ $type_id ] ?? null;
-				if ( ! ( $payments_unavailable && null !== $type_price && $type_price > 0 ) ) {
-					$first_enabled_type_id = $type_id;
-					break;
-				}
-			}
-			?>
-			<div class="form-row">
-				<fieldset class="fair-events-ticket-fieldset">
-					<legend class="form-label"><?php esc_html_e( 'Choose ticket type', 'fair-events' ); ?></legend>
-					<?php foreach ( $ticket_types as $ticket_type ) : ?>
-						<?php
-						$type_id          = (int) $ticket_type->id;
-						$type_price       = $price_by_type_id[ $type_id ] ?? null;
-						$type_unavailable = $payments_unavailable && null !== $type_price && $type_price > 0;
-						$label            = esc_html( $ticket_type->name );
-						if ( $show_ticket_price && null !== $type_price ) {
-							$label .= ' — ' . esc_html( \FairEventsShared\Money::format_inline( $type_price ) );
-						} elseif ( null === $active_sale_period ) {
-							$label .= ' — ' . esc_html__( 'No active sale period', 'fair-events' );
-						}
-						if ( $type_unavailable ) {
-							$label .= ' — ' . esc_html__( 'ticket sales temporarily unavailable', 'fair-events' );
-						}
-						$radio_id = $form_id . '-ticket-type-' . $type_id;
-						?>
-						<label class="fair-events-ticket-option" for="<?php echo esc_attr( $radio_id ); ?>">
-							<input
-								type="radio"
-								id="<?php echo esc_attr( $radio_id ); ?>"
-								name="ticket_type_id"
-								value="<?php echo esc_attr( $type_id ); ?>"
-								data-ticket-price="<?php echo esc_attr( null !== $type_price ? \FairEventsShared\Money::format_value( $type_price ) : '' ); ?>"
-								data-recurrence-scope="<?php echo esc_attr( $ticket_type->recurrence_scope ); ?>"
-								data-min-instances="<?php echo esc_attr( (string) $ticket_type->minimum_instances ); ?>"
-								data-min-activities="<?php echo esc_attr( (string) $ticket_type->minimum_activities ); ?>"
-								<?php echo $type_unavailable ? 'disabled' : ''; ?>
-								<?php echo $type_id === $first_enabled_type_id ? 'checked' : ''; ?>
-							/>
-							<?php echo esc_html( $label ); ?>
-						</label>
-					<?php endforeach; ?>
-				</fieldset>
-			</div>
-		<?php endif; ?>
-
-		<?php if ( ! empty( $ticket_options ) ) : ?>
-			<?php
-			// Effective minimum for the type pre-selected on first paint (the
-			// first not-payment-blocked type, mirroring the radio pre-selection
-			// above) — frontend.js recomputes this live as the buyer switches
-			// ticket type.
-			$preselected_type_min = 0;
-			if ( ! empty( $first_enabled_type_id ) ) {
-				foreach ( $ticket_types as $tt_preselected ) {
-					if ( (int) $tt_preselected->id === $first_enabled_type_id ) {
-						$preselected_type_min = (int) $tt_preselected->minimum_activities;
-						break;
-					}
-				}
-			}
-			// Whether a minimum-activities requirement (global or ticket-type-
-			// raised) applies, so the min-selection hint is only shown when
-			// relevant. Independent of $show_option_prices — the "+price"
-			// add-on tag is always emitted below when option prices are shown,
-			// with frontend.js toggling its visibility until the minimum is met.
-			$options_feature_active = ( $minimum_activities > 0 || $any_ticket_type_min > 0 );
-			$initial_min_activities = min( count( $ticket_options ), max( $minimum_activities, $preselected_type_min ) );
-			?>
-			<div class="form-row">
-				<fieldset class="fair-events-ticket-options">
-					<legend class="form-label"><?php esc_html_e( 'Select activities', 'fair-events' ); ?></legend>
-					<?php if ( $options_feature_active ) : ?>
-						<?php
-						$hint_text = $initial_min_activities > 0
-							? sprintf(
-								/* translators: %d: minimum number of activities required */
-								_n(
-									'Please select at least %d activity to sign up.',
-									'Please select at least %d activities to sign up.',
-									$initial_min_activities,
-									'fair-events'
-								),
-								$initial_min_activities
-							)
-							: '';
-						$hint_style = $initial_min_activities > 0 ? '' : ' style="display: none;"';
-						?>
-						<p class="fair-events-ticket-options-min-hint"<?php echo $hint_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static literal. ?>>
-							<?php echo esc_html( $hint_text ); ?>
-						</p>
-					<?php endif; ?>
-					<?php foreach ( $ticket_options as $opt ) : ?>
-						<?php
-						$opt_label   = $opt['name'];
-						$opt_is_full = ! empty( $opt['is_full'] );
-						if ( $opt_is_full ) {
-							$opt_label .= ' — ' . __( 'full', 'fair-events' );
-						}
-						$opt_checkbox_id = $form_id . '-opt-' . (int) $opt['id'];
-						$opt_classes     = 'fair-events-ticket-option-item';
-						if ( $opt_is_full ) {
-							$opt_classes .= ' fair-events-ticket-option-full';
-						}
-						?>
-						<label class="<?php echo esc_attr( $opt_classes ); ?>" for="<?php echo esc_attr( $opt_checkbox_id ); ?>">
-							<input
-								type="checkbox"
-								name="ticket_option_ids[]"
-								id="<?php echo esc_attr( $opt_checkbox_id ); ?>"
-								value="<?php echo (int) $opt['id']; ?>"
-								class="form-checkbox"
-								data-option-price="<?php echo esc_attr( \FairEventsShared\Money::format_value( $opt['price'] ) ); ?>"
-								data-option-short-name="<?php echo esc_attr( $opt['short_name'] ?? '' ); ?>"
-								<?php echo $opt_is_full ? 'disabled' : ''; ?>
-							/>
-							<span class="fair-events-ticket-option-text">
-								<?php echo esc_html( $opt_label ); ?>
-								<?php if ( $show_option_prices && 0.0 !== (float) $opt['price'] ) : ?>
-									<span class="fair-events-ticket-option-addon" style="display: none;">
-										<?php if ( $opt['price'] > 0 ) : ?>
-											<?php
-											printf(
-												/* translators: %s: formatted add-on price */
-												esc_html__( '+%s', 'fair-events' ),
-												esc_html( \FairEventsShared\Money::format_inline( $opt['price'] ) )
-											);
-											?>
-										<?php else : ?>
-											<?php
-											printf(
-												/* translators: %s: formatted add-on price */
-												esc_html__( '-%s', 'fair-events' ),
-												esc_html( \FairEventsShared\Money::format_inline( abs( $opt['price'] ) ) )
-											);
-											?>
-										<?php endif; ?>
-									</span>
-								<?php endif; ?>
-							</span>
-						</label>
-					<?php endforeach; ?>
-					<p class="fair-events-ticket-options-total"></p>
-				</fieldset>
-			</div>
-		<?php endif; ?>
+		<?php
+		// Both fieldsets are rendered by the shared FairEvents\Services\SignupFieldsetRenderer
+		// so the base render and the fair-events/v1/get-tickets/viewer-context
+		// REST endpoint (personalized fragments, #1300) produce identical markup
+		// for a given ticket-type/options set instead of templating it twice.
+		$ticket_type_fieldset_html    = \FairEvents\Services\SignupFieldsetRenderer::ticket_type_fieldset(
+			$ticket_types,
+			$price_by_type_id,
+			$active_sale_period,
+			$show_ticket_price,
+			$payments_unavailable,
+			$form_id
+		);
+		$ticket_options_fieldset_html = \FairEvents\Services\SignupFieldsetRenderer::ticket_options_fieldset(
+			$ticket_options,
+			$ticket_types,
+			$price_by_type_id,
+			$minimum_activities,
+			$show_option_prices,
+			$payments_unavailable,
+			$form_id
+		);
+		echo $ticket_type_fieldset_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- fully escaped inside the renderer.
+		echo $ticket_options_fieldset_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- fully escaped inside the renderer.
+		?>
 
 		<?php if ( $has_occurrence_dropdown ) : ?>
 			<div class="form-row fair-events-occurrence-picker" style="display: none;">


### PR DESCRIPTION
## Summary

- The Event Signup form's server render depended on the viewer (group-restricted
  tiers, group-discounted prices, name/email pre-fill, signed-up state), but was
  echoed straight into markup a full-page cache stores and replays — so a cached
  page could serve one visitor's tiers, price, or identity to a different visitor.
- The base render (`render.php`) now always produces the same viewer-independent
  baseline: unrestricted ticket types, undiscounted prices, empty pre-fill, never
  signed up.
- A new public `GET fair-events/v1/get-tickets/viewer-context` endpoint (no
  identity parameter — the viewer is resolved server-side from the session
  cookie/login, same as `/fair-audience/v1/event-signup/status`) resolves the
  actual viewer at request time and returns personalized HTML fragments.
  `frontend.js` fetches it after load for every viewer — cached page or not —
  and patches the fragments into the DOM, briefly disabling the submit button
  until it resolves or a short timeout elapses.
- `fair-audience`'s `SignupHookBridge` moves its enrichment from the render-time
  `fair_events_signup_render_context` filter (no longer hooked) to the new
  request-time `fair_events_signup_viewer_context` filter — same method, same
  render-slot actions, just resolved outside what the cache stores.
- The two selection fieldsets (ticket type, ticket options) are now rendered by
  a shared `FairEvents\Services\SignupFieldsetRenderer`, used by both the base
  render and the new endpoint, so the markup never diverges between them.

Closes #1300

## Acceptance criteria

- [x] **A page cached for an anonymous visitor and then served to a member shows
      the member's tiers and prices.** The baseline excludes group-restricted
      tiers server-side; `viewer-context` re-adds them (and re-resolves prices)
      once it recognises the viewer, and `frontend.js` swaps them in after load
      regardless of which viewer the cached HTML was originally generated for.
- [x] **The reverse case shows no restricted tiers, no discounted prices, and no
      pre-filled personal details.** Covered by the E2E spec's "stranger" browser
      context loading the exact same page.
- [x] **The per-viewer lookup discloses nothing about a participant other than
      the current viewer.** `viewer-context`'s `permission_callback` is
      `__return_true` safely, since the route takes no identity parameter at
      all — the viewer is resolved purely from cookie/login. Covered by the API
      spec (anonymous and an authenticated admin-with-no-linked-participant get
      the identical no-op payload).
- [x] **Prices and tiers are unchanged with caching disabled.** The same
      hydration now runs on every load; there's no separate "caching disabled"
      code path. The tradeoff (an ~instant hydration window on every load,
      instead of a synchronous server render) is the one the ticket's Open
      Questions section already recommended and this PR follows.
- [x] **E2E coverage of the form's per-viewer states.** New
      `fair-events/e2e/event-signup-viewer-context.spec.js`: one browser signs
      up (free ticket), reloads, and sees its own signed-up card; a second,
      unrelated browser loading the same page sees the plain baseline.

## Notes

- **Depends on #1296 for full production safety.** This PR builds against the
  existing `GroupSignupPricing::resolve_viewer_participant()` seam rather than
  blocking on #1296's trustworthy-viewer-identity work — no code here will need
  to change once #1296 lands, it inherits the fix automatically. Both should
  ship before this is considered fully safe in production.
- **Out of scope (per the approved plan):** the payment-callback resume/
  confirmed/retry card (smaller, separate caching hazard, own token/short
  session cookie) and the legacy/deprecated fair-audience Event Signup block
  (`inserter: false`) — flagged as a known residual risk, not fixed here.
- fair-events-experimental (group-restriction ticket tiers) isn't active on my
  local dev stack, so the E2E spec exercises the prefill/signed-up-state half
  of the leak (which the ticket explicitly calls out as sharing the same bug)
  rather than the restricted-tier half; the restricted-tier path is covered by
  the PHP-level logic directly (`SignupFieldsetRenderer`,
  `TicketTypeGroupRestriction` exclusion in `render.php`) and by
  `SignupHookBridge`'s existing `enrich_render_context()`, unchanged apart from
  which hook calls it.

## Test plan

- [x] `npm run build` in `fair-events` (JS/CSS changed).
- [x] `npm run format` in `fair-events` and `fair-audience` — no formatting
      noise staged.
- [x] `vendor/bin/phpcs` clean on every changed/new PHP file (pre-existing
      short-ternary/direct-DB-call findings elsewhere in those files are
      untouched by this diff).
- [x] `fair-events`: full Jest suite (`npx jest`) — 24 suites / 189 tests pass,
      including new `frontend.test.js` (7 tests: fetch wiring, fieldset
      patching, prefill, signed-up-occurrence marking, companion swap, submit
      gate + timeout fallback, no-op for a block with no event date).
- [x] `fair-events`: full PHPUnit suite — 194 tests pass.
- [x] `fair-audience`: full PHPUnit suite — 78 tests pass, including the
      updated `SignupHookBridgeRegistrationTest` hook-contract check.
- [x] New Playwright API spec (`GetTicketsViewerContext.api.spec.js`) run
      against the live dev stack — 5/5 pass.
- [x] New Playwright E2E spec (`event-signup-viewer-context.spec.js`) run
      against the live dev stack — 1/1 pass (real browser signup → reload →
      signed-up card; a second browser on the same page stays anonymous).
- [x] Manual `wp eval-file` check against the live stack, dispatching the new
      route in-process for an anonymous caller, an unknown `event_date_id`,
      and a recognised viewer — confirmed the exact expected JSON shape,
      including the rendered fieldset HTML and prefill.
