### PR TITLE
Fix duplicated Simple Payment blocks mischarging buyers

### DIFF
--- a/.changeset/fix-duplicate-simple-payment-block-id.md
+++ b/.changeset/fix-duplicate-simple-payment-block-id.md
@@ -1,0 +1,5 @@
+---
+"fair-payments-connector": patch
+---
+
+Fix a mischarge bug where duplicating a Simple Payment block copied its hidden identifier along with it: the editor now reassigns a fresh identifier to the duplicate and warns the owner to save, and the payment endpoint rejects a payment when the submitted identifier matches more than one saved block instead of trusting the first match.

--- a/e2e/mu-plugins/scripts/seed-payment-page-duplicate.php
+++ b/e2e/mu-plugins/scripts/seed-payment-page-duplicate.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Seed a published page carrying two simple-payment blocks that share the
+ * same blockId (as if the editor's duplicate-detection had never run, e.g. a
+ * pre-fix page nobody has reopened), for the E2E spec covering the
+ * endpoint's ambiguous-block hardening.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-payment-page-duplicate.php [amount1] [amount2]
+ *
+ * Prints a single `E2E_PAYMENT_PAGE_DUPLICATE:{json}` line with the page id,
+ * permalink, the shared block id, and each copy's own amount.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$amount_1 = isset( $args[0] ) && '' !== $args[0] ? (string) (float) $args[0] : '12.50';
+$amount_2 = isset( $args[1] ) && '' !== $args[1] ? (string) (float) $args[1] : '45.00';
+
+$block_id = wp_generate_uuid4();
+
+$block_content = '<!-- wp:fair-payment/simple-payment ' . wp_json_encode(
+	array(
+		'blockId'     => $block_id,
+		'amount'      => $amount_1,
+		'description' => 'E2E duplicate payment block 1',
+	)
+) . ' /-->' . "\n" . '<!-- wp:fair-payment/simple-payment ' . wp_json_encode(
+	array(
+		'blockId'     => $block_id,
+		'amount'      => $amount_2,
+		'description' => 'E2E duplicate payment block 2',
+	)
+) . ' /-->';
+
+$page_id = wp_insert_post(
+	array(
+		'post_type'    => 'page',
+		'post_status'  => 'publish',
+		'post_title'   => 'E2E Duplicate Simple Payment ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ),
+		'post_content' => $block_content,
+	),
+	true
+);
+
+if ( is_wp_error( $page_id ) ) {
+	WP_CLI::error( 'Failed to create duplicate payment page: ' . $page_id->get_error_message() );
+}
+
+echo 'E2E_PAYMENT_PAGE_DUPLICATE:' . wp_json_encode(
+	array(
+		'pageId'  => (int) $page_id,
+		'pageUrl' => get_permalink( $page_id ),
+		'blockId' => $block_id,
+		'amounts' => array( (float) $amount_1, (float) $amount_2 ),
+	)
+) . "\n";

--- a/e2e/mu-plugins/scripts/seed-payment-page-multi.php
+++ b/e2e/mu-plugins/scripts/seed-payment-page-multi.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Seed a published page carrying two simple-payment blocks with distinct
+ * identifiers and different prices, for the E2E specs covering multiple
+ * Simple Payment blocks coexisting on one page.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-payment-page-multi.php [amount1] [amount2]
+ *
+ * Prints a single `E2E_PAYMENT_PAGE_MULTI:{json}` line with the page id,
+ * permalink, and each block's own id + amount.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$amount_1 = isset( $args[0] ) && '' !== $args[0] ? (string) (float) $args[0] : '12.50';
+$amount_2 = isset( $args[1] ) && '' !== $args[1] ? (string) (float) $args[1] : '45.00';
+
+$block_id_1 = wp_generate_uuid4();
+$block_id_2 = wp_generate_uuid4();
+
+$block_content = '<!-- wp:fair-payment/simple-payment ' . wp_json_encode(
+	array(
+		'blockId'     => $block_id_1,
+		'amount'      => $amount_1,
+		'description' => 'E2E multi payment block 1',
+	)
+) . ' /-->' . "\n" . '<!-- wp:fair-payment/simple-payment ' . wp_json_encode(
+	array(
+		'blockId'     => $block_id_2,
+		'amount'      => $amount_2,
+		'description' => 'E2E multi payment block 2',
+	)
+) . ' /-->';
+
+$page_id = wp_insert_post(
+	array(
+		'post_type'    => 'page',
+		'post_status'  => 'publish',
+		'post_title'   => 'E2E Multi Simple Payment ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ),
+		'post_content' => $block_content,
+	),
+	true
+);
+
+if ( is_wp_error( $page_id ) ) {
+	WP_CLI::error( 'Failed to create multi payment page: ' . $page_id->get_error_message() );
+}
+
+echo 'E2E_PAYMENT_PAGE_MULTI:' . wp_json_encode(
+	array(
+		'pageId'  => (int) $page_id,
+		'pageUrl' => get_permalink( $page_id ),
+		'blocks'  => array(
+			array(
+				'blockId' => $block_id_1,
+				'amount'  => (float) $amount_1,
+			),
+			array(
+				'blockId' => $block_id_2,
+				'amount'  => (float) $amount_2,
+			),
+		),
+	)
+) . "\n";

--- a/e2e/user-flows/simple-payment-duplicate-block.spec.js
+++ b/e2e/user-flows/simple-payment-duplicate-block.spec.js
@@ -1,0 +1,60 @@
+/**
+ * E2E: fair-payments-connector — a page whose saved content already has two
+ * Simple Payment blocks sharing one blockId (as if the editor's
+ * duplicate-detection had never run on it, e.g. a pre-fix page or hand-edited
+ * markup).
+ *
+ * Covers the fix for #1325: the endpoint must reject the payment with 409
+ * ambiguous_block rather than trusting whichever block it matches first.
+ */
+
+import { test, expect } from '@playwright/test';
+import { runScript } from '../support/wp-cli.js';
+
+let seed;
+
+test.beforeAll(() => {
+	seed = runScript(
+		'seed-payment-page-duplicate.php',
+		'E2E_PAYMENT_PAGE_DUPLICATE',
+		'12.50 45.00'
+	);
+});
+
+test.afterAll(() => {
+	if (seed) {
+		runScript(
+			'cleanup-payment-page.php',
+			'E2E_PAYMENT_CLEANUP',
+			String(seed.pageId)
+		);
+	}
+});
+
+test.describe('two simple-payment blocks sharing one blockId', () => {
+	test('rejects the payment with 409 ambiguous_block instead of charging the first match', async ({
+		page,
+	}) => {
+		const nonceRes = await page.request.get(
+			'/wp-json/fair-payments-connector/v1/nonce'
+		);
+		const { nonce } = await nonceRes.json();
+
+		const res = await page.request.post(
+			'/wp-json/fair-payments-connector/v1/payments',
+			{
+				data: {
+					amount: String(seed.amounts[0]),
+					currency: 'EUR',
+					post_id: seed.pageId,
+					block_id: seed.blockId,
+					nonce,
+				},
+			}
+		);
+
+		expect(res.status()).toBe(409);
+		const body = await res.json();
+		expect(body.code).toBe('ambiguous_block');
+	});
+});

--- a/e2e/user-flows/simple-payment-multi-block.spec.js
+++ b/e2e/user-flows/simple-payment-multi-block.spec.js
@@ -1,0 +1,97 @@
+/**
+ * E2E: fair-payments-connector — two Simple Payment blocks with distinct
+ * identifiers and different prices coexisting on one page.
+ *
+ * Covers the fix for #1325: PaymentEndpoint::find_blocks_by_id() must resolve
+ * each block's own saved amount rather than the first block on the page, and
+ * each button must render its own blockId/amount (the editor's
+ * duplicate-detection guarantees distinct ids).
+ */
+
+import { test, expect } from '@playwright/test';
+import { runScript } from '../support/wp-cli.js';
+
+let seed;
+
+test.beforeAll(() => {
+	seed = runScript(
+		'seed-payment-page-multi.php',
+		'E2E_PAYMENT_PAGE_MULTI',
+		'12.50 45.00'
+	);
+});
+
+test.afterAll(() => {
+	if (seed) {
+		runScript(
+			'cleanup-payment-page.php',
+			'E2E_PAYMENT_CLEANUP',
+			String(seed.pageId)
+		);
+	}
+});
+
+test.describe('two simple-payment blocks on one page', () => {
+	test('each button renders its own blockId and amount', async ({ page }) => {
+		await page.goto(seed.pageUrl);
+
+		const buttons = page.locator('.fair-payments-connector-button');
+		await expect(buttons).toHaveCount(2);
+
+		for (let i = 0; i < seed.blocks.length; i++) {
+			await expect(buttons.nth(i)).toHaveAttribute(
+				'data-block-id',
+				seed.blocks[i].blockId
+			);
+			await expect(buttons.nth(i)).toHaveAttribute(
+				'data-amount',
+				String(seed.blocks[i].amount)
+			);
+		}
+	});
+
+	test("the endpoint charges each block its own price, not the other block's", async ({
+		page,
+	}) => {
+		const nonceRes = await page.request.get(
+			'/wp-json/fair-payments-connector/v1/nonce'
+		);
+		const { nonce } = await nonceRes.json();
+
+		const [block1, block2] = seed.blocks;
+
+		// Submitting block 1's own amount against block 1's id succeeds.
+		const okRes = await page.request.post(
+			'/wp-json/fair-payments-connector/v1/payments',
+			{
+				data: {
+					amount: String(block1.amount),
+					currency: 'EUR',
+					post_id: seed.pageId,
+					block_id: block1.blockId,
+					nonce,
+				},
+			}
+		);
+		expect(okRes.status()).toBe(201);
+
+		// Submitting block 1's (lower) amount against block 2's id is rejected —
+		// proving the endpoint resolved block 2's own, higher price rather than
+		// reusing whichever block it matched first.
+		const rejectedRes = await page.request.post(
+			'/wp-json/fair-payments-connector/v1/payments',
+			{
+				data: {
+					amount: String(block1.amount),
+					currency: 'EUR',
+					post_id: seed.pageId,
+					block_id: block2.blockId,
+					nonce,
+				},
+			}
+		);
+		expect(rejectedRes.status()).toBe(422);
+		const body = await rejectedRes.json();
+		expect(body.code).toBe('amount_too_low');
+	});
+});

--- a/fair-payments-connector/src/API/PaymentEndpoint.php
+++ b/fair-payments-connector/src/API/PaymentEndpoint.php
@@ -142,25 +142,31 @@ class PaymentEndpoint extends WP_REST_Controller {
 	}
 
 	/**
-	 * Find a block in a parsed block tree by its blockId attribute.
+	 * Find all blocks in a parsed block tree matching a blockId attribute.
+	 *
+	 * A page can legitimately contain unrelated blocks that happen to carry a
+	 * `blockId` attribute of their own; this only matches Simple Payment
+	 * blocks so it can't be confused by those.
 	 *
 	 * @param array  $blocks   Parsed blocks array.
 	 * @param string $block_id UUID to search for.
-	 * @return array|null Matching block or null.
+	 * @return array List of matching blocks (possibly empty).
 	 */
-	private function find_block_by_id( array $blocks, string $block_id ): ?array {
+	private function find_blocks_by_id( array $blocks, string $block_id ): array {
+		$matches = array();
 		foreach ( $blocks as $block ) {
-			if ( isset( $block['attrs']['blockId'] ) && $block['attrs']['blockId'] === $block_id ) {
-				return $block;
+			if (
+				'fair-payment/simple-payment' === ( $block['blockName'] ?? '' )
+				&& isset( $block['attrs']['blockId'] )
+				&& $block['attrs']['blockId'] === $block_id
+			) {
+				$matches[] = $block;
 			}
 			if ( ! empty( $block['innerBlocks'] ) ) {
-				$found = $this->find_block_by_id( $block['innerBlocks'], $block_id );
-				if ( null !== $found ) {
-					return $found;
-				}
+				$matches = array_merge( $matches, $this->find_blocks_by_id( $block['innerBlocks'], $block_id ) );
 			}
 		}
-		return null;
+		return $matches;
 	}
 
 	/**
@@ -213,10 +219,10 @@ class PaymentEndpoint extends WP_REST_Controller {
 			);
 		}
 
-		$blocks        = parse_blocks( $post->post_content );
-		$matched_block = $this->find_block_by_id( $blocks, $block_id );
+		$blocks         = parse_blocks( $post->post_content );
+		$matched_blocks = $this->find_blocks_by_id( $blocks, $block_id );
 
-		if ( ! $matched_block ) {
+		if ( ! $matched_blocks ) {
 			return new WP_Error(
 				'invalid_block',
 				__( 'Block not found.', 'fair-payments-connector' ),
@@ -224,6 +230,19 @@ class PaymentEndpoint extends WP_REST_Controller {
 			);
 		}
 
+		// More than one block shares this id (e.g. a pre-fix duplicated block
+		// nobody has reopened in the editor since). Trusting the first match
+		// would mischarge the buyer if the copies have different prices, so
+		// fail closed instead.
+		if ( count( $matched_blocks ) > 1 ) {
+			return new WP_Error(
+				'ambiguous_block',
+				__( 'This payment option is misconfigured. Please contact the site owner.', 'fair-payments-connector' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$matched_block    = $matched_blocks[0];
 		$expected_amount  = floatval( $matched_block['attrs']['amount'] ?? 0 );
 		$submitted_amount = floatval( $request->get_param( 'amount' ) );
 

--- a/fair-payments-connector/src/blocks/simple-payment/__tests__/index.test.jsx
+++ b/fair-payments-connector/src/blocks/simple-payment/__tests__/index.test.jsx
@@ -1,0 +1,177 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+const mockSelect = jest.fn();
+jest.mock('@wordpress/data', () => ({
+	select: (...args) => mockSelect(...args),
+}));
+
+jest.mock('@wordpress/block-editor', () => ({
+	useBlockProps: (props) => props || {},
+}));
+
+jest.mock('@wordpress/components', () => ({
+	Notice: ({ children }) => <div role="alert">{children}</div>,
+	TextControl: ({ label, value, onChange }) => (
+		<label>
+			{label}
+			<input value={value} onChange={(e) => onChange(e.target.value)} />
+		</label>
+	),
+}));
+
+let mockUuidCounter = 0;
+jest.mock('fair-events-shared', () => ({
+	generateUuid: () => `generated-uuid-${++mockUuidCounter}`,
+}));
+
+let capturedSettings;
+jest.mock('@wordpress/blocks', () => ({
+	registerBlockType: (name, settings) => {
+		capturedSettings = settings;
+	},
+}));
+
+/**
+ * Wire up mockSelect so the imperative `select('core/block-editor')` calls
+ * in index.js see a fake flat block list.
+ *
+ * @param {Array} blocks Fake blocks: `{ clientId, name, blockId }`.
+ */
+function mockBlockEditorStore(blocks) {
+	mockSelect.mockImplementation((store) => {
+		if (store !== 'core/block-editor') {
+			return {};
+		}
+		return {
+			getClientIdsWithDescendants: () => blocks.map((b) => b.clientId),
+			getBlockName: (clientId) =>
+				blocks.find((b) => b.clientId === clientId)?.name,
+			getBlockAttributes: (clientId) => ({
+				blockId: blocks.find((b) => b.clientId === clientId)?.blockId,
+			}),
+		};
+	});
+}
+
+describe('Simple Payment Edit', () => {
+	let Edit;
+
+	beforeAll(() => {
+		require('../index.js');
+		Edit = capturedSettings.edit;
+	});
+
+	beforeEach(() => {
+		mockUuidCounter = 0;
+	});
+
+	afterEach(() => {
+		delete window.fairPaymentsConnector;
+	});
+
+	const baseAttributes = {
+		blockId: '',
+		amount: '10',
+		currency: 'EUR',
+		description: '',
+	};
+
+	const renderEdit = (
+		attributes = {},
+		setAttributes = () => {},
+		clientId = 'block-1'
+	) =>
+		render(
+			<Edit
+				attributes={{ ...baseAttributes, ...attributes }}
+				setAttributes={setAttributes}
+				clientId={clientId}
+			/>
+		);
+
+	it('assigns a fresh id and shows the missing-id notice when blockId is empty', () => {
+		mockBlockEditorStore([
+			{
+				clientId: 'block-1',
+				name: 'fair-payment/simple-payment',
+				blockId: '',
+			},
+		]);
+		const setAttributes = jest.fn();
+		renderEdit({ blockId: '' }, setAttributes);
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			blockId: 'generated-uuid-1',
+		});
+		expect(screen.getByRole('alert')).toHaveTextContent(
+			/missing an identifier/
+		);
+	});
+
+	it('reassigns the id and shows the duplicate notice when an earlier block already owns it', () => {
+		mockBlockEditorStore([
+			{
+				clientId: 'block-1',
+				name: 'fair-payment/simple-payment',
+				blockId: 'shared-id',
+			},
+			{
+				clientId: 'block-2',
+				name: 'fair-payment/simple-payment',
+				blockId: 'shared-id',
+			},
+		]);
+		const setAttributes = jest.fn();
+		renderEdit({ blockId: 'shared-id' }, setAttributes, 'block-2');
+
+		expect(setAttributes).toHaveBeenCalledWith({
+			blockId: 'generated-uuid-1',
+		});
+		expect(screen.getByRole('alert')).toHaveTextContent(
+			/shared its identifier/
+		);
+	});
+
+	it('leaves an already-unique id untouched and shows no notice', () => {
+		mockBlockEditorStore([
+			{
+				clientId: 'block-1',
+				name: 'fair-payment/simple-payment',
+				blockId: 'unique-id',
+			},
+		]);
+		const setAttributes = jest.fn();
+		renderEdit({ blockId: 'unique-id' }, setAttributes, 'block-1');
+
+		expect(setAttributes).not.toHaveBeenCalledWith(
+			expect.objectContaining({ blockId: expect.anything() })
+		);
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+
+	it('does not treat an earlier block with a different id as a duplicate', () => {
+		mockBlockEditorStore([
+			{
+				clientId: 'block-1',
+				name: 'fair-payment/simple-payment',
+				blockId: 'other-id',
+			},
+			{
+				clientId: 'block-2',
+				name: 'fair-payment/simple-payment',
+				blockId: 'my-id',
+			},
+		]);
+		const setAttributes = jest.fn();
+		renderEdit({ blockId: 'my-id' }, setAttributes, 'block-2');
+
+		expect(setAttributes).not.toHaveBeenCalledWith(
+			expect.objectContaining({ blockId: expect.anything() })
+		);
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+});

--- a/fair-payments-connector/src/blocks/simple-payment/index.js
+++ b/fair-payments-connector/src/blocks/simple-payment/index.js
@@ -3,6 +3,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
+import { select as dataSelect } from '@wordpress/data';
 import { Notice, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
@@ -18,6 +19,32 @@ import { generateUuid } from 'fair-events-shared';
 import metadata from './block.json';
 
 /**
+ * Check whether another Simple Payment block earlier in document order
+ * already carries this exact blockId (e.g. this block was just duplicated
+ * from it).
+ *
+ * @param {string} clientId This block's client id.
+ * @param {string} blockId  This block's current blockId attribute.
+ * @return {boolean} True when an earlier block already owns this id.
+ */
+function isDuplicateBlockId(clientId, blockId) {
+	const { getClientIdsWithDescendants, getBlockName, getBlockAttributes } =
+		dataSelect('core/block-editor');
+	for (const id of getClientIdsWithDescendants()) {
+		if (id === clientId) {
+			return false;
+		}
+		if (
+			getBlockName(id) === metadata.name &&
+			getBlockAttributes(id)?.blockId === blockId
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
  * Register the Simple Payment block
  */
 registerBlockType(metadata.name, {
@@ -27,9 +54,10 @@ registerBlockType(metadata.name, {
 	 * @param {Object}   props               - Block props
 	 * @param {Object}   props.attributes    - Block attributes
 	 * @param {Function} props.setAttributes - Function to set attributes
+	 * @param {string}   props.clientId      - Block client id
 	 * @return {JSX.Element} The edit component
 	 */
-	edit: ({ attributes, setAttributes }) => {
+	edit: ({ attributes, setAttributes, clientId }) => {
 		const blockProps = useBlockProps();
 		const { blockId, amount, currency, description } = attributes;
 
@@ -38,9 +66,21 @@ registerBlockType(metadata.name, {
 		// even after the id is generated in-memory — until the user actually saves.
 		const [wasMissingBlockId] = useState(() => !blockId);
 
+		// One-time mount snapshot, like wasMissingBlockId above — a live useSelect
+		// would re-fire on every store change. Every later duplicate always sees
+		// an earlier one's original, not-yet-reassigned id in this snapshot, so
+		// document order alone is enough to pick which copy keeps the id.
+		const [duplicateBlockId] = useState(() =>
+			blockId && isDuplicateBlockId(clientId, blockId)
+				? generateUuid()
+				: null
+		);
+
 		useEffect(() => {
 			if (!blockId) {
 				setAttributes({ blockId: generateUuid() });
+			} else if (duplicateBlockId) {
+				setAttributes({ blockId: duplicateBlockId });
 			}
 			if (!currency) {
 				setAttributes({
@@ -59,6 +99,14 @@ registerBlockType(metadata.name, {
 						<Notice status="warning" isDismissible={false}>
 							{__(
 								'This block is missing an identifier and payments will fail until the post is saved. Save or update the post now.',
+								'fair-payments-connector'
+							)}
+						</Notice>
+					)}
+					{duplicateBlockId && (
+						<Notice status="warning" isDismissible={false}>
+							{__(
+								'This block shared its identifier with another Simple Payment block on this page, which could cause buyers to be charged the wrong price. A new identifier was assigned — save or update the post now.',
 								'fair-payments-connector'
 							)}
 						</Notice>


### PR DESCRIPTION
## Summary

- Duplicating a Simple Payment block copied its hidden `blockId` attribute
  along with everything else, so `PaymentEndpoint::find_block_by_id()`'s
  first-match lookup always resolved the first block's price for every copy —
  silently mischarging buyers of any block but the first.
- The editor now detects, at mount time, whether an earlier
  `fair-payment/simple-payment` block already owns this block's `blockId`;
  if so it assigns a fresh one and shows a warning notice telling the owner
  to save.
- The endpoint now fails closed: `find_blocks_by_id()` returns *all* matches,
  and a submitted `block_id` that matches more than one saved block is
  rejected with `409 ambiguous_block` instead of trusting the first one —
  covering pre-fix pages and hand-edited markup the editor fix can't reach.

Closes #1325

## Acceptance criteria

- [x] Duplicating a Simple Payment block yields two blocks with distinct
      identifiers — editor mount-time detection reassigns a fresh id to the
      later block (`src/blocks/simple-payment/index.js`).
- [x] A page with two Simple Payment blocks at different prices charges each
      buyer the price of the block whose button they clicked — verified
      end-to-end (`e2e/user-flows/simple-payment-multi-block.spec.js`).
- [x] A page whose saved content already contains duplicated identifiers
      shows a warning in the editor — new `Notice`, covered by
      `src/blocks/simple-payment/__tests__/index.test.jsx`.
- [x] A payment submitted against an identifier that matches more than one
      saved block is rejected rather than charged at the first match — `409
      ambiguous_block`, verified end-to-end
      (`e2e/user-flows/simple-payment-duplicate-block.spec.js`).
- [x] Blocks that already have a unique identifier keep it across a re-save —
      covered by the "leaves an already-unique id untouched" Jest case.
- [x] e2e coverage for the two-blocks-different-prices flow per
      TESTING.md — `simple-payment-multi-block.spec.js`.

## Test plan

- [x] `npm run test:js` (fair-payments-connector) — 5 suites / 13 tests pass.
- [x] `vendor/bin/phpcs` clean on all changed/added PHP files (one pre-existing,
      unrelated Yoda-condition finding in `PaymentEndpoint.php` predates this
      branch).
- [x] `npm run build` (fair-payments-connector).
- [x] e2e: new `simple-payment-multi-block.spec.js` and
      `simple-payment-duplicate-block.spec.js`, plus the existing
      `simple-payment-purchase.spec.js` and `PaymentEndpoint.api.spec.js`, all
      pass against a live wp-env instance.
