### PR TITLE
Wire the API test suite into CI

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -1,0 +1,141 @@
+name: API Tests
+
+permissions:
+    contents: read
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - '**/src/API/**'
+            - '**/playwright.config.js'
+            - '.wp-env.json'
+            - 'package.json'
+            - 'e2e/mu-plugins/**'
+            - '.github/workflows/api-tests.yml'
+    pull_request:
+        branches: [main]
+        paths:
+            - '**/src/API/**'
+            - '**/playwright.config.js'
+            - '.wp-env.json'
+            - 'package.json'
+            - 'e2e/mu-plugins/**'
+            - '.github/workflows/api-tests.yml'
+
+jobs:
+    api-tests:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # 2.37.0
+              with:
+                  php-version: '8.3'
+                  extensions: mbstring, intl, zip
+                  coverage: none
+
+            - name: Cache Composer packages
+              uses: actions/cache@v5
+              with:
+                  path: |
+                      ./fair-payments-connector/vendor
+                      ./fair-events/vendor
+                      ./fair-events-experimental/vendor
+                      ./fair-platform/vendor
+                      ./fair-audience/vendor
+                      ./fair-audience-experimental/vendor
+                      ./fair-form/vendor
+                      ./fair-finance/vendor
+                      ./fair-payments-connector-experimental/vendor
+                      ./vendor
+                  key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-php-
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: '24'
+
+            - name: Cache node_modules
+              id: npm-cache
+              uses: actions/cache@v5
+              with:
+                  path: |
+                      ./node_modules
+                      ./fair-events/node_modules
+                      ./fair-events-experimental/node_modules
+                      ./fair-payments-connector/node_modules
+                      ./fair-platform/node_modules
+                      ./fair-audience/node_modules
+                      ./fair-audience-experimental/node_modules
+                      ./fair-form/node_modules
+                      ./fair-finance/node_modules
+                      ./fair-payments-connector-experimental/node_modules
+                      ./fair-events-shared/node_modules
+                      ./fair-timetable/node_modules
+                  key: ${{ runner.os }}-node-v2-${{ hashFiles('package-lock.json') }}
+
+            - name: Install npm dependencies
+              if: steps.npm-cache.outputs.cache-hit != 'true'
+              run: HUSKY=0 npm ci --prefer-offline
+
+            - name: Install WP-CLI
+              run: |
+                  curl -L -o wp-cli.phar https://github.com/wp-cli/wp-cli/releases/download/v2.12.0/wp-cli-2.12.0.phar
+                  echo "be928f6b8ca1e8dfb9d2f4b75a13aa4aee0896f8a9a0a1c45cd5d2c98605e6172e6d014dda2e27f88c98befc16c040cbb2bd1bfa121510ea5cdf5f6a30fe8832  wp-cli.phar" | sha512sum -c -
+                  chmod +x wp-cli.phar
+                  sudo mv wp-cli.phar /usr/local/bin/wp
+                  wp --info
+
+            - name: Read PHP version from wp-env config
+              id: wp-env-config
+              run: echo "php_version=$(jq -r '.phpVersion' .wp-env.json)" >> $GITHUB_OUTPUT
+
+            - name: Cache Docker images
+              id: docker-cache
+              uses: actions/cache@v5
+              with:
+                  path: /tmp/docker-images.tar
+                  key: ${{ runner.os }}-docker-v2-${{ hashFiles('.wp-env.json') }}
+                  restore-keys: ${{ runner.os }}-docker-v2-
+
+            - name: Load cached Docker images
+              if: steps.docker-cache.outputs.cache-hit == 'true'
+              run: docker load -i /tmp/docker-images.tar
+
+            - name: Pull Docker images
+              if: steps.docker-cache.outputs.cache-hit != 'true'
+              run: |
+                  docker pull wordpress:php${{ steps.wp-env-config.outputs.php_version }}
+                  docker pull wordpress:cli-php${{ steps.wp-env-config.outputs.php_version }}
+                  docker pull mariadb:lts
+                  docker pull phpmyadmin
+
+            - name: Save Docker images to cache
+              if: steps.docker-cache.outputs.cache-hit != 'true'
+              run: docker save wordpress:php${{ steps.wp-env-config.outputs.php_version }} wordpress:cli-php${{ steps.wp-env-config.outputs.php_version }} mariadb:lts phpmyadmin -o /tmp/docker-images.tar
+
+            - name: Boot isolated WordPress env
+              run: npm run test:e2e:setup
+
+            - name: Run API tests
+              run: WP_BASE_URL=http://localhost:8889 WP_ADMIN_PASS=password npm run test:api
+
+            - name: Tear down WordPress env
+              if: always()
+              run: npm run test:e2e:teardown
+
+            - name: Upload Playwright report
+              if: failure()
+              uses: actions/upload-artifact@v6
+              with:
+                  name: api-playwright-report
+                  path: |
+                      */playwright-report/
+                      */test-results/
+                  retention-days: 7
+                  if-no-files-found: ignore

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -8,7 +8,9 @@
 		"./fair-audience",
 		"./fair-audience-experimental",
 		"./fair-form",
-		"./fair-platform"
+		"./fair-platform",
+		"./fair-finance",
+		"./fair-payments-connector-experimental"
 	],
 	"mappings": {
 		"wp-content/mu-plugins": "./e2e/mu-plugins"

--- a/TESTING.md
+++ b/TESTING.md
@@ -150,6 +150,34 @@ fair-{plugin-name}/
 -   Tests against running WordPress (localhost:8080)
 -   No PHP test suite setup required
 
+#### CI
+
+`.github/workflows/api-tests.yml` runs on PRs touching `**/src/API/**`,
+`**/playwright.config.js`, `.wp-env.json`, `package.json`, or `e2e/mu-plugins/**`.
+It boots the same isolated `@wordpress/env` `tests` instance as the E2E job
+(`npm run test:e2e:setup`, port **8889**) and runs `npm run test:api` from the
+repo root, which fans out to every workspace's `test:api` script. It reuses
+the E2E job's provisioning but skips the Chromium install/cache step — API
+specs authenticate via `request.newContext()` and never open a browser page.
+
+Specs authenticate with Basic Auth using the real admin login password
+(`WP_ADMIN_USER`/`WP_ADMIN_PASSWORD`, default `admin`/`password`; one spec
+reads `WP_ADMIN_PASS` instead — the CI job sets both). Plain WordPress 401s
+that; the `e2e/mu-plugins/fair-e2e-basic-auth.php` mu-plugin (a vendored copy
+of [WP-API/Basic-Auth](https://github.com/WP-API/Basic-Auth), test-only,
+mounted only into the wp-env `tests` instance) adds the `determine_current_user`
+handler that accepts it.
+
+To reproduce a CI API failure locally:
+
+```bash
+npm run test:e2e:setup      # boot the tests instance on :8889 (shared with E2E)
+WP_BASE_URL=http://localhost:8889 WP_ADMIN_PASS=password npm run test:api
+npm run test:e2e:teardown
+```
+
+Or scope to one plugin: `WP_BASE_URL=http://localhost:8889 WP_ADMIN_PASS=password npm run test:api --workspace=fair-events`.
+
 ### E2E Tests
 
 **Purpose**: Test complete user workflows through the browser

--- a/e2e/mu-plugins/fair-e2e-basic-auth.php
+++ b/e2e/mu-plugins/fair-e2e-basic-auth.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Plugin Name: Fair Events E2E Basic Auth
+ * Description: Basic Authentication handler for the REST API, test-only.
+ *              Loaded ONLY inside the Playwright wp-env instance (mounted via
+ *              the `mappings` entry in .wp-env.json) so `.api.spec.js` specs
+ *              can authenticate their requests with the admin login password
+ *              over Basic Auth. Never shipped to production and never
+ *              mounted by the dev `docker compose` stack. Vendored from
+ *              https://github.com/WP-API/Basic-Auth (WordPress API Team).
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Authenticate the current request from Basic Auth credentials, test-only.
+ *
+ * @param int|false|null $user Current user id/false/null from an earlier filter.
+ * @return int|null Authenticated user id, or the passed-through $user.
+ */
+function fair_e2e_basic_auth_handler( $user ) {
+	global $fair_e2e_basic_auth_error;
+
+	$fair_e2e_basic_auth_error = null;
+
+	// Don't authenticate twice.
+	if ( ! empty( $user ) ) {
+		return $user;
+	}
+
+	// Check that we're trying to authenticate.
+	if ( ! isset( $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'] ) ) {
+		return $user;
+	}
+
+	$username = sanitize_text_field( wp_unslash( $_SERVER['PHP_AUTH_USER'] ) );
+	$password = sanitize_text_field( wp_unslash( $_SERVER['PHP_AUTH_PW'] ) );
+
+	/*
+	 * wp_authenticate() re-enters determine_current_user via
+	 * wp_authenticate_spam_check on multisite; remove this filter for the
+	 * duration of the call to avoid infinite recursion.
+	 */
+	remove_filter( 'determine_current_user', 'fair_e2e_basic_auth_handler', 20 );
+
+	$user = wp_authenticate( $username, $password );
+
+	add_filter( 'determine_current_user', 'fair_e2e_basic_auth_handler', 20 );
+
+	if ( is_wp_error( $user ) ) {
+		$fair_e2e_basic_auth_error = $user;
+		return null;
+	}
+
+	$fair_e2e_basic_auth_error = true;
+
+	return $user->ID;
+}
+add_filter( 'determine_current_user', 'fair_e2e_basic_auth_handler', 20 );
+
+/**
+ * Surface a Basic Auth failure through the REST authentication errors filter.
+ *
+ * @param WP_Error|null|true $error Passed-through error from an earlier filter.
+ * @return WP_Error|null|true
+ */
+function fair_e2e_basic_auth_error( $error ) {
+	// Passthrough other errors.
+	if ( ! empty( $error ) ) {
+		return $error;
+	}
+
+	global $fair_e2e_basic_auth_error;
+
+	return $fair_e2e_basic_auth_error;
+}
+add_filter( 'rest_authentication_errors', 'fair_e2e_basic_auth_error' );

--- a/e2e/mu-plugins/fair-e2e-support.php
+++ b/e2e/mu-plugins/fair-e2e-support.php
@@ -6,7 +6,7 @@
  *              Never shipped to production and never mounted by the dev
  *              `docker compose` stack.
  *
- * It does three things, all confined to the test environment:
+ * It does four things, all confined to the test environment:
  *
  *   1. Captures outgoing mail into the `fair_e2e_captured_mail` option instead
  *      of sending it, so specs can assert on subject/recipient/body and no real
@@ -19,6 +19,9 @@
  *      so every Mollie API call returns canned responses. This keeps ALL of the
  *      real fair-payments-connector / fair-audience purchase code in play while making the
  *      "payment" deterministic and offline.
+ *   4. Bypasses GetTicketsController's per-IP rate limit, which a full API/E2E
+ *      test run exhausts well before it finishes (every spec run shares one
+ *      source IP).
  *
  * @package FairEventsE2E
  */
@@ -95,7 +98,17 @@ add_filter(
 );
 
 /*
- * 3. Capture mail instead of sending it.
+ * 3. Bypass GetTicketsController's per-IP rate limit (20 requests/hour in
+ *    production). A full test run drives far more than that many real
+ *    signups through the public get-tickets endpoint from the CI runner's
+ *    single IP, which would otherwise fail later specs with 429s unrelated
+ *    to what they're testing. The per-email limit is left untouched — it's
+ *    what EventSignupHookBridge.api.spec.js (#1245) exercises directly.
+ */
+add_filter( 'fair_events_get_tickets_rate_limit_bypass_ip', '__return_true' );
+
+/*
+ * 4. Capture mail instead of sending it.
  *
  * Returning a non-null value from `pre_wp_mail` short-circuits wp_mail() (so
  * nothing is dispatched) and becomes its return value. We log each message to

--- a/fair-audience-experimental/playwright.config.js
+++ b/fair-audience-experimental/playwright.config.js
@@ -22,10 +22,12 @@ export default defineConfig({
 			use: { ...devices['Desktop Chrome'] },
 		},
 	],
-	webServer: {
-		command: 'docker compose up',
-		url: 'http://localhost:8080',
-		reuseExistingServer: !process.env.CI,
-		timeout: 120 * 1000,
-	},
+	webServer: process.env.CI
+		? undefined
+		: {
+				command: 'docker compose up',
+				url: 'http://localhost:8080',
+				reuseExistingServer: !process.env.CI,
+				timeout: 120 * 1000,
+		  },
 });

--- a/fair-audience-experimental/src/API/__tests__/ScheduledMessagesController.api.spec.js
+++ b/fair-audience-experimental/src/API/__tests__/ScheduledMessagesController.api.spec.js
@@ -92,6 +92,7 @@ test.describe('ScheduledMessagesController', () => {
 	let eventDateId;
 	let signedUpId;
 	let interestedId;
+	let fixtureOk = true;
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
@@ -118,7 +119,13 @@ test.describe('ScheduledMessagesController', () => {
 				data: { participant_ids: [signedUpId], label: 'signed_up' },
 			}
 		);
-		expect(linkSigned.ok()).toBeTruthy();
+		// #1410 — publishing a fair_event doesn't auto-create its event-date;
+		// captured (not asserted) so every test below can skip with a
+		// reference instead of failing the hook.
+		fixtureOk = linkSigned.ok();
+		if (!fixtureOk) {
+			return;
+		}
 
 		const linkInterested = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/batch`,
@@ -146,6 +153,10 @@ test.describe('ScheduledMessagesController', () => {
 	});
 
 	test('unauthenticated create is rejected', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages`,
 			{ data: baseMessage(eventDateId) }
@@ -155,6 +166,10 @@ test.describe('ScheduledMessagesController', () => {
 	});
 
 	test('create schedules a message with a computed send time', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages`,
 			{ headers: authHeaders, data: baseMessage(eventDateId) }
@@ -175,6 +190,10 @@ test.describe('ScheduledMessagesController', () => {
 	});
 
 	test('sale-period anchors are rejected until #617', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages`,
 			{
@@ -188,6 +207,10 @@ test.describe('ScheduledMessagesController', () => {
 	});
 
 	test('create on a nonexistent event date is rejected', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/999999999/scheduled-messages`,
 			{ headers: authHeaders, data: baseMessage(999999999) }
@@ -196,6 +219,10 @@ test.describe('ScheduledMessagesController', () => {
 	});
 
 	test('list, edit, preview, and cancel lifecycle', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		// Create.
 		const createRes = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages`,
@@ -268,6 +295,10 @@ test.describe('ScheduledMessagesController', () => {
 	});
 
 	test('draft preview honors label filters without saving', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/scheduled-messages/preview-recipients`,
 			{
@@ -289,6 +320,10 @@ test.describe('ScheduledMessagesController', () => {
 	});
 
 	test('deleting the event date cancels its scheduled messages', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const tempEventId = await publishEvent(api, `Temp Event ${Date.now()}`);
 		const tempDateId = await resolveEventDateId(api, tempEventId);
 

--- a/fair-audience-experimental/src/API/__tests__/TimelineController.api.spec.js
+++ b/fair-audience-experimental/src/API/__tests__/TimelineController.api.spec.js
@@ -92,6 +92,10 @@ test.describe('TimelineController – ticket-sales testmode', () => {
 	});
 
 	test('switching to live mode causes the timeline endpoint to respond without error', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1412 — testmode tickets sold earlier in the run still appear after switching to live'
+		);
 		await setPaymentMode(api, 'live');
 
 		const res = await api.get('/wp-json/fair-audience/v1/timeline', {

--- a/fair-audience/package.json
+++ b/fair-audience/package.json
@@ -25,6 +25,7 @@
 		"test:js": "jest",
 		"test:php": "vendor/bin/phpunit",
 		"test:e2e": "playwright test",
+		"test:api": "playwright test src/API/__tests__/",
 		"playwright:run": "playwright test --headed",
 		"playwright:up": "playwright test --headed --ui",
 		"svn:checkout": "svn co https://plugins.svn.wordpress.org/fair-audience svn",

--- a/fair-audience/playwright.config.js
+++ b/fair-audience/playwright.config.js
@@ -22,10 +22,12 @@ export default defineConfig({
 			use: { ...devices['Desktop Chrome'] },
 		},
 	],
-	webServer: {
-		command: 'docker compose up',
-		url: 'http://localhost:8080',
-		reuseExistingServer: !process.env.CI,
-		timeout: 120 * 1000,
-	},
+	webServer: process.env.CI
+		? undefined
+		: {
+				command: 'docker compose up',
+				url: 'http://localhost:8080',
+				reuseExistingServer: !process.env.CI,
+				timeout: 120 * 1000,
+		  },
 });

--- a/fair-audience/src/API/__tests__/EventInterestController.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventInterestController.api.spec.js
@@ -68,6 +68,10 @@ test.describe('EventInterestController', () => {
 	});
 
 	test('POST creates a new interest registration', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post('/wp-json/fair-audience/v1/event-interest', {
 			data: {
 				event_id: eventId,
@@ -81,6 +85,10 @@ test.describe('EventInterestController', () => {
 	});
 
 	test('POST a second time with the same email is a no-op success', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const email = uniqueEmail('dup');
 		const first = await api.post(
 			'/wp-json/fair-audience/v1/event-interest',

--- a/fair-audience/src/API/__tests__/EventParticipantsMarketingConsent.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventParticipantsMarketingConsent.api.spec.js
@@ -45,6 +45,7 @@ test.describe('EventParticipantsController marketing-consent', () => {
 	let minimalNoEmailId;
 	let marketingId;
 	let declinedId;
+	let fixtureOk = true;
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
@@ -109,7 +110,10 @@ test.describe('EventParticipantsController marketing-consent', () => {
 				},
 			}
 		);
-		expect(linkRes.ok()).toBeTruthy();
+		// #1410 — publishing a fair_event doesn't auto-create its event-date, so
+		// eventDateId is null here; captured (not asserted) so every test below
+		// can skip with a reference instead of failing the hook.
+		fixtureOk = linkRes.ok();
 	});
 
 	test.afterAll(async () => {
@@ -136,6 +140,10 @@ test.describe('EventParticipantsController marketing-consent', () => {
 	});
 
 	test('participant list exposes email_profile including declined', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.get(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants`,
 			{ headers: authHeaders }
@@ -154,6 +162,10 @@ test.describe('EventParticipantsController marketing-consent', () => {
 	});
 
 	test('already-marketing participant in marketing_ids is skipped', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/marketing-consent`,
 			{
@@ -168,6 +180,10 @@ test.describe('EventParticipantsController marketing-consent', () => {
 	});
 
 	test('already-declined participant in marketing_ids is skipped', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/marketing-consent`,
 			{
@@ -182,6 +198,10 @@ test.describe('EventParticipantsController marketing-consent', () => {
 	});
 
 	test('marketing_ids upgrades minimal → marketing, logs, emails', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/marketing-consent`,
 			{
@@ -225,6 +245,10 @@ test.describe('EventParticipantsController marketing-consent', () => {
 	});
 
 	test('declined_ids sets minimal → declined, logs, sends no email', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/marketing-consent`,
 			{
@@ -253,6 +277,10 @@ test.describe('EventParticipantsController marketing-consent', () => {
 	});
 
 	test('mixed request applies both directions in one call', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		// Use fresh participants so we start from a known minimal state.
 		const yesId = await createParticipant(api, {
 			name: 'Mixed Yes',
@@ -309,6 +337,10 @@ test.describe('EventParticipantsController marketing-consent', () => {
 	});
 
 	test('unauthenticated request is rejected', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${eventDateId}/participants/marketing-consent`,
 			{ data: { marketing_ids: [minimalWithEmailId], declined_ids: [] } }
@@ -342,6 +374,7 @@ test.describe('EmailService consent enforcement (bulk sends)', () => {
 	let confirmedMarketingEmail;
 	let pendingId;
 	let pendingEmail;
+	let fixtureOk = true;
 
 	async function createTestEvent(title) {
 		const eventRes = await api.post('/wp-json/wp/v2/fair_event', {
@@ -441,7 +474,10 @@ test.describe('EmailService consent enforcement (bulk sends)', () => {
 				},
 			}
 		);
-		expect(linkRes.ok()).toBeTruthy();
+		// #1410 — publishing a fair_event doesn't auto-create its event-date, so
+		// eventDateId is null here; captured (not asserted) so the dependent
+		// test below can skip with a reference instead of failing the hook.
+		fixtureOk = linkRes.ok();
 	});
 
 	test.afterAll(async () => {
@@ -465,6 +501,10 @@ test.describe('EmailService consent enforcement (bulk sends)', () => {
 	});
 
 	test('declined and pending participants are skipped on custom-mail bulk send', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post('/wp-json/fair-audience/v1/custom-mail', {
 			headers: authHeaders,
 			data: {
@@ -490,6 +530,10 @@ test.describe('EmailService consent enforcement (bulk sends)', () => {
 	});
 
 	test('declined and pending participants are skipped on event-invitation bulk send', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			`/wp-json/fair-audience/v1/event-dates/${invitationsEventDateId}/event-invitations`,
 			{

--- a/fair-audience/src/API/__tests__/EventParticipantsMove.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventParticipantsMove.api.spec.js
@@ -58,6 +58,7 @@ test.describe('EventParticipantsController — move', () => {
 			headers: authHeaders,
 			data: {
 				event_id: eventPostId,
+				title: `Move test ${Date.now()}`,
 				start_datetime: '2036-06-01 10:00:00',
 				end_datetime: '2036-06-01 12:00:00',
 				rrule: 'FREQ=WEEKLY;COUNT=3',
@@ -71,6 +72,15 @@ test.describe('EventParticipantsController — move', () => {
 			...edBody.generated_occurrences.map((o) => o.id),
 		];
 		expect(occurrenceIds.length).toBe(3);
+
+		// The create endpoint doesn't wire event_id through — a PUT is
+		// needed to actually link the post (see CalendarFeedController.api.spec.js
+		// for the same quirk).
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{ headers: authHeaders, data: { event_id: eventPostId } }
+		);
+		expect(linkRes.ok()).toBeTruthy();
 
 		// Unrelated event date, not part of the recurring series above.
 		const otherPostRes = await api.post('/wp-json/wp/v2/fair_event', {
@@ -86,6 +96,7 @@ test.describe('EventParticipantsController — move', () => {
 				headers: authHeaders,
 				data: {
 					event_id: otherEventPostId,
+					title: `Unrelated event ${Date.now()}`,
 					start_datetime: '2036-06-15 10:00:00',
 					end_datetime: '2036-06-15 12:00:00',
 				},
@@ -93,6 +104,12 @@ test.describe('EventParticipantsController — move', () => {
 		);
 		expect(otherEdRes.ok()).toBeTruthy();
 		otherEventDateId = (await otherEdRes.json()).id;
+
+		const otherLinkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${otherEventDateId}`,
+			{ headers: authHeaders, data: { event_id: otherEventPostId } }
+		);
+		expect(otherLinkRes.ok()).toBeTruthy();
 
 		participantAId = await createParticipant(api, 'Move Person A');
 		participantBId = await createParticipant(api, 'Move Person B');

--- a/fair-audience/src/API/__tests__/EventSignupActivities.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupActivities.api.spec.js
@@ -72,6 +72,7 @@ test.describe('Selectable activities in the unified Event Signup form (#1243)', 
 	let event;
 	let freeOptionId;
 	let paidOptionId;
+	let fixtureOk = true;
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
@@ -120,7 +121,13 @@ test.describe('Selectable activities in the unified Event Signup form (#1243)', 
 				},
 			}
 		);
-		expect(ticketsRes.ok(), await ticketsRes.text()).toBeTruthy();
+		// #1410 — publishing a fair_event doesn't auto-create its event-date;
+		// captured (not asserted) so every test below can skip with a
+		// reference instead of failing the hook.
+		fixtureOk = ticketsRes.ok();
+		if (!fixtureOk) {
+			return;
+		}
 		const options = (await ticketsRes.json()).options || [];
 		freeOptionId = options.find((o) => o.name === 'Free Activity')?.id;
 		paidOptionId = options.find((o) => o.name === 'Paid Activity')?.id;
@@ -137,6 +144,10 @@ test.describe('Selectable activities in the unified Event Signup form (#1243)', 
 
 	test('a signup with no activities selected is rejected with 400 minimum_activities_not_met', async () => {
 		test.skip(!experimentalActive, 'fair-events-experimental not active');
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {
@@ -151,6 +162,10 @@ test.describe('Selectable activities in the unified Event Signup form (#1243)', 
 
 	test('an unknown activity id is rejected with 400 invalid_ticket_option', async () => {
 		test.skip(!experimentalActive, 'fair-events-experimental not active');
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {
@@ -166,6 +181,10 @@ test.describe('Selectable activities in the unified Event Signup form (#1243)', 
 
 	test('a paid activity is charged into the signup amount (503 without a payment connector proves it)', async () => {
 		test.skip(!experimentalActive, 'fair-events-experimental not active');
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {
@@ -181,6 +200,10 @@ test.describe('Selectable activities in the unified Event Signup form (#1243)', 
 
 	test('a free activity confirms immediately, then a capacity-1 activity 409s ticket_option_full for the next buyer', async () => {
 		test.skip(!experimentalActive, 'fair-events-experimental not active');
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 
 		const firstRes = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {

--- a/fair-audience/src/API/__tests__/EventSignupAddActivities.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupAddActivities.api.spec.js
@@ -52,6 +52,7 @@ test.describe('EventSignupController add-activities', () => {
 	let signedUpEvent;
 	let otherEvent;
 	let freeOptionId;
+	let fixtureOk = true;
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
@@ -98,7 +99,13 @@ test.describe('EventSignupController add-activities', () => {
 				data: { participant_ids: [participantId], label: 'signed_up' },
 			}
 		);
-		expect(linkRes.ok()).toBeTruthy();
+		// #1410 — publishing a fair_event doesn't auto-create its event-date;
+		// captured (not asserted) so every test below can skip with a
+		// reference instead of failing the hook.
+		fixtureOk = linkRes.ok();
+		if (!fixtureOk) {
+			return;
+		}
 
 		// Add a free activity option on the signed-up event date.
 		const ticketsRes = await api.put(
@@ -136,6 +143,10 @@ test.describe('EventSignupController add-activities', () => {
 	});
 
 	test('unauthenticated request is rejected', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			'/wp-json/fair-audience/v1/event-signup/add-activities',
 			{
@@ -149,6 +160,10 @@ test.describe('EventSignupController add-activities', () => {
 	});
 
 	test('unknown event returns 404', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			'/wp-json/fair-audience/v1/event-signup/add-activities',
 			{
@@ -160,6 +175,10 @@ test.describe('EventSignupController add-activities', () => {
 	});
 
 	test('adding to an event the participant is not signed up for is rejected', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			'/wp-json/fair-audience/v1/event-signup/add-activities',
 			{
@@ -175,6 +194,10 @@ test.describe('EventSignupController add-activities', () => {
 	});
 
 	test('free activity is added immediately and reflected on the subscription', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			'/wp-json/fair-audience/v1/event-signup/add-activities',
 			{
@@ -201,6 +224,10 @@ test.describe('EventSignupController add-activities', () => {
 	});
 
 	test('re-adding the same activity is rejected by the duplicate guard', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post(
 			'/wp-json/fair-audience/v1/event-signup/add-activities',
 			{

--- a/fair-audience/src/API/__tests__/EventSignupBasePricing.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupBasePricing.api.spec.js
@@ -66,6 +66,7 @@ test.describe('Base signup pricing — ticket-type price', () => {
 	let event;
 	let paidTypeId;
 	let freeTypeId;
+	let fixtureOk = true;
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
@@ -111,7 +112,13 @@ test.describe('Base signup pricing — ticket-type price', () => {
 				},
 			}
 		);
-		expect(ticketsRes.ok(), await ticketsRes.text()).toBeTruthy();
+		// #1410 — publishing a fair_event doesn't auto-create its event-date;
+		// captured (not asserted) so every test below can skip with a
+		// reference instead of failing the hook.
+		fixtureOk = ticketsRes.ok();
+		if (!fixtureOk) {
+			return;
+		}
 		const types = (await ticketsRes.json()).ticket_types || [];
 		paidTypeId = types.find((t) => t.name === 'Paid tier')?.id;
 		freeTypeId = types.find((t) => t.name === 'Free tier')?.id;
@@ -125,6 +132,10 @@ test.describe('Base signup pricing — ticket-type price', () => {
 	});
 
 	test('a priced ticket-type signup is rejected 503 and writes nothing', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
 			headers: authHeaders,
 			data: {
@@ -139,6 +150,10 @@ test.describe('Base signup pricing — ticket-type price', () => {
 	});
 
 	test('a ticket type with no price row (0) still confirms', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
 			headers: authHeaders,
 			data: {

--- a/fair-audience/src/API/__tests__/EventSignupGroupPricing.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupGroupPricing.api.spec.js
@@ -107,6 +107,7 @@ test.describe('Group-based pricing and group-restricted tiers', () => {
 	let restrictedTypeId;
 	let openTypeId;
 	let discountedTypeId;
+	let fixtureOk = true;
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
@@ -184,7 +185,13 @@ test.describe('Group-based pricing and group-restricted tiers', () => {
 				},
 			}
 		);
-		expect(ticketsRes.ok(), await ticketsRes.text()).toBeTruthy();
+		// #1410 — publishing a fair_event doesn't auto-create its event-date;
+		// captured (not asserted) so every test below can skip with a
+		// reference instead of failing the hook.
+		fixtureOk = ticketsRes.ok();
+		if (!fixtureOk) {
+			return;
+		}
 		const types = (await ticketsRes.json()).ticket_types || [];
 		restrictedTypeId = types.find((t) => t.name === 'Members Only')?.id;
 		openTypeId = types.find((t) => t.name === 'Open')?.id;
@@ -231,6 +238,10 @@ test.describe('Group-based pricing and group-restricted tiers', () => {
 			!groupsActive,
 			'fair-events-experimental / fair-audience-experimental not active'
 		);
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 
 		const anon = await request.newContext({ baseURL: BASE_URL });
 		const res = await anon.post('/wp-json/fair-events/v1/get-tickets', {
@@ -250,6 +261,10 @@ test.describe('Group-based pricing and group-restricted tiers', () => {
 		test.skip(
 			!groupsActive,
 			'fair-events-experimental / fair-audience-experimental not active'
+		);
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
 		);
 
 		const member = await request.newContext({ baseURL: BASE_URL });
@@ -284,6 +299,10 @@ test.describe('Group-based pricing and group-restricted tiers', () => {
 		test.skip(
 			!groupsActive,
 			'fair-events-experimental / fair-audience-experimental not active'
+		);
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
 		);
 
 		// Non-member: full price applies, and the dev stack has no payment

--- a/fair-audience/src/API/__tests__/EventSignupRecurrenceScope.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupRecurrenceScope.api.spec.js
@@ -115,6 +115,7 @@ test.describe('Recurrence-scope ticket types — signup semantics', () => {
 	let wholeSeriesTtId;
 	let singleInstanceTtId;
 	let participantId;
+	let fixtureOk = true;
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
@@ -134,18 +135,26 @@ test.describe('Recurrence-scope ticket types — signup semantics', () => {
 			`Recurrence Scope Test B ${Date.now()}`
 		);
 
-		wholeSeriesTtId = await createTicketType(
-			api,
-			eventA.masterEventDateId,
-			'Series Pass',
-			'whole_series'
-		);
-		singleInstanceTtId = await createTicketType(
-			api,
-			eventB.masterEventDateId,
-			'Drop-In',
-			'single_instance'
-		);
+		// #1410 — publishing a fair_event doesn't auto-create its event-date,
+		// so createTicketType() throws; captured (not left to fail the hook)
+		// so every test below can skip with a reference.
+		try {
+			wholeSeriesTtId = await createTicketType(
+				api,
+				eventA.masterEventDateId,
+				'Series Pass',
+				'whole_series'
+			);
+			singleInstanceTtId = await createTicketType(
+				api,
+				eventB.masterEventDateId,
+				'Drop-In',
+				'single_instance'
+			);
+		} catch {
+			fixtureOk = false;
+			return;
+		}
 
 		participantId = await createParticipant(
 			api,
@@ -174,6 +183,10 @@ test.describe('Recurrence-scope ticket types — signup semantics', () => {
 	});
 
 	test('whole_series signup is stored on the master event-date', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const signupRes = await api.post(
 			'/wp-json/fair-audience/v1/event-signup',
 			{
@@ -204,6 +217,10 @@ test.describe('Recurrence-scope ticket types — signup semantics', () => {
 	});
 
 	test('get_status for the master returns is_signed_up:true after whole_series signup', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const statusRes = await api.get(
 			'/wp-json/fair-audience/v1/event-signup/status',
 			{
@@ -220,6 +237,10 @@ test.describe('Recurrence-scope ticket types — signup semantics', () => {
 	});
 
 	test('single_instance signup is stored against the given event-date', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const signupRes = await api.post(
 			'/wp-json/fair-audience/v1/event-signup',
 			{
@@ -249,6 +270,10 @@ test.describe('Recurrence-scope ticket types — signup semantics', () => {
 	});
 
 	test('whole_series capacity: second participant is rejected when capacity=1 is full', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		// First create a second participant to attempt the signup.
 		const secondParticipantRes = await api.post(
 			'/wp-json/fair-audience/v1/participants',
@@ -338,6 +363,7 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 	let event;
 	let occurrenceIds;
 	let ttId;
+	let fixtureOk = true;
 
 	async function createRecurringEvent(title, rrule) {
 		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
@@ -351,6 +377,7 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 			headers: authHeaders,
 			data: {
 				event_id: eventId,
+				title,
 				start_datetime: '2035-04-02 10:00:00',
 				end_datetime: '2035-04-02 12:00:00',
 				rrule,
@@ -413,7 +440,13 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 			`Multiple Instances Test ${Date.now()}`,
 			'FREQ=WEEKLY;COUNT=4'
 		);
-		expect(event.occurrences.length).toBe(4);
+		// #1415 — the event_id list filter doesn't filter, so this count
+		// includes every event date in the test database; captured (not
+		// asserted) so every test below can skip with a reference.
+		fixtureOk = event.occurrences.length === 4;
+		if (!fixtureOk) {
+			return;
+		}
 		occurrenceIds = event.occurrences;
 
 		ttId = await createMultiInstanceTicketType(event.masterEventDateId, 2);
@@ -437,6 +470,10 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 	});
 
 	test('below the configured minimum is rejected', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1415 — event-dates list endpoint ignores the event_id filter'
+		);
 		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
 			headers: authHeaders,
 			data: {
@@ -452,6 +489,10 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 	});
 
 	test("an occurrence outside the ticket type's series is rejected", async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1415 — event-dates list endpoint ignores the event_id filter'
+		);
 		const otherEvent = await createRecurringEvent(
 			`Multiple Instances Foreign ${Date.now()}`,
 			'FREQ=WEEKLY;COUNT=2'
@@ -484,6 +525,10 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 	});
 
 	test('a valid selection creates one row per chosen occurrence', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1415 — event-dates list endpoint ignores the event_id filter'
+		);
 		const chosen = [occurrenceIds[0], occurrenceIds[1]];
 		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
 			headers: authHeaders,
@@ -532,6 +577,7 @@ test.describe('multiple_instances via register_and_signup — public "I\'m new" 
 	let occurrenceIds;
 	let ttId;
 	let createdParticipantIds;
+	let fixtureOk = true;
 
 	async function createRecurringEvent(title, rrule) {
 		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
@@ -545,6 +591,7 @@ test.describe('multiple_instances via register_and_signup — public "I\'m new" 
 			headers: authHeaders,
 			data: {
 				event_id: eventId,
+				title,
 				start_datetime: '2035-05-02 10:00:00',
 				end_datetime: '2035-05-02 12:00:00',
 				rrule,
@@ -611,7 +658,13 @@ test.describe('multiple_instances via register_and_signup — public "I\'m new" 
 			`Register Multi Instance Test ${Date.now()}`,
 			'FREQ=WEEKLY;COUNT=3'
 		);
-		expect(event.occurrences.length).toBe(3);
+		// #1415 — the event_id list filter doesn't filter, so this count
+		// includes every event date in the test database; captured (not
+		// asserted) so the test below can skip with a reference.
+		fixtureOk = event.occurrences.length === 3;
+		if (!fixtureOk) {
+			return;
+		}
 		occurrenceIds = event.occurrences;
 
 		// Free ticket type (no prices configured) — exercises the dispatch
@@ -634,6 +687,10 @@ test.describe('multiple_instances via register_and_signup — public "I\'m new" 
 	});
 
 	test('a brand-new buyer picking N occurrences gets one signup row per occurrence, not just one', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1415 — event-dates list endpoint ignores the event_id filter'
+		);
 		const email = uniqueEmail('register-multi-instance');
 		const chosen = [occurrenceIds[0], occurrenceIds[2]];
 
@@ -694,6 +751,7 @@ test.describe('Series-pass upgrade — single_instance → whole_series', () => 
 	let singleTtId;
 	let seriesTtId;
 	let participantId;
+	let fixtureOk = true;
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
@@ -733,7 +791,13 @@ test.describe('Series-pass upgrade — single_instance → whole_series', () => 
 				},
 			}
 		);
-		expect(res.ok(), 'create both ticket types').toBeTruthy();
+		// #1410 — publishing a fair_event doesn't auto-create its event-date;
+		// captured (not asserted) so the test below can skip with a
+		// reference instead of failing the hook.
+		fixtureOk = res.ok();
+		if (!fixtureOk) {
+			return;
+		}
 		const tts = (await res.json()).ticket_types;
 		singleTtId = tts.find(
 			(t) => t.recurrence_scope === 'single_instance'
@@ -759,6 +823,10 @@ test.describe('Series-pass upgrade — single_instance → whole_series', () => 
 	});
 
 	test('whole_series purchase after a single_instance signup on the master upgrades in place instead of reporting already_signed_up', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		// 1. Single-instance signup on the master (free).
 		const first = await api.post('/wp-json/fair-audience/v1/event-signup', {
 			headers: authHeaders,

--- a/fair-audience/src/API/__tests__/ParticipantsActivityTransactionStatus.api.spec.js
+++ b/fair-audience/src/API/__tests__/ParticipantsActivityTransactionStatus.api.spec.js
@@ -39,6 +39,7 @@ test.describe('ParticipantsController activity — transaction_status', () => {
 	let participantId;
 	let eventId;
 	let eventDateId;
+	let fixtureOk = true;
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
@@ -84,7 +85,10 @@ test.describe('ParticipantsController activity — transaction_status', () => {
 				data: { participant_id: participantId, label: 'signed_up' },
 			}
 		);
-		expect(linkRes.ok()).toBeTruthy();
+		// #1410 — publishing a fair_event doesn't auto-create its event-date;
+		// captured (not asserted) so every test below can skip with a
+		// reference instead of failing the hook.
+		fixtureOk = linkRes.ok();
 	});
 
 	test.afterAll(async () => {
@@ -104,6 +108,10 @@ test.describe('ParticipantsController activity — transaction_status', () => {
 	});
 
 	test('unauthenticated request is rejected', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.get(
 			`/wp-json/fair-audience/v1/participants/${participantId}/activity`
 		);
@@ -111,6 +119,10 @@ test.describe('ParticipantsController activity — transaction_status', () => {
 	});
 
 	test('a signup with no transaction reports null transaction_status', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
 		const res = await api.get(
 			`/wp-json/fair-audience/v1/participants/${participantId}/activity`,
 			{ headers: authHeaders }

--- a/fair-audience/src/API/__tests__/WeeklyDigestController.api.spec.js
+++ b/fair-audience/src/API/__tests__/WeeklyDigestController.api.spec.js
@@ -149,6 +149,10 @@ test.describe('WeeklyDigestController — /weekly-digest', () => {
 	});
 
 	test('PUT rejects out-of-range values by falling back to defaults', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1413 — week_scope hard-rejects while other fields fall back to defaults'
+		);
 		const res = await api.put('/wp-json/fair-audience/v1/weekly-digest', {
 			headers: authHeaders,
 			data: {

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -1620,10 +1620,26 @@ class GetTicketsController extends WP_REST_Controller {
 	 * @return bool
 	 */
 	private function is_rate_limited( $email ) {
-		$ip_key   = 'fair_events_get_tickets_rl_ip_' . md5( $_SERVER['REMOTE_ADDR'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		$ip_count = (int) get_transient( $ip_key );
-		if ( $ip_count >= self::RATE_LIMIT_MAX_PER_IP ) {
-			return true;
+		/**
+		 * Filters whether the per-IP portion of get-tickets rate limiting is
+		 * bypassed. The per-email limit below still applies.
+		 *
+		 * Test-only escape hatch: a CI/local test run drives far more than
+		 * RATE_LIMIT_MAX_PER_IP real signups through this public endpoint
+		 * from a single IP within the rate limit window (each using its own
+		 * email), which would otherwise fail unrelated later specs with
+		 * 429s. Never hooked in production.
+		 *
+		 * @param bool $bypass Whether to bypass the per-IP limit. Default false.
+		 */
+		$bypass_ip_limit = apply_filters( 'fair_events_get_tickets_rate_limit_bypass_ip', false );
+
+		if ( ! $bypass_ip_limit ) {
+			$ip_key   = 'fair_events_get_tickets_rl_ip_' . md5( $_SERVER['REMOTE_ADDR'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+			$ip_count = (int) get_transient( $ip_key );
+			if ( $ip_count >= self::RATE_LIMIT_MAX_PER_IP ) {
+				return true;
+			}
 		}
 
 		if ( '' !== $email ) {

--- a/fair-events/src/API/__tests__/EventDatesController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesController.api.spec.js
@@ -267,6 +267,7 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 			headers: adminHeaders,
 			data: {
 				event_id: eventPostId,
+				title: `Recurrence test ${Date.now()}`,
 				start_datetime: start,
 				end_datetime: start.replace('10:00:00', '12:00:00'),
 				rrule,
@@ -290,7 +291,7 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 	test('time-of-day shift preserves occurrence IDs', async ({
 		request: req,
 	}) => {
-		const localApi = await req.newContext({ baseURL: BASE_URL });
+		const localApi = req;
 		await createRecurringEvent(localApi, 'FREQ=WEEKLY;COUNT=3');
 
 		const before = await getMaster(localApi, masterEventDateId);
@@ -327,7 +328,11 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 	test('shortening RRULE soft-cancels removed occurrences instead of deleting them', async ({
 		request: req,
 	}) => {
-		const localApi = await req.newContext({ baseURL: BASE_URL });
+		test.skip(
+			true,
+			'Skipped pending #1406 — removed occurrence status is left blank instead of active/cancelled'
+		);
+		const localApi = req;
 		await createRecurringEvent(localApi, 'FREQ=WEEKLY;COUNT=4');
 
 		const before = await getMaster(localApi, masterEventDateId);
@@ -367,7 +372,7 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 	test('master time-of-day edit propagates to generated children', async ({
 		request: req,
 	}) => {
-		const localApi = await req.newContext({ baseURL: BASE_URL });
+		const localApi = req;
 		await createRecurringEvent(localApi, 'FREQ=WEEKLY;COUNT=3');
 
 		const putRes = await localApi.put(
@@ -432,6 +437,7 @@ test.describe('EventDatesController — ending a series', () => {
 			headers: adminHeaders,
 			data: {
 				event_id: eventPostId,
+				title: `End series test ${Date.now()}`,
 				start_datetime: start,
 				end_datetime: start.replace('10:00:00', '12:00:00'),
 				rrule,
@@ -455,7 +461,11 @@ test.describe('EventDatesController — ending a series', () => {
 	test('PUT rrule: "" clears the series and removes generated occurrences', async ({
 		request: req,
 	}) => {
-		const localApi = await req.newContext({ baseURL: BASE_URL });
+		test.skip(
+			true,
+			'Skipped pending #1406 — PUT rrule: "" does not clear the series'
+		);
+		const localApi = req;
 		const master = await createRecurringEvent(
 			localApi,
 			'FREQ=WEEKLY;COUNT=3'
@@ -478,7 +488,7 @@ test.describe('EventDatesController — ending a series', () => {
 	test('a details PUT that omits rrule leaves an existing series intact', async ({
 		request: req,
 	}) => {
-		const localApi = await req.newContext({ baseURL: BASE_URL });
+		const localApi = req;
 		const master = await createRecurringEvent(
 			localApi,
 			'FREQ=WEEKLY;COUNT=3'
@@ -530,7 +540,7 @@ test.describe('EventDatesController — cancel/restore via toggle-exdate', () =>
 	test('cancelling a date is a reversible status flip that keeps a dependent ticket type', async ({
 		request: req,
 	}) => {
-		const localApi = await req.newContext({ baseURL: BASE_URL });
+		const localApi = req;
 
 		const postRes = await localApi.post('/wp-json/wp/v2/fair_event', {
 			headers: adminHeaders,
@@ -545,6 +555,7 @@ test.describe('EventDatesController — cancel/restore via toggle-exdate', () =>
 				headers: adminHeaders,
 				data: {
 					event_id: eventPostId,
+					title: `Toggle series test ${Date.now()}`,
 					start_datetime: '2035-09-03 10:00:00',
 					end_datetime: '2035-09-03 12:00:00',
 					rrule: 'FREQ=WEEKLY;COUNT=3',
@@ -647,6 +658,7 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 			headers: adminHeaders,
 			data: {
 				event_id: eventPostId,
+				title: `Impact test ${Date.now()}`,
 				start_datetime: '2035-06-01 10:00:00',
 				end_datetime: '2035-06-01 12:00:00',
 				rrule,
@@ -686,7 +698,7 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 	test('time shift returns 200 with recurrence_impact summary', async ({
 		request: req,
 	}) => {
-		const localApi = await req.newContext({ baseURL: BASE_URL });
+		const localApi = req;
 
 		const postRes = await localApi.post('/wp-json/wp/v2/fair_event', {
 			headers: adminHeaders,
@@ -704,6 +716,7 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 				headers: adminHeaders,
 				data: {
 					event_id: eventPostId,
+					title: `Shift impact test ${Date.now()}`,
 					start_datetime: '2035-07-01 10:00:00',
 					end_datetime: '2035-07-01 12:00:00',
 					rrule: 'FREQ=WEEKLY;COUNT=3',
@@ -744,7 +757,7 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 	test('shortening RRULE to remove an occurrence with a ticket type soft-cancels it (non-destructive)', async ({
 		request: req,
 	}) => {
-		const localApi = await req.newContext({ baseURL: BASE_URL });
+		const localApi = req;
 		const { lastOccurrence, ticketCreated } =
 			await createRecurringEventWithTicket(
 				localApi,
@@ -794,7 +807,11 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 	test('shortening RRULE to remove an occurrence without dependents returns 200', async ({
 		request: req,
 	}) => {
-		const localApi = await req.newContext({ baseURL: BASE_URL });
+		test.skip(
+			true,
+			'Skipped pending #1406 — shortened series does not leave exactly one active occurrence'
+		);
+		const localApi = req;
 
 		const postRes = await localApi.post('/wp-json/wp/v2/fair_event', {
 			headers: adminHeaders,
@@ -809,6 +826,7 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 				headers: adminHeaders,
 				data: {
 					event_id: eventPostId,
+					title: `Safe shorten ${Date.now()}`,
 					start_datetime: '2035-08-01 10:00:00',
 					end_datetime: '2035-08-01 12:00:00',
 					rrule: 'FREQ=WEEKLY;COUNT=3',

--- a/fair-events/src/API/__tests__/EventDatesSiblings.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesSiblings.api.spec.js
@@ -39,6 +39,7 @@ test.describe('EventDatesController — siblings', () => {
 			headers: adminHeaders,
 			data: {
 				event_id: eventPostId,
+				title: `Siblings test ${Date.now()}`,
 				start_datetime: '2036-04-01 10:00:00',
 				end_datetime: '2036-04-01 12:00:00',
 				rrule: 'FREQ=WEEKLY;COUNT=3',

--- a/fair-events/src/API/__tests__/GetTicketsIrregularSeries.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsIrregularSeries.api.spec.js
@@ -145,6 +145,10 @@ test.describe('GetTicketsController — irregular (manual) series whole_series s
 	});
 
 	test('the signup persists against the child occurrence, priced from the master', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1409 — whole-series signup is not listed against its child occurrence'
+		);
 		const signupsRes = await api.get(
 			'/wp-json/fair-events/v1/get-tickets',
 			{

--- a/fair-events/src/API/__tests__/GetTicketsMultipleInstances.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsMultipleInstances.api.spec.js
@@ -147,6 +147,10 @@ test.describe('GetTicketsController — multiple_instances signup', () => {
 	});
 
 	test('a valid selection creates one signup row per chosen occurrence', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1408 — ticket type with sale_periods: [] is rejected as unavailable'
+		);
 		const chosen = [occurrenceIds[0], occurrenceIds[1]];
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {

--- a/fair-events/src/API/__tests__/GetTicketsPaymentUnavailable.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsPaymentUnavailable.api.spec.js
@@ -186,6 +186,10 @@ test.describe('GetTicketsController — payments unavailable (fail closed)', () 
 	});
 
 	test('a paid single-instance signup is rejected 503 and writes nothing', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1405 — the shared e2e test env forces a connected Mollie state'
+		);
 		const before = await countSignups(masterEventDateId);
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {
@@ -202,6 +206,10 @@ test.describe('GetTicketsController — payments unavailable (fail closed)', () 
 	});
 
 	test('a paid whole-series signup is rejected 503 and writes nothing', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1405 — the shared e2e test env forces a connected Mollie state'
+		);
 		const before = await countSignups(masterEventDateId);
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {
 			data: {
@@ -218,6 +226,10 @@ test.describe('GetTicketsController — payments unavailable (fail closed)', () 
 	});
 
 	test('a paid multiple-instances signup is rejected 503 and writes nothing', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1405 — the shared e2e test env forces a connected Mollie state'
+		);
 		const chosen = [occurrenceIds[0], occurrenceIds[1]];
 		const before = await Promise.all(chosen.map(countSignups));
 		const res = await api.post('/wp-json/fair-events/v1/get-tickets', {

--- a/fair-events/src/API/__tests__/GetTicketsRecurringMaster.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsRecurringMaster.api.spec.js
@@ -146,6 +146,10 @@ test.describe('GetTicketsController — recurring series master pivot', () => {
 	});
 
 	test('the signup persists against the child occurrence, priced from the master, not the master row', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1409 — whole-series signup is not listed against its child occurrence'
+		);
 		const signupsRes = await api.get(
 			'/wp-json/fair-events/v1/get-tickets',
 			{

--- a/fair-events/src/API/__tests__/GetTicketsSignupsList.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsSignupsList.api.spec.js
@@ -28,6 +28,7 @@ test.describe('GetTicketsController — admin signups list ticket_type_name', ()
 	let eventDateId;
 	let ticketTypeId;
 	let signupEmail;
+	let signupCreated;
 
 	test.beforeAll(async () => {
 		api = await request.newContext({ baseURL: BASE_URL });
@@ -99,7 +100,10 @@ test.describe('GetTicketsController — admin signups list ticket_type_name', ()
 				},
 			}
 		);
-		expect(signupRes.ok()).toBeTruthy();
+		// #1408 — a ticket type with sale_periods: [] is currently rejected as
+		// unavailable; captured (not asserted) here so the one test that
+		// depends on it can skip with a reference instead of failing the hook.
+		signupCreated = signupRes.ok();
 	});
 
 	test.afterAll(async () => {
@@ -113,6 +117,10 @@ test.describe('GetTicketsController — admin signups list ticket_type_name', ()
 	});
 
 	test('a signup with a valid ticket type gets ticket_type_name resolved', async () => {
+		test.skip(
+			!signupCreated,
+			'Skipped pending #1408 — ticket type with sale_periods: [] is rejected as unavailable'
+		);
 		const res = await api.get('/wp-json/fair-events/v1/get-tickets', {
 			headers: adminHeaders,
 			params: { event_date: eventDateId },
@@ -125,6 +133,10 @@ test.describe('GetTicketsController — admin signups list ticket_type_name', ()
 	});
 
 	test('a signup referencing a deleted ticket type gets ticket_type_name null', async () => {
+		test.skip(
+			!signupCreated,
+			'Skipped pending #1408 — ticket type with sale_periods: [] is rejected as unavailable'
+		);
 		const deleteRes = await api.put(
 			`/wp-json/fair-events/v1/event-dates/${eventDateId}/tickets`,
 			{

--- a/fair-events/src/API/__tests__/PublicEventsController.api.spec.js
+++ b/fair-events/src/API/__tests__/PublicEventsController.api.spec.js
@@ -84,6 +84,10 @@ test.describe('PublicEventsController — recurring post-linked occurrences', ()
 	});
 
 	test('generated occurrences get a non-empty, resolvable url', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1407 — feed url carries a date instead of the event_date id'
+		);
 		const res = await api.get(
 			'/wp-json/fair-events/v1/events?start_date=2035-07-01&end_date=2035-07-31&per_page=500'
 		);
@@ -220,6 +224,10 @@ test.describe('PublicEventsController — standalone events', () => {
 	});
 
 	test('external-link event carries location as an online marker', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1407 — location field is undefined for external-link events'
+		);
 		const res = await api.get(
 			'/wp-json/fair-events/v1/events?start_date=2035-08-01&end_date=2035-08-31&per_page=500'
 		);
@@ -335,6 +343,10 @@ test.describe('PublicEventsController — location field', () => {
 	});
 
 	test('free-text address resolves to a location object', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1407 — location object carries an unexpected extra "mode" key'
+		);
 		const res = await api.get(
 			'/wp-json/fair-events/v1/events?start_date=2035-08-10&end_date=2035-08-10&per_page=500'
 		);

--- a/fair-finance/package.json
+++ b/fair-finance/package.json
@@ -21,6 +21,7 @@
 		"updatepo": "wp i18n update-po languages/fair-finance.pot languages/",
 		"test": "jest",
 		"test:js": "jest",
+		"test:api": "playwright test src/API/__tests__/",
 		"svn:checkout": "svn co https://plugins.svn.wordpress.org/fair-finance svn",
 		"svn:copy": "cp -r readme.txt fair-finance.php composer* languages CHANGELOG.md svn/trunk"
 	},

--- a/fair-finance/playwright.config.js
+++ b/fair-finance/playwright.config.js
@@ -22,10 +22,12 @@ export default defineConfig({
 			use: { ...devices['Desktop Chrome'] },
 		},
 	],
-	webServer: {
-		command: 'docker compose up',
-		url: 'http://localhost:8080',
-		reuseExistingServer: !process.env.CI,
-		timeout: 120 * 1000,
-	},
+	webServer: process.env.CI
+		? undefined
+		: {
+				command: 'docker compose up',
+				url: 'http://localhost:8080',
+				reuseExistingServer: !process.env.CI,
+				timeout: 120 * 1000,
+		  },
 });

--- a/fair-form/playwright.config.js
+++ b/fair-form/playwright.config.js
@@ -22,10 +22,12 @@ export default defineConfig({
 			use: { ...devices['Desktop Chrome'] },
 		},
 	],
-	webServer: {
-		command: 'docker compose up',
-		url: 'http://localhost:8080',
-		reuseExistingServer: !process.env.CI,
-		timeout: 120 * 1000,
-	},
+	webServer: process.env.CI
+		? undefined
+		: {
+				command: 'docker compose up',
+				url: 'http://localhost:8080',
+				reuseExistingServer: !process.env.CI,
+				timeout: 120 * 1000,
+		  },
 });

--- a/fair-form/src/API/__tests__/UrlPreview.api.spec.js
+++ b/fair-form/src/API/__tests__/UrlPreview.api.spec.js
@@ -23,6 +23,10 @@ test.describe('UrlPreviewController', () => {
 	});
 
 	test('fetches and returns metadata from a known page, anonymously', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1411 — outbound fetch does not behave as expected in the wp-env test network'
+		);
 		const res = await api.post('/wp-json/fair-form/v1/url-preview', {
 			data: { url: 'https://example.com' },
 		});
@@ -43,6 +47,10 @@ test.describe('UrlPreviewController', () => {
 	});
 
 	test('returns 422 for an unreachable domain', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1411 — outbound fetch does not behave as expected in the wp-env test network'
+		);
 		const res = await api.post('/wp-json/fair-form/v1/url-preview', {
 			data: { url: 'https://this-domain-does-not-exist.example.test' },
 		});
@@ -51,6 +59,10 @@ test.describe('UrlPreviewController', () => {
 	});
 
 	test('returns 422 for a private-IP address (SSRF protection)', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1411 — outbound fetch does not behave as expected in the wp-env test network'
+		);
 		const res = await api.post('/wp-json/fair-form/v1/url-preview', {
 			data: { url: 'http://169.254.169.254/' },
 		});
@@ -59,6 +71,10 @@ test.describe('UrlPreviewController', () => {
 	});
 
 	test('returns 422 for a non-HTML response', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1411 — outbound fetch does not behave as expected in the wp-env test network'
+		);
 		const res = await api.post('/wp-json/fair-form/v1/url-preview', {
 			data: { url: 'https://api.github.com/zen' },
 		});

--- a/fair-payments-connector-experimental/package.json
+++ b/fair-payments-connector-experimental/package.json
@@ -23,6 +23,7 @@
 		"test": "npm-run-all test:js test:php",
 		"test:js": "wp-scripts test-unit-js --config jest.config.js",
 		"test:php": "vendor/bin/phpunit",
+		"test:api": "playwright test src/API/__tests__/",
 		"svn:checkout": "svn co https://plugins.svn.wordpress.org/fair-payments-connector-experimental svn",
 		"svn:copy": "cp -r readme.txt fair-payments-connector-experimental.php composer* languages CHANGELOG.md svn/trunk"
 	},

--- a/fair-payments-connector-experimental/playwright.config.js
+++ b/fair-payments-connector-experimental/playwright.config.js
@@ -22,10 +22,12 @@ export default defineConfig({
 			use: { ...devices['Desktop Chrome'] },
 		},
 	],
-	webServer: {
-		command: 'docker compose up',
-		url: 'http://localhost:8080',
-		reuseExistingServer: !process.env.CI,
-		timeout: 120 * 1000,
-	},
+	webServer: process.env.CI
+		? undefined
+		: {
+				command: 'docker compose up',
+				url: 'http://localhost:8080',
+				reuseExistingServer: !process.env.CI,
+				timeout: 120 * 1000,
+		  },
 });

--- a/fair-payments-connector/playwright.config.js
+++ b/fair-payments-connector/playwright.config.js
@@ -22,10 +22,12 @@ export default defineConfig({
 			use: { ...devices['Desktop Chrome'] },
 		},
 	],
-	webServer: {
-		command: 'docker compose up',
-		url: 'http://localhost:8080',
-		reuseExistingServer: !process.env.CI,
-		timeout: 120 * 1000,
-	},
+	webServer: process.env.CI
+		? undefined
+		: {
+				command: 'docker compose up',
+				url: 'http://localhost:8080',
+				reuseExistingServer: !process.env.CI,
+				timeout: 120 * 1000,
+		  },
 });

--- a/fair-payments-connector/src/API/__tests__/ConnectionController.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/ConnectionController.api.spec.js
@@ -36,6 +36,10 @@ test.describe('ConnectionController', () => {
 		});
 
 		test('returns a graceful error for an authenticated admin when not connected', async () => {
+			test.skip(
+				true,
+				'Skipped pending #1405 — the shared e2e test env forces a connected Mollie state'
+			);
 			// This suite runs before any spec establishes an OAuth connection, so
 			// the site is expected to be disconnected here. The live-Mollie
 			// success path can't be exercised in CI (no real Mollie creds).

--- a/fair-payments-connector/src/API/__tests__/OAuthCallbackController.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/OAuthCallbackController.api.spec.js
@@ -201,6 +201,10 @@ test.describe('OAuthCallbackController', () => {
 		});
 
 		test('clears the connection and returns 200 for an admin', async () => {
+			test.skip(
+				true,
+				'Skipped pending #1405 — the shared e2e test env forces a connected Mollie state'
+			);
 			// Connect first so there is something to disconnect.
 			const stateRes = await api.post(STATE_ENDPOINT, {
 				headers: adminAuth(),

--- a/fair-payments-connector/src/API/__tests__/TestPayment.api.spec.js
+++ b/fair-payments-connector/src/API/__tests__/TestPayment.api.spec.js
@@ -35,6 +35,10 @@ test.describe('Test payment endpoint', () => {
 	});
 
 	test('returns a graceful error for an authenticated admin when not connected', async () => {
+		test.skip(
+			true,
+			'Skipped pending #1405 — the shared e2e test env forces a connected Mollie state'
+		);
 		// This suite runs without an established OAuth connection, so the site is
 		// expected to be disconnected here. The live-Mollie success path can't be
 		// exercised in CI (no real Mollie creds).

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	"scripts": {
 		"test": "npm run test:js",
 		"test:js": "npm run test --workspaces",
+		"test:api": "npm run test:api --workspaces --if-present",
 		"test:e2e": "playwright test --config=playwright.config.js",
 		"test:e2e:headed": "playwright test --config=playwright.config.js --headed",
 		"test:e2e:ui": "playwright test --config=playwright.config.js --ui",


### PR DESCRIPTION
## Summary

- Add `.github/workflows/api-tests.yml`, a dedicated CI job that reuses the E2E job's isolated `@wordpress/env` instance to run the full API test suite (`npm run test:api`) on every PR, in parallel with the E2E job.
- Add a test-only `WP-API/Basic-Auth` mu-plugin (`e2e/mu-plugins/fair-e2e-basic-auth.php`) so `.api.spec.js` specs' existing Basic Auth headers (built from `WP_ADMIN_USER`/`WP_ADMIN_PASSWORD`) are actually accepted by the wp-env `tests` instance.
- Add `fair-finance` and `fair-payments-connector-experimental` to `.wp-env.json` so their API specs have a WordPress instance to run against.
- Add missing `test:api` scripts (`fair-audience`, `fair-finance`, `fair-payments-connector-experimental`) and fix six `playwright.config.js` files whose `webServer` block didn't no-op under CI, so `docker compose up` isn't attempted on the CI runner.
- Add a root `test:api` aggregate script and document the new CI job + local-repro command in TESTING.md.
- Triage the failures uncovered by actually running this suite together in one environment for the first time (see below).

Closes #1308

## Triage of failures found while wiring this up

Per the ticket's acceptance criteria, every pre-existing failure is either fixed directly or skipped with a link to a new tracking issue, so the check starts green:

**Fixed directly** (quick, mechanical, verified against a live wp-env instance):
- A genuine spec bug: `request` fixture (`req`) was being called with `.newContext()`, which only exists on the *module-level* `request` import it shadows — 9 tests in `EventDatesController.api.spec.js`.
- Several specs were missing the `title` param (or the documented "PUT to actually link `event_id`" follow-up call) on `POST /event-dates`, a required field — `EventDatesController`, `EventDatesSiblings`, `EventParticipantsMove`, `EventSignupRecurrenceScope` (2 of 4 originally-failing tests there).
- `GetTicketsController`'s per-IP rate limit (20 requests/hour, tuned for production abuse) was getting exhausted by the volume of real signups a full suite run drives through it from a single IP — added a test-only bypass filter (`fair_events_get_tickets_rate_limit_bypass_ip`, default `false`, only hooked from the e2e mu-plugin) that leaves the per-*email* limit untouched, since a fair-audience spec (`EventSignupHookBridge`, #1245) specifically exercises that one.

**Skipped with a reference** (real product-behavior questions or environment conflicts, out of scope for a CI-wiring PR):
- #1405 — the e2e mu-plugin's forced-connected Mollie state conflicts with specs that assert on the "not connected"/fail-closed path (fair-payments-connector ×3, fair-events `GetTicketsPaymentUnavailable` ×3).
- #1406 — three `EventDatesController` recurrence-reconciliation regressions (soft-cancel status, `rrule: ""` not clearing a series, shorten-without-dependents).
- #1407 — three `PublicEventsController` location/url field regressions.
- #1408 — a ticket type with `sale_periods: []` (explicitly empty, not merely unset) is rejected as unavailable instead of always-on-sale.
- #1409 — a whole-series signup against a child occurrence isn't listed when querying that occurrence.
- #1410 — several fair-audience (+ one fair-audience-experimental) specs assume publishing a `fair_event` post auto-creates its event-date row; it doesn't.
- #1411 — `UrlPreviewController` specs depend on real outbound network access from inside the wp-env container and get unexpected status codes there.
- #1412 — a testmode-vs-live timeline ambiguity in fair-audience-experimental.
- #1413 — `weekly-digest`'s `week_scope` hard-rejects while sibling fields fall back to defaults.
- #1415 — `GET /event-dates?event_id=` doesn't actually filter, so occurrence-count assertions fail once the test DB accumulates data across a full run.

## Acceptance criteria

- [x] The API suite runs automatically on pull requests and fails the build on a failing spec — `api-tests.yml`, triggered on the same path set as `e2e.yml` plus `**/src/API/**`.
- [x] The check is green on the main branch at merge time — pre-existing failures fixed or skipped with a linked ticket (see above); `npm run test:api` currently exits 0 (all pass or skip).
- [x] Environment provisioning is shared with, or deliberately parallel to, the e2e setup — `api-tests.yml`'s provisioning is copied from `e2e.yml` and both jobs boot the same `@wordpress/env` `tests` instance on port 8889; the API job skips the Playwright-browser install step since API specs never open a page.
- [x] The testing docs describe how to reproduce a CI API failure locally — new "CI" subsection under TESTING.md's REST API Tests section.

## Notes

- Verified `npm run test:api` is green (all pass/skip, exit 0) and the full E2E suite still passes (85/86 — the one failure is an unrelated login-timeout flake on the very first test right after a cold wp-env boot) against this branch, run locally against a fresh wp-env instance.
- No changeset: this is monorepo tooling/CI, not user-facing plugin behavior. The one production code change (`GetTicketsController`'s bypass filter) defaults to `false` and is only ever hooked from test-only code.
