### PR TITLE
Match the group discount note to the price actually charged

### DIFF
--- a/.changeset/fix-group-discount-note-mismatch.md
+++ b/.changeset/fix-group-discount-note-mismatch.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": patch
+---
+
+Fix the group discount note on the signup form so it always matches the price actually charged: it now compares each rule against the ticket's real price (not a notional reference price), stays hidden unless a price is genuinely reduced, and shows fractional percentages (e.g. 12.5%) without rounding them away. When different ticket tiers get their best price from different rules, the shared note is dropped in favor of a per-tier label.

--- a/e2e/mu-plugins/scripts/cleanup-group-discount-note-event.php
+++ b/e2e/mu-plugins/scripts/cleanup-group-discount-note-event.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Delete everything seed-group-discount-note-event.php created, by id.
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/cleanup-group-discount-note-event.php <eventId> <eventDateId> <participantId> [groupId] [ruleId]
+ *
+ * Unlike cleanup-event.php, the participant here was never linked via a real
+ * signup (event_participants row) — it's identified purely via
+ * ?participant_token=, so it must be deleted explicitly by id.
+ *
+ * @package FairEventsE2E
+ */
+
+$event_id       = isset( $args[0] ) ? (int) $args[0] : 0;
+$event_date_id  = isset( $args[1] ) ? (int) $args[1] : 0;
+$participant_id = isset( $args[2] ) ? (int) $args[2] : 0;
+$group_id       = isset( $args[3] ) ? (int) $args[3] : 0;
+$rule_id        = isset( $args[4] ) ? (int) $args[4] : 0;
+
+if ( ! $event_id || ! $event_date_id || ! $participant_id ) {
+	WP_CLI::error( 'Usage: cleanup-group-discount-note-event.php <eventId> <eventDateId> <participantId> [groupId] [ruleId]' );
+}
+
+global $wpdb;
+
+$deleted = array();
+
+if ( $rule_id ) {
+	$deleted['rule'] = \FairEventsExperimental\Models\GroupPricingRule::delete( $rule_id ) ? 1 : 0;
+}
+
+if ( $group_id ) {
+	$deleted['group'] = ( new \FairAudienceExperimental\Models\Group( array( 'id' => $group_id ) ) )->delete() ? 1 : 0;
+}
+
+$deleted['participant'] = ( new \FairAudience\Models\Participant( array( 'id' => $participant_id ) ) )->delete() ? 1 : 0;
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off teardown script, no cache to honour.
+$types_table  = $wpdb->prefix . 'fair_events_ticket_types';
+$prices_table = $wpdb->prefix . 'fair_events_ticket_prices';
+
+$type_ids = $wpdb->get_col(
+	$wpdb->prepare( 'SELECT id FROM %i WHERE event_date_id = %d', $types_table, $event_date_id )
+);
+if ( $type_ids ) {
+	$placeholders = implode( ', ', array_fill( 0, count( $type_ids ), '%d' ) );
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is a safe list of %d.
+	$wpdb->query(
+		$wpdb->prepare(
+			"DELETE FROM %i WHERE ticket_type_id IN ({$placeholders})",
+			array_merge( array( $prices_table ), $type_ids )
+		)
+	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+}
+$deleted['ticket_types'] = (int) $wpdb->query(
+	$wpdb->prepare( 'DELETE FROM %i WHERE event_date_id = %d', $types_table, $event_date_id )
+);
+
+$deleted['sale_periods'] = (int) $wpdb->query(
+	$wpdb->prepare( 'DELETE FROM %i WHERE event_date_id = %d', $wpdb->prefix . 'fair_events_ticket_sale_periods', $event_date_id )
+);
+
+$deleted['event_dates'] = (int) $wpdb->query(
+	$wpdb->prepare( 'DELETE FROM %i WHERE id = %d', $wpdb->prefix . 'fair_event_dates', $event_date_id )
+);
+// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+$deleted['post'] = wp_delete_post( $event_id, true ) ? 1 : 0;
+
+echo 'E2E_CLEANUP:' . wp_json_encode( $deleted ) . "\n";

--- a/e2e/mu-plugins/scripts/seed-group-discount-note-event.php
+++ b/e2e/mu-plugins/scripts/seed-group-discount-note-event.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Seed an event with a single ticket type, plus a fair-audience Participant
+ * who is a member of a group carrying a discount rule against that tier —
+ * for the group-discount-note E2E spec (#1297).
+ *
+ * Run via WP-CLI against the wp-env tests instance:
+ *   wp eval-file wp-content/mu-plugins/scripts/seed-group-discount-note-event.php <json-args>
+ *
+ * The event renders fair-audience's own event-signup block (event-factory's
+ * default) — the one variant that resolves the viewer synchronously via a
+ * `?participant_token=` URL, so the seeded participant's personalized note
+ * and price are present in the very first server-rendered page, no cookie or
+ * login choreography needed.
+ *
+ * Args (JSON object):
+ *   price          Ticket type base price. Default 20.00.
+ *   discountType   'percentage' | 'amount', or omitted for no rule at all
+ *                  (the "genuinely undiscounted" case).
+ *   discountValue  Discount magnitude. Required when discountType is set.
+ *
+ * Prints a single `E2E_SEED:{json}` line with the participant-token page URL
+ * and every id `cleanup-group-discount-note-event.php` needs to tear down.
+ *
+ * @package FairEventsE2E
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/../lib/event-factory.php';
+
+$overrides = array();
+if ( isset( $args[0] ) && '' !== $args[0] ) {
+	$decoded = json_decode( (string) $args[0], true );
+	if ( ! is_array( $decoded ) ) {
+		WP_CLI::error( 'Argument must be a JSON object, got: ' . $args[0] );
+	}
+	$overrides = $decoded;
+}
+
+$price          = isset( $overrides['price'] ) ? (float) $overrides['price'] : 20.00;
+$discount_type  = isset( $overrides['discountType'] ) ? (string) $overrides['discountType'] : null;
+$discount_value = isset( $overrides['discountValue'] ) ? (float) $overrides['discountValue'] : null;
+
+$event_id       = fair_e2e_create_event( 'E2E Group Discount Note Event ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ) );
+$event_date_id  = fair_e2e_add_date( $event_id );
+$sale_period_id = fair_e2e_add_sale_period( $event_date_id );
+$ticket_type_id = fair_e2e_add_ticket_type( $event_date_id, 'General Admission', null );
+fair_e2e_add_price( $ticket_type_id, $sale_period_id, $price, null );
+
+$participant = new \FairAudience\Models\Participant(
+	array(
+		'name'  => 'Discount Note Tester',
+		'email' => 'discount-note-' . gmdate( 'YmdHis' ) . '-' . wp_rand( 1000, 9999 ) . '@example.test',
+	)
+);
+$participant->save();
+
+$group_id = 0;
+$rule_id  = 0;
+if ( null !== $discount_type ) {
+	$group = new \FairAudienceExperimental\Models\Group(
+		array( 'name' => 'E2E Discount Note Group ' . gmdate( 'YmdHis' ) . ' ' . wp_rand( 1000, 9999 ) )
+	);
+	$group->save();
+	$group_id = (int) $group->id;
+
+	( new \FairAudienceExperimental\Database\GroupParticipantRepository() )
+		->add_participant_to_group( $group_id, (int) $participant->id );
+
+	$rule_id = \FairEventsExperimental\Models\GroupPricingRule::create(
+		$event_date_id,
+		$group_id,
+		$discount_type,
+		$discount_value
+	);
+}
+
+$token    = \FairAudience\Services\ParticipantToken::generate( (int) $participant->id, (int) $event_date_id );
+$page_url = add_query_arg( 'participant_token', $token, get_permalink( $event_id ) );
+
+echo 'E2E_SEED:' . wp_json_encode(
+	array(
+		'pageUrl'       => $page_url,
+		'eventId'       => (int) $event_id,
+		'eventDateId'   => (int) $event_date_id,
+		'ticketTypeId'  => (int) $ticket_type_id,
+		'participantId' => (int) $participant->id,
+		'groupId'       => $group_id,
+		'ruleId'        => $rule_id,
+		'price'         => $price,
+	)
+) . "\n";

--- a/e2e/user-flows/group-discount-note-accuracy.spec.js
+++ b/e2e/user-flows/group-discount-note-accuracy.spec.js
@@ -1,0 +1,128 @@
+/**
+ * E2E: the group discount note above the signup button must match the price
+ * actually shown/charged (#1297).
+ *
+ * Targets fair-audience's own event-signup block — the one variant that
+ * resolves the viewer synchronously from a `?participant_token=` URL, so a
+ * seeded member's personalized note and price are present in the very first
+ * server-rendered page (no cookie/login choreography needed). The unified
+ * fair-events/event-signup block (the default for new content since #1245)
+ * shares the same underlying resolver (SignupHookBridge::enrich_render_context,
+ * covered by the fix in this PR) but personalizes via an async viewer-context
+ * fetch, which needs a different testing technique — left to a follow-up.
+ *
+ * Each case seeds a single ticket type plus a group discount rule via
+ * seed-group-discount-note-event.php (real fair-audience/fair-events-experimental
+ * models, no HTTP round-trip), and reads the resolved price straight off the
+ * ticket-type radio's `data-ticket-price` attribute — a locale-independent
+ * numeric string — rather than parsing currency-formatted text, so the
+ * assertion doesn't depend on the site's currency/locale settings.
+ */
+
+import { test, expect } from '@playwright/test';
+import { runScript } from '../support/wp-cli.js';
+
+function seed(overrides) {
+	return runScript(
+		'seed-group-discount-note-event.php',
+		'E2E_SEED',
+		`'${JSON.stringify(overrides)}'`
+	);
+}
+
+function cleanup(event) {
+	runScript(
+		'cleanup-group-discount-note-event.php',
+		'E2E_CLEANUP',
+		`${event.eventId} ${event.eventDateId} ${event.participantId} ${event.groupId} ${event.ruleId}`
+	);
+}
+
+test.describe('Group discount note accuracy', () => {
+	test('a percentage rule: the note and the shown price agree', async ({
+		page,
+	}) => {
+		const event = seed({
+			price: 20,
+			discountType: 'percentage',
+			discountValue: 20,
+		});
+		try {
+			await page.goto(event.pageUrl);
+
+			const note = page.locator('.fair-audience-signup-discount-note');
+			await expect(note).toBeVisible();
+			await expect(note).toContainText('20% discount applied');
+
+			const radio = page.locator('input[name="ticket_type_id"]');
+			await expect(radio).toHaveAttribute('data-ticket-price', '16.00');
+		} finally {
+			cleanup(event);
+		}
+	});
+
+	test('an amount rule: the note and the shown price agree', async ({
+		page,
+	}) => {
+		const event = seed({
+			price: 20,
+			discountType: 'amount',
+			discountValue: 5,
+		});
+		try {
+			await page.goto(event.pageUrl);
+
+			const note = page.locator('.fair-audience-signup-discount-note');
+			await expect(note).toBeVisible();
+			await expect(note).toContainText('discount applied');
+
+			const radio = page.locator('input[name="ticket_type_id"]');
+			await expect(radio).toHaveAttribute('data-ticket-price', '15.00');
+		} finally {
+			cleanup(event);
+		}
+	});
+
+	test('a fractional percentage renders with its decimals, not rounded', async ({
+		page,
+	}) => {
+		const event = seed({
+			price: 20,
+			discountType: 'percentage',
+			discountValue: 12.5,
+		});
+		try {
+			await page.goto(event.pageUrl);
+
+			const note = page.locator('.fair-audience-signup-discount-note');
+			await expect(note).toContainText('12.5% discount applied');
+
+			const radio = page.locator('input[name="ticket_type_id"]');
+			await expect(radio).toHaveAttribute('data-ticket-price', '17.50');
+		} finally {
+			cleanup(event);
+		}
+	});
+
+	test('a free tier shows no note, even for a member with a matching rule', async ({
+		page,
+	}) => {
+		const event = seed({
+			price: 0,
+			discountType: 'percentage',
+			discountValue: 20,
+		});
+		try {
+			await page.goto(event.pageUrl);
+
+			await expect(
+				page.locator('.fair-audience-signup-discount-note')
+			).toHaveCount(0);
+
+			const radio = page.locator('input[name="ticket_type_id"]');
+			await expect(radio).toHaveAttribute('data-ticket-price', '0.00');
+		} finally {
+			cleanup(event);
+		}
+	});
+});

--- a/fair-audience/__tests__/Services/GroupSignupPricingTest.php
+++ b/fair-audience/__tests__/Services/GroupSignupPricingTest.php
@@ -131,4 +131,14 @@ class GroupSignupPricingTest extends TestCase {
 
 		$this->assertSame( '€5.00 discount applied (Staff)', $label );
 	}
+
+	/**
+	 * A fractional percentage renders with its decimals instead of being
+	 * rounded to a whole number (issue #1297).
+	 */
+	public function test_discount_note_label_percentage_keeps_fractional_decimals() {
+		$label = GroupSignupPricing::discount_note_label( $this->rule( 'percentage', 12.5 ), 'Volunteers' );
+
+		$this->assertSame( '12.5% discount applied (Volunteers)', $label );
+	}
 }

--- a/fair-audience/languages/fair-audience-de_DE.po
+++ b/fair-audience/languages/fair-audience-de_DE.po
@@ -64,16 +64,16 @@ msgstr "Veranstaltungsteilnehmer"
 #: src/API/EventParticipantsController.php:1468
 #: src/API/EventSignupController.php:468
 #: src/API/EventSignupController.php:613
-#: src/API/EventSignupController.php:1080
-#: src/API/EventSignupController.php:2137
-#: src/API/EventSignupController.php:2340
-#: src/API/EventSignupController.php:2532
-#: src/API/EventSignupController.php:2660
-#: src/API/EventSignupController.php:2960
-#: src/Services/EmailService.php:336
-#: src/Services/EmailService.php:560
-#: src/Services/EmailService.php:1400
-#: src/Services/EmailService.php:2816
+#: src/API/EventSignupController.php:1081
+#: src/API/EventSignupController.php:2125
+#: src/API/EventSignupController.php:2328
+#: src/API/EventSignupController.php:2520
+#: src/API/EventSignupController.php:2648
+#: src/API/EventSignupController.php:2949
+#: src/Services/EmailService.php:337
+#: src/Services/EmailService.php:561
+#: src/Services/EmailService.php:1401
+#: src/Services/EmailService.php:2792
 msgid "Event not found."
 msgstr "Veranstaltung nicht gefunden."
 
@@ -85,11 +85,11 @@ msgstr "Veranstaltung nicht gefunden."
 #: src/API/ParticipantsController.php:729
 #: src/API/ParticipantsController.php:762
 #: src/API/ParticipantsController.php:789
-#: src/Services/EmailService.php:360
-#: src/Services/EmailService.php:583
-#: src/Services/EmailService.php:1439
-#: src/Services/EmailService.php:1829
-#: src/Services/EmailService.php:2891
+#: src/Services/EmailService.php:361
+#: src/Services/EmailService.php:584
+#: src/Services/EmailService.php:1440
+#: src/Services/EmailService.php:1830
+#: src/Services/EmailService.php:2867
 #: src/Admin/participant-detail/ParticipantDetail.js:86
 msgid "Participant not found."
 msgstr "Teilnehmer nicht gefunden."
@@ -164,7 +164,7 @@ msgid "Add Participant"
 msgstr "Teilnehmer hinzufügen"
 
 #: src/blocks/event-interest/render.php:135
-#: src/Services/EmailService.php:1916
+#: src/Services/EmailService.php:1917
 #: src/Admin/all-participants/AllParticipants.js:93
 #: src/Admin/event-participants/EventParticipants.js:629
 #: src/Admin/manage-event-audience-tab/EventAudience.js:892
@@ -175,14 +175,14 @@ msgstr "Name"
 
 #: src/blocks/audience-signup/render.php:217
 #: src/blocks/event-interest/render.php:122
-#: src/blocks/event-signup/render.php:1265
-#: src/blocks/event-signup/render.php:1320
+#: src/blocks/event-signup/render.php:1333
+#: src/blocks/event-signup/render.php:1388
 #: src/blocks/mailing-signup/render.php:125
-#: src/Services/EmailService.php:1920
+#: src/Services/EmailService.php:1921
 #: src/Admin/all-participants/AllParticipants.js:108
 #: src/Admin/components/ParticipantEditModal.js:177
 #: src/Admin/participant-detail/ParticipantDetail.js:190
-#: src/blocks/event-signup/editor.js:123
+#: src/blocks/event-signup/editor.js:127
 msgid "Email"
 msgstr "E-Mail"
 
@@ -271,9 +271,9 @@ msgstr "Entfernen"
 msgid "Events"
 msgstr "Veranstaltungen"
 
-#: src/Services/EmailService.php:2253
-#: src/Services/EmailService.php:2403
-#: src/Services/EmailService.php:2525
+#: src/Services/EmailService.php:2256
+#: src/Services/EmailService.php:2363
+#: src/Services/EmailService.php:2493
 #: src/Admin/events-list/EventsList.js:37
 #: src/Admin/manage-event-audience-tab/EventAudience.js:778
 #: src/Admin/participant-detail/ParticipantDetail.js:271
@@ -281,7 +281,7 @@ msgstr "Veranstaltungen"
 msgid "Event"
 msgstr "Veranstaltung"
 
-#: src/Services/EmailService.php:325
+#: src/Services/EmailService.php:326
 msgid "Poll not found."
 msgstr "Umfrage nicht gefunden."
 
@@ -292,87 +292,87 @@ msgid "Invalid event ID."
 msgstr "Ungültige Ereignis-ID."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:210
+#: src/Services/EmailService.php:211
 #, php-format
 msgid "Quick question about %s"
 msgstr "Kurze Frage zu %s"
 
 #. translators: %s: participant first name
-#: src/Services/EmailService.php:239
-#: src/Services/EmailService.php:446
-#: src/Services/EmailService.php:666
-#: src/Services/EmailService.php:774
-#: src/Services/EmailService.php:875
-#: src/Services/EmailService.php:997
-#: src/Services/EmailService.php:1159
-#: src/Services/EmailService.php:1334
-#: src/Services/EmailService.php:1604
-#: src/Services/EmailService.php:1709
-#: src/Services/EmailService.php:2193
-#: src/Services/EmailService.php:2335
-#: src/Services/EmailService.php:2460
-#: src/Services/EmailService.php:2572
-#: src/Services/EmailService.php:2709
-#: src/Services/EmailService.php:2998
-#: src/Services/EmailService.php:3091
+#: src/Services/EmailService.php:240
+#: src/Services/EmailService.php:447
+#: src/Services/EmailService.php:667
+#: src/Services/EmailService.php:775
+#: src/Services/EmailService.php:876
+#: src/Services/EmailService.php:998
+#: src/Services/EmailService.php:1160
+#: src/Services/EmailService.php:1335
+#: src/Services/EmailService.php:1605
+#: src/Services/EmailService.php:1710
+#: src/Services/EmailService.php:2194
+#: src/Services/EmailService.php:2328
+#: src/Services/EmailService.php:2428
+#: src/Services/EmailService.php:2548
+#: src/Services/EmailService.php:2685
+#: src/Services/EmailService.php:2982
+#: src/Services/EmailService.php:3076
 #: src/Admin/event-participants/EventParticipants.js:1192
-#, php-format, js-format
+#, php-format,js-format
 msgid "Hi %s,"
 msgstr "Hallo %s,"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:247
+#: src/Services/EmailService.php:248
 #, php-format
 msgid "We'd love to hear from you about %s!"
 msgstr "Wir würden gerne Ihre Meinung zu %s hören!"
 
-#: src/Services/EmailService.php:261
+#: src/Services/EmailService.php:262
 msgid "Please take a moment to answer our quick poll:"
 msgstr "Bitte nehmen Sie sich einen Moment Zeit, unsere kurze Umfrage zu beantworten:"
 
-#: src/Services/EmailService.php:266
+#: src/Services/EmailService.php:267
 msgid "Answer Poll"
 msgstr "Umfrage beantworten"
 
 #. translators: 1: line break, 2: site name
-#: src/Services/EmailService.php:273
-#: src/Services/EmailService.php:498
-#: src/Services/EmailService.php:692
-#: src/Services/EmailService.php:796
-#: src/Services/EmailService.php:905
-#: src/Services/EmailService.php:1027
-#: src/Services/EmailService.php:1169
-#: src/Services/EmailService.php:1346
-#: src/Services/EmailService.php:1616
-#: src/Services/EmailService.php:1754
-#: src/Services/EmailService.php:2209
+#: src/Services/EmailService.php:274
+#: src/Services/EmailService.php:499
+#: src/Services/EmailService.php:693
+#: src/Services/EmailService.php:797
+#: src/Services/EmailService.php:906
+#: src/Services/EmailService.php:1028
+#: src/Services/EmailService.php:1170
+#: src/Services/EmailService.php:1347
+#: src/Services/EmailService.php:1617
+#: src/Services/EmailService.php:1755
+#: src/Services/EmailService.php:2210
 #, php-format
 msgid "Thanks,%1$sThe %2$s Team"
 msgstr "Vielen Dank,%1$sDas %2$s Team"
 
-#: src/Services/EmailService.php:285
-#: src/Services/EmailService.php:510
-#: src/Services/EmailService.php:704
-#: src/Services/EmailService.php:808
-#: src/Services/EmailService.php:917
-#: src/Services/EmailService.php:1039
-#: src/Services/EmailService.php:1769
-#: src/Services/EmailService.php:2755
+#: src/Services/EmailService.php:286
+#: src/Services/EmailService.php:511
+#: src/Services/EmailService.php:705
+#: src/Services/EmailService.php:809
+#: src/Services/EmailService.php:918
+#: src/Services/EmailService.php:1040
+#: src/Services/EmailService.php:1770
+#: src/Services/EmailService.php:2731
 msgid "If the button above doesn't work, copy and paste this link:"
 msgstr "Falls der Button oben nicht funktioniert, kopieren und fügen Sie diesen Link ein:"
 
-#: src/Services/EmailService.php:387
-#: src/Services/EmailService.php:609
-#: src/Services/EmailService.php:1472
-#: src/Services/EmailService.php:1549
-#: src/Services/EmailService.php:1864
-#: src/Services/EmailService.php:2927
+#: src/Services/EmailService.php:388
+#: src/Services/EmailService.php:610
+#: src/Services/EmailService.php:1473
+#: src/Services/EmailService.php:1550
+#: src/Services/EmailService.php:1865
+#: src/Services/EmailService.php:2903
 msgid "wp_mail() failed to send."
 msgstr "wp_mail() konnte keine E-Mail senden."
 
-#: src/blocks/event-signup/render.php:1253
+#: src/blocks/event-signup/render.php:1321
 #: src/Admin/components/ParticipantEditModal.js:170
-#: src/blocks/event-signup/editor.js:119
+#: src/blocks/event-signup/editor.js:123
 msgid "Surname"
 msgstr "Nachname"
 
@@ -470,16 +470,16 @@ msgstr "Teilnehmer-ID %d nicht gefunden"
 
 #: src/API/AudienceSignupController.php:204
 #: src/API/EventInterestController.php:156
-#: src/API/EventSignupController.php:2146
-#: src/API/EventSignupController.php:2678
+#: src/API/EventSignupController.php:2134
+#: src/API/EventSignupController.php:2666
 #: src/API/MailingSignupController.php:172
 msgid "Please enter a valid email address."
 msgstr "Bitte geben Sie eine gültige E-Mail-Adresse ein."
 
 #: src/API/AudienceSignupController.php:223
 #: src/API/EventInterestController.php:182
-#: src/API/EventSignupController.php:2155
-#: src/API/EventSignupController.php:2717
+#: src/API/EventSignupController.php:2143
+#: src/API/EventSignupController.php:2705
 #: src/API/MailingSignupController.php:192
 msgid "Too many requests. Please try again later."
 msgstr "Zu viele Anfragen. Bitte versuchen Sie es später erneut."
@@ -536,14 +536,14 @@ msgid "Subscribe"
 msgstr "Abonnieren"
 
 #: src/blocks/audience-signup/render.php:192
-#: src/blocks/event-signup/render.php:1240
+#: src/blocks/event-signup/render.php:1308
 #: src/blocks/mailing-signup/render.php:99
-#: src/blocks/event-signup/editor.js:115
+#: src/blocks/event-signup/editor.js:119
 msgid "First Name"
 msgstr "Vorname"
 
 #: src/blocks/audience-signup/render.php:199
-#: src/blocks/event-signup/render.php:1247
+#: src/blocks/event-signup/render.php:1315
 #: src/blocks/mailing-signup/render.php:106
 msgid "Enter your first name"
 msgstr "Geben Sie Ihren Vornamen ein"
@@ -559,54 +559,54 @@ msgid "Enter your last name"
 msgstr "Geben Sie Ihren Nachnamen ein"
 
 #: src/blocks/audience-signup/render.php:224
-#: src/blocks/event-signup/render.php:1272
-#: src/blocks/event-signup/render.php:1327
+#: src/blocks/event-signup/render.php:1340
+#: src/blocks/event-signup/render.php:1395
 #: src/blocks/mailing-signup/render.php:132
 msgid "Enter your email"
 msgstr "Geben Sie Ihre E-Mail-Adresse ein"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:417
+#: src/Services/EmailService.php:418
 #, php-format
 msgid "Photos from %s are ready!"
 msgstr "Fotos von %s sind fertig!"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:454
+#: src/Services/EmailService.php:455
 #: src/Admin/event-participants/EventParticipants.js:1204
-#, php-format, js-format
+#, php-format,js-format
 msgid "The photos from %s are now available for you to view and like!"
 msgstr "Die Fotos von %s sind jetzt für Sie zum Ansehen und Liken verfügbar!"
 
-#: src/Services/EmailService.php:468
+#: src/Services/EmailService.php:469
 #: src/Admin/event-participants/EventParticipants.js:1217
 msgid "Click the button below to browse the gallery and let us know which photos you like best:"
 msgstr "Klicken Sie auf die Schaltfläche unten, um die Galerie zu durchsuchen und uns mitzuteilen, welche Fotos Ihnen am besten gefallen:"
 
-#: src/Services/EmailService.php:473
+#: src/Services/EmailService.php:474
 #: src/Admin/event-participants/EventParticipants.js:1239
 msgid "View Gallery"
 msgstr "Galerie anzeigen"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:637
+#: src/Services/EmailService.php:638
 #, php-format
 msgid "Confirm your subscription to %s"
 msgstr "Bestätigen Sie Ihr Abonnement für %s"
 
-#: src/Services/EmailService.php:672
+#: src/Services/EmailService.php:673
 msgid "Thank you for signing up for our mailing list! Please confirm your email address by clicking the button below."
 msgstr "Vielen Dank, dass Sie sich für unseren Verteiler angemeldet haben! Bitte bestätigen Sie Ihre E-Mail-Adresse, indem Sie auf die Schaltfläche unten klicken."
 
-#: src/Services/EmailService.php:677
+#: src/Services/EmailService.php:678
 msgid "Confirm Email"
 msgstr "E-Mail bestätigen"
 
-#: src/Services/EmailService.php:682
+#: src/Services/EmailService.php:683
 msgid "This link will expire in 48 hours."
 msgstr "Dieser Link läuft in 48 Stunden ab."
 
-#: src/Services/EmailService.php:686
+#: src/Services/EmailService.php:687
 msgid "If you didn't sign up for this mailing list, you can safely ignore this email."
 msgstr "Wenn Sie sich nicht für diesen Verteiler angemeldet haben, können Sie diese E-Mail ignorieren."
 
@@ -714,7 +714,7 @@ msgstr "%d ausgewählte hinzufügen"
 
 #: src/blocks/audience-signup/editor.js:35
 #: src/blocks/event-interest/editor.js:26
-#: src/blocks/event-signup/editor.js:85
+#: src/blocks/event-signup/editor.js:89
 #: src/blocks/mailing-signup/editor.js:65
 msgid "Form Settings"
 msgstr "Formular-Einstellungen"
@@ -901,38 +901,38 @@ msgid "You must be logged in or have a valid signup link."
 msgstr "Sie müssen angemeldet sein oder einen gültigen Anmeldelink haben."
 
 #: src/API/EventSignupController.php:642
-#: src/API/EventSignupController.php:1108
-#: src/API/EventSignupController.php:2989
+#: src/API/EventSignupController.php:1109
+#: src/API/EventSignupController.php:2978
 msgid "Could not find your participant profile."
 msgstr "Ihr Teilnehmerprofil konnte nicht gefunden werden."
 
 #: src/API/EventSignupController.php:726
-#: src/API/EventSignupController.php:2368
-#: src/API/EventSignupController.php:2794
+#: src/API/EventSignupController.php:2356
+#: src/API/EventSignupController.php:2782
 msgid "You are already signed up for this event."
 msgstr "Sie sind bereits für diese Veranstaltung angemeldet."
 
-#: src/API/EventSignupController.php:776
-#: src/API/EventSignupController.php:918
+#: src/API/EventSignupController.php:777
+#: src/API/EventSignupController.php:919
 #: src/blocks/event-signup/render.php:66
 #: src/blocks/event-signup/frontend.js:961
 #: src/blocks/event-signup/frontend.js:1271
 msgid "You have successfully signed up for the event!"
 msgstr "Sie haben sich erfolgreich für die Veranstaltung angemeldet!"
 
-#: src/API/EventSignupController.php:2187
+#: src/API/EventSignupController.php:2175
 msgid "If your email is in our system, you will receive a signup link shortly. Please check your inbox."
 msgstr "Wenn Ihre E-Mail in unserem System ist, erhalten Sie gleich einen Anmeldelink. Bitte überprüfen Sie Ihren Posteingang."
 
-#: src/API/EventSignupController.php:2687
+#: src/API/EventSignupController.php:2675
 msgid "Please enter your name."
 msgstr "Bitte geben Sie Ihren Namen ein."
 
-#: src/API/EventSignupController.php:2821
+#: src/API/EventSignupController.php:2809
 msgid "Failed to process registration. Please try again."
 msgstr "Die Registrierung konnte nicht verarbeitet werden. Bitte versuchen Sie es erneut."
 
-#: src/API/EventSignupController.php:2938
+#: src/API/EventSignupController.php:2927
 msgid "You have successfully registered and signed up for the event!"
 msgstr "Sie haben sich erfolgreich registriert und für die Veranstaltung angemeldet!"
 
@@ -947,8 +947,8 @@ msgid "This WordPress user is already linked to another participant."
 msgstr "Dieser WordPress-Benutzer ist bereits mit einem anderen Teilnehmer verknüpft."
 
 #: src/blocks/event-signup/render.php:63
-#: src/blocks/event-signup/render.php:969
-#: src/blocks/event-signup/editor.js:92
+#: src/blocks/event-signup/render.php:1037
+#: src/blocks/event-signup/editor.js:96
 #: src/blocks/event-signup/frontend.js:472
 #: src/blocks/event-signup/frontend.js:506
 #: src/blocks/event-signup/frontend.js:1692
@@ -956,8 +956,8 @@ msgid "Sign Up"
 msgstr "Anmelden"
 
 #: src/blocks/event-signup/render.php:64
-#: src/blocks/event-signup/render.php:970
-#: src/blocks/event-signup/editor.js:143
+#: src/blocks/event-signup/render.php:1038
+#: src/blocks/event-signup/editor.js:147
 #: src/blocks/event-signup/frontend.js:475
 #: src/blocks/event-signup/frontend.js:509
 msgid "Register & Sign Up"
@@ -968,72 +968,72 @@ msgid "Send Signup Link"
 msgstr "Anmeldelink senden"
 
 #: src/blocks/event-interest/render.php:115
-#: src/blocks/event-signup/render.php:997
+#: src/blocks/event-signup/render.php:1065
 msgid "This block can only be used on event pages."
 msgstr "Dieser Block kann nur auf Ereignisseiten verwendet werden."
 
-#: src/blocks/event-signup/render.php:1125
+#: src/blocks/event-signup/render.php:1193
 #: src/blocks/event-signup/frontend.js:1140
 #: src/blocks/event-signup/frontend.js:1403
 msgid "You are signed up for this event!"
 msgstr "Sie sind für dieses Ereignis angemeldet!"
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1146
+#: src/blocks/event-signup/render.php:1214
 #, php-format
 msgid "Hi %s! Click the button below to sign up for this event."
 msgstr "Hallo %s! Klicken Sie auf die Schaltfläche unten, um sich für dieses Ereignis anzumelden."
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1152
+#: src/blocks/event-signup/render.php:1220
 #: src/blocks/event-signup/frontend.js:1671
-#, php-format, js-format
+#, php-format,js-format
 msgid "Hi %s! You can sign up for this event."
 msgstr "Hallo %s! Sie können sich für dieses Ereignis anmelden."
 
-#: src/blocks/event-signup/render.php:1225
+#: src/blocks/event-signup/render.php:1293
 msgid "I'm new"
 msgstr "Ich bin neu"
 
-#: src/blocks/event-signup/render.php:1228
+#: src/blocks/event-signup/render.php:1296
 msgid "I have an account"
 msgstr "Ich habe ein Konto"
 
-#: src/blocks/event-signup/render.php:1259
+#: src/blocks/event-signup/render.php:1327
 msgid "Enter your surname"
 msgstr "Geben Sie Ihren Nachnamen ein"
 
 #: src/blocks/audience-signup/render.php:386
-#: src/blocks/event-signup/render.php:1279
+#: src/blocks/event-signup/render.php:1347
 msgid "Keep me informed about future events"
 msgstr "Halten Sie mich über zukünftige Veranstaltungen auf dem Laufenden"
 
-#: src/blocks/event-signup/render.php:1316
+#: src/blocks/event-signup/render.php:1384
 msgid "Enter your email to receive a signup link."
 msgstr "Geben Sie Ihre E-Mail-Adresse ein, um einen Anmeldelink zu erhalten."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:846
+#: src/Services/EmailService.php:847
 #, php-format
 msgid "Sign up for %s"
 msgstr "Anmelden für %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:883
+#: src/Services/EmailService.php:884
 #, php-format
 msgid "You requested a signup link for %s."
 msgstr "Sie haben einen Anmeldelink für %s angefordert."
 
-#: src/Services/EmailService.php:889
+#: src/Services/EmailService.php:890
 msgid "Click the button below to sign up for the event:"
 msgstr "Klicken Sie auf die Schaltfläche unten, um sich für die Veranstaltung anzumelden:"
 
-#: src/Services/EmailService.php:894
-#: src/Services/EmailService.php:2736
+#: src/Services/EmailService.php:895
+#: src/Services/EmailService.php:2712
 msgid "Sign Up Now"
 msgstr "Jetzt anmelden"
 
-#: src/Services/EmailService.php:899
+#: src/Services/EmailService.php:900
 msgid "If you didn't request this link, you can safely ignore this email."
 msgstr "Wenn Sie diesen Link nicht angefordert haben, können Sie diese E-Mail ignorieren."
 
@@ -1085,11 +1085,11 @@ msgstr "Keine Benutzer gefunden."
 msgid "Role"
 msgstr "Rolle"
 
-#: src/blocks/event-signup/editor.js:87
+#: src/blocks/event-signup/editor.js:91
 msgid "Signup Button Text"
 msgstr "Text für Anmelde-Button"
 
-#: src/blocks/event-signup/editor.js:93
+#: src/blocks/event-signup/editor.js:97
 msgid "Button text for authenticated users."
 msgstr "Buttontext für authentifizierte Benutzer."
 
@@ -1193,26 +1193,26 @@ msgctxt "block keyword"
 msgid "list"
 msgstr "Liste"
 
-#: src/Services/EmailService.php:923
-#: src/Services/EmailService.php:1045
-#: src/Services/EmailService.php:2761
+#: src/Services/EmailService.php:924
+#: src/Services/EmailService.php:1046
+#: src/Services/EmailService.php:2737
 msgid "Don't want to receive event invitations?"
 msgstr "Möchten Sie keine Veranstaltungseinladungen mehr erhalten?"
 
-#: src/Services/EmailService.php:924
-#: src/Services/EmailService.php:1046
-#: src/Services/EmailService.php:1180
-#: src/Services/EmailService.php:1359
-#: src/Services/EmailService.php:1629
-#: src/Services/EmailService.php:2762
+#: src/Services/EmailService.php:925
+#: src/Services/EmailService.php:1047
+#: src/Services/EmailService.php:1181
+#: src/Services/EmailService.php:1360
+#: src/Services/EmailService.php:1630
+#: src/Services/EmailService.php:2738
 msgid "Manage your preferences"
 msgstr "Ihre Einstellungen verwalten"
 
-#: src/Services/EmailService.php:2879
+#: src/Services/EmailService.php:2855
 msgid "Already signed up"
 msgstr "Bereits angemeldet"
 
-#: src/Services/EmailService.php:164
+#: src/Services/EmailService.php:165
 msgid "Participant opted out of marketing emails."
 msgstr "Teilnehmer hat den Erhalt von Marketing-E-Mails abgelehnt."
 
@@ -1324,7 +1324,7 @@ msgstr "Einstellungen"
 msgid "Event date not found."
 msgstr "Veranstaltungsdatum nicht gefunden."
 
-#: src/Services/EmailService.php:1815
+#: src/Services/EmailService.php:1816
 msgid "Fee not found."
 msgstr "Gebühr nicht gefunden."
 
@@ -1332,12 +1332,12 @@ msgstr "Gebühr nicht gefunden."
 msgid "Could not read SVG file."
 msgstr "SVG-Datei konnte nicht gelesen werden."
 
-#: src/Hooks/PaymentHooks.php:819
+#: src/Hooks/PaymentHooks.php:832
 msgid "Paid online via Mollie"
 msgstr "Online bezahlt via Mollie"
 
 #. translators: %1$s: Mollie status, %2$d: transaction ID
-#: src/Hooks/PaymentHooks.php:863
+#: src/Hooks/PaymentHooks.php:876
 #, php-format
 msgid "Online payment %1$s (transaction #%2$d)"
 msgstr "Online-Zahlung %1$s (Transaktions-Nr. %2$d)"
@@ -1350,50 +1350,50 @@ msgstr "Du darfst keine SVG-Dateien hochladen."
 msgid "Invalid SVG file."
 msgstr "Ungültige SVG-Datei."
 
-#: src/Services/EmailService.php:369
-#: src/Services/EmailService.php:592
-#: src/Services/EmailService.php:1448
-#: src/Services/EmailService.php:1525
-#: src/Services/EmailService.php:1838
-#: src/Services/EmailService.php:2900
+#: src/Services/EmailService.php:370
+#: src/Services/EmailService.php:593
+#: src/Services/EmailService.php:1449
+#: src/Services/EmailService.php:1526
+#: src/Services/EmailService.php:1839
+#: src/Services/EmailService.php:2876
 msgid "Participant has no email address."
 msgstr "Teilnehmer hat keine E-Mail-Adresse."
 
-#: src/Services/EmailService.php:1179
-#: src/Services/EmailService.php:1358
-#: src/Services/EmailService.php:1628
+#: src/Services/EmailService.php:1180
+#: src/Services/EmailService.php:1359
+#: src/Services/EmailService.php:1629
 msgid "Don't want to receive these emails?"
 msgstr "Möchtest du diese E-Mails nicht mehr erhalten?"
 
-#: src/Services/EmailService.php:1428
-#: src/Services/EmailService.php:1516
+#: src/Services/EmailService.php:1429
+#: src/Services/EmailService.php:1517
 msgid "Manually skipped."
 msgstr "Manuell übersprungen."
 
 #. translators: %s: fee name
-#: src/Services/EmailService.php:1680
+#: src/Services/EmailService.php:1681
 #, php-format
 msgid "Payment reminder: %s"
 msgstr "Zahlungserinnerung: %s"
 
-#: src/Services/EmailService.php:1715
+#: src/Services/EmailService.php:1716
 msgid "This is a friendly reminder about a pending payment:"
 msgstr "Dies ist eine freundliche Erinnerung an eine ausstehende Zahlung:"
 
-#: src/Services/EmailService.php:1720
+#: src/Services/EmailService.php:1721
 msgid "Fee:"
 msgstr "Gebühr:"
 
-#: src/Services/EmailService.php:1724
-#: src/Services/EmailService.php:2544
+#: src/Services/EmailService.php:1725
+#: src/Services/EmailService.php:2520
 msgid "Amount:"
 msgstr "Betrag:"
 
-#: src/Services/EmailService.php:1731
+#: src/Services/EmailService.php:1732
 msgid "Due Date:"
 msgstr "Fälligkeitsdatum:"
 
-#: src/Services/EmailService.php:1745
+#: src/Services/EmailService.php:1746
 msgid "Pay Now"
 msgstr "Jetzt bezahlen"
 
@@ -1737,7 +1737,7 @@ msgstr "Sie wurden erfolgreich registriert!"
 msgid "Audience Signup"
 msgstr "Audience Signup"
 
-#: src/API/EventSignupController.php:2929
+#: src/API/EventSignupController.php:2918
 msgid "You have been signed up for the event! Please check your email to confirm your subscription."
 msgstr "Sie haben sich für die Veranstaltung angemeldet! Bitte überprüfen Sie Ihre E-Mail, um Ihr Abonnement zu bestätigen."
 
@@ -1758,39 +1758,39 @@ msgid "Update Answers"
 msgstr "Antworten aktualisieren"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:743
+#: src/Services/EmailService.php:744
 #, php-format
 msgid "Your signup answers — %s"
 msgstr "Ihre Anmeldeantworten — %s"
 
-#: src/Services/EmailService.php:780
+#: src/Services/EmailService.php:781
 msgid "Thank you for signing up! Here are the answers you submitted:"
 msgstr "Vielen Dank für Ihre Anmeldung! Hier sind die Antworten, die Sie eingereicht haben:"
 
-#: src/Services/EmailService.php:789
+#: src/Services/EmailService.php:790
 msgid "Edit Your Answers"
 msgstr "Bearbeiten Sie Ihre Antworten"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2680
+#: src/Services/EmailService.php:2656
 #, php-format
 msgid "You're invited: %s"
 msgstr "Sie sind eingeladen: %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2717
+#: src/Services/EmailService.php:2693
 #, php-format
 msgid "We have a new event coming up: %s."
 msgstr "Wir haben eine neue Veranstaltung: %s."
 
-#: src/Services/EmailService.php:2731
+#: src/Services/EmailService.php:2707
 msgid "Would you like to join? Click the button below to sign up:"
 msgstr "Möchten Sie teilnehmen? Klicken Sie auf die Schaltfläche unten, um sich anzumelden:"
 
 #. translators: 1: line break, 2: site name
-#: src/Services/EmailService.php:2360
-#: src/Services/EmailService.php:2480
-#: src/Services/EmailService.php:2743
+#: src/Services/EmailService.php:2337
+#: src/Services/EmailService.php:2448
+#: src/Services/EmailService.php:2719
 #, php-format
 msgid "See you there!%1$sThe %2$s Team"
 msgstr "Bis bald!%1$sThe %2$s Team"
@@ -1944,17 +1944,17 @@ msgctxt "block keyword"
 msgid "member"
 msgstr "Mitglied"
 
-#: src/API/EventSignupController.php:3010
+#: src/API/EventSignupController.php:2999
 msgid "You are not signed up for this event."
 msgstr "Sie sind nicht für diese Veranstaltung angemeldet."
 
-#: src/API/EventSignupController.php:3026
+#: src/API/EventSignupController.php:3015
 #: src/blocks/event-signup/frontend.js:1640
 msgid "You have been removed from this event."
 msgstr "Sie wurden aus dieser Veranstaltung entfernt."
 
-#: src/blocks/event-signup/render.php:1211
-#: src/Hooks/SignupHookBridge.php:342
+#: src/blocks/event-signup/render.php:1279
+#: src/Hooks/SignupHookBridge.php:362
 #: src/Admin/manage-event-audience-tab/EventAudience.js:2369
 #: src/blocks/event-signup/frontend.js:1411
 msgid "Cancel signup"
@@ -1974,9 +1974,9 @@ msgstr "Kein Veranstaltungsdatum für diese Veranstaltung gefunden"
 
 #: src/blocks/audience-signup/render.php:393
 #: src/blocks/event-interest/render.php:161
-#: src/blocks/event-signup/render.php:1291
+#: src/blocks/event-signup/render.php:1359
 #: src/blocks/mailing-signup/render.php:156
-#: src/Hooks/SignupHookBridge.php:369
+#: src/Hooks/SignupHookBridge.php:390
 msgid "Not you? Start fresh"
 msgstr "Nicht Sie? Von vorne beginnen"
 
@@ -2075,60 +2075,60 @@ msgstr "Datei ansehen"
 msgid "Failed to update attendance."
 msgstr "Anwesenheit konnte nicht aktualisiert werden."
 
-#: src/API/EventSignupController.php:1355
+#: src/API/EventSignupController.php:1348
 #: src/Services/GroupSignupPricing.php:113
 msgid "This ticket type is not available for your account."
 msgstr "Dieser Tickettyp ist für Ihr Konto nicht verfügbar."
 
-#: src/API/EventSignupController.php:1841
+#: src/API/EventSignupController.php:1829
 msgid "This event is fully booked."
 msgstr "Diese Veranstaltung ist vollständig ausgebucht."
 
 #. translators: %s: event title or occurrence date/time label
-#: src/API/EventSignupController.php:984
-#: src/API/EventSignupController.php:998
-#: src/API/EventSignupController.php:1873
+#: src/API/EventSignupController.php:985
+#: src/API/EventSignupController.php:999
+#: src/API/EventSignupController.php:1861
 #, php-format
 msgid "Signup for %s"
 msgstr "Anmeldung für %s"
 
-#: src/API/EventSignupController.php:1051
-#: src/API/EventSignupController.php:1317
-#: src/API/EventSignupController.php:1965
-#: src/API/EventSignupController.php:2112
-#: src/API/EventSignupController.php:2489
-#: src/API/EventSignupController.php:2630
+#: src/API/EventSignupController.php:1052
+#: src/API/EventSignupController.php:1310
+#: src/API/EventSignupController.php:1953
+#: src/API/EventSignupController.php:2100
+#: src/API/EventSignupController.php:2477
+#: src/API/EventSignupController.php:2618
 #: src/blocks/event-signup/frontend.js:1080
 #: src/blocks/event-signup/frontend.js:1362
 msgid "Redirecting to payment…"
 msgstr "Weiterleitung zur Zahlung…"
 
-#: src/blocks/event-signup/render.php:617
+#: src/blocks/event-signup/render.php:677
 #: src/blocks/event-signup/frontend.js:537
 msgid "Sign up for free"
 msgstr "Kostenlos anmelden"
 
-#: src/blocks/event-signup/render.php:618
+#: src/blocks/event-signup/render.php:678
 #: src/blocks/event-signup/frontend.js:538
 msgid "Register for free"
 msgstr "Kostenlos registrieren"
 
-#: src/blocks/event-signup/render.php:691
+#: src/blocks/event-signup/render.php:748
 msgid "Choose ticket type"
 msgstr "Tickettyp wählen"
 
-#: src/blocks/event-signup/render.php:702
-#: src/blocks/event-signup/render.php:779
-#: src/blocks/event-signup/render.php:841
-#: src/Hooks/SignupHookBridge.php:541
+#: src/blocks/event-signup/render.php:759
+#: src/blocks/event-signup/render.php:847
+#: src/blocks/event-signup/render.php:909
+#: src/Hooks/SignupHookBridge.php:564
 msgid "free"
 msgstr "kostenlos"
 
-#: src/blocks/event-signup/render.php:743
+#: src/blocks/event-signup/render.php:811
 msgid "Select activities"
 msgstr "Aktivitäten auswählen"
 
-#: src/Hooks/PaymentHooks.php:394
+#: src/Hooks/PaymentHooks.php:399
 #: src/Hooks/PendingSubscriptionTimeoutHooks.php:56
 #: src/Hooks/WeeklyDigestHooks.php:55
 msgid "Every 5 minutes (fair-audience)"
@@ -2208,62 +2208,62 @@ msgid "Submitted at"
 msgstr "Eingereicht am"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:1910
+#: src/Services/EmailService.php:1911
 #, php-format
 msgid "New form submission — %s"
 msgstr "Neue Formularübermittlung — %s"
 
 #. translators: %s: page title
-#: src/Services/EmailService.php:1931
+#: src/Services/EmailService.php:1932
 #, php-format
 msgid "Page: %s"
 msgstr "Seite: %s"
 
-#: src/Services/EmailService.php:1959
+#: src/Services/EmailService.php:1960
 msgid "A new form submission has been received."
 msgstr "Eine neue Formularübermittlung wurde empfangen."
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:2140
+#: src/Services/EmailService.php:2141
 #, php-format
 msgid "Your submission — %s"
 msgstr "Ihre Übermittlung — %s"
 
 #. translators: %s: page title
-#: src/Services/EmailService.php:2151
+#: src/Services/EmailService.php:2152
 #, php-format
 msgid "Form: %s"
 msgstr "Formular: %s"
 
-#: src/Services/EmailService.php:2161
+#: src/Services/EmailService.php:2162
 msgid "Here are the answers you submitted:"
 msgstr "Hier sind die Antworten, die Sie eingereicht haben:"
 
-#: src/Services/EmailService.php:2199
+#: src/Services/EmailService.php:2200
 msgid "Thank you for your submission! We have received your response."
 msgstr "Vielen Dank für Ihre Übermittlung! Wir haben Ihre Antwort erhalten."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2257
+#: src/Services/EmailService.php:2260
 #, php-format
 msgid "Signup confirmed — %s"
 msgstr "Anmeldung bestätigt — %s"
 
-#: src/Services/EmailService.php:2269
-#: src/Services/EmailService.php:2419
+#: src/Services/EmailService.php:2333
+#: src/Services/EmailService.php:2387
 #: src/blocks/event-signup/frontend.js:1816
 #: src/blocks/event-signup/frontend.js:1938
 msgid "Amount paid:"
 msgstr "Gezahlter Betrag:"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2344
+#: src/Services/EmailService.php:2309
 #, php-format
 msgid "Your signup for %s has been confirmed and your payment has been received."
 msgstr "Ihre Anmeldung für %s wurde bestätigt und Ihre Zahlung wurde empfangen."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2346
+#: src/Services/EmailService.php:2311
 #, php-format
 msgid "Your signup for %s has been confirmed."
 msgstr "Ihre Anmeldung für %s wurde bestätigt."
@@ -2287,57 +2287,57 @@ msgstr "Teilnehmerdatensatz für dieses Veranstaltungsdatum nicht gefunden."
 msgid "Selected ticket type was not found."
 msgstr "Ausgewählter Tickettyp wurde nicht gefunden."
 
-#: src/API/EventSignupController.php:1458
+#: src/API/EventSignupController.php:1451
 msgid "This ticket type is sold out. Please pick another option."
 msgstr "Dieser Tickettyp ist ausverkauft. Bitte wählen Sie eine andere Option."
 
 #. translators: %d: minimum number of activities required
-#: src/API/EventSignupController.php:1598
-#: src/blocks/event-signup/render.php:753
-#: src/Services/SignupActivities.php:187
+#: src/API/EventSignupController.php:1591
+#: src/blocks/event-signup/render.php:821
+#: src/Services/SignupActivities.php:210
 #: src/blocks/event-signup/frontend.js:391
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d activity to sign up."
 msgid_plural "Please select at least %d activities to sign up."
 msgstr[0] "Bitte wählen Sie mindestens %d Aktivität aus, um sich anzumelden."
 msgstr[1] "Bitte wählen Sie mindestens %d Aktivitäten aus, um sich anzumelden."
 
-#: src/API/EventSignupController.php:2206
+#: src/API/EventSignupController.php:2194
 msgid "Invalid transaction."
 msgstr "Ungültige Transaktion."
 
-#: src/API/EventSignupController.php:2214
+#: src/API/EventSignupController.php:2202
 msgid "Payment plugin is missing."
 msgstr "Zahlungs-Plugin fehlt."
 
-#: src/API/EventSignupController.php:2223
-#: src/API/EventSignupController.php:2288
+#: src/API/EventSignupController.php:2211
+#: src/API/EventSignupController.php:2276
 msgid "Transaction not found."
 msgstr "Transaktion nicht gefunden."
 
-#: src/API/EventSignupController.php:2264
+#: src/API/EventSignupController.php:2252
 msgid "You are not authorized to retry this payment."
 msgstr "Sie sind nicht berechtigt, diese Zahlung erneut zu versuchen."
 
-#: src/API/EventSignupController.php:2300
+#: src/API/EventSignupController.php:2288
 msgid "This payment cannot be retried."
 msgstr "Diese Zahlung kann nicht erneut versucht werden."
 
-#: src/API/EventSignupController.php:2318
+#: src/API/EventSignupController.php:2306
 msgid "This payment is not retriable from this endpoint."
 msgstr "Diese Zahlung kann von diesem Endpunkt aus nicht erneut versucht werden."
 
-#: src/API/EventSignupController.php:2331
-#: src/API/EventSignupController.php:2523
+#: src/API/EventSignupController.php:2319
+#: src/API/EventSignupController.php:2511
 msgid "This payment is missing context needed to retry."
 msgstr "Diese Zahlung fehlt der Kontext, der zum erneuten Versuch erforderlich ist."
 
-#: src/API/EventSignupController.php:2379
-#: src/API/EventSignupController.php:2566
+#: src/API/EventSignupController.php:2367
+#: src/API/EventSignupController.php:2554
 msgid "Original line items could not be loaded."
 msgstr "Originale Positionen konnten nicht geladen werden."
 
-#: src/API/EventSignupController.php:2769
+#: src/API/EventSignupController.php:2757
 #: src/blocks/event-signup/frontend.js:1096
 msgid "We recognise this email — check your inbox to continue."
 msgstr "Wir erkennen diese E-Mail — überprüfen Sie Ihren Posteingang, um fortzufahren."
@@ -2346,134 +2346,134 @@ msgstr "Wir erkennen diese E-Mail — überprüfen Sie Ihren Posteingang, um for
 msgid "You have been subscribed."
 msgstr "Sie wurden abonniert."
 
-#: src/blocks/event-signup/render.php:706
+#: src/blocks/event-signup/render.php:774
 msgid "sold out"
 msgstr "ausverkauft"
 
-#: src/blocks/event-signup/render.php:784
-#: src/blocks/event-signup/render.php:845
-#: src/Hooks/SignupHookBridge.php:544
+#: src/blocks/event-signup/render.php:852
+#: src/blocks/event-signup/render.php:913
+#: src/Hooks/SignupHookBridge.php:567
 msgid "full"
 msgstr "voll"
 
-#: src/blocks/event-signup/render.php:886
+#: src/blocks/event-signup/render.php:954
 msgid "Choose a date"
 msgstr "Wählen Sie ein Datum"
 
 #. translators: appended to a date label when the viewer is signed up — they can cancel from this row
-#: src/blocks/event-signup/render.php:897
+#: src/blocks/event-signup/render.php:965
 msgid "signed up (manage)"
 msgstr "angemeldet (verwalten)"
 
-#: src/blocks/event-signup/render.php:899
+#: src/blocks/event-signup/render.php:967
 msgid "signed up"
 msgstr "angemeldet"
 
-#: src/blocks/event-signup/render.php:1009
+#: src/blocks/event-signup/render.php:1077
 #: src/blocks/event-signup/frontend.js:1809
 msgid "Payment confirmed"
 msgstr "Zahlung bestätigt"
 
 #. translators: %s: event title
-#: src/blocks/event-signup/render.php:1015
+#: src/blocks/event-signup/render.php:1083
 #, php-format
 msgid "You're signed up for %s."
 msgstr "Du bist angemeldet für %s."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1024
+#: src/blocks/event-signup/render.php:1092
 #, php-format
 msgid "Amount paid: %s"
 msgstr "Gezahlter Betrag: %s"
 
-#: src/blocks/event-signup/render.php:1030
+#: src/blocks/event-signup/render.php:1098
 #: src/blocks/event-signup/frontend.js:1823
 msgid "A confirmation email is on its way. You can close this page."
 msgstr "Eine Bestätigungsmail ist unterwegs. Du kannst diese Seite jetzt schließen."
 
-#: src/blocks/event-signup/render.php:1037
+#: src/blocks/event-signup/render.php:1105
 msgid "Thank you for your payment!"
 msgstr "Vielen Dank für deine Zahlung!"
 
-#: src/blocks/event-signup/render.php:1040
+#: src/blocks/event-signup/render.php:1108
 msgid "We're confirming with your bank. This usually takes a few seconds — the page will update as soon as it's done."
 msgstr "Wir bestätigen dies mit deiner Bank. Das dauert normalerweise ein paar Sekunden — die Seite wird aktualisiert, sobald es fertig ist."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1046
+#: src/blocks/event-signup/render.php:1114
 #, php-format
 msgid "Amount: %s"
 msgstr "Betrag: %s"
 
-#: src/blocks/event-signup/render.php:1055
+#: src/blocks/event-signup/render.php:1123
 msgid "Your payment is waiting."
 msgstr "Deine Zahlung wartet."
 
-#: src/blocks/event-signup/render.php:1058
+#: src/blocks/event-signup/render.php:1126
 msgid "You can pick up where you left off on the secure payment page."
 msgstr "Du kannst dort weitermachen, wo du aufgehört hast, auf der sicheren Zahlungsseite."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1064
-#: src/blocks/event-signup/render.php:1091
+#: src/blocks/event-signup/render.php:1132
+#: src/blocks/event-signup/render.php:1159
 #, php-format
 msgid "Amount due: %s"
 msgstr "Fälliger Betrag: %s"
 
-#: src/blocks/event-signup/render.php:1071
+#: src/blocks/event-signup/render.php:1139
 msgid "Continue payment"
 msgstr "Zahlung fortsetzen"
 
-#: src/blocks/event-signup/render.php:1076
-#: src/blocks/event-signup/render.php:1103
+#: src/blocks/event-signup/render.php:1144
+#: src/blocks/event-signup/render.php:1171
 msgid "Cancel and start over"
 msgstr "Abbrechen und von vorne beginnen"
 
-#: src/blocks/event-signup/render.php:1085
+#: src/blocks/event-signup/render.php:1153
 msgid "Your payment didn't go through."
 msgstr "Deine Zahlung ist fehlgeschlagen."
 
-#: src/blocks/event-signup/render.php:1098
+#: src/blocks/event-signup/render.php:1166
 msgid "Retry payment"
 msgstr "Zahlung erneut versuchen"
 
 #. translators: %s: transaction status
-#: src/blocks/event-signup/render.php:1114
+#: src/blocks/event-signup/render.php:1182
 #, php-format
 msgid "Payment status: %s"
 msgstr "Zahlungsstatus: %s"
 
-#: src/blocks/event-signup/render.php:1185
-#: src/Hooks/SignupHookBridge.php:295
+#: src/blocks/event-signup/render.php:1253
+#: src/Hooks/SignupHookBridge.php:315
 msgid "You are signed up for this date."
 msgstr "Du bist für diesen Termin angemeldet."
 
-#: src/Services/EmailService.php:2282
+#: src/Services/EmailService.php:2334
 msgid "Selected options:"
 msgstr "Ausgewählte Optionen:"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2532
+#: src/Services/EmailService.php:2508
 #, php-format
 msgid "Payment didn’t go through — %s"
 msgstr "Zahlung fehlgeschlagen — %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2580
+#: src/Services/EmailService.php:2556
 #, php-format
 msgid "Your payment for %s didn’t go through. Your spot is still held for a short while — pick up where you left off using the link below."
 msgstr "Ihre Zahlung für %s ist fehlgeschlagen. Ihr Platz wird noch kurze Zeit reserviert — setzen Sie fort, wo Sie aufgehört haben, indem Sie den folgenden Link verwenden."
 
-#: src/Services/EmailService.php:2589
+#: src/Services/EmailService.php:2565
 msgid "Resume payment"
 msgstr "Zahlung fortsetzen"
 
-#: src/Services/EmailService.php:2594
+#: src/Services/EmailService.php:2570
 msgid "If the button doesn’t work, copy and paste this link into your browser:"
 msgstr "Wenn die Schaltfläche nicht funktioniert, kopieren Sie diesen Link und fügen Sie ihn in Ihren Browser ein:"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:2601
+#: src/Services/EmailService.php:2577
 #, php-format
 msgid "See you soon,%1$sThe %2$s Team"
 msgstr "Bis bald,%1$sIhr %2$s Team"
@@ -2569,30 +2569,30 @@ msgstr "Fehler beim Upgrade der Teilnehmer-ID %d"
 msgid "Verbal consent recorded by %1$s on %2$s at event %3$s"
 msgstr "Mündliche Zustimmung aufgezeichnet von %1$s am %2$s beim Event %3$s"
 
-#: src/API/EventSignupController.php:1130
+#: src/API/EventSignupController.php:1131
 msgid "You need an active signup before you can add activities."
 msgstr "Sie benötigen eine aktive Anmeldung, bevor Sie Aktivitäten hinzufügen können."
 
-#: src/API/EventSignupController.php:1152
+#: src/API/EventSignupController.php:1153
 msgid "No new activities to add."
 msgstr "Keine neuen Aktivitäten zum Hinzufügen."
 
-#: src/API/EventSignupController.php:1177
+#: src/API/EventSignupController.php:1178
 #: src/blocks/event-signup/frontend.js:1556
 msgid "Your activities have been added!"
 msgstr "Ihre Aktivitäten wurden hinzugefügt!"
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:1258
+#: src/API/EventSignupController.php:1251
 #, php-format
 msgid "Added activities for %s"
 msgstr "Aktivitäten hinzugefügt für %s"
 
-#: src/API/EventSignupController.php:2541
+#: src/API/EventSignupController.php:2529
 msgid "Your signup is no longer active."
 msgstr "Ihre Anmeldung ist nicht mehr aktiv."
 
-#: src/API/EventSignupController.php:2555
+#: src/API/EventSignupController.php:2543
 msgid "These activities are already on your signup."
 msgstr "Diese Aktivitäten befinden sich bereits in Ihrer Anmeldung."
 
@@ -2616,30 +2616,30 @@ msgstr "Bestätigungs-E-Mail versendet."
 msgid "Website"
 msgstr "Website"
 
-#: src/blocks/event-signup/render.php:833
-#: src/blocks/event-signup/render.php:863
-#: src/Hooks/SignupHookBridge.php:523
-#: src/Hooks/SignupHookBridge.php:561
+#: src/blocks/event-signup/render.php:901
+#: src/blocks/event-signup/render.php:931
+#: src/Hooks/SignupHookBridge.php:546
+#: src/Hooks/SignupHookBridge.php:584
 #: src/blocks/event-signup/frontend.js:1466
 msgid "Add activities"
 msgstr "Aktivitäten hinzufügen"
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1140
+#: src/blocks/event-signup/render.php:1208
 #, php-format
 msgid "Hi %s! Here is your registration for this event."
 msgstr "Hallo %s! Hier ist deine Anmeldung für dieses Ereignis."
 
 #. translators: %s: ticket type name
-#: src/blocks/event-signup/render.php:1192
-#: src/Hooks/SignupHookBridge.php:302
+#: src/blocks/event-signup/render.php:1260
+#: src/Hooks/SignupHookBridge.php:322
 #, php-format
 msgid "Your ticket: %s"
 msgstr "Dein Ticket: %s"
 
-#: src/blocks/event-signup/render.php:1200
-#: src/Hooks/SignupHookBridge.php:309
-#: src/Hooks/SignupHookBridge.php:526
+#: src/blocks/event-signup/render.php:1268
+#: src/Hooks/SignupHookBridge.php:329
+#: src/Hooks/SignupHookBridge.php:549
 msgid "Your activities:"
 msgstr "Deine Aktivitäten:"
 
@@ -2661,73 +2661,73 @@ msgid "Unsubscribed"
 msgstr "Abgemeldet"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2407
+#: src/Services/EmailService.php:2375
 #, php-format
 msgid "Activities added — %s"
 msgstr "Aktivitäten hinzugefügt — %s"
 
-#: src/Services/EmailService.php:2432
+#: src/Services/EmailService.php:2400
 msgid "Activities added:"
 msgstr "Aktivitäten hinzugefügt:"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2468
+#: src/Services/EmailService.php:2436
 #, php-format
 msgid "The following activities have been added to your signup for %s."
 msgstr "Die folgenden Aktivitäten wurden deiner Anmeldung für %s hinzugefügt."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2972
+#: src/Services/EmailService.php:2956
 #, php-format
 msgid "Thanks for your interest in %s"
 msgstr "Danke für dein Interesse an %s"
 
-#: src/Services/EmailService.php:2976
-#: src/Services/EmailService.php:3054
+#: src/Services/EmailService.php:2960
+#: src/Services/EmailService.php:3039
 msgid "there"
 msgstr "dort"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:3003
+#: src/Services/EmailService.php:2987
 #, php-format
 msgid "Thanks for registering your interest in %s. We will let you know when there are updates."
 msgstr "Danke, dass Sie Ihr Interesse an %s angemeldet haben. Wir werden Sie benachrichtigen, wenn es Updates gibt."
 
-#: src/Services/EmailService.php:3006
+#: src/Services/EmailService.php:2990
 msgid "If you didn't register your interest, you can safely ignore this email."
 msgstr "Wenn Sie Ihr Interesse nicht angemeldet haben, können Sie diese E-Mail ignorieren."
 
-#: src/Services/EmailService.php:3011
+#: src/Services/EmailService.php:2995
 msgid "No longer interested?"
 msgstr "Nicht mehr interessiert?"
 
-#: src/Services/EmailService.php:3012
+#: src/Services/EmailService.php:2996
 msgid "Unsubscribe from updates about this event"
 msgstr "Abmelden von Updates zu dieser Veranstaltung"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3050
+#: src/Services/EmailService.php:3035
 #, php-format
 msgid "Welcome to the %s mailing list"
 msgstr "Willkommen zur %s-Mailingliste"
 
 #. translators: 1: site name, 2: event title
-#: src/Services/EmailService.php:3059
+#: src/Services/EmailService.php:3044
 #, php-format
 msgid "You've been added to the %1$s mailing list following the consent you gave at %2$s. We'll keep you posted about upcoming events and news."
 msgstr "Sie wurden der %1$s-Mailingliste hinzugefügt, nachdem Sie Ihre Zustimmung bei %2$s erteilt haben. Wir halten Sie über kommende Veranstaltungen und Nachrichten auf dem Laufenden."
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3066
+#: src/Services/EmailService.php:3051
 #, php-format
 msgid "You've been added to the %s mailing list following the consent you gave. We'll keep you posted about upcoming events and news."
 msgstr "Sie wurden der %s-Mailingliste hinzugefügt, nachdem Sie Ihre Zustimmung erteilt haben. Wir halten Sie über kommende Veranstaltungen und Nachrichten auf dem Laufenden."
 
-#: src/Services/EmailService.php:3099
+#: src/Services/EmailService.php:3084
 msgid "Changed your mind?"
 msgstr "Haben Sie Ihre Meinung geändert?"
 
-#: src/Services/EmailService.php:3100
+#: src/Services/EmailService.php:3085
 msgid "Manage your subscription or unsubscribe"
 msgstr "Verwalten Sie Ihr Abonnement oder melden Sie sich ab"
 
@@ -2789,31 +2789,31 @@ msgid "interest"
 msgstr "Interesse"
 
 #: src/API/EventParticipantsController.php:582
-#: src/API/EventSignupController.php:1751
-#: src/Services/EmailService.php:2294
-#: src/blocks/event-signup/editor.js:110
+#: src/API/EventSignupController.php:1746
+#: src/Services/EmailService.php:2296
+#: src/blocks/event-signup/editor.js:114
 msgid "Event Signup"
 msgstr "Ereignisanmeldung"
 
-#: src/Services/EmailService.php:2303
+#: src/Services/EmailService.php:2335
 msgid "Your answers:"
 msgstr "Ihre Antworten:"
 
-#: src/blocks/event-signup/editor.js:128
+#: src/blocks/event-signup/editor.js:132
 msgid "Ticket types, activity options and pricing are rendered on the published page based on the event."
 msgstr "Tickettypen, Aktivitätsoptionen und Preise werden auf der veröffentlichten Seite basierend auf dem Ereignis angezeigt."
 
-#: src/blocks/event-signup/editor.js:134
+#: src/blocks/event-signup/editor.js:138
 msgid "Custom questions"
 msgstr "Benutzerdefinierte Fragen"
 
-#: src/API/EventSignupController.php:1485
+#: src/API/EventSignupController.php:1478
 msgid "This ticket type is no longer available. Please pick another option."
 msgstr "Dieser Tickettyp ist nicht mehr verfügbar. Bitte wählen Sie eine andere Option."
 
 #. translators: 1: discount percentage, 2: group name
-#: src/blocks/event-signup/render.php:663
-#: src/Services/GroupSignupPricing.php:134
+#: src/blocks/event-signup/render.php:720
+#: src/Services/GroupSignupPricing.php:146
 #, php-format
 msgid "%1$s%% discount applied (%2$s)"
 msgstr "%1$s%% Rabatt angewendet (%2$s)"
@@ -2855,59 +2855,59 @@ msgstr "Fehler beim Aufzeichnen der Ablehnung für Teilnehmer-ID %d"
 msgid "Decline recorded by %1$s on %2$s at event %3$s"
 msgstr "Ablehnung aufgezeichnet von %1$s am %2$s bei Veranstaltung %3$s"
 
-#: src/API/EventSignupController.php:805
+#: src/API/EventSignupController.php:806
 msgid "Please select at least one occurrence."
 msgstr "Bitte wählen Sie mindestens ein Vorkommen aus."
 
-#: src/API/EventSignupController.php:813
-#: src/API/EventSignupController.php:824
+#: src/API/EventSignupController.php:814
+#: src/API/EventSignupController.php:825
 msgid "Invalid ticket type."
 msgstr "Ungültiger Tickettyp."
 
-#: src/API/EventSignupController.php:835
+#: src/API/EventSignupController.php:836
 msgid "One of the selected occurrences is not valid for this ticket."
 msgstr "Eines der ausgewählten Vorkommen ist für dieses Ticket nicht gültig."
 
 #. translators: %d: minimum number of occurrences required
-#: src/API/EventSignupController.php:848
+#: src/API/EventSignupController.php:849
 #: src/blocks/event-signup/frontend.js:311
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d occurrence."
 msgid_plural "Please select at least %d occurrences."
 msgstr[0] "Bitte wählen Sie mindestens %d Vorkommen aus."
 msgstr[1] "Bitte wählen Sie mindestens %d Vorkommen aus."
 
-#: src/API/EventSignupController.php:875
+#: src/API/EventSignupController.php:876
 msgid "You are already signed up for these occurrences."
 msgstr "Sie sind bereits für diese Vorkommen angemeldet."
 
-#: src/API/EventSignupController.php:928
+#: src/API/EventSignupController.php:929
+#: src/API/EventSignupController.php:1804
 #: src/API/EventSignupController.php:1816
-#: src/API/EventSignupController.php:1828
-#: src/API/EventSignupController.php:2039
+#: src/API/EventSignupController.php:2027
 msgid "Paid signup is not available because the payment plugin is not configured."
 msgstr "Bezahlte Anmeldung ist nicht verfügbar, da das Zahlungs-Plugin nicht konfiguriert ist."
 
-#: src/API/EventSignupController.php:945
+#: src/API/EventSignupController.php:946
 msgid "One of the selected occurrences is fully booked."
 msgstr "Eines der ausgewählten Vorkommen ist vollständig gebucht."
 
-#: src/API/EventSignupController.php:1239
-#: src/API/EventSignupController.php:1251
+#: src/API/EventSignupController.php:1232
+#: src/API/EventSignupController.php:1244
 msgid "Paid activities are not available because the payment plugin is not configured."
 msgstr "Bezahlte Aktivitäten sind nicht verfügbar, da das Zahlungs-Plugin nicht konfiguriert ist."
 
-#: src/blocks/event-signup/render.php:938
+#: src/blocks/event-signup/render.php:1006
 msgid "Choose occurrences"
 msgstr "Vorkommen auswählen"
 
-#: src/blocks/event-signup/render.php:959
-#: src/Hooks/SignupHookBridge.php:331
+#: src/blocks/event-signup/render.php:1027
+#: src/Hooks/SignupHookBridge.php:351
 msgid "already signed up"
 msgstr "bereits angemeldet"
 
-#: src/blocks/event-signup/render.php:1174
-#: src/blocks/event-signup/render.php:1297
+#: src/blocks/event-signup/render.php:1242
+#: src/blocks/event-signup/render.php:1365
 msgid "Online payment is not available for this event at the moment. Please contact the organiser."
 msgstr "Online-Zahlung ist für diese Veranstaltung derzeit nicht verfügbar. Bitte kontaktieren Sie den Organisator."
 
@@ -2961,18 +2961,18 @@ msgstr "Dieser Link ist ungültig oder abgelaufen."
 msgid "This registration link has expired. Please fill in the form again."
 msgstr "Dieser Registrierungslink ist abgelaufen. Bitte füllen Sie das Formular erneut aus."
 
-#: src/API/EventSignupController.php:2030
+#: src/API/EventSignupController.php:2018
 msgid "Your series pass is now active!"
 msgstr "Ihre Serienpass ist jetzt aktiv!"
 
 #. translators: %s: ticket type name
-#: src/API/EventSignupController.php:2048
+#: src/API/EventSignupController.php:2036
 #, php-format
 msgid "Upgrade to series pass: %s"
 msgstr "Upgrade auf Serienpass: %s"
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:2062
+#: src/API/EventSignupController.php:2050
 #, php-format
 msgid "Series pass upgrade for %s"
 msgstr "Serienpass-Upgrade für %s"
@@ -3005,30 +3005,30 @@ msgid "Sent to %1$d, failed %2$d, skipped %3$d."
 msgstr "Gesendet an %1$d, fehlgeschlagen %2$d, übersprungen %3$d."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:964
+#: src/Services/EmailService.php:965
 #, php-format
 msgid "Continue registering for %s"
 msgstr "Registrierung für %s fortsetzen"
 
-#: src/Services/EmailService.php:969
+#: src/Services/EmailService.php:970
 msgid "Continue to payment"
 msgstr "Zur Zahlung fortfahren"
 
-#: src/Services/EmailService.php:970
+#: src/Services/EmailService.php:971
 msgid "Continue to sign up"
 msgstr "Zur Anmeldung fortfahren"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:1005
+#: src/Services/EmailService.php:1006
 #, php-format
 msgid "You're registering for %s."
 msgstr "Du registrierst dich für %s."
 
-#: src/Services/EmailService.php:1011
+#: src/Services/EmailService.php:1012
 msgid "We've saved your answers — click below to continue where you left off:"
 msgstr "Wir haben deine Antworten gespeichert – klicke unten, um dort weiterzumachen, wo du aufgehört hast:"
 
-#: src/Services/EmailService.php:1021
+#: src/Services/EmailService.php:1022
 msgid "If you didn't try to register, you can safely ignore this email."
 msgstr "Wenn du nicht versucht hast, dich zu registrieren, kannst du diese E-Mail ignorieren."
 
@@ -3616,11 +3616,11 @@ msgstr "Publikum"
 msgid "Outro text"
 msgstr "Outro-Text"
 
-#: src/Services/EmailService.php:153
+#: src/Services/EmailService.php:154
 msgid "Participant has not yet confirmed their marketing subscription."
 msgstr "Der Teilnehmer hat sein Marketing-Abonnement noch nicht bestätigt."
 
-#: src/Services/EmailService.php:2041
+#: src/Services/EmailService.php:2042
 msgid "[Test email — real sends to subscribers include a \"Manage your preferences\" unsubscribe link here.]"
 msgstr "[Test-E-Mail — echte Sendungen an Abonnenten enthalten hier einen \"Ihre Einstellungen verwalten\"-Abmelde-Link.]"
 
@@ -3638,7 +3638,7 @@ msgstr "Optionales HTML, das unter der Liste der Veranstaltungen angezeigt wird.
 msgid "Next digest: %s"
 msgstr "Nächste Zusammenfassung: %s"
 
-#: src/blocks/event-signup/editor.js:103
+#: src/blocks/event-signup/editor.js:107
 msgid "This block has moved to Event Signup (fair-events). Transform it to the new block."
 msgstr "Dieser Block wurde zu Event Signup (fair-events) verschoben. Transformieren Sie ihn zum neuen Block."
 
@@ -3656,10 +3656,11 @@ msgstr "Legacy-Anmeldungsblock. Ersetzt durch Event Signup (fair-events) — tra
 msgid "Reverted to minimal: marketing subscription was never confirmed within a week."
 msgstr "Auf minimal zurückgesetzt: Marketing-Abonnement wurde nicht innerhalb einer Woche bestätigt."
 
-#: src/Services/EmailService.php:161
+#: src/Services/EmailService.php:162
 msgid "Opted out of the weekly summary."
 msgstr "Wöchentliche Zusammenfassung abgemeldet."
 
+#. translators: %s: source host, e.g. "instagram.com".
 #. translators: %s: source domain, e.g. "example.com".
 #: src/Services/WeeklyDigestRenderer.php:165
 #: src/Services/WeeklyDigestRenderer.php:175
@@ -3689,38 +3690,38 @@ msgstr "Abgemeldet"
 msgid "Subscribed"
 msgstr "Abonniert"
 
-#: ../fair-events-shared/src/questionnaire.js:449
+#: ../fair-events-shared/src/questionnaire.js:453
 msgid "Please answer the required question: "
 msgstr "Bitte beantworten Sie die erforderliche Frage: "
 
-#: ../fair-events-shared/src/questionnaire.js:497
+#: ../fair-events-shared/src/questionnaire.js:501
 msgid "Please enter a valid email address for: "
 msgstr "Bitte geben Sie eine gültige E-Mail-Adresse ein für: "
 
-#: ../fair-events-shared/src/questionnaire.js:527
+#: ../fair-events-shared/src/questionnaire.js:616
 msgid "File is too large. Maximum size is "
 msgstr "Datei ist zu groß. Maximale Größe ist "
 
-#: ../fair-events-shared/src/questionnaire.js:472
+#: ../fair-events-shared/src/questionnaire.js:476
 msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
 msgstr "Geben Sie eine gültige Telefonnummer mit Ländervorwahl ein (z. B. +49 170 123 45 67) für: %s"
 
 #. translators: 1: base button label, 2: formatted price
-#: src/blocks/event-signup/render.php:606
-#: src/blocks/event-signup/render.php:612
+#: src/blocks/event-signup/render.php:666
+#: src/blocks/event-signup/render.php:672
 #, php-format
 msgid "%1$s — %2$s"
 msgstr "%1$s — %2$s"
 
 #. translators: 1: discount amount, 2: group name
-#: src/blocks/event-signup/render.php:670
-#: src/Services/GroupSignupPricing.php:142
+#: src/blocks/event-signup/render.php:727
+#: src/Services/GroupSignupPricing.php:154
 #, php-format
 msgid "%1$s discount applied (%2$s)"
 msgstr "%1$s Rabatt angewendet (%2$s)"
 
 #. translators: %s: formatted add-on price
-#: src/blocks/event-signup/render.php:810
+#: src/blocks/event-signup/render.php:878
 #, php-format
 msgid "(+%s)"
 msgstr "(+%s)"
@@ -3735,18 +3736,47 @@ msgstr "Gesamt: %s"
 msgid "Translations"
 msgstr "Übersetzungen"
 
-#: src/Hooks/SignupHookBridge.php:244
+#: src/Hooks/SignupHookBridge.php:263
 msgid "You already have a ticket for this date."
 msgstr "Sie haben bereits ein Ticket für dieses Datum."
 
-#: src/Services/SignupActivities.php:145
-#: src/Services/SignupActivities.php:164
+#: src/Services/SignupActivities.php:168
+#: src/Services/SignupActivities.php:187
 msgid "One of the selected activities is not available for this event."
 msgstr "Eine der ausgewählten Aktivitäten ist für diese Veranstaltung nicht verfügbar."
 
 #. translators: %s: activity name
-#: src/Services/SignupActivities.php:173
+#: src/Services/SignupActivities.php:196
 #, php-format
 msgid "\"%s\" is full."
 msgstr "\"%s\" ist voll."
 
+#. translators: 1: discount magnitude e.g. "20%" or "€5.00", 2: group name
+#: src/blocks/event-signup/render.php:768
+#, php-format
+msgid "%1$s off · %2$s"
+msgstr ""
+
+#: src/Services/EmailService.php:2330
+msgid "Event date:"
+msgstr ""
+
+#: src/Services/EmailService.php:2331
+msgid "Registration reference:"
+msgstr ""
+
+#: src/Services/EmailService.php:2332
+msgid "Ticket type:"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:537
+msgid "Please enter a valid web address for: %s"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:561
+msgid "Please enter a valid date for: %s"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:585
+msgid "Please enter a valid date and time for: %s"
+msgstr ""

--- a/fair-audience/languages/fair-audience-es_ES.po
+++ b/fair-audience/languages/fair-audience-es_ES.po
@@ -64,16 +64,16 @@ msgstr "Participantes del Evento"
 #: src/API/EventParticipantsController.php:1468
 #: src/API/EventSignupController.php:468
 #: src/API/EventSignupController.php:613
-#: src/API/EventSignupController.php:1080
-#: src/API/EventSignupController.php:2137
-#: src/API/EventSignupController.php:2340
-#: src/API/EventSignupController.php:2532
-#: src/API/EventSignupController.php:2660
-#: src/API/EventSignupController.php:2960
-#: src/Services/EmailService.php:336
-#: src/Services/EmailService.php:560
-#: src/Services/EmailService.php:1400
-#: src/Services/EmailService.php:2816
+#: src/API/EventSignupController.php:1081
+#: src/API/EventSignupController.php:2125
+#: src/API/EventSignupController.php:2328
+#: src/API/EventSignupController.php:2520
+#: src/API/EventSignupController.php:2648
+#: src/API/EventSignupController.php:2949
+#: src/Services/EmailService.php:337
+#: src/Services/EmailService.php:561
+#: src/Services/EmailService.php:1401
+#: src/Services/EmailService.php:2792
 msgid "Event not found."
 msgstr "Evento no encontrado."
 
@@ -85,11 +85,11 @@ msgstr "Evento no encontrado."
 #: src/API/ParticipantsController.php:729
 #: src/API/ParticipantsController.php:762
 #: src/API/ParticipantsController.php:789
-#: src/Services/EmailService.php:360
-#: src/Services/EmailService.php:583
-#: src/Services/EmailService.php:1439
-#: src/Services/EmailService.php:1829
-#: src/Services/EmailService.php:2891
+#: src/Services/EmailService.php:361
+#: src/Services/EmailService.php:584
+#: src/Services/EmailService.php:1440
+#: src/Services/EmailService.php:1830
+#: src/Services/EmailService.php:2867
 #: src/Admin/participant-detail/ParticipantDetail.js:86
 msgid "Participant not found."
 msgstr "Participante no encontrado."
@@ -164,7 +164,7 @@ msgid "Add Participant"
 msgstr "Agregar Participante"
 
 #: src/blocks/event-interest/render.php:135
-#: src/Services/EmailService.php:1916
+#: src/Services/EmailService.php:1917
 #: src/Admin/all-participants/AllParticipants.js:93
 #: src/Admin/event-participants/EventParticipants.js:629
 #: src/Admin/manage-event-audience-tab/EventAudience.js:892
@@ -175,14 +175,14 @@ msgstr "Nombre"
 
 #: src/blocks/audience-signup/render.php:217
 #: src/blocks/event-interest/render.php:122
-#: src/blocks/event-signup/render.php:1265
-#: src/blocks/event-signup/render.php:1320
+#: src/blocks/event-signup/render.php:1333
+#: src/blocks/event-signup/render.php:1388
 #: src/blocks/mailing-signup/render.php:125
-#: src/Services/EmailService.php:1920
+#: src/Services/EmailService.php:1921
 #: src/Admin/all-participants/AllParticipants.js:108
 #: src/Admin/components/ParticipantEditModal.js:177
 #: src/Admin/participant-detail/ParticipantDetail.js:190
-#: src/blocks/event-signup/editor.js:123
+#: src/blocks/event-signup/editor.js:127
 msgid "Email"
 msgstr "Correo electrónico"
 
@@ -271,9 +271,9 @@ msgstr "Eliminar"
 msgid "Events"
 msgstr "Eventos"
 
-#: src/Services/EmailService.php:2253
-#: src/Services/EmailService.php:2403
-#: src/Services/EmailService.php:2525
+#: src/Services/EmailService.php:2256
+#: src/Services/EmailService.php:2363
+#: src/Services/EmailService.php:2493
 #: src/Admin/events-list/EventsList.js:37
 #: src/Admin/manage-event-audience-tab/EventAudience.js:778
 #: src/Admin/participant-detail/ParticipantDetail.js:271
@@ -281,7 +281,7 @@ msgstr "Eventos"
 msgid "Event"
 msgstr "Evento"
 
-#: src/Services/EmailService.php:325
+#: src/Services/EmailService.php:326
 msgid "Poll not found."
 msgstr "Encuesta no encontrada."
 
@@ -292,87 +292,87 @@ msgid "Invalid event ID."
 msgstr "ID de evento no válido."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:210
+#: src/Services/EmailService.php:211
 #, php-format
 msgid "Quick question about %s"
 msgstr "Pregunta rápida sobre %s"
 
 #. translators: %s: participant first name
-#: src/Services/EmailService.php:239
-#: src/Services/EmailService.php:446
-#: src/Services/EmailService.php:666
-#: src/Services/EmailService.php:774
-#: src/Services/EmailService.php:875
-#: src/Services/EmailService.php:997
-#: src/Services/EmailService.php:1159
-#: src/Services/EmailService.php:1334
-#: src/Services/EmailService.php:1604
-#: src/Services/EmailService.php:1709
-#: src/Services/EmailService.php:2193
-#: src/Services/EmailService.php:2335
-#: src/Services/EmailService.php:2460
-#: src/Services/EmailService.php:2572
-#: src/Services/EmailService.php:2709
-#: src/Services/EmailService.php:2998
-#: src/Services/EmailService.php:3091
+#: src/Services/EmailService.php:240
+#: src/Services/EmailService.php:447
+#: src/Services/EmailService.php:667
+#: src/Services/EmailService.php:775
+#: src/Services/EmailService.php:876
+#: src/Services/EmailService.php:998
+#: src/Services/EmailService.php:1160
+#: src/Services/EmailService.php:1335
+#: src/Services/EmailService.php:1605
+#: src/Services/EmailService.php:1710
+#: src/Services/EmailService.php:2194
+#: src/Services/EmailService.php:2328
+#: src/Services/EmailService.php:2428
+#: src/Services/EmailService.php:2548
+#: src/Services/EmailService.php:2685
+#: src/Services/EmailService.php:2982
+#: src/Services/EmailService.php:3076
 #: src/Admin/event-participants/EventParticipants.js:1192
-#, php-format, js-format
+#, php-format,js-format
 msgid "Hi %s,"
 msgstr "Hola %s,"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:247
+#: src/Services/EmailService.php:248
 #, php-format
 msgid "We'd love to hear from you about %s!"
 msgstr "¡Nos encantaría saber tu opinión sobre %s!"
 
-#: src/Services/EmailService.php:261
+#: src/Services/EmailService.php:262
 msgid "Please take a moment to answer our quick poll:"
 msgstr "Por favor, tómate un momento para responder nuestra breve encuesta:"
 
-#: src/Services/EmailService.php:266
+#: src/Services/EmailService.php:267
 msgid "Answer Poll"
 msgstr "Responder Encuesta"
 
 #. translators: 1: line break, 2: site name
-#: src/Services/EmailService.php:273
-#: src/Services/EmailService.php:498
-#: src/Services/EmailService.php:692
-#: src/Services/EmailService.php:796
-#: src/Services/EmailService.php:905
-#: src/Services/EmailService.php:1027
-#: src/Services/EmailService.php:1169
-#: src/Services/EmailService.php:1346
-#: src/Services/EmailService.php:1616
-#: src/Services/EmailService.php:1754
-#: src/Services/EmailService.php:2209
+#: src/Services/EmailService.php:274
+#: src/Services/EmailService.php:499
+#: src/Services/EmailService.php:693
+#: src/Services/EmailService.php:797
+#: src/Services/EmailService.php:906
+#: src/Services/EmailService.php:1028
+#: src/Services/EmailService.php:1170
+#: src/Services/EmailService.php:1347
+#: src/Services/EmailService.php:1617
+#: src/Services/EmailService.php:1755
+#: src/Services/EmailService.php:2210
 #, php-format
 msgid "Thanks,%1$sThe %2$s Team"
 msgstr "Gracias,%1$sEl equipo de %2$s"
 
-#: src/Services/EmailService.php:285
-#: src/Services/EmailService.php:510
-#: src/Services/EmailService.php:704
-#: src/Services/EmailService.php:808
-#: src/Services/EmailService.php:917
-#: src/Services/EmailService.php:1039
-#: src/Services/EmailService.php:1769
-#: src/Services/EmailService.php:2755
+#: src/Services/EmailService.php:286
+#: src/Services/EmailService.php:511
+#: src/Services/EmailService.php:705
+#: src/Services/EmailService.php:809
+#: src/Services/EmailService.php:918
+#: src/Services/EmailService.php:1040
+#: src/Services/EmailService.php:1770
+#: src/Services/EmailService.php:2731
 msgid "If the button above doesn't work, copy and paste this link:"
 msgstr "Si el botón de arriba no funciona, copia y pega este enlace:"
 
-#: src/Services/EmailService.php:387
-#: src/Services/EmailService.php:609
-#: src/Services/EmailService.php:1472
-#: src/Services/EmailService.php:1549
-#: src/Services/EmailService.php:1864
-#: src/Services/EmailService.php:2927
+#: src/Services/EmailService.php:388
+#: src/Services/EmailService.php:610
+#: src/Services/EmailService.php:1473
+#: src/Services/EmailService.php:1550
+#: src/Services/EmailService.php:1865
+#: src/Services/EmailService.php:2903
 msgid "wp_mail() failed to send."
 msgstr "wp_mail() no pudo enviar."
 
-#: src/blocks/event-signup/render.php:1253
+#: src/blocks/event-signup/render.php:1321
 #: src/Admin/components/ParticipantEditModal.js:170
-#: src/blocks/event-signup/editor.js:119
+#: src/blocks/event-signup/editor.js:123
 msgid "Surname"
 msgstr "Apellido"
 
@@ -470,16 +470,16 @@ msgstr "ID de participante %d no encontrado"
 
 #: src/API/AudienceSignupController.php:204
 #: src/API/EventInterestController.php:156
-#: src/API/EventSignupController.php:2146
-#: src/API/EventSignupController.php:2678
+#: src/API/EventSignupController.php:2134
+#: src/API/EventSignupController.php:2666
 #: src/API/MailingSignupController.php:172
 msgid "Please enter a valid email address."
 msgstr "Por favor, introduzca una dirección de correo electrónico válida."
 
 #: src/API/AudienceSignupController.php:223
 #: src/API/EventInterestController.php:182
-#: src/API/EventSignupController.php:2155
-#: src/API/EventSignupController.php:2717
+#: src/API/EventSignupController.php:2143
+#: src/API/EventSignupController.php:2705
 #: src/API/MailingSignupController.php:192
 msgid "Too many requests. Please try again later."
 msgstr "Demasiadas solicitudes. Inténtelo de nuevo más tarde."
@@ -536,14 +536,14 @@ msgid "Subscribe"
 msgstr "Suscribirse"
 
 #: src/blocks/audience-signup/render.php:192
-#: src/blocks/event-signup/render.php:1240
+#: src/blocks/event-signup/render.php:1308
 #: src/blocks/mailing-signup/render.php:99
-#: src/blocks/event-signup/editor.js:115
+#: src/blocks/event-signup/editor.js:119
 msgid "First Name"
 msgstr "Nombre"
 
 #: src/blocks/audience-signup/render.php:199
-#: src/blocks/event-signup/render.php:1247
+#: src/blocks/event-signup/render.php:1315
 #: src/blocks/mailing-signup/render.php:106
 msgid "Enter your first name"
 msgstr "Introduce tu nombre"
@@ -559,54 +559,54 @@ msgid "Enter your last name"
 msgstr "Introduce tu apellido"
 
 #: src/blocks/audience-signup/render.php:224
-#: src/blocks/event-signup/render.php:1272
-#: src/blocks/event-signup/render.php:1327
+#: src/blocks/event-signup/render.php:1340
+#: src/blocks/event-signup/render.php:1395
 #: src/blocks/mailing-signup/render.php:132
 msgid "Enter your email"
 msgstr "Introduce tu correo electrónico"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:417
+#: src/Services/EmailService.php:418
 #, php-format
 msgid "Photos from %s are ready!"
 msgstr "¡Las fotos de %s están listas!"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:454
+#: src/Services/EmailService.php:455
 #: src/Admin/event-participants/EventParticipants.js:1204
-#, php-format, js-format
+#, php-format,js-format
 msgid "The photos from %s are now available for you to view and like!"
 msgstr "¡Las fotos de %s ya están disponibles para que las veas y te gusten!"
 
-#: src/Services/EmailService.php:468
+#: src/Services/EmailService.php:469
 #: src/Admin/event-participants/EventParticipants.js:1217
 msgid "Click the button below to browse the gallery and let us know which photos you like best:"
 msgstr "Haz clic en el botón de abajo para navegar por la galería y decirnos qué fotos te gustan más:"
 
-#: src/Services/EmailService.php:473
+#: src/Services/EmailService.php:474
 #: src/Admin/event-participants/EventParticipants.js:1239
 msgid "View Gallery"
 msgstr "Ver Galería"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:637
+#: src/Services/EmailService.php:638
 #, php-format
 msgid "Confirm your subscription to %s"
 msgstr "Confirma tu suscripción a %s"
 
-#: src/Services/EmailService.php:672
+#: src/Services/EmailService.php:673
 msgid "Thank you for signing up for our mailing list! Please confirm your email address by clicking the button below."
 msgstr "¡Gracias por suscribirte a nuestra lista de correo! Por favor, confirma tu dirección de correo electrónico haciendo clic en el botón de abajo."
 
-#: src/Services/EmailService.php:677
+#: src/Services/EmailService.php:678
 msgid "Confirm Email"
 msgstr "Confirmar Correo"
 
-#: src/Services/EmailService.php:682
+#: src/Services/EmailService.php:683
 msgid "This link will expire in 48 hours."
 msgstr "Este enlace caducará en 48 horas."
 
-#: src/Services/EmailService.php:686
+#: src/Services/EmailService.php:687
 msgid "If you didn't sign up for this mailing list, you can safely ignore this email."
 msgstr "Si no te has suscrito a esta lista de correo, puedes ignorar este correo electrónico de forma segura."
 
@@ -714,7 +714,7 @@ msgstr "Agregar %d seleccionado(s)"
 
 #: src/blocks/audience-signup/editor.js:35
 #: src/blocks/event-interest/editor.js:26
-#: src/blocks/event-signup/editor.js:85
+#: src/blocks/event-signup/editor.js:89
 #: src/blocks/mailing-signup/editor.js:65
 msgid "Form Settings"
 msgstr "Configuración del Formulario"
@@ -901,38 +901,38 @@ msgid "You must be logged in or have a valid signup link."
 msgstr "Debe iniciar sesión o tener un enlace de registro válido."
 
 #: src/API/EventSignupController.php:642
-#: src/API/EventSignupController.php:1108
-#: src/API/EventSignupController.php:2989
+#: src/API/EventSignupController.php:1109
+#: src/API/EventSignupController.php:2978
 msgid "Could not find your participant profile."
 msgstr "No se pudo encontrar su perfil de participante."
 
 #: src/API/EventSignupController.php:726
-#: src/API/EventSignupController.php:2368
-#: src/API/EventSignupController.php:2794
+#: src/API/EventSignupController.php:2356
+#: src/API/EventSignupController.php:2782
 msgid "You are already signed up for this event."
 msgstr "Ya está inscrito en este evento."
 
-#: src/API/EventSignupController.php:776
-#: src/API/EventSignupController.php:918
+#: src/API/EventSignupController.php:777
+#: src/API/EventSignupController.php:919
 #: src/blocks/event-signup/render.php:66
 #: src/blocks/event-signup/frontend.js:961
 #: src/blocks/event-signup/frontend.js:1271
 msgid "You have successfully signed up for the event!"
 msgstr "¡Se ha inscrito exitosamente en el evento!"
 
-#: src/API/EventSignupController.php:2187
+#: src/API/EventSignupController.php:2175
 msgid "If your email is in our system, you will receive a signup link shortly. Please check your inbox."
 msgstr "Si su correo electrónico está en nuestro sistema, recibirá un enlace de registro pronto. Por favor, revise su bandeja de entrada."
 
-#: src/API/EventSignupController.php:2687
+#: src/API/EventSignupController.php:2675
 msgid "Please enter your name."
 msgstr "Por favor, ingrese su nombre."
 
-#: src/API/EventSignupController.php:2821
+#: src/API/EventSignupController.php:2809
 msgid "Failed to process registration. Please try again."
 msgstr "No se pudo procesar el registro. Intente de nuevo."
 
-#: src/API/EventSignupController.php:2938
+#: src/API/EventSignupController.php:2927
 msgid "You have successfully registered and signed up for the event!"
 msgstr "¡Se ha registrado e inscrito exitosamente en el evento!"
 
@@ -947,8 +947,8 @@ msgid "This WordPress user is already linked to another participant."
 msgstr "Este usuario de WordPress ya está vinculado a otro participante."
 
 #: src/blocks/event-signup/render.php:63
-#: src/blocks/event-signup/render.php:969
-#: src/blocks/event-signup/editor.js:92
+#: src/blocks/event-signup/render.php:1037
+#: src/blocks/event-signup/editor.js:96
 #: src/blocks/event-signup/frontend.js:472
 #: src/blocks/event-signup/frontend.js:506
 #: src/blocks/event-signup/frontend.js:1692
@@ -956,8 +956,8 @@ msgid "Sign Up"
 msgstr "Inscribirse"
 
 #: src/blocks/event-signup/render.php:64
-#: src/blocks/event-signup/render.php:970
-#: src/blocks/event-signup/editor.js:143
+#: src/blocks/event-signup/render.php:1038
+#: src/blocks/event-signup/editor.js:147
 #: src/blocks/event-signup/frontend.js:475
 #: src/blocks/event-signup/frontend.js:509
 msgid "Register & Sign Up"
@@ -968,72 +968,72 @@ msgid "Send Signup Link"
 msgstr "Enviar enlace de inscripción"
 
 #: src/blocks/event-interest/render.php:115
-#: src/blocks/event-signup/render.php:997
+#: src/blocks/event-signup/render.php:1065
 msgid "This block can only be used on event pages."
 msgstr "Este bloque solo se puede usar en páginas de eventos."
 
-#: src/blocks/event-signup/render.php:1125
+#: src/blocks/event-signup/render.php:1193
 #: src/blocks/event-signup/frontend.js:1140
 #: src/blocks/event-signup/frontend.js:1403
 msgid "You are signed up for this event!"
 msgstr "¡Estás inscrito en este evento!"
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1146
+#: src/blocks/event-signup/render.php:1214
 #, php-format
 msgid "Hi %s! Click the button below to sign up for this event."
 msgstr "¡Hola %s! Haz clic en el botón de abajo para inscribirte en este evento."
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1152
+#: src/blocks/event-signup/render.php:1220
 #: src/blocks/event-signup/frontend.js:1671
-#, php-format, js-format
+#, php-format,js-format
 msgid "Hi %s! You can sign up for this event."
 msgstr "¡Hola %s! Puedes inscribirte en este evento."
 
-#: src/blocks/event-signup/render.php:1225
+#: src/blocks/event-signup/render.php:1293
 msgid "I'm new"
 msgstr "Soy nuevo"
 
-#: src/blocks/event-signup/render.php:1228
+#: src/blocks/event-signup/render.php:1296
 msgid "I have an account"
 msgstr "Tengo una cuenta"
 
-#: src/blocks/event-signup/render.php:1259
+#: src/blocks/event-signup/render.php:1327
 msgid "Enter your surname"
 msgstr "Introduce tu apellido"
 
 #: src/blocks/audience-signup/render.php:386
-#: src/blocks/event-signup/render.php:1279
+#: src/blocks/event-signup/render.php:1347
 msgid "Keep me informed about future events"
 msgstr "Manténgame informado sobre futuros eventos"
 
-#: src/blocks/event-signup/render.php:1316
+#: src/blocks/event-signup/render.php:1384
 msgid "Enter your email to receive a signup link."
 msgstr "Ingrese su correo electrónico para recibir un enlace de registro."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:846
+#: src/Services/EmailService.php:847
 #, php-format
 msgid "Sign up for %s"
 msgstr "Regístrese para %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:883
+#: src/Services/EmailService.php:884
 #, php-format
 msgid "You requested a signup link for %s."
 msgstr "Ha solicitado un enlace de registro para %s."
 
-#: src/Services/EmailService.php:889
+#: src/Services/EmailService.php:890
 msgid "Click the button below to sign up for the event:"
 msgstr "Haga clic en el botón de abajo para registrarse en el evento:"
 
-#: src/Services/EmailService.php:894
-#: src/Services/EmailService.php:2736
+#: src/Services/EmailService.php:895
+#: src/Services/EmailService.php:2712
 msgid "Sign Up Now"
 msgstr "Registrarse Ahora"
 
-#: src/Services/EmailService.php:899
+#: src/Services/EmailService.php:900
 msgid "If you didn't request this link, you can safely ignore this email."
 msgstr "Si no solicitó este enlace, puede ignorar este correo electrónico sin problemas."
 
@@ -1085,11 +1085,11 @@ msgstr "No se encontraron usuarios."
 msgid "Role"
 msgstr "Rol"
 
-#: src/blocks/event-signup/editor.js:87
+#: src/blocks/event-signup/editor.js:91
 msgid "Signup Button Text"
 msgstr "Texto del botón de registro"
 
-#: src/blocks/event-signup/editor.js:93
+#: src/blocks/event-signup/editor.js:97
 msgid "Button text for authenticated users."
 msgstr "Texto del botón para usuarios autenticados."
 
@@ -1193,26 +1193,26 @@ msgctxt "block keyword"
 msgid "list"
 msgstr "lista"
 
-#: src/Services/EmailService.php:923
-#: src/Services/EmailService.php:1045
-#: src/Services/EmailService.php:2761
+#: src/Services/EmailService.php:924
+#: src/Services/EmailService.php:1046
+#: src/Services/EmailService.php:2737
 msgid "Don't want to receive event invitations?"
 msgstr "¿No quiere recibir invitaciones de eventos?"
 
-#: src/Services/EmailService.php:924
-#: src/Services/EmailService.php:1046
-#: src/Services/EmailService.php:1180
-#: src/Services/EmailService.php:1359
-#: src/Services/EmailService.php:1629
-#: src/Services/EmailService.php:2762
+#: src/Services/EmailService.php:925
+#: src/Services/EmailService.php:1047
+#: src/Services/EmailService.php:1181
+#: src/Services/EmailService.php:1360
+#: src/Services/EmailService.php:1630
+#: src/Services/EmailService.php:2738
 msgid "Manage your preferences"
 msgstr "Administre sus preferencias"
 
-#: src/Services/EmailService.php:2879
+#: src/Services/EmailService.php:2855
 msgid "Already signed up"
 msgstr "Ya inscrito"
 
-#: src/Services/EmailService.php:164
+#: src/Services/EmailService.php:165
 msgid "Participant opted out of marketing emails."
 msgstr "El participante ha optado por no recibir correos electrónicos de marketing."
 
@@ -1324,7 +1324,7 @@ msgstr "Configuración"
 msgid "Event date not found."
 msgstr "Fecha del evento no encontrada."
 
-#: src/Services/EmailService.php:1815
+#: src/Services/EmailService.php:1816
 msgid "Fee not found."
 msgstr "Tarifa no encontrada."
 
@@ -1332,12 +1332,12 @@ msgstr "Tarifa no encontrada."
 msgid "Could not read SVG file."
 msgstr "No se pudo leer el archivo SVG."
 
-#: src/Hooks/PaymentHooks.php:819
+#: src/Hooks/PaymentHooks.php:832
 msgid "Paid online via Mollie"
 msgstr "Pagado en línea a través de Mollie"
 
 #. translators: %1$s: Mollie status, %2$d: transaction ID
-#: src/Hooks/PaymentHooks.php:863
+#: src/Hooks/PaymentHooks.php:876
 #, php-format
 msgid "Online payment %1$s (transaction #%2$d)"
 msgstr "Pago en línea %1$s (transacción #%2$d)"
@@ -1350,50 +1350,50 @@ msgstr "No está permitido cargar archivos SVG."
 msgid "Invalid SVG file."
 msgstr "Archivo SVG no válido."
 
-#: src/Services/EmailService.php:369
-#: src/Services/EmailService.php:592
-#: src/Services/EmailService.php:1448
-#: src/Services/EmailService.php:1525
-#: src/Services/EmailService.php:1838
-#: src/Services/EmailService.php:2900
+#: src/Services/EmailService.php:370
+#: src/Services/EmailService.php:593
+#: src/Services/EmailService.php:1449
+#: src/Services/EmailService.php:1526
+#: src/Services/EmailService.php:1839
+#: src/Services/EmailService.php:2876
 msgid "Participant has no email address."
 msgstr "El participante no tiene dirección de correo electrónico."
 
-#: src/Services/EmailService.php:1179
-#: src/Services/EmailService.php:1358
-#: src/Services/EmailService.php:1628
+#: src/Services/EmailService.php:1180
+#: src/Services/EmailService.php:1359
+#: src/Services/EmailService.php:1629
 msgid "Don't want to receive these emails?"
 msgstr "¿No desea recibir estos correos electrónicos?"
 
-#: src/Services/EmailService.php:1428
-#: src/Services/EmailService.php:1516
+#: src/Services/EmailService.php:1429
+#: src/Services/EmailService.php:1517
 msgid "Manually skipped."
 msgstr "Omitido manualmente."
 
 #. translators: %s: fee name
-#: src/Services/EmailService.php:1680
+#: src/Services/EmailService.php:1681
 #, php-format
 msgid "Payment reminder: %s"
 msgstr "Recordatorio de pago: %s"
 
-#: src/Services/EmailService.php:1715
+#: src/Services/EmailService.php:1716
 msgid "This is a friendly reminder about a pending payment:"
 msgstr "Este es un recordatorio amistoso sobre un pago pendiente:"
 
-#: src/Services/EmailService.php:1720
+#: src/Services/EmailService.php:1721
 msgid "Fee:"
 msgstr "Tarifa:"
 
-#: src/Services/EmailService.php:1724
-#: src/Services/EmailService.php:2544
+#: src/Services/EmailService.php:1725
+#: src/Services/EmailService.php:2520
 msgid "Amount:"
 msgstr "Cantidad:"
 
-#: src/Services/EmailService.php:1731
+#: src/Services/EmailService.php:1732
 msgid "Due Date:"
 msgstr "Fecha de vencimiento:"
 
-#: src/Services/EmailService.php:1745
+#: src/Services/EmailService.php:1746
 msgid "Pay Now"
 msgstr "Pagar ahora"
 
@@ -1737,7 +1737,7 @@ msgstr "¡Te has registrado correctamente!"
 msgid "Audience Signup"
 msgstr "Registro de Audiencia"
 
-#: src/API/EventSignupController.php:2929
+#: src/API/EventSignupController.php:2918
 msgid "You have been signed up for the event! Please check your email to confirm your subscription."
 msgstr "¡Te has inscrito en el evento! Por favor, revisa tu correo electrónico para confirmar tu suscripción."
 
@@ -1758,39 +1758,39 @@ msgid "Update Answers"
 msgstr "Actualizar Respuestas"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:743
+#: src/Services/EmailService.php:744
 #, php-format
 msgid "Your signup answers — %s"
 msgstr "Tus respuestas de inscripción — %s"
 
-#: src/Services/EmailService.php:780
+#: src/Services/EmailService.php:781
 msgid "Thank you for signing up! Here are the answers you submitted:"
 msgstr "¡Gracias por inscribirte! Aquí están las respuestas que enviaste:"
 
-#: src/Services/EmailService.php:789
+#: src/Services/EmailService.php:790
 msgid "Edit Your Answers"
 msgstr "Editar Tus Respuestas"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2680
+#: src/Services/EmailService.php:2656
 #, php-format
 msgid "You're invited: %s"
 msgstr "Estás invitado: %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2717
+#: src/Services/EmailService.php:2693
 #, php-format
 msgid "We have a new event coming up: %s."
 msgstr "Tenemos un nuevo evento próximo: %s."
 
-#: src/Services/EmailService.php:2731
+#: src/Services/EmailService.php:2707
 msgid "Would you like to join? Click the button below to sign up:"
 msgstr "¿Te gustaría participar? Haz clic en el botón de abajo para inscribirte:"
 
 #. translators: 1: line break, 2: site name
-#: src/Services/EmailService.php:2360
-#: src/Services/EmailService.php:2480
-#: src/Services/EmailService.php:2743
+#: src/Services/EmailService.php:2337
+#: src/Services/EmailService.php:2448
+#: src/Services/EmailService.php:2719
 #, php-format
 msgid "See you there!%1$sThe %2$s Team"
 msgstr "¡Nos vemos allí!%1$sEl equipo de %2$s"
@@ -1944,17 +1944,17 @@ msgctxt "block keyword"
 msgid "member"
 msgstr "miembro"
 
-#: src/API/EventSignupController.php:3010
+#: src/API/EventSignupController.php:2999
 msgid "You are not signed up for this event."
 msgstr "No estás registrado para este evento."
 
-#: src/API/EventSignupController.php:3026
+#: src/API/EventSignupController.php:3015
 #: src/blocks/event-signup/frontend.js:1640
 msgid "You have been removed from this event."
 msgstr "Has sido eliminado de este evento."
 
-#: src/blocks/event-signup/render.php:1211
-#: src/Hooks/SignupHookBridge.php:342
+#: src/blocks/event-signup/render.php:1279
+#: src/Hooks/SignupHookBridge.php:362
 #: src/Admin/manage-event-audience-tab/EventAudience.js:2369
 #: src/blocks/event-signup/frontend.js:1411
 msgid "Cancel signup"
@@ -1974,9 +1974,9 @@ msgstr "No se encontró fecha de evento para este evento"
 
 #: src/blocks/audience-signup/render.php:393
 #: src/blocks/event-interest/render.php:161
-#: src/blocks/event-signup/render.php:1291
+#: src/blocks/event-signup/render.php:1359
 #: src/blocks/mailing-signup/render.php:156
-#: src/Hooks/SignupHookBridge.php:369
+#: src/Hooks/SignupHookBridge.php:390
 msgid "Not you? Start fresh"
 msgstr "¿No eres tú? Empezar de nuevo"
 
@@ -2075,60 +2075,60 @@ msgstr "Ver archivo"
 msgid "Failed to update attendance."
 msgstr "Error al actualizar la asistencia."
 
-#: src/API/EventSignupController.php:1355
+#: src/API/EventSignupController.php:1348
 #: src/Services/GroupSignupPricing.php:113
 msgid "This ticket type is not available for your account."
 msgstr "Este tipo de entrada no está disponible para tu cuenta."
 
-#: src/API/EventSignupController.php:1841
+#: src/API/EventSignupController.php:1829
 msgid "This event is fully booked."
 msgstr "Este evento está completamente reservado."
 
 #. translators: %s: event title or occurrence date/time label
-#: src/API/EventSignupController.php:984
-#: src/API/EventSignupController.php:998
-#: src/API/EventSignupController.php:1873
+#: src/API/EventSignupController.php:985
+#: src/API/EventSignupController.php:999
+#: src/API/EventSignupController.php:1861
 #, php-format
 msgid "Signup for %s"
 msgstr "Registro para %s"
 
-#: src/API/EventSignupController.php:1051
-#: src/API/EventSignupController.php:1317
-#: src/API/EventSignupController.php:1965
-#: src/API/EventSignupController.php:2112
-#: src/API/EventSignupController.php:2489
-#: src/API/EventSignupController.php:2630
+#: src/API/EventSignupController.php:1052
+#: src/API/EventSignupController.php:1310
+#: src/API/EventSignupController.php:1953
+#: src/API/EventSignupController.php:2100
+#: src/API/EventSignupController.php:2477
+#: src/API/EventSignupController.php:2618
 #: src/blocks/event-signup/frontend.js:1080
 #: src/blocks/event-signup/frontend.js:1362
 msgid "Redirecting to payment…"
 msgstr "Redirigiendo al pago…"
 
-#: src/blocks/event-signup/render.php:617
+#: src/blocks/event-signup/render.php:677
 #: src/blocks/event-signup/frontend.js:537
 msgid "Sign up for free"
 msgstr "Regístrate gratis"
 
-#: src/blocks/event-signup/render.php:618
+#: src/blocks/event-signup/render.php:678
 #: src/blocks/event-signup/frontend.js:538
 msgid "Register for free"
 msgstr "Regístrate gratis"
 
-#: src/blocks/event-signup/render.php:691
+#: src/blocks/event-signup/render.php:748
 msgid "Choose ticket type"
 msgstr "Elige tipo de entrada"
 
-#: src/blocks/event-signup/render.php:702
-#: src/blocks/event-signup/render.php:779
-#: src/blocks/event-signup/render.php:841
-#: src/Hooks/SignupHookBridge.php:541
+#: src/blocks/event-signup/render.php:759
+#: src/blocks/event-signup/render.php:847
+#: src/blocks/event-signup/render.php:909
+#: src/Hooks/SignupHookBridge.php:564
 msgid "free"
 msgstr "gratis"
 
-#: src/blocks/event-signup/render.php:743
+#: src/blocks/event-signup/render.php:811
 msgid "Select activities"
 msgstr "Selecciona actividades"
 
-#: src/Hooks/PaymentHooks.php:394
+#: src/Hooks/PaymentHooks.php:399
 #: src/Hooks/PendingSubscriptionTimeoutHooks.php:56
 #: src/Hooks/WeeklyDigestHooks.php:55
 msgid "Every 5 minutes (fair-audience)"
@@ -2208,62 +2208,62 @@ msgid "Submitted at"
 msgstr "Enviado en"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:1910
+#: src/Services/EmailService.php:1911
 #, php-format
 msgid "New form submission — %s"
 msgstr "Nuevo envío de formulario — %s"
 
 #. translators: %s: page title
-#: src/Services/EmailService.php:1931
+#: src/Services/EmailService.php:1932
 #, php-format
 msgid "Page: %s"
 msgstr "Página: %s"
 
-#: src/Services/EmailService.php:1959
+#: src/Services/EmailService.php:1960
 msgid "A new form submission has been received."
 msgstr "Se ha recibido un nuevo envío de formulario."
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:2140
+#: src/Services/EmailService.php:2141
 #, php-format
 msgid "Your submission — %s"
 msgstr "Tu envío — %s"
 
 #. translators: %s: page title
-#: src/Services/EmailService.php:2151
+#: src/Services/EmailService.php:2152
 #, php-format
 msgid "Form: %s"
 msgstr "Formulario: %s"
 
-#: src/Services/EmailService.php:2161
+#: src/Services/EmailService.php:2162
 msgid "Here are the answers you submitted:"
 msgstr "Aquí están las respuestas que enviaste:"
 
-#: src/Services/EmailService.php:2199
+#: src/Services/EmailService.php:2200
 msgid "Thank you for your submission! We have received your response."
 msgstr "¡Gracias por tu envío! Hemos recibido tu respuesta."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2257
+#: src/Services/EmailService.php:2260
 #, php-format
 msgid "Signup confirmed — %s"
 msgstr "Registro confirmado — %s"
 
-#: src/Services/EmailService.php:2269
-#: src/Services/EmailService.php:2419
+#: src/Services/EmailService.php:2333
+#: src/Services/EmailService.php:2387
 #: src/blocks/event-signup/frontend.js:1816
 #: src/blocks/event-signup/frontend.js:1938
 msgid "Amount paid:"
 msgstr "Cantidad pagada:"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2344
+#: src/Services/EmailService.php:2309
 #, php-format
 msgid "Your signup for %s has been confirmed and your payment has been received."
 msgstr "Tu registro para %s ha sido confirmado y hemos recibido tu pago."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2346
+#: src/Services/EmailService.php:2311
 #, php-format
 msgid "Your signup for %s has been confirmed."
 msgstr "Tu registro para %s ha sido confirmado."
@@ -2287,57 +2287,57 @@ msgstr "Fila de participante no encontrada para esta fecha de evento."
 msgid "Selected ticket type was not found."
 msgstr "El tipo de entrada seleccionado no fue encontrado."
 
-#: src/API/EventSignupController.php:1458
+#: src/API/EventSignupController.php:1451
 msgid "This ticket type is sold out. Please pick another option."
 msgstr "Este tipo de entrada está agotado. Por favor, elija otra opción."
 
 #. translators: %d: minimum number of activities required
-#: src/API/EventSignupController.php:1598
-#: src/blocks/event-signup/render.php:753
-#: src/Services/SignupActivities.php:187
+#: src/API/EventSignupController.php:1591
+#: src/blocks/event-signup/render.php:821
+#: src/Services/SignupActivities.php:210
 #: src/blocks/event-signup/frontend.js:391
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d activity to sign up."
 msgid_plural "Please select at least %d activities to sign up."
 msgstr[0] "Por favor, selecciona al menos %d actividad para registrarte."
 msgstr[1] "Por favor, selecciona al menos %d actividades para registrarte."
 
-#: src/API/EventSignupController.php:2206
+#: src/API/EventSignupController.php:2194
 msgid "Invalid transaction."
 msgstr "Transacción inválida."
 
-#: src/API/EventSignupController.php:2214
+#: src/API/EventSignupController.php:2202
 msgid "Payment plugin is missing."
 msgstr "Falta el complemento de pago."
 
-#: src/API/EventSignupController.php:2223
-#: src/API/EventSignupController.php:2288
+#: src/API/EventSignupController.php:2211
+#: src/API/EventSignupController.php:2276
 msgid "Transaction not found."
 msgstr "Transacción no encontrada."
 
-#: src/API/EventSignupController.php:2264
+#: src/API/EventSignupController.php:2252
 msgid "You are not authorized to retry this payment."
 msgstr "No está autorizado para reintentar este pago."
 
-#: src/API/EventSignupController.php:2300
+#: src/API/EventSignupController.php:2288
 msgid "This payment cannot be retried."
 msgstr "Este pago no puede ser reintentado."
 
-#: src/API/EventSignupController.php:2318
+#: src/API/EventSignupController.php:2306
 msgid "This payment is not retriable from this endpoint."
 msgstr "Este pago no se puede reintentar desde este endpoint."
 
-#: src/API/EventSignupController.php:2331
-#: src/API/EventSignupController.php:2523
+#: src/API/EventSignupController.php:2319
+#: src/API/EventSignupController.php:2511
 msgid "This payment is missing context needed to retry."
 msgstr "Este pago no tiene el contexto necesario para reintentar."
 
-#: src/API/EventSignupController.php:2379
-#: src/API/EventSignupController.php:2566
+#: src/API/EventSignupController.php:2367
+#: src/API/EventSignupController.php:2554
 msgid "Original line items could not be loaded."
 msgstr "No se pudieron cargar los artículos de línea originales."
 
-#: src/API/EventSignupController.php:2769
+#: src/API/EventSignupController.php:2757
 #: src/blocks/event-signup/frontend.js:1096
 msgid "We recognise this email — check your inbox to continue."
 msgstr "Reconocemos este correo electrónico — revise su bandeja de entrada para continuar."
@@ -2346,134 +2346,134 @@ msgstr "Reconocemos este correo electrónico — revise su bandeja de entrada pa
 msgid "You have been subscribed."
 msgstr "Ha sido suscrito."
 
-#: src/blocks/event-signup/render.php:706
+#: src/blocks/event-signup/render.php:774
 msgid "sold out"
 msgstr "agotado"
 
-#: src/blocks/event-signup/render.php:784
-#: src/blocks/event-signup/render.php:845
-#: src/Hooks/SignupHookBridge.php:544
+#: src/blocks/event-signup/render.php:852
+#: src/blocks/event-signup/render.php:913
+#: src/Hooks/SignupHookBridge.php:567
 msgid "full"
 msgstr "completo"
 
-#: src/blocks/event-signup/render.php:886
+#: src/blocks/event-signup/render.php:954
 msgid "Choose a date"
 msgstr "Elija una fecha"
 
 #. translators: appended to a date label when the viewer is signed up — they can cancel from this row
-#: src/blocks/event-signup/render.php:897
+#: src/blocks/event-signup/render.php:965
 msgid "signed up (manage)"
 msgstr "registrado (gestionar)"
 
-#: src/blocks/event-signup/render.php:899
+#: src/blocks/event-signup/render.php:967
 msgid "signed up"
 msgstr "registrado"
 
-#: src/blocks/event-signup/render.php:1009
+#: src/blocks/event-signup/render.php:1077
 #: src/blocks/event-signup/frontend.js:1809
 msgid "Payment confirmed"
 msgstr "Pago confirmado"
 
 #. translators: %s: event title
-#: src/blocks/event-signup/render.php:1015
+#: src/blocks/event-signup/render.php:1083
 #, php-format
 msgid "You're signed up for %s."
 msgstr "Estás registrado para %s."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1024
+#: src/blocks/event-signup/render.php:1092
 #, php-format
 msgid "Amount paid: %s"
 msgstr "Cantidad pagada: %s"
 
-#: src/blocks/event-signup/render.php:1030
+#: src/blocks/event-signup/render.php:1098
 #: src/blocks/event-signup/frontend.js:1823
 msgid "A confirmation email is on its way. You can close this page."
 msgstr "Un correo de confirmación está en camino. Puedes cerrar esta página."
 
-#: src/blocks/event-signup/render.php:1037
+#: src/blocks/event-signup/render.php:1105
 msgid "Thank you for your payment!"
 msgstr "¡Gracias por tu pago!"
 
-#: src/blocks/event-signup/render.php:1040
+#: src/blocks/event-signup/render.php:1108
 msgid "We're confirming with your bank. This usually takes a few seconds — the page will update as soon as it's done."
 msgstr "Estamos confirmando con tu banco. Esto normalmente tarda unos segundos — la página se actualizará en cuanto esté hecho."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1046
+#: src/blocks/event-signup/render.php:1114
 #, php-format
 msgid "Amount: %s"
 msgstr "Cantidad: %s"
 
-#: src/blocks/event-signup/render.php:1055
+#: src/blocks/event-signup/render.php:1123
 msgid "Your payment is waiting."
 msgstr "Tu pago está pendiente."
 
-#: src/blocks/event-signup/render.php:1058
+#: src/blocks/event-signup/render.php:1126
 msgid "You can pick up where you left off on the secure payment page."
 msgstr "Puedes continuar donde lo dejaste en la página de pago seguro."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1064
-#: src/blocks/event-signup/render.php:1091
+#: src/blocks/event-signup/render.php:1132
+#: src/blocks/event-signup/render.php:1159
 #, php-format
 msgid "Amount due: %s"
 msgstr "Cantidad adeudada: %s"
 
-#: src/blocks/event-signup/render.php:1071
+#: src/blocks/event-signup/render.php:1139
 msgid "Continue payment"
 msgstr "Continuar con el pago"
 
-#: src/blocks/event-signup/render.php:1076
-#: src/blocks/event-signup/render.php:1103
+#: src/blocks/event-signup/render.php:1144
+#: src/blocks/event-signup/render.php:1171
 msgid "Cancel and start over"
 msgstr "Cancelar y empezar de nuevo"
 
-#: src/blocks/event-signup/render.php:1085
+#: src/blocks/event-signup/render.php:1153
 msgid "Your payment didn't go through."
 msgstr "Tu pago no se procesó."
 
-#: src/blocks/event-signup/render.php:1098
+#: src/blocks/event-signup/render.php:1166
 msgid "Retry payment"
 msgstr "Reintentar pago"
 
 #. translators: %s: transaction status
-#: src/blocks/event-signup/render.php:1114
+#: src/blocks/event-signup/render.php:1182
 #, php-format
 msgid "Payment status: %s"
 msgstr "Estado del pago: %s"
 
-#: src/blocks/event-signup/render.php:1185
-#: src/Hooks/SignupHookBridge.php:295
+#: src/blocks/event-signup/render.php:1253
+#: src/Hooks/SignupHookBridge.php:315
 msgid "You are signed up for this date."
 msgstr "Estás registrado para esta fecha."
 
-#: src/Services/EmailService.php:2282
+#: src/Services/EmailService.php:2334
 msgid "Selected options:"
 msgstr "Opciones seleccionadas:"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2532
+#: src/Services/EmailService.php:2508
 #, php-format
 msgid "Payment didn’t go through — %s"
 msgstr "El pago no se procesó — %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2580
+#: src/Services/EmailService.php:2556
 #, php-format
 msgid "Your payment for %s didn’t go through. Your spot is still held for a short while — pick up where you left off using the link below."
 msgstr "Tu pago para %s no se procesó. Tu lugar sigue reservado por un tiempo — continúa donde lo dejaste usando el enlace a continuación."
 
-#: src/Services/EmailService.php:2589
+#: src/Services/EmailService.php:2565
 msgid "Resume payment"
 msgstr "Reanudar pago"
 
-#: src/Services/EmailService.php:2594
+#: src/Services/EmailService.php:2570
 msgid "If the button doesn’t work, copy and paste this link into your browser:"
 msgstr "Si el botón no funciona, copia y pega este enlace en tu navegador:"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:2601
+#: src/Services/EmailService.php:2577
 #, php-format
 msgid "See you soon,%1$sThe %2$s Team"
 msgstr "Hasta pronto,%1$sEl equipo de %2$s"
@@ -2569,30 +2569,30 @@ msgstr "Error al actualizar el ID de participante %d"
 msgid "Verbal consent recorded by %1$s on %2$s at event %3$s"
 msgstr "Consentimiento verbal registrado por %1$s el %2$s en el evento %3$s"
 
-#: src/API/EventSignupController.php:1130
+#: src/API/EventSignupController.php:1131
 msgid "You need an active signup before you can add activities."
 msgstr "Necesitas un registro activo antes de poder añadir actividades."
 
-#: src/API/EventSignupController.php:1152
+#: src/API/EventSignupController.php:1153
 msgid "No new activities to add."
 msgstr "No hay nuevas actividades para añadir."
 
-#: src/API/EventSignupController.php:1177
+#: src/API/EventSignupController.php:1178
 #: src/blocks/event-signup/frontend.js:1556
 msgid "Your activities have been added!"
 msgstr "¡Tus actividades han sido añadidas!"
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:1258
+#: src/API/EventSignupController.php:1251
 #, php-format
 msgid "Added activities for %s"
 msgstr "Actividades añadidas para %s"
 
-#: src/API/EventSignupController.php:2541
+#: src/API/EventSignupController.php:2529
 msgid "Your signup is no longer active."
 msgstr "Tu registro ya no está activo."
 
-#: src/API/EventSignupController.php:2555
+#: src/API/EventSignupController.php:2543
 msgid "These activities are already on your signup."
 msgstr "Estas actividades ya están en tu registro."
 
@@ -2616,30 +2616,30 @@ msgstr "Correo de confirmación enviado."
 msgid "Website"
 msgstr "Sitio web"
 
-#: src/blocks/event-signup/render.php:833
-#: src/blocks/event-signup/render.php:863
-#: src/Hooks/SignupHookBridge.php:523
-#: src/Hooks/SignupHookBridge.php:561
+#: src/blocks/event-signup/render.php:901
+#: src/blocks/event-signup/render.php:931
+#: src/Hooks/SignupHookBridge.php:546
+#: src/Hooks/SignupHookBridge.php:584
 #: src/blocks/event-signup/frontend.js:1466
 msgid "Add activities"
 msgstr "Añadir actividades"
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1140
+#: src/blocks/event-signup/render.php:1208
 #, php-format
 msgid "Hi %s! Here is your registration for this event."
 msgstr "¡Hola %s! Aquí está tu registro para este evento."
 
 #. translators: %s: ticket type name
-#: src/blocks/event-signup/render.php:1192
-#: src/Hooks/SignupHookBridge.php:302
+#: src/blocks/event-signup/render.php:1260
+#: src/Hooks/SignupHookBridge.php:322
 #, php-format
 msgid "Your ticket: %s"
 msgstr "Tu entrada: %s"
 
-#: src/blocks/event-signup/render.php:1200
-#: src/Hooks/SignupHookBridge.php:309
-#: src/Hooks/SignupHookBridge.php:526
+#: src/blocks/event-signup/render.php:1268
+#: src/Hooks/SignupHookBridge.php:329
+#: src/Hooks/SignupHookBridge.php:549
 msgid "Your activities:"
 msgstr "Tus actividades:"
 
@@ -2661,73 +2661,73 @@ msgid "Unsubscribed"
 msgstr "Desuscrito"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2407
+#: src/Services/EmailService.php:2375
 #, php-format
 msgid "Activities added — %s"
 msgstr "Actividades añadidas — %s"
 
-#: src/Services/EmailService.php:2432
+#: src/Services/EmailService.php:2400
 msgid "Activities added:"
 msgstr "Actividades añadidas:"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2468
+#: src/Services/EmailService.php:2436
 #, php-format
 msgid "The following activities have been added to your signup for %s."
 msgstr "Las siguientes actividades se han añadido a tu registro para %s."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2972
+#: src/Services/EmailService.php:2956
 #, php-format
 msgid "Thanks for your interest in %s"
 msgstr "Gracias por tu interés en %s"
 
-#: src/Services/EmailService.php:2976
-#: src/Services/EmailService.php:3054
+#: src/Services/EmailService.php:2960
+#: src/Services/EmailService.php:3039
 msgid "there"
 msgstr "allá"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:3003
+#: src/Services/EmailService.php:2987
 #, php-format
 msgid "Thanks for registering your interest in %s. We will let you know when there are updates."
 msgstr "Gracias por registrar tu interés en %s. Te notificaremos cuando haya actualizaciones."
 
-#: src/Services/EmailService.php:3006
+#: src/Services/EmailService.php:2990
 msgid "If you didn't register your interest, you can safely ignore this email."
 msgstr "Si no registraste tu interés, puedes ignorar este correo electrónico con seguridad."
 
-#: src/Services/EmailService.php:3011
+#: src/Services/EmailService.php:2995
 msgid "No longer interested?"
 msgstr "¿Ya no estás interesado?"
 
-#: src/Services/EmailService.php:3012
+#: src/Services/EmailService.php:2996
 msgid "Unsubscribe from updates about this event"
 msgstr "Desuscribirse de las actualizaciones sobre este evento"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3050
+#: src/Services/EmailService.php:3035
 #, php-format
 msgid "Welcome to the %s mailing list"
 msgstr "Bienvenido a la lista de correo de %s"
 
 #. translators: 1: site name, 2: event title
-#: src/Services/EmailService.php:3059
+#: src/Services/EmailService.php:3044
 #, php-format
 msgid "You've been added to the %1$s mailing list following the consent you gave at %2$s. We'll keep you posted about upcoming events and news."
 msgstr "Has sido añadido a la lista de correo de %1$s tras el consentimiento que diste en %2$s. Te mantendremos informado sobre próximos eventos y noticias."
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3066
+#: src/Services/EmailService.php:3051
 #, php-format
 msgid "You've been added to the %s mailing list following the consent you gave. We'll keep you posted about upcoming events and news."
 msgstr "Has sido añadido a la lista de correo de %s tras el consentimiento que diste. Te mantendremos informado sobre próximos eventos y noticias."
 
-#: src/Services/EmailService.php:3099
+#: src/Services/EmailService.php:3084
 msgid "Changed your mind?"
 msgstr "¿Cambió de opinión?"
 
-#: src/Services/EmailService.php:3100
+#: src/Services/EmailService.php:3085
 msgid "Manage your subscription or unsubscribe"
 msgstr "Gestiona tu suscripción o desuscríbete"
 
@@ -2789,31 +2789,31 @@ msgid "interest"
 msgstr "interés"
 
 #: src/API/EventParticipantsController.php:582
-#: src/API/EventSignupController.php:1751
-#: src/Services/EmailService.php:2294
-#: src/blocks/event-signup/editor.js:110
+#: src/API/EventSignupController.php:1746
+#: src/Services/EmailService.php:2296
+#: src/blocks/event-signup/editor.js:114
 msgid "Event Signup"
 msgstr "Registro de evento"
 
-#: src/Services/EmailService.php:2303
+#: src/Services/EmailService.php:2335
 msgid "Your answers:"
 msgstr "Tus respuestas:"
 
-#: src/blocks/event-signup/editor.js:128
+#: src/blocks/event-signup/editor.js:132
 msgid "Ticket types, activity options and pricing are rendered on the published page based on the event."
 msgstr "Los tipos de entradas, opciones de actividades y precios se renderizan en la página publicada según el evento."
 
-#: src/blocks/event-signup/editor.js:134
+#: src/blocks/event-signup/editor.js:138
 msgid "Custom questions"
 msgstr "Preguntas personalizadas"
 
-#: src/API/EventSignupController.php:1485
+#: src/API/EventSignupController.php:1478
 msgid "This ticket type is no longer available. Please pick another option."
 msgstr "Este tipo de entrada ya no está disponible. Por favor, elige otra opción."
 
 #. translators: 1: discount percentage, 2: group name
-#: src/blocks/event-signup/render.php:663
-#: src/Services/GroupSignupPricing.php:134
+#: src/blocks/event-signup/render.php:720
+#: src/Services/GroupSignupPricing.php:146
 #, php-format
 msgid "%1$s%% discount applied (%2$s)"
 msgstr "Descuento del %1$s%% aplicado (%2$s)"
@@ -2855,59 +2855,59 @@ msgstr "No se pudo registrar el rechazo para el participante ID %d"
 msgid "Decline recorded by %1$s on %2$s at event %3$s"
 msgstr "Rechazo registrado por %1$s el %2$s en el evento %3$s"
 
-#: src/API/EventSignupController.php:805
+#: src/API/EventSignupController.php:806
 msgid "Please select at least one occurrence."
 msgstr "Selecciona al menos una fecha."
 
-#: src/API/EventSignupController.php:813
-#: src/API/EventSignupController.php:824
+#: src/API/EventSignupController.php:814
+#: src/API/EventSignupController.php:825
 msgid "Invalid ticket type."
 msgstr "Tipo de entrada no válido."
 
-#: src/API/EventSignupController.php:835
+#: src/API/EventSignupController.php:836
 msgid "One of the selected occurrences is not valid for this ticket."
 msgstr "Una de las fechas seleccionadas no es válida para esta entrada."
 
 #. translators: %d: minimum number of occurrences required
-#: src/API/EventSignupController.php:848
+#: src/API/EventSignupController.php:849
 #: src/blocks/event-signup/frontend.js:311
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d occurrence."
 msgid_plural "Please select at least %d occurrences."
 msgstr[0] "Selecciona al menos %d ocurrencia."
 msgstr[1] "Selecciona al menos %d ocurrencias."
 
-#: src/API/EventSignupController.php:875
+#: src/API/EventSignupController.php:876
 msgid "You are already signed up for these occurrences."
 msgstr "Ya estás inscrito en estas fechas."
 
-#: src/API/EventSignupController.php:928
+#: src/API/EventSignupController.php:929
+#: src/API/EventSignupController.php:1804
 #: src/API/EventSignupController.php:1816
-#: src/API/EventSignupController.php:1828
-#: src/API/EventSignupController.php:2039
+#: src/API/EventSignupController.php:2027
 msgid "Paid signup is not available because the payment plugin is not configured."
 msgstr "La inscripción de pago no está disponible porque el complemento de pago no está configurado."
 
-#: src/API/EventSignupController.php:945
+#: src/API/EventSignupController.php:946
 msgid "One of the selected occurrences is fully booked."
 msgstr "Una de las fechas seleccionadas está completa."
 
-#: src/API/EventSignupController.php:1239
-#: src/API/EventSignupController.php:1251
+#: src/API/EventSignupController.php:1232
+#: src/API/EventSignupController.php:1244
 msgid "Paid activities are not available because the payment plugin is not configured."
 msgstr "Las actividades de pago no están disponibles porque el complemento de pago no está configurado."
 
-#: src/blocks/event-signup/render.php:938
+#: src/blocks/event-signup/render.php:1006
 msgid "Choose occurrences"
 msgstr "Selecciona fechas"
 
-#: src/blocks/event-signup/render.php:959
-#: src/Hooks/SignupHookBridge.php:331
+#: src/blocks/event-signup/render.php:1027
+#: src/Hooks/SignupHookBridge.php:351
 msgid "already signed up"
 msgstr "ya inscrito"
 
-#: src/blocks/event-signup/render.php:1174
-#: src/blocks/event-signup/render.php:1297
+#: src/blocks/event-signup/render.php:1242
+#: src/blocks/event-signup/render.php:1365
 msgid "Online payment is not available for this event at the moment. Please contact the organiser."
 msgstr "El pago en línea no está disponible para este evento en este momento. Ponte en contacto con el organizador."
 
@@ -2961,18 +2961,18 @@ msgstr "Este enlace no es válido o ha expirado."
 msgid "This registration link has expired. Please fill in the form again."
 msgstr "Este enlace de registro ha expirado. Por favor, rellena el formulario de nuevo."
 
-#: src/API/EventSignupController.php:2030
+#: src/API/EventSignupController.php:2018
 msgid "Your series pass is now active!"
 msgstr "¡Tu pase de serie ya está activo!"
 
 #. translators: %s: ticket type name
-#: src/API/EventSignupController.php:2048
+#: src/API/EventSignupController.php:2036
 #, php-format
 msgid "Upgrade to series pass: %s"
 msgstr "Actualizar a pase de serie: %s"
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:2062
+#: src/API/EventSignupController.php:2050
 #, php-format
 msgid "Series pass upgrade for %s"
 msgstr "Actualización de pase de serie para %s"
@@ -3005,30 +3005,30 @@ msgid "Sent to %1$d, failed %2$d, skipped %3$d."
 msgstr "Enviado a %1$d, falló %2$d, omitido %3$d."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:964
+#: src/Services/EmailService.php:965
 #, php-format
 msgid "Continue registering for %s"
 msgstr "Continúa registrándote para %s"
 
-#: src/Services/EmailService.php:969
+#: src/Services/EmailService.php:970
 msgid "Continue to payment"
 msgstr "Continúa al pago"
 
-#: src/Services/EmailService.php:970
+#: src/Services/EmailService.php:971
 msgid "Continue to sign up"
 msgstr "Continúa a la inscripción"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:1005
+#: src/Services/EmailService.php:1006
 #, php-format
 msgid "You're registering for %s."
 msgstr "Te estás registrando para %s."
 
-#: src/Services/EmailService.php:1011
+#: src/Services/EmailService.php:1012
 msgid "We've saved your answers — click below to continue where you left off:"
 msgstr "Hemos guardado tus respuestas — haz clic a continuación para continuar donde lo dejaste:"
 
-#: src/Services/EmailService.php:1021
+#: src/Services/EmailService.php:1022
 msgid "If you didn't try to register, you can safely ignore this email."
 msgstr "Si no intentaste registrarte, puedes ignorar este correo con seguridad."
 
@@ -3616,11 +3616,11 @@ msgstr "Audiencia"
 msgid "Outro text"
 msgstr "Texto de cierre"
 
-#: src/Services/EmailService.php:153
+#: src/Services/EmailService.php:154
 msgid "Participant has not yet confirmed their marketing subscription."
 msgstr "El participante aún no ha confirmado su suscripción a marketing."
 
-#: src/Services/EmailService.php:2041
+#: src/Services/EmailService.php:2042
 msgid "[Test email — real sends to subscribers include a \"Manage your preferences\" unsubscribe link here.]"
 msgstr "[Correo de prueba — los envíos reales a suscriptores incluyen un enlace de desuscripción «Gestionar tus preferencias» aquí.]"
 
@@ -3638,7 +3638,7 @@ msgstr "HTML opcional mostrado debajo de la lista de eventos."
 msgid "Next digest: %s"
 msgstr "Próximo resumen: %s"
 
-#: src/blocks/event-signup/editor.js:103
+#: src/blocks/event-signup/editor.js:107
 msgid "This block has moved to Event Signup (fair-events). Transform it to the new block."
 msgstr "Este bloque se ha movido a Event Signup (fair-events). Transforma el bloque a la nueva versión."
 
@@ -3656,10 +3656,11 @@ msgstr "Bloque de registro heredado. Reemplazado por Event Signup (fair-events) 
 msgid "Reverted to minimal: marketing subscription was never confirmed within a week."
 msgstr "Revertido a mínimo: la suscripción de marketing nunca fue confirmada en una semana."
 
-#: src/Services/EmailService.php:161
+#: src/Services/EmailService.php:162
 msgid "Opted out of the weekly summary."
 msgstr "Ha rechazado el resumen semanal."
 
+#. translators: %s: source host, e.g. "instagram.com".
 #. translators: %s: source domain, e.g. "example.com".
 #: src/Services/WeeklyDigestRenderer.php:165
 #: src/Services/WeeklyDigestRenderer.php:175
@@ -3689,38 +3690,38 @@ msgstr "Rechazado"
 msgid "Subscribed"
 msgstr "Suscrito"
 
-#: ../fair-events-shared/src/questionnaire.js:449
+#: ../fair-events-shared/src/questionnaire.js:453
 msgid "Please answer the required question: "
 msgstr "Por favor, responde la pregunta requerida: "
 
-#: ../fair-events-shared/src/questionnaire.js:497
+#: ../fair-events-shared/src/questionnaire.js:501
 msgid "Please enter a valid email address for: "
 msgstr "Por favor, introduce una dirección de correo electrónico válida para: "
 
-#: ../fair-events-shared/src/questionnaire.js:527
+#: ../fair-events-shared/src/questionnaire.js:616
 msgid "File is too large. Maximum size is "
 msgstr "El archivo es demasiado grande. El tamaño máximo es "
 
-#: ../fair-events-shared/src/questionnaire.js:472
+#: ../fair-events-shared/src/questionnaire.js:476
 msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
 msgstr "Introduce un número de teléfono válido con código de país (por ejemplo +49 170 123 45 67) para: %s"
 
 #. translators: 1: base button label, 2: formatted price
-#: src/blocks/event-signup/render.php:606
-#: src/blocks/event-signup/render.php:612
+#: src/blocks/event-signup/render.php:666
+#: src/blocks/event-signup/render.php:672
 #, php-format
 msgid "%1$s — %2$s"
 msgstr "%1$s — %2$s"
 
 #. translators: 1: discount amount, 2: group name
-#: src/blocks/event-signup/render.php:670
-#: src/Services/GroupSignupPricing.php:142
+#: src/blocks/event-signup/render.php:727
+#: src/Services/GroupSignupPricing.php:154
 #, php-format
 msgid "%1$s discount applied (%2$s)"
 msgstr "Descuento %1$s aplicado (%2$s)"
 
 #. translators: %s: formatted add-on price
-#: src/blocks/event-signup/render.php:810
+#: src/blocks/event-signup/render.php:878
 #, php-format
 msgid "(+%s)"
 msgstr "(+%s)"
@@ -3735,18 +3736,47 @@ msgstr "Total: %s"
 msgid "Translations"
 msgstr "Traducciones"
 
-#: src/Hooks/SignupHookBridge.php:244
+#: src/Hooks/SignupHookBridge.php:263
 msgid "You already have a ticket for this date."
 msgstr "Ya tienes un ticket para esta fecha."
 
-#: src/Services/SignupActivities.php:145
-#: src/Services/SignupActivities.php:164
+#: src/Services/SignupActivities.php:168
+#: src/Services/SignupActivities.php:187
 msgid "One of the selected activities is not available for this event."
 msgstr "Una de las actividades seleccionadas no está disponible para este evento."
 
 #. translators: %s: activity name
-#: src/Services/SignupActivities.php:173
+#: src/Services/SignupActivities.php:196
 #, php-format
 msgid "\"%s\" is full."
 msgstr "\"%s\" está completo."
 
+#. translators: 1: discount magnitude e.g. "20%" or "€5.00", 2: group name
+#: src/blocks/event-signup/render.php:768
+#, php-format
+msgid "%1$s off · %2$s"
+msgstr ""
+
+#: src/Services/EmailService.php:2330
+msgid "Event date:"
+msgstr ""
+
+#: src/Services/EmailService.php:2331
+msgid "Registration reference:"
+msgstr ""
+
+#: src/Services/EmailService.php:2332
+msgid "Ticket type:"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:537
+msgid "Please enter a valid web address for: %s"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:561
+msgid "Please enter a valid date for: %s"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:585
+msgid "Please enter a valid date and time for: %s"
+msgstr ""

--- a/fair-audience/languages/fair-audience-fr_FR.po
+++ b/fair-audience/languages/fair-audience-fr_FR.po
@@ -64,16 +64,16 @@ msgstr "Participants à l'événement"
 #: src/API/EventParticipantsController.php:1468
 #: src/API/EventSignupController.php:468
 #: src/API/EventSignupController.php:613
-#: src/API/EventSignupController.php:1080
-#: src/API/EventSignupController.php:2137
-#: src/API/EventSignupController.php:2340
-#: src/API/EventSignupController.php:2532
-#: src/API/EventSignupController.php:2660
-#: src/API/EventSignupController.php:2960
-#: src/Services/EmailService.php:336
-#: src/Services/EmailService.php:560
-#: src/Services/EmailService.php:1400
-#: src/Services/EmailService.php:2816
+#: src/API/EventSignupController.php:1081
+#: src/API/EventSignupController.php:2125
+#: src/API/EventSignupController.php:2328
+#: src/API/EventSignupController.php:2520
+#: src/API/EventSignupController.php:2648
+#: src/API/EventSignupController.php:2949
+#: src/Services/EmailService.php:337
+#: src/Services/EmailService.php:561
+#: src/Services/EmailService.php:1401
+#: src/Services/EmailService.php:2792
 msgid "Event not found."
 msgstr "Événement non trouvé."
 
@@ -85,11 +85,11 @@ msgstr "Événement non trouvé."
 #: src/API/ParticipantsController.php:729
 #: src/API/ParticipantsController.php:762
 #: src/API/ParticipantsController.php:789
-#: src/Services/EmailService.php:360
-#: src/Services/EmailService.php:583
-#: src/Services/EmailService.php:1439
-#: src/Services/EmailService.php:1829
-#: src/Services/EmailService.php:2891
+#: src/Services/EmailService.php:361
+#: src/Services/EmailService.php:584
+#: src/Services/EmailService.php:1440
+#: src/Services/EmailService.php:1830
+#: src/Services/EmailService.php:2867
 #: src/Admin/participant-detail/ParticipantDetail.js:86
 msgid "Participant not found."
 msgstr "Participant non trouvé."
@@ -164,7 +164,7 @@ msgid "Add Participant"
 msgstr "Ajouter un participant"
 
 #: src/blocks/event-interest/render.php:135
-#: src/Services/EmailService.php:1916
+#: src/Services/EmailService.php:1917
 #: src/Admin/all-participants/AllParticipants.js:93
 #: src/Admin/event-participants/EventParticipants.js:629
 #: src/Admin/manage-event-audience-tab/EventAudience.js:892
@@ -175,14 +175,14 @@ msgstr "Nom"
 
 #: src/blocks/audience-signup/render.php:217
 #: src/blocks/event-interest/render.php:122
-#: src/blocks/event-signup/render.php:1265
-#: src/blocks/event-signup/render.php:1320
+#: src/blocks/event-signup/render.php:1333
+#: src/blocks/event-signup/render.php:1388
 #: src/blocks/mailing-signup/render.php:125
-#: src/Services/EmailService.php:1920
+#: src/Services/EmailService.php:1921
 #: src/Admin/all-participants/AllParticipants.js:108
 #: src/Admin/components/ParticipantEditModal.js:177
 #: src/Admin/participant-detail/ParticipantDetail.js:190
-#: src/blocks/event-signup/editor.js:123
+#: src/blocks/event-signup/editor.js:127
 msgid "Email"
 msgstr "E-mail"
 
@@ -271,9 +271,9 @@ msgstr "Retirer"
 msgid "Events"
 msgstr "Événements"
 
-#: src/Services/EmailService.php:2253
-#: src/Services/EmailService.php:2403
-#: src/Services/EmailService.php:2525
+#: src/Services/EmailService.php:2256
+#: src/Services/EmailService.php:2363
+#: src/Services/EmailService.php:2493
 #: src/Admin/events-list/EventsList.js:37
 #: src/Admin/manage-event-audience-tab/EventAudience.js:778
 #: src/Admin/participant-detail/ParticipantDetail.js:271
@@ -281,7 +281,7 @@ msgstr "Événements"
 msgid "Event"
 msgstr "Événement"
 
-#: src/Services/EmailService.php:325
+#: src/Services/EmailService.php:326
 msgid "Poll not found."
 msgstr "Sondage non trouvé."
 
@@ -292,87 +292,87 @@ msgid "Invalid event ID."
 msgstr "ID d'événement invalide."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:210
+#: src/Services/EmailService.php:211
 #, php-format
 msgid "Quick question about %s"
 msgstr "Une petite question à propos de %s"
 
 #. translators: %s: participant first name
-#: src/Services/EmailService.php:239
-#: src/Services/EmailService.php:446
-#: src/Services/EmailService.php:666
-#: src/Services/EmailService.php:774
-#: src/Services/EmailService.php:875
-#: src/Services/EmailService.php:997
-#: src/Services/EmailService.php:1159
-#: src/Services/EmailService.php:1334
-#: src/Services/EmailService.php:1604
-#: src/Services/EmailService.php:1709
-#: src/Services/EmailService.php:2193
-#: src/Services/EmailService.php:2335
-#: src/Services/EmailService.php:2460
-#: src/Services/EmailService.php:2572
-#: src/Services/EmailService.php:2709
-#: src/Services/EmailService.php:2998
-#: src/Services/EmailService.php:3091
+#: src/Services/EmailService.php:240
+#: src/Services/EmailService.php:447
+#: src/Services/EmailService.php:667
+#: src/Services/EmailService.php:775
+#: src/Services/EmailService.php:876
+#: src/Services/EmailService.php:998
+#: src/Services/EmailService.php:1160
+#: src/Services/EmailService.php:1335
+#: src/Services/EmailService.php:1605
+#: src/Services/EmailService.php:1710
+#: src/Services/EmailService.php:2194
+#: src/Services/EmailService.php:2328
+#: src/Services/EmailService.php:2428
+#: src/Services/EmailService.php:2548
+#: src/Services/EmailService.php:2685
+#: src/Services/EmailService.php:2982
+#: src/Services/EmailService.php:3076
 #: src/Admin/event-participants/EventParticipants.js:1192
-#, php-format, js-format
+#, php-format,js-format
 msgid "Hi %s,"
 msgstr "Bonjour %s,"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:247
+#: src/Services/EmailService.php:248
 #, php-format
 msgid "We'd love to hear from you about %s!"
 msgstr "Nous aimerions avoir votre avis sur %s !"
 
-#: src/Services/EmailService.php:261
+#: src/Services/EmailService.php:262
 msgid "Please take a moment to answer our quick poll:"
 msgstr "Prenez un moment pour répondre à notre sondage rapide :"
 
-#: src/Services/EmailService.php:266
+#: src/Services/EmailService.php:267
 msgid "Answer Poll"
 msgstr "Répondre au sondage"
 
 #. translators: 1: line break, 2: site name
-#: src/Services/EmailService.php:273
-#: src/Services/EmailService.php:498
-#: src/Services/EmailService.php:692
-#: src/Services/EmailService.php:796
-#: src/Services/EmailService.php:905
-#: src/Services/EmailService.php:1027
-#: src/Services/EmailService.php:1169
-#: src/Services/EmailService.php:1346
-#: src/Services/EmailService.php:1616
-#: src/Services/EmailService.php:1754
-#: src/Services/EmailService.php:2209
+#: src/Services/EmailService.php:274
+#: src/Services/EmailService.php:499
+#: src/Services/EmailService.php:693
+#: src/Services/EmailService.php:797
+#: src/Services/EmailService.php:906
+#: src/Services/EmailService.php:1028
+#: src/Services/EmailService.php:1170
+#: src/Services/EmailService.php:1347
+#: src/Services/EmailService.php:1617
+#: src/Services/EmailService.php:1755
+#: src/Services/EmailService.php:2210
 #, php-format
 msgid "Thanks,%1$sThe %2$s Team"
 msgstr "Merci,%1$sL'équipe %2$s"
 
-#: src/Services/EmailService.php:285
-#: src/Services/EmailService.php:510
-#: src/Services/EmailService.php:704
-#: src/Services/EmailService.php:808
-#: src/Services/EmailService.php:917
-#: src/Services/EmailService.php:1039
-#: src/Services/EmailService.php:1769
-#: src/Services/EmailService.php:2755
+#: src/Services/EmailService.php:286
+#: src/Services/EmailService.php:511
+#: src/Services/EmailService.php:705
+#: src/Services/EmailService.php:809
+#: src/Services/EmailService.php:918
+#: src/Services/EmailService.php:1040
+#: src/Services/EmailService.php:1770
+#: src/Services/EmailService.php:2731
 msgid "If the button above doesn't work, copy and paste this link:"
 msgstr "Si le bouton ci-dessus ne fonctionne pas, copiez et collez ce lien :"
 
-#: src/Services/EmailService.php:387
-#: src/Services/EmailService.php:609
-#: src/Services/EmailService.php:1472
-#: src/Services/EmailService.php:1549
-#: src/Services/EmailService.php:1864
-#: src/Services/EmailService.php:2927
+#: src/Services/EmailService.php:388
+#: src/Services/EmailService.php:610
+#: src/Services/EmailService.php:1473
+#: src/Services/EmailService.php:1550
+#: src/Services/EmailService.php:1865
+#: src/Services/EmailService.php:2903
 msgid "wp_mail() failed to send."
 msgstr "L'envoi par wp_mail() a échoué."
 
-#: src/blocks/event-signup/render.php:1253
+#: src/blocks/event-signup/render.php:1321
 #: src/Admin/components/ParticipantEditModal.js:170
-#: src/blocks/event-signup/editor.js:119
+#: src/blocks/event-signup/editor.js:123
 msgid "Surname"
 msgstr "Nom de famille"
 
@@ -470,16 +470,16 @@ msgstr "ID du participant %d non trouvé"
 
 #: src/API/AudienceSignupController.php:204
 #: src/API/EventInterestController.php:156
-#: src/API/EventSignupController.php:2146
-#: src/API/EventSignupController.php:2678
+#: src/API/EventSignupController.php:2134
+#: src/API/EventSignupController.php:2666
 #: src/API/MailingSignupController.php:172
 msgid "Please enter a valid email address."
 msgstr "Veuillez saisir une adresse e-mail valide."
 
 #: src/API/AudienceSignupController.php:223
 #: src/API/EventInterestController.php:182
-#: src/API/EventSignupController.php:2155
-#: src/API/EventSignupController.php:2717
+#: src/API/EventSignupController.php:2143
+#: src/API/EventSignupController.php:2705
 #: src/API/MailingSignupController.php:192
 msgid "Too many requests. Please try again later."
 msgstr "Trop de requêtes. Veuillez réessayer plus tard."
@@ -536,14 +536,14 @@ msgid "Subscribe"
 msgstr "S'abonner"
 
 #: src/blocks/audience-signup/render.php:192
-#: src/blocks/event-signup/render.php:1240
+#: src/blocks/event-signup/render.php:1308
 #: src/blocks/mailing-signup/render.php:99
-#: src/blocks/event-signup/editor.js:115
+#: src/blocks/event-signup/editor.js:119
 msgid "First Name"
 msgstr "Prénom"
 
 #: src/blocks/audience-signup/render.php:199
-#: src/blocks/event-signup/render.php:1247
+#: src/blocks/event-signup/render.php:1315
 #: src/blocks/mailing-signup/render.php:106
 msgid "Enter your first name"
 msgstr "Entrez votre prénom"
@@ -559,54 +559,54 @@ msgid "Enter your last name"
 msgstr "Entrez votre nom de famille"
 
 #: src/blocks/audience-signup/render.php:224
-#: src/blocks/event-signup/render.php:1272
-#: src/blocks/event-signup/render.php:1327
+#: src/blocks/event-signup/render.php:1340
+#: src/blocks/event-signup/render.php:1395
 #: src/blocks/mailing-signup/render.php:132
 msgid "Enter your email"
 msgstr "Entrez votre adresse e-mail"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:417
+#: src/Services/EmailService.php:418
 #, php-format
 msgid "Photos from %s are ready!"
 msgstr "Les photos de %s sont prêtes !"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:454
+#: src/Services/EmailService.php:455
 #: src/Admin/event-participants/EventParticipants.js:1204
-#, php-format, js-format
+#, php-format,js-format
 msgid "The photos from %s are now available for you to view and like!"
 msgstr "Les photos de %s sont maintenant disponibles pour que vous puissiez les consulter et les aimer !"
 
-#: src/Services/EmailService.php:468
+#: src/Services/EmailService.php:469
 #: src/Admin/event-participants/EventParticipants.js:1217
 msgid "Click the button below to browse the gallery and let us know which photos you like best:"
 msgstr "Cliquez sur le bouton ci-dessous pour parcourir la galerie et nous indiquer quelles photos vous préférez :"
 
-#: src/Services/EmailService.php:473
+#: src/Services/EmailService.php:474
 #: src/Admin/event-participants/EventParticipants.js:1239
 msgid "View Gallery"
 msgstr "Voir la galerie"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:637
+#: src/Services/EmailService.php:638
 #, php-format
 msgid "Confirm your subscription to %s"
 msgstr "Confirmez votre abonnement à %s"
 
-#: src/Services/EmailService.php:672
+#: src/Services/EmailService.php:673
 msgid "Thank you for signing up for our mailing list! Please confirm your email address by clicking the button below."
 msgstr "Merci de vous être inscrit à notre liste de diffusion ! Veuillez confirmer votre adresse e-mail en cliquant sur le bouton ci-dessous."
 
-#: src/Services/EmailService.php:677
+#: src/Services/EmailService.php:678
 msgid "Confirm Email"
 msgstr "Confirmer l'e-mail"
 
-#: src/Services/EmailService.php:682
+#: src/Services/EmailService.php:683
 msgid "This link will expire in 48 hours."
 msgstr "Ce lien expirera dans 48 heures."
 
-#: src/Services/EmailService.php:686
+#: src/Services/EmailService.php:687
 msgid "If you didn't sign up for this mailing list, you can safely ignore this email."
 msgstr "Si vous ne vous êtes pas inscrit à cette liste de diffusion, vous pouvez ignorer ce message en toute sécurité."
 
@@ -714,7 +714,7 @@ msgstr "Ajouter %d sélectionné(s)"
 
 #: src/blocks/audience-signup/editor.js:35
 #: src/blocks/event-interest/editor.js:26
-#: src/blocks/event-signup/editor.js:85
+#: src/blocks/event-signup/editor.js:89
 #: src/blocks/mailing-signup/editor.js:65
 msgid "Form Settings"
 msgstr "Paramètres du formulaire"
@@ -901,38 +901,38 @@ msgid "You must be logged in or have a valid signup link."
 msgstr "Vous devez être connecté ou avoir un lien d'inscription valide."
 
 #: src/API/EventSignupController.php:642
-#: src/API/EventSignupController.php:1108
-#: src/API/EventSignupController.php:2989
+#: src/API/EventSignupController.php:1109
+#: src/API/EventSignupController.php:2978
 msgid "Could not find your participant profile."
 msgstr "Impossible de trouver votre profil de participant."
 
 #: src/API/EventSignupController.php:726
-#: src/API/EventSignupController.php:2368
-#: src/API/EventSignupController.php:2794
+#: src/API/EventSignupController.php:2356
+#: src/API/EventSignupController.php:2782
 msgid "You are already signed up for this event."
 msgstr "Vous êtes déjà inscrit à cet événement."
 
-#: src/API/EventSignupController.php:776
-#: src/API/EventSignupController.php:918
+#: src/API/EventSignupController.php:777
+#: src/API/EventSignupController.php:919
 #: src/blocks/event-signup/render.php:66
 #: src/blocks/event-signup/frontend.js:961
 #: src/blocks/event-signup/frontend.js:1271
 msgid "You have successfully signed up for the event!"
 msgstr "Vous vous êtes inscrit avec succès à l'événement !"
 
-#: src/API/EventSignupController.php:2187
+#: src/API/EventSignupController.php:2175
 msgid "If your email is in our system, you will receive a signup link shortly. Please check your inbox."
 msgstr "Si votre e-mail est dans notre système, vous recevrez un lien d'inscription sous peu. Veuillez vérifier votre boîte de réception."
 
-#: src/API/EventSignupController.php:2687
+#: src/API/EventSignupController.php:2675
 msgid "Please enter your name."
 msgstr "Veuillez saisir votre nom."
 
-#: src/API/EventSignupController.php:2821
+#: src/API/EventSignupController.php:2809
 msgid "Failed to process registration. Please try again."
 msgstr "Échec du traitement de l'inscription. Veuillez réessayer."
 
-#: src/API/EventSignupController.php:2938
+#: src/API/EventSignupController.php:2927
 msgid "You have successfully registered and signed up for the event!"
 msgstr "Vous vous êtes inscrit et enregistré avec succès pour l'événement !"
 
@@ -947,8 +947,8 @@ msgid "This WordPress user is already linked to another participant."
 msgstr "Cet utilisateur WordPress est déjà lié à un autre participant."
 
 #: src/blocks/event-signup/render.php:63
-#: src/blocks/event-signup/render.php:969
-#: src/blocks/event-signup/editor.js:92
+#: src/blocks/event-signup/render.php:1037
+#: src/blocks/event-signup/editor.js:96
 #: src/blocks/event-signup/frontend.js:472
 #: src/blocks/event-signup/frontend.js:506
 #: src/blocks/event-signup/frontend.js:1692
@@ -956,8 +956,8 @@ msgid "Sign Up"
 msgstr "S'inscrire"
 
 #: src/blocks/event-signup/render.php:64
-#: src/blocks/event-signup/render.php:970
-#: src/blocks/event-signup/editor.js:143
+#: src/blocks/event-signup/render.php:1038
+#: src/blocks/event-signup/editor.js:147
 #: src/blocks/event-signup/frontend.js:475
 #: src/blocks/event-signup/frontend.js:509
 msgid "Register & Sign Up"
@@ -968,72 +968,72 @@ msgid "Send Signup Link"
 msgstr "Envoyer le lien d'inscription"
 
 #: src/blocks/event-interest/render.php:115
-#: src/blocks/event-signup/render.php:997
+#: src/blocks/event-signup/render.php:1065
 msgid "This block can only be used on event pages."
 msgstr "Ce bloc ne peut être utilisé que sur les pages d'événements."
 
-#: src/blocks/event-signup/render.php:1125
+#: src/blocks/event-signup/render.php:1193
 #: src/blocks/event-signup/frontend.js:1140
 #: src/blocks/event-signup/frontend.js:1403
 msgid "You are signed up for this event!"
 msgstr "Vous êtes inscrit à cet événement !"
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1146
+#: src/blocks/event-signup/render.php:1214
 #, php-format
 msgid "Hi %s! Click the button below to sign up for this event."
 msgstr "Bonjour %s ! Cliquez sur le bouton ci-dessous pour vous inscrire à cet événement."
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1152
+#: src/blocks/event-signup/render.php:1220
 #: src/blocks/event-signup/frontend.js:1671
-#, php-format, js-format
+#, php-format,js-format
 msgid "Hi %s! You can sign up for this event."
 msgstr "Bonjour %s ! Vous pouvez vous inscrire à cet événement."
 
-#: src/blocks/event-signup/render.php:1225
+#: src/blocks/event-signup/render.php:1293
 msgid "I'm new"
 msgstr "Je suis nouveau"
 
-#: src/blocks/event-signup/render.php:1228
+#: src/blocks/event-signup/render.php:1296
 msgid "I have an account"
 msgstr "J'ai un compte"
 
-#: src/blocks/event-signup/render.php:1259
+#: src/blocks/event-signup/render.php:1327
 msgid "Enter your surname"
 msgstr "Entrez votre nom de famille"
 
 #: src/blocks/audience-signup/render.php:386
-#: src/blocks/event-signup/render.php:1279
+#: src/blocks/event-signup/render.php:1347
 msgid "Keep me informed about future events"
 msgstr "Tenez-moi informé des événements futurs"
 
-#: src/blocks/event-signup/render.php:1316
+#: src/blocks/event-signup/render.php:1384
 msgid "Enter your email to receive a signup link."
 msgstr "Entrez votre e-mail pour recevoir un lien d'inscription."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:846
+#: src/Services/EmailService.php:847
 #, php-format
 msgid "Sign up for %s"
 msgstr "Inscription à %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:883
+#: src/Services/EmailService.php:884
 #, php-format
 msgid "You requested a signup link for %s."
 msgstr "Vous avez demandé un lien d'inscription pour %s."
 
-#: src/Services/EmailService.php:889
+#: src/Services/EmailService.php:890
 msgid "Click the button below to sign up for the event:"
 msgstr "Cliquez sur le bouton ci-dessous pour vous inscrire à l'événement :"
 
-#: src/Services/EmailService.php:894
-#: src/Services/EmailService.php:2736
+#: src/Services/EmailService.php:895
+#: src/Services/EmailService.php:2712
 msgid "Sign Up Now"
 msgstr "S'inscrire maintenant"
 
-#: src/Services/EmailService.php:899
+#: src/Services/EmailService.php:900
 msgid "If you didn't request this link, you can safely ignore this email."
 msgstr "Si vous n'avez pas demandé ce lien, vous pouvez ignorer cet e-mail en toute sécurité."
 
@@ -1085,11 +1085,11 @@ msgstr "Aucun utilisateur trouvé."
 msgid "Role"
 msgstr "Rôle"
 
-#: src/blocks/event-signup/editor.js:87
+#: src/blocks/event-signup/editor.js:91
 msgid "Signup Button Text"
 msgstr "Texte du bouton d'inscription"
 
-#: src/blocks/event-signup/editor.js:93
+#: src/blocks/event-signup/editor.js:97
 msgid "Button text for authenticated users."
 msgstr "Texte du bouton pour les utilisateurs authentifiés."
 
@@ -1193,26 +1193,26 @@ msgctxt "block keyword"
 msgid "list"
 msgstr "liste"
 
-#: src/Services/EmailService.php:923
-#: src/Services/EmailService.php:1045
-#: src/Services/EmailService.php:2761
+#: src/Services/EmailService.php:924
+#: src/Services/EmailService.php:1046
+#: src/Services/EmailService.php:2737
 msgid "Don't want to receive event invitations?"
 msgstr "Vous ne voulez plus recevoir d'invitations à des événements ?"
 
-#: src/Services/EmailService.php:924
-#: src/Services/EmailService.php:1046
-#: src/Services/EmailService.php:1180
-#: src/Services/EmailService.php:1359
-#: src/Services/EmailService.php:1629
-#: src/Services/EmailService.php:2762
+#: src/Services/EmailService.php:925
+#: src/Services/EmailService.php:1047
+#: src/Services/EmailService.php:1181
+#: src/Services/EmailService.php:1360
+#: src/Services/EmailService.php:1630
+#: src/Services/EmailService.php:2738
 msgid "Manage your preferences"
 msgstr "Gérer vos préférences"
 
-#: src/Services/EmailService.php:2879
+#: src/Services/EmailService.php:2855
 msgid "Already signed up"
 msgstr "Déjà inscrit"
 
-#: src/Services/EmailService.php:164
+#: src/Services/EmailService.php:165
 msgid "Participant opted out of marketing emails."
 msgstr "Le participant a refusé les emails marketing."
 
@@ -1324,7 +1324,7 @@ msgstr "Paramètres"
 msgid "Event date not found."
 msgstr "Date de l'événement introuvable."
 
-#: src/Services/EmailService.php:1815
+#: src/Services/EmailService.php:1816
 msgid "Fee not found."
 msgstr "Frais non trouvés."
 
@@ -1332,12 +1332,12 @@ msgstr "Frais non trouvés."
 msgid "Could not read SVG file."
 msgstr "Impossible de lire le fichier SVG."
 
-#: src/Hooks/PaymentHooks.php:819
+#: src/Hooks/PaymentHooks.php:832
 msgid "Paid online via Mollie"
 msgstr "Payé en ligne via Mollie"
 
 #. translators: %1$s: Mollie status, %2$d: transaction ID
-#: src/Hooks/PaymentHooks.php:863
+#: src/Hooks/PaymentHooks.php:876
 #, php-format
 msgid "Online payment %1$s (transaction #%2$d)"
 msgstr "Paiement en ligne %1$s (transaction #%2$d)"
@@ -1350,50 +1350,50 @@ msgstr "Vous n'êtes pas autorisé à télécharger des fichiers SVG."
 msgid "Invalid SVG file."
 msgstr "Fichier SVG invalide."
 
-#: src/Services/EmailService.php:369
-#: src/Services/EmailService.php:592
-#: src/Services/EmailService.php:1448
-#: src/Services/EmailService.php:1525
-#: src/Services/EmailService.php:1838
-#: src/Services/EmailService.php:2900
+#: src/Services/EmailService.php:370
+#: src/Services/EmailService.php:593
+#: src/Services/EmailService.php:1449
+#: src/Services/EmailService.php:1526
+#: src/Services/EmailService.php:1839
+#: src/Services/EmailService.php:2876
 msgid "Participant has no email address."
 msgstr "Le participant n'a pas d'adresse e-mail."
 
-#: src/Services/EmailService.php:1179
-#: src/Services/EmailService.php:1358
-#: src/Services/EmailService.php:1628
+#: src/Services/EmailService.php:1180
+#: src/Services/EmailService.php:1359
+#: src/Services/EmailService.php:1629
 msgid "Don't want to receive these emails?"
 msgstr "Vous ne voulez pas recevoir ces e-mails ?"
 
-#: src/Services/EmailService.php:1428
-#: src/Services/EmailService.php:1516
+#: src/Services/EmailService.php:1429
+#: src/Services/EmailService.php:1517
 msgid "Manually skipped."
 msgstr "Ignoré manuellement."
 
 #. translators: %s: fee name
-#: src/Services/EmailService.php:1680
+#: src/Services/EmailService.php:1681
 #, php-format
 msgid "Payment reminder: %s"
 msgstr "Rappel de paiement : %s"
 
-#: src/Services/EmailService.php:1715
+#: src/Services/EmailService.php:1716
 msgid "This is a friendly reminder about a pending payment:"
 msgstr "Ceci est un rappel amical concernant un paiement en attente :"
 
-#: src/Services/EmailService.php:1720
+#: src/Services/EmailService.php:1721
 msgid "Fee:"
 msgstr "Frais :"
 
-#: src/Services/EmailService.php:1724
-#: src/Services/EmailService.php:2544
+#: src/Services/EmailService.php:1725
+#: src/Services/EmailService.php:2520
 msgid "Amount:"
 msgstr "Montant :"
 
-#: src/Services/EmailService.php:1731
+#: src/Services/EmailService.php:1732
 msgid "Due Date:"
 msgstr "Date d'échéance :"
 
-#: src/Services/EmailService.php:1745
+#: src/Services/EmailService.php:1746
 msgid "Pay Now"
 msgstr "Payer maintenant"
 
@@ -1737,7 +1737,7 @@ msgstr "Vous avez été inscrit avec succès !"
 msgid "Audience Signup"
 msgstr "Inscription du public"
 
-#: src/API/EventSignupController.php:2929
+#: src/API/EventSignupController.php:2918
 msgid "You have been signed up for the event! Please check your email to confirm your subscription."
 msgstr "Vous vous êtes inscrit à l'événement ! Veuillez vérifier votre e-mail pour confirmer votre abonnement."
 
@@ -1758,39 +1758,39 @@ msgid "Update Answers"
 msgstr "Mettre à jour les réponses"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:743
+#: src/Services/EmailService.php:744
 #, php-format
 msgid "Your signup answers — %s"
 msgstr "Vos réponses d'inscription — %s"
 
-#: src/Services/EmailService.php:780
+#: src/Services/EmailService.php:781
 msgid "Thank you for signing up! Here are the answers you submitted:"
 msgstr "Merci de vous être inscrit ! Voici les réponses que vous avez soumises :"
 
-#: src/Services/EmailService.php:789
+#: src/Services/EmailService.php:790
 msgid "Edit Your Answers"
 msgstr "Modifier vos réponses"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2680
+#: src/Services/EmailService.php:2656
 #, php-format
 msgid "You're invited: %s"
 msgstr "Vous êtes invité : %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2717
+#: src/Services/EmailService.php:2693
 #, php-format
 msgid "We have a new event coming up: %s."
 msgstr "Nous avons un nouvel événement à venir : %s."
 
-#: src/Services/EmailService.php:2731
+#: src/Services/EmailService.php:2707
 msgid "Would you like to join? Click the button below to sign up:"
 msgstr "Aimeriez-vous participer ? Cliquez sur le bouton ci-dessous pour vous inscrire :"
 
 #. translators: 1: line break, 2: site name
-#: src/Services/EmailService.php:2360
-#: src/Services/EmailService.php:2480
-#: src/Services/EmailService.php:2743
+#: src/Services/EmailService.php:2337
+#: src/Services/EmailService.php:2448
+#: src/Services/EmailService.php:2719
 #, php-format
 msgid "See you there!%1$sThe %2$s Team"
 msgstr "À bientôt !%1$sL'équipe %2$s"
@@ -1944,17 +1944,17 @@ msgctxt "block keyword"
 msgid "member"
 msgstr "membre"
 
-#: src/API/EventSignupController.php:3010
+#: src/API/EventSignupController.php:2999
 msgid "You are not signed up for this event."
 msgstr "Vous n'êtes pas inscrit à cet événement."
 
-#: src/API/EventSignupController.php:3026
+#: src/API/EventSignupController.php:3015
 #: src/blocks/event-signup/frontend.js:1640
 msgid "You have been removed from this event."
 msgstr "Vous avez été retiré de cet événement."
 
-#: src/blocks/event-signup/render.php:1211
-#: src/Hooks/SignupHookBridge.php:342
+#: src/blocks/event-signup/render.php:1279
+#: src/Hooks/SignupHookBridge.php:362
 #: src/Admin/manage-event-audience-tab/EventAudience.js:2369
 #: src/blocks/event-signup/frontend.js:1411
 msgid "Cancel signup"
@@ -1974,9 +1974,9 @@ msgstr "Aucune date d'événement trouvée pour cet événement"
 
 #: src/blocks/audience-signup/render.php:393
 #: src/blocks/event-interest/render.php:161
-#: src/blocks/event-signup/render.php:1291
+#: src/blocks/event-signup/render.php:1359
 #: src/blocks/mailing-signup/render.php:156
-#: src/Hooks/SignupHookBridge.php:369
+#: src/Hooks/SignupHookBridge.php:390
 msgid "Not you? Start fresh"
 msgstr "Ce n'est pas vous ? Recommencer"
 
@@ -2075,60 +2075,60 @@ msgstr "Afficher le fichier"
 msgid "Failed to update attendance."
 msgstr "Échec de la mise à jour de la présence."
 
-#: src/API/EventSignupController.php:1355
+#: src/API/EventSignupController.php:1348
 #: src/Services/GroupSignupPricing.php:113
 msgid "This ticket type is not available for your account."
 msgstr "Ce type de billet n'est pas disponible pour votre compte."
 
-#: src/API/EventSignupController.php:1841
+#: src/API/EventSignupController.php:1829
 msgid "This event is fully booked."
 msgstr "Cet événement est complet."
 
 #. translators: %s: event title or occurrence date/time label
-#: src/API/EventSignupController.php:984
-#: src/API/EventSignupController.php:998
-#: src/API/EventSignupController.php:1873
+#: src/API/EventSignupController.php:985
+#: src/API/EventSignupController.php:999
+#: src/API/EventSignupController.php:1861
 #, php-format
 msgid "Signup for %s"
 msgstr "Inscription pour %s"
 
-#: src/API/EventSignupController.php:1051
-#: src/API/EventSignupController.php:1317
-#: src/API/EventSignupController.php:1965
-#: src/API/EventSignupController.php:2112
-#: src/API/EventSignupController.php:2489
-#: src/API/EventSignupController.php:2630
+#: src/API/EventSignupController.php:1052
+#: src/API/EventSignupController.php:1310
+#: src/API/EventSignupController.php:1953
+#: src/API/EventSignupController.php:2100
+#: src/API/EventSignupController.php:2477
+#: src/API/EventSignupController.php:2618
 #: src/blocks/event-signup/frontend.js:1080
 #: src/blocks/event-signup/frontend.js:1362
 msgid "Redirecting to payment…"
 msgstr "Redirection vers le paiement…"
 
-#: src/blocks/event-signup/render.php:617
+#: src/blocks/event-signup/render.php:677
 #: src/blocks/event-signup/frontend.js:537
 msgid "Sign up for free"
 msgstr "S'inscrire gratuitement"
 
-#: src/blocks/event-signup/render.php:618
+#: src/blocks/event-signup/render.php:678
 #: src/blocks/event-signup/frontend.js:538
 msgid "Register for free"
 msgstr "S'enregistrer gratuitement"
 
-#: src/blocks/event-signup/render.php:691
+#: src/blocks/event-signup/render.php:748
 msgid "Choose ticket type"
 msgstr "Choisir le type de billet"
 
-#: src/blocks/event-signup/render.php:702
-#: src/blocks/event-signup/render.php:779
-#: src/blocks/event-signup/render.php:841
-#: src/Hooks/SignupHookBridge.php:541
+#: src/blocks/event-signup/render.php:759
+#: src/blocks/event-signup/render.php:847
+#: src/blocks/event-signup/render.php:909
+#: src/Hooks/SignupHookBridge.php:564
 msgid "free"
 msgstr "gratuit"
 
-#: src/blocks/event-signup/render.php:743
+#: src/blocks/event-signup/render.php:811
 msgid "Select activities"
 msgstr "Sélectionner les activités"
 
-#: src/Hooks/PaymentHooks.php:394
+#: src/Hooks/PaymentHooks.php:399
 #: src/Hooks/PendingSubscriptionTimeoutHooks.php:56
 #: src/Hooks/WeeklyDigestHooks.php:55
 msgid "Every 5 minutes (fair-audience)"
@@ -2208,62 +2208,62 @@ msgid "Submitted at"
 msgstr "Soumis le"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:1910
+#: src/Services/EmailService.php:1911
 #, php-format
 msgid "New form submission — %s"
 msgstr "Nouvelle soumission de formulaire — %s"
 
 #. translators: %s: page title
-#: src/Services/EmailService.php:1931
+#: src/Services/EmailService.php:1932
 #, php-format
 msgid "Page: %s"
 msgstr "Page : %s"
 
-#: src/Services/EmailService.php:1959
+#: src/Services/EmailService.php:1960
 msgid "A new form submission has been received."
 msgstr "Une nouvelle soumission de formulaire a été reçue."
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:2140
+#: src/Services/EmailService.php:2141
 #, php-format
 msgid "Your submission — %s"
 msgstr "Votre soumission — %s"
 
 #. translators: %s: page title
-#: src/Services/EmailService.php:2151
+#: src/Services/EmailService.php:2152
 #, php-format
 msgid "Form: %s"
 msgstr "Formulaire : %s"
 
-#: src/Services/EmailService.php:2161
+#: src/Services/EmailService.php:2162
 msgid "Here are the answers you submitted:"
 msgstr "Voici les réponses que vous avez soumises :"
 
-#: src/Services/EmailService.php:2199
+#: src/Services/EmailService.php:2200
 msgid "Thank you for your submission! We have received your response."
 msgstr "Merci pour votre soumission ! Nous avons reçu votre réponse."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2257
+#: src/Services/EmailService.php:2260
 #, php-format
 msgid "Signup confirmed — %s"
 msgstr "Inscription confirmée — %s"
 
-#: src/Services/EmailService.php:2269
-#: src/Services/EmailService.php:2419
+#: src/Services/EmailService.php:2333
+#: src/Services/EmailService.php:2387
 #: src/blocks/event-signup/frontend.js:1816
 #: src/blocks/event-signup/frontend.js:1938
 msgid "Amount paid:"
 msgstr "Montant payé :"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2344
+#: src/Services/EmailService.php:2309
 #, php-format
 msgid "Your signup for %s has been confirmed and your payment has been received."
 msgstr "Votre inscription pour %s a été confirmée et votre paiement a été reçu."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2346
+#: src/Services/EmailService.php:2311
 #, php-format
 msgid "Your signup for %s has been confirmed."
 msgstr "Votre inscription pour %s a été confirmée."
@@ -2287,57 +2287,57 @@ msgstr "Ligne de participant non trouvée pour cette date d'événement."
 msgid "Selected ticket type was not found."
 msgstr "Le type de billet sélectionné n'a pas été trouvé."
 
-#: src/API/EventSignupController.php:1458
+#: src/API/EventSignupController.php:1451
 msgid "This ticket type is sold out. Please pick another option."
 msgstr "Ce type de billet est épuisé. Veuillez choisir une autre option."
 
 #. translators: %d: minimum number of activities required
-#: src/API/EventSignupController.php:1598
-#: src/blocks/event-signup/render.php:753
-#: src/Services/SignupActivities.php:187
+#: src/API/EventSignupController.php:1591
+#: src/blocks/event-signup/render.php:821
+#: src/Services/SignupActivities.php:210
 #: src/blocks/event-signup/frontend.js:391
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d activity to sign up."
 msgid_plural "Please select at least %d activities to sign up."
 msgstr[0] "Veuillez sélectionner au moins %d activité pour vous inscrire."
 msgstr[1] "Veuillez sélectionner au moins %d activités pour vous inscrire."
 
-#: src/API/EventSignupController.php:2206
+#: src/API/EventSignupController.php:2194
 msgid "Invalid transaction."
 msgstr "Transaction invalide."
 
-#: src/API/EventSignupController.php:2214
+#: src/API/EventSignupController.php:2202
 msgid "Payment plugin is missing."
 msgstr "Le plugin de paiement est manquant."
 
-#: src/API/EventSignupController.php:2223
-#: src/API/EventSignupController.php:2288
+#: src/API/EventSignupController.php:2211
+#: src/API/EventSignupController.php:2276
 msgid "Transaction not found."
 msgstr "Transaction non trouvée."
 
-#: src/API/EventSignupController.php:2264
+#: src/API/EventSignupController.php:2252
 msgid "You are not authorized to retry this payment."
 msgstr "Vous n'êtes pas autorisé à réessayer ce paiement."
 
-#: src/API/EventSignupController.php:2300
+#: src/API/EventSignupController.php:2288
 msgid "This payment cannot be retried."
 msgstr "Ce paiement ne peut pas être réessayé."
 
-#: src/API/EventSignupController.php:2318
+#: src/API/EventSignupController.php:2306
 msgid "This payment is not retriable from this endpoint."
 msgstr "Ce paiement ne peut pas être réessayé à partir de ce point de terminaison."
 
-#: src/API/EventSignupController.php:2331
-#: src/API/EventSignupController.php:2523
+#: src/API/EventSignupController.php:2319
+#: src/API/EventSignupController.php:2511
 msgid "This payment is missing context needed to retry."
 msgstr "Ce paiement manque du contexte nécessaire pour réessayer."
 
-#: src/API/EventSignupController.php:2379
-#: src/API/EventSignupController.php:2566
+#: src/API/EventSignupController.php:2367
+#: src/API/EventSignupController.php:2554
 msgid "Original line items could not be loaded."
 msgstr "Les articles de ligne originaux n'ont pas pu être chargés."
 
-#: src/API/EventSignupController.php:2769
+#: src/API/EventSignupController.php:2757
 #: src/blocks/event-signup/frontend.js:1096
 msgid "We recognise this email — check your inbox to continue."
 msgstr "Nous reconnaissons cette adresse e-mail — vérifiez votre boîte de réception pour continuer."
@@ -2346,134 +2346,134 @@ msgstr "Nous reconnaissons cette adresse e-mail — vérifiez votre boîte de r�
 msgid "You have been subscribed."
 msgstr "Vous avez été abonné."
 
-#: src/blocks/event-signup/render.php:706
+#: src/blocks/event-signup/render.php:774
 msgid "sold out"
 msgstr "épuisé"
 
-#: src/blocks/event-signup/render.php:784
-#: src/blocks/event-signup/render.php:845
-#: src/Hooks/SignupHookBridge.php:544
+#: src/blocks/event-signup/render.php:852
+#: src/blocks/event-signup/render.php:913
+#: src/Hooks/SignupHookBridge.php:567
 msgid "full"
 msgstr "complet"
 
-#: src/blocks/event-signup/render.php:886
+#: src/blocks/event-signup/render.php:954
 msgid "Choose a date"
 msgstr "Choisir une date"
 
 #. translators: appended to a date label when the viewer is signed up — they can cancel from this row
-#: src/blocks/event-signup/render.php:897
+#: src/blocks/event-signup/render.php:965
 msgid "signed up (manage)"
 msgstr "inscrit (gérer)"
 
-#: src/blocks/event-signup/render.php:899
+#: src/blocks/event-signup/render.php:967
 msgid "signed up"
 msgstr "inscrit"
 
-#: src/blocks/event-signup/render.php:1009
+#: src/blocks/event-signup/render.php:1077
 #: src/blocks/event-signup/frontend.js:1809
 msgid "Payment confirmed"
 msgstr "Paiement confirmé"
 
 #. translators: %s: event title
-#: src/blocks/event-signup/render.php:1015
+#: src/blocks/event-signup/render.php:1083
 #, php-format
 msgid "You're signed up for %s."
 msgstr "Vous êtes inscrit pour %s."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1024
+#: src/blocks/event-signup/render.php:1092
 #, php-format
 msgid "Amount paid: %s"
 msgstr "Montant payé : %s"
 
-#: src/blocks/event-signup/render.php:1030
+#: src/blocks/event-signup/render.php:1098
 #: src/blocks/event-signup/frontend.js:1823
 msgid "A confirmation email is on its way. You can close this page."
 msgstr "Un email de confirmation est en route. Vous pouvez fermer cette page."
 
-#: src/blocks/event-signup/render.php:1037
+#: src/blocks/event-signup/render.php:1105
 msgid "Thank you for your payment!"
 msgstr "Merci pour votre paiement !"
 
-#: src/blocks/event-signup/render.php:1040
+#: src/blocks/event-signup/render.php:1108
 msgid "We're confirming with your bank. This usually takes a few seconds — the page will update as soon as it's done."
 msgstr "Nous confirmons auprès de votre banque. Cela prend généralement quelques secondes — la page se mettra à jour dès que ce sera fait."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1046
+#: src/blocks/event-signup/render.php:1114
 #, php-format
 msgid "Amount: %s"
 msgstr "Montant : %s"
 
-#: src/blocks/event-signup/render.php:1055
+#: src/blocks/event-signup/render.php:1123
 msgid "Your payment is waiting."
 msgstr "Votre paiement est en attente."
 
-#: src/blocks/event-signup/render.php:1058
+#: src/blocks/event-signup/render.php:1126
 msgid "You can pick up where you left off on the secure payment page."
 msgstr "Vous pouvez reprendre où vous vous étiez arrêté sur la page de paiement sécurisée."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1064
-#: src/blocks/event-signup/render.php:1091
+#: src/blocks/event-signup/render.php:1132
+#: src/blocks/event-signup/render.php:1159
 #, php-format
 msgid "Amount due: %s"
 msgstr "Montant dû : %s"
 
-#: src/blocks/event-signup/render.php:1071
+#: src/blocks/event-signup/render.php:1139
 msgid "Continue payment"
 msgstr "Continuer le paiement"
 
-#: src/blocks/event-signup/render.php:1076
-#: src/blocks/event-signup/render.php:1103
+#: src/blocks/event-signup/render.php:1144
+#: src/blocks/event-signup/render.php:1171
 msgid "Cancel and start over"
 msgstr "Annuler et recommencer"
 
-#: src/blocks/event-signup/render.php:1085
+#: src/blocks/event-signup/render.php:1153
 msgid "Your payment didn't go through."
 msgstr "Votre paiement n'a pas abouti."
 
-#: src/blocks/event-signup/render.php:1098
+#: src/blocks/event-signup/render.php:1166
 msgid "Retry payment"
 msgstr "Réessayer le paiement"
 
 #. translators: %s: transaction status
-#: src/blocks/event-signup/render.php:1114
+#: src/blocks/event-signup/render.php:1182
 #, php-format
 msgid "Payment status: %s"
 msgstr "Statut du paiement : %s"
 
-#: src/blocks/event-signup/render.php:1185
-#: src/Hooks/SignupHookBridge.php:295
+#: src/blocks/event-signup/render.php:1253
+#: src/Hooks/SignupHookBridge.php:315
 msgid "You are signed up for this date."
 msgstr "Vous êtes inscrit pour cette date."
 
-#: src/Services/EmailService.php:2282
+#: src/Services/EmailService.php:2334
 msgid "Selected options:"
 msgstr "Options sélectionnées :"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2532
+#: src/Services/EmailService.php:2508
 #, php-format
 msgid "Payment didn’t go through — %s"
 msgstr "Le paiement n'a pas abouti — %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2580
+#: src/Services/EmailService.php:2556
 #, php-format
 msgid "Your payment for %s didn’t go through. Your spot is still held for a short while — pick up where you left off using the link below."
 msgstr "Votre paiement pour %s n'a pas été traité. Votre place est toujours réservée pour un court moment — reprenez où vous vous étiez arrêté en utilisant le lien ci-dessous."
 
-#: src/Services/EmailService.php:2589
+#: src/Services/EmailService.php:2565
 msgid "Resume payment"
 msgstr "Reprendre le paiement"
 
-#: src/Services/EmailService.php:2594
+#: src/Services/EmailService.php:2570
 msgid "If the button doesn’t work, copy and paste this link into your browser:"
 msgstr "Si le bouton ne fonctionne pas, copiez et collez ce lien dans votre navigateur :"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:2601
+#: src/Services/EmailService.php:2577
 #, php-format
 msgid "See you soon,%1$sThe %2$s Team"
 msgstr "À bientôt,%1$sL'équipe %2$s"
@@ -2569,30 +2569,30 @@ msgstr "Échec de la mise à niveau du participant ID %d"
 msgid "Verbal consent recorded by %1$s on %2$s at event %3$s"
 msgstr "Consentement verbal enregistré par %1$s le %2$s à l'événement %3$s"
 
-#: src/API/EventSignupController.php:1130
+#: src/API/EventSignupController.php:1131
 msgid "You need an active signup before you can add activities."
 msgstr "Vous devez avoir une inscription active avant de pouvoir ajouter des activités."
 
-#: src/API/EventSignupController.php:1152
+#: src/API/EventSignupController.php:1153
 msgid "No new activities to add."
 msgstr "Aucune nouvelle activité à ajouter."
 
-#: src/API/EventSignupController.php:1177
+#: src/API/EventSignupController.php:1178
 #: src/blocks/event-signup/frontend.js:1556
 msgid "Your activities have been added!"
 msgstr "Vos activités ont été ajoutées !"
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:1258
+#: src/API/EventSignupController.php:1251
 #, php-format
 msgid "Added activities for %s"
 msgstr "Activités ajoutées pour %s"
 
-#: src/API/EventSignupController.php:2541
+#: src/API/EventSignupController.php:2529
 msgid "Your signup is no longer active."
 msgstr "Votre inscription n'est plus active."
 
-#: src/API/EventSignupController.php:2555
+#: src/API/EventSignupController.php:2543
 msgid "These activities are already on your signup."
 msgstr "Ces activités sont déjà dans votre inscription."
 
@@ -2616,30 +2616,30 @@ msgstr "E-mail de confirmation envoyé."
 msgid "Website"
 msgstr "Site web"
 
-#: src/blocks/event-signup/render.php:833
-#: src/blocks/event-signup/render.php:863
-#: src/Hooks/SignupHookBridge.php:523
-#: src/Hooks/SignupHookBridge.php:561
+#: src/blocks/event-signup/render.php:901
+#: src/blocks/event-signup/render.php:931
+#: src/Hooks/SignupHookBridge.php:546
+#: src/Hooks/SignupHookBridge.php:584
 #: src/blocks/event-signup/frontend.js:1466
 msgid "Add activities"
 msgstr "Ajouter des activités"
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1140
+#: src/blocks/event-signup/render.php:1208
 #, php-format
 msgid "Hi %s! Here is your registration for this event."
 msgstr "Bonjour %s ! Voici votre inscription pour cet événement."
 
 #. translators: %s: ticket type name
-#: src/blocks/event-signup/render.php:1192
-#: src/Hooks/SignupHookBridge.php:302
+#: src/blocks/event-signup/render.php:1260
+#: src/Hooks/SignupHookBridge.php:322
 #, php-format
 msgid "Your ticket: %s"
 msgstr "Votre billet : %s"
 
-#: src/blocks/event-signup/render.php:1200
-#: src/Hooks/SignupHookBridge.php:309
-#: src/Hooks/SignupHookBridge.php:526
+#: src/blocks/event-signup/render.php:1268
+#: src/Hooks/SignupHookBridge.php:329
+#: src/Hooks/SignupHookBridge.php:549
 msgid "Your activities:"
 msgstr "Vos activités :"
 
@@ -2661,73 +2661,73 @@ msgid "Unsubscribed"
 msgstr "Désinscrit"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2407
+#: src/Services/EmailService.php:2375
 #, php-format
 msgid "Activities added — %s"
 msgstr "Activités ajoutées — %s"
 
-#: src/Services/EmailService.php:2432
+#: src/Services/EmailService.php:2400
 msgid "Activities added:"
 msgstr "Activités ajoutées :"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2468
+#: src/Services/EmailService.php:2436
 #, php-format
 msgid "The following activities have been added to your signup for %s."
 msgstr "Les activités suivantes ont été ajoutées à votre inscription pour %s."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2972
+#: src/Services/EmailService.php:2956
 #, php-format
 msgid "Thanks for your interest in %s"
 msgstr "Merci de votre intérêt pour %s"
 
-#: src/Services/EmailService.php:2976
-#: src/Services/EmailService.php:3054
+#: src/Services/EmailService.php:2960
+#: src/Services/EmailService.php:3039
 msgid "there"
 msgstr "là"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:3003
+#: src/Services/EmailService.php:2987
 #, php-format
 msgid "Thanks for registering your interest in %s. We will let you know when there are updates."
 msgstr "Merci de vous être inscrit pour %s. Nous vous tiendrons informé des mises à jour."
 
-#: src/Services/EmailService.php:3006
+#: src/Services/EmailService.php:2990
 msgid "If you didn't register your interest, you can safely ignore this email."
 msgstr "Si vous ne vous êtes pas inscrit, vous pouvez ignorer cet e-mail en toute sécurité."
 
-#: src/Services/EmailService.php:3011
+#: src/Services/EmailService.php:2995
 msgid "No longer interested?"
 msgstr "Plus intéressé ?"
 
-#: src/Services/EmailService.php:3012
+#: src/Services/EmailService.php:2996
 msgid "Unsubscribe from updates about this event"
 msgstr "Se désabonner des mises à jour concernant cet événement"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3050
+#: src/Services/EmailService.php:3035
 #, php-format
 msgid "Welcome to the %s mailing list"
 msgstr "Bienvenue sur la liste de diffusion %s"
 
 #. translators: 1: site name, 2: event title
-#: src/Services/EmailService.php:3059
+#: src/Services/EmailService.php:3044
 #, php-format
 msgid "You've been added to the %1$s mailing list following the consent you gave at %2$s. We'll keep you posted about upcoming events and news."
 msgstr "Vous avez été ajouté à la liste de diffusion %1$s suite au consentement que vous avez donné le %2$s. Nous vous tiendrons informé des événements et actualités à venir."
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3066
+#: src/Services/EmailService.php:3051
 #, php-format
 msgid "You've been added to the %s mailing list following the consent you gave. We'll keep you posted about upcoming events and news."
 msgstr "Vous avez été ajouté à la liste de diffusion %s suite au consentement que vous avez donné. Nous vous tiendrons informé des événements et actualités à venir."
 
-#: src/Services/EmailService.php:3099
+#: src/Services/EmailService.php:3084
 msgid "Changed your mind?"
 msgstr "Vous avez changé d'avis ?"
 
-#: src/Services/EmailService.php:3100
+#: src/Services/EmailService.php:3085
 msgid "Manage your subscription or unsubscribe"
 msgstr "Gérer votre abonnement ou vous désabonner"
 
@@ -2789,31 +2789,31 @@ msgid "interest"
 msgstr "intérêt"
 
 #: src/API/EventParticipantsController.php:582
-#: src/API/EventSignupController.php:1751
-#: src/Services/EmailService.php:2294
-#: src/blocks/event-signup/editor.js:110
+#: src/API/EventSignupController.php:1746
+#: src/Services/EmailService.php:2296
+#: src/blocks/event-signup/editor.js:114
 msgid "Event Signup"
 msgstr "Inscription à l'événement"
 
-#: src/Services/EmailService.php:2303
+#: src/Services/EmailService.php:2335
 msgid "Your answers:"
 msgstr "Vos réponses :"
 
-#: src/blocks/event-signup/editor.js:128
+#: src/blocks/event-signup/editor.js:132
 msgid "Ticket types, activity options and pricing are rendered on the published page based on the event."
 msgstr "Les types de billets, les options d'activité et la tarification sont affichés sur la page publiée en fonction de l'événement."
 
-#: src/blocks/event-signup/editor.js:134
+#: src/blocks/event-signup/editor.js:138
 msgid "Custom questions"
 msgstr "Questions personnalisées"
 
-#: src/API/EventSignupController.php:1485
+#: src/API/EventSignupController.php:1478
 msgid "This ticket type is no longer available. Please pick another option."
 msgstr "Ce type de billet n'est plus disponible. Veuillez choisir une autre option."
 
 #. translators: 1: discount percentage, 2: group name
-#: src/blocks/event-signup/render.php:663
-#: src/Services/GroupSignupPricing.php:134
+#: src/blocks/event-signup/render.php:720
+#: src/Services/GroupSignupPricing.php:146
 #, php-format
 msgid "%1$s%% discount applied (%2$s)"
 msgstr "%1$s%% de réduction appliquée (%2$s)"
@@ -2855,59 +2855,59 @@ msgstr "Impossible d'enregistrer le refus pour l'ID participant %d"
 msgid "Decline recorded by %1$s on %2$s at event %3$s"
 msgstr "Refus enregistré par %1$s le %2$s à l'événement %3$s"
 
-#: src/API/EventSignupController.php:805
+#: src/API/EventSignupController.php:806
 msgid "Please select at least one occurrence."
 msgstr "Veuillez sélectionner au moins une occurrence."
 
-#: src/API/EventSignupController.php:813
-#: src/API/EventSignupController.php:824
+#: src/API/EventSignupController.php:814
+#: src/API/EventSignupController.php:825
 msgid "Invalid ticket type."
 msgstr "Type de billet invalide."
 
-#: src/API/EventSignupController.php:835
+#: src/API/EventSignupController.php:836
 msgid "One of the selected occurrences is not valid for this ticket."
 msgstr "L'une des occurrences sélectionnées n'est pas valide pour ce billet."
 
 #. translators: %d: minimum number of occurrences required
-#: src/API/EventSignupController.php:848
+#: src/API/EventSignupController.php:849
 #: src/blocks/event-signup/frontend.js:311
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d occurrence."
 msgid_plural "Please select at least %d occurrences."
 msgstr[0] "Veuillez sélectionner au moins %d occurrence."
 msgstr[1] "Veuillez sélectionner au moins %d occurrences."
 
-#: src/API/EventSignupController.php:875
+#: src/API/EventSignupController.php:876
 msgid "You are already signed up for these occurrences."
 msgstr "Vous êtes déjà inscrit à ces occurrences."
 
-#: src/API/EventSignupController.php:928
+#: src/API/EventSignupController.php:929
+#: src/API/EventSignupController.php:1804
 #: src/API/EventSignupController.php:1816
-#: src/API/EventSignupController.php:1828
-#: src/API/EventSignupController.php:2039
+#: src/API/EventSignupController.php:2027
 msgid "Paid signup is not available because the payment plugin is not configured."
 msgstr "L'inscription payante n'est pas disponible car le plugin de paiement n'est pas configuré."
 
-#: src/API/EventSignupController.php:945
+#: src/API/EventSignupController.php:946
 msgid "One of the selected occurrences is fully booked."
 msgstr "L'une des occurrences sélectionnées est complètement réservée."
 
-#: src/API/EventSignupController.php:1239
-#: src/API/EventSignupController.php:1251
+#: src/API/EventSignupController.php:1232
+#: src/API/EventSignupController.php:1244
 msgid "Paid activities are not available because the payment plugin is not configured."
 msgstr "Les activités payantes ne sont pas disponibles car le plugin de paiement n'est pas configuré."
 
-#: src/blocks/event-signup/render.php:938
+#: src/blocks/event-signup/render.php:1006
 msgid "Choose occurrences"
 msgstr "Choisir les occurrences"
 
-#: src/blocks/event-signup/render.php:959
-#: src/Hooks/SignupHookBridge.php:331
+#: src/blocks/event-signup/render.php:1027
+#: src/Hooks/SignupHookBridge.php:351
 msgid "already signed up"
 msgstr "déjà inscrit"
 
-#: src/blocks/event-signup/render.php:1174
-#: src/blocks/event-signup/render.php:1297
+#: src/blocks/event-signup/render.php:1242
+#: src/blocks/event-signup/render.php:1365
 msgid "Online payment is not available for this event at the moment. Please contact the organiser."
 msgstr "Le paiement en ligne n'est pas disponible pour cet événement pour le moment. Veuillez contacter l'organisateur."
 
@@ -2961,18 +2961,18 @@ msgstr "Ce lien est invalide ou a expiré."
 msgid "This registration link has expired. Please fill in the form again."
 msgstr "Ce lien d'inscription a expiré. Veuillez remplir le formulaire à nouveau."
 
-#: src/API/EventSignupController.php:2030
+#: src/API/EventSignupController.php:2018
 msgid "Your series pass is now active!"
 msgstr "Votre passe série est maintenant actif !"
 
 #. translators: %s: ticket type name
-#: src/API/EventSignupController.php:2048
+#: src/API/EventSignupController.php:2036
 #, php-format
 msgid "Upgrade to series pass: %s"
 msgstr "Passer à un passe série : %s"
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:2062
+#: src/API/EventSignupController.php:2050
 #, php-format
 msgid "Series pass upgrade for %s"
 msgstr "Mise à niveau du passe série pour %s"
@@ -3005,30 +3005,30 @@ msgid "Sent to %1$d, failed %2$d, skipped %3$d."
 msgstr "Envoyé à %1$d, échoué %2$d, ignoré %3$d."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:964
+#: src/Services/EmailService.php:965
 #, php-format
 msgid "Continue registering for %s"
 msgstr "Continuer l'inscription pour %s"
 
-#: src/Services/EmailService.php:969
+#: src/Services/EmailService.php:970
 msgid "Continue to payment"
 msgstr "Continuer vers le paiement"
 
-#: src/Services/EmailService.php:970
+#: src/Services/EmailService.php:971
 msgid "Continue to sign up"
 msgstr "Continuer l'inscription"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:1005
+#: src/Services/EmailService.php:1006
 #, php-format
 msgid "You're registering for %s."
 msgstr "Vous vous inscrivez pour %s."
 
-#: src/Services/EmailService.php:1011
+#: src/Services/EmailService.php:1012
 msgid "We've saved your answers — click below to continue where you left off:"
 msgstr "Nous avons enregistré vos réponses — cliquez ci-dessous pour continuer où vous vous étiez arrêté :"
 
-#: src/Services/EmailService.php:1021
+#: src/Services/EmailService.php:1022
 msgid "If you didn't try to register, you can safely ignore this email."
 msgstr "Si vous n'avez pas essayé de vous inscrire, vous pouvez ignorer cet e-mail en toute sécurité."
 
@@ -3616,11 +3616,11 @@ msgstr "Audience"
 msgid "Outro text"
 msgstr "Texte de conclusion"
 
-#: src/Services/EmailService.php:153
+#: src/Services/EmailService.php:154
 msgid "Participant has not yet confirmed their marketing subscription."
 msgstr "Le participant n'a pas encore confirmé son abonnement au marketing."
 
-#: src/Services/EmailService.php:2041
+#: src/Services/EmailService.php:2042
 msgid "[Test email — real sends to subscribers include a \"Manage your preferences\" unsubscribe link here.]"
 msgstr "[E-mail de test — les envois réels aux abonnés incluent un lien de désinscription « Gérer vos préférences » ici.]"
 
@@ -3638,7 +3638,7 @@ msgstr "HTML optionnel affiché sous la liste des événements."
 msgid "Next digest: %s"
 msgstr "Prochain digest : %s"
 
-#: src/blocks/event-signup/editor.js:103
+#: src/blocks/event-signup/editor.js:107
 msgid "This block has moved to Event Signup (fair-events). Transform it to the new block."
 msgstr "Ce bloc a été déplacé vers Event Signup (fair-events). Transformez-le en nouveau bloc."
 
@@ -3656,10 +3656,11 @@ msgstr "Bloc d'inscription hérité. Remplacé par Event Signup (fair-events) �
 msgid "Reverted to minimal: marketing subscription was never confirmed within a week."
 msgstr "Revenu à minimal : l'abonnement marketing n'a jamais été confirmé dans la semaine."
 
-#: src/Services/EmailService.php:161
+#: src/Services/EmailService.php:162
 msgid "Opted out of the weekly summary."
 msgstr "Désinscrit du résumé hebdomadaire."
 
+#. translators: %s: source host, e.g. "instagram.com".
 #. translators: %s: source domain, e.g. "example.com".
 #: src/Services/WeeklyDigestRenderer.php:165
 #: src/Services/WeeklyDigestRenderer.php:175
@@ -3689,38 +3690,38 @@ msgstr "Désinscrit"
 msgid "Subscribed"
 msgstr "Abonné"
 
-#: ../fair-events-shared/src/questionnaire.js:449
+#: ../fair-events-shared/src/questionnaire.js:453
 msgid "Please answer the required question: "
 msgstr "Veuillez répondre à la question obligatoire : "
 
-#: ../fair-events-shared/src/questionnaire.js:497
+#: ../fair-events-shared/src/questionnaire.js:501
 msgid "Please enter a valid email address for: "
 msgstr "Veuillez entrer une adresse e-mail valide pour : "
 
-#: ../fair-events-shared/src/questionnaire.js:527
+#: ../fair-events-shared/src/questionnaire.js:616
 msgid "File is too large. Maximum size is "
 msgstr "Le fichier est trop volumineux. La taille maximale est "
 
-#: ../fair-events-shared/src/questionnaire.js:472
+#: ../fair-events-shared/src/questionnaire.js:476
 msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
 msgstr "Entrez un numéro de téléphone valide avec l'indicatif du pays (par exemple +49 170 123 45 67) pour : %s"
 
 #. translators: 1: base button label, 2: formatted price
-#: src/blocks/event-signup/render.php:606
-#: src/blocks/event-signup/render.php:612
+#: src/blocks/event-signup/render.php:666
+#: src/blocks/event-signup/render.php:672
 #, php-format
 msgid "%1$s — %2$s"
 msgstr "%1$s — %2$s"
 
 #. translators: 1: discount amount, 2: group name
-#: src/blocks/event-signup/render.php:670
-#: src/Services/GroupSignupPricing.php:142
+#: src/blocks/event-signup/render.php:727
+#: src/Services/GroupSignupPricing.php:154
 #, php-format
 msgid "%1$s discount applied (%2$s)"
 msgstr "Réduction %1$s appliquée (%2$s)"
 
 #. translators: %s: formatted add-on price
-#: src/blocks/event-signup/render.php:810
+#: src/blocks/event-signup/render.php:878
 #, php-format
 msgid "(+%s)"
 msgstr "(+%s)"
@@ -3735,18 +3736,47 @@ msgstr "Total : %s"
 msgid "Translations"
 msgstr "Traductions"
 
-#: src/Hooks/SignupHookBridge.php:244
+#: src/Hooks/SignupHookBridge.php:263
 msgid "You already have a ticket for this date."
 msgstr "Vous avez déjà un billet pour cette date."
 
-#: src/Services/SignupActivities.php:145
-#: src/Services/SignupActivities.php:164
+#: src/Services/SignupActivities.php:168
+#: src/Services/SignupActivities.php:187
 msgid "One of the selected activities is not available for this event."
 msgstr "L'une des activités sélectionnées n'est pas disponible pour cet événement."
 
 #. translators: %s: activity name
-#: src/Services/SignupActivities.php:173
+#: src/Services/SignupActivities.php:196
 #, php-format
 msgid "\"%s\" is full."
 msgstr "\"%s\" est complet."
 
+#. translators: 1: discount magnitude e.g. "20%" or "€5.00", 2: group name
+#: src/blocks/event-signup/render.php:768
+#, php-format
+msgid "%1$s off · %2$s"
+msgstr ""
+
+#: src/Services/EmailService.php:2330
+msgid "Event date:"
+msgstr ""
+
+#: src/Services/EmailService.php:2331
+msgid "Registration reference:"
+msgstr ""
+
+#: src/Services/EmailService.php:2332
+msgid "Ticket type:"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:537
+msgid "Please enter a valid web address for: %s"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:561
+msgid "Please enter a valid date for: %s"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:585
+msgid "Please enter a valid date and time for: %s"
+msgstr ""

--- a/fair-audience/languages/fair-audience-pl_PL.po
+++ b/fair-audience/languages/fair-audience-pl_PL.po
@@ -64,16 +64,16 @@ msgstr "Uczestnicy wydarzenia"
 #: src/API/EventParticipantsController.php:1468
 #: src/API/EventSignupController.php:468
 #: src/API/EventSignupController.php:613
-#: src/API/EventSignupController.php:1080
-#: src/API/EventSignupController.php:2137
-#: src/API/EventSignupController.php:2340
-#: src/API/EventSignupController.php:2532
-#: src/API/EventSignupController.php:2660
-#: src/API/EventSignupController.php:2960
-#: src/Services/EmailService.php:336
-#: src/Services/EmailService.php:560
-#: src/Services/EmailService.php:1400
-#: src/Services/EmailService.php:2816
+#: src/API/EventSignupController.php:1081
+#: src/API/EventSignupController.php:2125
+#: src/API/EventSignupController.php:2328
+#: src/API/EventSignupController.php:2520
+#: src/API/EventSignupController.php:2648
+#: src/API/EventSignupController.php:2949
+#: src/Services/EmailService.php:337
+#: src/Services/EmailService.php:561
+#: src/Services/EmailService.php:1401
+#: src/Services/EmailService.php:2792
 msgid "Event not found."
 msgstr "Nie znaleziono wydarzenia."
 
@@ -85,11 +85,11 @@ msgstr "Nie znaleziono wydarzenia."
 #: src/API/ParticipantsController.php:729
 #: src/API/ParticipantsController.php:762
 #: src/API/ParticipantsController.php:789
-#: src/Services/EmailService.php:360
-#: src/Services/EmailService.php:583
-#: src/Services/EmailService.php:1439
-#: src/Services/EmailService.php:1829
-#: src/Services/EmailService.php:2891
+#: src/Services/EmailService.php:361
+#: src/Services/EmailService.php:584
+#: src/Services/EmailService.php:1440
+#: src/Services/EmailService.php:1830
+#: src/Services/EmailService.php:2867
 #: src/Admin/participant-detail/ParticipantDetail.js:86
 msgid "Participant not found."
 msgstr "Nie znaleziono uczestnika."
@@ -164,7 +164,7 @@ msgid "Add Participant"
 msgstr "Dodaj Uczestnika"
 
 #: src/blocks/event-interest/render.php:135
-#: src/Services/EmailService.php:1916
+#: src/Services/EmailService.php:1917
 #: src/Admin/all-participants/AllParticipants.js:93
 #: src/Admin/event-participants/EventParticipants.js:629
 #: src/Admin/manage-event-audience-tab/EventAudience.js:892
@@ -175,14 +175,14 @@ msgstr "Imię"
 
 #: src/blocks/audience-signup/render.php:217
 #: src/blocks/event-interest/render.php:122
-#: src/blocks/event-signup/render.php:1265
-#: src/blocks/event-signup/render.php:1320
+#: src/blocks/event-signup/render.php:1333
+#: src/blocks/event-signup/render.php:1388
 #: src/blocks/mailing-signup/render.php:125
-#: src/Services/EmailService.php:1920
+#: src/Services/EmailService.php:1921
 #: src/Admin/all-participants/AllParticipants.js:108
 #: src/Admin/components/ParticipantEditModal.js:177
 #: src/Admin/participant-detail/ParticipantDetail.js:190
-#: src/blocks/event-signup/editor.js:123
+#: src/blocks/event-signup/editor.js:127
 msgid "Email"
 msgstr "E-mail"
 
@@ -271,9 +271,9 @@ msgstr "Usuń"
 msgid "Events"
 msgstr "Wydarzenia"
 
-#: src/Services/EmailService.php:2253
-#: src/Services/EmailService.php:2403
-#: src/Services/EmailService.php:2525
+#: src/Services/EmailService.php:2256
+#: src/Services/EmailService.php:2363
+#: src/Services/EmailService.php:2493
 #: src/Admin/events-list/EventsList.js:37
 #: src/Admin/manage-event-audience-tab/EventAudience.js:778
 #: src/Admin/participant-detail/ParticipantDetail.js:271
@@ -281,7 +281,7 @@ msgstr "Wydarzenia"
 msgid "Event"
 msgstr "Wydarzenie"
 
-#: src/Services/EmailService.php:325
+#: src/Services/EmailService.php:326
 msgid "Poll not found."
 msgstr "Nie znaleziono ankiety."
 
@@ -292,87 +292,87 @@ msgid "Invalid event ID."
 msgstr "Nieprawidłowy identyfikator zdarzenia."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:210
+#: src/Services/EmailService.php:211
 #, php-format
 msgid "Quick question about %s"
 msgstr "Szybkie pytanie o %s"
 
 #. translators: %s: participant first name
-#: src/Services/EmailService.php:239
-#: src/Services/EmailService.php:446
-#: src/Services/EmailService.php:666
-#: src/Services/EmailService.php:774
-#: src/Services/EmailService.php:875
-#: src/Services/EmailService.php:997
-#: src/Services/EmailService.php:1159
-#: src/Services/EmailService.php:1334
-#: src/Services/EmailService.php:1604
-#: src/Services/EmailService.php:1709
-#: src/Services/EmailService.php:2193
-#: src/Services/EmailService.php:2335
-#: src/Services/EmailService.php:2460
-#: src/Services/EmailService.php:2572
-#: src/Services/EmailService.php:2709
-#: src/Services/EmailService.php:2998
-#: src/Services/EmailService.php:3091
+#: src/Services/EmailService.php:240
+#: src/Services/EmailService.php:447
+#: src/Services/EmailService.php:667
+#: src/Services/EmailService.php:775
+#: src/Services/EmailService.php:876
+#: src/Services/EmailService.php:998
+#: src/Services/EmailService.php:1160
+#: src/Services/EmailService.php:1335
+#: src/Services/EmailService.php:1605
+#: src/Services/EmailService.php:1710
+#: src/Services/EmailService.php:2194
+#: src/Services/EmailService.php:2328
+#: src/Services/EmailService.php:2428
+#: src/Services/EmailService.php:2548
+#: src/Services/EmailService.php:2685
+#: src/Services/EmailService.php:2982
+#: src/Services/EmailService.php:3076
 #: src/Admin/event-participants/EventParticipants.js:1192
-#, php-format, js-format
+#, php-format,js-format
 msgid "Hi %s,"
 msgstr "Cześć %s,"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:247
+#: src/Services/EmailService.php:248
 #, php-format
 msgid "We'd love to hear from you about %s!"
 msgstr "Chętnie usłyszymy Twoją opinię o %s!"
 
-#: src/Services/EmailService.php:261
+#: src/Services/EmailService.php:262
 msgid "Please take a moment to answer our quick poll:"
 msgstr "Prosimy o poświęcenie chwili na odpowiedź w naszej krótkiej ankiecie:"
 
-#: src/Services/EmailService.php:266
+#: src/Services/EmailService.php:267
 msgid "Answer Poll"
 msgstr "Odpowiedz na ankietę"
 
 #. translators: 1: line break, 2: site name
-#: src/Services/EmailService.php:273
-#: src/Services/EmailService.php:498
-#: src/Services/EmailService.php:692
-#: src/Services/EmailService.php:796
-#: src/Services/EmailService.php:905
-#: src/Services/EmailService.php:1027
-#: src/Services/EmailService.php:1169
-#: src/Services/EmailService.php:1346
-#: src/Services/EmailService.php:1616
-#: src/Services/EmailService.php:1754
-#: src/Services/EmailService.php:2209
+#: src/Services/EmailService.php:274
+#: src/Services/EmailService.php:499
+#: src/Services/EmailService.php:693
+#: src/Services/EmailService.php:797
+#: src/Services/EmailService.php:906
+#: src/Services/EmailService.php:1028
+#: src/Services/EmailService.php:1170
+#: src/Services/EmailService.php:1347
+#: src/Services/EmailService.php:1617
+#: src/Services/EmailService.php:1755
+#: src/Services/EmailService.php:2210
 #, php-format
 msgid "Thanks,%1$sThe %2$s Team"
 msgstr "Dziękujemy,%1$sZespół %2$s"
 
-#: src/Services/EmailService.php:285
-#: src/Services/EmailService.php:510
-#: src/Services/EmailService.php:704
-#: src/Services/EmailService.php:808
-#: src/Services/EmailService.php:917
-#: src/Services/EmailService.php:1039
-#: src/Services/EmailService.php:1769
-#: src/Services/EmailService.php:2755
+#: src/Services/EmailService.php:286
+#: src/Services/EmailService.php:511
+#: src/Services/EmailService.php:705
+#: src/Services/EmailService.php:809
+#: src/Services/EmailService.php:918
+#: src/Services/EmailService.php:1040
+#: src/Services/EmailService.php:1770
+#: src/Services/EmailService.php:2731
 msgid "If the button above doesn't work, copy and paste this link:"
 msgstr "Jeśli przycisk powyżej nie działa, skopiuj i wklej ten link:"
 
-#: src/Services/EmailService.php:387
-#: src/Services/EmailService.php:609
-#: src/Services/EmailService.php:1472
-#: src/Services/EmailService.php:1549
-#: src/Services/EmailService.php:1864
-#: src/Services/EmailService.php:2927
+#: src/Services/EmailService.php:388
+#: src/Services/EmailService.php:610
+#: src/Services/EmailService.php:1473
+#: src/Services/EmailService.php:1550
+#: src/Services/EmailService.php:1865
+#: src/Services/EmailService.php:2903
 msgid "wp_mail() failed to send."
 msgstr "Wysłanie wp_mail() nie powiodło się."
 
-#: src/blocks/event-signup/render.php:1253
+#: src/blocks/event-signup/render.php:1321
 #: src/Admin/components/ParticipantEditModal.js:170
-#: src/blocks/event-signup/editor.js:119
+#: src/blocks/event-signup/editor.js:123
 msgid "Surname"
 msgstr "Nazwisko"
 
@@ -470,16 +470,16 @@ msgstr "Nie znaleziono identyfikatora uczestnika %d"
 
 #: src/API/AudienceSignupController.php:204
 #: src/API/EventInterestController.php:156
-#: src/API/EventSignupController.php:2146
-#: src/API/EventSignupController.php:2678
+#: src/API/EventSignupController.php:2134
+#: src/API/EventSignupController.php:2666
 #: src/API/MailingSignupController.php:172
 msgid "Please enter a valid email address."
 msgstr "Proszę wprowadzić prawidłowy adres e-mail."
 
 #: src/API/AudienceSignupController.php:223
 #: src/API/EventInterestController.php:182
-#: src/API/EventSignupController.php:2155
-#: src/API/EventSignupController.php:2717
+#: src/API/EventSignupController.php:2143
+#: src/API/EventSignupController.php:2705
 #: src/API/MailingSignupController.php:192
 msgid "Too many requests. Please try again later."
 msgstr "Zbyt wiele żądań. Proszę spróbować ponownie później."
@@ -536,14 +536,14 @@ msgid "Subscribe"
 msgstr "Zapisz się"
 
 #: src/blocks/audience-signup/render.php:192
-#: src/blocks/event-signup/render.php:1240
+#: src/blocks/event-signup/render.php:1308
 #: src/blocks/mailing-signup/render.php:99
-#: src/blocks/event-signup/editor.js:115
+#: src/blocks/event-signup/editor.js:119
 msgid "First Name"
 msgstr "Imię"
 
 #: src/blocks/audience-signup/render.php:199
-#: src/blocks/event-signup/render.php:1247
+#: src/blocks/event-signup/render.php:1315
 #: src/blocks/mailing-signup/render.php:106
 msgid "Enter your first name"
 msgstr "Wprowadź swoje imię"
@@ -559,54 +559,54 @@ msgid "Enter your last name"
 msgstr "Wprowadź swoje nazwisko"
 
 #: src/blocks/audience-signup/render.php:224
-#: src/blocks/event-signup/render.php:1272
-#: src/blocks/event-signup/render.php:1327
+#: src/blocks/event-signup/render.php:1340
+#: src/blocks/event-signup/render.php:1395
 #: src/blocks/mailing-signup/render.php:132
 msgid "Enter your email"
 msgstr "Wprowadź swój adres e-mail"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:417
+#: src/Services/EmailService.php:418
 #, php-format
 msgid "Photos from %s are ready!"
 msgstr "Zdjęcia z %s są gotowe!"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:454
+#: src/Services/EmailService.php:455
 #: src/Admin/event-participants/EventParticipants.js:1204
-#, php-format, js-format
+#, php-format,js-format
 msgid "The photos from %s are now available for you to view and like!"
 msgstr "Zdjęcia z %s są już dostępne do przeglądania i polubienia!"
 
-#: src/Services/EmailService.php:468
+#: src/Services/EmailService.php:469
 #: src/Admin/event-participants/EventParticipants.js:1217
 msgid "Click the button below to browse the gallery and let us know which photos you like best:"
 msgstr "Kliknij poniższy przycisk, aby przeglądnąć galerię i dać nam znać, które zdjęcia przypadły Ci najbardziej do gustu:"
 
-#: src/Services/EmailService.php:473
+#: src/Services/EmailService.php:474
 #: src/Admin/event-participants/EventParticipants.js:1239
 msgid "View Gallery"
 msgstr "Wyświetl galerię"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:637
+#: src/Services/EmailService.php:638
 #, php-format
 msgid "Confirm your subscription to %s"
 msgstr "Potwierdź subskrypcję %s"
 
-#: src/Services/EmailService.php:672
+#: src/Services/EmailService.php:673
 msgid "Thank you for signing up for our mailing list! Please confirm your email address by clicking the button below."
 msgstr "Dziękujemy za zapisanie się do naszej listy mailingowej! Potwierdź swój adres e-mail, klikając poniższy przycisk."
 
-#: src/Services/EmailService.php:677
+#: src/Services/EmailService.php:678
 msgid "Confirm Email"
 msgstr "Potwierdź e-mail"
 
-#: src/Services/EmailService.php:682
+#: src/Services/EmailService.php:683
 msgid "This link will expire in 48 hours."
 msgstr "Ten link wygaśnie za 48 godzin."
 
-#: src/Services/EmailService.php:686
+#: src/Services/EmailService.php:687
 msgid "If you didn't sign up for this mailing list, you can safely ignore this email."
 msgstr "Jeśli nie rejestrowałeś się na tej liście mailingowej, możesz bezpiecznie zignorować tę wiadomość."
 
@@ -714,7 +714,7 @@ msgstr "Dodaj %d wybranych"
 
 #: src/blocks/audience-signup/editor.js:35
 #: src/blocks/event-interest/editor.js:26
-#: src/blocks/event-signup/editor.js:85
+#: src/blocks/event-signup/editor.js:89
 #: src/blocks/mailing-signup/editor.js:65
 msgid "Form Settings"
 msgstr "Ustawienia formularza"
@@ -901,38 +901,38 @@ msgid "You must be logged in or have a valid signup link."
 msgstr "Musisz być zalogowany lub posiadać ważny link rejestracyjny."
 
 #: src/API/EventSignupController.php:642
-#: src/API/EventSignupController.php:1108
-#: src/API/EventSignupController.php:2989
+#: src/API/EventSignupController.php:1109
+#: src/API/EventSignupController.php:2978
 msgid "Could not find your participant profile."
 msgstr "Nie można znaleźć Twojego profilu uczestnika."
 
 #: src/API/EventSignupController.php:726
-#: src/API/EventSignupController.php:2368
-#: src/API/EventSignupController.php:2794
+#: src/API/EventSignupController.php:2356
+#: src/API/EventSignupController.php:2782
 msgid "You are already signed up for this event."
 msgstr "Jesteś już zapisany na to wydarzenie."
 
-#: src/API/EventSignupController.php:776
-#: src/API/EventSignupController.php:918
+#: src/API/EventSignupController.php:777
+#: src/API/EventSignupController.php:919
 #: src/blocks/event-signup/render.php:66
 #: src/blocks/event-signup/frontend.js:961
 #: src/blocks/event-signup/frontend.js:1271
 msgid "You have successfully signed up for the event!"
 msgstr "Pomyślnie zapisano się na wydarzenie!"
 
-#: src/API/EventSignupController.php:2187
+#: src/API/EventSignupController.php:2175
 msgid "If your email is in our system, you will receive a signup link shortly. Please check your inbox."
 msgstr "Jeśli Twój adres e-mail jest w naszym systemie, wkrótce otrzymasz link rejestracyjny. Sprawdź swoją skrzynkę odbiorczą."
 
-#: src/API/EventSignupController.php:2687
+#: src/API/EventSignupController.php:2675
 msgid "Please enter your name."
 msgstr "Proszę wprowadzić imię i nazwisko."
 
-#: src/API/EventSignupController.php:2821
+#: src/API/EventSignupController.php:2809
 msgid "Failed to process registration. Please try again."
 msgstr "Nie udało się przetworzyć rejestracji. Spróbuj ponownie."
 
-#: src/API/EventSignupController.php:2938
+#: src/API/EventSignupController.php:2927
 msgid "You have successfully registered and signed up for the event!"
 msgstr "Pomyślnie zarejestrowano i zapisano się na wydarzenie!"
 
@@ -947,8 +947,8 @@ msgid "This WordPress user is already linked to another participant."
 msgstr "Ten użytkownik WordPress jest już powiązany z innym uczestnikiem."
 
 #: src/blocks/event-signup/render.php:63
-#: src/blocks/event-signup/render.php:969
-#: src/blocks/event-signup/editor.js:92
+#: src/blocks/event-signup/render.php:1037
+#: src/blocks/event-signup/editor.js:96
 #: src/blocks/event-signup/frontend.js:472
 #: src/blocks/event-signup/frontend.js:506
 #: src/blocks/event-signup/frontend.js:1692
@@ -956,8 +956,8 @@ msgid "Sign Up"
 msgstr "Zarejestruj się"
 
 #: src/blocks/event-signup/render.php:64
-#: src/blocks/event-signup/render.php:970
-#: src/blocks/event-signup/editor.js:143
+#: src/blocks/event-signup/render.php:1038
+#: src/blocks/event-signup/editor.js:147
 #: src/blocks/event-signup/frontend.js:475
 #: src/blocks/event-signup/frontend.js:509
 msgid "Register & Sign Up"
@@ -968,72 +968,72 @@ msgid "Send Signup Link"
 msgstr "Wyślij link rejestracyjny"
 
 #: src/blocks/event-interest/render.php:115
-#: src/blocks/event-signup/render.php:997
+#: src/blocks/event-signup/render.php:1065
 msgid "This block can only be used on event pages."
 msgstr "Ten blok może być używany tylko na stronach wydarzeń."
 
-#: src/blocks/event-signup/render.php:1125
+#: src/blocks/event-signup/render.php:1193
 #: src/blocks/event-signup/frontend.js:1140
 #: src/blocks/event-signup/frontend.js:1403
 msgid "You are signed up for this event!"
 msgstr "Jesteś zapisany na to wydarzenie!"
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1146
+#: src/blocks/event-signup/render.php:1214
 #, php-format
 msgid "Hi %s! Click the button below to sign up for this event."
 msgstr "Cześć %s! Kliknij poniższy przycisk, aby zapisać się na to wydarzenie."
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1152
+#: src/blocks/event-signup/render.php:1220
 #: src/blocks/event-signup/frontend.js:1671
-#, php-format, js-format
+#, php-format,js-format
 msgid "Hi %s! You can sign up for this event."
 msgstr "Cześć %s! Możesz zapisać się na to wydarzenie."
 
-#: src/blocks/event-signup/render.php:1225
+#: src/blocks/event-signup/render.php:1293
 msgid "I'm new"
 msgstr "Jestem nowy"
 
-#: src/blocks/event-signup/render.php:1228
+#: src/blocks/event-signup/render.php:1296
 msgid "I have an account"
 msgstr "Mam konto"
 
-#: src/blocks/event-signup/render.php:1259
+#: src/blocks/event-signup/render.php:1327
 msgid "Enter your surname"
 msgstr "Wprowadź swoje nazwisko"
 
 #: src/blocks/audience-signup/render.php:386
-#: src/blocks/event-signup/render.php:1279
+#: src/blocks/event-signup/render.php:1347
 msgid "Keep me informed about future events"
 msgstr "Informuj mnie o przyszłych wydarzeniach"
 
-#: src/blocks/event-signup/render.php:1316
+#: src/blocks/event-signup/render.php:1384
 msgid "Enter your email to receive a signup link."
 msgstr "Wprowadź swój adres e-mail, aby otrzymać link rejestracyjny."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:846
+#: src/Services/EmailService.php:847
 #, php-format
 msgid "Sign up for %s"
 msgstr "Zarejestruj się na %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:883
+#: src/Services/EmailService.php:884
 #, php-format
 msgid "You requested a signup link for %s."
 msgstr "Poprosiłeś o link rejestracyjny dla %s."
 
-#: src/Services/EmailService.php:889
+#: src/Services/EmailService.php:890
 msgid "Click the button below to sign up for the event:"
 msgstr "Kliknij poniższy przycisk, aby zarejestrować się na wydarzenie:"
 
-#: src/Services/EmailService.php:894
-#: src/Services/EmailService.php:2736
+#: src/Services/EmailService.php:895
+#: src/Services/EmailService.php:2712
 msgid "Sign Up Now"
 msgstr "Zarejestruj się teraz"
 
-#: src/Services/EmailService.php:899
+#: src/Services/EmailService.php:900
 msgid "If you didn't request this link, you can safely ignore this email."
 msgstr "Jeśli nie prosiłeś o ten link, możesz bezpiecznie zignorować tę wiadomość."
 
@@ -1085,11 +1085,11 @@ msgstr "Nie znaleziono użytkowników."
 msgid "Role"
 msgstr "Rola"
 
-#: src/blocks/event-signup/editor.js:87
+#: src/blocks/event-signup/editor.js:91
 msgid "Signup Button Text"
 msgstr "Tekst przycisku zapisu"
 
-#: src/blocks/event-signup/editor.js:93
+#: src/blocks/event-signup/editor.js:97
 msgid "Button text for authenticated users."
 msgstr "Tekst przycisku dla uwierzytelnionych użytkowników."
 
@@ -1195,26 +1195,26 @@ msgctxt "block keyword"
 msgid "list"
 msgstr "lista"
 
-#: src/Services/EmailService.php:923
-#: src/Services/EmailService.php:1045
-#: src/Services/EmailService.php:2761
+#: src/Services/EmailService.php:924
+#: src/Services/EmailService.php:1046
+#: src/Services/EmailService.php:2737
 msgid "Don't want to receive event invitations?"
 msgstr "Nie chcesz otrzymywać zaproszeń na wydarzenia?"
 
-#: src/Services/EmailService.php:924
-#: src/Services/EmailService.php:1046
-#: src/Services/EmailService.php:1180
-#: src/Services/EmailService.php:1359
-#: src/Services/EmailService.php:1629
-#: src/Services/EmailService.php:2762
+#: src/Services/EmailService.php:925
+#: src/Services/EmailService.php:1047
+#: src/Services/EmailService.php:1181
+#: src/Services/EmailService.php:1360
+#: src/Services/EmailService.php:1630
+#: src/Services/EmailService.php:2738
 msgid "Manage your preferences"
 msgstr "Zarządzaj swoimi preferencjami"
 
-#: src/Services/EmailService.php:2879
+#: src/Services/EmailService.php:2855
 msgid "Already signed up"
 msgstr "Już zarejestrowany"
 
-#: src/Services/EmailService.php:164
+#: src/Services/EmailService.php:165
 msgid "Participant opted out of marketing emails."
 msgstr "Uczestnik zrezygnował z otrzymywania wiadomości marketingowych."
 
@@ -1326,7 +1326,7 @@ msgstr "Ustawienia"
 msgid "Event date not found."
 msgstr "Data wydarzenia nie znaleziona."
 
-#: src/Services/EmailService.php:1815
+#: src/Services/EmailService.php:1816
 msgid "Fee not found."
 msgstr "Opłata nie znaleziona."
 
@@ -1334,12 +1334,12 @@ msgstr "Opłata nie znaleziona."
 msgid "Could not read SVG file."
 msgstr "Nie można odczytać pliku SVG."
 
-#: src/Hooks/PaymentHooks.php:819
+#: src/Hooks/PaymentHooks.php:832
 msgid "Paid online via Mollie"
 msgstr "Opłacone online za pośrednictwem Mollie"
 
 #. translators: %1$s: Mollie status, %2$d: transaction ID
-#: src/Hooks/PaymentHooks.php:863
+#: src/Hooks/PaymentHooks.php:876
 #, php-format
 msgid "Online payment %1$s (transaction #%2$d)"
 msgstr "Płatność online %1$s (transakcja #%2$d)"
@@ -1352,50 +1352,50 @@ msgstr "Nie masz uprawnień do przesyłania plików SVG."
 msgid "Invalid SVG file."
 msgstr "Nieprawidłowy plik SVG."
 
-#: src/Services/EmailService.php:369
-#: src/Services/EmailService.php:592
-#: src/Services/EmailService.php:1448
-#: src/Services/EmailService.php:1525
-#: src/Services/EmailService.php:1838
-#: src/Services/EmailService.php:2900
+#: src/Services/EmailService.php:370
+#: src/Services/EmailService.php:593
+#: src/Services/EmailService.php:1449
+#: src/Services/EmailService.php:1526
+#: src/Services/EmailService.php:1839
+#: src/Services/EmailService.php:2876
 msgid "Participant has no email address."
 msgstr "Uczestnik nie ma adresu e-mail."
 
-#: src/Services/EmailService.php:1179
-#: src/Services/EmailService.php:1358
-#: src/Services/EmailService.php:1628
+#: src/Services/EmailService.php:1180
+#: src/Services/EmailService.php:1359
+#: src/Services/EmailService.php:1629
 msgid "Don't want to receive these emails?"
 msgstr "Nie chcesz otrzymywać tych wiadomości e-mail?"
 
-#: src/Services/EmailService.php:1428
-#: src/Services/EmailService.php:1516
+#: src/Services/EmailService.php:1429
+#: src/Services/EmailService.php:1517
 msgid "Manually skipped."
 msgstr "Ręcznie pominięte."
 
 #. translators: %s: fee name
-#: src/Services/EmailService.php:1680
+#: src/Services/EmailService.php:1681
 #, php-format
 msgid "Payment reminder: %s"
 msgstr "Przypomnienie o płatności: %s"
 
-#: src/Services/EmailService.php:1715
+#: src/Services/EmailService.php:1716
 msgid "This is a friendly reminder about a pending payment:"
 msgstr "To jest przyjazne przypomnienie o oczekującej płatności:"
 
-#: src/Services/EmailService.php:1720
+#: src/Services/EmailService.php:1721
 msgid "Fee:"
 msgstr "Opłata:"
 
-#: src/Services/EmailService.php:1724
-#: src/Services/EmailService.php:2544
+#: src/Services/EmailService.php:1725
+#: src/Services/EmailService.php:2520
 msgid "Amount:"
 msgstr "Kwota:"
 
-#: src/Services/EmailService.php:1731
+#: src/Services/EmailService.php:1732
 msgid "Due Date:"
 msgstr "Termin płatności:"
 
-#: src/Services/EmailService.php:1745
+#: src/Services/EmailService.php:1746
 msgid "Pay Now"
 msgstr "Zapłać teraz"
 
@@ -1739,7 +1739,7 @@ msgstr "Zostałeś pomyślnie zarejestrowany!"
 msgid "Audience Signup"
 msgstr "Rejestracja odbiorców"
 
-#: src/API/EventSignupController.php:2929
+#: src/API/EventSignupController.php:2918
 msgid "You have been signed up for the event! Please check your email to confirm your subscription."
 msgstr "Zostałeś zarejestrowany na to wydarzenie! Sprawdź swoją skrzynkę e-mail, aby potwierdzić subskrypcję."
 
@@ -1760,39 +1760,39 @@ msgid "Update Answers"
 msgstr "Aktualizuj odpowiedzi"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:743
+#: src/Services/EmailService.php:744
 #, php-format
 msgid "Your signup answers — %s"
 msgstr "Twoje odpowiedzi rejestracyjne — %s"
 
-#: src/Services/EmailService.php:780
+#: src/Services/EmailService.php:781
 msgid "Thank you for signing up! Here are the answers you submitted:"
 msgstr "Dziękujemy za rejestrację! Oto odpowiedzi, które przesłałeś:"
 
-#: src/Services/EmailService.php:789
+#: src/Services/EmailService.php:790
 msgid "Edit Your Answers"
 msgstr "Edytuj swoje odpowiedzi"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2680
+#: src/Services/EmailService.php:2656
 #, php-format
 msgid "You're invited: %s"
 msgstr "Jesteś zaproszony: %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2717
+#: src/Services/EmailService.php:2693
 #, php-format
 msgid "We have a new event coming up: %s."
 msgstr "Mamy nadchodzące wydarzenie: %s."
 
-#: src/Services/EmailService.php:2731
+#: src/Services/EmailService.php:2707
 msgid "Would you like to join? Click the button below to sign up:"
 msgstr "Chciałbyś się przyłączyć? Kliknij poniższy przycisk, aby się zarejestrować:"
 
 #. translators: 1: line break, 2: site name
-#: src/Services/EmailService.php:2360
-#: src/Services/EmailService.php:2480
-#: src/Services/EmailService.php:2743
+#: src/Services/EmailService.php:2337
+#: src/Services/EmailService.php:2448
+#: src/Services/EmailService.php:2719
 #, php-format
 msgid "See you there!%1$sThe %2$s Team"
 msgstr "Do zobaczenia!%1$sZespół %2$s"
@@ -1946,17 +1946,17 @@ msgctxt "block keyword"
 msgid "member"
 msgstr "członek"
 
-#: src/API/EventSignupController.php:3010
+#: src/API/EventSignupController.php:2999
 msgid "You are not signed up for this event."
 msgstr "Nie jesteś zarejestrowany na to wydarzenie."
 
-#: src/API/EventSignupController.php:3026
+#: src/API/EventSignupController.php:3015
 #: src/blocks/event-signup/frontend.js:1640
 msgid "You have been removed from this event."
 msgstr "Zostałeś usunięty z tego wydarzenia."
 
-#: src/blocks/event-signup/render.php:1211
-#: src/Hooks/SignupHookBridge.php:342
+#: src/blocks/event-signup/render.php:1279
+#: src/Hooks/SignupHookBridge.php:362
 #: src/Admin/manage-event-audience-tab/EventAudience.js:2369
 #: src/blocks/event-signup/frontend.js:1411
 msgid "Cancel signup"
@@ -1976,9 +1976,9 @@ msgstr "Nie znaleziono daty wydarzenia dla tego wydarzenia"
 
 #: src/blocks/audience-signup/render.php:393
 #: src/blocks/event-interest/render.php:161
-#: src/blocks/event-signup/render.php:1291
+#: src/blocks/event-signup/render.php:1359
 #: src/blocks/mailing-signup/render.php:156
-#: src/Hooks/SignupHookBridge.php:369
+#: src/Hooks/SignupHookBridge.php:390
 msgid "Not you? Start fresh"
 msgstr "To nie ty? Zacznij od nowa"
 
@@ -2077,60 +2077,60 @@ msgstr "Wyświetl plik"
 msgid "Failed to update attendance."
 msgstr "Nie udało się zaktualizować frekwencji."
 
-#: src/API/EventSignupController.php:1355
+#: src/API/EventSignupController.php:1348
 #: src/Services/GroupSignupPricing.php:113
 msgid "This ticket type is not available for your account."
 msgstr "Ten typ biletu nie jest dostępny dla Twojego konta."
 
-#: src/API/EventSignupController.php:1841
+#: src/API/EventSignupController.php:1829
 msgid "This event is fully booked."
 msgstr "To wydarzenie jest w pełni zarezerwowane."
 
 #. translators: %s: event title or occurrence date/time label
-#: src/API/EventSignupController.php:984
-#: src/API/EventSignupController.php:998
-#: src/API/EventSignupController.php:1873
+#: src/API/EventSignupController.php:985
+#: src/API/EventSignupController.php:999
+#: src/API/EventSignupController.php:1861
 #, php-format
 msgid "Signup for %s"
 msgstr "Rejestracja dla %s"
 
-#: src/API/EventSignupController.php:1051
-#: src/API/EventSignupController.php:1317
-#: src/API/EventSignupController.php:1965
-#: src/API/EventSignupController.php:2112
-#: src/API/EventSignupController.php:2489
-#: src/API/EventSignupController.php:2630
+#: src/API/EventSignupController.php:1052
+#: src/API/EventSignupController.php:1310
+#: src/API/EventSignupController.php:1953
+#: src/API/EventSignupController.php:2100
+#: src/API/EventSignupController.php:2477
+#: src/API/EventSignupController.php:2618
 #: src/blocks/event-signup/frontend.js:1080
 #: src/blocks/event-signup/frontend.js:1362
 msgid "Redirecting to payment…"
 msgstr "Przekierowanie do płatności…"
 
-#: src/blocks/event-signup/render.php:617
+#: src/blocks/event-signup/render.php:677
 #: src/blocks/event-signup/frontend.js:537
 msgid "Sign up for free"
 msgstr "Zarejestruj się za darmo"
 
-#: src/blocks/event-signup/render.php:618
+#: src/blocks/event-signup/render.php:678
 #: src/blocks/event-signup/frontend.js:538
 msgid "Register for free"
 msgstr "Zarejestruj się bezpłatnie"
 
-#: src/blocks/event-signup/render.php:691
+#: src/blocks/event-signup/render.php:748
 msgid "Choose ticket type"
 msgstr "Wybierz typ biletu"
 
-#: src/blocks/event-signup/render.php:702
-#: src/blocks/event-signup/render.php:779
-#: src/blocks/event-signup/render.php:841
-#: src/Hooks/SignupHookBridge.php:541
+#: src/blocks/event-signup/render.php:759
+#: src/blocks/event-signup/render.php:847
+#: src/blocks/event-signup/render.php:909
+#: src/Hooks/SignupHookBridge.php:564
 msgid "free"
 msgstr "bezpłatnie"
 
-#: src/blocks/event-signup/render.php:743
+#: src/blocks/event-signup/render.php:811
 msgid "Select activities"
 msgstr "Wybierz aktywności"
 
-#: src/Hooks/PaymentHooks.php:394
+#: src/Hooks/PaymentHooks.php:399
 #: src/Hooks/PendingSubscriptionTimeoutHooks.php:56
 #: src/Hooks/WeeklyDigestHooks.php:55
 msgid "Every 5 minutes (fair-audience)"
@@ -2210,62 +2210,62 @@ msgid "Submitted at"
 msgstr "Przesłano w"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:1910
+#: src/Services/EmailService.php:1911
 #, php-format
 msgid "New form submission — %s"
 msgstr "Nowe przesłanie formularza — %s"
 
 #. translators: %s: page title
-#: src/Services/EmailService.php:1931
+#: src/Services/EmailService.php:1932
 #, php-format
 msgid "Page: %s"
 msgstr "Strona: %s"
 
-#: src/Services/EmailService.php:1959
+#: src/Services/EmailService.php:1960
 msgid "A new form submission has been received."
 msgstr "Otrzymaliśmy nowe przesłanie formularza."
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:2140
+#: src/Services/EmailService.php:2141
 #, php-format
 msgid "Your submission — %s"
 msgstr "Twoje przesłanie — %s"
 
 #. translators: %s: page title
-#: src/Services/EmailService.php:2151
+#: src/Services/EmailService.php:2152
 #, php-format
 msgid "Form: %s"
 msgstr "Formularz: %s"
 
-#: src/Services/EmailService.php:2161
+#: src/Services/EmailService.php:2162
 msgid "Here are the answers you submitted:"
 msgstr "Oto odpowiedzi, które przesłałeś:"
 
-#: src/Services/EmailService.php:2199
+#: src/Services/EmailService.php:2200
 msgid "Thank you for your submission! We have received your response."
 msgstr "Dziękujemy za Twoje przesłanie! Otrzymaliśmy Twoją odpowiedź."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2257
+#: src/Services/EmailService.php:2260
 #, php-format
 msgid "Signup confirmed — %s"
 msgstr "Rejestracja potwierdzona — %s"
 
-#: src/Services/EmailService.php:2269
-#: src/Services/EmailService.php:2419
+#: src/Services/EmailService.php:2333
+#: src/Services/EmailService.php:2387
 #: src/blocks/event-signup/frontend.js:1816
 #: src/blocks/event-signup/frontend.js:1938
 msgid "Amount paid:"
 msgstr "Kwota zapłacona:"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2344
+#: src/Services/EmailService.php:2309
 #, php-format
 msgid "Your signup for %s has been confirmed and your payment has been received."
 msgstr "Twoja rejestracja na %s została potwierdzona i otrzymaliśmy Twoją płatność."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2346
+#: src/Services/EmailService.php:2311
 #, php-format
 msgid "Your signup for %s has been confirmed."
 msgstr "Twoja rejestracja na %s została potwierdzona."
@@ -2289,58 +2289,58 @@ msgstr "Wiersz uczestnika nie został znaleziony dla tej daty wydarzenia."
 msgid "Selected ticket type was not found."
 msgstr "Wybrany typ biletu nie został znaleziony."
 
-#: src/API/EventSignupController.php:1458
+#: src/API/EventSignupController.php:1451
 msgid "This ticket type is sold out. Please pick another option."
 msgstr "Ten typ biletu jest wyprzedany. Proszę wybrać inną opcję."
 
 #. translators: %d: minimum number of activities required
-#: src/API/EventSignupController.php:1598
-#: src/blocks/event-signup/render.php:753
-#: src/Services/SignupActivities.php:187
+#: src/API/EventSignupController.php:1591
+#: src/blocks/event-signup/render.php:821
+#: src/Services/SignupActivities.php:210
 #: src/blocks/event-signup/frontend.js:391
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d activity to sign up."
 msgid_plural "Please select at least %d activities to sign up."
 msgstr[0] "Proszę wybrać co najmniej %d aktywność do zarejestowania."
 msgstr[1] "Proszę wybrać co najmniej %d aktywności do zarejestowania."
 msgstr[2] "Proszę wybrać co najmniej %d aktywności do zarejestowania."
 
-#: src/API/EventSignupController.php:2206
+#: src/API/EventSignupController.php:2194
 msgid "Invalid transaction."
 msgstr "Nieprawidłowa transakcja."
 
-#: src/API/EventSignupController.php:2214
+#: src/API/EventSignupController.php:2202
 msgid "Payment plugin is missing."
 msgstr "Brakuje wtyczki płatności."
 
-#: src/API/EventSignupController.php:2223
-#: src/API/EventSignupController.php:2288
+#: src/API/EventSignupController.php:2211
+#: src/API/EventSignupController.php:2276
 msgid "Transaction not found."
 msgstr "Transakcja nie została znaleziona."
 
-#: src/API/EventSignupController.php:2264
+#: src/API/EventSignupController.php:2252
 msgid "You are not authorized to retry this payment."
 msgstr "Nie masz uprawnień do ponowienia tej płatności."
 
-#: src/API/EventSignupController.php:2300
+#: src/API/EventSignupController.php:2288
 msgid "This payment cannot be retried."
 msgstr "Ta płatność nie może być ponowiona."
 
-#: src/API/EventSignupController.php:2318
+#: src/API/EventSignupController.php:2306
 msgid "This payment is not retriable from this endpoint."
 msgstr "Ta płatność nie może być ponawiana z tego punktu końcowego."
 
-#: src/API/EventSignupController.php:2331
-#: src/API/EventSignupController.php:2523
+#: src/API/EventSignupController.php:2319
+#: src/API/EventSignupController.php:2511
 msgid "This payment is missing context needed to retry."
 msgstr "Ta płatność nie ma kontekstu potrzebnego do ponowienia."
 
-#: src/API/EventSignupController.php:2379
-#: src/API/EventSignupController.php:2566
+#: src/API/EventSignupController.php:2367
+#: src/API/EventSignupController.php:2554
 msgid "Original line items could not be loaded."
 msgstr "Nie można załadować oryginalnych pozycji."
 
-#: src/API/EventSignupController.php:2769
+#: src/API/EventSignupController.php:2757
 #: src/blocks/event-signup/frontend.js:1096
 msgid "We recognise this email — check your inbox to continue."
 msgstr "Rozpoznajemy ten adres e-mail — sprawdź swoją skrzynkę odbiorczą, aby kontynuować."
@@ -2349,134 +2349,134 @@ msgstr "Rozpoznajemy ten adres e-mail — sprawdź swoją skrzynkę odbiorczą, 
 msgid "You have been subscribed."
 msgstr "Zostałeś zapisany."
 
-#: src/blocks/event-signup/render.php:706
+#: src/blocks/event-signup/render.php:774
 msgid "sold out"
 msgstr "wyprzedane"
 
-#: src/blocks/event-signup/render.php:784
-#: src/blocks/event-signup/render.php:845
-#: src/Hooks/SignupHookBridge.php:544
+#: src/blocks/event-signup/render.php:852
+#: src/blocks/event-signup/render.php:913
+#: src/Hooks/SignupHookBridge.php:567
 msgid "full"
 msgstr "pełne"
 
-#: src/blocks/event-signup/render.php:886
+#: src/blocks/event-signup/render.php:954
 msgid "Choose a date"
 msgstr "Wybierz datę"
 
 #. translators: appended to a date label when the viewer is signed up — they can cancel from this row
-#: src/blocks/event-signup/render.php:897
+#: src/blocks/event-signup/render.php:965
 msgid "signed up (manage)"
 msgstr "zarejestrowany (zarządzaj)"
 
-#: src/blocks/event-signup/render.php:899
+#: src/blocks/event-signup/render.php:967
 msgid "signed up"
 msgstr "zarejestrowany"
 
-#: src/blocks/event-signup/render.php:1009
+#: src/blocks/event-signup/render.php:1077
 #: src/blocks/event-signup/frontend.js:1809
 msgid "Payment confirmed"
 msgstr "Płatność potwierdzona"
 
 #. translators: %s: event title
-#: src/blocks/event-signup/render.php:1015
+#: src/blocks/event-signup/render.php:1083
 #, php-format
 msgid "You're signed up for %s."
 msgstr "Jesteś zarejestrowany na %s."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1024
+#: src/blocks/event-signup/render.php:1092
 #, php-format
 msgid "Amount paid: %s"
 msgstr "Zapłacona kwota: %s"
 
-#: src/blocks/event-signup/render.php:1030
+#: src/blocks/event-signup/render.php:1098
 #: src/blocks/event-signup/frontend.js:1823
 msgid "A confirmation email is on its way. You can close this page."
 msgstr "Wiadomość potwierdzająca jest w drodze. Możesz zamknąć tę stronę."
 
-#: src/blocks/event-signup/render.php:1037
+#: src/blocks/event-signup/render.php:1105
 msgid "Thank you for your payment!"
 msgstr "Dziękujemy za Twoją płatność!"
 
-#: src/blocks/event-signup/render.php:1040
+#: src/blocks/event-signup/render.php:1108
 msgid "We're confirming with your bank. This usually takes a few seconds — the page will update as soon as it's done."
 msgstr "Potwierdzamy z Twoim bankiem. Zwykle trwa to kilka sekund — strona zaktualizuje się, gdy tylko będzie gotowe."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1046
+#: src/blocks/event-signup/render.php:1114
 #, php-format
 msgid "Amount: %s"
 msgstr "Kwota: %s"
 
-#: src/blocks/event-signup/render.php:1055
+#: src/blocks/event-signup/render.php:1123
 msgid "Your payment is waiting."
 msgstr "Twoja płatność czeka."
 
-#: src/blocks/event-signup/render.php:1058
+#: src/blocks/event-signup/render.php:1126
 msgid "You can pick up where you left off on the secure payment page."
 msgstr "Możesz wznowić od miejsca, w którym skończyłeś na bezpiecznej stronie płatności."
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1064
-#: src/blocks/event-signup/render.php:1091
+#: src/blocks/event-signup/render.php:1132
+#: src/blocks/event-signup/render.php:1159
 #, php-format
 msgid "Amount due: %s"
 msgstr "Kwota do zapłaty: %s"
 
-#: src/blocks/event-signup/render.php:1071
+#: src/blocks/event-signup/render.php:1139
 msgid "Continue payment"
 msgstr "Kontynuuj płatność"
 
-#: src/blocks/event-signup/render.php:1076
-#: src/blocks/event-signup/render.php:1103
+#: src/blocks/event-signup/render.php:1144
+#: src/blocks/event-signup/render.php:1171
 msgid "Cancel and start over"
 msgstr "Anuluj i zacznij od nowa"
 
-#: src/blocks/event-signup/render.php:1085
+#: src/blocks/event-signup/render.php:1153
 msgid "Your payment didn't go through."
 msgstr "Twoja płatność nie przeszła."
 
-#: src/blocks/event-signup/render.php:1098
+#: src/blocks/event-signup/render.php:1166
 msgid "Retry payment"
 msgstr "Spróbuj ponownie"
 
 #. translators: %s: transaction status
-#: src/blocks/event-signup/render.php:1114
+#: src/blocks/event-signup/render.php:1182
 #, php-format
 msgid "Payment status: %s"
 msgstr "Status płatności: %s"
 
-#: src/blocks/event-signup/render.php:1185
-#: src/Hooks/SignupHookBridge.php:295
+#: src/blocks/event-signup/render.php:1253
+#: src/Hooks/SignupHookBridge.php:315
 msgid "You are signed up for this date."
 msgstr "Jesteś zarejestrowany na ten termin."
 
-#: src/Services/EmailService.php:2282
+#: src/Services/EmailService.php:2334
 msgid "Selected options:"
 msgstr "Wybrane opcje:"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2532
+#: src/Services/EmailService.php:2508
 #, php-format
 msgid "Payment didn’t go through — %s"
 msgstr "Płatność nie przeszła — %s"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2580
+#: src/Services/EmailService.php:2556
 #, php-format
 msgid "Your payment for %s didn’t go through. Your spot is still held for a short while — pick up where you left off using the link below."
 msgstr "Twoja płatność za %s nie została zrealizowana. Twoje miejsce jest wciąż zarezerwowane na krótki czas — wznów gdzie skończyłeś, używając poniższego linku."
 
-#: src/Services/EmailService.php:2589
+#: src/Services/EmailService.php:2565
 msgid "Resume payment"
 msgstr "Wznów płatność"
 
-#: src/Services/EmailService.php:2594
+#: src/Services/EmailService.php:2570
 msgid "If the button doesn’t work, copy and paste this link into your browser:"
 msgstr "Jeśli przycisk nie działa, skopiuj i wklej ten link do przeglądarki:"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:2601
+#: src/Services/EmailService.php:2577
 #, php-format
 msgid "See you soon,%1$sThe %2$s Team"
 msgstr "Do zobaczenia wkrótce,%1$sZespół %2$s"
@@ -2572,30 +2572,30 @@ msgstr "Nie udało się uaktualnić ID uczestnika %d"
 msgid "Verbal consent recorded by %1$s on %2$s at event %3$s"
 msgstr "Ustna zgoda zarejestrowana przez %1$s dnia %2$s na wydarzeniu %3$s"
 
-#: src/API/EventSignupController.php:1130
+#: src/API/EventSignupController.php:1131
 msgid "You need an active signup before you can add activities."
 msgstr "Musisz mieć aktywną rejestrację, zanim będziesz mógł dodawać aktywności."
 
-#: src/API/EventSignupController.php:1152
+#: src/API/EventSignupController.php:1153
 msgid "No new activities to add."
 msgstr "Brak nowych aktywności do dodania."
 
-#: src/API/EventSignupController.php:1177
+#: src/API/EventSignupController.php:1178
 #: src/blocks/event-signup/frontend.js:1556
 msgid "Your activities have been added!"
 msgstr "Twoje aktywności zostały dodane!"
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:1258
+#: src/API/EventSignupController.php:1251
 #, php-format
 msgid "Added activities for %s"
 msgstr "Dodane aktywności dla %s"
 
-#: src/API/EventSignupController.php:2541
+#: src/API/EventSignupController.php:2529
 msgid "Your signup is no longer active."
 msgstr "Twoja rejestracja nie jest już aktywna."
 
-#: src/API/EventSignupController.php:2555
+#: src/API/EventSignupController.php:2543
 msgid "These activities are already on your signup."
 msgstr "Te aktywności znajdują się już na Twojej rejestracji."
 
@@ -2619,30 +2619,30 @@ msgstr "Wiadomość e-mail potwierdzająca została wysłana."
 msgid "Website"
 msgstr "Strona internetowa"
 
-#: src/blocks/event-signup/render.php:833
-#: src/blocks/event-signup/render.php:863
-#: src/Hooks/SignupHookBridge.php:523
-#: src/Hooks/SignupHookBridge.php:561
+#: src/blocks/event-signup/render.php:901
+#: src/blocks/event-signup/render.php:931
+#: src/Hooks/SignupHookBridge.php:546
+#: src/Hooks/SignupHookBridge.php:584
 #: src/blocks/event-signup/frontend.js:1466
 msgid "Add activities"
 msgstr "Dodaj aktywności"
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1140
+#: src/blocks/event-signup/render.php:1208
 #, php-format
 msgid "Hi %s! Here is your registration for this event."
 msgstr "Cześć %s! Oto Twoja rejestracja na to wydarzenie."
 
 #. translators: %s: ticket type name
-#: src/blocks/event-signup/render.php:1192
-#: src/Hooks/SignupHookBridge.php:302
+#: src/blocks/event-signup/render.php:1260
+#: src/Hooks/SignupHookBridge.php:322
 #, php-format
 msgid "Your ticket: %s"
 msgstr "Twój bilet: %s"
 
-#: src/blocks/event-signup/render.php:1200
-#: src/Hooks/SignupHookBridge.php:309
-#: src/Hooks/SignupHookBridge.php:526
+#: src/blocks/event-signup/render.php:1268
+#: src/Hooks/SignupHookBridge.php:329
+#: src/Hooks/SignupHookBridge.php:549
 msgid "Your activities:"
 msgstr "Twoje aktywności:"
 
@@ -2664,73 +2664,73 @@ msgid "Unsubscribed"
 msgstr "Zrezygnowano z subskrypcji"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2407
+#: src/Services/EmailService.php:2375
 #, php-format
 msgid "Activities added — %s"
 msgstr "Aktywności dodane — %s"
 
-#: src/Services/EmailService.php:2432
+#: src/Services/EmailService.php:2400
 msgid "Activities added:"
 msgstr "Dodane aktywności:"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2468
+#: src/Services/EmailService.php:2436
 #, php-format
 msgid "The following activities have been added to your signup for %s."
 msgstr "Następujące aktywności zostały dodane do Twojej rejestracji dla %s."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2972
+#: src/Services/EmailService.php:2956
 #, php-format
 msgid "Thanks for your interest in %s"
 msgstr "Dziękujemy za zainteresowanie %s"
 
-#: src/Services/EmailService.php:2976
-#: src/Services/EmailService.php:3054
+#: src/Services/EmailService.php:2960
+#: src/Services/EmailService.php:3039
 msgid "there"
 msgstr "tam"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:3003
+#: src/Services/EmailService.php:2987
 #, php-format
 msgid "Thanks for registering your interest in %s. We will let you know when there are updates."
 msgstr "Dziękujemy za zarejestrowanie zainteresowania %s. Powiadomimy Cię, gdy będą dostępne aktualizacje."
 
-#: src/Services/EmailService.php:3006
+#: src/Services/EmailService.php:2990
 msgid "If you didn't register your interest, you can safely ignore this email."
 msgstr "Jeśli nie zarejestrowałeś zainteresowania, możesz bezpiecznie zignorować tę wiadomość."
 
-#: src/Services/EmailService.php:3011
+#: src/Services/EmailService.php:2995
 msgid "No longer interested?"
 msgstr "Nie jesteś już zainteresowany?"
 
-#: src/Services/EmailService.php:3012
+#: src/Services/EmailService.php:2996
 msgid "Unsubscribe from updates about this event"
 msgstr "Zrezygnuj z otrzymywania aktualizacji dotyczących tego wydarzenia"
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3050
+#: src/Services/EmailService.php:3035
 #, php-format
 msgid "Welcome to the %s mailing list"
 msgstr "Witaj na liście mailingowej %s"
 
 #. translators: 1: site name, 2: event title
-#: src/Services/EmailService.php:3059
+#: src/Services/EmailService.php:3044
 #, php-format
 msgid "You've been added to the %1$s mailing list following the consent you gave at %2$s. We'll keep you posted about upcoming events and news."
 msgstr "Zostałeś dodany do listy mailingowej %1$s po wyrażeniu zgody na %2$s. Będziemy Cię informować o nadchodzących wydarzeniach i wiadomościach."
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3066
+#: src/Services/EmailService.php:3051
 #, php-format
 msgid "You've been added to the %s mailing list following the consent you gave. We'll keep you posted about upcoming events and news."
 msgstr "Zostałeś dodany do listy mailingowej %s po wyrażeniu zgody. Będziemy Cię informować o nadchodzących wydarzeniach i wiadomościach."
 
-#: src/Services/EmailService.php:3099
+#: src/Services/EmailService.php:3084
 msgid "Changed your mind?"
 msgstr "Zmieniłeś zdanie?"
 
-#: src/Services/EmailService.php:3100
+#: src/Services/EmailService.php:3085
 msgid "Manage your subscription or unsubscribe"
 msgstr "Zarządzaj subskrypcją lub zrezygnuj"
 
@@ -2792,31 +2792,31 @@ msgid "interest"
 msgstr "zainteresowanie"
 
 #: src/API/EventParticipantsController.php:582
-#: src/API/EventSignupController.php:1751
-#: src/Services/EmailService.php:2294
-#: src/blocks/event-signup/editor.js:110
+#: src/API/EventSignupController.php:1746
+#: src/Services/EmailService.php:2296
+#: src/blocks/event-signup/editor.js:114
 msgid "Event Signup"
 msgstr "Rejestracja na wydarzenie"
 
-#: src/Services/EmailService.php:2303
+#: src/Services/EmailService.php:2335
 msgid "Your answers:"
 msgstr "Twoje odpowiedzi:"
 
-#: src/blocks/event-signup/editor.js:128
+#: src/blocks/event-signup/editor.js:132
 msgid "Ticket types, activity options and pricing are rendered on the published page based on the event."
 msgstr "Typy biletów, opcje aktywności i ceny są renderowane na opublikowanej stronie na podstawie wydarzenia."
 
-#: src/blocks/event-signup/editor.js:134
+#: src/blocks/event-signup/editor.js:138
 msgid "Custom questions"
 msgstr "Pytania niestandardowe"
 
-#: src/API/EventSignupController.php:1485
+#: src/API/EventSignupController.php:1478
 msgid "This ticket type is no longer available. Please pick another option."
 msgstr "Ten typ biletu nie jest już dostępny. Proszę wybrać inną opcję."
 
 #. translators: 1: discount percentage, 2: group name
-#: src/blocks/event-signup/render.php:663
-#: src/Services/GroupSignupPricing.php:134
+#: src/blocks/event-signup/render.php:720
+#: src/Services/GroupSignupPricing.php:146
 #, php-format
 msgid "%1$s%% discount applied (%2$s)"
 msgstr "%1$s%% rabatu zastosowano (%2$s)"
@@ -2858,60 +2858,60 @@ msgstr "Nie udało się zarejestrować odmowy dla uczestnika o ID %d"
 msgid "Decline recorded by %1$s on %2$s at event %3$s"
 msgstr "Odmowa zarejestrowana przez %1$s dnia %2$s na imprezie %3$s"
 
-#: src/API/EventSignupController.php:805
+#: src/API/EventSignupController.php:806
 msgid "Please select at least one occurrence."
 msgstr "Proszę wybrać co najmniej jedno wystąpienie."
 
-#: src/API/EventSignupController.php:813
-#: src/API/EventSignupController.php:824
+#: src/API/EventSignupController.php:814
+#: src/API/EventSignupController.php:825
 msgid "Invalid ticket type."
 msgstr "Nieprawidłowy typ biletu."
 
-#: src/API/EventSignupController.php:835
+#: src/API/EventSignupController.php:836
 msgid "One of the selected occurrences is not valid for this ticket."
 msgstr "Jedno z wybranych wystąpień nie jest ważne dla tego biletu."
 
 #. translators: %d: minimum number of occurrences required
-#: src/API/EventSignupController.php:848
+#: src/API/EventSignupController.php:849
 #: src/blocks/event-signup/frontend.js:311
-#, php-format, js-format
+#, php-format,js-format
 msgid "Please select at least %d occurrence."
 msgid_plural "Please select at least %d occurrences."
 msgstr[0] "Proszę wybrać co najmniej %d wystąpienie."
 msgstr[1] "Proszę wybrać co najmniej %d wystąpienia."
 msgstr[2] "Proszę wybrać co najmniej %d wystąpień."
 
-#: src/API/EventSignupController.php:875
+#: src/API/EventSignupController.php:876
 msgid "You are already signed up for these occurrences."
 msgstr "Jesteś już zapisany na te wystąpienia."
 
-#: src/API/EventSignupController.php:928
+#: src/API/EventSignupController.php:929
+#: src/API/EventSignupController.php:1804
 #: src/API/EventSignupController.php:1816
-#: src/API/EventSignupController.php:1828
-#: src/API/EventSignupController.php:2039
+#: src/API/EventSignupController.php:2027
 msgid "Paid signup is not available because the payment plugin is not configured."
 msgstr "Rejestracja płatna nie jest dostępna, ponieważ wtyczka płatności nie jest skonfigurowana."
 
-#: src/API/EventSignupController.php:945
+#: src/API/EventSignupController.php:946
 msgid "One of the selected occurrences is fully booked."
 msgstr "Jedno z wybranych wystąpień jest w pełni zarezerwowane."
 
-#: src/API/EventSignupController.php:1239
-#: src/API/EventSignupController.php:1251
+#: src/API/EventSignupController.php:1232
+#: src/API/EventSignupController.php:1244
 msgid "Paid activities are not available because the payment plugin is not configured."
 msgstr "Płatne zajęcia nie są dostępne, ponieważ wtyczka płatności nie jest skonfigurowana."
 
-#: src/blocks/event-signup/render.php:938
+#: src/blocks/event-signup/render.php:1006
 msgid "Choose occurrences"
 msgstr "Wybierz wystąpienia"
 
-#: src/blocks/event-signup/render.php:959
-#: src/Hooks/SignupHookBridge.php:331
+#: src/blocks/event-signup/render.php:1027
+#: src/Hooks/SignupHookBridge.php:351
 msgid "already signed up"
 msgstr "już zapisany"
 
-#: src/blocks/event-signup/render.php:1174
-#: src/blocks/event-signup/render.php:1297
+#: src/blocks/event-signup/render.php:1242
+#: src/blocks/event-signup/render.php:1365
 msgid "Online payment is not available for this event at the moment. Please contact the organiser."
 msgstr "Płatność online nie jest dostępna dla tej imprezy w tej chwili. Proszę skontaktować się z organizatorem."
 
@@ -2965,18 +2965,18 @@ msgstr "Ten link jest nieprawidłowy lub wygasł."
 msgid "This registration link has expired. Please fill in the form again."
 msgstr "Ten link rejestracyjny wygasł. Proszę wypełnić formularz ponownie."
 
-#: src/API/EventSignupController.php:2030
+#: src/API/EventSignupController.php:2018
 msgid "Your series pass is now active!"
 msgstr "Twój karnet serii jest teraz aktywny!"
 
 #. translators: %s: ticket type name
-#: src/API/EventSignupController.php:2048
+#: src/API/EventSignupController.php:2036
 #, php-format
 msgid "Upgrade to series pass: %s"
 msgstr "Uaktualnij do karnetu serii: %s"
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:2062
+#: src/API/EventSignupController.php:2050
 #, php-format
 msgid "Series pass upgrade for %s"
 msgstr "Uaktualnienie karnetu serii dla %s"
@@ -3009,30 +3009,30 @@ msgid "Sent to %1$d, failed %2$d, skipped %3$d."
 msgstr "Wysłano do %1$d, nie powiodło się %2$d, pominięto %3$d."
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:964
+#: src/Services/EmailService.php:965
 #, php-format
 msgid "Continue registering for %s"
 msgstr "Kontynuuj rejestrację dla %s"
 
-#: src/Services/EmailService.php:969
+#: src/Services/EmailService.php:970
 msgid "Continue to payment"
 msgstr "Przejdź do płatności"
 
-#: src/Services/EmailService.php:970
+#: src/Services/EmailService.php:971
 msgid "Continue to sign up"
 msgstr "Przejdź do rejestracji"
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:1005
+#: src/Services/EmailService.php:1006
 #, php-format
 msgid "You're registering for %s."
 msgstr "Rejestrujesz się na %s."
 
-#: src/Services/EmailService.php:1011
+#: src/Services/EmailService.php:1012
 msgid "We've saved your answers — click below to continue where you left off:"
 msgstr "Zapisaliśmy Twoje odpowiedzi — kliknij poniżej, aby kontynuować od miejsca, w którym skończyłeś:"
 
-#: src/Services/EmailService.php:1021
+#: src/Services/EmailService.php:1022
 msgid "If you didn't try to register, you can safely ignore this email."
 msgstr "Jeśli nie próbowałeś się rejestrować, możesz bezpiecznie zignorować tę wiadomość e-mail."
 
@@ -3623,11 +3623,11 @@ msgstr "Publiczność"
 msgid "Outro text"
 msgstr "Tekst zakończenia"
 
-#: src/Services/EmailService.php:153
+#: src/Services/EmailService.php:154
 msgid "Participant has not yet confirmed their marketing subscription."
 msgstr "Uczestnik nie potwierdził jeszcze swojej subskrypcji marketingowej."
 
-#: src/Services/EmailService.php:2041
+#: src/Services/EmailService.php:2042
 msgid "[Test email — real sends to subscribers include a \"Manage your preferences\" unsubscribe link here.]"
 msgstr "[Test e-mail — rzeczywiste wysyłki do subskrybentów zawierają tutaj link do rezygnacji \"Zarządzaj swoimi preferencjami\".]"
 
@@ -3645,7 +3645,7 @@ msgstr "Opcjonalny kod HTML wyświetlany poniżej listy wydarzeń."
 msgid "Next digest: %s"
 msgstr "Następny przegląd: %s"
 
-#: src/blocks/event-signup/editor.js:103
+#: src/blocks/event-signup/editor.js:107
 msgid "This block has moved to Event Signup (fair-events). Transform it to the new block."
 msgstr "Ten blok został przeniesiony do Event Signup (fair-events). Przekształć go w nowy blok."
 
@@ -3663,10 +3663,11 @@ msgstr "Starszy blok rejestracji. Zastąpiony przez Event Signup (fair-events) �
 msgid "Reverted to minimal: marketing subscription was never confirmed within a week."
 msgstr "Przywrócono do minimalnego: subskrypcja marketingowa nie została potwierdzona w ciągu tygodnia."
 
-#: src/Services/EmailService.php:161
+#: src/Services/EmailService.php:162
 msgid "Opted out of the weekly summary."
 msgstr "Zrezygnowano z cotygodniowego podsumowania."
 
+#. translators: %s: source host, e.g. "instagram.com".
 #. translators: %s: source domain, e.g. "example.com".
 #: src/Services/WeeklyDigestRenderer.php:165
 #: src/Services/WeeklyDigestRenderer.php:175
@@ -3696,38 +3697,38 @@ msgstr "Zrezygnowano"
 msgid "Subscribed"
 msgstr "Subskrybowany"
 
-#: ../fair-events-shared/src/questionnaire.js:449
+#: ../fair-events-shared/src/questionnaire.js:453
 msgid "Please answer the required question: "
 msgstr "Odpowiedz na wymagane pytanie: "
 
-#: ../fair-events-shared/src/questionnaire.js:497
+#: ../fair-events-shared/src/questionnaire.js:501
 msgid "Please enter a valid email address for: "
 msgstr "Wpisz prawidłowy adres e-mail dla: "
 
-#: ../fair-events-shared/src/questionnaire.js:527
+#: ../fair-events-shared/src/questionnaire.js:616
 msgid "File is too large. Maximum size is "
 msgstr "Plik jest zbyt duży. Maksymalny rozmiar to "
 
-#: ../fair-events-shared/src/questionnaire.js:472
+#: ../fair-events-shared/src/questionnaire.js:476
 msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
 msgstr "Wpisz prawidłowy numer telefonu z kodem kraju (na przykład +49 170 123 45 67) dla: %s"
 
 #. translators: 1: base button label, 2: formatted price
-#: src/blocks/event-signup/render.php:606
-#: src/blocks/event-signup/render.php:612
+#: src/blocks/event-signup/render.php:666
+#: src/blocks/event-signup/render.php:672
 #, php-format
 msgid "%1$s — %2$s"
 msgstr "%1$s — %2$s"
 
 #. translators: 1: discount amount, 2: group name
-#: src/blocks/event-signup/render.php:670
-#: src/Services/GroupSignupPricing.php:142
+#: src/blocks/event-signup/render.php:727
+#: src/Services/GroupSignupPricing.php:154
 #, php-format
 msgid "%1$s discount applied (%2$s)"
 msgstr "Zastosowana zniżka %1$s (%2$s)"
 
 #. translators: %s: formatted add-on price
-#: src/blocks/event-signup/render.php:810
+#: src/blocks/event-signup/render.php:878
 #, php-format
 msgid "(+%s)"
 msgstr "(+%s)"
@@ -3742,18 +3743,47 @@ msgstr "Razem: %s"
 msgid "Translations"
 msgstr "Tłumaczenia"
 
-#: src/Hooks/SignupHookBridge.php:244
+#: src/Hooks/SignupHookBridge.php:263
 msgid "You already have a ticket for this date."
 msgstr "Masz już bilet na tę datę."
 
-#: src/Services/SignupActivities.php:145
-#: src/Services/SignupActivities.php:164
+#: src/Services/SignupActivities.php:168
+#: src/Services/SignupActivities.php:187
 msgid "One of the selected activities is not available for this event."
 msgstr "Jedna z wybranych aktywności nie jest dostępna dla tego wydarzenia."
 
 #. translators: %s: activity name
-#: src/Services/SignupActivities.php:173
+#: src/Services/SignupActivities.php:196
 #, php-format
 msgid "\"%s\" is full."
 msgstr "\"%s\" jest pełne."
 
+#. translators: 1: discount magnitude e.g. "20%" or "€5.00", 2: group name
+#: src/blocks/event-signup/render.php:768
+#, php-format
+msgid "%1$s off · %2$s"
+msgstr ""
+
+#: src/Services/EmailService.php:2330
+msgid "Event date:"
+msgstr ""
+
+#: src/Services/EmailService.php:2331
+msgid "Registration reference:"
+msgstr ""
+
+#: src/Services/EmailService.php:2332
+msgid "Ticket type:"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:537
+msgid "Please enter a valid web address for: %s"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:561
+msgid "Please enter a valid date for: %s"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:585
+msgid "Please enter a valid date and time for: %s"
+msgstr ""

--- a/fair-audience/languages/fair-audience.pot
+++ b/fair-audience/languages/fair-audience.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-03T15:42:59+00:00\n"
+"POT-Creation-Date: 2026-08-06T07:43:50+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fair-audience\n"
@@ -68,16 +68,16 @@ msgstr ""
 
 #: src/API/AudienceSignupController.php:204
 #: src/API/EventInterestController.php:156
-#: src/API/EventSignupController.php:2147
-#: src/API/EventSignupController.php:2679
+#: src/API/EventSignupController.php:2134
+#: src/API/EventSignupController.php:2666
 #: src/API/MailingSignupController.php:172
 msgid "Please enter a valid email address."
 msgstr ""
 
 #: src/API/AudienceSignupController.php:223
 #: src/API/EventInterestController.php:182
-#: src/API/EventSignupController.php:2156
-#: src/API/EventSignupController.php:2718
+#: src/API/EventSignupController.php:2143
+#: src/API/EventSignupController.php:2705
 #: src/API/MailingSignupController.php:192
 msgid "Too many requests. Please try again later."
 msgstr ""
@@ -148,22 +148,22 @@ msgstr ""
 #: src/API/EventSignupController.php:468
 #: src/API/EventSignupController.php:613
 #: src/API/EventSignupController.php:1081
-#: src/API/EventSignupController.php:2138
-#: src/API/EventSignupController.php:2341
-#: src/API/EventSignupController.php:2533
-#: src/API/EventSignupController.php:2661
-#: src/API/EventSignupController.php:2962
+#: src/API/EventSignupController.php:2125
+#: src/API/EventSignupController.php:2328
+#: src/API/EventSignupController.php:2520
+#: src/API/EventSignupController.php:2648
+#: src/API/EventSignupController.php:2949
 #: src/Services/EmailService.php:337
 #: src/Services/EmailService.php:561
 #: src/Services/EmailService.php:1401
-#: src/Services/EmailService.php:2771
+#: src/Services/EmailService.php:2792
 msgid "Event not found."
 msgstr ""
 
 #: src/API/EventParticipantsController.php:582
-#: src/API/EventSignupController.php:1752
-#: src/Services/EmailService.php:2293
-#: src/blocks/event-signup/editor.js:110
+#: src/API/EventSignupController.php:1746
+#: src/Services/EmailService.php:2296
+#: src/blocks/event-signup/editor.js:114
 msgid "Event Signup"
 msgstr ""
 
@@ -179,7 +179,7 @@ msgstr ""
 #: src/Services/EmailService.php:584
 #: src/Services/EmailService.php:1440
 #: src/Services/EmailService.php:1830
-#: src/Services/EmailService.php:2846
+#: src/Services/EmailService.php:2867
 #: src/Admin/participant-detail/ParticipantDetail.js:86
 msgid "Participant not found."
 msgstr ""
@@ -305,13 +305,13 @@ msgstr ""
 
 #: src/API/EventSignupController.php:642
 #: src/API/EventSignupController.php:1109
-#: src/API/EventSignupController.php:2991
+#: src/API/EventSignupController.php:2978
 msgid "Could not find your participant profile."
 msgstr ""
 
 #: src/API/EventSignupController.php:726
-#: src/API/EventSignupController.php:2369
-#: src/API/EventSignupController.php:2795
+#: src/API/EventSignupController.php:2356
+#: src/API/EventSignupController.php:2782
 msgid "You are already signed up for this event."
 msgstr ""
 
@@ -350,9 +350,9 @@ msgid "You are already signed up for these occurrences."
 msgstr ""
 
 #: src/API/EventSignupController.php:929
-#: src/API/EventSignupController.php:1817
-#: src/API/EventSignupController.php:1829
-#: src/API/EventSignupController.php:2040
+#: src/API/EventSignupController.php:1804
+#: src/API/EventSignupController.php:1816
+#: src/API/EventSignupController.php:2027
 msgid "Paid signup is not available because the payment plugin is not configured."
 msgstr ""
 
@@ -363,17 +363,17 @@ msgstr ""
 #. translators: %s: event title or occurrence date/time label
 #: src/API/EventSignupController.php:985
 #: src/API/EventSignupController.php:999
-#: src/API/EventSignupController.php:1874
+#: src/API/EventSignupController.php:1861
 #, php-format
 msgid "Signup for %s"
 msgstr ""
 
 #: src/API/EventSignupController.php:1052
-#: src/API/EventSignupController.php:1318
-#: src/API/EventSignupController.php:1966
-#: src/API/EventSignupController.php:2113
-#: src/API/EventSignupController.php:2490
-#: src/API/EventSignupController.php:2631
+#: src/API/EventSignupController.php:1310
+#: src/API/EventSignupController.php:1953
+#: src/API/EventSignupController.php:2100
+#: src/API/EventSignupController.php:2477
+#: src/API/EventSignupController.php:2618
 #: src/blocks/event-signup/frontend.js:1080
 #: src/blocks/event-signup/frontend.js:1362
 msgid "Redirecting to payment…"
@@ -392,34 +392,34 @@ msgstr ""
 msgid "Your activities have been added!"
 msgstr ""
 
-#: src/API/EventSignupController.php:1240
-#: src/API/EventSignupController.php:1252
+#: src/API/EventSignupController.php:1232
+#: src/API/EventSignupController.php:1244
 msgid "Paid activities are not available because the payment plugin is not configured."
 msgstr ""
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:1259
+#: src/API/EventSignupController.php:1251
 #, php-format
 msgid "Added activities for %s"
 msgstr ""
 
-#: src/API/EventSignupController.php:1356
+#: src/API/EventSignupController.php:1348
 #: src/Services/GroupSignupPricing.php:113
 msgid "This ticket type is not available for your account."
 msgstr ""
 
-#: src/API/EventSignupController.php:1459
+#: src/API/EventSignupController.php:1451
 msgid "This ticket type is sold out. Please pick another option."
 msgstr ""
 
-#: src/API/EventSignupController.php:1486
+#: src/API/EventSignupController.php:1478
 msgid "This ticket type is no longer available. Please pick another option."
 msgstr ""
 
 #. translators: %d: minimum number of activities required
-#: src/API/EventSignupController.php:1599
-#: src/blocks/event-signup/render.php:753
-#: src/Services/SignupActivities.php:187
+#: src/API/EventSignupController.php:1591
+#: src/blocks/event-signup/render.php:821
+#: src/Services/SignupActivities.php:210
 #: src/blocks/event-signup/frontend.js:391
 #, php-format,js-format
 msgid "Please select at least %d activity to sign up."
@@ -427,99 +427,99 @@ msgid_plural "Please select at least %d activities to sign up."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/API/EventSignupController.php:1842
+#: src/API/EventSignupController.php:1829
 msgid "This event is fully booked."
 msgstr ""
 
-#: src/API/EventSignupController.php:2031
+#: src/API/EventSignupController.php:2018
 msgid "Your series pass is now active!"
 msgstr ""
 
 #. translators: %s: ticket type name
-#: src/API/EventSignupController.php:2049
+#: src/API/EventSignupController.php:2036
 #, php-format
 msgid "Upgrade to series pass: %s"
 msgstr ""
 
 #. translators: %s: event title
-#: src/API/EventSignupController.php:2063
+#: src/API/EventSignupController.php:2050
 #, php-format
 msgid "Series pass upgrade for %s"
 msgstr ""
 
-#: src/API/EventSignupController.php:2188
+#: src/API/EventSignupController.php:2175
 msgid "If your email is in our system, you will receive a signup link shortly. Please check your inbox."
 msgstr ""
 
-#: src/API/EventSignupController.php:2207
+#: src/API/EventSignupController.php:2194
 msgid "Invalid transaction."
 msgstr ""
 
-#: src/API/EventSignupController.php:2215
+#: src/API/EventSignupController.php:2202
 msgid "Payment plugin is missing."
 msgstr ""
 
-#: src/API/EventSignupController.php:2224
-#: src/API/EventSignupController.php:2289
+#: src/API/EventSignupController.php:2211
+#: src/API/EventSignupController.php:2276
 msgid "Transaction not found."
 msgstr ""
 
-#: src/API/EventSignupController.php:2265
+#: src/API/EventSignupController.php:2252
 msgid "You are not authorized to retry this payment."
 msgstr ""
 
-#: src/API/EventSignupController.php:2301
+#: src/API/EventSignupController.php:2288
 msgid "This payment cannot be retried."
 msgstr ""
 
-#: src/API/EventSignupController.php:2319
+#: src/API/EventSignupController.php:2306
 msgid "This payment is not retriable from this endpoint."
 msgstr ""
 
-#: src/API/EventSignupController.php:2332
-#: src/API/EventSignupController.php:2524
+#: src/API/EventSignupController.php:2319
+#: src/API/EventSignupController.php:2511
 msgid "This payment is missing context needed to retry."
 msgstr ""
 
-#: src/API/EventSignupController.php:2380
-#: src/API/EventSignupController.php:2567
+#: src/API/EventSignupController.php:2367
+#: src/API/EventSignupController.php:2554
 msgid "Original line items could not be loaded."
 msgstr ""
 
-#: src/API/EventSignupController.php:2542
+#: src/API/EventSignupController.php:2529
 msgid "Your signup is no longer active."
 msgstr ""
 
-#: src/API/EventSignupController.php:2556
+#: src/API/EventSignupController.php:2543
 msgid "These activities are already on your signup."
 msgstr ""
 
-#: src/API/EventSignupController.php:2688
+#: src/API/EventSignupController.php:2675
 msgid "Please enter your name."
 msgstr ""
 
-#: src/API/EventSignupController.php:2770
+#: src/API/EventSignupController.php:2757
 #: src/blocks/event-signup/frontend.js:1096
 msgid "We recognise this email — check your inbox to continue."
 msgstr ""
 
-#: src/API/EventSignupController.php:2822
+#: src/API/EventSignupController.php:2809
 msgid "Failed to process registration. Please try again."
 msgstr ""
 
-#: src/API/EventSignupController.php:2931
+#: src/API/EventSignupController.php:2918
 msgid "You have been signed up for the event! Please check your email to confirm your subscription."
 msgstr ""
 
-#: src/API/EventSignupController.php:2940
+#: src/API/EventSignupController.php:2927
 msgid "You have successfully registered and signed up for the event!"
 msgstr ""
 
-#: src/API/EventSignupController.php:3012
+#: src/API/EventSignupController.php:2999
 msgid "You are not signed up for this event."
 msgstr ""
 
-#: src/API/EventSignupController.php:3028
+#: src/API/EventSignupController.php:3015
 #: src/blocks/event-signup/frontend.js:1640
 msgid "You have been removed from this event."
 msgstr ""
@@ -628,14 +628,14 @@ msgid "No event source configured for the weekly digest."
 msgstr ""
 
 #: src/blocks/audience-signup/render.php:192
-#: src/blocks/event-signup/render.php:1240
+#: src/blocks/event-signup/render.php:1308
 #: src/blocks/mailing-signup/render.php:99
-#: src/blocks/event-signup/editor.js:115
+#: src/blocks/event-signup/editor.js:119
 msgid "First Name"
 msgstr ""
 
 #: src/blocks/audience-signup/render.php:199
-#: src/blocks/event-signup/render.php:1247
+#: src/blocks/event-signup/render.php:1315
 #: src/blocks/mailing-signup/render.php:106
 msgid "Enter your first name"
 msgstr ""
@@ -652,20 +652,20 @@ msgstr ""
 
 #: src/blocks/audience-signup/render.php:217
 #: src/blocks/event-interest/render.php:122
-#: src/blocks/event-signup/render.php:1265
-#: src/blocks/event-signup/render.php:1320
+#: src/blocks/event-signup/render.php:1333
+#: src/blocks/event-signup/render.php:1388
 #: src/blocks/mailing-signup/render.php:125
 #: src/Services/EmailService.php:1921
 #: src/Admin/all-participants/AllParticipants.js:108
 #: src/Admin/components/ParticipantEditModal.js:177
 #: src/Admin/participant-detail/ParticipantDetail.js:190
-#: src/blocks/event-signup/editor.js:123
+#: src/blocks/event-signup/editor.js:127
 msgid "Email"
 msgstr ""
 
 #: src/blocks/audience-signup/render.php:224
-#: src/blocks/event-signup/render.php:1272
-#: src/blocks/event-signup/render.php:1327
+#: src/blocks/event-signup/render.php:1340
+#: src/blocks/event-signup/render.php:1395
 #: src/blocks/mailing-signup/render.php:132
 msgid "Enter your email"
 msgstr ""
@@ -686,15 +686,15 @@ msgid "Select..."
 msgstr ""
 
 #: src/blocks/audience-signup/render.php:386
-#: src/blocks/event-signup/render.php:1279
+#: src/blocks/event-signup/render.php:1347
 msgid "Keep me informed about future events"
 msgstr ""
 
 #: src/blocks/audience-signup/render.php:393
 #: src/blocks/event-interest/render.php:161
-#: src/blocks/event-signup/render.php:1291
+#: src/blocks/event-signup/render.php:1359
 #: src/blocks/mailing-signup/render.php:156
-#: src/Hooks/SignupHookBridge.php:369
+#: src/Hooks/SignupHookBridge.php:390
 msgid "Not you? Start fresh"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgid "Update Answers"
 msgstr ""
 
 #: src/blocks/event-interest/render.php:115
-#: src/blocks/event-signup/render.php:997
+#: src/blocks/event-signup/render.php:1065
 msgid "This block can only be used on event pages."
 msgstr ""
 
@@ -722,8 +722,8 @@ msgid "Website"
 msgstr ""
 
 #: src/blocks/event-signup/render.php:63
-#: src/blocks/event-signup/render.php:969
-#: src/blocks/event-signup/editor.js:92
+#: src/blocks/event-signup/render.php:1037
+#: src/blocks/event-signup/editor.js:96
 #: src/blocks/event-signup/frontend.js:472
 #: src/blocks/event-signup/frontend.js:506
 #: src/blocks/event-signup/frontend.js:1692
@@ -731,8 +731,8 @@ msgid "Sign Up"
 msgstr ""
 
 #: src/blocks/event-signup/render.php:64
-#: src/blocks/event-signup/render.php:970
-#: src/blocks/event-signup/editor.js:143
+#: src/blocks/event-signup/render.php:1038
+#: src/blocks/event-signup/editor.js:147
 #: src/blocks/event-signup/frontend.js:475
 #: src/blocks/event-signup/frontend.js:509
 msgid "Register & Sign Up"
@@ -743,245 +743,251 @@ msgid "Send Signup Link"
 msgstr ""
 
 #. translators: 1: base button label, 2: formatted price
-#: src/blocks/event-signup/render.php:606
-#: src/blocks/event-signup/render.php:612
+#: src/blocks/event-signup/render.php:666
+#: src/blocks/event-signup/render.php:672
 #, php-format
 msgid "%1$s — %2$s"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:617
+#: src/blocks/event-signup/render.php:677
 #: src/blocks/event-signup/frontend.js:537
 msgid "Sign up for free"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:618
+#: src/blocks/event-signup/render.php:678
 #: src/blocks/event-signup/frontend.js:538
 msgid "Register for free"
 msgstr ""
 
 #. translators: 1: discount percentage, 2: group name
-#: src/blocks/event-signup/render.php:663
-#: src/Services/GroupSignupPricing.php:134
+#: src/blocks/event-signup/render.php:720
+#: src/Services/GroupSignupPricing.php:146
 #, php-format
 msgid "%1$s%% discount applied (%2$s)"
 msgstr ""
 
 #. translators: 1: discount amount, 2: group name
-#: src/blocks/event-signup/render.php:670
-#: src/Services/GroupSignupPricing.php:142
+#: src/blocks/event-signup/render.php:727
+#: src/Services/GroupSignupPricing.php:154
 #, php-format
 msgid "%1$s discount applied (%2$s)"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:691
+#: src/blocks/event-signup/render.php:748
 msgid "Choose ticket type"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:702
-#: src/blocks/event-signup/render.php:779
-#: src/blocks/event-signup/render.php:841
-#: src/Hooks/SignupHookBridge.php:541
+#: src/blocks/event-signup/render.php:759
+#: src/blocks/event-signup/render.php:847
+#: src/blocks/event-signup/render.php:909
+#: src/Hooks/SignupHookBridge.php:564
 msgid "free"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:706
+#. translators: 1: discount magnitude e.g. "20%" or "€5.00", 2: group name
+#: src/blocks/event-signup/render.php:768
+#, php-format
+msgid "%1$s off · %2$s"
+msgstr ""
+
+#: src/blocks/event-signup/render.php:774
 msgid "sold out"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:743
+#: src/blocks/event-signup/render.php:811
 msgid "Select activities"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:784
-#: src/blocks/event-signup/render.php:845
-#: src/Hooks/SignupHookBridge.php:544
+#: src/blocks/event-signup/render.php:852
+#: src/blocks/event-signup/render.php:913
+#: src/Hooks/SignupHookBridge.php:567
 msgid "full"
 msgstr ""
 
 #. translators: %s: formatted add-on price
-#: src/blocks/event-signup/render.php:810
+#: src/blocks/event-signup/render.php:878
 #, php-format
 msgid "(+%s)"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:833
-#: src/blocks/event-signup/render.php:863
-#: src/Hooks/SignupHookBridge.php:523
-#: src/Hooks/SignupHookBridge.php:561
+#: src/blocks/event-signup/render.php:901
+#: src/blocks/event-signup/render.php:931
+#: src/Hooks/SignupHookBridge.php:546
+#: src/Hooks/SignupHookBridge.php:584
 #: src/blocks/event-signup/frontend.js:1466
 msgid "Add activities"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:886
+#: src/blocks/event-signup/render.php:954
 msgid "Choose a date"
 msgstr ""
 
 #. translators: appended to a date label when the viewer is signed up — they can cancel from this row
-#: src/blocks/event-signup/render.php:897
+#: src/blocks/event-signup/render.php:965
 msgid "signed up (manage)"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:899
+#: src/blocks/event-signup/render.php:967
 msgid "signed up"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:938
+#: src/blocks/event-signup/render.php:1006
 msgid "Choose occurrences"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:959
-#: src/Hooks/SignupHookBridge.php:331
+#: src/blocks/event-signup/render.php:1027
+#: src/Hooks/SignupHookBridge.php:351
 msgid "already signed up"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1009
+#: src/blocks/event-signup/render.php:1077
 #: src/blocks/event-signup/frontend.js:1809
 msgid "Payment confirmed"
 msgstr ""
 
 #. translators: %s: event title
-#: src/blocks/event-signup/render.php:1015
+#: src/blocks/event-signup/render.php:1083
 #, php-format
 msgid "You're signed up for %s."
 msgstr ""
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1024
+#: src/blocks/event-signup/render.php:1092
 #, php-format
 msgid "Amount paid: %s"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1030
+#: src/blocks/event-signup/render.php:1098
 #: src/blocks/event-signup/frontend.js:1823
 msgid "A confirmation email is on its way. You can close this page."
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1037
+#: src/blocks/event-signup/render.php:1105
 msgid "Thank you for your payment!"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1040
+#: src/blocks/event-signup/render.php:1108
 msgid "We're confirming with your bank. This usually takes a few seconds — the page will update as soon as it's done."
 msgstr ""
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1046
+#: src/blocks/event-signup/render.php:1114
 #, php-format
 msgid "Amount: %s"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1055
+#: src/blocks/event-signup/render.php:1123
 msgid "Your payment is waiting."
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1058
+#: src/blocks/event-signup/render.php:1126
 msgid "You can pick up where you left off on the secure payment page."
 msgstr ""
 
 #. translators: %s: formatted amount with currency
-#: src/blocks/event-signup/render.php:1064
-#: src/blocks/event-signup/render.php:1091
+#: src/blocks/event-signup/render.php:1132
+#: src/blocks/event-signup/render.php:1159
 #, php-format
 msgid "Amount due: %s"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1071
+#: src/blocks/event-signup/render.php:1139
 msgid "Continue payment"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1076
-#: src/blocks/event-signup/render.php:1103
+#: src/blocks/event-signup/render.php:1144
+#: src/blocks/event-signup/render.php:1171
 msgid "Cancel and start over"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1085
+#: src/blocks/event-signup/render.php:1153
 msgid "Your payment didn't go through."
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1098
+#: src/blocks/event-signup/render.php:1166
 msgid "Retry payment"
 msgstr ""
 
 #. translators: %s: transaction status
-#: src/blocks/event-signup/render.php:1114
+#: src/blocks/event-signup/render.php:1182
 #, php-format
 msgid "Payment status: %s"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1125
+#: src/blocks/event-signup/render.php:1193
 #: src/blocks/event-signup/frontend.js:1140
 #: src/blocks/event-signup/frontend.js:1403
 msgid "You are signed up for this event!"
 msgstr ""
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1140
+#: src/blocks/event-signup/render.php:1208
 #, php-format
 msgid "Hi %s! Here is your registration for this event."
 msgstr ""
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1146
+#: src/blocks/event-signup/render.php:1214
 #, php-format
 msgid "Hi %s! Click the button below to sign up for this event."
 msgstr ""
 
 #. translators: %s: participant name
-#: src/blocks/event-signup/render.php:1152
+#: src/blocks/event-signup/render.php:1220
 #: src/blocks/event-signup/frontend.js:1671
 #, php-format,js-format
 msgid "Hi %s! You can sign up for this event."
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1174
-#: src/blocks/event-signup/render.php:1297
+#: src/blocks/event-signup/render.php:1242
+#: src/blocks/event-signup/render.php:1365
 msgid "Online payment is not available for this event at the moment. Please contact the organiser."
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1185
-#: src/Hooks/SignupHookBridge.php:295
+#: src/blocks/event-signup/render.php:1253
+#: src/Hooks/SignupHookBridge.php:315
 msgid "You are signed up for this date."
 msgstr ""
 
 #. translators: %s: ticket type name
-#: src/blocks/event-signup/render.php:1192
-#: src/Hooks/SignupHookBridge.php:302
+#: src/blocks/event-signup/render.php:1260
+#: src/Hooks/SignupHookBridge.php:322
 #, php-format
 msgid "Your ticket: %s"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1200
-#: src/Hooks/SignupHookBridge.php:309
-#: src/Hooks/SignupHookBridge.php:526
+#: src/blocks/event-signup/render.php:1268
+#: src/Hooks/SignupHookBridge.php:329
+#: src/Hooks/SignupHookBridge.php:549
 msgid "Your activities:"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1211
-#: src/Hooks/SignupHookBridge.php:342
+#: src/blocks/event-signup/render.php:1279
+#: src/Hooks/SignupHookBridge.php:362
 #: src/Admin/manage-event-audience-tab/EventAudience.js:2369
 #: src/blocks/event-signup/frontend.js:1411
 msgid "Cancel signup"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1225
+#: src/blocks/event-signup/render.php:1293
 msgid "I'm new"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1228
+#: src/blocks/event-signup/render.php:1296
 msgid "I have an account"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1253
+#: src/blocks/event-signup/render.php:1321
 #: src/Admin/components/ParticipantEditModal.js:170
-#: src/blocks/event-signup/editor.js:119
+#: src/blocks/event-signup/editor.js:123
 msgid "Surname"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1259
+#: src/blocks/event-signup/render.php:1327
 msgid "Enter your surname"
 msgstr ""
 
-#: src/blocks/event-signup/render.php:1316
+#: src/blocks/event-signup/render.php:1384
 msgid "Enter your email to receive a signup link."
 msgstr ""
 
@@ -1051,18 +1057,18 @@ msgstr ""
 msgid "Unsubscribed"
 msgstr ""
 
-#: src/Hooks/PaymentHooks.php:394
+#: src/Hooks/PaymentHooks.php:399
 #: src/Hooks/PendingSubscriptionTimeoutHooks.php:56
 #: src/Hooks/WeeklyDigestHooks.php:55
 msgid "Every 5 minutes (fair-audience)"
 msgstr ""
 
-#: src/Hooks/PaymentHooks.php:827
+#: src/Hooks/PaymentHooks.php:832
 msgid "Paid online via Mollie"
 msgstr ""
 
 #. translators: %1$s: Mollie status, %2$d: transaction ID
-#: src/Hooks/PaymentHooks.php:871
+#: src/Hooks/PaymentHooks.php:876
 #, php-format
 msgid "Online payment %1$s (transaction #%2$d)"
 msgstr ""
@@ -1071,7 +1077,7 @@ msgstr ""
 msgid "Reverted to minimal: marketing subscription was never confirmed within a week."
 msgstr ""
 
-#: src/Hooks/SignupHookBridge.php:244
+#: src/Hooks/SignupHookBridge.php:263
 msgid "You already have a ticket for this date."
 msgstr ""
 
@@ -1135,12 +1141,12 @@ msgstr ""
 #: src/Services/EmailService.php:1605
 #: src/Services/EmailService.php:1710
 #: src/Services/EmailService.php:2194
-#: src/Services/EmailService.php:2325
-#: src/Services/EmailService.php:2415
-#: src/Services/EmailService.php:2527
-#: src/Services/EmailService.php:2664
-#: src/Services/EmailService.php:2953
-#: src/Services/EmailService.php:3046
+#: src/Services/EmailService.php:2328
+#: src/Services/EmailService.php:2428
+#: src/Services/EmailService.php:2548
+#: src/Services/EmailService.php:2685
+#: src/Services/EmailService.php:2982
+#: src/Services/EmailService.php:3076
 #: src/Admin/event-participants/EventParticipants.js:1192
 #, php-format,js-format
 msgid "Hi %s,"
@@ -1183,7 +1189,7 @@ msgstr ""
 #: src/Services/EmailService.php:918
 #: src/Services/EmailService.php:1040
 #: src/Services/EmailService.php:1770
-#: src/Services/EmailService.php:2710
+#: src/Services/EmailService.php:2731
 msgid "If the button above doesn't work, copy and paste this link:"
 msgstr ""
 
@@ -1196,7 +1202,7 @@ msgstr ""
 #: src/Services/EmailService.php:1449
 #: src/Services/EmailService.php:1526
 #: src/Services/EmailService.php:1839
-#: src/Services/EmailService.php:2855
+#: src/Services/EmailService.php:2876
 msgid "Participant has no email address."
 msgstr ""
 
@@ -1205,7 +1211,7 @@ msgstr ""
 #: src/Services/EmailService.php:1473
 #: src/Services/EmailService.php:1550
 #: src/Services/EmailService.php:1865
-#: src/Services/EmailService.php:2882
+#: src/Services/EmailService.php:2903
 msgid "wp_mail() failed to send."
 msgstr ""
 
@@ -1285,7 +1291,7 @@ msgid "Click the button below to sign up for the event:"
 msgstr ""
 
 #: src/Services/EmailService.php:895
-#: src/Services/EmailService.php:2691
+#: src/Services/EmailService.php:2712
 msgid "Sign Up Now"
 msgstr ""
 
@@ -1295,7 +1301,7 @@ msgstr ""
 
 #: src/Services/EmailService.php:924
 #: src/Services/EmailService.php:1046
-#: src/Services/EmailService.php:2716
+#: src/Services/EmailService.php:2737
 msgid "Don't want to receive event invitations?"
 msgstr ""
 
@@ -1304,7 +1310,7 @@ msgstr ""
 #: src/Services/EmailService.php:1181
 #: src/Services/EmailService.php:1360
 #: src/Services/EmailService.php:1630
-#: src/Services/EmailService.php:2717
+#: src/Services/EmailService.php:2738
 msgid "Manage your preferences"
 msgstr ""
 
@@ -1362,7 +1368,7 @@ msgid "Fee:"
 msgstr ""
 
 #: src/Services/EmailService.php:1725
-#: src/Services/EmailService.php:2499
+#: src/Services/EmailService.php:2520
 msgid "Amount:"
 msgstr ""
 
@@ -1419,8 +1425,8 @@ msgid "Thank you for your submission! We have received your response."
 msgstr ""
 
 #: src/Services/EmailService.php:2256
-#: src/Services/EmailService.php:2358
-#: src/Services/EmailService.php:2480
+#: src/Services/EmailService.php:2363
+#: src/Services/EmailService.php:2493
 #: src/Admin/events-list/EventsList.js:37
 #: src/Admin/manage-event-audience-tab/EventAudience.js:778
 #: src/Admin/participant-detail/ParticipantDetail.js:271
@@ -1435,176 +1441,176 @@ msgid "Signup confirmed — %s"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2306
+#: src/Services/EmailService.php:2309
 #, php-format
 msgid "Your signup for %s has been confirmed and your payment has been received."
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2308
+#: src/Services/EmailService.php:2311
 #, php-format
 msgid "Your signup for %s has been confirmed."
 msgstr ""
 
-#: src/Services/EmailService.php:2327
+#: src/Services/EmailService.php:2330
 msgid "Event date:"
 msgstr ""
 
-#: src/Services/EmailService.php:2328
+#: src/Services/EmailService.php:2331
 msgid "Registration reference:"
 msgstr ""
 
-#: src/Services/EmailService.php:2329
+#: src/Services/EmailService.php:2332
 msgid "Ticket type:"
 msgstr ""
 
-#: src/Services/EmailService.php:2330
-#: src/Services/EmailService.php:2374
+#: src/Services/EmailService.php:2333
+#: src/Services/EmailService.php:2387
 #: src/blocks/event-signup/frontend.js:1816
 #: src/blocks/event-signup/frontend.js:1938
 msgid "Amount paid:"
 msgstr ""
 
-#: src/Services/EmailService.php:2331
+#: src/Services/EmailService.php:2334
 msgid "Selected options:"
 msgstr ""
 
-#: src/Services/EmailService.php:2332
+#: src/Services/EmailService.php:2335
 msgid "Your answers:"
 msgstr ""
 
 #. translators: 1: line break, 2: site name
-#: src/Services/EmailService.php:2334
-#: src/Services/EmailService.php:2435
-#: src/Services/EmailService.php:2698
+#: src/Services/EmailService.php:2337
+#: src/Services/EmailService.php:2448
+#: src/Services/EmailService.php:2719
 #, php-format
 msgid "See you there!%1$sThe %2$s Team"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2362
+#: src/Services/EmailService.php:2375
 #, php-format
 msgid "Activities added — %s"
 msgstr ""
 
-#: src/Services/EmailService.php:2387
+#: src/Services/EmailService.php:2400
 msgid "Activities added:"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2423
+#: src/Services/EmailService.php:2436
 #, php-format
 msgid "The following activities have been added to your signup for %s."
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2487
+#: src/Services/EmailService.php:2508
 #, php-format
 msgid "Payment didn’t go through — %s"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2535
+#: src/Services/EmailService.php:2556
 #, php-format
 msgid "Your payment for %s didn’t go through. Your spot is still held for a short while — pick up where you left off using the link below."
 msgstr ""
 
-#: src/Services/EmailService.php:2544
+#: src/Services/EmailService.php:2565
 msgid "Resume payment"
 msgstr ""
 
-#: src/Services/EmailService.php:2549
+#: src/Services/EmailService.php:2570
 msgid "If the button doesn’t work, copy and paste this link into your browser:"
 msgstr ""
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:2556
+#: src/Services/EmailService.php:2577
 #, php-format
 msgid "See you soon,%1$sThe %2$s Team"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2635
+#: src/Services/EmailService.php:2656
 #, php-format
 msgid "You're invited: %s"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2672
+#: src/Services/EmailService.php:2693
 #, php-format
 msgid "We have a new event coming up: %s."
 msgstr ""
 
-#: src/Services/EmailService.php:2686
+#: src/Services/EmailService.php:2707
 msgid "Would you like to join? Click the button below to sign up:"
 msgstr ""
 
-#: src/Services/EmailService.php:2834
+#: src/Services/EmailService.php:2855
 msgid "Already signed up"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2927
+#: src/Services/EmailService.php:2956
 #, php-format
 msgid "Thanks for your interest in %s"
 msgstr ""
 
-#: src/Services/EmailService.php:2931
-#: src/Services/EmailService.php:3009
+#: src/Services/EmailService.php:2960
+#: src/Services/EmailService.php:3039
 msgid "there"
 msgstr ""
 
 #. translators: %s: event title
-#: src/Services/EmailService.php:2958
+#: src/Services/EmailService.php:2987
 #, php-format
 msgid "Thanks for registering your interest in %s. We will let you know when there are updates."
 msgstr ""
 
-#: src/Services/EmailService.php:2961
+#: src/Services/EmailService.php:2990
 msgid "If you didn't register your interest, you can safely ignore this email."
 msgstr ""
 
-#: src/Services/EmailService.php:2966
+#: src/Services/EmailService.php:2995
 msgid "No longer interested?"
 msgstr ""
 
-#: src/Services/EmailService.php:2967
+#: src/Services/EmailService.php:2996
 msgid "Unsubscribe from updates about this event"
 msgstr ""
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3005
+#: src/Services/EmailService.php:3035
 #, php-format
 msgid "Welcome to the %s mailing list"
 msgstr ""
 
 #. translators: 1: site name, 2: event title
-#: src/Services/EmailService.php:3014
+#: src/Services/EmailService.php:3044
 #, php-format
 msgid "You've been added to the %1$s mailing list following the consent you gave at %2$s. We'll keep you posted about upcoming events and news."
 msgstr ""
 
 #. translators: %s: site name
-#: src/Services/EmailService.php:3021
+#: src/Services/EmailService.php:3051
 #, php-format
 msgid "You've been added to the %s mailing list following the consent you gave. We'll keep you posted about upcoming events and news."
 msgstr ""
 
-#: src/Services/EmailService.php:3054
+#: src/Services/EmailService.php:3084
 msgid "Changed your mind?"
 msgstr ""
 
-#: src/Services/EmailService.php:3055
+#: src/Services/EmailService.php:3085
 msgid "Manage your subscription or unsubscribe"
 msgstr ""
 
-#: src/Services/SignupActivities.php:145
-#: src/Services/SignupActivities.php:164
+#: src/Services/SignupActivities.php:168
+#: src/Services/SignupActivities.php:187
 msgid "One of the selected activities is not available for this event."
 msgstr ""
 
 #. translators: %s: activity name
-#: src/Services/SignupActivities.php:173
+#: src/Services/SignupActivities.php:196
 #, php-format
 msgid "\"%s\" is full."
 msgstr ""
@@ -3266,7 +3272,7 @@ msgstr ""
 
 #: src/blocks/audience-signup/editor.js:35
 #: src/blocks/event-interest/editor.js:26
-#: src/blocks/event-signup/editor.js:85
+#: src/blocks/event-signup/editor.js:89
 #: src/blocks/mailing-signup/editor.js:65
 msgid "Form Settings"
 msgstr ""
@@ -3475,23 +3481,23 @@ msgstr ""
 msgid "Failed to register your interest. Please try again."
 msgstr ""
 
-#: src/blocks/event-signup/editor.js:87
+#: src/blocks/event-signup/editor.js:91
 msgid "Signup Button Text"
 msgstr ""
 
-#: src/blocks/event-signup/editor.js:93
+#: src/blocks/event-signup/editor.js:97
 msgid "Button text for authenticated users."
 msgstr ""
 
-#: src/blocks/event-signup/editor.js:103
+#: src/blocks/event-signup/editor.js:107
 msgid "This block has moved to Event Signup (fair-events). Transform it to the new block."
 msgstr ""
 
-#: src/blocks/event-signup/editor.js:128
+#: src/blocks/event-signup/editor.js:132
 msgid "Ticket types, activity options and pricing are rendered on the published page based on the event."
 msgstr ""
 
-#: src/blocks/event-signup/editor.js:134
+#: src/blocks/event-signup/editor.js:138
 msgid "Custom questions"
 msgstr ""
 
@@ -3748,23 +3754,31 @@ msgctxt "block keyword"
 msgid "list"
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:449
+#: ../fair-events-shared/src/questionnaire.js:453
 msgid "Please answer the required question: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:472
+#: ../fair-events-shared/src/questionnaire.js:476
 msgid "Enter a valid phone number with country code (for example +49 170 123 45 67) for: %s"
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:497
+#: ../fair-events-shared/src/questionnaire.js:501
 msgid "Please enter a valid email address for: "
 msgstr ""
 
-#: ../fair-events-shared/src/questionnaire.js:533
+#: ../fair-events-shared/src/questionnaire.js:537
 msgid "Please enter a valid web address for: %s"
 msgstr ""
 
 #: ../fair-events-shared/src/questionnaire.js:561
+msgid "Please enter a valid date for: %s"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:585
+msgid "Please enter a valid date and time for: %s"
+msgstr ""
+
+#: ../fair-events-shared/src/questionnaire.js:616
 msgid "File is too large. Maximum size is "
 msgstr ""
 

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -1200,18 +1200,10 @@ class EventSignupController extends WP_REST_Controller {
 	 * @return \WP_REST_Response|\WP_Error|null Response/error on paid path, null on free path.
 	 */
 	private function maybe_start_addon_payment( $event_id, $event_date_id, $participant, $event_participant, $user_id, $new_options ) {
-		$best_discount_rule = null;
-		if ( $event_date_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$best_discount_rule = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
-				$event_date_id,
-				$participant->id
-			);
-		}
-
 		$line_items   = array();
 		$total_amount = 0;
 		foreach ( $new_options as $opt ) {
-			$opt_price     = $this->compute_option_price( $opt, $event_date_id, $best_discount_rule );
+			$opt_price     = $this->compute_option_price( $opt, $event_date_id, (int) $participant->id );
 			$total_amount += $opt_price;
 			if ( 0.0 !== (float) $opt_price ) {
 				$line_items[] = array(
@@ -1658,27 +1650,29 @@ class EventSignupController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Compute the effective price for a ticket option, applying the group
-	 * pricing rule when the buyer qualifies.
+	 * Compute the effective price for a ticket option, applying the buyer's
+	 * best-matching group pricing rule for this option's own real base
+	 * price — not a shared event-date-level rule, so mixed percentage/amount
+	 * rules resolve correctly per option (issue #1297).
 	 *
-	 * @param object      $option              TicketOption object.
-	 * @param int         $event_date_id       Event date ID.
-	 * @param object|null $best_discount_rule  Best group pricing rule for the buyer, if any.
+	 * @param object   $option         TicketOption object.
+	 * @param int      $event_date_id  Event date ID.
+	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
 	 * @return float Effective option price (>= 0 inputs assumed; may be 0).
 	 */
-	private function compute_option_price( $option, $event_date_id, $best_discount_rule ) {
+	private function compute_option_price( $option, $event_date_id, $participant_id ) {
 		if ( class_exists( \FairEventsExperimental\Services\ActivityOptionPriceResolver::class ) ) {
 			$resolved  = \FairEventsExperimental\Services\ActivityOptionPriceResolver::resolve( $option );
 			$opt_price = null !== $resolved ? (float) $resolved : 0.0;
 		} else {
 			$opt_price = (float) $option->price;
 		}
-		if ( $best_discount_rule && $opt_price > 0 && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$opt_price = \FairEventsExperimental\Services\EventSignupPricing::apply_discount(
+		if ( $participant_id && $opt_price > 0 && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			$opt_price = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule(
 				$opt_price,
-				$best_discount_rule->discount_type,
-				(float) $best_discount_rule->discount_value
-			);
+				$event_date_id,
+				$participant_id
+			)['price'];
 		}
 		return $opt_price;
 	}
@@ -1779,22 +1773,15 @@ class EventSignupController extends WP_REST_Controller {
 			$final_price = \FairAudience\Services\SignupPriceResolver::resolve_price_for_ticket_type( $ticket_type_id, $participant->id );
 		}
 
-		// Apply group discount to option prices when the participant qualifies.
-		$best_discount_rule = null;
-		if ( $event_date_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$best_discount_rule = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
-				$event_date_id,
-				$participant->id
-			);
-		}
-
 		// Option prices count towards the total even when there is no base price.
+		// Each option resolves its own best-matching group discount rule
+		// against its own real base price (issue #1297).
 		$options_total = 0;
 		foreach ( $option_items as $opt ) {
 			$options_total += $this->compute_option_price(
 				$opt,
 				$event_date_id,
-				$best_discount_rule
+				(int) $participant->id
 			);
 		}
 		$total_amount = (float) ( $final_price ?? 0 ) + $options_total;
@@ -1889,7 +1876,7 @@ class EventSignupController extends WP_REST_Controller {
 			$opt_price = $this->compute_option_price(
 				$opt,
 				$event_date_id,
-				$best_discount_rule
+				(int) $participant->id
 			);
 			if ( 0.0 !== $opt_price ) {
 				$line_items[] = array(

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -226,23 +226,28 @@ class PaymentHooks {
 	/**
 	 * Format the applied group-discount rule as a human-readable label.
 	 *
-	 * Re-resolves the best discount rule for the participant on the event date —
-	 * the same call EventSignupController uses at price-computation time — and
-	 * formats it as e.g. "Students -20%" or "Members -5.00 EUR".
+	 * Re-resolves the rule that actually won against the participant's
+	 * ticket type's real price — the same resolution EventSignupController
+	 * uses at charge time (issue #1297) — and formats it as e.g.
+	 * "Students -20%" or "Members -5.00 EUR". Signups with no ticket type
+	 * (options-only events) have no single price to resolve a rule against,
+	 * so no label is shown for them.
 	 *
 	 * @param object $event_participant Event participant row.
 	 * @param object $transaction       Transaction row.
 	 * @return string Formatted label, or empty string when no discount applies.
 	 */
 	private static function format_applied_discount( $event_participant, $transaction ) {
-		if ( ! class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+		if ( empty( $event_participant->ticket_type_id )
+			|| ! class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
 			return '';
 		}
 
-		$rule = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
-			(int) $event_participant->event_date_id,
+		$resolved = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule_for_ticket_type(
+			(int) $event_participant->ticket_type_id,
 			(int) $event_participant->participant_id
 		);
+		$rule     = $resolved['rule'] ?? null;
 		if ( ! $rule ) {
 			return '';
 		}

--- a/fair-audience/src/Hooks/SignupHookBridge.php
+++ b/fair-audience/src/Hooks/SignupHookBridge.php
@@ -114,21 +114,31 @@ class SignupHookBridge {
 			// Re-resolve prices for the surviving types through the same authority
 			// the create route uses, so the displayed price matches what gets
 			// charged. Clamped at 0 — an amount-discount larger than the price
-			// can never show (or charge) a negative amount.
+			// can never show (or charge) a negative amount. Each type's own
+			// winning rule rides along so the note below can tell whether every
+			// discounted type agrees on the same rule (issue #1297).
 			$price_by_type_id = array();
+			$rule_by_type_id  = array();
 			foreach ( $context['ticket_types'] as $ticket_type ) {
-				$resolved = SignupPriceResolver::resolve_price_for_ticket_type( (int) $ticket_type->id, $participant_id );
-				if ( null !== $resolved ) {
-					$price_by_type_id[ (int) $ticket_type->id ] = max( 0, $resolved );
+				$resolved = SignupPriceResolver::resolve_price_and_rule_for_ticket_type( (int) $ticket_type->id, $participant_id );
+				if ( null === $resolved ) {
+					continue;
+				}
+				$price_by_type_id[ (int) $ticket_type->id ] = max( 0, $resolved['price'] );
+				if ( null !== $resolved['rule'] ) {
+					$rule_by_type_id[ (int) $ticket_type->id ] = $resolved['rule'];
 				}
 			}
 			$context['price_by_type_id'] = $price_by_type_id;
 
-			if ( $participant_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-				$context['group_discount_rule'] = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
-					$pricing_event_date_id,
-					$participant_id
-				);
+			// A single note can only name one rule, so it's shown solely when
+			// every discounted type resolved to the same rule. A mixed-rule
+			// event drops the note rather than risk misnaming a type's discount
+			// — this block's note-only template has no per-type slot to attach
+			// a per-type tag to (unlike fair-audience's own event-signup block).
+			$reduced_rule_ids = array_values( array_unique( array_map( static fn( $rule ) => (int) $rule->id, $rule_by_type_id ) ) );
+			if ( 1 === count( $reduced_rule_ids ) ) {
+				$context['group_discount_rule'] = reset( $rule_by_type_id );
 			}
 		}
 

--- a/fair-audience/src/Services/GroupSignupPricing.php
+++ b/fair-audience/src/Services/GroupSignupPricing.php
@@ -129,10 +129,22 @@ class GroupSignupPricing {
 	 */
 	public static function discount_note_label( $rule, $group_name ) {
 		if ( 'percentage' === $rule->discount_type ) {
+			// A fractional percentage (e.g. 12.5%) must render with its
+			// decimals instead of being rounded away (issue #1297) — but no
+			// more than it needs (12.5, not 12.50). discount_value is
+			// DECIMAL(10,2), so rounding to whole hundredths and checking
+			// divisibility avoids float-precision surprises.
+			$value      = (float) $rule->discount_value;
+			$hundredths = (int) round( $value * 100 );
+			if ( 0 === $hundredths % 100 ) {
+				$decimals = 0;
+			} else {
+				$decimals = 0 === $hundredths % 10 ? 1 : 2;
+			}
 			return sprintf(
 				/* translators: 1: discount percentage, 2: group name */
 				__( '%1$s%% discount applied (%2$s)', 'fair-audience' ),
-				number_format_i18n( (float) $rule->discount_value ),
+				number_format_i18n( $value, $decimals ),
 				$group_name
 			);
 		}

--- a/fair-audience/src/Services/SignupActivities.php
+++ b/fair-audience/src/Services/SignupActivities.php
@@ -85,6 +85,29 @@ class SignupActivities {
 	}
 
 	/**
+	 * Resolve an activity option's price for the viewer via the real-price
+	 * group-discount resolver: each option is compared against its own base
+	 * price, not one rule shared across the whole event date, so mixed
+	 * percentage/amount rules pick the correct winner per option (issue
+	 * #1297).
+	 *
+	 * @param float    $base_price            Base (undiscounted) option price.
+	 * @param int      $pricing_event_date_id Event date the discount rules belong to.
+	 * @param int|null $participant_id        Viewer's participant ID, or null for anonymous.
+	 * @return float Resolved price.
+	 */
+	public static function resolve_price_for_participant( $base_price, $pricing_event_date_id, $participant_id ) {
+		if ( ! $participant_id || $base_price <= 0 || ! class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			return $base_price;
+		}
+		return \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule(
+			(float) $base_price,
+			$pricing_event_date_id,
+			$participant_id
+		)['price'];
+	}
+
+	/**
 	 * Whether a raw TicketOption is full, based on its configured capacity.
 	 *
 	 * @param object                     $option Raw TicketOption row (needs `id`, `capacity`).
@@ -201,10 +224,10 @@ class SignupActivities {
 
 	/**
 	 * Resolve priced line items for a submitted activity selection, applying
-	 * the participant's best group discount rule. Hooked on
-	 * `fair_events_signup_option_line_items`. Assumes the selection was
-	 * already validated by validate_selection() — an ID that no longer
-	 * resolves is skipped rather than erroring.
+	 * each option's own best-matching group discount rule against its own
+	 * real base price. Hooked on `fair_events_signup_option_line_items`.
+	 * Assumes the selection was already validated by validate_selection() —
+	 * an ID that no longer resolves is skipped rather than erroring.
 	 *
 	 * @param int[]    $ticket_option_ids     Submitted option IDs.
 	 * @param int      $pricing_event_date_id Event date the activity catalogue belongs to.
@@ -214,14 +237,6 @@ class SignupActivities {
 	public static function line_items( array $ticket_option_ids, $pricing_event_date_id, $participant_id ) {
 		if ( empty( $ticket_option_ids ) || ! class_exists( \FairEventsExperimental\Models\TicketOption::class ) ) {
 			return array();
-		}
-
-		$discount_rule = null;
-		if ( $participant_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$discount_rule = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
-				$pricing_event_date_id,
-				$participant_id
-			);
 		}
 
 		$line_items = array();
@@ -241,7 +256,7 @@ class SignupActivities {
 			$line_items[] = array(
 				'name'     => $option->name,
 				'quantity' => 1,
-				'amount'   => self::resolve_price( (float) $base_price, $discount_rule ),
+				'amount'   => self::resolve_price_for_participant( (float) $base_price, $pricing_event_date_id, $participant_id ),
 			);
 		}
 
@@ -268,14 +283,6 @@ class SignupActivities {
 
 		$pricing_event_date_id = (int) $context['pricing_event_date_id'];
 
-		$discount_rule = null;
-		if ( $participant_id && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$discount_rule = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
-				$pricing_event_date_id,
-				$participant_id
-			);
-		}
-
 		$event_participant_repository = new EventParticipantRepository();
 
 		$signed_row = null;
@@ -294,7 +301,7 @@ class SignupActivities {
 			: array();
 
 		foreach ( $context['ticket_options'] as &$option ) {
-			$option['price'] = self::resolve_price( (float) $option['price'], $discount_rule );
+			$option['price'] = self::resolve_price_for_participant( (float) $option['price'], $pricing_event_date_id, $participant_id );
 
 			$is_full = false;
 			if ( class_exists( \FairEventsExperimental\Models\TicketOption::class ) ) {

--- a/fair-audience/src/Services/SignupPriceResolver.php
+++ b/fair-audience/src/Services/SignupPriceResolver.php
@@ -42,6 +42,34 @@ class SignupPriceResolver {
 	}
 
 	/**
+	 * Resolve the effective price for a specific ticket type, plus the
+	 * group discount rule that produced it (if any). Mirrors
+	 * resolve_price_for_ticket_type()'s fallback pattern: prefers the
+	 * full-featured experimental resolver, and otherwise falls back to the
+	 * base fair-events price with no rule (group discounts are
+	 * experimental-only).
+	 *
+	 * @param int      $ticket_type_id Ticket type ID.
+	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
+	 * @return array{price: float, rule: object|null}|null Null when not purchasable right now.
+	 */
+	public static function resolve_price_and_rule_for_ticket_type( $ticket_type_id, $participant_id = null ) {
+		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			return \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule_for_ticket_type( $ticket_type_id, $participant_id );
+		}
+
+		if ( class_exists( \FairEvents\Services\TicketPricing::class ) ) {
+			$price = \FairEvents\Services\TicketPricing::resolve_unit_price( $ticket_type_id );
+			return null === $price ? null : array(
+				'price' => $price,
+				'rule'  => null,
+			);
+		}
+
+		return null;
+	}
+
+	/**
 	 * Check whether a positive price is configured for a ticket type,
 	 * ignoring discount rules and sale-period timing. Used by the
 	 * fail-closed "payment unavailable" guard so a paid event never

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -421,13 +421,15 @@ if ( $pricing_event_date_id && class_exists( \FairEvents\Models\TicketType::clas
 			}
 		}
 
-		$tt_price = \FairAudience\Services\SignupPriceResolver::resolve_price_for_ticket_type(
+		$tt_resolved = \FairAudience\Services\SignupPriceResolver::resolve_price_and_rule_for_ticket_type(
 			$tt->id,
 			$participant ? (int) $participant->id : null
 		);
-		if ( null === $tt_price ) {
+		if ( null === $tt_resolved ) {
 			continue;
 		}
+		$tt_price = $tt_resolved['price'];
+		$tt_rule  = $tt_resolved['rule'];
 
 		// Capacity check: limited-quantity tiers (e.g. "Early Bird – first
 		// 10") disappear once capacity is reached. We render them as a
@@ -445,6 +447,7 @@ if ( $pricing_event_date_id && class_exists( \FairEvents\Models\TicketType::clas
 			'id'                 => (int) $tt->id,
 			'name'               => $tt->name,
 			'price'              => $tt_price,
+			'rule'               => $tt_rule,
 			'minimum_activities' => (int) $tt->minimum_activities,
 			'recurrence_scope'   => $tt->recurrence_scope,
 			'minimum_instances'  => (int) $tt->minimum_instances,
@@ -454,14 +457,71 @@ if ( $pricing_event_date_id && class_exists( \FairEvents\Models\TicketType::clas
 }
 $has_ticket_types = ! empty( $ticket_types_for_display );
 
-// Resolve best group discount rule; used for both option pricing and the discount note.
-$best_discount_rule = null;
-if ( $pricing_event_date_id && $participant && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-	$best_discount_rule = \FairEventsExperimental\Services\EventSignupPricing::resolve_best_discount_rule(
-		(int) $pricing_event_date_id,
-		(int) $participant->id
-	);
+// Group discount rules that actually reduced a displayed tier's price
+// (issue #1297) — each tier resolved its own winning rule against its own
+// real base price, so mixed percentage/amount rules can legitimately name
+// different rules per tier. Drives both the single note (0 or 1 unique
+// rule) and the per-tier inline tags (2+ unique rules) below.
+$reduced_tiers    = array_filter(
+	$ticket_types_for_display,
+	static function ( $tt ) {
+		return null !== $tt['rule'];
+	}
+);
+$reduced_rule_ids = array_values(
+	array_unique(
+		array_map(
+			static function ( $tt ) {
+				return (int) $tt['rule']->id;
+			},
+			$reduced_tiers
+		)
+	)
+);
+// A single note names the rule only when every discounted tier agrees on
+// which rule won; otherwise the note would misname the discount for at
+// least one tier, so it's dropped in favor of the per-tier inline tags.
+$note_rule = null;
+if ( 1 === count( $reduced_rule_ids ) ) {
+	foreach ( $reduced_tiers as $reduced_tier ) {
+		$note_rule = $reduced_tier['rule'];
+		break;
+	}
 }
+$show_inline_discount_tags = count( $reduced_rule_ids ) >= 2;
+
+// Shared group-name lookup + magnitude formatting for the note and the
+// per-tier inline tags, so both surfaces describe a rule identically.
+$discount_group_repo         = class_exists( \FairAudienceExperimental\Database\GroupRepository::class )
+	? new \FairAudienceExperimental\Database\GroupRepository()
+	: null;
+$resolve_discount_group_name = static function ( $rule ) use ( $discount_group_repo ) {
+	if ( ! $discount_group_repo ) {
+		return '';
+	}
+	$group = $discount_group_repo->get_by_id( (int) $rule->group_id );
+	return $group ? $group->name : '';
+};
+// A fractional percentage (e.g. 12.5%) must render with its decimals
+// instead of being rounded away (issue #1297) — but no more than it needs
+// (12.5, not 12.50). discount_value is DECIMAL(10,2), so rounding to whole
+// hundredths and checking divisibility avoids float-precision surprises.
+$discount_percentage_decimals = static function ( $value ) {
+	$hundredths = (int) round( $value * 100 );
+	if ( 0 === $hundredths % 100 ) {
+		return 0;
+	}
+	return 0 === $hundredths % 10 ? 1 : 2;
+};
+// Full magnitude label used only by the per-tier inline tag, e.g. "12.5%"
+// or "€5.00" — the single note keeps its own existing translated strings.
+$format_discount_magnitude = static function ( $rule ) use ( $discount_percentage_decimals ) {
+	if ( 'percentage' === $rule->discount_type ) {
+		$value = (float) $rule->discount_value;
+		return number_format_i18n( $value, $discount_percentage_decimals( $value ) ) . '%';
+	}
+	return Money::format_inline( (float) $rule->discount_value );
+};
 
 // Resolve ticket options for this event date, if any. Options are displayed
 // as checkboxes — participants can select zero or more at signup.
@@ -478,12 +538,12 @@ if ( $pricing_event_date_id && class_exists( \FairEventsExperimental\Models\Tick
 			continue;
 		}
 		$opt_price = (float) $resolved_base;
-		if ( $best_discount_rule && $opt_price > 0 ) {
-			$opt_price = \FairEventsExperimental\Services\EventSignupPricing::apply_discount(
+		if ( $participant && $opt_price > 0 && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			$opt_price = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule(
 				$opt_price,
-				$best_discount_rule->discount_type,
-				(float) $best_discount_rule->discount_value
-			);
+				(int) $pricing_event_date_id,
+				(int) $participant->id
+			)['price'];
 		}
 
 		$is_full = false;
@@ -645,30 +705,27 @@ if ( null !== $signup_price ) {
 	}
 }
 
-// Build a group discount note to render near the signup button.
+// Build a group discount note to render near the signup button. Only shown
+// when every discounted tier agrees on the same rule ($note_rule, computed
+// above); a mixed-rule event instead gets per-tier inline tags in
+// $render_ticket_types, so the note is never left naming the wrong tier's
+// discount (issue #1297).
 $discount_note_html = '';
-if ( $best_discount_rule ) {
-	$group_name = '';
-	if ( class_exists( \FairAudienceExperimental\Database\GroupRepository::class ) ) {
-		$group_repo = new \FairAudienceExperimental\Database\GroupRepository();
-		$group      = $group_repo->get_by_id( (int) $best_discount_rule->group_id );
-		if ( $group ) {
-			$group_name = $group->name;
-		}
-	}
+if ( $note_rule ) {
+	$group_name = $resolve_discount_group_name( $note_rule );
 
-	if ( 'percentage' === $best_discount_rule->discount_type ) {
+	if ( 'percentage' === $note_rule->discount_type ) {
 		$discount_label = sprintf(
 			/* translators: 1: discount percentage, 2: group name */
 			__( '%1$s%% discount applied (%2$s)', 'fair-audience' ),
-			number_format_i18n( (float) $best_discount_rule->discount_value ),
+			number_format_i18n( (float) $note_rule->discount_value, $discount_percentage_decimals( (float) $note_rule->discount_value ) ),
 			$group_name
 		);
 	} else {
 		$discount_label = sprintf(
 			/* translators: 1: discount amount, 2: group name */
 			__( '%1$s discount applied (%2$s)', 'fair-audience' ),
-			Money::format_inline( (float) $best_discount_rule->discount_value ),
+			Money::format_inline( (float) $note_rule->discount_value ),
 			$group_name
 		);
 	}
@@ -682,7 +739,7 @@ if ( $best_discount_rule ) {
  * Render the ticket-type radio fieldset. No-op when the event date has no
  * ticket types configured. First enabled option is pre-selected.
  */
-$render_ticket_types = static function () use ( $ticket_types_for_display, $has_ticket_types, $form_id ) {
+$render_ticket_types = static function () use ( $ticket_types_for_display, $has_ticket_types, $form_id, $show_inline_discount_tags, $format_discount_magnitude, $resolve_discount_group_name ) {
 	if ( ! $has_ticket_types ) {
 		return;
 	}
@@ -701,6 +758,17 @@ $render_ticket_types = static function () use ( $ticket_types_for_display, $has_
 			} else {
 				$tt_label .= ' — ' . __( 'free', 'fair-audience' );
 			}
+		}
+		// Mixed-rule event: the shared note above the submit button was
+		// suppressed, so each discounted tier names its own rule inline
+		// instead (issue #1297).
+		if ( $show_inline_discount_tags && ! empty( $tt['rule'] ) ) {
+			$tt_label .= ' (' . sprintf(
+				/* translators: 1: discount magnitude e.g. "20%" or "€5.00", 2: group name */
+				__( '%1$s off · %2$s', 'fair-audience' ),
+				$format_discount_magnitude( $tt['rule'] ),
+				$resolve_discount_group_name( $tt['rule'] )
+			) . ')';
 		}
 		if ( $tt_is_full ) {
 			$tt_label .= ' — ' . __( 'sold out', 'fair-audience' );

--- a/fair-events-experimental/__tests__/Services/EventSignupPricingTest.php
+++ b/fair-events-experimental/__tests__/Services/EventSignupPricingTest.php
@@ -32,4 +32,108 @@ class EventSignupPricingTest extends TestCase {
 		// resolver clamps to 0 separately; this asserts raw math.
 		$this->assertEqualsWithDelta( -2.0, EventSignupPricing::apply_discount( 3.0, 'amount', 5.0 ), 0.001 );
 	}
+
+	/**
+	 * Build a discount rule stub.
+	 *
+	 * @param int    $id             Rule ID.
+	 * @param string $discount_type  'percentage' or 'amount'.
+	 * @param float  $discount_value Discount magnitude.
+	 * @return object
+	 */
+	private function rule( $id, $discount_type, $discount_value ) {
+		$rule                 = new \stdClass();
+		$rule->id             = $id;
+		$rule->discount_type  = $discount_type;
+		$rule->discount_value = $discount_value;
+		return $rule;
+	}
+
+	/**
+	 * With one matching rule, that rule wins and its discounted price is
+	 * returned.
+	 */
+	public function test_best_rule_for_price_single_rule_wins() {
+		$result = EventSignupPricing::best_rule_for_price( 10.0, array( $this->rule( 1, 'percentage', 20 ) ) );
+
+		$this->assertEqualsWithDelta( 8.0, $result['price'], 0.0001 );
+		$this->assertSame( 1, $result['rule']->id );
+	}
+
+	/**
+	 * Percentage vs. fixed-amount rules must be compared against the real
+	 * base price, not a notional reference price (issue #1297). At a base
+	 * price of €10, a 50% rule (→ €5) beats a €2 amount rule (→ €8).
+	 */
+	public function test_best_rule_for_price_picks_the_rule_that_wins_on_the_real_price() {
+		$percentage_rule = $this->rule( 1, 'percentage', 50 );
+		$amount_rule     = $this->rule( 2, 'amount', 2 );
+
+		$result = EventSignupPricing::best_rule_for_price( 10.0, array( $percentage_rule, $amount_rule ) );
+
+		$this->assertEqualsWithDelta( 5.0, $result['price'], 0.0001 );
+		$this->assertSame( 1, $result['rule']->id );
+	}
+
+	/**
+	 * At a different base price the ranking can flip — the €2 amount rule
+	 * now beats the 10% percentage rule, proving the winner depends on the
+	 * real price rather than a fixed reference.
+	 */
+	public function test_best_rule_for_price_ranking_depends_on_base_price() {
+		$percentage_rule = $this->rule( 1, 'percentage', 10 );
+		$amount_rule     = $this->rule( 2, 'amount', 2 );
+
+		$result = EventSignupPricing::best_rule_for_price( 5.0, array( $percentage_rule, $amount_rule ) );
+
+		// 10% off €5 = €4.50; €5 - €2 = €3.00 → amount rule wins here.
+		$this->assertEqualsWithDelta( 3.0, $result['price'], 0.0001 );
+		$this->assertSame( 2, $result['rule']->id );
+	}
+
+	/**
+	 * A percentage rule can never move a €0 base price (any percentage of
+	 * zero is still zero), so it never comes back with a rule attached —
+	 * there's nothing to visibly discount and no note should appear.
+	 */
+	public function test_best_rule_for_price_suppresses_rule_on_free_percentage_tier() {
+		$result = EventSignupPricing::best_rule_for_price( 0.0, array( $this->rule( 1, 'percentage', 20 ) ) );
+
+		$this->assertEqualsWithDelta( 0.0, $result['price'], 0.0001 );
+		$this->assertNull( $result['rule'] );
+	}
+
+	/**
+	 * An amount rule genuinely changes a €0 base price (into a negative,
+	 * "solidarity ticket" amount), so — unlike a percentage rule — it does
+	 * come back with a rule attached; callers clamp the display/charge at 0
+	 * separately. This mirrors the existing ticket-type resolver's behavior.
+	 */
+	public function test_best_rule_for_price_amount_rule_still_applies_to_free_tier() {
+		$result = EventSignupPricing::best_rule_for_price( 0.0, array( $this->rule( 1, 'amount', 5 ) ) );
+
+		$this->assertEqualsWithDelta( -5.0, $result['price'], 0.0001 );
+		$this->assertSame( 1, $result['rule']->id );
+	}
+
+	/**
+	 * A fractional discount_value passes through unrounded — the resolver
+	 * itself does no display formatting.
+	 */
+	public function test_best_rule_for_price_fractional_discount_value_passthrough() {
+		$result = EventSignupPricing::best_rule_for_price( 10.0, array( $this->rule( 1, 'percentage', 12.5 ) ) );
+
+		$this->assertEqualsWithDelta( 8.75, $result['price'], 0.0001 );
+		$this->assertEqualsWithDelta( 12.5, $result['rule']->discount_value, 0.0001 );
+	}
+
+	/**
+	 * No matching rules leaves the base price untouched with no rule.
+	 */
+	public function test_best_rule_for_price_no_rules_returns_base_price() {
+		$result = EventSignupPricing::best_rule_for_price( 10.0, array() );
+
+		$this->assertSame( 10.0, $result['price'] );
+		$this->assertNull( $result['rule'] );
+	}
 }

--- a/fair-events-experimental/src/Services/EventSignupPricing.php
+++ b/fair-events-experimental/src/Services/EventSignupPricing.php
@@ -32,6 +32,22 @@ class EventSignupPricing {
 	 * @return float|null Final price, or null when not purchasable right now.
 	 */
 	public static function resolve_price_for_ticket_type( $ticket_type_id, $participant_id = null ) {
+		$resolved = self::resolve_price_and_rule_for_ticket_type( $ticket_type_id, $participant_id );
+		return null === $resolved ? null : $resolved['price'];
+	}
+
+	/**
+	 * Resolve the effective price for a specific ticket type, plus the
+	 * group discount rule that produced it (if any). The single source of
+	 * truth for both the charged price and the rule that explains it,
+	 * closing the gap where a note could name a different rule than the one
+	 * that actually won on the real price (issue #1297).
+	 *
+	 * @param int      $ticket_type_id Ticket type ID.
+	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
+	 * @return array{price: float, rule: GroupPricingRule|null}|null Null when not purchasable right now.
+	 */
+	public static function resolve_price_and_rule_for_ticket_type( $ticket_type_id, $participant_id = null ) {
 		$ticket_type = TicketType::get_by_id( $ticket_type_id );
 		if ( ! $ticket_type ) {
 			return null;
@@ -42,29 +58,79 @@ class EventSignupPricing {
 			return null;
 		}
 
+		return self::resolve_price_and_rule( $base_price, $ticket_type->event_date_id, $participant_id );
+	}
+
+	/**
+	 * Resolve the best group discount rule for a base price on an event
+	 * date, and the price it produces. Compares every matching rule against
+	 * the real `$base_price` — not a notional reference price — so a
+	 * percentage rule and a fixed-amount rule are compared on equal footing
+	 * for the price actually being charged (issue #1297). The returned rule
+	 * is only set when it strictly reduced the price, so a free/€0 base
+	 * price never comes back with a rule attached.
+	 *
+	 * @param float    $base_price     Base (undiscounted) price.
+	 * @param int      $event_date_id  Event date ID the discount rules belong to.
+	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
+	 * @return array{price: float, rule: GroupPricingRule|null} Resolved price and the rule that produced it.
+	 */
+	public static function resolve_price_and_rule( $base_price, $event_date_id, $participant_id = null ) {
 		if ( empty( $participant_id ) ) {
-			return $base_price;
+			return array(
+				'price' => $base_price,
+				'rule'  => null,
+			);
 		}
 
-		$rules = GroupPricingRule::get_all_by_event_date_id( $ticket_type->event_date_id );
+		$rules = GroupPricingRule::get_all_by_event_date_id( $event_date_id );
 		if ( empty( $rules ) || ! class_exists( \FairAudienceExperimental\Database\GroupParticipantRepository::class ) ) {
-			return $base_price;
+			return array(
+				'price' => $base_price,
+				'rule'  => null,
+			);
 		}
 
-		$group_repo = new \FairAudienceExperimental\Database\GroupParticipantRepository();
-		$best_price = $base_price;
-
+		$group_repo     = new \FairAudienceExperimental\Database\GroupParticipantRepository();
+		$matching_rules = array();
 		foreach ( $rules as $rule ) {
-			if ( ! $group_repo->get_by_group_and_participant( $rule->group_id, $participant_id ) ) {
-				continue;
+			if ( $group_repo->get_by_group_and_participant( $rule->group_id, $participant_id ) ) {
+				$matching_rules[] = $rule;
 			}
+		}
+
+		return self::best_rule_for_price( $base_price, $matching_rules );
+	}
+
+	/**
+	 * Pick the discount rule that produces the lowest price for a given base
+	 * price, out of a list of rules already known to match the participant
+	 * (e.g. group membership already checked by the caller). Pure math, no DB
+	 * access — the seam that makes the mixed percentage/amount comparison
+	 * from issue #1297 unit-testable without a WordPress bootstrap. The
+	 * returned rule is only set when it strictly reduced the price, so a
+	 * free/€0 base price never comes back with a rule attached.
+	 *
+	 * @param float              $base_price     Base (undiscounted) price.
+	 * @param GroupPricingRule[] $matching_rules Rules that already match the participant.
+	 * @return array{price: float, rule: GroupPricingRule|null} Resolved price and the rule that produced it.
+	 */
+	public static function best_rule_for_price( $base_price, array $matching_rules ) {
+		$best_price = $base_price;
+		$best_rule  = null;
+
+		foreach ( $matching_rules as $rule ) {
 			$candidate = self::apply_discount( $base_price, $rule->discount_type, (float) $rule->discount_value );
 			if ( $candidate < $best_price ) {
 				$best_price = $candidate;
+				$best_rule  = $rule;
 			}
 		}
 
-		return $best_price;
+		return array(
+			'price' => $best_price,
+			'rule'  => $best_rule,
+		);
 	}
 
 	/**
@@ -79,44 +145,6 @@ class EventSignupPricing {
 	 */
 	public static function resolve_active_sale_period( $event_date_id ) {
 		return TicketPricing::resolve_active_sale_period( $event_date_id );
-	}
-
-	/**
-	 * Resolve the best group discount rule for a participant on an event date.
-	 *
-	 * Returns the GroupPricingRule that yields the lowest price, or null
-	 * when no discount applies.
-	 *
-	 * @param int      $event_date_id  Event date ID.
-	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
-	 * @return GroupPricingRule|null Best matching rule, or null.
-	 */
-	public static function resolve_best_discount_rule( $event_date_id, $participant_id = null ) {
-		if ( empty( $participant_id ) ) {
-			return null;
-		}
-
-		$rules = GroupPricingRule::get_all_by_event_date_id( $event_date_id );
-		if ( empty( $rules ) || ! class_exists( \FairAudienceExperimental\Database\GroupParticipantRepository::class ) ) {
-			return null;
-		}
-
-		$group_repo = new \FairAudienceExperimental\Database\GroupParticipantRepository();
-		$best_rule  = null;
-		$best_price = PHP_FLOAT_MAX;
-
-		foreach ( $rules as $rule ) {
-			if ( ! $group_repo->get_by_group_and_participant( $rule->group_id, $participant_id ) ) {
-				continue;
-			}
-			$candidate = self::apply_discount( 100.0, $rule->discount_type, (float) $rule->discount_value );
-			if ( $candidate < $best_price ) {
-				$best_price = $candidate;
-				$best_rule  = $rule;
-			}
-		}
-
-		return $best_rule;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `EventSignupPricing` had two independent code paths for group discount rules: one applied rules to a tier's **real base price** (what's actually charged), the other picked the "best" rule by testing against a **notional €100 reference** (what the note named). Percentage and fixed-amount rules scale differently, so the two paths could legitimately disagree, and the note could round a fractional percentage to a whole number.
- Replaced `resolve_best_discount_rule()` with `resolve_price_and_rule()` (and `resolve_price_and_rule_for_ticket_type()`), the single source of truth for both the charged price and the rule that produced it, and migrated every consumer onto it — not just the note, but every place that used the old notional-€100 rule to price ticket options for real charges.
- Closes #1297

## Scope note

While migrating, `resolve_best_discount_rule()` turned out to be called from four more files the original plan didn't account for — two of which (`EventSignupController::maybe_start_addon_payment()` / `maybe_start_paid_signup()`) compute the **actual amount charged** for ticket options, so they carried the same rule-mismatch bug for real money, not just display. This was flagged and confirmed before implementing (see the "Decision — call-site scope" addendum on the plan comment on the issue); the full list of files touched is below.

## What changed

- **`fair-events-experimental/src/Services/EventSignupPricing.php`** — deleted `resolve_best_discount_rule()`; added `resolve_price_and_rule()` (pure rule-selection wraps a new `best_rule_for_price()` seam) and `resolve_price_and_rule_for_ticket_type()`; `resolve_price_for_ticket_type()` is now a thin wrapper.
- **`fair-audience/src/Services/SignupPriceResolver.php`** — added the `resolve_price_and_rule_for_ticket_type()` facade (mirrors the existing fallback pattern).
- **`fair-audience/src/blocks/event-signup/render.php`** — ticket types each resolve their own winning rule; the shared note is shown only when every discounted tier agrees on the same rule (0 or 1 unique rule), otherwise it's dropped in favor of a per-tier inline tag (e.g. "— €18.00 (20% off · VIP)"); ticket options resolve their own rule against their own real price; the note's percentage now keeps fractional decimals instead of rounding to a whole number.
- **`fair-audience/src/Hooks/SignupHookBridge.php`** — the unified `fair-events/event-signup` block's note (`group_discount_rule`) uses the same real-price/unique-rule logic as `render.php`, minus the per-tier inline-tag UI (that block's note-only template has no per-tier price slot to attach a tag to — noted as a follow-up if wanted).
- **`fair-audience/src/API/EventSignupController.php`** — `compute_option_price()` now resolves each option's own rule against its own real price instead of a shared event-date-level rule; updated both call sites (`maybe_start_addon_payment`, `maybe_start_paid_signup`) that compute real charged amounts.
- **`fair-audience/src/Services/SignupActivities.php`** — `line_items()` / `enrich_render_context()` resolve each option's rule against its own real price via a new `resolve_price_for_participant()` helper.
- **`fair-audience/src/Hooks/PaymentHooks.php`** — the post-payment notification label (`format_applied_discount()`) now resolves against the participant's own ticket type's real price.
- **`fair-audience/src/Services/GroupSignupPricing.php`** — same fractional-percentage decimals fix for the unified block's note text.
- Tests: new PHPUnit coverage for `EventSignupPricing::best_rule_for_price()` (same-rule-wins, percentage-vs-amount mismatch on the real price, free-tier suppression per rule type, fractional passthrough), a fractional-percentage test on `GroupSignupPricingTest`, and a new e2e spec (`e2e/user-flows/group-discount-note-accuracy.spec.js`) driving fair-audience's own event-signup block end to end via a `?participant_token=` URL (percentage/amount/fractional/free cases), with its own seed/cleanup WP-CLI fixture scripts.
- Changeset added for `fair-audience` (patch).

## Acceptance criteria

- [x] **No discount note on an event where every visible price is free or unavailable, even for a member with a matching rule.** A percentage rule can never move a €0 price, so `resolve_price_and_rule()` never attaches a rule to it — covered by `test_best_rule_for_price_suppresses_rule_on_free_percentage_tier` and the e2e "free tier" case. (An *amount* rule genuinely reducing a €0 tier into a negative "solidarity ticket" price is intentionally still shown — that's a real price change, not "free", matching the existing ticket-type convention of allowing negative/solidarity prices.)
- [x] **With a percentage rule and a fixed-amount rule both matching, the note describes the rule that produces the charged price.** `resolve_price_and_rule()` compares every matching rule against the real base price; covered by `test_best_rule_for_price_picks_the_rule_that_wins_on_the_real_price` and `test_best_rule_for_price_ranking_depends_on_base_price` (shows the ranking flips depending on the real price, not a fixed reference).
- [x] **A fractional percentage renders with its decimals.** Fixed in both note-rendering paths (`render.php`, `GroupSignupPricing::discount_note_label()`); covered by PHPUnit and the e2e "fractional percentage" case (12.5% → "12.5%", not "13%" or "12.50%").
- [x] **Note and price agree for a member across at least one percentage case and one amount case.** Covered end-to-end by the new e2e spec, reading the resolved price straight off the ticket-type radio's `data-ticket-price` attribute (locale-independent) alongside the rendered note text.

## Test plan

- [x] `npm run test:php` — `fair-events-experimental` (25 tests) and `fair-audience` (87 tests) both pass.
- [x] `npm run test:js` — `fair-audience` (27 tests) passes.
- [x] `npm run test:api` (relevant specs: `EventSignupGroupPricing`, `EventSignupActivities`, plus the full `fair-audience` suite) — 35 passed / 37 skipped (pre-existing skip conditions unrelated to this change), 0 failures.
- [x] `npm run test:e2e` — new `group-discount-note-accuracy.spec.js` (4/4 passing) plus `unified-signup-activities`, `signup-occurrence-pickers`, `signup-cancel-and-restart` (8/8 passing, no regressions).
- [x] `vendor/bin/phpcs` clean on every changed file (verified against the pre-change baseline — all reported findings elsewhere in touched files are pre-existing).
- [x] Translation catalogs regenerated (`makepot`/`updatepo`/`makemo`) for the one new string (`"%1$s off · %2$s"`); no existing string's `msgid` changed.
