### PR TITLE
Make the transaction table the Finance tab's income source

### DIFF
--- a/.changeset/redesign-finance-tab-income-source.md
+++ b/.changeset/redesign-finance-tab-income-source.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix the event Finance tab double-counting income: Total Income now comes only from paid transactions instead of also adding fair-finance entries, which could duplicate the same money when an entry wasn't explicitly reconciliation-matched. The entries table is now cost-only, and the Payments table shows each transaction's linked budget entry (if any).

--- a/fair-events/src/Admin/manage-event/EventFinance.js
+++ b/fair-events/src/Admin/manage-event/EventFinance.js
@@ -54,7 +54,7 @@ const renderParticipant = (tx) => {
 
 export default function EventFinance({ eventDateId, entriesUrl }) {
 	const [totals, setTotals] = useState(null);
-	const [entries, setEntries] = useState([]);
+	const [costEntries, setCostEntries] = useState([]);
 	const [transactions, setTransactions] = useState([]);
 	const [failedTransactions, setFailedTransactions] = useState([]);
 	const [loading, setLoading] = useState(true);
@@ -82,10 +82,10 @@ export default function EventFinance({ eventDateId, entriesUrl }) {
 				expiredData,
 			] = await Promise.all([
 				apiFetch({
-					path: `/fair-finance/v1/financial-entries/totals?event_date_id=${eventDateId}&unmatched=true`,
+					path: `/fair-finance/v1/financial-entries/totals?event_date_id=${eventDateId}`,
 				}),
 				apiFetch({
-					path: `/fair-finance/v1/financial-entries?event_date_id=${eventDateId}&per_page=10&unmatched=true`,
+					path: `/fair-finance/v1/financial-entries?event_date_id=${eventDateId}&per_page=10&entry_type=cost`,
 				}),
 				apiFetch({
 					path: `/fair-payments-connector/v1/transactions?event_date_id=${eventDateId}&status=paid&mode=live&per_page=100`,
@@ -127,15 +127,16 @@ export default function EventFinance({ eventDateId, entriesUrl }) {
 				(b.created_at || '').localeCompare(a.created_at || '')
 			);
 
+			const totalCost = totalsData.total_cost || 0;
+
 			setTotals({
-				...totalsData,
-				total_income:
-					(totalsData.total_income || 0) + transactionIncome,
-				balance: (totalsData.balance || 0) + transactionIncome,
+				total_cost: totalCost,
+				total_income: transactionIncome,
+				balance: transactionIncome - totalCost,
 				total_net: transactionNet,
 				net_complete: netComplete,
 			});
-			setEntries(entriesData.entries || []);
+			setCostEntries(entriesData.entries || []);
 			setTransactions(paidTransactions);
 			setFailedTransactions(failed);
 		} catch (err) {
@@ -252,13 +253,15 @@ export default function EventFinance({ eventDateId, entriesUrl }) {
 							</HStack>
 						)}
 
-						{entries.length > 0 && (
+						{costEntries.length > 0 && (
 							<div style={{ overflowX: 'auto' }}>
+								<h3 style={{ marginBottom: '8px' }}>
+									{__('Costs', 'fair-events')}
+								</h3>
 								<table className="wp-list-table widefat striped">
 									<thead>
 										<tr>
 											<th>{__('Date', 'fair-events')}</th>
-											<th>{__('Type', 'fair-events')}</th>
 											<th>
 												{__('Amount', 'fair-events')}
 											</th>
@@ -271,34 +274,15 @@ export default function EventFinance({ eventDateId, entriesUrl }) {
 										</tr>
 									</thead>
 									<tbody>
-										{entries.map((entry) => (
+										{costEntries.map((entry) => (
 											<tr key={entry.id}>
 												<td>{entry.entry_date}</td>
 												<td>
-													<span
+													<strong
 														style={{
-															color:
-																entry.entry_type ===
-																'cost'
-																	? '#d63638'
-																	: '#007017',
-															fontWeight: 'bold',
+															color: '#d63638',
 														}}
 													>
-														{entry.entry_type ===
-														'cost'
-															? __(
-																	'Cost',
-																	'fair-events'
-															  )
-															: __(
-																	'Income',
-																	'fair-events'
-															  )}
-													</span>
-												</td>
-												<td>
-													<strong>
 														{formatAmount(
 															entry.amount
 														)}
@@ -348,6 +332,12 @@ export default function EventFinance({ eventDateId, entriesUrl }) {
 											<th>
 												{__(
 													'Participant',
+													'fair-events'
+												)}
+											</th>
+											<th>
+												{__(
+													'Budget entry',
 													'fair-events'
 												)}
 											</th>
@@ -403,6 +393,16 @@ export default function EventFinance({ eventDateId, entriesUrl }) {
 													</td>
 													<td>
 														{renderParticipant(tx)}
+													</td>
+													<td>
+														{tx.entry_ids?.length
+															? tx.entry_ids
+																	.map(
+																		(id) =>
+																			`#${id}`
+																	)
+																	.join(', ')
+															: '-'}
 													</td>
 												</tr>
 											);
@@ -490,7 +490,7 @@ export default function EventFinance({ eventDateId, entriesUrl }) {
 							</div>
 						)}
 
-						{entries.length === 0 &&
+						{costEntries.length === 0 &&
 							transactions.length === 0 &&
 							failedTransactions.length === 0 &&
 							!totals?.total_cost &&

--- a/fair-events/src/Admin/manage-event/__tests__/EventFinance.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventFinance.test.jsx
@@ -1,12 +1,13 @@
 /**
  * @jest-environment jsdom
  *
- * Component tests for the Finance tab double-counting fix (#1337).
+ * Component tests for the redesigned Finance tab (#1337).
  *
- * fair-finance FinancialEntry rows that have been reconciliation-matched to a
- * fair-payments-connector Transaction must be excluded from the totals/entries
- * fetched here (via `unmatched=true`), since the matched transaction's gross
- * amount already covers that income.
+ * The transaction table is the single source of truth for income — entries
+ * never contribute to Total Income, which removes the double-count bug class
+ * from the earlier `unmatched=true` approach (a matched-but-unlinked entry
+ * could still be summed on top of its transaction). fair-finance entries are
+ * reduced to a cost-only annotation table.
  */
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -15,36 +16,45 @@ import EventFinance from '../EventFinance.js';
 
 jest.mock('@wordpress/api-fetch');
 
-const paidTransaction = {
+const paidTransactionWithEntry = {
 	id: 1,
 	amount: 45,
 	mollie_fee: 0.79,
 	application_fee: 0,
 	status: 'paid',
 	created_at: '2026-07-20 10:00:00',
+	entry_ids: [5],
 };
 
-const unmatchedIncomeEntry = {
-	id: 5,
-	entry_type: 'income',
+const paidTransactionWithoutEntry = {
+	id: 2,
+	amount: 50,
+	mollie_fee: 0.88,
+	application_fee: 0,
+	status: 'paid',
+	created_at: '2026-07-21 10:00:00',
+	entry_ids: [],
+};
+
+const costEntry = {
+	id: 9,
+	entry_type: 'cost',
 	entry_date: '2026-07-19',
-	amount: 30,
-	description: 'Sponsorship',
+	amount: 12,
+	description: 'Venue rental',
 };
 
 function mockApiFetchByPath({
 	totals = { total_income: 0, total_cost: 0, balance: 0 },
-	entries = [],
+	costEntries = [],
 	paidTransactions = [],
 } = {}) {
 	apiFetch.mockImplementation(({ path }) => {
 		if (path.startsWith('/fair-finance/v1/financial-entries/totals')) {
-			expect(path).toContain('unmatched=true');
 			return Promise.resolve(totals);
 		}
 		if (path.startsWith('/fair-finance/v1/financial-entries')) {
-			expect(path).toContain('unmatched=true');
-			return Promise.resolve({ entries });
+			return Promise.resolve({ entries: costEntries });
 		}
 		if (path.includes('status=paid')) {
 			return Promise.resolve({ transactions: paidTransactions });
@@ -61,13 +71,11 @@ function statValue(label) {
 	return screen.getByText(label).previousSibling.textContent;
 }
 
-describe('EventFinance — reconciled entries are not double-counted (#1337)', () => {
-	it('reports Total Income as only the gross transaction amount when the matching entry is excluded', async () => {
-		// Simulates the backend already filtering out the matched entry via
-		// unmatched=true — totals only reflect the paid transaction.
+describe('EventFinance — transaction table is the income source of truth (#1337)', () => {
+	it('reports Total Income as the transaction gross sum, ignoring entries entirely', async () => {
 		mockApiFetchByPath({
-			totals: { total_income: 0, total_cost: 0, balance: 0 },
-			paidTransactions: [paidTransaction],
+			totals: { total_income: 999, total_cost: 0, balance: 999 },
+			paidTransactions: [paidTransactionWithEntry],
 		});
 
 		render(<EventFinance eventDateId={42} entriesUrl="admin.php" />);
@@ -79,23 +87,47 @@ describe('EventFinance — reconciled entries are not double-counted (#1337)', (
 		expect(statValue('Total Income')).toBe('€45.00');
 	});
 
-	it('still includes an unmatched manual entry in totals and the entries table', async () => {
+	it('shows the linked entry id in the Budget entry column', async () => {
 		mockApiFetchByPath({
-			totals: { total_income: 30, total_cost: 0, balance: 30 },
-			entries: [unmatchedIncomeEntry],
-			paidTransactions: [],
+			paidTransactions: [paidTransactionWithEntry],
+		});
+
+		render(<EventFinance eventDateId={42} entriesUrl="admin.php" />);
+
+		await waitFor(() => expect(screen.getByText('#5')).toBeInTheDocument());
+	});
+
+	it('shows a dash in the Budget entry column when the transaction has no linked entry', async () => {
+		mockApiFetchByPath({
+			paidTransactions: [paidTransactionWithoutEntry],
 		});
 
 		render(<EventFinance eventDateId={42} entriesUrl="admin.php" />);
 
 		await waitFor(() =>
-			expect(screen.getByText('Sponsorship')).toBeInTheDocument()
+			expect(screen.getByText('Payments')).toBeInTheDocument()
 		);
 
-		expect(statValue('Total Income')).toBe('€30.00');
+		const row = screen.getByRole('link', { name: '€50.00' }).closest('tr');
+		expect(row).toHaveTextContent('-');
 	});
 
-	it('requests both fair-finance endpoints with unmatched=true', async () => {
+	it('lists a cost entry in the Costs table and includes it in Total Costs', async () => {
+		mockApiFetchByPath({
+			totals: { total_income: 0, total_cost: 12, balance: -12 },
+			costEntries: [costEntry],
+		});
+
+		render(<EventFinance eventDateId={42} entriesUrl="admin.php" />);
+
+		await waitFor(() =>
+			expect(screen.getByText('Venue rental')).toBeInTheDocument()
+		);
+
+		expect(statValue('Total Costs')).toBe('€12.00');
+	});
+
+	it('requests only cost-type entries', async () => {
 		mockApiFetchByPath({});
 
 		render(<EventFinance eventDateId={42} entriesUrl="admin.php" />);
@@ -103,23 +135,17 @@ describe('EventFinance — reconciled entries are not double-counted (#1337)', (
 		await waitFor(() => expect(apiFetch).toHaveBeenCalled());
 
 		const calledPaths = apiFetch.mock.calls.map((call) => call[0].path);
-		const totalsCall = calledPaths.find((p) =>
-			p.startsWith('/fair-finance/v1/financial-entries/totals')
-		);
 		const entriesCall = calledPaths.find(
 			(p) =>
-				p.startsWith('/fair-finance/v1/financial-entries?') ||
-				(p.startsWith('/fair-finance/v1/financial-entries') &&
-					!p.includes('/totals'))
+				p.startsWith('/fair-finance/v1/financial-entries?') &&
+				!p.includes('/totals')
 		);
-		expect(totalsCall).toContain('unmatched=true');
-		expect(entriesCall).toContain('unmatched=true');
+		expect(entriesCall).toContain('entry_type=cost');
 	});
 
 	it('still computes Total Net from paid-transaction fee data', async () => {
 		mockApiFetchByPath({
-			totals: { total_income: 0, total_cost: 0, balance: 0 },
-			paidTransactions: [paidTransaction],
+			paidTransactions: [paidTransactionWithEntry],
 		});
 
 		render(<EventFinance eventDateId={42} entriesUrl="admin.php" />);


### PR DESCRIPTION
## Summary

- The Finance tab's Total Income still double-counted money after the first fix (`c5c60b79`), because that fix only excluded fair-finance entries that were explicitly reconciliation-matched to a transaction — entries that merely *looked* like a duplicate (same net amount) but were never linked still got added on top of the transaction total.
- This redesigns the tab around the transaction table as the single source of truth for income: Total Income is now the sum of paid transactions only, entries never contribute to it, and the old mixed "Finanzas" table is replaced with a cost-only Costs table. The Payments table gains a Budget entry column showing each transaction's linked entry id(s) (`-` if none), sourced from the `entry_ids` the transactions endpoint already returns.
- Closes #1337

## Plan checklist

From the [approved implementation plan](https://github.com/marcin-wosinek/fair-event-plugins/issues/1337#issuecomment-5201847922):

- [x] Cost-only entries fetch (`entry_type=cost`), state renamed `entries` → `costEntries`
- [x] `totals` computed as `total_cost` (from the totals endpoint), `total_income`/`balance` from transactions only, `total_net`/`net_complete` unchanged
- [x] Payments table: new "Budget entry" column rendering `#<id>` (comma-joined) or `-`
- [x] "Finanzas" table renamed to "Costs", Type column dropped (cost-only now)
- [x] Empty-state check uses `costEntries.length === 0`
- [x] `failedTransactions` handling unchanged
- [x] Test file rewritten to match the new behavior (income-from-transactions-only, cost-only entries, Budget entry column, `entry_type=cost` in the request)
- [x] Changeset added for `fair-events` (patch)

## Test plan

- [x] `npm run test:js` in `fair-events` — 206/206 pass, including the rewritten `EventFinance.test.jsx` (6 tests)
- [x] `npm run build` in `fair-events`
- [x] `npm run format` in `fair-events`
- [x] Manual WP-CLI `eval-file` check against a real WordPress instance: created a paid transaction (gross 45.00) alongside a stray, *unmatched* fair-finance income entry with the same net amount (44.21) — the exact shape of the originally reported bug — plus a separate cost entry (12.00). Verified via the real REST controllers:
  - Total Income = 45.00 (transaction gross only; the stray entry is never added)
  - `entry_type=cost` list contains only the cost entry, not the stray income entry
  - `totals.total_cost` = 12.00
  - Linking the cost entry to the transaction makes `entry_ids` (and therefore the Budget entry column) report `[7]`
  - All assertions passed

No PHP changed (both new query params/filters already existed on the backend), so no `phpcs` run was needed.
