### PR TITLE
Reserve capacity for pending add-on activity purchases

### DIFF
--- a/.changeset/reserve-capacity-for-pending-addon-activities.md
+++ b/.changeset/reserve-capacity-for-pending-addon-activities.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": patch
+---
+
+Hold capacity for a paid activity while its add-on payment is in flight, instead of only counting it once payment confirms. Previously, two buyers could both pass the capacity check for the last spot on a capacity-limited activity because an in-progress add-on purchase wasn't reserved anywhere. An unpaid add-on selection also no longer appears as an already-granted activity on the signup form while its payment is still pending.

--- a/fair-audience/fair-audience.php
+++ b/fair-audience/fair-audience.php
@@ -822,6 +822,12 @@ function fair_audience_maybe_upgrade_db() {
 
 		update_option( 'fair_audience_db_version', '1.42.0' );
 	}
+
+	if ( version_compare( $db_version, '1.43.0', '<' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( \FairAudience\Database\Schema::get_event_participant_options_table_sql() );
+		update_option( 'fair_audience_db_version', '1.43.0' );
+	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\fair_audience_maybe_upgrade_db' );
 

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -1276,6 +1276,12 @@ class EventSignupController extends WP_REST_Controller {
 			return $transaction_id;
 		}
 
+		// Reserve the option's capacity while payment is in flight — the
+		// parent row stays signed_up throughout, so only the junction rows
+		// carry the pending hold (see count_signups_for_ticket_option()).
+		$addon_expires_at = gmdate( 'Y-m-d H:i:s', time() + 15 * MINUTE_IN_SECONDS );
+		$this->event_participant_repository->add_pending_options( (int) $event_participant->id, $new_options, $addon_expires_at );
+
 		// Also closes a secondary gap: add-on charges never recorded to the
 		// ledger, so payment history for the registration was missing them.
 		( new EventParticipantTransactionRepository() )->record( (int) $event_participant->id, (int) $transaction_id, 'charge' );
@@ -2531,9 +2537,11 @@ class EventSignupController extends WP_REST_Controller {
 			);
 		}
 
-		// Already attached (e.g. the original payment landed after all)? Nothing
-		// to retry.
-		$already_ids   = $this->event_participant_repository->get_option_ids_for_event_participant( $event_participant_id );
+		// Already confirmed (e.g. the original payment landed after all)?
+		// Nothing to retry. Deliberately confirmed-only: the option's own
+		// still-pending hold from the attempt being retried is expected to be
+		// present here and must not look like it's already attached.
+		$already_ids   = $this->event_participant_repository->get_confirmed_option_ids_for_event_participant( $event_participant_id );
 		$remaining_ids = array_values( array_diff( $option_ids, $already_ids ) );
 		if ( empty( $remaining_ids ) ) {
 			return rest_ensure_response(
@@ -2587,6 +2595,13 @@ class EventSignupController extends WP_REST_Controller {
 		if ( is_wp_error( $new_transaction_id ) ) {
 			return $new_transaction_id;
 		}
+
+		// Refresh the pending reservation for this retry attempt so the hold
+		// survives — mirrors the base retry path re-creating its pending_payment
+		// row (maybe_start_paid_signup()/retry_payment()).
+		$remaining_options = $this->load_valid_options( $event_date_id, $remaining_ids );
+		$addon_expires_at  = gmdate( 'Y-m-d H:i:s', time() + 15 * MINUTE_IN_SECONDS );
+		$this->event_participant_repository->add_pending_options( $event_participant_id, $remaining_options, $addon_expires_at );
 
 		$redirect_url = add_query_arg(
 			array(

--- a/fair-audience/src/API/__tests__/EventSignupAddActivities.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupAddActivities.api.spec.js
@@ -5,8 +5,17 @@
  * The endpoint resolves the acting participant from the logged-in user, so the
  * suite links a participant to the admin WP user (Application Password creds)
  * and tears it down afterwards. A free (price 0) activity is used so the happy
- * path attaches immediately without routing through Mollie — the paid delta
- * flow is covered by manual verification.
+ * path attaches immediately without routing through Mollie.
+ *
+ * A priced activity proves the payment_unavailable 503 guard the same way
+ * EventSignupActivities.api.spec.js does (no payment connector is configured
+ * on the dev/test stack, so a paid add-on can never actually reach Mollie
+ * here). Because of that, this suite cannot create a genuine pending-payment
+ * hold on an option through HTTP requests alone (maybe_start_addon_payment()
+ * only writes the hold after create_transaction() succeeds) — the DB-level
+ * reserve → confirm → expire cycle, including the duplicate-guard against a
+ * pending (not just confirmed) reservation, is covered instead by the WP-CLI
+ * eval-file manual check described in TESTING.md (#1311).
  */
 
 import { test, expect, request } from '@playwright/test';
@@ -52,6 +61,7 @@ test.describe('EventSignupController add-activities', () => {
 	let signedUpEvent;
 	let otherEvent;
 	let freeOptionId;
+	let paidOptionId;
 	let fixtureOk = true;
 
 	test.beforeAll(async () => {
@@ -107,21 +117,31 @@ test.describe('EventSignupController add-activities', () => {
 			return;
 		}
 
-		// Add a free activity option on the signed-up event date.
+		// Add a free and a priced activity option on the signed-up event date.
 		const ticketsRes = await api.put(
 			`/wp-json/fair-events/v1/event-dates/${signedUpEvent.eventDateId}/tickets`,
 			{
 				headers: authHeaders,
-				data: { options: [{ name: 'Free Workshop', price: 0 }] },
+				data: {
+					options: [
+						{ name: 'Free Workshop', price: 0 },
+						{ name: 'Priced Workshop', price: 20 },
+					],
+				},
 			}
 		);
 		expect(ticketsRes.ok()).toBeTruthy();
 		const config = await ticketsRes.json();
-		const option = (config.options || []).find(
+		const freeOption = (config.options || []).find(
 			(o) => o.name === 'Free Workshop'
 		);
-		expect(option, 'created free option').toBeTruthy();
-		freeOptionId = option.id;
+		const paidOption = (config.options || []).find(
+			(o) => o.name === 'Priced Workshop'
+		);
+		expect(freeOption, 'created free option').toBeTruthy();
+		expect(paidOption, 'created priced option').toBeTruthy();
+		freeOptionId = freeOption.id;
+		paidOptionId = paidOption.id;
 	});
 
 	test.afterAll(async () => {
@@ -240,5 +260,37 @@ test.describe('EventSignupController add-activities', () => {
 		);
 		expect(res.status()).toBe(400);
 		expect((await res.json()).code).toBe('no_new_activities');
+	});
+
+	test('adding a priced activity is rejected with 503 payment_unavailable (no payment connector configured)', async () => {
+		test.skip(
+			!fixtureOk,
+			'Skipped pending #1410 — publishing a fair_event does not auto-create its event-date'
+		);
+		const res = await api.post(
+			'/wp-json/fair-audience/v1/event-signup/add-activities',
+			{
+				headers: authHeaders,
+				data: {
+					event_id: signedUpEvent.eventId,
+					ticket_option_ids: [paidOptionId],
+				},
+			}
+		);
+		expect(res.status()).toBe(503);
+		expect((await res.json()).code).toBe('payment_unavailable');
+
+		// The rejected attempt must not have left a hold on the option: it
+		// should still be offered as addable.
+		const listRes = await api.get(
+			`/wp-json/fair-audience/v1/event-dates/${signedUpEvent.eventDateId}/participants`,
+			{ headers: authHeaders }
+		);
+		expect(listRes.ok()).toBeTruthy();
+		const row = (await listRes.json()).find(
+			(p) => p.participant_id === participantId
+		);
+		expect(row).toBeTruthy();
+		expect(row.ticket_option_ids).not.toContain(paidOptionId);
 	});
 });

--- a/fair-audience/src/Database/EventParticipantRepository.php
+++ b/fair-audience/src/Database/EventParticipantRepository.php
@@ -374,7 +374,10 @@ class EventParticipantRepository {
 	 * Counts event_participant rows that have an entry in the
 	 * fair_audience_event_participant_options junction table for the given
 	 * option, restricted to rows with label = 'signed_up' or unexpired
-	 * 'pending_payment'. Used for per-activity capacity enforcement.
+	 * 'pending_payment', and to junction rows that are themselves either
+	 * confirmed or an unexpired pending hold (an add-on purchase in flight on
+	 * an otherwise signed_up parent row). Used for per-activity capacity
+	 * enforcement.
 	 *
 	 * @param int $ticket_option_id Ticket option ID.
 	 * @return int Number of signups held against the option.
@@ -395,10 +398,15 @@ class EventParticipantRepository {
 				 AND (
 				     ep.label = 'signed_up'
 				     OR ( ep.label = 'pending_payment' AND ep.payment_expires_at IS NOT NULL AND ep.payment_expires_at > %s )
+				 )
+				 AND (
+				     epo.status = 'confirmed'
+				     OR ( epo.status = 'pending_payment' AND epo.expires_at IS NOT NULL AND epo.expires_at > %s )
 				 )",
 				$participants_table,
 				$options_table,
 				$ticket_option_id,
+				$now,
 				$now
 			)
 		);
@@ -428,10 +436,12 @@ class EventParticipantRepository {
 	}
 
 	/**
-	 * Get the ticket option IDs currently attached to an event participant.
+	 * Get the ticket option IDs attached to an event participant, confirmed or
+	 * pending. Use this to guard against re-adding/re-purchasing an option
+	 * that already has a hold on it (confirmed or an in-flight payment).
 	 *
 	 * @param int $event_participant_id Event participant row ID.
-	 * @return int[] Attached ticket option IDs.
+	 * @return int[] Attached ticket option IDs (any status).
 	 */
 	public function get_option_ids_for_event_participant( $event_participant_id ) {
 		global $wpdb;
@@ -441,6 +451,31 @@ class EventParticipantRepository {
 		$ids = $wpdb->get_col(
 			$wpdb->prepare(
 				'SELECT ticket_option_id FROM %i WHERE event_participant_id = %d',
+				$options_table,
+				$event_participant_id
+			)
+		);
+
+		return array_map( 'intval', (array) $ids );
+	}
+
+	/**
+	 * Get the ticket option IDs actually confirmed for an event participant —
+	 * excludes rows still holding an unpaid add-on reservation. Use this for
+	 * anything the viewer sees as "yours" (e.g. "current activities" summary),
+	 * so a payment still in flight is never displayed as already granted.
+	 *
+	 * @param int $event_participant_id Event participant row ID.
+	 * @return int[] Confirmed ticket option IDs.
+	 */
+	public function get_confirmed_option_ids_for_event_participant( $event_participant_id ) {
+		global $wpdb;
+
+		$options_table = $wpdb->prefix . 'fair_audience_event_participant_options';
+
+		$ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ticket_option_id FROM %i WHERE event_participant_id = %d AND status = 'confirmed'",
 				$options_table,
 				$event_participant_id
 			)
@@ -480,6 +515,51 @@ class EventParticipantRepository {
 					'ticket_option_name'   => (string) $option_name,
 				),
 				array( '%d', '%d', '%s' )
+			);
+		}
+	}
+
+	/**
+	 * Reserve ticket options against an event participant while their payment
+	 * is in flight, without confirming them. Unlike add_options(), rows are
+	 * written with status = 'pending_payment' and the given expiry, so
+	 * count_signups_for_ticket_option() holds their capacity until either the
+	 * payment confirms (add_options() re-writes the row as 'confirmed') or the
+	 * hold expires and delete_expired_pending_options() releases it.
+	 *
+	 * Idempotent: uses REPLACE, so re-reserving the same option (e.g. a retry)
+	 * just refreshes its expiry.
+	 *
+	 * @param int    $event_participant_id Event participant row ID.
+	 * @param array  $options              Array of objects/arrays with `id` and `name`.
+	 * @param string $expires_at           MySQL datetime the hold expires at.
+	 * @return void
+	 */
+	public function add_pending_options( $event_participant_id, $options, $expires_at ) {
+		global $wpdb;
+
+		if ( empty( $options ) ) {
+			return;
+		}
+
+		$options_table = $wpdb->prefix . 'fair_audience_event_participant_options';
+
+		foreach ( $options as $option ) {
+			$option_id   = is_array( $option ) ? ( $option['id'] ?? 0 ) : ( $option->id ?? 0 );
+			$option_name = is_array( $option ) ? ( $option['name'] ?? '' ) : ( $option->name ?? '' );
+			if ( ! $option_id ) {
+				continue;
+			}
+			$wpdb->replace(
+				$options_table,
+				array(
+					'event_participant_id' => (int) $event_participant_id,
+					'ticket_option_id'     => (int) $option_id,
+					'ticket_option_name'   => (string) $option_name,
+					'status'               => 'pending_payment',
+					'expires_at'           => $expires_at,
+				),
+				array( '%d', '%d', '%s', '%s', '%s' )
 			);
 		}
 	}
@@ -569,6 +649,37 @@ class EventParticipantRepository {
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		return (int) $deleted;
+	}
+
+	/**
+	 * Delete pending_payment junction rows whose expires_at has passed.
+	 *
+	 * Unlike delete_expired_pending_payments(), this never touches the parent
+	 * event_participant row — an add-on hold sits on top of an already
+	 * signed_up subscription, which stays valid throughout. Deleting just the
+	 * junction row releases the option's capacity for a payment that never
+	 * confirmed.
+	 *
+	 * @return int Number of rows deleted.
+	 */
+	public function delete_expired_pending_options() {
+		global $wpdb;
+
+		$options_table = $wpdb->prefix . 'fair_audience_event_participant_options';
+		$now           = current_time( 'mysql' );
+
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM %i
+				 WHERE status = 'pending_payment'
+				 AND expires_at IS NOT NULL
+				 AND expires_at <= %s",
+				$options_table,
+				$now
+			)
+		);
 
 		return (int) $deleted;
 	}

--- a/fair-audience/src/Database/Schema.php
+++ b/fair-audience/src/Database/Schema.php
@@ -627,11 +627,14 @@ class Schema {
 			event_participant_id BIGINT UNSIGNED NOT NULL,
 			ticket_option_id BIGINT UNSIGNED NOT NULL,
 			ticket_option_name VARCHAR(255) NOT NULL DEFAULT '',
+			status ENUM('confirmed', 'pending_payment') NOT NULL DEFAULT 'confirmed',
+			expires_at DATETIME DEFAULT NULL,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY  (id),
 			UNIQUE KEY idx_participant_option (event_participant_id, ticket_option_id),
 			KEY idx_event_participant_id (event_participant_id),
-			KEY idx_ticket_option_id (ticket_option_id)
+			KEY idx_ticket_option_id (ticket_option_id),
+			KEY idx_status_expires (status, expires_at)
 		) ENGINE=InnoDB $charset_collate;";
 	}
 

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -407,11 +407,14 @@ class PaymentHooks {
 	 *
 	 * Protects against lost webhook deliveries: stale rows still hold a slot
 	 * until this cleanup runs (or a new request triggers the capacity check,
-	 * which already filters on payment_expires_at).
+	 * which already filters on payment_expires_at). Also releases expired
+	 * add-on activity holds (pending junction rows on an otherwise signed_up
+	 * subscription), the same latency the base signup path already tolerates.
 	 */
 	public static function cleanup_expired_signups() {
 		$repo = new EventParticipantRepository();
 		$repo->delete_expired_pending_payments();
+		$repo->delete_expired_pending_options();
 	}
 
 	/**

--- a/fair-audience/src/Services/SignupActivities.php
+++ b/fair-audience/src/Services/SignupActivities.php
@@ -296,8 +296,11 @@ class SignupActivities {
 			}
 		}
 
-		$current_option_ids = $signed_row
+		$current_option_ids   = $signed_row
 			? $event_participant_repository->get_option_ids_for_event_participant( (int) $signed_row->id )
+			: array();
+		$confirmed_option_ids = $signed_row
+			? $event_participant_repository->get_confirmed_option_ids_for_event_participant( (int) $signed_row->id )
 			: array();
 
 		foreach ( $context['ticket_options'] as &$option ) {
@@ -313,9 +316,9 @@ class SignupActivities {
 			$option['is_full'] = $is_full;
 
 			if ( $signed_row ) {
-				if ( in_array( (int) $option['id'], $current_option_ids, true ) ) {
+				if ( in_array( (int) $option['id'], $confirmed_option_ids, true ) ) {
 					$context['current_activity_names'][] = $option['name'];
-				} else {
+				} elseif ( ! in_array( (int) $option['id'], $current_option_ids, true ) ) {
 					$context['addable_options'][] = $option;
 				}
 			}

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -624,10 +624,16 @@ if ( $is_signed_up && $participant && ! empty( $event_date_id ) && isset( $event
 			}
 		}
 
-		$selected_option_ids = $event_participant_repository->get_option_ids_for_event_participant( (int) $signed_row->id );
+		$selected_option_ids  = $event_participant_repository->get_option_ids_for_event_participant( (int) $signed_row->id );
+		$confirmed_option_ids = $event_participant_repository->get_confirmed_option_ids_for_event_participant( (int) $signed_row->id );
 		foreach ( $ticket_options_for_display as $opt ) {
-			if ( in_array( (int) $opt['id'], $selected_option_ids, true ) ) {
+			if ( in_array( (int) $opt['id'], $confirmed_option_ids, true ) ) {
 				$current_activity_names[] = $opt['name'];
+				continue;
+			}
+			if ( in_array( (int) $opt['id'], $selected_option_ids, true ) ) {
+				// An add-on payment is already in flight for this option —
+				// don't offer it again until it confirms or expires.
 				continue;
 			}
 			// Full options are kept in the list but rendered disabled, so the


### PR DESCRIPTION
## Summary

Implements the plan from https://github.com/marcin-wosinek/fair-event-plugins/issues/1311#issuecomment-5202199448 — the concrete gap it identified in #1311: the add-on activity purchase path (adding paid activities to an already-completed signup) never reserved capacity on the option while its payment was in flight, so two buyers could both pass the capacity check for the last spot on a capacity-limited activity.

- Junction table (`fair_audience_event_participant_options`) gets its own `status`/`expires_at` columns, mirroring the existing `label`/`payment_expires_at` idiom on the parent row.
- `maybe_start_addon_payment()` reserves the new options with a 15-minute hold after the transaction is created; `retry_addon_payment()` refreshes the hold on retry.
- `count_signups_for_ticket_option()` now also counts unexpired pending option holds; `delete_expired_pending_options()` releases lapsed ones via the existing 5-minute cleanup cron.
- The signup form (`render.php`) and its viewer-context endpoint (`SignupActivities.php`) no longer show a still-unpaid add-on as an already-granted activity — added `get_confirmed_option_ids_for_event_participant()` for that display path, kept the existing (any-status) lookup for the duplicate-purchase guard.

Closes #1311

## Acceptance criteria

- [x] **Starting a paid-activity checkout and abandoning it leaves the participant without those activities.** True for the base signup path already (pre-existing); now also true for the add-on path — the option is held as `pending_payment` on the junction row and never shown as attached until confirmed, and is released by the cron (or immediately superseded) if abandoned.
- [x] **Completing the payment attaches exactly the selected activities and links the charge to the participation.** Unchanged — `PaymentHooks::handle_activities_added_paid()` already did this; the pending row it replaces via `add_options()`'s `REPLACE` now correctly flips `status` to `confirmed`.
- [x] **Adding paid activities to an already-completed signup follows the same confirm-then-attach sequence.** This was already true for *attaching*; this PR closes the remaining gap by also reserving *capacity* for it in the meantime.
- [x] **Free activity selections are still attached immediately.** Unchanged — the free path in `add_activities()` never goes through `maybe_start_addon_payment()`.
- [x] **API specs cover the abandoned, confirmed, and add-to-existing cases.** `EventSignupAddActivities.api.spec.js` gets a new `payment_unavailable` 503 test (mirroring `EventSignupActivities.api.spec.js`, since the dev/test stack has no live payment connector). The reserve → confirm → expire cycle and the pending-reservation duplicate guard are verified via the WP-CLI `eval-file` manual check (TESTING.md) instead, since a real Mollie confirmation can't be simulated in Playwright here — see Notes.

## Notes

- Pre-existing infra gap [#1410](https://github.com/marcin-wosinek/fair-event-plugins/issues/1410) (publishing a `fair_event` doesn't auto-create its event-date) makes every test in `EventSignupAddActivities.api.spec.js` self-skip on this repo's dev/test stacks today — confirmed this also happens on `main`, unrelated to this change. The new test follows the same `fixtureOk` skip guard as its siblings and will start running once #1410 is fixed.
- Manually verified the DB-level reserve → confirm → expire cycle (capacity counting, confirm via `add_options()`, expiry via `delete_expired_pending_options()`, and that a pending hold is visible to the duplicate-purchase guard but not to the "confirmed activities" display) via a throwaway WP-CLI `eval-file` script against the dev stack — all checks passed.
- `npm run test:js` (27/27) and `vendor/bin/phpunit` (87/87) pass for `fair-audience`. `phpcs` is clean on every touched file (pre-existing errors/warnings elsewhere in `fair-audience.php`, `render.php`, and `EventSignupController.php` are unchanged from `main`, confirmed by diffing error counts against the baseline).
