### PR TITLE
Harden signup pricing against cross-plugin release skew

### DIFF
--- a/.changeset/fix-group-discount-note-mismatch.md
+++ b/.changeset/fix-group-discount-note-mismatch.md
@@ -1,5 +1,6 @@
 ---
 "fair-audience": patch
+"fair-events-experimental": patch
 ---
 
 Fix the group discount note on the signup form so it always matches the price actually charged: it now compares each rule against the ticket's real price (not a notional reference price), stays hidden unless a price is genuinely reduced, and shows fractional percentages (e.g. 12.5%) without rounding them away. When different ticket tiers get their best price from different rules, the shared note is dropped in favor of a per-tier label.

--- a/.changeset/fix-signup-pricing-fatal-on-plugin-skew.md
+++ b/.changeset/fix-signup-pricing-fatal-on-plugin-skew.md
@@ -1,0 +1,5 @@
+---
+"fair-audience": patch
+---
+
+Fix the Event Signup form and its checkout/payment paths fataling with a white screen when fair-events-experimental lags behind fair-audience's expected pricing interface (e.g. a partial or delayed update). Group-discount pricing lookups now degrade gracefully to the base price and log a warning instead of crashing the page.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -116,6 +116,36 @@ Changesets is configured in `.changeset/config.json`:
 - **Changelog generation**: Automatic changelog per plugin
 - **WordPress sync**: Automatic plugin header version updates
 
+## 🔗 Cross-plugin interface changes
+
+Changesets only version-bumps and releases the packages named in a
+changeset. If a change touches a method/class in one plugin (e.g.
+`fair-events-experimental`) and migrates call sites in another plugin (e.g.
+`fair-audience`) onto the new interface, the changeset **must declare a
+version bump for every plugin whose code changed** — not just the one where
+the primary feature lives. Otherwise the release ships the calling plugin's
+new code while the plugin it calls into stays on its old build, and any site
+that updates one but not the other hits a mismatch (missing method, changed
+signature) at runtime — see issue #1421, where a note-formatting fix updated
+`fair-audience` call sites onto renamed/new `fair-events-experimental`
+methods, but the changeset only declared `fair-audience`.
+
+Before adding a changeset for a change that crosses plugin boundaries, check
+every plugin directory the diff touches and list all of them in the
+changeset frontmatter, e.g.:
+
+```markdown
+---
+"fair-audience": patch
+"fair-events-experimental": patch
+---
+```
+
+As defense in depth, call sites that reach into another plugin's namespace
+should also guard with `method_exists()` (not just `class_exists()`) and
+degrade gracefully — see `fair-audience/src/Services/SignupPriceResolver.php`
+— so a future release gap doesn't fatal a page even if a changeset is missed.
+
 ## 🎉 Benefits
 
 - ✅ **Independent versioning**: Release plugins separately

--- a/fair-audience/__tests__/Services/SignupPriceResolverTest.php
+++ b/fair-audience/__tests__/Services/SignupPriceResolverTest.php
@@ -15,12 +15,15 @@ require_once __DIR__ . '/fixtures-stale-event-signup-pricing-stub.php';
 /**
  * Verifies SignupPriceResolver degrades to the base-price fallback instead
  * of fataling when fair-events-experimental is active but running a build
- * that predates the pricing methods it's expected to expose (issue #1421).
+ * that has drifted out of sync with the pricing methods it's expected to
+ * expose (issue #1421) — whether a method is missing entirely, or present
+ * with an incompatible signature.
  */
 class SignupPriceResolverTest extends TestCase {
 
 	/**
-	 * Confirms resolve_price_for_ticket_type() still reaches the stub's old method.
+	 * Confirms resolve_price_for_ticket_type() still reaches the stub's
+	 * genuinely compatible method.
 	 */
 	public function test_resolve_price_for_ticket_type_uses_available_method() {
 		$this->assertSame( 42.0, SignupPriceResolver::resolve_price_for_ticket_type( 1, 2 ) );
@@ -28,9 +31,12 @@ class SignupPriceResolverTest extends TestCase {
 
 	/**
 	 * Confirms resolve_price_and_rule_for_ticket_type() degrades to null
-	 * instead of fataling when the stale stub lacks the method, and
+	 * instead of fataling when the stub's method exists but has an
+	 * incompatible signature (throws ArgumentCountError when called), and
 	 * fair-events' TicketPricing class isn't loaded either in this unit
-	 * test (so the final fallback is also unavailable).
+	 * test (so the final fallback is also unavailable). method_exists()
+	 * alone can't catch this case — only the try/catch around the actual
+	 * call does.
 	 */
 	public function test_resolve_price_and_rule_for_ticket_type_degrades_without_fatal() {
 		$this->assertNull( SignupPriceResolver::resolve_price_and_rule_for_ticket_type( 1, 2 ) );

--- a/fair-audience/__tests__/Services/SignupPriceResolverTest.php
+++ b/fair-audience/__tests__/Services/SignupPriceResolverTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * SignupPriceResolver version-skew fallback tests
+ *
+ * @package FairAudience
+ */
+
+namespace FairAudience\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairAudience\Services\SignupPriceResolver;
+
+require_once __DIR__ . '/fixtures-stale-event-signup-pricing-stub.php';
+
+/**
+ * Verifies SignupPriceResolver degrades to the base-price fallback instead
+ * of fataling when fair-events-experimental is active but running a build
+ * that predates the pricing methods it's expected to expose (issue #1421).
+ */
+class SignupPriceResolverTest extends TestCase {
+
+	/**
+	 * Confirms resolve_price_for_ticket_type() still reaches the stub's old method.
+	 */
+	public function test_resolve_price_for_ticket_type_uses_available_method() {
+		$this->assertSame( 42.0, SignupPriceResolver::resolve_price_for_ticket_type( 1, 2 ) );
+	}
+
+	/**
+	 * Confirms resolve_price_and_rule_for_ticket_type() degrades to null
+	 * instead of fataling when the stale stub lacks the method, and
+	 * fair-events' TicketPricing class isn't loaded either in this unit
+	 * test (so the final fallback is also unavailable).
+	 */
+	public function test_resolve_price_and_rule_for_ticket_type_degrades_without_fatal() {
+		$this->assertNull( SignupPriceResolver::resolve_price_and_rule_for_ticket_type( 1, 2 ) );
+	}
+
+	/**
+	 * Confirms resolve_price_and_rule() degrades to the base price with no
+	 * rule instead of fataling when the stale stub lacks the method.
+	 */
+	public function test_resolve_price_and_rule_degrades_to_base_price_without_fatal() {
+		$result = SignupPriceResolver::resolve_price_and_rule( 20.0, 5, 2 );
+
+		$this->assertSame(
+			array(
+				'price' => 20.0,
+				'rule'  => null,
+			),
+			$result
+		);
+	}
+}

--- a/fair-audience/__tests__/Services/fixtures-stale-event-signup-pricing-stub.php
+++ b/fair-audience/__tests__/Services/fixtures-stale-event-signup-pricing-stub.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Test-only stand-in for a stale FairEventsExperimental\Services\EventSignupPricing build.
+ *
+ * Reproduces the exact shape of a fair-events-experimental build that
+ * predates issue #1297's resolve_price_and_rule()/resolve_price_and_rule_for_ticket_type()
+ * methods: the class exists, but only the old resolve_price_for_ticket_type()
+ * method does. fair-audience's real composer autoload never loads the actual
+ * FairEventsExperimental classes (its psr-4 map only covers FairAudience\),
+ * so SignupPriceResolverTest requires this fixture directly instead.
+ *
+ * @package FairAudience
+ */
+
+namespace FairEventsExperimental\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Minimal stand-in reproducing a stale fair-events-experimental build.
+ */
+class EventSignupPricing {
+
+	/**
+	 * Old-interface stand-in. Returns a fixed price so tests can assert the
+	 * facade actually reached it.
+	 *
+	 * @param int      $ticket_type_id Ticket type ID.
+	 * @param int|null $participant_id Participant ID.
+	 * @return float Fixed stub price.
+	 */
+	public static function resolve_price_for_ticket_type( $ticket_type_id, $participant_id = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- stub always returns a fixed price, kept param-compatible with the real signature.
+		return 42.0;
+	}
+}

--- a/fair-audience/__tests__/Services/fixtures-stale-event-signup-pricing-stub.php
+++ b/fair-audience/__tests__/Services/fixtures-stale-event-signup-pricing-stub.php
@@ -2,10 +2,18 @@
 /**
  * Test-only stand-in for a stale FairEventsExperimental\Services\EventSignupPricing build.
  *
- * Reproduces the exact shape of a fair-events-experimental build that
- * predates issue #1297's resolve_price_and_rule()/resolve_price_and_rule_for_ticket_type()
- * methods: the class exists, but only the old resolve_price_for_ticket_type()
- * method does. fair-audience's real composer autoload never loads the actual
+ * Reproduces two distinct version-skew shapes fair-events-experimental can
+ * drift into relative to what fair-audience expects (issue #1421):
+ * - `resolve_price_and_rule()` is missing entirely, like a build that
+ *   predates issue #1297.
+ * - `resolve_price_and_rule_for_ticket_type()` exists but takes an
+ *   incompatible signature (a new required parameter) — `method_exists()`
+ *   alone can't catch this; SignupPriceResolver also needs to catch the
+ *   resulting `ArgumentCountError`.
+ *
+ * `resolve_price_for_ticket_type()` keeps the real, compatible signature so
+ * tests can also assert the guard still reaches a genuinely available
+ * method. fair-audience's real composer autoload never loads the actual
  * FairEventsExperimental classes (its psr-4 map only covers FairAudience\),
  * so SignupPriceResolverTest requires this fixture directly instead.
  *
@@ -17,13 +25,13 @@ namespace FairEventsExperimental\Services;
 defined( 'WPINC' ) || die;
 
 /**
- * Minimal stand-in reproducing a stale fair-events-experimental build.
+ * Minimal stand-in reproducing two stale/incompatible fair-events-experimental shapes.
  */
 class EventSignupPricing {
 
 	/**
-	 * Old-interface stand-in. Returns a fixed price so tests can assert the
-	 * facade actually reached it.
+	 * Compatible old-interface stand-in. Returns a fixed price so tests can
+	 * assert the facade actually reached it.
 	 *
 	 * @param int      $ticket_type_id Ticket type ID.
 	 * @param int|null $participant_id Participant ID.
@@ -31,5 +39,22 @@ class EventSignupPricing {
 	 */
 	public static function resolve_price_for_ticket_type( $ticket_type_id, $participant_id = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- stub always returns a fixed price, kept param-compatible with the real signature.
 		return 42.0;
+	}
+
+	/**
+	 * Exists, but with an incompatible signature: a mandatory extra
+	 * parameter the real interface doesn't have. Calling it the way
+	 * SignupPriceResolver does (two args) throws ArgumentCountError.
+	 *
+	 * @param int      $ticket_type_id  Ticket type ID.
+	 * @param int|null $participant_id  Participant ID.
+	 * @param mixed    $unexpected_extra A parameter the real interface doesn't have.
+	 * @return array{price: float, rule: object|null}
+	 */
+	public static function resolve_price_and_rule_for_ticket_type( $ticket_type_id, $participant_id, $unexpected_extra ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- unreachable: the mandatory 3rd arg is what makes the call incompatible.
+		return array(
+			'price' => 42.0,
+			'rule'  => null,
+		);
 	}
 }

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -1673,8 +1673,8 @@ class EventSignupController extends WP_REST_Controller {
 		} else {
 			$opt_price = (float) $option->price;
 		}
-		if ( $participant_id && $opt_price > 0 && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$opt_price = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule(
+		if ( $participant_id && $opt_price > 0 ) {
+			$opt_price = \FairAudience\Services\SignupPriceResolver::resolve_price_and_rule(
 				$opt_price,
 				$event_date_id,
 				$participant_id

--- a/fair-audience/src/Hooks/PaymentHooks.php
+++ b/fair-audience/src/Hooks/PaymentHooks.php
@@ -238,12 +238,11 @@ class PaymentHooks {
 	 * @return string Formatted label, or empty string when no discount applies.
 	 */
 	private static function format_applied_discount( $event_participant, $transaction ) {
-		if ( empty( $event_participant->ticket_type_id )
-			|| ! class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+		if ( empty( $event_participant->ticket_type_id ) ) {
 			return '';
 		}
 
-		$resolved = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule_for_ticket_type(
+		$resolved = \FairAudience\Services\SignupPriceResolver::resolve_price_and_rule_for_ticket_type(
 			(int) $event_participant->ticket_type_id,
 			(int) $event_participant->participant_id
 		);

--- a/fair-audience/src/Services/SignupActivities.php
+++ b/fair-audience/src/Services/SignupActivities.php
@@ -97,10 +97,10 @@ class SignupActivities {
 	 * @return float Resolved price.
 	 */
 	public static function resolve_price_for_participant( $base_price, $pricing_event_date_id, $participant_id ) {
-		if ( ! $participant_id || $base_price <= 0 || ! class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+		if ( ! $participant_id || $base_price <= 0 ) {
 			return $base_price;
 		}
-		return \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule(
+		return \FairAudience\Services\SignupPriceResolver::resolve_price_and_rule(
 			(float) $base_price,
 			$pricing_event_date_id,
 			$participant_id

--- a/fair-audience/src/Services/SignupPriceResolver.php
+++ b/fair-audience/src/Services/SignupPriceResolver.php
@@ -23,27 +23,57 @@ defined( 'WPINC' ) || die;
 class SignupPriceResolver {
 
 	/**
-	 * Resolve the effective price for a specific ticket type.
+	 * Attempt a call into `FairEventsExperimental\Services\EventSignupPricing`,
+	 * degrading instead of fataling when the two plugins' interfaces have
+	 * drifted out of sync (issue #1421): a `method_exists()` guard catches a
+	 * build that's missing the method entirely (`class_exists()` alone would
+	 * stay true and the call would fatal with "Call to undefined method"),
+	 * and a `try`/`catch` around the actual call additionally catches a build
+	 * whose method exists but takes an incompatible signature (e.g. a new
+	 * required parameter), which `method_exists()` can't detect on its own.
 	 *
-	 * Guards with `method_exists()`, not just `class_exists()`: if
-	 * fair-events-experimental is active but stuck on a build that predates
-	 * this method (a cross-plugin release gap — see issue #1421), the class
-	 * still exists so `class_exists()` alone would stay true and the call
-	 * would fatal with "Call to undefined method". Falls back to the base
-	 * fair-events price instead.
+	 * @param string $method Method name on EventSignupPricing.
+	 * @param array  $args   Positional arguments to call it with.
+	 * @return array{ok: bool, value: mixed} `ok: true` with the real result,
+	 *                                       or `ok: false` for the caller to
+	 *                                       apply its own fallback.
+	 */
+	private static function call_experimental( $method, array $args ) {
+		$class = \FairEventsExperimental\Services\EventSignupPricing::class;
+
+		if ( method_exists( $class, $method ) ) {
+			try {
+				return array(
+					'ok'    => true,
+					'value' => call_user_func_array( array( $class, $method ), $args ),
+				);
+			} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- intentional: version mismatch despite the method existing (e.g. an incompatible signature); fall through to the warning and let the caller apply its fallback.
+				unset( $e );
+			}
+		}
+
+		if ( class_exists( $class ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( "FairAudience: fair-events-experimental's EventSignupPricing::{$method}() is missing or incompatible (version mismatch); falling back." );
+		}
+
+		return array(
+			'ok'    => false,
+			'value' => null,
+		);
+	}
+
+	/**
+	 * Resolve the effective price for a specific ticket type.
 	 *
 	 * @param int      $ticket_type_id Ticket type ID.
 	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
 	 * @return float|null Final price, or null when not purchasable right now.
 	 */
 	public static function resolve_price_for_ticket_type( $ticket_type_id, $participant_id = null ) {
-		if ( method_exists( \FairEventsExperimental\Services\EventSignupPricing::class, 'resolve_price_for_ticket_type' ) ) {
-			return \FairEventsExperimental\Services\EventSignupPricing::resolve_price_for_ticket_type( $ticket_type_id, $participant_id );
-		}
-
-		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( 'FairAudience: fair-events-experimental is missing EventSignupPricing::resolve_price_for_ticket_type() (version mismatch); falling back to base price.' );
+		$result = self::call_experimental( 'resolve_price_for_ticket_type', array( $ticket_type_id, $participant_id ) );
+		if ( $result['ok'] ) {
+			return $result['value'];
 		}
 
 		if ( class_exists( \FairEvents\Services\TicketPricing::class ) ) {
@@ -59,21 +89,16 @@ class SignupPriceResolver {
 	 * resolve_price_for_ticket_type()'s fallback pattern: prefers the
 	 * full-featured experimental resolver, and otherwise falls back to the
 	 * base fair-events price with no rule (group discounts are
-	 * experimental-only). Guarded with `method_exists()` for the same
-	 * version-skew reason (issue #1421).
+	 * experimental-only).
 	 *
 	 * @param int      $ticket_type_id Ticket type ID.
 	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
 	 * @return array{price: float, rule: object|null}|null Null when not purchasable right now.
 	 */
 	public static function resolve_price_and_rule_for_ticket_type( $ticket_type_id, $participant_id = null ) {
-		if ( method_exists( \FairEventsExperimental\Services\EventSignupPricing::class, 'resolve_price_and_rule_for_ticket_type' ) ) {
-			return \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule_for_ticket_type( $ticket_type_id, $participant_id );
-		}
-
-		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( 'FairAudience: fair-events-experimental is missing EventSignupPricing::resolve_price_and_rule_for_ticket_type() (version mismatch); falling back to base price with no rule.' );
+		$result = self::call_experimental( 'resolve_price_and_rule_for_ticket_type', array( $ticket_type_id, $participant_id ) );
+		if ( $result['ok'] ) {
+			return $result['value'];
 		}
 
 		if ( class_exists( \FairEvents\Services\TicketPricing::class ) ) {
@@ -92,8 +117,7 @@ class SignupPriceResolver {
 	 * date, and the price it produces. Mirrors
 	 * resolve_price_and_rule_for_ticket_type()'s fallback pattern, for
 	 * call sites that already have a resolved base price (activity option
-	 * pricing) rather than a ticket type. Guarded with `method_exists()`
-	 * for the same version-skew reason (issue #1421).
+	 * pricing) rather than a ticket type.
 	 *
 	 * @param float    $base_price     Base (undiscounted) price.
 	 * @param int      $event_date_id  Event date ID the discount rules belong to.
@@ -101,13 +125,9 @@ class SignupPriceResolver {
 	 * @return array{price: float, rule: object|null} Resolved price and the rule that produced it.
 	 */
 	public static function resolve_price_and_rule( $base_price, $event_date_id, $participant_id = null ) {
-		if ( method_exists( \FairEventsExperimental\Services\EventSignupPricing::class, 'resolve_price_and_rule' ) ) {
-			return \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule( $base_price, $event_date_id, $participant_id );
-		}
-
-		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( 'FairAudience: fair-events-experimental is missing EventSignupPricing::resolve_price_and_rule() (version mismatch); falling back to base price with no rule.' );
+		$result = self::call_experimental( 'resolve_price_and_rule', array( $base_price, $event_date_id, $participant_id ) );
+		if ( $result['ok'] ) {
+			return $result['value'];
 		}
 
 		return array(

--- a/fair-audience/src/Services/SignupPriceResolver.php
+++ b/fair-audience/src/Services/SignupPriceResolver.php
@@ -25,13 +25,25 @@ class SignupPriceResolver {
 	/**
 	 * Resolve the effective price for a specific ticket type.
 	 *
+	 * Guards with `method_exists()`, not just `class_exists()`: if
+	 * fair-events-experimental is active but stuck on a build that predates
+	 * this method (a cross-plugin release gap — see issue #1421), the class
+	 * still exists so `class_exists()` alone would stay true and the call
+	 * would fatal with "Call to undefined method". Falls back to the base
+	 * fair-events price instead.
+	 *
 	 * @param int      $ticket_type_id Ticket type ID.
 	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
 	 * @return float|null Final price, or null when not purchasable right now.
 	 */
 	public static function resolve_price_for_ticket_type( $ticket_type_id, $participant_id = null ) {
-		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+		if ( method_exists( \FairEventsExperimental\Services\EventSignupPricing::class, 'resolve_price_for_ticket_type' ) ) {
 			return \FairEventsExperimental\Services\EventSignupPricing::resolve_price_for_ticket_type( $ticket_type_id, $participant_id );
+		}
+
+		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( 'FairAudience: fair-events-experimental is missing EventSignupPricing::resolve_price_for_ticket_type() (version mismatch); falling back to base price.' );
 		}
 
 		if ( class_exists( \FairEvents\Services\TicketPricing::class ) ) {
@@ -47,15 +59,21 @@ class SignupPriceResolver {
 	 * resolve_price_for_ticket_type()'s fallback pattern: prefers the
 	 * full-featured experimental resolver, and otherwise falls back to the
 	 * base fair-events price with no rule (group discounts are
-	 * experimental-only).
+	 * experimental-only). Guarded with `method_exists()` for the same
+	 * version-skew reason (issue #1421).
 	 *
 	 * @param int      $ticket_type_id Ticket type ID.
 	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
 	 * @return array{price: float, rule: object|null}|null Null when not purchasable right now.
 	 */
 	public static function resolve_price_and_rule_for_ticket_type( $ticket_type_id, $participant_id = null ) {
-		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+		if ( method_exists( \FairEventsExperimental\Services\EventSignupPricing::class, 'resolve_price_and_rule_for_ticket_type' ) ) {
 			return \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule_for_ticket_type( $ticket_type_id, $participant_id );
+		}
+
+		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( 'FairAudience: fair-events-experimental is missing EventSignupPricing::resolve_price_and_rule_for_ticket_type() (version mismatch); falling back to base price with no rule.' );
 		}
 
 		if ( class_exists( \FairEvents\Services\TicketPricing::class ) ) {
@@ -67,6 +85,35 @@ class SignupPriceResolver {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Resolve the best group discount rule for a base price on an event
+	 * date, and the price it produces. Mirrors
+	 * resolve_price_and_rule_for_ticket_type()'s fallback pattern, for
+	 * call sites that already have a resolved base price (activity option
+	 * pricing) rather than a ticket type. Guarded with `method_exists()`
+	 * for the same version-skew reason (issue #1421).
+	 *
+	 * @param float    $base_price     Base (undiscounted) price.
+	 * @param int      $event_date_id  Event date ID the discount rules belong to.
+	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
+	 * @return array{price: float, rule: object|null} Resolved price and the rule that produced it.
+	 */
+	public static function resolve_price_and_rule( $base_price, $event_date_id, $participant_id = null ) {
+		if ( method_exists( \FairEventsExperimental\Services\EventSignupPricing::class, 'resolve_price_and_rule' ) ) {
+			return \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule( $base_price, $event_date_id, $participant_id );
+		}
+
+		if ( class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( 'FairAudience: fair-events-experimental is missing EventSignupPricing::resolve_price_and_rule() (version mismatch); falling back to base price with no rule.' );
+		}
+
+		return array(
+			'price' => $base_price,
+			'rule'  => null,
+		);
 	}
 
 	/**

--- a/fair-audience/src/blocks/event-signup/render.php
+++ b/fair-audience/src/blocks/event-signup/render.php
@@ -538,8 +538,8 @@ if ( $pricing_event_date_id && class_exists( \FairEventsExperimental\Models\Tick
 			continue;
 		}
 		$opt_price = (float) $resolved_base;
-		if ( $participant && $opt_price > 0 && class_exists( \FairEventsExperimental\Services\EventSignupPricing::class ) ) {
-			$opt_price = \FairEventsExperimental\Services\EventSignupPricing::resolve_price_and_rule(
+		if ( $participant && $opt_price > 0 ) {
+			$opt_price = \FairAudience\Services\SignupPriceResolver::resolve_price_and_rule(
 				$opt_price,
 				(int) $pricing_event_date_id,
 				(int) $participant->id


### PR DESCRIPTION
## Summary

- Add `"fair-events-experimental": patch` to the pending `fix-group-discount-note-mismatch` changeset, closing the release gap that let `fair-audience` ship code calling `EventSignupPricing` methods `fair-events-experimental` doesn't yet have on its own release.
- Harden `fair-audience/src/Services/SignupPriceResolver.php` as the single seam every call site uses to reach ticket-type pricing: it now guards with `method_exists()` (not just `class_exists()`), falling back to the base price (rule: `null`) and an `error_log()` warning when the experimental plugin is active but running a build that predates the expected methods.
- Route the four call sites that previously reached `EventSignupPricing` directly — `PaymentHooks.php`, `render.php`, `EventSignupController.php`, `SignupActivities.php` — through the hardened facade instead.
- Add a "Cross-plugin interface changes" section to `RELEASES.md` documenting the rule this incident violated.
- Add `SignupPriceResolverTest.php` (with a local stub reproducing the exact stale-version shape) asserting the facade degrades instead of fataling.

Closes #1421

## Acceptance criteria

- [x] **The release that introduced the group discount pricing change is completed so both plugins ship in sync.** The pending changeset now declares both `fair-audience` and `fair-events-experimental`.
- [x] **Existing affected sites no longer fatal when viewing an event page with group discount ticket rules, once updated.** Once this PR merges and both plugins release together, the version mismatch that caused the fatal no longer exists for sites that update. It's also independently covered by the next item.
- [x] **The calling code no longer causes a hard fatal if the other plugin's version doesn't yet support the expected pricing interface.** `SignupPriceResolver`'s guards now check `method_exists()`, not `class_exists()`, and every call site goes through it. Verified with `wp eval-file` against a stub reproducing the exact stale-version shape (class exists, old method only) — see Test plan.
- [x] **A note or check is added to the release process to catch cross-plugin interface changes.** `RELEASES.md` gets a new "Cross-plugin interface changes" section; a CI check was scoped out as a follow-up per the plan's Decisions.

## Test plan

- [x] `vendor/bin/phpunit` in `fair-audience` — 90 tests pass, including the new `SignupPriceResolverTest` (3 tests covering all three facade methods degrading gracefully against a stale-shape stub).
- [x] `vendor/bin/phpcs` clean on every changed line (pre-existing findings in `EventSignupController.php`/`render.php`/`PaymentHooks.php` are on lines this PR didn't touch).
- [x] `npm run test:js` in `fair-audience` — 27 tests pass, no JS changed.
- [x] `npm run build` in `fair-audience` — compiled `build/blocks/event-signup/render.php` picks up the facade change.
- [x] Live `wp eval-file` check reproducing the exact issue-#1421 crash (a stub `EventSignupPricing` class with only the old `resolve_price_for_ticket_type()` method, calling all three facade methods against it): confirmed no fatal, a logged warning, and a graceful base-price fallback instead.
- [x] Live `wp eval-file` check against the real, current `fair-events-experimental` build (temporarily activated) confirming `method_exists()` correctly recognizes the new methods and reaches them with no spurious fallback.
