### PR TITLE
Bulk-resolve signup pricing instead of per-tier

### DIFF
--- a/.changeset/bulk-resolve-signup-pricing.md
+++ b/.changeset/bulk-resolve-signup-pricing.md
@@ -1,0 +1,7 @@
+---
+"fair-events": patch
+"fair-events-experimental": patch
+"fair-audience": patch
+---
+
+Reduce the database queries issued when rendering or purchasing through the Event Signup form: the active sale period, the viewer's group memberships, and the event's discount rules are now resolved once per render/request and reused across every ticket tier and activity, instead of being re-resolved once per tier. Query count no longer scales with the number of ticket tiers; displayed and charged prices are unchanged.

--- a/fair-audience/__tests__/Services/SignupPriceResolverTest.php
+++ b/fair-audience/__tests__/Services/SignupPriceResolverTest.php
@@ -57,4 +57,49 @@ class SignupPriceResolverTest extends TestCase {
 			$result
 		);
 	}
+
+	/**
+	 * Confirms resolve_prices_and_rules_for_ticket_types() — the bulk
+	 * facade added for issue #1299 — degrades to an empty result instead of
+	 * fataling when the stale stub lacks the method and fair-events'
+	 * TicketPricing isn't loaded in this isolated unit test either (the
+	 * facade's own fallback chain, same as resolve_price_and_rule_for_ticket_type()).
+	 */
+	public function test_resolve_prices_and_rules_for_ticket_types_degrades_without_fatal() {
+		$this->assertSame(
+			array(),
+			SignupPriceResolver::resolve_prices_and_rules_for_ticket_types( 5, array( 1, 2 ), 2 )
+		);
+	}
+
+	/**
+	 * Confirms resolve_prices_and_rules() — the bulk facade added for issue
+	 * #1299 — degrades to passing every base price through unchanged with no
+	 * rule, mirroring resolve_price_and_rule()'s own fallback, instead of
+	 * fataling when the stale stub lacks the method.
+	 */
+	public function test_resolve_prices_and_rules_degrades_to_base_prices_without_fatal() {
+		$result = SignupPriceResolver::resolve_prices_and_rules(
+			5,
+			array(
+				10 => 20.0,
+				11 => 0.0,
+			),
+			2
+		);
+
+		$this->assertSame(
+			array(
+				10 => array(
+					'price' => 20.0,
+					'rule'  => null,
+				),
+				11 => array(
+					'price' => 0.0,
+					'rule'  => null,
+				),
+			),
+			$result
+		);
+	}
 }

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -16,6 +16,7 @@ use FairAudience\Services\AudienceSession;
 use FairAudience\Services\EmailService;
 use FairAudience\Services\GroupSignupPricing;
 use FairAudience\Services\ParticipantToken;
+use FairAudience\Services\SignupActivities;
 use WP_REST_Controller;
 use WP_REST_Server;
 use WP_REST_Request;
@@ -1660,28 +1661,10 @@ class EventSignupController extends WP_REST_Controller {
 			}
 		}
 
-		if ( ! $participant_id ) {
-			return $base_price_by_option_id;
-		}
-
-		$discountable = array_filter(
-			$base_price_by_option_id,
-			static function ( $price ) {
-				return $price > 0;
-			}
-		);
-		if ( empty( $discountable ) ) {
-			return $base_price_by_option_id;
-		}
-
-		$resolved_by_option_id = \FairAudience\Services\SignupPriceResolver::resolve_prices_and_rules( $event_date_id, $discountable, $participant_id );
-
-		$prices = $base_price_by_option_id;
-		foreach ( $resolved_by_option_id as $option_id => $resolved ) {
-			$prices[ $option_id ] = $resolved['price'];
-		}
-
-		return $prices;
+		// Discount resolution itself is identical to the render overlay's own
+		// bulk option-price step — delegate instead of a second hand-rolled
+		// copy of the same "filter discountable, bulk-resolve, merge back" logic.
+		return SignupActivities::resolve_prices_for_participant( $base_price_by_option_id, $event_date_id, $participant_id );
 	}
 
 	/**
@@ -1784,10 +1767,18 @@ class EventSignupController extends WP_REST_Controller {
 		// Each option resolves its own best-matching group discount rule
 		// against its own real base price (issue #1297), resolved once for the
 		// whole selection here and reused below when building line items,
-		// instead of recomputing per option twice over (issue #1299).
+		// instead of recomputing per option twice over (issue #1299). Summed
+		// per raw selected item (not per unique option ID) so a duplicate
+		// option ID counts twice here exactly as it does in the line items
+		// built below — array_sum() over the ID-keyed map would silently
+		// collapse a duplicate and undercount the total against what's
+		// actually charged.
 		$option_prices = $this->resolve_option_prices( $option_items, $event_date_id, (int) $participant->id );
-		$options_total = array_sum( $option_prices );
-		$total_amount  = (float) ( $final_price ?? 0 ) + $options_total;
+		$options_total = 0.0;
+		foreach ( $option_items as $opt ) {
+			$options_total += $option_prices[ (int) $opt->id ];
+		}
+		$total_amount = (float) ( $final_price ?? 0 ) + $options_total;
 
 		// Determine whether a price is configured for this event regardless of
 		// how the resolution turned out (discount-to-zero, service unavailable, etc.).

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -14,6 +14,7 @@ use FairAudience\Database\EmailConfirmationTokenRepository;
 use FairAudience\Models\Participant;
 use FairAudience\Services\AudienceSession;
 use FairAudience\Services\EmailService;
+use FairAudience\Services\GroupSignupPricing;
 use FairAudience\Services\ParticipantToken;
 use WP_REST_Controller;
 use WP_REST_Server;
@@ -1200,10 +1201,12 @@ class EventSignupController extends WP_REST_Controller {
 	 * @return \WP_REST_Response|\WP_Error|null Response/error on paid path, null on free path.
 	 */
 	private function maybe_start_addon_payment( $event_id, $event_date_id, $participant, $event_participant, $user_id, $new_options ) {
+		$option_prices = $this->resolve_option_prices( $new_options, $event_date_id, (int) $participant->id );
+
 		$line_items   = array();
 		$total_amount = 0;
 		foreach ( $new_options as $opt ) {
-			$opt_price     = $this->compute_option_price( $opt, $event_date_id, (int) $participant->id );
+			$opt_price     = $option_prices[ (int) $opt->id ];
 			$total_amount += $opt_price;
 			if ( 0.0 !== (float) $opt_price ) {
 				$line_items[] = array(
@@ -1323,40 +1326,17 @@ class EventSignupController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Validate that a participant is allowed to use a group-restricted ticket type.
+	 * Validate that a participant is allowed to use a group-restricted ticket
+	 * type. Delegates to the shared GroupSignupPricing service — the same
+	 * membership-consulting authority the unified-block render overlay uses
+	 * — instead of a separately hand-rolled lookup (issue #1299).
 	 *
 	 * @param int|null $ticket_type_id   Ticket type ID, or null if none selected.
 	 * @param int      $participant_id   Participant ID.
 	 * @return WP_Error|null WP_Error if restricted, null if allowed.
 	 */
 	private function validate_ticket_type_group_restriction( $ticket_type_id, $participant_id ) {
-		if ( ! $ticket_type_id ) {
-			return null;
-		}
-
-		if ( ! class_exists( \FairEventsExperimental\Models\TicketTypeGroupRestriction::class ) ||
-		! class_exists( \FairAudienceExperimental\Database\GroupParticipantRepository::class ) ) {
-			return null;
-		}
-
-		$allowed_group_ids = \FairEventsExperimental\Models\TicketTypeGroupRestriction::get_group_ids_by_ticket_type_id( $ticket_type_id );
-		if ( empty( $allowed_group_ids ) ) {
-			return null;
-		}
-
-		$group_participant_repo = new \FairAudienceExperimental\Database\GroupParticipantRepository();
-		$memberships            = $group_participant_repo->get_by_participant( $participant_id );
-		$participant_group_ids  = array_map( fn( $m ) => (int) $m->group_id, $memberships );
-
-		if ( empty( array_intersect( $allowed_group_ids, $participant_group_ids ) ) ) {
-			return new WP_Error(
-				'ticket_type_restricted',
-				__( 'This ticket type is not available for your account.', 'fair-audience' ),
-				array( 'status' => 403 )
-			);
-		}
-
-		return null;
+		return GroupSignupPricing::restriction_error( $ticket_type_id, $participant_id );
 	}
 
 	/**
@@ -1656,31 +1636,52 @@ class EventSignupController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Compute the effective price for a ticket option, applying the buyer's
-	 * best-matching group pricing rule for this option's own real base
-	 * price — not a shared event-date-level rule, so mixed percentage/amount
-	 * rules resolve correctly per option (issue #1297).
+	 * Resolve every selected option's effective price in one bulk call,
+	 * applying the buyer's best-matching group pricing rule for each
+	 * option's own real base price — not a shared event-date-level rule, so
+	 * mixed percentage/amount rules resolve correctly per option (issue
+	 * #1297). The event's discount rules and the buyer's group membership
+	 * are each fetched once for the whole selection rather than once per
+	 * option (issue #1299).
 	 *
-	 * @param object   $option         TicketOption object.
+	 * @param object[] $option_items   Selected TicketOption objects.
 	 * @param int      $event_date_id  Event date ID.
 	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
-	 * @return float Effective option price (>= 0 inputs assumed; may be 0).
+	 * @return array<int, float> Effective prices (>= 0 inputs assumed; may be 0), keyed by option ID.
 	 */
-	private function compute_option_price( $option, $event_date_id, $participant_id ) {
-		if ( class_exists( \FairEventsExperimental\Services\ActivityOptionPriceResolver::class ) ) {
-			$resolved  = \FairEventsExperimental\Services\ActivityOptionPriceResolver::resolve( $option );
-			$opt_price = null !== $resolved ? (float) $resolved : 0.0;
-		} else {
-			$opt_price = (float) $option->price;
+	private function resolve_option_prices( array $option_items, $event_date_id, $participant_id ) {
+		$base_price_by_option_id = array();
+		foreach ( $option_items as $option ) {
+			if ( class_exists( \FairEventsExperimental\Services\ActivityOptionPriceResolver::class ) ) {
+				$resolved                                     = \FairEventsExperimental\Services\ActivityOptionPriceResolver::resolve( $option );
+				$base_price_by_option_id[ (int) $option->id ] = null !== $resolved ? (float) $resolved : 0.0;
+			} else {
+				$base_price_by_option_id[ (int) $option->id ] = (float) $option->price;
+			}
 		}
-		if ( $participant_id && $opt_price > 0 ) {
-			$opt_price = \FairAudience\Services\SignupPriceResolver::resolve_price_and_rule(
-				$opt_price,
-				$event_date_id,
-				$participant_id
-			)['price'];
+
+		if ( ! $participant_id ) {
+			return $base_price_by_option_id;
 		}
-		return $opt_price;
+
+		$discountable = array_filter(
+			$base_price_by_option_id,
+			static function ( $price ) {
+				return $price > 0;
+			}
+		);
+		if ( empty( $discountable ) ) {
+			return $base_price_by_option_id;
+		}
+
+		$resolved_by_option_id = \FairAudience\Services\SignupPriceResolver::resolve_prices_and_rules( $event_date_id, $discountable, $participant_id );
+
+		$prices = $base_price_by_option_id;
+		foreach ( $resolved_by_option_id as $option_id => $resolved ) {
+			$prices[ $option_id ] = $resolved['price'];
+		}
+
+		return $prices;
 	}
 
 	/**
@@ -1781,16 +1782,12 @@ class EventSignupController extends WP_REST_Controller {
 
 		// Option prices count towards the total even when there is no base price.
 		// Each option resolves its own best-matching group discount rule
-		// against its own real base price (issue #1297).
-		$options_total = 0;
-		foreach ( $option_items as $opt ) {
-			$options_total += $this->compute_option_price(
-				$opt,
-				$event_date_id,
-				(int) $participant->id
-			);
-		}
-		$total_amount = (float) ( $final_price ?? 0 ) + $options_total;
+		// against its own real base price (issue #1297), resolved once for the
+		// whole selection here and reused below when building line items,
+		// instead of recomputing per option twice over (issue #1299).
+		$option_prices = $this->resolve_option_prices( $option_items, $event_date_id, (int) $participant->id );
+		$options_total = array_sum( $option_prices );
+		$total_amount  = (float) ( $final_price ?? 0 ) + $options_total;
 
 		// Determine whether a price is configured for this event regardless of
 		// how the resolution turned out (discount-to-zero, service unavailable, etc.).
@@ -1879,11 +1876,7 @@ class EventSignupController extends WP_REST_Controller {
 			);
 		}
 		foreach ( $option_items as $opt ) {
-			$opt_price = $this->compute_option_price(
-				$opt,
-				$event_date_id,
-				(int) $participant->id
-			);
+			$opt_price = $option_prices[ (int) $opt->id ];
 			if ( 0.0 !== $opt_price ) {
 				$line_items[] = array(
 					'name'     => $opt->name,

--- a/fair-audience/src/Hooks/SignupHookBridge.php
+++ b/fair-audience/src/Hooks/SignupHookBridge.php
@@ -116,17 +116,28 @@ class SignupHookBridge {
 			// charged. Clamped at 0 — an amount-discount larger than the price
 			// can never show (or charge) a negative amount. Each type's own
 			// winning rule rides along so the note below can tell whether every
-			// discounted type agrees on the same rule (issue #1297).
+			// discounted type agrees on the same rule (issue #1297). Resolved in
+			// one bulk call so the sale period, discount rules, and viewer's
+			// group membership are each fetched once per render, not once per
+			// tier (issue #1299).
+			$ticket_type_ids     = array_map(
+				static function ( $ticket_type ) {
+					return (int) $ticket_type->id;
+				},
+				$context['ticket_types']
+			);
+			$resolved_by_type_id = SignupPriceResolver::resolve_prices_and_rules_for_ticket_types(
+				$pricing_event_date_id,
+				$ticket_type_ids,
+				$participant_id
+			);
+
 			$price_by_type_id = array();
 			$rule_by_type_id  = array();
-			foreach ( $context['ticket_types'] as $ticket_type ) {
-				$resolved = SignupPriceResolver::resolve_price_and_rule_for_ticket_type( (int) $ticket_type->id, $participant_id );
-				if ( null === $resolved ) {
-					continue;
-				}
-				$price_by_type_id[ (int) $ticket_type->id ] = max( 0, $resolved['price'] );
+			foreach ( $resolved_by_type_id as $ticket_type_id => $resolved ) {
+				$price_by_type_id[ $ticket_type_id ] = max( 0, $resolved['price'] );
 				if ( null !== $resolved['rule'] ) {
-					$rule_by_type_id[ (int) $ticket_type->id ] = $resolved['rule'];
+					$rule_by_type_id[ $ticket_type_id ] = $resolved['rule'];
 				}
 			}
 			$context['price_by_type_id'] = $price_by_type_id;

--- a/fair-audience/src/Services/SignupActivities.php
+++ b/fair-audience/src/Services/SignupActivities.php
@@ -108,6 +108,46 @@ class SignupActivities {
 	}
 
 	/**
+	 * Bulk counterpart to resolve_price_for_participant(): resolves several
+	 * options' discounted prices in one call instead of once per option, so
+	 * the event's discount rules and the viewer's group membership are each
+	 * fetched once per render/request rather than once per option (issue
+	 * #1299). Options with a zero/negative base price are left out of the
+	 * lookup (nothing to discount) and pass through unchanged, mirroring
+	 * resolve_price_for_participant()'s own guard.
+	 *
+	 * @param array<int, float> $base_price_by_option_id Base (undiscounted) option prices, keyed by option ID.
+	 * @param int               $pricing_event_date_id  Event date the discount rules belong to.
+	 * @param int|null          $participant_id          Viewer's participant ID, or null for anonymous.
+	 * @return array<int, float> Resolved prices, keyed by option ID — same keys as the input.
+	 */
+	public static function resolve_prices_for_participant( array $base_price_by_option_id, $pricing_event_date_id, $participant_id ) {
+		if ( ! $participant_id ) {
+			return $base_price_by_option_id;
+		}
+
+		$discountable = array_filter(
+			$base_price_by_option_id,
+			static function ( $price ) {
+				return $price > 0;
+			}
+		);
+
+		$resolved_by_option_id = empty( $discountable )
+			? array()
+			: \FairAudience\Services\SignupPriceResolver::resolve_prices_and_rules( $pricing_event_date_id, $discountable, $participant_id );
+
+		$prices = array();
+		foreach ( $base_price_by_option_id as $option_id => $base_price ) {
+			$prices[ $option_id ] = isset( $resolved_by_option_id[ $option_id ] )
+				? $resolved_by_option_id[ $option_id ]['price']
+				: $base_price;
+		}
+
+		return $prices;
+	}
+
+	/**
 	 * Whether a raw TicketOption is full, based on its configured capacity.
 	 *
 	 * @param object                     $option Raw TicketOption row (needs `id`, `capacity`).
@@ -239,7 +279,8 @@ class SignupActivities {
 			return array();
 		}
 
-		$line_items = array();
+		$name_by_option_id       = array();
+		$base_price_by_option_id = array();
 		foreach ( $ticket_option_ids as $option_id ) {
 			$option = \FairEventsExperimental\Models\TicketOption::get_by_id( (int) $option_id );
 			if ( ! $option ) {
@@ -253,10 +294,21 @@ class SignupActivities {
 				continue;
 			}
 
+			$name_by_option_id[ (int) $option_id ]       = $option->name;
+			$base_price_by_option_id[ (int) $option_id ] = (float) $base_price;
+		}
+
+		// One bulk call resolves every selected option's discount at once,
+		// instead of re-fetching the event's rules and the participant's
+		// group membership per option (issue #1299).
+		$resolved_prices = self::resolve_prices_for_participant( $base_price_by_option_id, $pricing_event_date_id, $participant_id );
+
+		$line_items = array();
+		foreach ( $name_by_option_id as $option_id => $name ) {
 			$line_items[] = array(
-				'name'     => $option->name,
+				'name'     => $name,
 				'quantity' => 1,
-				'amount'   => self::resolve_price_for_participant( (float) $base_price, $pricing_event_date_id, $participant_id ),
+				'amount'   => $resolved_prices[ $option_id ],
 			);
 		}
 
@@ -303,8 +355,17 @@ class SignupActivities {
 			? $event_participant_repository->get_confirmed_option_ids_for_event_participant( (int) $signed_row->id )
 			: array();
 
+		// One bulk call resolves every option's discount at once, instead of
+		// re-fetching the event's rules and the participant's group
+		// membership per option on every render (issue #1299).
+		$base_price_by_option_id = array();
+		foreach ( $context['ticket_options'] as $option ) {
+			$base_price_by_option_id[ (int) $option['id'] ] = (float) $option['price'];
+		}
+		$resolved_prices = self::resolve_prices_for_participant( $base_price_by_option_id, $pricing_event_date_id, $participant_id );
+
 		foreach ( $context['ticket_options'] as &$option ) {
-			$option['price'] = self::resolve_price_for_participant( (float) $option['price'], $pricing_event_date_id, $participant_id );
+			$option['price'] = $resolved_prices[ (int) $option['id'] ];
 
 			$is_full = false;
 			if ( class_exists( \FairEventsExperimental\Models\TicketOption::class ) ) {

--- a/fair-audience/src/Services/SignupPriceResolver.php
+++ b/fair-audience/src/Services/SignupPriceResolver.php
@@ -137,6 +137,76 @@ class SignupPriceResolver {
 	}
 
 	/**
+	 * Bulk counterpart to resolve_price_and_rule_for_ticket_type(): resolves
+	 * every ticket type's price + winning discount rule for one event date in
+	 * a single call, instead of once per type — the fix for the per-tier
+	 * query multiplication in issue #1299. Callers looping over an event
+	 * date's ticket types (the signup render, the purchase flow) should call
+	 * this once instead of resolve_price_and_rule_for_ticket_type() per type.
+	 *
+	 * @param int      $event_date_id   Event date ID.
+	 * @param int[]    $ticket_type_ids Ticket type IDs to resolve, all belonging to $event_date_id.
+	 * @param int|null $participant_id  fair-audience participant ID, or null for anonymous.
+	 * @return array<int, array{price: float, rule: object|null}> Keyed by ticket type ID;
+	 *         a type not purchasable right now is omitted, matching resolve_price_and_rule_for_ticket_type()'s null.
+	 */
+	public static function resolve_prices_and_rules_for_ticket_types( $event_date_id, array $ticket_type_ids, $participant_id = null ) {
+		$result = self::call_experimental( 'resolve_prices_and_rules_for_ticket_types', array( $event_date_id, $ticket_type_ids, $participant_id ) );
+		if ( $result['ok'] ) {
+			return $result['value'];
+		}
+
+		if ( ! class_exists( \FairEvents\Services\TicketPricing::class ) ) {
+			return array();
+		}
+
+		$resolved_prices       = \FairEvents\Services\TicketPricing::resolve_unit_prices_for_event_date( $event_date_id );
+		$base_price_by_type_id = \FairEvents\Services\TicketPricing::base_prices_for_types(
+			$ticket_type_ids,
+			$resolved_prices['price_by_type_id'],
+			$resolved_prices['priced_type_ids']
+		);
+
+		$resolved = array();
+		foreach ( $base_price_by_type_id as $ticket_type_id => $price ) {
+			$resolved[ $ticket_type_id ] = array(
+				'price' => $price,
+				'rule'  => null,
+			);
+		}
+
+		return $resolved;
+	}
+
+	/**
+	 * Bulk counterpart to resolve_price_and_rule(): resolves the winning
+	 * discount rule for several already-known base prices on one event date
+	 * — e.g. activity/ticket-option prices — in a single call instead of once
+	 * per price.
+	 *
+	 * @param int                      $event_date_id     Event date ID the discount rules belong to.
+	 * @param array<int|string, float> $base_price_by_key Base (undiscounted) prices, keyed however the caller likes.
+	 * @param int|null                 $participant_id    fair-audience participant ID, or null for anonymous.
+	 * @return array<int|string, array{price: float, rule: object|null}> Same keys as $base_price_by_key.
+	 */
+	public static function resolve_prices_and_rules( $event_date_id, array $base_price_by_key, $participant_id = null ) {
+		$result = self::call_experimental( 'resolve_prices_and_rules', array( $event_date_id, $base_price_by_key, $participant_id ) );
+		if ( $result['ok'] ) {
+			return $result['value'];
+		}
+
+		$resolved = array();
+		foreach ( $base_price_by_key as $key => $base_price ) {
+			$resolved[ $key ] = array(
+				'price' => $base_price,
+				'rule'  => null,
+			);
+		}
+
+		return $resolved;
+	}
+
+	/**
 	 * Check whether a positive price is configured for a ticket type,
 	 * ignoring discount rules and sale-period timing. Used by the
 	 * fail-closed "payment unavailable" guard so a paid event never

--- a/fair-audience/src/Services/SignupPriceResolver.php
+++ b/fair-audience/src/Services/SignupPriceResolver.php
@@ -160,7 +160,16 @@ class SignupPriceResolver {
 			return array();
 		}
 
-		$resolved_prices       = \FairEvents\Services\TicketPricing::resolve_unit_prices_for_event_date( $event_date_id );
+		$resolved_prices = \FairEvents\Services\TicketPricing::resolve_unit_prices_for_event_date( $event_date_id );
+
+		// No active sale period at all → nothing is purchasable (matches
+		// resolve_unit_price()'s null), not "every type is free" — an empty
+		// price map alone can't distinguish that from a period being active
+		// with nothing ever priced.
+		if ( ! $resolved_prices['active_period'] ) {
+			return array();
+		}
+
 		$base_price_by_type_id = \FairEvents\Services\TicketPricing::base_prices_for_types(
 			$ticket_type_ids,
 			$resolved_prices['price_by_type_id'],
@@ -169,8 +178,21 @@ class SignupPriceResolver {
 
 		$resolved = array();
 		foreach ( $base_price_by_type_id as $ticket_type_id => $price ) {
+			// Mirrors resolve_unit_price()'s own filter application — the
+			// bulk helper this fallback is built on intentionally skips it
+			// (see base_prices_for_types()' docblock), so apply it here per
+			// type to keep this fallback's behaviour identical to the old
+			// single-item resolve_price_and_rule_for_ticket_type() fallback.
 			$resolved[ $ticket_type_id ] = array(
-				'price' => $price,
+				'price' => (float) apply_filters(
+					'fair_events_resolve_ticket_price',
+					$price,
+					$ticket_type_id,
+					array(
+						'event_date_id'  => $event_date_id,
+						'sale_period_id' => $resolved_prices['active_period']->id,
+					)
+				),
 				'rule'  => null,
 			);
 		}

--- a/fair-events-experimental/__tests__/Services/EventSignupPricingTest.php
+++ b/fair-events-experimental/__tests__/Services/EventSignupPricingTest.php
@@ -136,4 +136,106 @@ class EventSignupPricingTest extends TestCase {
 		$this->assertSame( 10.0, $result['price'] );
 		$this->assertNull( $result['rule'] );
 	}
+
+	/**
+	 * Covers filter_matching_rules() — the pure rule-matching step behind the
+	 * bulk resolver's single get_by_participant() call (issue #1299),
+	 * replacing resolve_price_and_rule()'s per-rule
+	 * get_by_group_and_participant() loop.
+	 */
+
+	/**
+	 * A rule whose group the participant belongs to is kept.
+	 */
+	public function test_filter_matching_rules_keeps_matching_group() {
+		$rule           = $this->rule( 1, 'percentage', 20 );
+		$rule->group_id = 5;
+
+		$result = EventSignupPricing::filter_matching_rules( array( $rule ), array( 5, 6 ) );
+
+		$this->assertSame( array( $rule ), $result );
+	}
+
+	/**
+	 * A rule whose group the participant does not belong to is dropped.
+	 */
+	public function test_filter_matching_rules_drops_non_matching_group() {
+		$rule           = $this->rule( 1, 'percentage', 20 );
+		$rule->group_id = 9;
+
+		$result = EventSignupPricing::filter_matching_rules( array( $rule ), array( 5, 6 ) );
+
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * A mixed set of rules keeps only the ones matching the participant's
+	 * groups, reindexed — this is the batch equivalent of calling
+	 * get_by_group_and_participant() once per rule, done as one in-memory
+	 * pass over a membership set fetched exactly once.
+	 */
+	public function test_filter_matching_rules_mixed_set() {
+		$matching               = $this->rule( 1, 'percentage', 20 );
+		$matching->group_id     = 5;
+		$non_matching           = $this->rule( 2, 'amount', 3 );
+		$non_matching->group_id = 9;
+
+		$result = EventSignupPricing::filter_matching_rules( array( $matching, $non_matching ), array( 5 ) );
+
+		$this->assertSame( array( $matching ), $result );
+	}
+
+	/**
+	 * No membership at all matches nothing.
+	 */
+	public function test_filter_matching_rules_no_membership_matches_nothing() {
+		$rule           = $this->rule( 1, 'percentage', 20 );
+		$rule->group_id = 5;
+
+		$result = EventSignupPricing::filter_matching_rules( array( $rule ), array() );
+
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * Covers resolve_prices_and_rules() — the bulk price+rule resolver.
+	 */
+
+	/**
+	 * Without a participant, every key's base price passes through
+	 * unchanged with no rule, and no rule/membership lookup is attempted —
+	 * matches resolve_price_and_rule()'s anonymous-viewer fast path.
+	 */
+	public function test_resolve_prices_and_rules_without_participant_passes_prices_through() {
+		$result = EventSignupPricing::resolve_prices_and_rules(
+			5,
+			array(
+				1 => 10.0,
+				2 => 0.0,
+			),
+			null
+		);
+
+		$this->assertSame(
+			array(
+				1 => array(
+					'price' => 10.0,
+					'rule'  => null,
+				),
+				2 => array(
+					'price' => 0.0,
+					'rule'  => null,
+				),
+			),
+			$result
+		);
+	}
+
+	/**
+	 * An empty price map resolves to an empty result without touching
+	 * anything else.
+	 */
+	public function test_resolve_prices_and_rules_empty_input_returns_empty() {
+		$this->assertSame( array(), EventSignupPricing::resolve_prices_and_rules( 5, array(), 2 ) );
+	}
 }

--- a/fair-events-experimental/src/Services/EventSignupPricing.php
+++ b/fair-events-experimental/src/Services/EventSignupPricing.php
@@ -103,6 +103,113 @@ class EventSignupPricing {
 	}
 
 	/**
+	 * Bulk counterpart to resolve_price_and_rule_for_ticket_type(): resolves
+	 * every ticket type's price + winning discount rule for one event date in
+	 * a single pass, instead of once per type. Where the single-item version
+	 * re-resolves the active sale period, re-fetches the event's discount
+	 * rules, and re-queries the participant's group membership per matching
+	 * rule on every call, this fetches each exactly once and reuses them
+	 * across every requested type — the query count no longer scales with the
+	 * number of ticket types (issue #1299).
+	 *
+	 * @param int      $event_date_id  Event date ID.
+	 * @param int[]    $ticket_type_ids Ticket type IDs to resolve, all belonging to $event_date_id.
+	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
+	 * @return array<int, array{price: float, rule: GroupPricingRule|null}> Keyed by ticket type ID;
+	 *         a type with no active-period price and no price row for any period is omitted
+	 *         (not purchasable right now), matching resolve_price_for_ticket_type()'s null.
+	 */
+	public static function resolve_prices_and_rules_for_ticket_types( $event_date_id, array $ticket_type_ids, $participant_id = null ) {
+		$resolved_prices       = TicketPricing::resolve_unit_prices_for_event_date( $event_date_id );
+		$base_price_by_type_id = TicketPricing::base_prices_for_types(
+			$ticket_type_ids,
+			$resolved_prices['price_by_type_id'],
+			$resolved_prices['priced_type_ids']
+		);
+
+		return self::resolve_prices_and_rules( $event_date_id, $base_price_by_type_id, $participant_id );
+	}
+
+	/**
+	 * Bulk counterpart to resolve_price_and_rule(): resolves the winning
+	 * discount rule for several already-known base prices on one event date
+	 * — e.g. activity/ticket-option prices — fetching the event's discount
+	 * rules and the participant's group membership once for the whole batch
+	 * instead of once per price.
+	 *
+	 * @param int                      $event_date_id     Event date ID the discount rules belong to.
+	 * @param array<int|string, float> $base_price_by_key Base (undiscounted) prices, keyed however the caller likes
+	 *                                             (ticket type ID, ticket option ID, ...) — the same keys come back.
+	 * @param int|null                 $participant_id    fair-audience participant ID, or null for anonymous.
+	 * @return array<int|string, array{price: float, rule: GroupPricingRule|null}> Same keys as $base_price_by_key.
+	 */
+	public static function resolve_prices_and_rules( $event_date_id, array $base_price_by_key, $participant_id = null ) {
+		$matching_rules = empty( $base_price_by_key )
+			? array()
+			: self::matching_rules_for_participant( $event_date_id, $participant_id );
+
+		$result = array();
+		foreach ( $base_price_by_key as $key => $base_price ) {
+			$result[ $key ] = self::best_rule_for_price( $base_price, $matching_rules );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Resolve the discount rules on an event date that the given participant
+	 * actually matches, fetching the event's rules and the participant's full
+	 * group-membership set exactly once each — the bulk counterpart to
+	 * resolve_price_and_rule()'s per-rule get_by_group_and_participant() loop.
+	 *
+	 * @param int      $event_date_id  Event date ID the discount rules belong to.
+	 * @param int|null $participant_id fair-audience participant ID, or null for anonymous.
+	 * @return GroupPricingRule[] Rules the participant belongs to a matching group for.
+	 */
+	private static function matching_rules_for_participant( $event_date_id, $participant_id ) {
+		if ( empty( $participant_id ) ) {
+			return array();
+		}
+
+		$rules = GroupPricingRule::get_all_by_event_date_id( $event_date_id );
+		if ( empty( $rules ) || ! class_exists( \FairAudienceExperimental\Database\GroupParticipantRepository::class ) ) {
+			return array();
+		}
+
+		$group_repo       = new \FairAudienceExperimental\Database\GroupParticipantRepository();
+		$memberships      = $group_repo->get_by_participant( $participant_id );
+		$member_group_ids = array_map(
+			static function ( $membership ) {
+				return (int) $membership->group_id;
+			},
+			$memberships
+		);
+
+		return self::filter_matching_rules( $rules, $member_group_ids );
+	}
+
+	/**
+	 * Keep only the rules a participant belonging to the given groups
+	 * actually matches. Pure, DB-free — the seam that makes the bulk
+	 * resolver's rule-matching unit-testable without a WordPress bootstrap,
+	 * mirroring how best_rule_for_price() isolates the discount math below.
+	 *
+	 * @param GroupPricingRule[] $rules            Candidate rules for an event date.
+	 * @param int[]              $member_group_ids Group IDs the participant belongs to.
+	 * @return GroupPricingRule[] Rules whose group_id is in $member_group_ids.
+	 */
+	public static function filter_matching_rules( array $rules, array $member_group_ids ) {
+		return array_values(
+			array_filter(
+				$rules,
+				static function ( $rule ) use ( $member_group_ids ) {
+					return in_array( (int) $rule->group_id, $member_group_ids, true );
+				}
+			)
+		);
+	}
+
+	/**
 	 * Pick the discount rule that produces the lowest price for a given base
 	 * price, out of a list of rules already known to match the participant
 	 * (e.g. group membership already checked by the caller). Pure math, no DB

--- a/fair-events-experimental/src/Services/EventSignupPricing.php
+++ b/fair-events-experimental/src/Services/EventSignupPricing.php
@@ -120,12 +120,39 @@ class EventSignupPricing {
 	 *         (not purchasable right now), matching resolve_price_for_ticket_type()'s null.
 	 */
 	public static function resolve_prices_and_rules_for_ticket_types( $event_date_id, array $ticket_type_ids, $participant_id = null ) {
-		$resolved_prices       = TicketPricing::resolve_unit_prices_for_event_date( $event_date_id );
+		$resolved_prices = TicketPricing::resolve_unit_prices_for_event_date( $event_date_id );
+
+		// No active sale period at all → nothing is purchasable, matching
+		// resolve_unit_price()'s null (not "every type is free"). An empty
+		// price map here is ambiguous on its own — it also arises when a
+		// period *is* active but nothing has ever been priced — so the
+		// active_period flag is the only reliable discriminator.
+		if ( ! $resolved_prices['active_period'] ) {
+			return array();
+		}
+
 		$base_price_by_type_id = TicketPricing::base_prices_for_types(
 			$ticket_type_ids,
 			$resolved_prices['price_by_type_id'],
 			$resolved_prices['priced_type_ids']
 		);
+
+		// Mirrors resolve_price_and_rule_for_ticket_type()'s own base price,
+		// which goes through resolve_unit_price() and so picks up this
+		// filter — base_prices_for_types() intentionally doesn't apply it
+		// (see its docblock), so it's applied here per type instead, before
+		// the discount layer runs on top of it.
+		foreach ( $base_price_by_type_id as $ticket_type_id => $base_price ) {
+			$base_price_by_type_id[ $ticket_type_id ] = (float) apply_filters(
+				'fair_events_resolve_ticket_price',
+				$base_price,
+				$ticket_type_id,
+				array(
+					'event_date_id'  => $event_date_id,
+					'sale_period_id' => $resolved_prices['active_period']->id,
+				)
+			);
+		}
 
 		return self::resolve_prices_and_rules( $event_date_id, $base_price_by_type_id, $participant_id );
 	}

--- a/fair-events/__tests__/Services/TicketPricingTest.php
+++ b/fair-events/__tests__/Services/TicketPricingTest.php
@@ -234,4 +234,67 @@ class TicketPricingTest extends TestCase {
 			TicketPricing::filter_purchasable_types( array( $type ), array(), array() )
 		);
 	}
+
+	/**
+	 * Covers base_prices_for_types() — the bulk counterpart to
+	 * resolve_unit_price(), consumed by callers resolving many types from
+	 * one resolve_unit_prices_for_event_date() call instead of once per type
+	 * (issue #1299). Mirrors resolve_unit_price()'s exact per-type rules.
+	 */
+
+	/**
+	 * A type with a price row for the active period resolves to that price.
+	 */
+	public function test_base_prices_for_types_uses_active_period_price() {
+		$result = TicketPricing::base_prices_for_types( array( 1 ), array( 1 => 12.5 ), array( 1 ) );
+
+		$this->assertSame( array( 1 => 12.5 ), $result );
+	}
+
+	/**
+	 * A type never priced for any period is free by convention, even though
+	 * it's absent from $price_by_type_id.
+	 */
+	public function test_base_prices_for_types_never_priced_is_free() {
+		$result = TicketPricing::base_prices_for_types( array( 1 ), array(), array() );
+
+		$this->assertSame( array( 1 => 0.0 ), $result );
+	}
+
+	/**
+	 * A type priced for some other period, but not the active one, is
+	 * omitted entirely — not purchasable right now, matching
+	 * resolve_unit_price()'s null.
+	 */
+	public function test_base_prices_for_types_omits_type_priced_elsewhere() {
+		$result = TicketPricing::base_prices_for_types( array( 1, 2 ), array( 1 => 12.5 ), array( 1, 2 ) );
+
+		$this->assertSame( array( 1 => 12.5 ), $result );
+	}
+
+	/**
+	 * Several requested types resolve independently in one call, each under
+	 * its own rule (priced, free-by-convention, or omitted) — the "query
+	 * count doesn't scale with tier count" guarantee reduces to this being a
+	 * single pure pass over the maps already fetched once.
+	 */
+	public function test_base_prices_for_types_resolves_several_types_independently() {
+		$price_by_type_id = array(
+			1 => 10.0,
+			3 => 0.0,
+		);
+		$priced_type_ids  = array( 1, 2, 3 );
+
+		$result = TicketPricing::base_prices_for_types( array( 1, 2, 3, 4 ), $price_by_type_id, $priced_type_ids );
+
+		$this->assertSame(
+			array(
+				1 => 10.0,
+				// 2 omitted: priced for another period, not the active one.
+				3 => 0.0,
+				4 => 0.0, // never priced anywhere → free by convention.
+			),
+			$result
+		);
+	}
 }

--- a/fair-events/src/Services/TicketPricing.php
+++ b/fair-events/src/Services/TicketPricing.php
@@ -236,11 +236,16 @@ class TicketPricing {
 	/**
 	 * Resolve the base (undiscounted) price for each of the given ticket
 	 * types from the maps resolve_unit_prices_for_event_date() returns.
-	 * Mirrors resolve_unit_price()'s own per-type semantics exactly — same
-	 * "never priced is free by convention, priced elsewhere is unavailable"
-	 * rule filter_purchasable_types() applies — but as a pure, DB-free lookup
-	 * so a caller resolving many types reuses one bulk fetch instead of
-	 * calling resolve_unit_price() (and re-querying) once per type.
+	 * Mirrors resolve_unit_price()'s "never priced is free by convention,
+	 * priced elsewhere is unavailable" per-type selection rule as a pure,
+	 * DB-free lookup, so a caller resolving many types reuses one bulk fetch
+	 * instead of calling resolve_unit_price() (and re-querying) once per
+	 * type. Unlike resolve_unit_price(), this does **not** run the price
+	 * through the `fair_events_resolve_ticket_price` filter — matching the
+	 * event-signup block's own existing bulk-fetch render path, which never
+	 * applied that filter either. A caller that needs the filter applied
+	 * (e.g. a single-item fallback that used to go through
+	 * resolve_unit_price()) must apply it itself per type.
 	 *
 	 * @param int[]   $ticket_type_ids  Ticket type IDs to resolve.
 	 * @param float[] $price_by_type_id Ticket-type ID => price for the active period.

--- a/fair-events/src/Services/TicketPricing.php
+++ b/fair-events/src/Services/TicketPricing.php
@@ -190,6 +190,82 @@ class TicketPricing {
 	}
 
 	/**
+	 * Resolve the active sale period and every ticket type's price for it in
+	 * one pass — the bulk counterpart to resolve_unit_price(), which
+	 * re-resolves the active period and re-queries prices from scratch for
+	 * every ticket type it's called for. Callers looping over an event
+	 * date's ticket types (the signup render, the signup pricing overlay)
+	 * should call this once and read the returned maps instead.
+	 *
+	 * @param int $event_date_id Event date ID.
+	 * @return array{
+	 *     active_period: TicketSalePeriod|null,
+	 *     price_by_type_id: float[],
+	 *     priced_type_ids: int[]
+	 * } `price_by_type_id` covers only types with a price row for the
+	 *   active period; `priced_type_ids` lists every type with a price row
+	 *   for *any* period, for filter_purchasable_types()'s "never priced is
+	 *   free by convention" check.
+	 */
+	public static function resolve_unit_prices_for_event_date( $event_date_id ) {
+		$active_period = self::resolve_active_sale_period( $event_date_id );
+		if ( ! $active_period ) {
+			return array(
+				'active_period'    => null,
+				'price_by_type_id' => array(),
+				'priced_type_ids'  => array(),
+			);
+		}
+
+		$price_by_type_id   = array();
+		$priced_type_id_set = array();
+		foreach ( TicketPrice::get_all_by_event_date_id( $event_date_id ) as $price_row ) {
+			$priced_type_id_set[ (int) $price_row->ticket_type_id ] = true;
+			if ( (int) $price_row->sale_period_id === (int) $active_period->id ) {
+				$price_by_type_id[ (int) $price_row->ticket_type_id ] = (float) $price_row->price;
+			}
+		}
+
+		return array(
+			'active_period'    => $active_period,
+			'price_by_type_id' => $price_by_type_id,
+			'priced_type_ids'  => array_keys( $priced_type_id_set ),
+		);
+	}
+
+	/**
+	 * Resolve the base (undiscounted) price for each of the given ticket
+	 * types from the maps resolve_unit_prices_for_event_date() returns.
+	 * Mirrors resolve_unit_price()'s own per-type semantics exactly — same
+	 * "never priced is free by convention, priced elsewhere is unavailable"
+	 * rule filter_purchasable_types() applies — but as a pure, DB-free lookup
+	 * so a caller resolving many types reuses one bulk fetch instead of
+	 * calling resolve_unit_price() (and re-querying) once per type.
+	 *
+	 * @param int[]   $ticket_type_ids  Ticket type IDs to resolve.
+	 * @param float[] $price_by_type_id Ticket-type ID => price for the active period.
+	 * @param int[]   $priced_type_ids  Ticket-type IDs with a price row for at least one period.
+	 * @return float[] Base price, keyed by ticket type ID; a type priced for
+	 *                 other periods but not the active one is omitted (not
+	 *                 purchasable right now), matching resolve_unit_price()'s null.
+	 */
+	public static function base_prices_for_types( array $ticket_type_ids, array $price_by_type_id, array $priced_type_ids ) {
+		$base_price_by_type_id = array();
+
+		foreach ( $ticket_type_ids as $ticket_type_id ) {
+			$ticket_type_id = (int) $ticket_type_id;
+			if ( array_key_exists( $ticket_type_id, $price_by_type_id ) ) {
+				$base_price_by_type_id[ $ticket_type_id ] = (float) $price_by_type_id[ $ticket_type_id ];
+			} elseif ( ! in_array( $ticket_type_id, $priced_type_ids, true ) ) {
+				$base_price_by_type_id[ $ticket_type_id ] = 0.0;
+			}
+			// Else: priced for other periods but not the active one → not purchasable, omitted.
+		}
+
+		return $base_price_by_type_id;
+	}
+
+	/**
 	 * Keep only the ticket types actually purchasable right now under the
 	 * currently active sale period. A type is purchasable when it either has
 	 * a resolved price for the active period ($price_by_type_id), or has

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -228,19 +228,12 @@ $has_instance_picker = $has_multiple_instances_type && ! empty( $occurrences_for
 $price_by_type_id   = array();
 $priced_type_ids    = array();
 $active_sale_period = null;
-if ( class_exists( \FairEvents\Services\TicketPricing::class ) && class_exists( \FairEvents\Models\TicketPrice::class ) ) {
-	$active_sale_period = \FairEvents\Services\TicketPricing::resolve_active_sale_period( $pricing_event_date_id );
-	if ( $active_sale_period ) {
-		$prices = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id );
-		foreach ( $prices as $price ) {
-			$priced_type_ids[ (int) $price->ticket_type_id ] = true;
-			if ( (int) $price->sale_period_id === (int) $active_sale_period->id ) {
-				$price_by_type_id[ (int) $price->ticket_type_id ] = (float) $price->price;
-			}
-		}
-	}
+if ( class_exists( \FairEvents\Services\TicketPricing::class ) ) {
+	$resolved_prices    = \FairEvents\Services\TicketPricing::resolve_unit_prices_for_event_date( $pricing_event_date_id );
+	$active_sale_period = $resolved_prices['active_period'];
+	$price_by_type_id   = $resolved_prices['price_by_type_id'];
+	$priced_type_ids    = $resolved_prices['priced_type_ids'];
 }
-$priced_type_ids = array_keys( $priced_type_ids );
 
 // A ticket type with no price row for the active sale period, but priced for
 // some other period, isn't purchasable right now — drop it from the list


### PR DESCRIPTION
## Summary

- The unified Event Signup form's group-pricing overlay (`SignupHookBridge`/`SignupActivities`, layered on fair-events' base block) re-resolved the active sale period, the event's group-discount rules, and the viewer's group membership once **per ticket tier** and once **per activity option**, so a render with several tiers and a few group rules issued dozens of uncached queries.
- Added bulk resolvers — `TicketPricing::resolve_unit_prices_for_event_date()`/`base_prices_for_types()` in fair-events, `EventSignupPricing::resolve_prices_and_rules_for_ticket_types()`/`resolve_prices_and_rules()`/`filter_matching_rules()` in fair-events-experimental, exposed through fair-audience's `SignupPriceResolver` facade with the same version-skew fallback guard used elsewhere — that fetch the sale period, discount rules, and membership set exactly **once per render/request** and reuse them across every tier/option.
- Wired the render overlay (`SignupHookBridge::enrich_render_context()`, `SignupActivities::enrich_render_context()`/`line_items()`) and the purchase controller (`EventSignupController::maybe_start_paid_signup()`/`maybe_start_addon_payment()`) through the bulk path. Also folded the purchase controller's separately hand-rolled group-restriction check (`validate_ticket_type_group_restriction()`) into the shared `GroupSignupPricing::restriction_error()` service instead of duplicating it.
- No displayed or charged price changes — verified by a WP-CLI `eval-file` check comparing the bulk resolver's output against the old per-tier loop for a fixture with 5 tiers and 2 competing group-discount rules (percentage vs. fixed-amount), and by re-running the existing group-pricing/activity API specs.

Closes #1299

## Query-count result (manual WP-CLI check, 5 ticket types + 2 discount rules)

| | Old (per-tier loop) | New (bulk) |
|---|---|---|
| 1 ticket type | 8 queries | 5 queries |
| 5 ticket types | 40 queries | 5 queries |

## Acceptance criteria

- [x] Rendering a form with many tiers issues roughly the same number of queries as one with a single tier — confirmed: 5 queries flat regardless of tier count (vs. 8/tier before).
- [x] Displayed prices are unchanged for anonymous visitors, members with a discount, and members without one — the bulk resolver reuses the exact same `best_rule_for_price()` math; parity with the old per-tier/per-option loop verified directly against a live DB.
- [x] A price adjustment applied earlier in the pricing pass survives the group-discount step — already true as of a prior fix (#1297); locked in with a regression test (`test_best_rule_for_price_picks_the_rule_that_wins_on_the_real_price` et al., pre-existing, still green).
- [x] Charged price still matches displayed price — the render overlay and the purchase controller now call the same bulk facade methods; existing `EventSignupGroupPricing.api.spec.js`/`EventSignupActivities.api.spec.js`/`EventSignupBasePricing.api.spec.js` API specs pass unchanged.

## Scope note

The plan comment on #1299 also surfaced a **second**, separate `event-signup` block still registered by fair-audience (`fair-audience/src/blocks/event-signup/render.php`, independent of the unified fair-events block + `SignupHookBridge` overlay this PR fixes) with the identical per-tier/per-option resolver-in-a-loop pattern. Confirmed with Marcin during implementation that it's out of scope for this ticket — tracked as a follow-up rather than folded in here (recorded on the plan comment).

## Testing

- `vendor/bin/phpunit` — green in `fair-events` (216 tests), `fair-events-experimental` (31 tests), `fair-audience` (92 tests), including new unit tests for the bulk resolvers' pure bookkeeping/rule-matching logic and an extended version-skew fallback test.
- `vendor/bin/phpcs` — clean on all changed files (pre-existing unrelated findings in `EventSignupController.php` left untouched, confirmed identical before/after).
- `npm run test:api` (fair-events, fair-audience, against the wp-env `tests` instance) — all relevant signup/pricing/activity specs pass.
- Manual WP-CLI `eval-file` check: bulk resolver output vs. old per-tier loop for 5 tiers × 2 competing discount rules — exact price/rule parity, and query count collapses from 40 → 5.

## Notes for reviewers

- The plan's "PHPUnit spy test asserting each DB-touching method is invoked exactly once" wasn't added as a permanent unit test — this repo's PHPUnit suites are explicitly DB-free/no-WP-bootstrap by convention (`TicketPricingTest`/`EventSignupPricingTest`'s own header comments: "Database-backed lookups are exercised via API integration tests, not here"), and the query-count guarantee crosses two plugins' PSR-4 boundaries that aren't cross-autoloaded in either plugin's isolated test suite. Verified instead via the manual WP-CLI check above (documented in this PR for reviewers/future reference) plus the pure-logic unit tests covering the actual bookkeeping/rule-matching math.
