### PR TITLE
Add Date and Date & Time question blocks to Fair Form

### DIFF
--- a/.changeset/add-date-datetime-question-blocks.md
+++ b/.changeset/add-date-datetime-question-blocks.md
@@ -1,0 +1,5 @@
+---
+"fair-form": minor
+---
+
+Add "Date" and "Date & Time" question blocks (mirroring the email/phone/url questions) that render the browser's native date/date-time picker on the frontend. Values are validated server-side as real, well-formed dates and rejected with the same error conventions as other typed fields; datetime answers are stored as site-local time. Stored answers render as localized, human-readable dates in the submission-detail and questionnaire-responses admin views.

--- a/e2e/mu-plugins/scripts/seed-event.php
+++ b/e2e/mu-plugins/scripts/seed-event.php
@@ -142,6 +142,16 @@ if ( 'audience-ticket-scopes' === $flavour ) {
 			'<!-- /wp:fair-events/event-signup -->',
 		)
 	);
+} elseif ( isset( $overrides['block'] ) && 'unified-with-date-fields' === $overrides['block'] ) {
+	$block_content = implode(
+		"\n",
+		array(
+			'<!-- wp:fair-events/event-signup -->',
+			'<!-- wp:fair-audience/fair-form-date {"questionKey":"visit_date","questionText":"Visit date"} /-->',
+			'<!-- wp:fair-audience/fair-form-datetime {"questionKey":"appointment_slot","questionText":"Appointment slot"} /-->',
+			'<!-- /wp:fair-events/event-signup -->',
+		)
+	);
 } elseif ( 'address' === $flavour ) {
 	// event-info block (renders the address/venue) + a calendar button — no
 	// signup block, since this flavour never touches the purchase path.

--- a/e2e/user-flows/unified-signup-date-fields.spec.js
+++ b/e2e/user-flows/unified-signup-date-fields.spec.js
@@ -1,0 +1,49 @@
+/**
+ * E2E: signup with Date and Date & Time questions nested in the unified
+ * Event Signup block (#1350). Both use the browser's native picker inputs
+ * and must complete signup end to end, mirroring
+ * unified-signup-url-question.spec.js for the URL question.
+ */
+
+import { test, expect } from '../support/fixtures.js';
+
+test.describe('unified event-signup block: nested Date and Date & Time questions', () => {
+	test('a free signup with a date and a date/time answer completes', async ({
+		page,
+		seedEvent,
+	}) => {
+		const event = seedEvent('free', { block: 'unified-with-date-fields' });
+		const stamp = Date.now();
+		const email = `unified.date.${stamp}@example.test`;
+
+		await page.goto(event.pageUrl);
+
+		const form = page.locator('.fair-events-get-tickets-form');
+		await expect(form).toBeVisible();
+
+		const dateQuestion = form.locator('[data-question-key="visit_date"]');
+		await expect(dateQuestion).toBeVisible();
+		await expect(dateQuestion).toContainText('Visit date');
+
+		const datetimeQuestion = form.locator(
+			'[data-question-key="appointment_slot"]'
+		);
+		await expect(datetimeQuestion).toBeVisible();
+		await expect(datetimeQuestion).toContainText('Appointment slot');
+
+		await form.locator('input[name="name"]').fill('Unified Visitor');
+		await form.locator('input[name="email"]').fill(email);
+		await dateQuestion.locator('input[type="date"]').fill('2026-09-01');
+		await datetimeQuestion
+			.locator('input[type="datetime-local"]')
+			.fill('2026-09-01T14:30');
+
+		await form.locator('.form-button').click();
+
+		await expect(
+			page.getByText('You have successfully registered', {
+				exact: false,
+			})
+		).toBeVisible();
+	});
+});

--- a/fair-audience/src/blocks/event-signup/editor.js
+++ b/fair-audience/src/blocks/event-signup/editor.js
@@ -27,6 +27,8 @@ const ALLOWED_BLOCKS = [
 	'fair-audience/fair-form-email',
 	'fair-audience/fair-form-phone',
 	'fair-audience/fair-form-url',
+	'fair-audience/fair-form-date',
+	'fair-audience/fair-form-datetime',
 	'fair-audience/fair-form-select-one',
 	'fair-audience/fair-form-radio',
 	'fair-audience/fair-form-multiselect',

--- a/fair-events-shared/src/question-utils.js
+++ b/fair-events-shared/src/question-utils.js
@@ -14,6 +14,8 @@ export const FAIR_FORM_QUESTION_BLOCK_NAMES = [
 	'fair-audience/fair-form-email',
 	'fair-audience/fair-form-phone',
 	'fair-audience/fair-form-url',
+	'fair-audience/fair-form-date',
+	'fair-audience/fair-form-datetime',
 	'fair-audience/fair-form-select-one',
 	'fair-audience/fair-form-multiselect',
 	'fair-audience/fair-form-radio',

--- a/fair-events-shared/src/questionnaire.js
+++ b/fair-events-shared/src/questionnaire.js
@@ -542,6 +542,57 @@ export function validateQuestions(form) {
 		}
 	}
 
+	// Validate date questions (defense in depth; real enforcement is
+	// server-side — see QuestionnaireService::sanitize_answers()).
+	const dateQuestions = form.querySelectorAll(
+		'[data-fair-form-question][data-question-type="date"]'
+	);
+	for (const el of dateQuestions) {
+		if (!isQuestionVisible(el)) {
+			continue;
+		}
+		const input = el.querySelector('input[type="date"]');
+		const value = input ? input.value.trim() : '';
+		if (!value) {
+			continue;
+		}
+		if (Number.isNaN(new Date(`${value}T00:00:00`).getTime())) {
+			const questionText = el.dataset.questionText || '';
+			return sprintf(
+				/* translators: %s: question text */
+				__('Please enter a valid date for: %s', 'fair-audience'),
+				questionText
+			);
+		}
+	}
+
+	// Validate date & time questions (defense in depth; real enforcement is
+	// server-side — see QuestionnaireService::sanitize_answers()).
+	const datetimeQuestions = form.querySelectorAll(
+		'[data-fair-form-question][data-question-type="datetime"]'
+	);
+	for (const el of datetimeQuestions) {
+		if (!isQuestionVisible(el)) {
+			continue;
+		}
+		const input = el.querySelector('input[type="datetime-local"]');
+		const value = input ? input.value.trim() : '';
+		if (!value) {
+			continue;
+		}
+		if (Number.isNaN(new Date(value).getTime())) {
+			const questionText = el.dataset.questionText || '';
+			return sprintf(
+				/* translators: %s: question text */
+				__(
+					'Please enter a valid date and time for: %s',
+					'fair-audience'
+				),
+				questionText
+			);
+		}
+	}
+
 	// Validate file upload constraints (size), skip hidden ones.
 	const fileUploadQuestions = form.querySelectorAll(
 		'[data-fair-form-question][data-question-type="file_upload"]'

--- a/fair-events/src/blocks/event-signup/editor.js
+++ b/fair-events/src/blocks/event-signup/editor.js
@@ -54,6 +54,8 @@ const FAIR_FORM_ALLOWED_BLOCKS = [
 	'fair-audience/fair-form-email',
 	'fair-audience/fair-form-phone',
 	'fair-audience/fair-form-url',
+	'fair-audience/fair-form-date',
+	'fair-audience/fair-form-datetime',
 	'fair-audience/fair-form-select-one',
 	'fair-audience/fair-form-radio',
 	'fair-audience/fair-form-multiselect',

--- a/fair-form/fair-form.php
+++ b/fair-form/fair-form.php
@@ -114,5 +114,20 @@ function fair_form_maybe_upgrade_db() {
 
 		update_option( 'fair_form_db_version', '0.4.0' );
 	}
+
+	if ( version_compare( $db_version, '0.5.0', '<' ) ) {
+		global $wpdb;
+
+		$answers_table = $wpdb->prefix . 'fair_audience_questionnaire_answers';
+
+		// Add 'datetime' to the question_type ENUM so Date & Time question
+		// answers persist correctly ('date' is already present).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->query(
+			$wpdb->prepare( "ALTER TABLE %i MODIFY question_type ENUM('radio','checkbox','short_text','long_text','select','number','date','multiselect','file_upload','email','phone','url','datetime') NOT NULL DEFAULT 'short_text'", $answers_table )
+		);
+
+		update_option( 'fair_form_db_version', '0.5.0' );
+	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_form_maybe_upgrade_db' );

--- a/fair-form/src/API/__tests__/FairFormDateAnswers.api.spec.js
+++ b/fair-form/src/API/__tests__/FairFormDateAnswers.api.spec.js
@@ -1,0 +1,166 @@
+/**
+ * Playwright API tests for Date-question validation in
+ * FairFormController::create_item() / QuestionnaireService::sanitize_answers()
+ * (#1350): a well-formed `YYYY-MM-DD` value is accepted and stored unchanged,
+ * an out-of-range or malformed value is rejected with the same error shape
+ * used by other typed fields (e.g. `invalid_email`/`invalid_url`), and an
+ * empty, non-required answer is accepted.
+ *
+ * Every accept-case payload carries its own unique email answer so the
+ * FairFormController rate limiter (3/hour, keyed on email when present) keys
+ * per-submission instead of falling back to the shared IP key.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}-${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+const emailQuestion = (value) => ({
+	question_key: 'email',
+	question_text: 'Email?',
+	question_type: 'email',
+	answer_value: value,
+	display_order: 0,
+});
+
+const dateQuestion = (value) => ({
+	question_key: 'visit_date',
+	question_text: 'Preferred visit date?',
+	question_type: 'date',
+	answer_value: value,
+	display_order: 1,
+});
+
+const ACCEPT_CASES = ['2026-09-01', '2000-02-29'];
+
+const REJECT_CASES = ['2026-02-30', 'not-a-date', '2026/09/01'];
+
+test.describe('FairFormController — Date question validation (#1350)', () => {
+	let api;
+	let fairAudienceActive = false;
+	const postId = Date.now();
+
+	async function findSubmissionByEmail(email) {
+		const res = await api.get(
+			'/wp-json/fair-form/v1/questionnaire-responses',
+			{
+				headers: adminHeaders,
+				params: { post_id: postId, title: 'Fair Form' },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const submissions = await res.json();
+		return submissions.find((s) =>
+			s.answers.some((a) => a.answer_value === email)
+		);
+	}
+
+	async function ensureParticipant(email) {
+		if (!fairAudienceActive) {
+			return;
+		}
+		await api.post('/wp-json/fair-audience/v1/participants', {
+			headers: adminHeaders,
+			data: { name: 'Date Test', email },
+		});
+	}
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	for (const value of ACCEPT_CASES) {
+		test(`accepts and stores ${JSON.stringify(value)}`, async () => {
+			const email = uniqueEmail('date-accept');
+			await ensureParticipant(email);
+			const res = await api.post(
+				'/wp-json/fair-form/v1/fair-form-submit',
+				{
+					data: {
+						post_id: postId,
+						questionnaire_answers: [
+							emailQuestion(email),
+							dateQuestion(value),
+						],
+					},
+				}
+			);
+			expect(res.ok()).toBeTruthy();
+
+			const submission = await findSubmissionByEmail(email);
+			expect(submission).toBeTruthy();
+			const dateAnswer = submission.answers.find(
+				(a) => a.question_key === 'visit_date'
+			);
+			expect(dateAnswer.answer_value).toBe(value);
+		});
+	}
+
+	test('accepts an empty, non-required date answer', async () => {
+		const email = uniqueEmail('date-empty');
+		await ensureParticipant(email);
+		const res = await api.post('/wp-json/fair-form/v1/fair-form-submit', {
+			data: {
+				post_id: postId,
+				questionnaire_answers: [emailQuestion(email), dateQuestion('')],
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+
+		const submission = await findSubmissionByEmail(email);
+		expect(submission).toBeTruthy();
+		const dateAnswer = submission.answers.find(
+			(a) => a.question_key === 'visit_date'
+		);
+		expect(dateAnswer.answer_value).toBe('');
+	});
+
+	for (const value of REJECT_CASES) {
+		test(`rejects ${JSON.stringify(value)}`, async () => {
+			const email = uniqueEmail('date-reject');
+			const res = await api.post(
+				'/wp-json/fair-form/v1/fair-form-submit',
+				{
+					data: {
+						post_id: postId,
+						questionnaire_answers: [
+							emailQuestion(email),
+							dateQuestion(value),
+						],
+					},
+				}
+			);
+			expect(res.status()).toBe(400);
+			expect((await res.json()).code).toBe('invalid_date');
+		});
+	}
+});

--- a/fair-form/src/API/__tests__/FairFormDatetimeAnswers.api.spec.js
+++ b/fair-form/src/API/__tests__/FairFormDatetimeAnswers.api.spec.js
@@ -1,0 +1,172 @@
+/**
+ * Playwright API tests for Date & Time-question validation in
+ * FairFormController::create_item() / QuestionnaireService::sanitize_answers()
+ * (#1350): a well-formed `YYYY-MM-DDTHH:mm` value (the native
+ * `datetime-local` input format) is accepted and normalized to
+ * `Y-m-d H:i:00`, a malformed value is rejected with the same error shape
+ * used by other typed fields, and an empty, non-required answer is accepted.
+ *
+ * Every accept-case payload carries its own unique email answer so the
+ * FairFormController rate limiter (3/hour, keyed on email when present) keys
+ * per-submission instead of falling back to the shared IP key.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+function uniqueEmail(prefix) {
+	return `${prefix}-${Date.now()}-${Math.floor(
+		Math.random() * 1e6
+	)}@example.test`;
+}
+
+const emailQuestion = (value) => ({
+	question_key: 'email',
+	question_text: 'Email?',
+	question_type: 'email',
+	answer_value: value,
+	display_order: 0,
+});
+
+const datetimeQuestion = (value) => ({
+	question_key: 'appointment_slot',
+	question_text: 'Preferred appointment slot?',
+	question_type: 'datetime',
+	answer_value: value,
+	display_order: 1,
+});
+
+const ACCEPT_CASES = [
+	{ input: '2026-09-01T14:30', expected: '2026-09-01 14:30:00' },
+	{ input: '2026-01-05T00:00', expected: '2026-01-05 00:00:00' },
+];
+
+const REJECT_CASES = ['2026-02-30T10:00', 'not-a-datetime', '2026-09-01'];
+
+test.describe('FairFormController — Date & Time question validation (#1350)', () => {
+	let api;
+	let fairAudienceActive = false;
+	const postId = Date.now();
+
+	async function findSubmissionByEmail(email) {
+		const res = await api.get(
+			'/wp-json/fair-form/v1/questionnaire-responses',
+			{
+				headers: adminHeaders,
+				params: { post_id: postId, title: 'Fair Form' },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const submissions = await res.json();
+		return submissions.find((s) =>
+			s.answers.some((a) => a.answer_value === email)
+		);
+	}
+
+	async function ensureParticipant(email) {
+		if (!fairAudienceActive) {
+			return;
+		}
+		await api.post('/wp-json/fair-audience/v1/participants', {
+			headers: adminHeaders,
+			data: { name: 'Datetime Test', email },
+		});
+	}
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		const pluginsRes = await api.get('/wp-json/wp/v2/plugins', {
+			headers: adminHeaders,
+		});
+		if (pluginsRes.ok()) {
+			const plugins = await pluginsRes.json();
+			fairAudienceActive = plugins.some(
+				(p) =>
+					p.plugin?.includes('fair-audience') && p.status === 'active'
+			);
+		}
+	});
+
+	test.afterAll(async () => {
+		await api.dispose();
+	});
+
+	for (const { input, expected } of ACCEPT_CASES) {
+		test(`normalizes ${JSON.stringify(input)} to ${expected}`, async () => {
+			const email = uniqueEmail('datetime-accept');
+			await ensureParticipant(email);
+			const res = await api.post(
+				'/wp-json/fair-form/v1/fair-form-submit',
+				{
+					data: {
+						post_id: postId,
+						questionnaire_answers: [
+							emailQuestion(email),
+							datetimeQuestion(input),
+						],
+					},
+				}
+			);
+			expect(res.ok()).toBeTruthy();
+
+			const submission = await findSubmissionByEmail(email);
+			expect(submission).toBeTruthy();
+			const datetimeAnswer = submission.answers.find(
+				(a) => a.question_key === 'appointment_slot'
+			);
+			expect(datetimeAnswer.answer_value).toBe(expected);
+		});
+	}
+
+	test('accepts an empty, non-required datetime answer', async () => {
+		const email = uniqueEmail('datetime-empty');
+		await ensureParticipant(email);
+		const res = await api.post('/wp-json/fair-form/v1/fair-form-submit', {
+			data: {
+				post_id: postId,
+				questionnaire_answers: [
+					emailQuestion(email),
+					datetimeQuestion(''),
+				],
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+
+		const submission = await findSubmissionByEmail(email);
+		expect(submission).toBeTruthy();
+		const datetimeAnswer = submission.answers.find(
+			(a) => a.question_key === 'appointment_slot'
+		);
+		expect(datetimeAnswer.answer_value).toBe('');
+	});
+
+	for (const value of REJECT_CASES) {
+		test(`rejects ${JSON.stringify(value)}`, async () => {
+			const email = uniqueEmail('datetime-reject');
+			const res = await api.post(
+				'/wp-json/fair-form/v1/fair-form-submit',
+				{
+					data: {
+						post_id: postId,
+						questionnaire_answers: [
+							emailQuestion(email),
+							datetimeQuestion(value),
+						],
+					},
+				}
+			);
+			expect(res.status()).toBe(400);
+			expect((await res.json()).code).toBe('invalid_datetime');
+		});
+	}
+});

--- a/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
+++ b/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
@@ -16,6 +16,7 @@ import {
 } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import { formatDate } from '../utils/format-date.js';
+import { formatSiteLocalDatetime, formatDateOnly } from 'fair-events-shared';
 
 const DEFAULT_VIEW = {
 	type: 'table',
@@ -290,6 +291,24 @@ export default function QuestionnaireResponses() {
 							)}
 						</span>
 					);
+				},
+			}),
+			...(col.type === 'date' && {
+				render: ({ item }) => {
+					const answer = (item.answers || []).find(
+						(a) => a.question_key === col.key
+					);
+					return formatDateOnly(answer?.answer_value) || '';
+				},
+			}),
+			...(col.type === 'datetime' && {
+				render: ({ item }) => {
+					const answer = (item.answers || []).find(
+						(a) => a.question_key === col.key
+					);
+					return answer?.answer_value
+						? formatSiteLocalDatetime(answer.answer_value)
+						: '';
 				},
 			}),
 		}));

--- a/fair-form/src/Admin/submission-detail/SubmissionDetail.js
+++ b/fair-form/src/Admin/submission-detail/SubmissionDetail.js
@@ -111,6 +111,14 @@ function AnswerDisplay({ answer }) {
 		);
 	}
 
+	if (question_type === 'date' && answer_value) {
+		return <span>{formatDateOnly(answer_value)}</span>;
+	}
+
+	if (question_type === 'datetime' && answer_value) {
+		return <span>{formatSiteLocalDatetime(answer_value)}</span>;
+	}
+
 	return <span>{answer_value || '—'}</span>;
 }
 

--- a/fair-form/src/Database/Schema.php
+++ b/fair-form/src/Database/Schema.php
@@ -62,7 +62,7 @@ class Schema {
 			submission_id BIGINT UNSIGNED NOT NULL,
 			question_key VARCHAR(100) DEFAULT '',
 			question_text VARCHAR(500) NOT NULL,
-			question_type ENUM('radio','checkbox','short_text','long_text','select','number','date','multiselect','file_upload','email','phone','url') NOT NULL DEFAULT 'short_text',
+			question_type ENUM('radio','checkbox','short_text','long_text','select','number','date','multiselect','file_upload','email','phone','url','datetime') NOT NULL DEFAULT 'short_text',
 			answer_value TEXT NOT NULL,
 			answer_meta LONGTEXT NULL DEFAULT NULL,
 			display_order INT DEFAULT 0,

--- a/fair-form/src/Hooks/BlockHooks.php
+++ b/fair-form/src/Hooks/BlockHooks.php
@@ -38,6 +38,8 @@ class BlockHooks {
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-email' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-phone' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-url' );
+		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-date' );
+		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-datetime' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-select-one' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-multiselect' );
 		register_block_type( FAIR_FORM_DIR . 'build/blocks/fair-form-radio' );
@@ -57,6 +59,8 @@ class BlockHooks {
 		wp_set_script_translations( 'fair-form-fair-form-email-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-phone-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-url-editor-script', 'fair-audience', $translations_path );
+		wp_set_script_translations( 'fair-form-fair-form-date-editor-script', 'fair-audience', $translations_path );
+		wp_set_script_translations( 'fair-form-fair-form-datetime-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-select-one-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-multiselect-editor-script', 'fair-audience', $translations_path );
 		wp_set_script_translations( 'fair-form-fair-form-radio-editor-script', 'fair-audience', $translations_path );

--- a/fair-form/src/Models/QuestionnaireAnswer.php
+++ b/fair-form/src/Models/QuestionnaireAnswer.php
@@ -32,6 +32,7 @@ class QuestionnaireAnswer {
 		'phone',
 		'email',
 		'url',
+		'datetime',
 	);
 
 	/**

--- a/fair-form/src/Services/QuestionnaireService.php
+++ b/fair-form/src/Services/QuestionnaireService.php
@@ -52,7 +52,7 @@ class QuestionnaireService {
 	 *
 	 * @var array
 	 */
-	const VALID_TYPES = array( 'radio', 'checkbox', 'short_text', 'long_text', 'select', 'number', 'date', 'multiselect', 'file_upload', 'phone', 'email', 'url' );
+	const VALID_TYPES = array( 'radio', 'checkbox', 'short_text', 'long_text', 'select', 'number', 'date', 'datetime', 'multiselect', 'file_upload', 'phone', 'email', 'url' );
 
 	/**
 	 * HTML `pattern` attribute value for the phone question's `<input>`.
@@ -234,6 +234,38 @@ class QuestionnaireService {
 				$answer_value = $normalized;
 			}
 
+			if ( 'date' === $question_type && '' !== $answer_value ) {
+				$normalized = self::normalize_date( $answer_value );
+				if ( null === $normalized ) {
+					return new WP_Error(
+						'invalid_date',
+						sprintf(
+							/* translators: %s: question text */
+							__( 'Please enter a valid date for: %s', 'fair-form' ),
+							$question_text
+						),
+						array( 'status' => 400 )
+					);
+				}
+				$answer_value = $normalized;
+			}
+
+			if ( 'datetime' === $question_type && '' !== $answer_value ) {
+				$normalized = self::normalize_datetime( $answer_value );
+				if ( null === $normalized ) {
+					return new WP_Error(
+						'invalid_datetime',
+						sprintf(
+							/* translators: %s: question text */
+							__( 'Please enter a valid date and time for: %s', 'fair-form' ),
+							$question_text
+						),
+						array( 'status' => 400 )
+					);
+				}
+				$answer_value = $normalized;
+			}
+
 			$sanitized[] = array(
 				'question_key'          => sanitize_key( $answer['question_key'] ?? '' ),
 				'question_text'         => $question_text,
@@ -295,6 +327,41 @@ class QuestionnaireService {
 
 		$scheme = wp_parse_url( $filtered, PHP_URL_SCHEME );
 		return in_array( $scheme, array( 'http', 'https' ), true );
+	}
+
+	/**
+	 * Validate a date question value (native `type="date"` value,
+	 * `YYYY-MM-DD`) and re-serialize it, rejecting out-of-range values (e.g.
+	 * `2024-02-30`) that `DateTime::createFromFormat()` would otherwise
+	 * silently roll over to a different date.
+	 *
+	 * @param string $value Raw date value.
+	 * @return string|null The value unchanged if valid, null otherwise.
+	 */
+	public static function normalize_date( $value ) {
+		$date = \DateTime::createFromFormat( 'Y-m-d', $value );
+		if ( false === $date || $date->format( 'Y-m-d' ) !== $value ) {
+			return null;
+		}
+		return $value;
+	}
+
+	/**
+	 * Validate a datetime question value (native `type="datetime-local"`
+	 * value, `YYYY-MM-DDTHH:mm`) and normalize it to `Y-m-d H:i:00` (space
+	 * separator, seconds appended) so it's directly consumable by the JS
+	 * `formatSiteLocalDatetime()` helper without a second conversion layer.
+	 * Stored as site-local wall-clock time, not converted to UTC.
+	 *
+	 * @param string $value Raw datetime-local value.
+	 * @return string|null The normalized value if valid, null otherwise.
+	 */
+	public static function normalize_datetime( $value ) {
+		$date = \DateTime::createFromFormat( 'Y-m-d\TH:i', $value );
+		if ( false === $date || $date->format( 'Y-m-d\TH:i' ) !== $value ) {
+			return null;
+		}
+		return $date->format( 'Y-m-d H:i:00' );
 	}
 
 	/**

--- a/fair-form/src/blocks/fair-form-date/__tests__/editor.test.jsx
+++ b/fair-form/src/blocks/fair-form-date/__tests__/editor.test.jsx
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('@wordpress/block-editor', () => ({
+	useBlockProps: (props) => props || {},
+	InspectorControls: ({ children }) => children,
+}));
+
+jest.mock('@wordpress/components', () => ({
+	PanelBody: ({ children }) => children,
+	TextControl: ({ label, value, onChange, help }) => (
+		<div>
+			<label>
+				{label}
+				<input
+					value={value}
+					onChange={(e) => onChange(e.target.value)}
+				/>
+			</label>
+			{help}
+		</div>
+	),
+	ToggleControl: ({ label, checked, onChange }) => (
+		<label>
+			<input
+				type="checkbox"
+				checked={checked}
+				onChange={(e) => onChange(e.target.checked)}
+			/>
+			{label}
+		</label>
+	),
+}));
+
+jest.mock('fair-events-shared', () => ({
+	generateQuestionKey: (text) =>
+		text
+			.toLowerCase()
+			.trim()
+			.replace(/[^a-z0-9]+/g, '_')
+			.replace(/^_+|_+$/g, ''),
+}));
+
+let capturedSettings;
+jest.mock('@wordpress/blocks', () => ({
+	registerBlockType: (name, settings) => {
+		capturedSettings = settings;
+	},
+}));
+
+describe('Fair Form Date Question Edit', () => {
+	let Edit;
+
+	beforeAll(() => {
+		require('../editor.js');
+		Edit = capturedSettings.edit;
+	});
+
+	const baseAttributes = {
+		questionText: '',
+		questionKey: '',
+		required: false,
+		placeholder: '',
+	};
+
+	const renderEdit = (attributes = {}, setAttributes = () => {}) =>
+		render(
+			<Edit
+				attributes={{ ...baseAttributes, ...attributes }}
+				setAttributes={setAttributes}
+			/>
+		);
+
+	it('derives the question key from the question text', () => {
+		const setAttributes = jest.fn();
+		renderEdit({}, setAttributes);
+
+		const questionTextInput = screen.getByPlaceholderText(
+			'Enter your question...'
+		);
+		fireEvent.change(questionTextInput, {
+			target: { value: 'Preferred visit date' },
+		});
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			questionText: 'Preferred visit date',
+			questionKey: 'preferred_visit_date',
+		});
+	});
+
+	it('does not override a manually-edited question key', () => {
+		const setAttributes = jest.fn();
+		renderEdit(
+			{ questionText: 'Birthdate', questionKey: 'custom_key' },
+			setAttributes
+		);
+
+		const questionTextInput = screen.getByPlaceholderText(
+			'Enter your question...'
+		);
+		fireEvent.change(questionTextInput, {
+			target: { value: 'Birthdate updated' },
+		});
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			questionText: 'Birthdate updated',
+		});
+	});
+
+	it('renders the Required toggle and Placeholder controls', () => {
+		renderEdit();
+
+		expect(screen.getByLabelText('Required')).toBeInTheDocument();
+		expect(screen.getByLabelText('Placeholder')).toBeInTheDocument();
+		expect(screen.getByLabelText('Question Key')).toBeInTheDocument();
+	});
+
+	it('renders a disabled native date input preview', () => {
+		renderEdit();
+
+		const preview = document.querySelector('input[type="date"]');
+		expect(preview).toBeInTheDocument();
+		expect(preview).toBeDisabled();
+	});
+
+	it('toggles the required attribute', () => {
+		const setAttributes = jest.fn();
+		renderEdit({}, setAttributes);
+
+		fireEvent.click(screen.getByLabelText('Required'));
+
+		expect(setAttributes).toHaveBeenCalledWith({ required: true });
+	});
+
+	it('updates the placeholder attribute', () => {
+		const setAttributes = jest.fn();
+		renderEdit({}, setAttributes);
+
+		fireEvent.change(screen.getByLabelText('Placeholder'), {
+			target: { value: 'YYYY-MM-DD' },
+		});
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			placeholder: 'YYYY-MM-DD',
+		});
+	});
+});

--- a/fair-form/src/blocks/fair-form-date/block.json
+++ b/fair-form/src/blocks/fair-form-date/block.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "fair-audience/fair-form-date",
+	"version": "1.0.0",
+	"title": "Date Question",
+	"category": "widgets",
+	"icon": "calendar-alt",
+	"description": "A date input question using the browser's native date picker for Fair Form",
+	"keywords": ["question", "date", "input"],
+	"textdomain": "fair-audience",
+	"ancestor": [
+		"fair-audience/fair-form",
+		"fair-audience/event-signup",
+		"fair-events/event-signup"
+	],
+	"supports": {
+		"html": false
+	},
+	"attributes": {
+		"questionText": {
+			"type": "string",
+			"default": ""
+		},
+		"questionKey": {
+			"type": "string",
+			"default": ""
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		},
+		"placeholder": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"editorScript": "file:./editor.js",
+	"render": "file:./render.php",
+	"style": "file:./style-editor.css"
+}

--- a/fair-form/src/blocks/fair-form-date/editor.js
+++ b/fair-form/src/blocks/fair-form-date/editor.js
@@ -1,0 +1,85 @@
+import './style.css';
+
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { generateQuestionKey } from 'fair-events-shared';
+
+registerBlockType('fair-audience/fair-form-date', {
+	edit: ({ attributes, setAttributes }) => {
+		const { questionText, questionKey, required, placeholder } = attributes;
+
+		const onQuestionTextChange = (value) => {
+			const updates = { questionText: value };
+			if (
+				!questionKey ||
+				questionKey === generateQuestionKey(questionText)
+			) {
+				updates.questionKey = generateQuestionKey(value);
+			}
+			setAttributes(updates);
+		};
+
+		const blockProps = useBlockProps({
+			className: 'fair-form-question fair-form-question-date',
+		});
+
+		return (
+			<>
+				<InspectorControls>
+					<PanelBody title={__('Question Settings', 'fair-audience')}>
+						<TextControl
+							label={__('Question Key', 'fair-audience')}
+							value={questionKey}
+							onChange={(value) =>
+								setAttributes({ questionKey: value })
+							}
+							help={__(
+								'A unique identifier for this question (e.g. "birthdate"). Used internally.',
+								'fair-audience'
+							)}
+						/>
+						<ToggleControl
+							label={__('Required', 'fair-audience')}
+							checked={required}
+							onChange={(value) =>
+								setAttributes({ required: value })
+							}
+						/>
+						<TextControl
+							label={__('Placeholder', 'fair-audience')}
+							value={placeholder}
+							onChange={(value) =>
+								setAttributes({ placeholder: value })
+							}
+						/>
+					</PanelBody>
+				</InspectorControls>
+
+				<div {...blockProps}>
+					<p>
+						<input
+							type="text"
+							value={questionText}
+							onChange={(e) =>
+								onQuestionTextChange(e.target.value)
+							}
+							placeholder={__(
+								'Enter your question...',
+								'fair-audience'
+							)}
+							className="fair-form-question-label-input"
+						/>
+						{required && <span className="required"> *</span>}
+						<br />
+						<input type="date" disabled placeholder={placeholder} />
+					</p>
+				</div>
+			</>
+		);
+	},
+	save: () => {
+		return null;
+	},
+});

--- a/fair-form/src/blocks/fair-form-date/render.php
+++ b/fair-form/src/blocks/fair-form-date/render.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Render callback for the Fair Form Date question block
+ *
+ * @package FairForm
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block content.
+ * @param WP_Block $block      Block instance.
+ * @return string Rendered block HTML.
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ * Variables in block render templates are scoped to the template and don't need prefixing.
+ */
+
+defined( 'WPINC' ) || die;
+
+$question_text = $attributes['questionText'] ?? '';
+$question_key  = $attributes['questionKey'] ?? '';
+$required      = ! empty( $attributes['required'] );
+$placeholder   = $attributes['placeholder'] ?? '';
+
+// Skip rendering if no question text is set.
+if ( empty( $question_text ) ) {
+	return '';
+}
+
+// Generate unique ID for this input.
+$input_id = 'fair-form-q-' . sanitize_title( $question_key ) . '-' . wp_unique_id();
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class'                   => 'fair-form-question fair-form-question-date',
+		'data-fair-form-question' => '',
+		'data-question-key'       => esc_attr( $question_key ),
+		'data-question-text'      => esc_attr( $question_text ),
+		'data-question-type'      => 'date',
+		'data-required'           => $required ? '1' : '0',
+	)
+);
+?>
+
+<div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
+	<label for="<?php echo esc_attr( $input_id ); ?>">
+		<?php echo esc_html( $question_text ); ?>
+		<?php if ( $required ) : ?>
+			<span class="required">*</span>
+		<?php endif; ?>
+	</label>
+	<input
+		type="date"
+		id="<?php echo esc_attr( $input_id ); ?>"
+		name="<?php echo esc_attr( 'fair_form_q_' . $question_key ); ?>"
+		<?php if ( $required ) : ?>
+			required
+		<?php endif; ?>
+		<?php if ( ! empty( $placeholder ) ) : ?>
+			placeholder="<?php echo esc_attr( $placeholder ); ?>"
+		<?php endif; ?>
+	/>
+</div>

--- a/fair-form/src/blocks/fair-form-date/style.css
+++ b/fair-form/src/blocks/fair-form-date/style.css
@@ -1,0 +1,24 @@
+.fair-form-question-date .fair-form-question-label-input {
+	border: none;
+	border-bottom: 1px dashed #8c8f94;
+	background: transparent;
+	font-weight: 600;
+	padding: 2px 0;
+	font-size: inherit;
+	width: auto;
+}
+
+.fair-form-question-date .fair-form-question-label-input:focus {
+	outline: none;
+	border-bottom-color: #2271b1;
+}
+
+.fair-form-question-date input[type="date"]:disabled {
+	width: 100%;
+	padding: 8px 12px;
+	border: 1px solid #8c8f94;
+	border-radius: 4px;
+	font-size: inherit;
+	line-height: 1.5;
+	background: #f0f0f0;
+}

--- a/fair-form/src/blocks/fair-form-datetime/__tests__/editor.test.jsx
+++ b/fair-form/src/blocks/fair-form-datetime/__tests__/editor.test.jsx
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('@wordpress/block-editor', () => ({
+	useBlockProps: (props) => props || {},
+	InspectorControls: ({ children }) => children,
+}));
+
+jest.mock('@wordpress/components', () => ({
+	PanelBody: ({ children }) => children,
+	TextControl: ({ label, value, onChange, help }) => (
+		<div>
+			<label>
+				{label}
+				<input
+					value={value}
+					onChange={(e) => onChange(e.target.value)}
+				/>
+			</label>
+			{help}
+		</div>
+	),
+	ToggleControl: ({ label, checked, onChange }) => (
+		<label>
+			<input
+				type="checkbox"
+				checked={checked}
+				onChange={(e) => onChange(e.target.checked)}
+			/>
+			{label}
+		</label>
+	),
+}));
+
+jest.mock('fair-events-shared', () => ({
+	generateQuestionKey: (text) =>
+		text
+			.toLowerCase()
+			.trim()
+			.replace(/[^a-z0-9]+/g, '_')
+			.replace(/^_+|_+$/g, ''),
+}));
+
+let capturedSettings;
+jest.mock('@wordpress/blocks', () => ({
+	registerBlockType: (name, settings) => {
+		capturedSettings = settings;
+	},
+}));
+
+describe('Fair Form Date & Time Question Edit', () => {
+	let Edit;
+
+	beforeAll(() => {
+		require('../editor.js');
+		Edit = capturedSettings.edit;
+	});
+
+	const baseAttributes = {
+		questionText: '',
+		questionKey: '',
+		required: false,
+		placeholder: '',
+	};
+
+	const renderEdit = (attributes = {}, setAttributes = () => {}) =>
+		render(
+			<Edit
+				attributes={{ ...baseAttributes, ...attributes }}
+				setAttributes={setAttributes}
+			/>
+		);
+
+	it('derives the question key from the question text', () => {
+		const setAttributes = jest.fn();
+		renderEdit({}, setAttributes);
+
+		const questionTextInput = screen.getByPlaceholderText(
+			'Enter your question...'
+		);
+		fireEvent.change(questionTextInput, {
+			target: { value: 'Preferred appointment slot' },
+		});
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			questionText: 'Preferred appointment slot',
+			questionKey: 'preferred_appointment_slot',
+		});
+	});
+
+	it('does not override a manually-edited question key', () => {
+		const setAttributes = jest.fn();
+		renderEdit(
+			{ questionText: 'Appointment', questionKey: 'custom_key' },
+			setAttributes
+		);
+
+		const questionTextInput = screen.getByPlaceholderText(
+			'Enter your question...'
+		);
+		fireEvent.change(questionTextInput, {
+			target: { value: 'Appointment updated' },
+		});
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			questionText: 'Appointment updated',
+		});
+	});
+
+	it('renders the Required toggle and Placeholder controls', () => {
+		renderEdit();
+
+		expect(screen.getByLabelText('Required')).toBeInTheDocument();
+		expect(screen.getByLabelText('Placeholder')).toBeInTheDocument();
+		expect(screen.getByLabelText('Question Key')).toBeInTheDocument();
+	});
+
+	it('renders a disabled native datetime-local input preview', () => {
+		renderEdit();
+
+		const preview = document.querySelector('input[type="datetime-local"]');
+		expect(preview).toBeInTheDocument();
+		expect(preview).toBeDisabled();
+	});
+
+	it('toggles the required attribute', () => {
+		const setAttributes = jest.fn();
+		renderEdit({}, setAttributes);
+
+		fireEvent.click(screen.getByLabelText('Required'));
+
+		expect(setAttributes).toHaveBeenCalledWith({ required: true });
+	});
+
+	it('updates the placeholder attribute', () => {
+		const setAttributes = jest.fn();
+		renderEdit({}, setAttributes);
+
+		fireEvent.change(screen.getByLabelText('Placeholder'), {
+			target: { value: 'YYYY-MM-DD HH:mm' },
+		});
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			placeholder: 'YYYY-MM-DD HH:mm',
+		});
+	});
+});

--- a/fair-form/src/blocks/fair-form-datetime/block.json
+++ b/fair-form/src/blocks/fair-form-datetime/block.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "fair-audience/fair-form-datetime",
+	"version": "1.0.0",
+	"title": "Date & Time Question",
+	"category": "widgets",
+	"icon": "clock",
+	"description": "A date-and-time input question using the browser's native date/time picker for Fair Form",
+	"keywords": ["question", "date", "time", "datetime", "input"],
+	"textdomain": "fair-audience",
+	"ancestor": [
+		"fair-audience/fair-form",
+		"fair-audience/event-signup",
+		"fair-events/event-signup"
+	],
+	"supports": {
+		"html": false
+	},
+	"attributes": {
+		"questionText": {
+			"type": "string",
+			"default": ""
+		},
+		"questionKey": {
+			"type": "string",
+			"default": ""
+		},
+		"required": {
+			"type": "boolean",
+			"default": false
+		},
+		"placeholder": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"editorScript": "file:./editor.js",
+	"render": "file:./render.php",
+	"style": "file:./style-editor.css"
+}

--- a/fair-form/src/blocks/fair-form-datetime/editor.js
+++ b/fair-form/src/blocks/fair-form-datetime/editor.js
@@ -1,0 +1,89 @@
+import './style.css';
+
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { generateQuestionKey } from 'fair-events-shared';
+
+registerBlockType('fair-audience/fair-form-datetime', {
+	edit: ({ attributes, setAttributes }) => {
+		const { questionText, questionKey, required, placeholder } = attributes;
+
+		const onQuestionTextChange = (value) => {
+			const updates = { questionText: value };
+			if (
+				!questionKey ||
+				questionKey === generateQuestionKey(questionText)
+			) {
+				updates.questionKey = generateQuestionKey(value);
+			}
+			setAttributes(updates);
+		};
+
+		const blockProps = useBlockProps({
+			className: 'fair-form-question fair-form-question-datetime',
+		});
+
+		return (
+			<>
+				<InspectorControls>
+					<PanelBody title={__('Question Settings', 'fair-audience')}>
+						<TextControl
+							label={__('Question Key', 'fair-audience')}
+							value={questionKey}
+							onChange={(value) =>
+								setAttributes({ questionKey: value })
+							}
+							help={__(
+								'A unique identifier for this question (e.g. "appointment_slot"). Used internally.',
+								'fair-audience'
+							)}
+						/>
+						<ToggleControl
+							label={__('Required', 'fair-audience')}
+							checked={required}
+							onChange={(value) =>
+								setAttributes({ required: value })
+							}
+						/>
+						<TextControl
+							label={__('Placeholder', 'fair-audience')}
+							value={placeholder}
+							onChange={(value) =>
+								setAttributes({ placeholder: value })
+							}
+						/>
+					</PanelBody>
+				</InspectorControls>
+
+				<div {...blockProps}>
+					<p>
+						<input
+							type="text"
+							value={questionText}
+							onChange={(e) =>
+								onQuestionTextChange(e.target.value)
+							}
+							placeholder={__(
+								'Enter your question...',
+								'fair-audience'
+							)}
+							className="fair-form-question-label-input"
+						/>
+						{required && <span className="required"> *</span>}
+						<br />
+						<input
+							type="datetime-local"
+							disabled
+							placeholder={placeholder}
+						/>
+					</p>
+				</div>
+			</>
+		);
+	},
+	save: () => {
+		return null;
+	},
+});

--- a/fair-form/src/blocks/fair-form-datetime/render.php
+++ b/fair-form/src/blocks/fair-form-datetime/render.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Render callback for the Fair Form Date & Time question block
+ *
+ * @package FairForm
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block content.
+ * @param WP_Block $block      Block instance.
+ * @return string Rendered block HTML.
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ * Variables in block render templates are scoped to the template and don't need prefixing.
+ */
+
+defined( 'WPINC' ) || die;
+
+$question_text = $attributes['questionText'] ?? '';
+$question_key  = $attributes['questionKey'] ?? '';
+$required      = ! empty( $attributes['required'] );
+$placeholder   = $attributes['placeholder'] ?? '';
+
+// Skip rendering if no question text is set.
+if ( empty( $question_text ) ) {
+	return '';
+}
+
+// Generate unique ID for this input.
+$input_id = 'fair-form-q-' . sanitize_title( $question_key ) . '-' . wp_unique_id();
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class'                   => 'fair-form-question fair-form-question-datetime',
+		'data-fair-form-question' => '',
+		'data-question-key'       => esc_attr( $question_key ),
+		'data-question-text'      => esc_attr( $question_text ),
+		'data-question-type'      => 'datetime',
+		'data-required'           => $required ? '1' : '0',
+	)
+);
+?>
+
+<div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
+	<label for="<?php echo esc_attr( $input_id ); ?>">
+		<?php echo esc_html( $question_text ); ?>
+		<?php if ( $required ) : ?>
+			<span class="required">*</span>
+		<?php endif; ?>
+	</label>
+	<input
+		type="datetime-local"
+		id="<?php echo esc_attr( $input_id ); ?>"
+		name="<?php echo esc_attr( 'fair_form_q_' . $question_key ); ?>"
+		<?php if ( $required ) : ?>
+			required
+		<?php endif; ?>
+		<?php if ( ! empty( $placeholder ) ) : ?>
+			placeholder="<?php echo esc_attr( $placeholder ); ?>"
+		<?php endif; ?>
+	/>
+</div>

--- a/fair-form/src/blocks/fair-form-datetime/style.css
+++ b/fair-form/src/blocks/fair-form-datetime/style.css
@@ -1,0 +1,24 @@
+.fair-form-question-datetime .fair-form-question-label-input {
+	border: none;
+	border-bottom: 1px dashed #8c8f94;
+	background: transparent;
+	font-weight: 600;
+	padding: 2px 0;
+	font-size: inherit;
+	width: auto;
+}
+
+.fair-form-question-datetime .fair-form-question-label-input:focus {
+	outline: none;
+	border-bottom-color: #2271b1;
+}
+
+.fair-form-question-datetime input[type="datetime-local"]:disabled {
+	width: 100%;
+	padding: 8px 12px;
+	border: 1px solid #8c8f94;
+	border-radius: 4px;
+	font-size: inherit;
+	line-height: 1.5;
+	background: #f0f0f0;
+}


### PR DESCRIPTION
## Summary

- Adds "Date" and "Date & Time" question blocks to Fair Form, mirroring the phone/email/url question pattern: native browser picker on the frontend, server-side format validation with the same error shape, and localized display in the admin submission views.
- "Date" reuses the `date` answer type that already existed in the schema/allow-lists but had no block or validation built on it. "Date & Time" adds a new `datetime` type (schema ENUM + versioned DB migration for already-active installs), stored as site-local time and normalized to `Y-m-d H:i:00` so it's directly consumable by the existing `formatSiteLocalDatetime()` helper.

Closes #1350

## Acceptance criteria

- [x] "Date" block can be inserted in the form editor with question text, key, required toggle, and placeholder — verified in the running editor (inserter search, Question Settings panel).
- [x] "Date & Time" block can be inserted with the same controls.
- [x] Published form renders a native date picker for "Date" and a native date-and-time picker for "Date & Time" — verified on the frontend.
- [x] Server rejects a malformed date/datetime value submitted directly via the API, with the same error-response shape used by other typed fields (`invalid_date` / `invalid_datetime`, 400) — verified live and covered by API spec tests.
- [x] Server accepts a valid date/datetime value and stores it under the correct answer type — verified live (date stored as-is, datetime normalized to `Y-m-d H:i:00`).
- [x] Non-required date/datetime fields can be submitted empty — covered by API spec tests.
- [x] Admin submission/response views render stored date and datetime answers as localized, human-readable dates (`SubmissionDetail.js`, `QuestionnaireResponses.js`), reusing the existing `formatDateOnly`/`formatSiteLocalDatetime` helpers.
- [x] API spec test covering valid/invalid/empty submission for both new types (`FairFormDateAnswers.api.spec.js`, `FairFormDatetimeAnswers.api.spec.js`).
- [x] Component test for both blocks' editor UI (`fair-form-date/__tests__/editor.test.jsx`, `fair-form-datetime/__tests__/editor.test.jsx`).
- [x] e2e test covering filling and submitting a form with a Date and a Date & Time field (`unified-signup-date-fields.spec.js`).

## Notes

- Both blocks are added to all three allowed contexts (Fair Form, fair-audience Event Signup, fair-events Event Signup) — same footing as phone/email/url, per FAIR_FORM_QUESTION_BLOCKS.md.
- Timezone: datetime answers are stored as site-local, naive time (no UTC conversion) — matches the ticket's own recommendation and the existing native-datetime-input convention used elsewhere (e.g. fair-events' event-proposal block).
- Date range limits (min/max) are out of scope per the ticket's own recommendation.
- Included a changeset (`fair-form`: minor).

## Test plan

- [x] `npm run build` in fair-form, fair-audience, fair-events
- [x] `npm run format` in fair-form, fair-audience, fair-events
- [x] `vendor/bin/phpcs` clean on changed PHP files
- [x] `npm run test:js` passing in fair-form, fair-audience, fair-events-shared
- [x] Manually verified in the running site (docker compose, :8080):
  - Both blocks appear in the Fair Form block's inserter
  - Date block preview/live render correctly in editor and frontend
  - Live REST submission accepts valid date/datetime and normalizes correctly
  - Live REST submission rejects malformed date/datetime with `invalid_date`/`invalid_datetime`
  - DB migration (`0.5.0`) correctly adds `datetime` to the `question_type` ENUM on an already-active install
