### PR TITLE
Fix double-counted income on the event Finance tab

### DIFF
--- a/.changeset/fix-finance-double-counted-income.md
+++ b/.changeset/fix-finance-double-counted-income.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix the event Finance tab counting income twice when a bank-statement entry has been reconciliation-matched to a payment transaction: matched financial entries are now excluded from totals, so only the transaction's gross amount is counted.

--- a/fair-events/src/Admin/manage-event/EventFinance.js
+++ b/fair-events/src/Admin/manage-event/EventFinance.js
@@ -82,10 +82,10 @@ export default function EventFinance({ eventDateId, entriesUrl }) {
 				expiredData,
 			] = await Promise.all([
 				apiFetch({
-					path: `/fair-finance/v1/financial-entries/totals?event_date_id=${eventDateId}`,
+					path: `/fair-finance/v1/financial-entries/totals?event_date_id=${eventDateId}&unmatched=true`,
 				}),
 				apiFetch({
-					path: `/fair-finance/v1/financial-entries?event_date_id=${eventDateId}&per_page=10`,
+					path: `/fair-finance/v1/financial-entries?event_date_id=${eventDateId}&per_page=10&unmatched=true`,
 				}),
 				apiFetch({
 					path: `/fair-payments-connector/v1/transactions?event_date_id=${eventDateId}&status=paid&mode=live&per_page=100`,

--- a/fair-events/src/Admin/manage-event/__tests__/EventFinance.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventFinance.test.jsx
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Component tests for the Finance tab double-counting fix (#1337).
+ *
+ * fair-finance FinancialEntry rows that have been reconciliation-matched to a
+ * fair-payments-connector Transaction must be excluded from the totals/entries
+ * fetched here (via `unmatched=true`), since the matched transaction's gross
+ * amount already covers that income.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import EventFinance from '../EventFinance.js';
+
+jest.mock('@wordpress/api-fetch');
+
+const paidTransaction = {
+	id: 1,
+	amount: 45,
+	mollie_fee: 0.79,
+	application_fee: 0,
+	status: 'paid',
+	created_at: '2026-07-20 10:00:00',
+};
+
+const unmatchedIncomeEntry = {
+	id: 5,
+	entry_type: 'income',
+	entry_date: '2026-07-19',
+	amount: 30,
+	description: 'Sponsorship',
+};
+
+function mockApiFetchByPath({
+	totals = { total_income: 0, total_cost: 0, balance: 0 },
+	entries = [],
+	paidTransactions = [],
+} = {}) {
+	apiFetch.mockImplementation(({ path }) => {
+		if (path.startsWith('/fair-finance/v1/financial-entries/totals')) {
+			expect(path).toContain('unmatched=true');
+			return Promise.resolve(totals);
+		}
+		if (path.startsWith('/fair-finance/v1/financial-entries')) {
+			expect(path).toContain('unmatched=true');
+			return Promise.resolve({ entries });
+		}
+		if (path.includes('status=paid')) {
+			return Promise.resolve({ transactions: paidTransactions });
+		}
+		return Promise.resolve({ transactions: [] });
+	});
+}
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+function statValue(label) {
+	return screen.getByText(label).previousSibling.textContent;
+}
+
+describe('EventFinance — reconciled entries are not double-counted (#1337)', () => {
+	it('reports Total Income as only the gross transaction amount when the matching entry is excluded', async () => {
+		// Simulates the backend already filtering out the matched entry via
+		// unmatched=true — totals only reflect the paid transaction.
+		mockApiFetchByPath({
+			totals: { total_income: 0, total_cost: 0, balance: 0 },
+			paidTransactions: [paidTransaction],
+		});
+
+		render(<EventFinance eventDateId={42} entriesUrl="admin.php" />);
+
+		await waitFor(() =>
+			expect(screen.getByText('Total Income')).toBeInTheDocument()
+		);
+
+		expect(statValue('Total Income')).toBe('€45.00');
+	});
+
+	it('still includes an unmatched manual entry in totals and the entries table', async () => {
+		mockApiFetchByPath({
+			totals: { total_income: 30, total_cost: 0, balance: 30 },
+			entries: [unmatchedIncomeEntry],
+			paidTransactions: [],
+		});
+
+		render(<EventFinance eventDateId={42} entriesUrl="admin.php" />);
+
+		await waitFor(() =>
+			expect(screen.getByText('Sponsorship')).toBeInTheDocument()
+		);
+
+		expect(statValue('Total Income')).toBe('€30.00');
+	});
+
+	it('requests both fair-finance endpoints with unmatched=true', async () => {
+		mockApiFetchByPath({});
+
+		render(<EventFinance eventDateId={42} entriesUrl="admin.php" />);
+
+		await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+
+		const calledPaths = apiFetch.mock.calls.map((call) => call[0].path);
+		const totalsCall = calledPaths.find((p) =>
+			p.startsWith('/fair-finance/v1/financial-entries/totals')
+		);
+		const entriesCall = calledPaths.find(
+			(p) =>
+				p.startsWith('/fair-finance/v1/financial-entries?') ||
+				(p.startsWith('/fair-finance/v1/financial-entries') &&
+					!p.includes('/totals'))
+		);
+		expect(totalsCall).toContain('unmatched=true');
+		expect(entriesCall).toContain('unmatched=true');
+	});
+
+	it('still computes Total Net from paid-transaction fee data', async () => {
+		mockApiFetchByPath({
+			totals: { total_income: 0, total_cost: 0, balance: 0 },
+			paidTransactions: [paidTransaction],
+		});
+
+		render(<EventFinance eventDateId={42} entriesUrl="admin.php" />);
+
+		await waitFor(() =>
+			expect(screen.getByText('Total Net')).toBeInTheDocument()
+		);
+
+		// 45 - 0.79 mollie fee - 0 application fee = 44.21
+		expect(statValue('Total Net')).toBe('€44.21');
+	});
+});


### PR DESCRIPTION
## Summary

- Fixes the event Finance tab double-counting income when a fair-finance financial entry has been reconciliation-matched to a fair-payments-connector transaction. `EventFinance.js` was summing fair-finance's `total_income`/`total_cost` (all entries, matched or not) alongside the gross sum of paid transactions, so every matched payment was counted once as the matched entry and again as the raw transaction.
- Both fair-finance endpoints already accept an `unmatched=true` filter that excludes entries linked to a transaction via the reconciliation junction table — no backend change needed, only the query params in `EventFinance.js`'s `loadData()`.

Closes #1337

## Acceptance criteria

The implementation plan in [the linked comment](https://github.com/marcin-wosinek/fair-event-plugins/issues/1337#issuecomment-5190130436) specifies:

- **Add `unmatched=true` to both fair-finance calls** — done, on `/fair-finance/v1/financial-entries/totals` and `/fair-finance/v1/financial-entries`.
- **Totals combination stays structurally the same** — unchanged; it's now correct because `totalsData` only reflects unmatched entries.
- **No changes to `total_net`/`net_complete`** or the Payments/Failed Payments tables — unchanged, as planned.
- **New test file** `EventFinance.test.jsx` — added, covering: Total Income equals only the gross transaction amount when the matching entry is filtered server-side; an unmatched manual entry is still included in totals and the entries table; both `apiFetch` calls include `unmatched=true`; Total Net still computes correctly from fee data.

## Verification

- `npm run test:js` in `fair-events`: 25 suites / 193 tests pass, including the 4 new `EventFinance.test.jsx` tests.
- `npm run build` in `fair-events`; confirmed the built `admin/manage-event/index.js` bundle contains the `unmatched=true` query strings.
- `npm run format` in `fair-events`: no formatting noise.
- End-to-end check via a throwaway WP-CLI `eval-file` script against the dev environment (fair-finance temporarily activated, then restored to its original inactive state): created a paid transaction (gross 45.00) reconciliation-matched to a financial entry (net 44.21) for a real event date, then hit `/fair-finance/v1/financial-entries/totals` directly —
  - without `unmatched=true`: `total_income: 44.21` (the matched entry, would double-count against the transaction)
  - with `unmatched=true`: `total_income: 0` (correctly excluded — the transaction's gross amount now accounts for it on the frontend side)
  All test data and plugin activation state were cleaned up afterward.

## Test plan

- [x] `npm run test:js` passes (including new `EventFinance.test.jsx`)
- [x] `npm run build` succeeds and bundles the query-param change
- [x] `npm run format` clean
- [x] Manual REST verification of the `unmatched=true` filter against reconciled data in the dev environment
