### PR TITLE
Hide sale-periods calendar in single-period mode

### DIFF
--- a/.changeset/simplify-sale-period-single-mode.md
+++ b/.changeset/simplify-sale-period-single-mode.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Hide the multi-period sale-periods calendar on the Tickets tab when Multiple pricing periods is off, so the single From/Until sale window isn't cluttered with chrome built for comparing several named periods.

--- a/fair-events/src/Admin/manage-event/EventTickets.js
+++ b/fair-events/src/Admin/manage-event/EventTickets.js
@@ -1008,7 +1008,7 @@ export default function EventTickets({
 									</div>
 								</HStack>
 							)}
-							{salePeriods.length > 0 && (
+							{effectiveMultiple && salePeriods.length > 0 && (
 								<SalePeriodsCalendar
 									salePeriods={salePeriods}
 									eventDay={eventDay}

--- a/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventTickets.test.jsx
@@ -1261,6 +1261,25 @@ describe('EventTickets — Add-on collaborator discount removed (#1139)', () => 
 });
 
 describe('EventTickets — SalePeriodsCalendar wiring (#1197)', () => {
+	const initialDataWithOnePeriod = {
+		...initialDataWithTicketType,
+		sale_periods: [
+			{
+				id: 501,
+				name: '',
+				sale_start: '2026-01-01',
+				sale_end: '2026-02-01',
+			},
+		],
+		prices: [
+			{
+				ticket_type_id: 1,
+				sale_period_id: 501,
+				price: '12',
+			},
+		],
+	};
+
 	const initialDataWithTwoPeriods = {
 		...initialDataWithTicketType,
 		sale_periods: [
@@ -1312,5 +1331,70 @@ describe('EventTickets — SalePeriodsCalendar wiring (#1197)', () => {
 		expect(rows[1].querySelector('td span').style.background).toBe(
 			hexToRgb(salePeriodColor(1))
 		);
+	});
+
+	it('hides the calendar when Multiple pricing periods is off, with a single stored period', () => {
+		renderTickets({
+			initialData: initialDataWithOnePeriod,
+			startDatetime: '2026-01-10 10:00:00',
+			endDatetime: '2026-02-01 12:00:00',
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		expect(screen.queryByText(/Event day/i)).not.toBeInTheDocument();
+	});
+
+	it('shows the calendar when Multiple pricing periods is on, with two stored periods', () => {
+		renderTickets({
+			initialData: initialDataWithTwoPeriods,
+			startDatetime: '2026-01-25 10:00:00',
+			endDatetime: '2026-02-01 12:00:00',
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+
+		expect(screen.getByText(/Event day/i)).toBeInTheDocument();
+	});
+
+	it('shows the calendar after turning on Multiple pricing periods from a single period', () => {
+		renderTickets({
+			initialData: initialDataWithOnePeriod,
+			startDatetime: '2026-01-10 10:00:00',
+			endDatetime: '2026-02-01 12:00:00',
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+		expect(screen.queryByText(/Event day/i)).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		fireEvent.click(
+			screen.getByRole('checkbox', {
+				name: /Multiple pricing periods/i,
+			})
+		);
+
+		expect(screen.getByText(/Event day/i)).toBeInTheDocument();
+	});
+
+	it('hides the calendar again after confirming the merge back to a single period', () => {
+		renderTickets({
+			initialData: initialDataWithTwoPeriods,
+			startDatetime: '2026-01-25 10:00:00',
+			endDatetime: '2026-02-01 12:00:00',
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /Sale Periods/i }));
+		expect(screen.getByText(/Event day/i)).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole('button', { name: /More options/i }));
+		fireEvent.click(
+			screen.getByRole('checkbox', {
+				name: /Multiple pricing periods/i,
+			})
+		);
+		fireEvent.click(screen.getByRole('button', { name: 'Merge periods' }));
+
+		expect(screen.queryByText(/Event day/i)).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary

- Gate the `SalePeriodsCalendar` heatmap on the same `effectiveMultiple` flag the periods table already branches on, so it only renders in multi-period mode.
- Extend the Tickets tab component tests to cover calendar visibility across both toggle states, including turning "Multiple pricing periods" on/off.

Closes #1341

## Acceptance criteria

- [x] With Multiple pricing periods off, the Tickets tab shows a single From/Until sale-date control and no multi-period calendar/table chrome — the table view was already gated on `effectiveMultiple`; this PR gates the calendar the same way.
- [x] The existing "reset to automatic" behaviour for the single sale window still works — untouched, single-period branch wasn't modified.
- [x] With Multiple pricing periods on, the tab is unchanged from current behaviour (multi-period table, calendar, per-period pricing columns, auto-split, merge-on-disable confirmation) — `effectiveMultiple` is already `true` whenever `salePeriods.length > 1`, so this only changes the single-stored-period, toggle-off case.
- [x] An event date with a pre-existing custom (non-automatic) single sale window still displays and edits those dates correctly after this change — unaffected, no changes to date storage/editing logic.
- [x] Component tests for the Tickets tab cover both toggle states' visibility of the calendar/table chrome — 4 new tests added to the `SalePeriodsCalendar wiring` describe block.

## Test plan

- `npx jest src/Admin/manage-event/__tests__/EventTickets.test.jsx` — 60/60 passing (including 4 new tests)
- `npx jest src/Admin/manage-event` — 133/133 passing (full suite for the area)
- Verified manually on the running site (docker compose, `:8080`): with Multiple pricing periods off, the Sale Periods panel shows only the From/Until fields and Sale start/end summary, no calendar; turning the toggle on splits into two named periods as before (pre-existing, unchanged behavior).
