### PR TITLE
Style event signup's newsletter checkbox and question fields

### DIFF
--- a/.changeset/fix-event-signup-question-styling.md
+++ b/.changeset/fix-event-signup-question-styling.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix the event signup form's newsletter checkbox and custom question fields (short text, long text, select, radio, multiselect, consent) rendering unstyled — they now match the form's standard input styling and the newsletter checkbox drops to its own row instead of sitting inline with the quantity field.

--- a/fair-events/src/blocks/event-signup/frontend.css
+++ b/fair-events/src/blocks/event-signup/frontend.css
@@ -107,11 +107,73 @@
 	margin-bottom: 0;
 }
 
-.fair-events-get-tickets-form .fair-events-quantity-newsletter-row {
+.fair-events-get-tickets-form .form-checkbox-label {
 	display: flex;
-	flex-wrap: wrap;
-	gap: 16px;
-	align-items: flex-end;
+	align-items: center;
+	gap: 8px;
+	font-weight: normal;
+	cursor: pointer;
+}
+
+.fair-events-get-tickets-form .form-checkbox {
+	width: 18px;
+	height: 18px;
+	cursor: pointer;
+	flex-shrink: 0;
+}
+
+/* Custom question fields (fair-form question blocks nested in this form).
+ * Their own styling only targets fair-form's own .fair-form-form ancestor,
+ * which doesn't exist here, so the label/spacing/input treatment is
+ * reproduced under this form's own class instead. */
+.fair-events-get-tickets-form .fair-form-question {
+	margin-bottom: 16px;
+}
+
+.fair-events-get-tickets-form .fair-form-question > label {
+	display: block;
+	font-weight: 600;
+	margin-bottom: 4px;
+}
+
+.fair-events-get-tickets-form .fair-form-question .required {
+	color: #d63638;
+	margin-left: 2px;
+}
+
+.fair-events-get-tickets-form .fair-form-question input[type="text"],
+.fair-events-get-tickets-form .fair-form-question input[type="email"],
+.fair-events-get-tickets-form .fair-form-question input[type="tel"],
+.fair-events-get-tickets-form .fair-form-question input[type="url"],
+.fair-events-get-tickets-form .fair-form-question input[type="date"],
+.fair-events-get-tickets-form .fair-form-question input[type="datetime-local"],
+.fair-events-get-tickets-form .fair-form-question textarea,
+.fair-events-get-tickets-form .fair-form-question select {
+	width: 100%;
+	max-width: 400px;
+	padding: 14px 16px;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	font-size: 1em;
+	background-color: #fafafa;
+	box-sizing: border-box;
+	transition: border-color 0.2s ease;
+}
+
+.fair-events-get-tickets-form .fair-form-question input[type="text"]:focus,
+.fair-events-get-tickets-form .fair-form-question input[type="email"]:focus,
+.fair-events-get-tickets-form .fair-form-question input[type="tel"]:focus,
+.fair-events-get-tickets-form .fair-form-question input[type="url"]:focus,
+.fair-events-get-tickets-form .fair-form-question input[type="date"]:focus,
+.fair-events-get-tickets-form
+	.fair-form-question
+	input[type="datetime-local"]:focus,
+.fair-events-get-tickets-form .fair-form-question textarea:focus,
+.fair-events-get-tickets-form .fair-form-question select:focus {
+	outline: none;
+	border-color: #0073aa;
+	box-shadow: 0 0 0 1px #0073aa;
+	background-color: #fff;
 }
 
 /* Activities (ticket options) */

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -705,33 +705,31 @@ if ( ! empty( $attributes['isEditorPreview'] ) ) {
 			/>
 		</div>
 
-		<div class="fair-events-quantity-newsletter-row">
-			<div class="form-row fair-events-quantity-row">
-				<label for="<?php echo esc_attr( $form_id ); ?>-quantity" class="form-label">
-					<?php esc_html_e( 'Quantity', 'fair-events' ); ?>
-				</label>
-				<input
-					type="number"
-					id="<?php echo esc_attr( $form_id ); ?>-quantity"
-					name="quantity"
-					class="form-input"
-					value="1"
-					min="1"
-					max="10"
-				/>
-			</div>
+		<div class="form-row fair-events-quantity-row">
+			<label for="<?php echo esc_attr( $form_id ); ?>-quantity" class="form-label">
+				<?php esc_html_e( 'Quantity', 'fair-events' ); ?>
+			</label>
+			<input
+				type="number"
+				id="<?php echo esc_attr( $form_id ); ?>-quantity"
+				name="quantity"
+				class="form-input"
+				value="1"
+				min="1"
+				max="10"
+			/>
+		</div>
 
-			<div class="form-row">
-				<label class="form-checkbox-label">
-					<input
-						type="checkbox"
-						name="mailing_opt_in"
-						value="1"
-						class="form-checkbox"
-					/>
-					<?php esc_html_e( 'Keep me informed about future events', 'fair-events' ); ?>
-				</label>
-			</div>
+		<div class="form-row">
+			<label class="form-checkbox-label">
+				<input
+					type="checkbox"
+					name="mailing_opt_in"
+					value="1"
+					class="form-checkbox"
+				/>
+				<?php esc_html_e( 'Keep me informed about future events', 'fair-events' ); ?>
+			</label>
 		</div>
 
 		<?php if ( ! empty( $attributes['isEditorPreview'] ) ) : ?>


### PR DESCRIPTION
## Summary

- The event signup form's newsletter checkbox and its custom question fields (short text, long text, select, radio, multiselect, consent) rendered with no visual styling — they only inherited it through fair-form's own `.fair-form-form` ancestor rule, which doesn't exist on this form.
- Flattens the `.fair-events-quantity-newsletter-row` wrapper so the quantity field and newsletter checkbox become stacked sibling rows, and reproduces the label/spacing/input treatment for every question type under this form's own class.

Closes #1377

## Acceptance criteria

- [x] Newsletter checkbox appears on its own line, not inline with the quantity field — wrapper div removed, both are now sibling `.form-row` elements.
- [x] Short-text, long-text, and select question fields render full-width with a visible border and standard height/padding, matching the rest of the form — plus radio, multiselect, and consent, which share the same gap (see Decisions below).
- [x] Fields inside a conditional block get the same styling once visible — verified in the browser: the conditional wrapper is a plain div, so the descendant selector reaches nested fields with no extra CSS needed.
- [x] No regression to the standalone form product's own styling — change is scoped entirely to `fair-events/src/blocks/event-signup/`; nothing in `fair-form/` or `fair-audience/` is touched.
- [x] Verified visually at mobile and desktop widths — screenshots below.

## Implementation plan

Followed the plan agreed in [the linked comment](https://github.com/marcin-wosinek/fair-event-plugins/issues/1377#issuecomment-5175769565), including its decisions to cover all six question types available in event-signup (not just the three named in the AC) and to flatten the wrapper markup rather than just changing its flex direction.

## Verification

- `npm run build` (fair-events) — clean.
- `vendor/bin/phpcs` on the changed PHP file — clean.
- Manual visual check via a seeded event with all six question types + a conditional-revealed field, screenshotted at desktop and mobile, and confirmed in a live browser session that the conditional field picks up the same styling once its `fair-form-conditional-visible` class is present.
- No JS logic changed — `e2e/user-flows/conditional-signup-fields.spec.js` wasn't run against this branch (root e2e wp-env instance port conflicted with another local project), but the reveal mechanism (CSS class toggle on a plain wrapper div) is untouched by this diff.

## Test plan

- [x] Visual check at desktop/tablet/mobile widths
- [x] `npm run build` / `phpcs` clean
