### PR TITLE
Link the event name in confirmation-family emails

### DIFF
--- a/.changeset/link-event-name-in-emails.md
+++ b/.changeset/link-event-name-in-emails.md
@@ -1,0 +1,7 @@
+---
+"fair-events-shared": minor
+"fair-events": minor
+"fair-audience": minor
+---
+
+Link the event name to its page in the confirmation-family emails — signup confirmation, payment-failed, activities-added, event-interest, and mailing-list-welcome — instead of just bolding it. Falls back to the previous bold-only text when no event URL is available.

--- a/fair-audience-experimental/composer.lock
+++ b/fair-audience-experimental/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "fair-events/shared",
-            "version": "0.2.3",
+            "version": "0.2.5",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "113286293569fe13947bd9840c030cbfa68baff4"
+                "reference": "d310c5ada6a8edd40c001d2c9f421f198076e3cd"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-audience/__tests__/Services/EmailServiceTest.php
+++ b/fair-audience/__tests__/Services/EmailServiceTest.php
@@ -50,6 +50,7 @@ class EmailServiceTest extends TestCase {
 	 */
 	private function event() {
 		return (object) array(
+			'ID'         => 5,
 			'post_title' => 'Community Meetup',
 		);
 	}
@@ -166,5 +167,95 @@ class EmailServiceTest extends TestCase {
 
 		$this->assertFalse( $result );
 		$this->assertCount( 0, $GLOBALS['_fair_test_sent_emails'] );
+	}
+
+	/**
+	 * With no event_date_id, FairEvents\Models\EventDates is never reached
+	 * (class_exists() guard no-ops), so no event URL is available and the
+	 * inline event-name mention stays bold-only.
+	 */
+	public function test_signup_payment_confirmation_bolds_event_name_without_link(): void {
+		$email_service = new EmailService();
+
+		$email_service->send_signup_payment_confirmation( $this->participant(), $this->event(), null, array(), 0, 0, 1 );
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( '<strong>Community Meetup</strong>', $sent['message'] );
+		$this->assertStringNotContainsString( '<a href', $sent['message'] );
+	}
+
+	/**
+	 * The activities-added email bolds the event name without a link when no
+	 * event_date_id is passed (default 0).
+	 */
+	public function test_activities_added_confirmation_bolds_event_name_without_link(): void {
+		$email_service = new EmailService();
+
+		$result = $email_service->send_activities_added_confirmation( $this->participant(), $this->event(), null, array( 'Workshop A' ) );
+
+		$this->assertTrue( $result );
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( '<strong>Community Meetup</strong>', $sent['message'] );
+		$this->assertStringNotContainsString( '<a href', $sent['message'] );
+	}
+
+	/**
+	 * The payment-failed email keeps the inline event-name mention bold-only
+	 * (no FairEvents\Models\EventDates lookup reachable in this test process)
+	 * while the existing resume-link button still renders.
+	 */
+	public function test_signup_payment_failed_bolds_event_name_without_link(): void {
+		$email_service = new EmailService();
+
+		$result = $email_service->send_signup_payment_failed( $this->participant(), $this->event(), 0, null );
+
+		$this->assertTrue( $result );
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( '<strong>Community Meetup</strong>', $sent['message'] );
+		$this->assertStringContainsString( 'Resume payment', $sent['message'] );
+	}
+
+	/**
+	 * The event-interest confirmation bolds the event name without a link
+	 * when no event_date_id row resolves.
+	 */
+	public function test_event_interest_confirmation_bolds_event_name_without_link(): void {
+		$GLOBALS['_fair_test_post_titles'] = array( 5 => 'Community Meetup' );
+
+		$email_service = new EmailService();
+		$result        = $email_service->send_event_interest_confirmation( $this->participant(), 5, 0 );
+
+		$this->assertTrue( $result );
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( '<strong>Community Meetup</strong>', $sent['message'] );
+	}
+
+	/**
+	 * The mailing-list welcome email links the event name via a plain
+	 * get_permalink() lookup — no FairEvents\Models\EventDates involved.
+	 */
+	public function test_mailing_list_welcome_links_event_name_via_permalink(): void {
+		$GLOBALS['_fair_test_post_titles'] = array( 5 => 'Community Meetup' );
+
+		$email_service = new EmailService();
+		$result        = $email_service->send_mailing_list_welcome( $this->participant(), 5 );
+
+		$this->assertTrue( $result );
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( '<a href="https://example.com/?p=5"', $sent['message'] );
+		$this->assertStringContainsString( 'Community Meetup', $sent['message'] );
+	}
+
+	/**
+	 * With no event_id, send_mailing_list_welcome() drops the "at <event>"
+	 * clause entirely — only the manage-subscription link remains.
+	 */
+	public function test_mailing_list_welcome_omits_event_mention_without_event_id(): void {
+		$email_service = new EmailService();
+		$result        = $email_service->send_mailing_list_welcome( $this->participant(), 0 );
+
+		$this->assertTrue( $result );
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertSame( 1, substr_count( $sent['message'], '<a href' ) );
 	}
 }

--- a/fair-audience/__tests__/Shared/SignupConfirmationEmailTest.php
+++ b/fair-audience/__tests__/Shared/SignupConfirmationEmailTest.php
@@ -172,4 +172,26 @@ class SignupConfirmationEmailTest extends TestCase {
 		// Footer repeats the site name in its own <p>.
 		$this->assertSame( 2, substr_count( $html, 'Test Site' ) );
 	}
+
+	/**
+	 * The linked-event-title helper falls back to plain bold markup when no
+	 * URL is given.
+	 */
+	public function test_linked_event_title_bolds_when_url_empty(): void {
+		$this->assertSame(
+			'<strong>Test Event</strong>',
+			SignupConfirmationEmail::linked_event_title( 'Test Event' )
+		);
+	}
+
+	/**
+	 * The linked-event-title helper wraps the title in a styled link when a
+	 * URL is given.
+	 */
+	public function test_linked_event_title_links_when_url_present(): void {
+		$this->assertSame(
+			'<a href="https://example.com/event" style="color:#0073aa; font-weight:bold; text-decoration:underline;">Test Event</a>',
+			SignupConfirmationEmail::linked_event_title( 'Test Event', 'https://example.com/event' )
+		);
+	}
 }

--- a/fair-audience/__tests__/bootstrap.php
+++ b/fair-audience/__tests__/bootstrap.php
@@ -364,3 +364,77 @@ if ( ! function_exists( '__' ) ) {
 		return $text;
 	}
 }
+
+if ( ! function_exists( 'home_url' ) ) {
+	/**
+	 * Stub of WordPress home_url() — overridable via $GLOBALS['_fair_test_home_url'].
+	 *
+	 * @param string $path Path to append.
+	 * @return string Fake home URL.
+	 */
+	function home_url( $path = '' ) {
+		$base = isset( $GLOBALS['_fair_test_home_url'] ) ? $GLOBALS['_fair_test_home_url'] : 'https://example.com';
+		return $base . $path;
+	}
+}
+
+if ( ! function_exists( 'get_permalink' ) ) {
+	/**
+	 * Stub of WordPress get_permalink() — a deterministic fake URL keyed on the post ID.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Fake permalink.
+	 */
+	function get_permalink( $post_id ) {
+		return 'https://example.com/?p=' . (int) $post_id;
+	}
+}
+
+if ( ! function_exists( 'get_the_title' ) ) {
+	/**
+	 * Stub of WordPress get_the_title() backed by $GLOBALS['_fair_test_post_titles'].
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Title, or '' if not seeded.
+	 */
+	function get_the_title( $post_id ) {
+		$titles = isset( $GLOBALS['_fair_test_post_titles'] ) ? $GLOBALS['_fair_test_post_titles'] : array();
+		return isset( $titles[ $post_id ] ) ? $titles[ $post_id ] : '';
+	}
+}
+
+if ( ! function_exists( 'add_query_arg' ) ) {
+	/**
+	 * Stub of WordPress add_query_arg() — supports the two call shapes used in
+	 * this codebase: a single key/value pair, or an associative array.
+	 *
+	 * @param string|array $key   Query arg key, or an associative array of args.
+	 * @param string       $value Query arg value (when $key is a string).
+	 * @param string       $url   Base URL.
+	 * @return string URL with the query args appended.
+	 */
+	function add_query_arg( $key, $value = '', $url = '' ) {
+		if ( is_array( $key ) ) {
+			$args = $key;
+			$url  = $value;
+		} else {
+			$args = array( $key => $value );
+		}
+
+		$separator = false === strpos( $url, '?' ) ? '?' : '&';
+		return $url . $separator . http_build_query( $args );
+	}
+}
+
+if ( ! function_exists( 'wp_salt' ) ) {
+	/**
+	 * Stub of WordPress wp_salt() — a fixed value, sufficient for deterministic
+	 * HMAC signing in tests.
+	 *
+	 * @param string $scheme Salt scheme (ignored).
+	 * @return string Fake salt.
+	 */
+	function wp_salt( $scheme = 'auth' ) {
+		return 'test-salt';
+	}
+}

--- a/fair-audience/composer.lock
+++ b/fair-audience/composer.lock
@@ -87,11 +87,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.3",
+            "version": "0.2.5",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "113286293569fe13947bd9840c030cbfa68baff4"
+                "reference": "d310c5ada6a8edd40c001d2c9f421f198076e3cd"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -736,7 +736,7 @@ class PaymentHooks {
 		$added_names = array_map( static fn( $row ) => $row['name'], $option_rows );
 
 		$email_service = new EmailService();
-		$email_service->send_activities_added_confirmation( $participant, $event, $transaction, $added_names );
+		$email_service->send_activities_added_confirmation( $participant, $event, $transaction, $added_names, (int) $event_participant->event_date_id );
 	}
 
 	/**

--- a/fair-audience/src/Services/EmailService.php
+++ b/fair-audience/src/Services/EmailService.php
@@ -2260,9 +2260,12 @@ class EmailService {
 			__( 'Signup confirmed — %s', 'fair-audience' );
 
 		$event_date_display = '';
+		$event_url          = '';
 		if ( $event_date_id > 0 && class_exists( \FairEvents\Models\EventDates::class ) ) {
 			$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
 			if ( $event_date ) {
+				$event_url = (string) $event_date->get_display_url();
+
 				$timestamp = strtotime( $event_date->start_datetime );
 				if ( false !== $timestamp ) {
 					$event_date_display = wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
@@ -2306,7 +2309,7 @@ class EmailService {
 				? esc_html__( 'Your signup for %s has been confirmed and your payment has been received.', 'fair-audience' )
 				/* translators: %s: event title */
 				: esc_html__( 'Your signup for %s has been confirmed.', 'fair-audience' ),
-			'<strong>' . esc_html( $event_title ) . '</strong>'
+			SignupConfirmationEmail::linked_event_title( esc_html( $event_title ), esc_url( $event_url ) )
 		);
 
 		$subject = SignupConfirmationEmail::subject( $subject_template, $event_title );
@@ -2347,15 +2350,25 @@ class EmailService {
 	 * @param \WP_Post|null $event             Event post object (nullable).
 	 * @param object|null   $transaction       Transaction row (null for free adds).
 	 * @param array         $added_option_names Names of the activities that were added.
+	 * @param int           $event_date_id     Event date ID — used only to link the event
+	 *                                          name in the body sentence. Pass 0 to omit the link.
 	 * @return bool Success.
 	 */
-	public function send_activities_added_confirmation( Participant $participant, $event, $transaction = null, $added_option_names = array() ): bool {
+	public function send_activities_added_confirmation( Participant $participant, $event, $transaction = null, $added_option_names = array(), int $event_date_id = 0 ): bool {
 		if ( ! $this->has_valid_email( $participant ) ) {
 			return false;
 		}
 
 		$site_name   = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
 		$event_title = $event ? $event->post_title : __( 'Event', 'fair-audience' );
+
+		$event_url = '';
+		if ( $event_date_id > 0 && class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+			if ( $event_date ) {
+				$event_url = (string) $event_date->get_display_url();
+			}
+		}
 
 		$subject = sprintf(
 			/* translators: %s: event title */
@@ -2421,7 +2434,7 @@ class EmailService {
 								' . sprintf(
 									/* translators: %s: event title */
 								esc_html__( 'The following activities have been added to your signup for %s.', 'fair-audience' ),
-								'<strong>' . esc_html( $event_title ) . '</strong>'
+								SignupConfirmationEmail::linked_event_title( esc_html( $event_title ), esc_url( $event_url ) )
 							) . '
 							</p>
 
@@ -2482,6 +2495,14 @@ class EmailService {
 
 		$resume_url = ParticipantToken::get_url( (int) $participant->id, $event_date_id, $event_id );
 
+		$event_url = '';
+		if ( $event_date_id > 0 && class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+			if ( $event_date ) {
+				$event_url = (string) $event_date->get_display_url();
+			}
+		}
+
 		$subject = sprintf(
 			/* translators: %s: event title */
 			__( 'Payment didn’t go through — %s', 'fair-audience' ),
@@ -2533,7 +2554,7 @@ class EmailService {
 								' . sprintf(
 									/* translators: %s: event title */
 								esc_html__( 'Your payment for %s didn’t go through. Your spot is still held for a short while — pick up where you left off using the link below.', 'fair-audience' ),
-								'<strong>' . esc_html( $event_title ) . '</strong>'
+								SignupConfirmationEmail::linked_event_title( esc_html( $event_title ), esc_url( $event_url ) )
 							) . '
 							</p>
 
@@ -2909,6 +2930,14 @@ class EmailService {
 			$event_title = $site_name;
 		}
 
+		$event_url = '';
+		if ( $event_date_id > 0 && class_exists( \FairEvents\Models\EventDates::class ) ) {
+			$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
+			if ( $event_date ) {
+				$event_url = (string) $event_date->get_display_url();
+			}
+		}
+
 		// Token encodes (participant_id, event_date_id) so the unsubscribe is
 		// scoped to this single event. The query var triggers a
 		// template_redirect handler that runs the same logic as the DELETE
@@ -2956,7 +2985,7 @@ class EmailService {
 							<p style="margin: 0 0 20px 0;">' . sprintf(
 								/* translators: %s: event title */
 								esc_html__( 'Thanks for registering your interest in %s. We will let you know when there are updates.', 'fair-audience' ),
-								'<strong>' . esc_html( $event_title ) . '</strong>'
+								SignupConfirmationEmail::linked_event_title( esc_html( $event_title ), esc_url( $event_url ) )
 							) . '</p>
 							<p style="margin: 0 0 10px 0; font-size: 14px; color: #666666;">' . esc_html__( "If you didn't register your interest, you can safely ignore this email.", 'fair-audience' ) . '</p>
 						</td>
@@ -2997,6 +3026,7 @@ class EmailService {
 
 		$site_name   = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
 		$event_title = $event_id ? get_the_title( $event_id ) : '';
+		$event_url   = $event_id ? (string) get_permalink( $event_id ) : '';
 
 		$manage_subscription_url = ManageSubscriptionToken::get_url( (int) $participant->id );
 
@@ -3013,7 +3043,7 @@ class EmailService {
 				/* translators: 1: site name, 2: event title */
 				esc_html__( 'You\'ve been added to the %1$s mailing list following the consent you gave at %2$s. We\'ll keep you posted about upcoming events and news.', 'fair-audience' ),
 				'<strong>' . esc_html( $site_name ) . '</strong>',
-				'<strong>' . esc_html( $event_title ) . '</strong>'
+				SignupConfirmationEmail::linked_event_title( esc_html( $event_title ), esc_url( $event_url ) )
 			);
 		} else {
 			$intro = sprintf(

--- a/fair-events-shared/php/composer.json
+++ b/fair-events-shared/php/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "fair-events/shared",
 	"description": "Shared PHP utilities for Fair Event plugins",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"type": "library",
 	"license": "GPL-3.0-or-later",
 	"autoload": {

--- a/fair-events-shared/php/src/Notifications/SignupConfirmationEmail.php
+++ b/fair-events-shared/php/src/Notifications/SignupConfirmationEmail.php
@@ -28,6 +28,23 @@ class SignupConfirmationEmail {
 	}
 
 	/**
+	 * Wrap the event title for its inline mention in the confirmation
+	 * sentence — a link when an event URL is available, otherwise the
+	 * existing bold-only markup.
+	 *
+	 * @param string $event_title_html Pre-escaped event title.
+	 * @param string $event_url        Pre-escaped event URL. Pass '' to omit the link.
+	 * @return string HTML fragment: `<a href="…">…</a>` or `<strong>…</strong>`.
+	 */
+	public static function linked_event_title( string $event_title_html, string $event_url = '' ): string {
+		if ( '' === $event_url ) {
+			return '<strong>' . $event_title_html . '</strong>';
+		}
+
+		return '<a href="' . $event_url . '" style="color:#0073aa; font-weight:bold; text-decoration:underline;">' . $event_title_html . '</a>';
+	}
+
+	/**
 	 * Build the full HTML email body.
 	 *
 	 * `$args` keys — data: event_title, participant_name, site_name,

--- a/fair-events/__tests__/Services/EmailServiceTest.php
+++ b/fair-events/__tests__/Services/EmailServiceTest.php
@@ -73,6 +73,20 @@ class EmailServiceTest extends TestCase {
 	}
 
 	/**
+	 * With no event_date_id, EventDates::get_by_id() finds no row, so no event
+	 * URL is available and the inline event-name mention stays bold-only.
+	 */
+	public function test_free_signup_bolds_event_name_without_link(): void {
+		$email_service = new EmailService();
+
+		$email_service->send_signup_confirmation( 42, 0, 'Jane Doe', 'jane@example.test' );
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( '<strong>the event</strong>', $sent['message'] );
+		$this->assertStringNotContainsString( '<a href', $sent['message'] );
+	}
+
+	/**
 	 * The email is sent as HTML (wp_mail_content_type filtered to text/html).
 	 */
 	public function test_sends_as_html(): void {
@@ -114,5 +128,20 @@ class EmailServiceTest extends TestCase {
 
 		$sent = $GLOBALS['_fair_test_sent_emails'][0];
 		$this->assertStringContainsString( 'Payment', $sent['subject'] );
+	}
+
+	/**
+	 * With no event_date_id, the action button still falls back to the home
+	 * URL, but the inline event-name mention in the sentence must not link
+	 * there too — it stays bold-only. Only the action button's href appears.
+	 */
+	public function test_payment_failed_inline_event_name_not_linked_on_fallback(): void {
+		$email_service = new EmailService();
+
+		$email_service->send_signup_payment_failed( 42, 0, 'Jane Doe', 'jane@example.test' );
+
+		$sent = $GLOBALS['_fair_test_sent_emails'][0];
+		$this->assertStringContainsString( '<strong>the event</strong>', $sent['message'] );
+		$this->assertSame( 1, substr_count( $sent['message'], '<a href' ) );
 	}
 }

--- a/fair-events/composer.lock
+++ b/fair-events/composer.lock
@@ -154,11 +154,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.4",
+            "version": "0.2.5",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "fd8e20b0d3fc7bc79506d1cc925a3e9fc044daca"
+                "reference": "d310c5ada6a8edd40c001d2c9f421f198076e3cd"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-events/src/Services/EmailService.php
+++ b/fair-events/src/Services/EmailService.php
@@ -34,13 +34,16 @@ class EmailService {
 	public function send_signup_confirmation( $signup_id, $event_date_id, $name, $email, $ticket_type_id = 0, $amount = 0.0 ) {
 		$event_title        = __( 'the event', 'fair-events' );
 		$event_date_display = '';
+		$event_url          = '';
 
 		$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
 		if ( $event_date ) {
-			$event = get_post( $event_date->event_id );
+			$event = get_post( $event_date->get_resolved_event_id() );
 			if ( $event ) {
 				$event_title = $event->post_title;
 			}
+
+			$event_url = (string) $event_date->get_display_url();
 
 			$timestamp = strtotime( $event_date->start_datetime );
 			if ( false !== $timestamp ) {
@@ -81,7 +84,7 @@ class EmailService {
 				'confirmation_sentence'        => sprintf(
 					/* translators: %s: event title */
 					esc_html__( 'Your registration for %s is confirmed.', 'fair-events' ),
-					'<strong>' . esc_html( $event_title ) . '</strong>'
+					SignupConfirmationEmail::linked_event_title( esc_html( $event_title ), esc_url( $event_url ) )
 				),
 				'event_date_label'             => esc_html__( 'Event date:', 'fair-events' ),
 				'registration_reference_label' => esc_html__( 'Registration reference:', 'fair-events' ),
@@ -116,6 +119,7 @@ class EmailService {
 		$event_title        = __( 'the event', 'fair-events' );
 		$event_date_display = '';
 		$event_url          = home_url( '/' );
+		$inline_link_url    = '';
 
 		$event_date = \FairEvents\Models\EventDates::get_by_id( $event_date_id );
 		if ( $event_date ) {
@@ -126,7 +130,8 @@ class EmailService {
 
 			$display_url = $event_date->get_display_url();
 			if ( $display_url ) {
-				$event_url = $display_url;
+				$event_url       = $display_url;
+				$inline_link_url = $display_url;
 			}
 
 			$timestamp = strtotime( $event_date->start_datetime );
@@ -169,7 +174,7 @@ class EmailService {
 				'confirmation_sentence'        => sprintf(
 					/* translators: %s: event title */
 					esc_html__( 'Your payment for %s didn’t go through, so the registration wasn’t completed.', 'fair-events' ),
-					'<strong>' . esc_html( $event_title ) . '</strong>'
+					SignupConfirmationEmail::linked_event_title( esc_html( $event_title ), esc_url( $inline_link_url ) )
 				),
 				'event_date_label'             => esc_html__( 'Event date:', 'fair-events' ),
 				'registration_reference_label' => esc_html__( 'Registration reference:', 'fair-events' ),

--- a/fair-payments-connector/composer.lock
+++ b/fair-payments-connector/composer.lock
@@ -80,11 +80,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.3",
+            "version": "0.2.5",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "113286293569fe13947bd9840c030cbfa68baff4"
+                "reference": "d310c5ada6a8edd40c001d2c9f421f198076e3cd"
             },
             "require": {
                 "php": ">=7.4 <9.0"

--- a/fair-timetable/composer.lock
+++ b/fair-timetable/composer.lock
@@ -154,11 +154,11 @@
         },
         {
             "name": "fair-events/shared",
-            "version": "0.2.3",
+            "version": "0.2.5",
             "dist": {
                 "type": "path",
                 "url": "../fair-events-shared/php",
-                "reference": "113286293569fe13947bd9840c030cbfa68baff4"
+                "reference": "d310c5ada6a8edd40c001d2c9f421f198076e3cd"
             },
             "require": {
                 "php": ">=7.4 <9.0"


### PR DESCRIPTION
## Summary

The signup/payment confirmation email bolded the event name inline (`Your signup for **Dance connection** has been confirmed...`) but never linked it, even though the event's own display URL is already resolvable at send time. The same bold-but-unlinked pattern appeared in five sibling emails in `fair-audience`. This PR adds a shared `linked_event_title()` helper and wires it into all six confirmation-family emails, falling back to the previous bold-only markup whenever no event URL is available.

Refs #1339 (implements the plan posted at https://github.com/marcin-wosinek/fair-event-plugins/issues/1339#issuecomment-5180157298)

## What changed

- **`fair-events-shared`**: added `SignupConfirmationEmail::linked_event_title()` — returns a styled `<a href>` when a URL is given, else the existing `<strong>` markup. Bumped `composer.json` 0.2.4 → 0.2.5 and ran `composer:update:shared` across every consumer.
- **`fair-events/EmailService`**:
  - `send_signup_confirmation()` now resolves the event's display URL and links the inline mention; also fixed a latent title bug by switching to `get_resolved_event_id()` (previously used the raw `event_id`, which is wrong for generated recurring occurrences).
  - `send_signup_payment_failed()` gets a second, non-fallback URL variable so the inline name link never points at the homepage (the CTA button's `home_url()` fallback is untouched).
- **`fair-audience/EmailService`**: added the event-URL lookup + link to `send_signup_payment_confirmation()`, `send_signup_payment_failed()`, `send_event_interest_confirmation()`, and `send_activities_added_confirmation()` (new optional `$event_date_id` param, backward-compatible default `0`; its one caller in `PaymentHooks::send_activities_added_email()` updated to pass it). `send_mailing_list_welcome()` links via a plain `get_permalink()` (no occurrence concept in scope there).
- Per the plan's decision, the `<h1>` header banner event title stays plain text in every email — only the inline body-sentence mention becomes a link.

## Acceptance criteria

- [x] Event name in the signup/payment confirmation email links to the event page instead of just bolding it — verified via unit tests and a WP-CLI `eval-file` manual check against a real event/event-date.
- [x] Falls back to the previous bold-only markup when no event URL is available — covered by fallback unit tests for every touched method.
- [x] Scope extended to all six confirmation-family emails per the plan's decision (signup confirmation, payment-failed ×2, activities-added, event-interest, mailing-list-welcome).
- [x] No i18n impact — translated strings unchanged, only their substituted content.

## Testing

- `vendor/bin/phpunit` — full suite green in both `fair-events` and `fair-audience` (no regressions).
- New PHPUnit coverage: `linked_event_title()` (empty vs. non-empty URL) in the shared formatter test, plus fallback-path assertions (no `<a href` when `event_date_id = 0`, still bolded) for every touched method in both plugins.
- `vendor/bin/phpcs` clean on every changed file (pre-existing unrelated warnings/errors in `fair-audience/src/Services/EmailService.php` and `PaymentHooks.php` left untouched).
- WP-CLI `eval-file` manual check against a real event/event-date, covering `send_signup_confirmation()` (fair-events), `send_signup_payment_confirmation()` and `send_event_interest_confirmation()` (fair-audience) — all three render the linked markup. Scratch script written, run, and deleted per TESTING.md.
- Added a changeset (`fair-events-shared`, `fair-events`, `fair-audience`: minor).
