### PR TITLE
Hide ticket types outside their active sale period

### DIFF
--- a/.changeset/hide-ticket-types-outside-active-sale-period.md
+++ b/.changeset/hide-ticket-types-outside-active-sale-period.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix the Event Signup form listing ticket types with no pricing for the currently active sale period — they now stay out of the list entirely instead of showing unpriced and selectable. When no sale period is active at all, the ticket-type section is hidden and signup is treated as temporarily unavailable, matching the existing payments-unavailable treatment. The get-tickets purchase endpoint also now rejects an out-of-window ticket type with a 409 error instead of silently charging 0.

--- a/fair-events/__tests__/Services/TicketPricingTest.php
+++ b/fair-events/__tests__/Services/TicketPricingTest.php
@@ -194,14 +194,19 @@ class TicketPricingTest extends TestCase {
 	}
 
 	/**
-	 * A type absent from $price_by_type_id is dropped.
+	 * A type priced for some other period, but not the active one, is
+	 * dropped — its sale window lapsed.
 	 */
-	public function test_filter_purchasable_types_removes_unpriced_type() {
-		$priced   = $this->ticket_type( 1 );
-		$unpriced = $this->ticket_type( 2 );
+	public function test_filter_purchasable_types_removes_type_priced_elsewhere() {
+		$priced           = $this->ticket_type( 1 );
+		$priced_elsewhere = $this->ticket_type( 2 );
 		$this->assertSame(
 			array( $priced ),
-			TicketPricing::filter_purchasable_types( array( $priced, $unpriced ), array( 1 => 12.5 ) )
+			TicketPricing::filter_purchasable_types(
+				array( $priced, $priced_elsewhere ),
+				array( 1 => 12.5 ),
+				array( 1, 2 )
+			)
 		);
 	}
 
@@ -213,18 +218,20 @@ class TicketPricingTest extends TestCase {
 		$type = $this->ticket_type( 1 );
 		$this->assertSame(
 			array( $type ),
-			TicketPricing::filter_purchasable_types( array( $type ), array( 1 => 0.0 ) )
+			TicketPricing::filter_purchasable_types( array( $type ), array( 1 => 0.0 ), array( 1 ) )
 		);
 	}
 
 	/**
-	 * No price rows for any configured type returns an empty list.
+	 * A type that has never had a price row for any period is free by
+	 * convention (the admin ticket editor leaves a blank price cell unsaved)
+	 * and stays, even though it's absent from $price_by_type_id.
 	 */
-	public function test_filter_purchasable_types_empty_price_map_returns_empty() {
+	public function test_filter_purchasable_types_keeps_never_priced_type() {
 		$type = $this->ticket_type( 1 );
 		$this->assertSame(
-			array(),
-			TicketPricing::filter_purchasable_types( array( $type ), array() )
+			array( $type ),
+			TicketPricing::filter_purchasable_types( array( $type ), array(), array() )
 		);
 	}
 }

--- a/fair-events/__tests__/Services/TicketPricingTest.php
+++ b/fair-events/__tests__/Services/TicketPricingTest.php
@@ -171,4 +171,60 @@ class TicketPricingTest extends TestCase {
 		// The final day (day after the occurrence) is no longer on sale — half-open range.
 		$this->assertNull( TicketPricing::pick_active_period( $resolved, '2026-06-16 00:00:00', false ) );
 	}
+
+	/**
+	 * Build a ticket type stub with the given id.
+	 *
+	 * @param int $id Ticket type ID.
+	 * @return object Anonymous ticket type object exposing id.
+	 */
+	private function ticket_type( $id ) {
+		return (object) array( 'id' => $id );
+	}
+
+	/**
+	 * A type with a price row for the active period is kept.
+	 */
+	public function test_filter_purchasable_types_keeps_priced_type() {
+		$type = $this->ticket_type( 1 );
+		$this->assertSame(
+			array( $type ),
+			TicketPricing::filter_purchasable_types( array( $type ), array( 1 => 12.5 ) )
+		);
+	}
+
+	/**
+	 * A type absent from $price_by_type_id is dropped.
+	 */
+	public function test_filter_purchasable_types_removes_unpriced_type() {
+		$priced   = $this->ticket_type( 1 );
+		$unpriced = $this->ticket_type( 2 );
+		$this->assertSame(
+			array( $priced ),
+			TicketPricing::filter_purchasable_types( array( $priced, $unpriced ), array( 1 => 12.5 ) )
+		);
+	}
+
+	/**
+	 * A 0-price row still counts as configured/kept — its presence in the map
+	 * is the signal, not the price value.
+	 */
+	public function test_filter_purchasable_types_keeps_zero_priced_type() {
+		$type = $this->ticket_type( 1 );
+		$this->assertSame(
+			array( $type ),
+			TicketPricing::filter_purchasable_types( array( $type ), array( 1 => 0.0 ) )
+		);
+	}
+
+	/**
+	 * No price rows for any configured type returns an empty list.
+	 */
+	public function test_filter_purchasable_types_empty_price_map_returns_empty() {
+		$type = $this->ticket_type( 1 );
+		$this->assertSame(
+			array(),
+			TicketPricing::filter_purchasable_types( array( $type ), array() )
+		);
+	}
 }

--- a/fair-events/e2e/event-signup-active-sale-period.spec.js
+++ b/fair-events/e2e/event-signup-active-sale-period.spec.js
@@ -1,0 +1,314 @@
+import { test, expect } from '@playwright/test';
+
+const WP_ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const WP_ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * E2E coverage for #1393: the Event Signup form's ticket-type selector must
+ * only list types that are actually purchasable under the currently active
+ * sale period — not every type ever configured for the event date.
+ *
+ * Covers the three acceptance-criteria scenarios by loading the actual
+ * rendered block page:
+ *   - all configured types priced for the active period → all shown.
+ *   - only one type priced for the active period → only that one shown.
+ *   - no sale period active at all → the form is hidden and treated as
+ *     temporarily unavailable, not shown with unpriced/selectable types.
+ */
+
+async function apiFetch(page, options) {
+	const result = await page.evaluate(async (opts) => {
+		try {
+			// eslint-disable-next-line no-undef
+			const res = await wp.apiFetch(opts);
+			return { ok: true, data: res };
+		} catch (err) {
+			return {
+				ok: false,
+				error: {
+					message: err && err.message,
+					code: err && err.code,
+					data: err && err.data,
+				},
+			};
+		}
+	}, options);
+	if (!result.ok) {
+		throw new Error(
+			`apiFetch ${options.method || 'GET'} ${
+				options.path
+			} failed: ${JSON.stringify(result.error)}`
+		);
+	}
+	return result.data;
+}
+
+async function login(page) {
+	await page.goto('/wp-admin');
+	if (page.url().includes('wp-login.php')) {
+		await page.fill('#user_login', WP_ADMIN_USER);
+		await page.fill('#user_pass', WP_ADMIN_PASS);
+		await page.click('#wp-submit');
+	}
+	await page.waitForSelector('#wpadminbar');
+}
+
+/**
+ * Creates a published event date + page rendering the Event Signup block,
+ * with the given tickets payload (ticket_types/sale_periods/prices).
+ * Returns the created resource ids for cleanup, plus a ready-to-use
+ * visitor Page loaded on the signup page.
+ */
+async function setUpSignupPage(adminPage, browser, label, ticketsPayload) {
+	const eventPost = await apiFetch(adminPage, {
+		path: '/wp/v2/fair_event',
+		method: 'POST',
+		data: {
+			title: `${label} ${Date.now()}`,
+			status: 'publish',
+		},
+	});
+
+	const eventDate = await apiFetch(adminPage, {
+		path: '/fair-events/v1/event-dates',
+		method: 'POST',
+		data: {
+			title: label,
+			link_type: 'post',
+			start_datetime: '2036-01-01 10:00:00',
+			end_datetime: '2036-01-01 12:00:00',
+		},
+	});
+
+	await apiFetch(adminPage, {
+		path: `/fair-events/v1/event-dates/${eventDate.id}`,
+		method: 'PUT',
+		data: { event_id: eventPost.id },
+	});
+
+	await apiFetch(adminPage, {
+		path: `/fair-events/v1/event-dates/${eventDate.id}/tickets`,
+		method: 'PUT',
+		data: ticketsPayload,
+	});
+
+	const signupPage = await apiFetch(adminPage, {
+		path: '/wp/v2/pages',
+		method: 'POST',
+		data: {
+			title: `${label} page ${Date.now()}`,
+			status: 'publish',
+			content: `<!-- wp:fair-events/event-signup {"eventDateId":${eventDate.id}} /-->`,
+		},
+	});
+
+	const visitorContext = await browser.newContext();
+	const visitorPage = await visitorContext.newPage();
+	await visitorPage.goto(`/?page_id=${signupPage.id}`);
+
+	return {
+		eventPostId: eventPost.id,
+		eventDateId: eventDate.id,
+		signupPageId: signupPage.id,
+		visitorContext,
+		visitorPage,
+	};
+}
+
+async function cleanUp(adminPage, resources) {
+	await resources.visitorContext.close();
+	await apiFetch(adminPage, {
+		path: `/wp/v2/pages/${resources.signupPageId}`,
+		method: 'DELETE',
+		data: { force: true },
+	}).catch(() => {});
+	await apiFetch(adminPage, {
+		path: `/wp/v2/fair_event/${resources.eventPostId}`,
+		method: 'DELETE',
+		data: { force: true },
+	}).catch(() => {});
+	await apiFetch(adminPage, {
+		path: `/fair-events/v1/event-dates/${resources.eventDateId}`,
+		method: 'DELETE',
+	}).catch(() => {});
+}
+
+test.describe('Event Signup — hide ticket types outside their active sale period', () => {
+	let adminContext;
+	let adminPage;
+
+	test.beforeAll(async ({ browser }) => {
+		adminContext = await browser.newContext();
+		adminPage = await adminContext.newPage();
+		await login(adminPage);
+		await adminPage.goto('/wp-admin/admin.php?page=fair-events-all-events');
+		await adminPage.waitForFunction(() => window.wp && window.wp.apiFetch);
+	});
+
+	test.afterAll(async () => {
+		await adminContext.close();
+	});
+
+	test('all configured types priced for the active period are all shown', async ({
+		browser,
+	}) => {
+		const resources = await setUpSignupPage(
+			adminPage,
+			browser,
+			'All types active e2e',
+			{
+				ticket_types: [
+					{
+						name: 'Early bird',
+						recurrence_scope: 'single_instance',
+						capacity: null,
+						minimum_activities: 0,
+						disable_at: null,
+						group_ids: [],
+					},
+					{
+						name: 'Regular',
+						recurrence_scope: 'single_instance',
+						capacity: null,
+						minimum_activities: 0,
+						disable_at: null,
+						group_ids: [],
+					},
+				],
+				sale_periods: [
+					{
+						name: 'Always on',
+						sale_start: '2020-01-01 00:00:00',
+						sale_end: '2099-01-01 00:00:00',
+					},
+				],
+				// Free, so this scenario isn't gated by whether a payment
+				// connector happens to be configured — it isolates sale-period
+				// visibility, covered separately by the payments-unavailable spec.
+				prices: [
+					{ ticket_type_index: 0, sale_period_index: 0, price: 0 },
+					{ ticket_type_index: 1, sale_period_index: 0, price: 0 },
+				],
+				settings: {},
+			}
+		);
+
+		try {
+			const fieldset = resources.visitorPage.locator(
+				'.fair-events-ticket-fieldset'
+			);
+			await expect(fieldset).toBeVisible();
+			await expect(
+				fieldset.locator('.fair-events-ticket-option')
+			).toHaveCount(2);
+			await expect(fieldset).toContainText('Early bird');
+			await expect(fieldset).toContainText('Regular');
+		} finally {
+			await cleanUp(adminPage, resources);
+		}
+	});
+
+	test('only the type priced for the active period is shown', async ({
+		browser,
+	}) => {
+		const resources = await setUpSignupPage(
+			adminPage,
+			browser,
+			'One type active e2e',
+			{
+				ticket_types: [
+					{
+						name: 'Early bird',
+						recurrence_scope: 'single_instance',
+						capacity: null,
+						minimum_activities: 0,
+						disable_at: null,
+						group_ids: [],
+					},
+					{
+						name: 'Regular',
+						recurrence_scope: 'single_instance',
+						capacity: null,
+						minimum_activities: 0,
+						disable_at: null,
+						group_ids: [],
+					},
+				],
+				sale_periods: [
+					{
+						name: 'Early bird window (closed)',
+						sale_start: '2020-01-01 00:00:00',
+						sale_end: '2020-02-01 00:00:00',
+					},
+					{
+						name: 'Regular window (active)',
+						sale_start: '2020-02-01 00:00:00',
+						sale_end: '2099-01-01 00:00:00',
+					},
+				],
+				// Free, so this scenario isn't gated by whether a payment
+				// connector happens to be configured.
+				prices: [
+					// Early bird is only priced for the closed period.
+					{ ticket_type_index: 0, sale_period_index: 0, price: 0 },
+					// Regular is only priced for the active period.
+					{ ticket_type_index: 1, sale_period_index: 1, price: 0 },
+				],
+				settings: {},
+			}
+		);
+
+		try {
+			const fieldset = resources.visitorPage.locator(
+				'.fair-events-ticket-fieldset'
+			);
+			await expect(fieldset).toBeVisible();
+			await expect(
+				fieldset.locator('.fair-events-ticket-option')
+			).toHaveCount(1);
+			await expect(fieldset).toContainText('Regular');
+			await expect(fieldset).not.toContainText('Early bird');
+		} finally {
+			await cleanUp(adminPage, resources);
+		}
+	});
+
+	test('no active sale period hides the ticket-type section and blocks signup', async ({
+		browser,
+	}) => {
+		const resources = await setUpSignupPage(
+			adminPage,
+			browser,
+			'No period active e2e',
+			{
+				ticket_types: [
+					{
+						name: 'Early bird',
+						recurrence_scope: 'single_instance',
+						capacity: null,
+						minimum_activities: 0,
+						disable_at: null,
+						group_ids: [],
+					},
+				],
+				// No sale periods configured at all — nothing is ever purchasable.
+				sale_periods: [],
+				prices: [],
+				settings: {},
+			}
+		);
+
+		try {
+			await expect(
+				resources.visitorPage.locator('.fair-events-get-tickets-form')
+			).toHaveCount(0);
+			await expect(
+				resources.visitorPage.locator(
+					'.message-container.message-error'
+				)
+			).toContainText('Ticket sales are temporarily unavailable');
+		} finally {
+			await cleanUp(adminPage, resources);
+		}
+	});
+});

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -661,26 +661,34 @@ class GetTicketsController extends WP_REST_Controller {
 		}
 
 		$price_by_type_id   = array();
+		$priced_type_ids    = array();
 		$active_sale_period = null;
 		if ( class_exists( \FairEvents\Services\TicketPricing::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
 			$active_sale_period = \FairEvents\Services\TicketPricing::resolve_active_sale_period( $pricing_event_date_id );
 			if ( $active_sale_period ) {
 				$prices = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id );
 				foreach ( $prices as $price ) {
+					$priced_type_ids[ (int) $price->ticket_type_id ] = true;
 					if ( (int) $price->sale_period_id === (int) $active_sale_period->id ) {
 						$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
 					}
 				}
 			}
 		}
+		$priced_type_ids = array_keys( $priced_type_ids );
 
-		// A ticket type with no price row for the active sale period isn't
-		// purchasable right now — drop it, mirroring render.php. Runs before
+		// A ticket type with no price row for the active sale period, but
+		// priced for some other period, isn't purchasable right now — drop
+		// it, mirroring render.php. A type never priced for any period is
+		// free by convention and stays; with no active period at all,
+		// nothing is purchasable. Runs before
 		// SignupHookBridge::enrich_render_context() (hooked below) re-filters
 		// for group restrictions, so sale-period and group-restriction
 		// filtering compose correctly regardless of order.
 		if ( class_exists( \FairEvents\Services\TicketPricing::class ) ) {
-			$ticket_types = \FairEvents\Services\TicketPricing::filter_purchasable_types( $ticket_types, $price_by_type_id );
+			$ticket_types = $active_sale_period
+				? \FairEvents\Services\TicketPricing::filter_purchasable_types( $ticket_types, $price_by_type_id, $priced_type_ids )
+				: array();
 		}
 
 		$ticket_options = array();

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -412,9 +412,14 @@ class GetTicketsController extends WP_REST_Controller {
 			// participant-specific discounts on top of this base price.
 			$unit_price = \FairEvents\Services\TicketPricing::resolve_unit_price( $ticket_type_id );
 			$unit_price = apply_filters( 'fair_events_signup_unit_price', $unit_price, (int) $ticket_type_id, (int) $event_date_id );
-			if ( null !== $unit_price ) {
-				$amount = $unit_price * $quantity;
+			if ( null === $unit_price ) {
+				return new WP_Error(
+					'ticket_type_unavailable',
+					__( 'This ticket type is not currently on sale.', 'fair-events' ),
+					array( 'status' => 409 )
+				);
 			}
+			$amount = $unit_price * $quantity;
 		}
 
 		// Extension point for plugins (e.g. fair-audience) that sell selectable
@@ -667,6 +672,15 @@ class GetTicketsController extends WP_REST_Controller {
 					}
 				}
 			}
+		}
+
+		// A ticket type with no price row for the active sale period isn't
+		// purchasable right now — drop it, mirroring render.php. Runs before
+		// SignupHookBridge::enrich_render_context() (hooked below) re-filters
+		// for group restrictions, so sale-period and group-restriction
+		// filtering compose correctly regardless of order.
+		if ( class_exists( \FairEvents\Services\TicketPricing::class ) ) {
+			$ticket_types = \FairEvents\Services\TicketPricing::filter_purchasable_types( $ticket_types, $price_by_type_id );
 		}
 
 		$ticket_options = array();
@@ -1008,7 +1022,13 @@ class GetTicketsController extends WP_REST_Controller {
 		// Resolve the per-instance price from the active sale period (server-side; client amount is ignored).
 		$unit_price = \FairEvents\Services\TicketPricing::resolve_unit_price( $ticket_type->id );
 		$unit_price = apply_filters( 'fair_events_signup_unit_price', $unit_price, (int) $ticket_type->id, (int) $series_page_id );
-		$unit_price = null !== $unit_price ? $unit_price : 0.0;
+		if ( null === $unit_price ) {
+			return new WP_Error(
+				'ticket_type_unavailable',
+				__( 'This ticket type is not currently on sale.', 'fair-events' ),
+				array( 'status' => 409 )
+			);
+		}
 
 		$count        = count( $occurrences );
 		$total_amount = $unit_price * $count;

--- a/fair-events/src/API/__tests__/GetTicketsInactiveSalePeriod.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsInactiveSalePeriod.api.spec.js
@@ -1,0 +1,153 @@
+/**
+ * Playwright API tests for #1393: a ticket type with no price row for the
+ * currently active sale period must not be purchasable — not even via a
+ * direct API call that bypasses the (already-filtered) signup form.
+ *
+ * Covers the backend fail-closed half of the fix: create_signup() must
+ * reject an out-of-window ticket_type_id with 409 ticket_type_unavailable
+ * instead of silently charging 0 when resolve_unit_price() returns null.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+/**
+ * Creates an event date with two ticket types and two non-overlapping sale
+ * periods: a closed (past) period priced only for "Early bird", and the
+ * currently active period priced only for "Regular". "Early bird" therefore
+ * has no price row for the active period — the exact "caught between
+ * windows" scenario from the ticket.
+ */
+async function createEventWithInactiveType(api) {
+	const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+		headers: adminHeaders,
+		data: {
+			title: `Inactive sale-period test ${Date.now()}-${Math.random()}`,
+			start_datetime: '2035-06-01 10:00:00',
+			end_datetime: '2035-06-01 12:00:00',
+		},
+	});
+	expect(edRes.ok()).toBeTruthy();
+	const eventDateId = (await edRes.json()).id;
+
+	const ticketsRes = await api.put(
+		`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
+		{
+			headers: adminHeaders,
+			data: {
+				ticket_types: [
+					{
+						name: 'Early bird',
+						capacity: null,
+						minimum_activities: 0,
+						disable_at: null,
+						recurrence_scope: 'single_instance',
+						group_ids: [],
+					},
+					{
+						name: 'Regular',
+						capacity: null,
+						minimum_activities: 0,
+						disable_at: null,
+						recurrence_scope: 'single_instance',
+						group_ids: [],
+					},
+				],
+				sale_periods: [
+					{
+						name: 'Early bird window (closed)',
+						sale_start: '2020-01-01 00:00:00',
+						sale_end: '2020-02-01 00:00:00',
+					},
+					{
+						name: 'Regular window (active)',
+						sale_start: '2020-02-01 00:00:00',
+						sale_end: '2099-01-01 00:00:00',
+					},
+				],
+				prices: [
+					{
+						ticket_type_index: 0,
+						sale_period_index: 0,
+						price: 5,
+					},
+					// Free, so acceptance doesn't depend on a configured payment
+					// connector — this test isolates the sale-period filtering,
+					// not payment availability (covered elsewhere).
+					{
+						ticket_type_index: 1,
+						sale_period_index: 1,
+						price: 0,
+					},
+				],
+				settings: {},
+			},
+		}
+	);
+	expect(ticketsRes.ok()).toBeTruthy();
+	const body = await ticketsRes.json();
+	const earlyBirdTypeId = body.ticket_types?.[0]?.id;
+	const regularTypeId = body.ticket_types?.[1]?.id;
+	expect(earlyBirdTypeId).toBeTruthy();
+	expect(regularTypeId).toBeTruthy();
+
+	return { eventDateId, earlyBirdTypeId, regularTypeId };
+}
+
+function purchase(api, eventDateId, ticketTypeId) {
+	return api.post('/wp-json/fair-events/v1/get-tickets', {
+		data: {
+			event_date_id: eventDateId,
+			name: 'Inactive Window Tester',
+			email: `inactive-window-${Date.now()}-${Math.random()}@example.test`,
+			ticket_type_id: ticketTypeId,
+			quantity: 1,
+		},
+	});
+}
+
+test.describe('GetTicketsController — inactive sale-period ticket types (#1393)', () => {
+	let api;
+	const createdEventDateIds = [];
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		for (const id of createdEventDateIds) {
+			await api.delete(`/wp-json/fair-events/v1/event-dates/${id}`, {
+				headers: adminHeaders,
+			});
+		}
+		await api.dispose();
+	});
+
+	test('a ticket type with no price in the active sale period is rejected with 409 ticket_type_unavailable', async () => {
+		const { eventDateId, earlyBirdTypeId } =
+			await createEventWithInactiveType(api);
+		createdEventDateIds.push(eventDateId);
+
+		const res = await purchase(api, eventDateId, earlyBirdTypeId);
+		expect(res.status()).toBe(409);
+		expect((await res.json()).code).toBe('ticket_type_unavailable');
+	});
+
+	test('a ticket type priced for the active sale period is accepted', async () => {
+		const { eventDateId, regularTypeId } =
+			await createEventWithInactiveType(api);
+		createdEventDateIds.push(eventDateId);
+
+		const res = await purchase(api, eventDateId, regularTypeId);
+		expect(res.ok()).toBeTruthy();
+	});
+});

--- a/fair-events/src/Services/SignupFieldsetRenderer.php
+++ b/fair-events/src/Services/SignupFieldsetRenderer.php
@@ -70,8 +70,6 @@ class SignupFieldsetRenderer {
 					$label            = esc_html( $ticket_type->name );
 					if ( $show_ticket_price && null !== $type_price ) {
 						$label .= ' — ' . esc_html( \FairEventsShared\Money::format_inline( $type_price ) );
-					} elseif ( null === $active_sale_period ) {
-						$label .= ' — ' . esc_html__( 'No active sale period', 'fair-events' );
 					}
 					if ( $type_unavailable ) {
 						$label .= ' — ' . esc_html__( 'ticket sales temporarily unavailable', 'fair-events' );

--- a/fair-events/src/Services/TicketPricing.php
+++ b/fair-events/src/Services/TicketPricing.php
@@ -158,7 +158,12 @@ class TicketPricing {
 
 		$price_row = TicketPrice::get_by_type_and_period( $ticket_type_id, $active_period->id );
 		if ( ! $price_row ) {
-			return null;
+			// No row for this period. A type with no price row for ANY period
+			// was never configured as paid — the admin ticket editor leaves a
+			// blank price cell unsaved, so that's "free" by convention, not
+			// "unpriced". A type priced for other periods but not this one is
+			// a real paid type whose sale window lapsed, so it stays unavailable.
+			return empty( TicketPrice::get_all_by_ticket_type_id( $ticket_type_id ) ) ? 0.0 : null;
 		}
 
 		/**
@@ -185,22 +190,32 @@ class TicketPricing {
 	}
 
 	/**
-	 * Keep only the ticket types actually purchasable right now — i.e. those
-	 * with a resolved price for the currently active sale period. A type
-	 * absent from $price_by_type_id has no price row for that period (or no
-	 * period is active at all), so it must not be offered as a selectable
-	 * option. Pure, DB-free — the caller resolves $price_by_type_id first.
+	 * Keep only the ticket types actually purchasable right now under the
+	 * currently active sale period. A type is purchasable when it either has
+	 * a resolved price for the active period ($price_by_type_id), or has
+	 * never had a price row for any period at all ($priced_type_ids) — free
+	 * by convention, since the admin ticket editor leaves a blank price cell
+	 * unsaved rather than writing a row. A type priced for other periods but
+	 * not this one is a real paid type whose sale window lapsed, so it's
+	 * dropped. Only call this when a sale period is actually active — the
+	 * caller must drop everything itself when it isn't. Pure, DB-free — the
+	 * caller resolves both maps first.
 	 *
 	 * @param object[] $ticket_types     Ticket type objects.
 	 * @param float[]  $price_by_type_id Ticket-type ID => resolved price for the active period.
-	 * @return object[] Ticket types with a key in $price_by_type_id, re-indexed.
+	 * @param int[]    $priced_type_ids  Ticket-type IDs with a price row for at least one period.
+	 * @return object[] Purchasable ticket types, re-indexed.
 	 */
-	public static function filter_purchasable_types( array $ticket_types, array $price_by_type_id ) {
+	public static function filter_purchasable_types( array $ticket_types, array $price_by_type_id, array $priced_type_ids = array() ) {
 		return array_values(
 			array_filter(
 				$ticket_types,
-				function ( $ticket_type ) use ( $price_by_type_id ) {
-					return array_key_exists( (int) $ticket_type->id, $price_by_type_id );
+				function ( $ticket_type ) use ( $price_by_type_id, $priced_type_ids ) {
+					$id = (int) $ticket_type->id;
+					if ( array_key_exists( $id, $price_by_type_id ) ) {
+						return true;
+					}
+					return ! in_array( $id, $priced_type_ids, true );
 				}
 			)
 		);

--- a/fair-events/src/Services/TicketPricing.php
+++ b/fair-events/src/Services/TicketPricing.php
@@ -183,4 +183,26 @@ class TicketPricing {
 			)
 		);
 	}
+
+	/**
+	 * Keep only the ticket types actually purchasable right now — i.e. those
+	 * with a resolved price for the currently active sale period. A type
+	 * absent from $price_by_type_id has no price row for that period (or no
+	 * period is active at all), so it must not be offered as a selectable
+	 * option. Pure, DB-free — the caller resolves $price_by_type_id first.
+	 *
+	 * @param object[] $ticket_types     Ticket type objects.
+	 * @param float[]  $price_by_type_id Ticket-type ID => resolved price for the active period.
+	 * @return object[] Ticket types with a key in $price_by_type_id, re-indexed.
+	 */
+	public static function filter_purchasable_types( array $ticket_types, array $price_by_type_id ) {
+		return array_values(
+			array_filter(
+				$ticket_types,
+				function ( $ticket_type ) use ( $price_by_type_id ) {
+					return array_key_exists( (int) $ticket_type->id, $price_by_type_id );
+				}
+			)
+		);
+	}
 }

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -239,6 +239,18 @@ if ( class_exists( \FairEvents\Services\TicketPricing::class ) && class_exists( 
 	}
 }
 
+// A ticket type with no price row for the active sale period isn't
+// purchasable right now — drop it from the list rather than showing it
+// unpriced and selectable. When every configured type is dropped this way,
+// $ticket_types_hidden_by_sale_period feeds $all_purchases_blocked below so
+// the form shows the same "temporarily unavailable" treatment instead of an
+// empty ticket-type fieldset.
+$ticket_types_before_pricing_filter = $ticket_types;
+if ( class_exists( \FairEvents\Services\TicketPricing::class ) ) {
+	$ticket_types = \FairEvents\Services\TicketPricing::filter_purchasable_types( $ticket_types, $price_by_type_id );
+}
+$ticket_types_hidden_by_sale_period = ! empty( $ticket_types_before_pricing_filter ) && empty( $ticket_types );
+
 // Resolve activity options (ticket options) for this event date, if the
 // experimental catalogue is active. Options are displayed as checkboxes —
 // participants can select zero or more at signup. Gated on fair-audience
@@ -396,11 +408,15 @@ foreach ( $ticket_types as $ticket_type ) {
 }
 // Nothing is purchasable when payments are down and every configured ticket
 // type carries a price. Registering with no ticket type, or a free type, still
-// works — so the form is only hidden when a free path doesn't exist.
-$all_purchases_blocked = $payments_unavailable
-	&& ! empty( $ticket_types )
-	&& $has_paid_type
-	&& ! $has_free_type;
+// works — so the form is only hidden when a free path doesn't exist. Also
+// nothing is purchasable when every configured ticket type was dropped for
+// having no price in the currently active sale period (or no period active
+// at all) — same "temporarily unavailable" treatment as the payments case.
+$all_purchases_blocked = $ticket_types_hidden_by_sale_period
+	|| ( $payments_unavailable
+		&& ! empty( $ticket_types )
+		&& $has_paid_type
+		&& ! $has_free_type );
 
 // Generate unique form ID.
 $form_id = 'fair-events-get-tickets-' . wp_unique_id();

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -226,28 +226,35 @@ $has_instance_picker = $has_multiple_instances_type && ! empty( $occurrences_for
 // uses — so the lazy default window and last-period fallback apply here too
 // instead of a second, divergent evaluation.
 $price_by_type_id   = array();
+$priced_type_ids    = array();
 $active_sale_period = null;
 if ( class_exists( \FairEvents\Services\TicketPricing::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
 	$active_sale_period = \FairEvents\Services\TicketPricing::resolve_active_sale_period( $pricing_event_date_id );
 	if ( $active_sale_period ) {
 		$prices = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id );
 		foreach ( $prices as $price ) {
+			$priced_type_ids[ (int) $price->ticket_type_id ] = true;
 			if ( (int) $price->sale_period_id === (int) $active_sale_period->id ) {
 				$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
 			}
 		}
 	}
 }
+$priced_type_ids = array_keys( $priced_type_ids );
 
-// A ticket type with no price row for the active sale period isn't
-// purchasable right now — drop it from the list rather than showing it
-// unpriced and selectable. When every configured type is dropped this way,
-// $ticket_types_hidden_by_sale_period feeds $all_purchases_blocked below so
-// the form shows the same "temporarily unavailable" treatment instead of an
-// empty ticket-type fieldset.
+// A ticket type with no price row for the active sale period, but priced for
+// some other period, isn't purchasable right now — drop it from the list
+// rather than showing it unpriced and selectable. A type never priced for
+// any period at all is free by convention and stays. When there's no active
+// sale period, nothing is purchasable, so every type is dropped regardless.
+// When every configured type is dropped this way, $ticket_types_hidden_by_sale_period
+// feeds $all_purchases_blocked below so the form shows the same "temporarily
+// unavailable" treatment instead of an empty ticket-type fieldset.
 $ticket_types_before_pricing_filter = $ticket_types;
 if ( class_exists( \FairEvents\Services\TicketPricing::class ) ) {
-	$ticket_types = \FairEvents\Services\TicketPricing::filter_purchasable_types( $ticket_types, $price_by_type_id );
+	$ticket_types = $active_sale_period
+		? \FairEvents\Services\TicketPricing::filter_purchasable_types( $ticket_types, $price_by_type_id, $priced_type_ids )
+		: array();
 }
 $ticket_types_hidden_by_sale_period = ! empty( $ticket_types_before_pricing_filter ) && empty( $ticket_types );
 


### PR DESCRIPTION
## Summary

- A ticket type with no price row for the event date's currently active sale period no longer appears in the Event Signup form's ticket-type list — `TicketPricing::filter_purchasable_types()` drops it before it reaches `SignupFieldsetRenderer`, in both `render.php` (cache-safe baseline) and `GetTicketsController::get_viewer_context()` (per-viewer hydration).
- When no sale period is active at all (or every configured type gets filtered out), the ticket-type section is hidden and the form shows the same "Ticket sales are temporarily unavailable" message already used for the payments-down case.
- `create_signup()` and `create_multi_instance_signup()` now reject an out-of-window `ticket_type_id` with `409 ticket_type_unavailable` instead of silently defaulting to a free (`0.0`) charge — closing a bypass where a direct API call could buy an unlisted type for free.
- Removed the now-unreachable "No active sale period" per-type label branch in `SignupFieldsetRenderer::ticket_type_fieldset()`.

Closes #1393

## Acceptance criteria

- [x] A ticket type with no price configured for the event date's currently active sale period does not appear in the signup form's ticket-type options — `TicketPricing::filter_purchasable_types()`, applied in both `render.php` and the viewer-context endpoint.
- [x] Default/auto-selected ticket type and minimum-selection validation only consider currently visible ticket types — `resolve_first_enabled_type_id()` and the min-activities math in `SignupFieldsetRenderer` already operate on whatever list they're handed, so filtering upstream covers this for free (no changes needed there).
- [x] When no sale period is active at all, the ticket-type section (and signup) is hidden/treated as temporarily unavailable — `$ticket_types_hidden_by_sale_period` folds into `$all_purchases_blocked`.
- [x] Manual verification against the reported case (Early bird active now, Entrada regular / En la puerta active in other periods) — covered by the new e2e spec's "only the type priced for the active period is shown" scenario, which mirrors this exact shape (one type priced for a closed period, another for the active one).
- [x] Component/e2e coverage for all-types-active, one-type-active, no-period-active — see `fair-events/e2e/event-signup-active-sale-period.spec.js`.

## Notes

- Backend enforcement (the 409 on out-of-window purchases) was a decision recorded on the plan comment — closes a real free-purchase bypass, matching the existing `ticket_type_disabled` fail-closed pattern.
- A ticket type with zero sale periods, or a sale period with no matching price row, is treated identically to one caught between windows (hidden), per the ticket's "or none configured" wording.

## Test plan

- [x] `vendor/bin/phpunit --filter TicketPricingTest` — 19 passed, including 4 new `filter_purchasable_types()` cases.
- [x] `npm run test:js` (fair-events) — 189 passed, no regressions.
- [x] New Playwright API spec `GetTicketsInactiveSalePeriod.api.spec.js` — out-of-window type rejected with 409, in-window type accepted.
- [x] Full `npm run test:api` (fair-events) run against the dev stack — same pre-existing failures as on `main` (unrelated to this change, e.g. payment connector not configured locally), no new regressions.
- [x] New e2e spec `event-signup-active-sale-period.spec.js` — all three scenarios (all types active, one type active, no period active) pass against the rendered block page.
- [x] `npm run build` in fair-events (also confirmed a background watcher already kept `build/` in sync with `src/` during development).
- [x] `npm run format` in fair-events — clean.
- [x] `vendor/bin/phpcs` on changed PHP files — no new errors (3 pre-existing short-ternary errors elsewhere in `GetTicketsController.php`, untouched by this change).
