### PR TITLE
Confirm before clearing organizer logo override

### DIFF
--- a/.changeset/confirm-remove-organizer-logo.md
+++ b/.changeset/confirm-remove-organizer-logo.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Require confirmation before clearing the organizer logo override, matching the confirmation pattern used for other destructive actions in the admin.

--- a/fair-events/src/Admin/settings/OrganizerTab.js
+++ b/fair-events/src/Admin/settings/OrganizerTab.js
@@ -12,6 +12,7 @@ import {
 	CardBody,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
+	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 
 /**
@@ -87,6 +88,7 @@ export default function OrganizerTab({ onNotice }) {
 	const [logoPreviewUrl, setLogoPreviewUrl] = useState('');
 	const [isLoading, setIsLoading] = useState(true);
 	const [isSaving, setIsSaving] = useState(false);
+	const [removeLogoDialogOpen, setRemoveLogoDialogOpen] = useState(false);
 
 	const applySettings = (settings) => {
 		const { defaults: siteDefaults, ...organizerData } = settings;
@@ -302,7 +304,7 @@ export default function OrganizerTab({ onNotice }) {
 										variant="tertiary"
 										isDestructive
 										onClick={() =>
-											updateField('logo_id', 0)
+											setRemoveLogoDialogOpen(true)
 										}
 										disabled={isSaving}
 									>
@@ -495,6 +497,18 @@ export default function OrganizerTab({ onNotice }) {
 					)}
 				</div>
 			</VStack>
+			<ConfirmDialog
+				isOpen={removeLogoDialogOpen}
+				onConfirm={() => {
+					updateField('logo_id', 0);
+					setRemoveLogoDialogOpen(false);
+				}}
+				onCancel={() => setRemoveLogoDialogOpen(false)}
+				confirmButtonText={__('Remove logo', 'fair-events')}
+				cancelButtonText={__('Cancel', 'fair-events')}
+			>
+				{__('Remove organizer logo?', 'fair-events')}
+			</ConfirmDialog>
 		</form>
 	);
 }

--- a/fair-events/src/Admin/settings/__tests__/OrganizerTab.test.jsx
+++ b/fair-events/src/Admin/settings/__tests__/OrganizerTab.test.jsx
@@ -194,9 +194,58 @@ test('picking a logo stores its attachment id and shows a preview; removing it r
 
 	fireEvent.click(removeButton);
 
+	const confirmButton = await screen.findByRole('button', {
+		name: /Remove logo/i,
+	});
+	fireEvent.click(confirmButton);
+
 	await waitFor(() =>
 		expect(
 			screen.queryByRole('button', { name: /^Remove$/i })
 		).not.toBeInTheDocument()
 	);
+});
+
+test('cancelling the remove-logo dialog leaves the override untouched', async () => {
+	const handlers = {};
+	const frame = {
+		on: (event, cb) => {
+			handlers[event] = cb;
+		},
+		open: () => handlers.select(),
+		state: () => ({
+			get: () => ({
+				first: () => ({
+					toJSON: () => ({
+						id: 42,
+						url: 'https://example.com/logo.png',
+					}),
+				}),
+			}),
+		}),
+	};
+	global.wp = { ...global.wp, media: jest.fn(() => frame) };
+
+	render(<OrganizerTab onNotice={jest.fn()} />);
+	await waitFor(() => expect(nameField()).toBeInTheDocument());
+
+	fireEvent.click(screen.getByRole('button', { name: /Change image/i }));
+
+	await waitFor(() =>
+		expect(screen.getByAltText('')).toHaveAttribute(
+			'src',
+			'https://example.com/logo.png'
+		)
+	);
+
+	fireEvent.click(screen.getByRole('button', { name: /^Remove$/i }));
+
+	const cancelButton = await screen.findByRole('button', {
+		name: /Cancel/i,
+	});
+	fireEvent.click(cancelButton);
+
+	expect(
+		screen.getByRole('button', { name: /^Remove$/i })
+	).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary

- Gate the organizer logo "Remove" action behind a confirmation dialog, matching the pattern already used elsewhere in the admin (`__experimentalConfirmDialog`).
- Persistence is unchanged: confirming only updates local component state, still requiring the existing "Save organizer" button.

Closes #1301

## Acceptance criteria

- [x] Clicking Remove opens a confirmation dialog instead of clearing the override immediately
- [x] Confirming the dialog clears the logo override
- [x] Cancelling the dialog leaves the logo override unchanged
- [x] Component test covers both the confirm and cancel paths

## Test plan

- `npx jest src/Admin/settings/__tests__/OrganizerTab.test.jsx` — 10/10 passing
- Verified manually on the running site (docker compose, `:8080`): imported a test logo, opened the Organizer settings tab, clicked Remove, confirmed the dialog appears with "Remove organizer logo?" / Cancel / "Remove logo"; Cancel leaves the logo untouched, confirming clears it.
