### PR TITLE
Bump Babel toolchain to 8.x in the Jest transform layer

### DIFF
--- a/fair-audience-experimental/package.json
+++ b/fair-audience-experimental/package.json
@@ -34,13 +34,14 @@
 		"@wordpress/i18n": "^6.21.0"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.28.3",
-		"@babel/preset-env": "^7.28.3",
+		"@babel/core": "^8.0.1",
+		"@babel/preset-env": "^8.0.2",
+		"@babel/preset-react": "^8.0.1",
 		"@playwright/test": "^1.40.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",
-		"babel-jest": "^30.0.5",
+		"babel-jest": "^30.4.1",
 		"jest": "^30.0.0",
 		"npm-run-all2": "^9.0.2",
 		"webpack-bundle-output": "^1.1.0"

--- a/fair-audience/package.json
+++ b/fair-audience/package.json
@@ -43,14 +43,14 @@
 		"react-easy-crop": "^5.5.6"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.28.3",
-		"@babel/preset-env": "^7.28.3",
-		"@babel/preset-react": "^7.28.3",
+		"@babel/core": "^8.0.1",
+		"@babel/preset-env": "^8.0.2",
+		"@babel/preset-react": "^8.0.1",
 		"@playwright/test": "^1.40.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",
-		"babel-jest": "^30.0.5",
+		"babel-jest": "^30.4.1",
 		"dotenv": "^16.3.1",
 		"jest": "^30.0.0",
 		"npm-run-all2": "^9.0.2",

--- a/fair-events-experimental/package.json
+++ b/fair-events-experimental/package.json
@@ -36,13 +36,14 @@
 		"recharts": "^3.0.0"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.28.3",
-		"@babel/preset-env": "^7.28.3",
+		"@babel/core": "^8.0.1",
+		"@babel/preset-env": "^8.0.2",
+		"@babel/preset-react": "^8.0.1",
 		"@playwright/test": "^1.40.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",
-		"babel-jest": "^30.0.5",
+		"babel-jest": "^30.4.1",
 		"jest": "^30.0.0",
 		"npm-run-all2": "^9.0.2",
 		"webpack-bundle-output": "^1.1.0"

--- a/fair-events-shared/package.json
+++ b/fair-events-shared/package.json
@@ -8,6 +8,12 @@
 	"scripts": {
 		"test": "jest"
 	},
+	"devDependencies": {
+		"@babel/core": "^8.0.1",
+		"@babel/preset-env": "^8.0.2",
+		"@babel/preset-react": "^8.0.1",
+		"babel-jest": "^30.4.1"
+	},
 	"keywords": [
 		"wordpress",
 		"events",

--- a/fair-events/package.json
+++ b/fair-events/package.json
@@ -52,13 +52,14 @@
 		"react-easy-crop": "^5.5.6"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.28.3",
-		"@babel/preset-env": "^7.28.3",
+		"@babel/core": "^8.0.1",
+		"@babel/preset-env": "^8.0.2",
+		"@babel/preset-react": "^8.0.1",
 		"@playwright/test": "^1.40.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",
-		"babel-jest": "^30.0.5",
+		"babel-jest": "^30.4.1",
 		"dotenv": "^16.3.1",
 		"jest": "^30.0.0",
 		"webpack-bundle-output": "^1.1.0"

--- a/fair-finance/package.json
+++ b/fair-finance/package.json
@@ -26,9 +26,13 @@
 		"svn:copy": "cp -r readme.txt fair-finance.php composer* languages CHANGELOG.md svn/trunk"
 	},
 	"devDependencies": {
+		"@babel/core": "^8.0.1",
+		"@babel/preset-env": "^8.0.2",
+		"@babel/preset-react": "^8.0.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",
+		"babel-jest": "^30.4.1",
 		"webpack-bundle-output": "^1.1.0"
 	},
 	"dependencies": {

--- a/fair-form/package.json
+++ b/fair-form/package.json
@@ -27,13 +27,13 @@
 		"svn:copy": "cp -r readme.txt fair-form.php composer* languages CHANGELOG.md svn/trunk"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.28.3",
-		"@babel/preset-env": "^7.28.3",
-		"@babel/preset-react": "^7.28.3",
+		"@babel/core": "^8.0.1",
+		"@babel/preset-env": "^8.0.2",
+		"@babel/preset-react": "^8.0.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",
-		"babel-jest": "^30.0.5",
+		"babel-jest": "^30.4.1",
 		"webpack-bundle-output": "^1.1.0"
 	},
 	"dependencies": {

--- a/fair-payments-connector-experimental/package.json
+++ b/fair-payments-connector-experimental/package.json
@@ -28,9 +28,13 @@
 		"svn:copy": "cp -r readme.txt fair-payments-connector-experimental.php composer* languages CHANGELOG.md svn/trunk"
 	},
 	"devDependencies": {
+		"@babel/core": "^8.0.1",
+		"@babel/preset-env": "^8.0.2",
+		"@babel/preset-react": "^8.0.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",
+		"babel-jest": "^30.4.1",
 		"webpack-bundle-output": "^1.1.0"
 	},
 	"dependencies": {

--- a/fair-payments-connector/package.json
+++ b/fair-payments-connector/package.json
@@ -34,10 +34,14 @@
 	"author": "Fair Event Plugins",
 	"license": "GPL-2.0-or-later",
 	"devDependencies": {
+		"@babel/core": "^8.0.1",
+		"@babel/preset-env": "^8.0.2",
+		"@babel/preset-react": "^8.0.1",
 		"@playwright/test": "^1.40.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@wordpress/scripts": "^32.4.0",
+		"babel-jest": "^30.4.1",
 		"dotenv": "^16.3.1",
 		"webpack-bundle-output": "^1.1.0"
 	},

--- a/fair-timetable/package.json
+++ b/fair-timetable/package.json
@@ -42,11 +42,11 @@
 		"date-fns": "^4.4.0"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.28.3",
-		"@babel/preset-env": "^7.28.3",
+		"@babel/core": "^8.0.1",
+		"@babel/preset-env": "^8.0.2",
 		"@playwright/test": "^1.40.0",
 		"@wordpress/scripts": "^32.4.0",
-		"babel-jest": "^30.0.5",
+		"babel-jest": "^30.4.1",
 		"dotenv": "^16.3.1",
 		"jest": "^30.0.0",
 		"jest-environment-node": "^30.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,14 +50,14 @@
 				"react-easy-crop": "^5.5.6"
 			},
 			"devDependencies": {
-				"@babel/core": "^7.28.3",
-				"@babel/preset-env": "^7.28.3",
-				"@babel/preset-react": "^7.28.3",
+				"@babel/core": "^8.0.1",
+				"@babel/preset-env": "^8.0.2",
+				"@babel/preset-react": "^8.0.1",
 				"@playwright/test": "^1.40.0",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@wordpress/scripts": "^32.4.0",
-				"babel-jest": "^30.0.5",
+				"babel-jest": "^30.4.1",
 				"dotenv": "^16.3.1",
 				"jest": "^30.0.0",
 				"npm-run-all2": "^9.0.2",
@@ -76,16 +76,1621 @@
 				"fair-events-shared": "*"
 			},
 			"devDependencies": {
-				"@babel/core": "^7.28.3",
-				"@babel/preset-env": "^7.28.3",
+				"@babel/core": "^8.0.1",
+				"@babel/preset-env": "^8.0.2",
+				"@babel/preset-react": "^8.0.1",
 				"@playwright/test": "^1.40.0",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@wordpress/scripts": "^32.4.0",
-				"babel-jest": "^30.0.5",
+				"babel-jest": "^30.4.1",
 				"jest": "^30.0.0",
 				"npm-run-all2": "^9.0.2",
 				"webpack-bundle-output": "^1.1.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/code-frame": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+			"integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"js-tokens": "^10.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/compat-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+			"integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/core": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+			"integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helpers": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@types/gensync": "^1.0.5",
+				"convert-source-map": "^2.0.0",
+				"empathic": "^2.0.1",
+				"gensync": "^1.0.0-beta.2",
+				"import-meta-resolve": "^4.2.0",
+				"json5": "^2.2.3",
+				"obug": "^2.1.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/generator": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+			"integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"@types/jsesc": "^2.5.0",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-annotate-as-pure": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+			"integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-compilation-targets": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+			"integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-validator-option": "^8.0.0",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^11.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-create-regexp-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"regexpu-core": "^6.3.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-1.0.0.tgz",
+			"integrity": "sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.0",
+				"lodash.debounce": "^4.0.8"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-globals": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+			"integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+			"integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-module-imports": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+			"integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-module-transforms": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+			"integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-optimise-call-expression": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+			"integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-remap-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-wrap-function": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-replace-supers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+			"integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+			"integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-validator-option": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+			"integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helper-wrap-function": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-8.0.0.tgz",
+			"integrity": "sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/helpers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/parser": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.4"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-8.0.1.tgz",
+			"integrity": "sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-8.0.1.tgz",
+			"integrity": "sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-8.0.1.tgz",
+			"integrity": "sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-8.0.1.tgz",
+			"integrity": "sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-8.0.1.tgz",
+			"integrity": "sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-syntax-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+			"integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-arrow-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-8.0.1.tgz",
+			"integrity": "sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-async-generator-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-8.0.1.tgz",
+			"integrity": "sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-block-scoped-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-8.0.1.tgz",
+			"integrity": "sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-block-scoping": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-8.0.1.tgz",
+			"integrity": "sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-class-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-8.0.1.tgz",
+			"integrity": "sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-class-static-block": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-8.0.1.tgz",
+			"integrity": "sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-classes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-8.0.1.tgz",
+			"integrity": "sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-computed-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-8.0.1.tgz",
+			"integrity": "sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-destructuring": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+			"integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-dotall-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-8.0.1.tgz",
+			"integrity": "sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-duplicate-keys": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-8.0.1.tgz",
+			"integrity": "sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-dynamic-import": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-8.0.1.tgz",
+			"integrity": "sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+			"integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-exponentiation-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-8.0.1.tgz",
+			"integrity": "sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-export-namespace-from": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-8.0.1.tgz",
+			"integrity": "sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-for-of": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-8.0.1.tgz",
+			"integrity": "sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-function-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-8.0.1.tgz",
+			"integrity": "sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-json-strings": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-8.0.1.tgz",
+			"integrity": "sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-8.0.1.tgz",
+			"integrity": "sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-8.0.1.tgz",
+			"integrity": "sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-member-expression-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-8.0.1.tgz",
+			"integrity": "sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-modules-amd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-8.0.1.tgz",
+			"integrity": "sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-modules-commonjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+			"integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-modules-systemjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-8.0.1.tgz",
+			"integrity": "sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-identifier": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-modules-umd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-8.0.1.tgz",
+			"integrity": "sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-new-target": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-8.0.1.tgz",
+			"integrity": "sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-8.0.1.tgz",
+			"integrity": "sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-numeric-separator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-8.0.1.tgz",
+			"integrity": "sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-object-rest-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-8.0.1.tgz",
+			"integrity": "sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-object-super": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-8.0.1.tgz",
+			"integrity": "sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-optional-catch-binding": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-8.0.1.tgz",
+			"integrity": "sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-parameters": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-8.0.1.tgz",
+			"integrity": "sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-private-methods": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-8.0.1.tgz",
+			"integrity": "sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-private-property-in-object": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-8.0.1.tgz",
+			"integrity": "sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-property-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-8.0.1.tgz",
+			"integrity": "sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+			"integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+			"integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-syntax-jsx": "^8.0.1",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+			"integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-react-pure-annotations": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+			"integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-regenerator": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-8.0.2.tgz",
+			"integrity": "sha512-aFfsjCRYducRV4dPnpsBbdRkLjboca9FVDg6HZCgy0Ahvk2ZQ/2exmCRC5qS9P6rsWwrmIheNaIM6A1j2F8KMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-8.0.1.tgz",
+			"integrity": "sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-reserved-words": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-8.0.1.tgz",
+			"integrity": "sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-shorthand-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-8.0.1.tgz",
+			"integrity": "sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-8.0.1.tgz",
+			"integrity": "sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-sticky-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-8.0.1.tgz",
+			"integrity": "sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-template-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-8.0.1.tgz",
+			"integrity": "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-typeof-symbol": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-8.0.1.tgz",
+			"integrity": "sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-unicode-escapes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
+			"integrity": "sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-unicode-property-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-8.0.1.tgz",
+			"integrity": "sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-unicode-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-8.0.1.tgz",
+			"integrity": "sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-8.0.1.tgz",
+			"integrity": "sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/preset-env": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-8.0.2.tgz",
+			"integrity": "sha512-CUGLn9hNBCF/eXnwdFAWERbniCcXCRvnKwLV9fegeUEIqv7YlU2MepsWMMM54GcILx5XYMnRh+JAL+K5G+mK6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^8.0.1",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^8.0.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^8.0.1",
+				"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^8.0.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^8.0.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^8.0.1",
+				"@babel/plugin-transform-arrow-functions": "^8.0.1",
+				"@babel/plugin-transform-async-generator-functions": "^8.0.1",
+				"@babel/plugin-transform-async-to-generator": "^8.0.1",
+				"@babel/plugin-transform-block-scoped-functions": "^8.0.1",
+				"@babel/plugin-transform-block-scoping": "^8.0.1",
+				"@babel/plugin-transform-class-properties": "^8.0.1",
+				"@babel/plugin-transform-class-static-block": "^8.0.1",
+				"@babel/plugin-transform-classes": "^8.0.1",
+				"@babel/plugin-transform-computed-properties": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-duplicate-keys": "^8.0.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-dynamic-import": "^8.0.1",
+				"@babel/plugin-transform-explicit-resource-management": "^8.0.1",
+				"@babel/plugin-transform-exponentiation-operator": "^8.0.1",
+				"@babel/plugin-transform-export-namespace-from": "^8.0.1",
+				"@babel/plugin-transform-for-of": "^8.0.1",
+				"@babel/plugin-transform-function-name": "^8.0.1",
+				"@babel/plugin-transform-json-strings": "^8.0.1",
+				"@babel/plugin-transform-literals": "^8.0.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^8.0.1",
+				"@babel/plugin-transform-member-expression-literals": "^8.0.1",
+				"@babel/plugin-transform-modules-amd": "^8.0.1",
+				"@babel/plugin-transform-modules-commonjs": "^8.0.1",
+				"@babel/plugin-transform-modules-systemjs": "^8.0.1",
+				"@babel/plugin-transform-modules-umd": "^8.0.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-new-target": "^8.0.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^8.0.1",
+				"@babel/plugin-transform-numeric-separator": "^8.0.1",
+				"@babel/plugin-transform-object-rest-spread": "^8.0.1",
+				"@babel/plugin-transform-object-super": "^8.0.1",
+				"@babel/plugin-transform-optional-catch-binding": "^8.0.1",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1",
+				"@babel/plugin-transform-private-methods": "^8.0.1",
+				"@babel/plugin-transform-private-property-in-object": "^8.0.1",
+				"@babel/plugin-transform-property-literals": "^8.0.1",
+				"@babel/plugin-transform-regenerator": "^8.0.2",
+				"@babel/plugin-transform-regexp-modifiers": "^8.0.1",
+				"@babel/plugin-transform-reserved-words": "^8.0.1",
+				"@babel/plugin-transform-shorthand-properties": "^8.0.1",
+				"@babel/plugin-transform-spread": "^8.0.1",
+				"@babel/plugin-transform-sticky-regex": "^8.0.1",
+				"@babel/plugin-transform-template-literals": "^8.0.1",
+				"@babel/plugin-transform-typeof-symbol": "^8.0.1",
+				"@babel/plugin-transform-unicode-escapes": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^8.0.1",
+				"@babel/preset-modules": "^0.2.0",
+				"babel-plugin-polyfill-corejs3": "^1.0.0",
+				"core-js-compat": "^3.48.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/preset-modules": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.2.0.tgz",
+			"integrity": "sha512-yz0RBN2fx4fjCeFcTWsWgL7PxSRltvTa0Qg14HkWCU3qS8MO7ZSJlBVbGceynd5C9NsJwwUHNQD3dc6tYO+jqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/types": "^8.0.0",
+				"esutils": "^2.0.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/preset-react": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+			"integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-transform-react-display-name": "^8.0.1",
+				"@babel/plugin-transform-react-jsx": "^8.0.1",
+				"@babel/plugin-transform-react-jsx-development": "^8.0.1",
+				"@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/template": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+			"integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/traverse": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+			"integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/parser": "^8.0.4",
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.4",
+				"obug": "^2.1.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-1.0.0.tgz",
+			"integrity": "sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^1.0.0",
+				"core-js-compat": "^3.48.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-audience-experimental/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-audience-experimental/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"fair-audience-experimental/node_modules/npm-run-all2": {
@@ -115,6 +1720,1606 @@
 				"npm": ">= 10"
 			}
 		},
+		"fair-audience-experimental/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"fair-audience/node_modules/@babel/code-frame": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+			"integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"js-tokens": "^10.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/compat-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+			"integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/core": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+			"integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helpers": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@types/gensync": "^1.0.5",
+				"convert-source-map": "^2.0.0",
+				"empathic": "^2.0.1",
+				"gensync": "^1.0.0-beta.2",
+				"import-meta-resolve": "^4.2.0",
+				"json5": "^2.2.3",
+				"obug": "^2.1.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"fair-audience/node_modules/@babel/generator": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+			"integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"@types/jsesc": "^2.5.0",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-annotate-as-pure": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+			"integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-compilation-targets": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+			"integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-validator-option": "^8.0.0",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^11.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-create-regexp-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"regexpu-core": "^6.3.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-1.0.0.tgz",
+			"integrity": "sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.0",
+				"lodash.debounce": "^4.0.8"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-globals": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+			"integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+			"integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-module-imports": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+			"integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-module-transforms": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+			"integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-optimise-call-expression": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+			"integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-remap-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-wrap-function": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-replace-supers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+			"integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+			"integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-validator-option": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+			"integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helper-wrap-function": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-8.0.0.tgz",
+			"integrity": "sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/helpers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/parser": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.4"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-8.0.1.tgz",
+			"integrity": "sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-8.0.1.tgz",
+			"integrity": "sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-8.0.1.tgz",
+			"integrity": "sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-8.0.1.tgz",
+			"integrity": "sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-8.0.1.tgz",
+			"integrity": "sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-syntax-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+			"integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-arrow-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-8.0.1.tgz",
+			"integrity": "sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-async-generator-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-8.0.1.tgz",
+			"integrity": "sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-block-scoped-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-8.0.1.tgz",
+			"integrity": "sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-block-scoping": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-8.0.1.tgz",
+			"integrity": "sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-class-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-8.0.1.tgz",
+			"integrity": "sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-class-static-block": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-8.0.1.tgz",
+			"integrity": "sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-classes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-8.0.1.tgz",
+			"integrity": "sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-computed-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-8.0.1.tgz",
+			"integrity": "sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-destructuring": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+			"integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-dotall-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-8.0.1.tgz",
+			"integrity": "sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-duplicate-keys": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-8.0.1.tgz",
+			"integrity": "sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-dynamic-import": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-8.0.1.tgz",
+			"integrity": "sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+			"integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-exponentiation-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-8.0.1.tgz",
+			"integrity": "sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-export-namespace-from": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-8.0.1.tgz",
+			"integrity": "sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-for-of": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-8.0.1.tgz",
+			"integrity": "sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-function-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-8.0.1.tgz",
+			"integrity": "sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-json-strings": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-8.0.1.tgz",
+			"integrity": "sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-8.0.1.tgz",
+			"integrity": "sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-8.0.1.tgz",
+			"integrity": "sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-member-expression-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-8.0.1.tgz",
+			"integrity": "sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-modules-amd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-8.0.1.tgz",
+			"integrity": "sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-modules-commonjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+			"integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-modules-systemjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-8.0.1.tgz",
+			"integrity": "sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-identifier": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-modules-umd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-8.0.1.tgz",
+			"integrity": "sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-new-target": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-8.0.1.tgz",
+			"integrity": "sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-8.0.1.tgz",
+			"integrity": "sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-numeric-separator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-8.0.1.tgz",
+			"integrity": "sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-object-rest-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-8.0.1.tgz",
+			"integrity": "sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-object-super": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-8.0.1.tgz",
+			"integrity": "sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-optional-catch-binding": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-8.0.1.tgz",
+			"integrity": "sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-parameters": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-8.0.1.tgz",
+			"integrity": "sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-private-methods": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-8.0.1.tgz",
+			"integrity": "sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-private-property-in-object": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-8.0.1.tgz",
+			"integrity": "sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-property-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-8.0.1.tgz",
+			"integrity": "sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+			"integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+			"integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-syntax-jsx": "^8.0.1",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+			"integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-react-pure-annotations": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+			"integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-regenerator": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-8.0.2.tgz",
+			"integrity": "sha512-aFfsjCRYducRV4dPnpsBbdRkLjboca9FVDg6HZCgy0Ahvk2ZQ/2exmCRC5qS9P6rsWwrmIheNaIM6A1j2F8KMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-8.0.1.tgz",
+			"integrity": "sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-reserved-words": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-8.0.1.tgz",
+			"integrity": "sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-shorthand-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-8.0.1.tgz",
+			"integrity": "sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-8.0.1.tgz",
+			"integrity": "sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-sticky-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-8.0.1.tgz",
+			"integrity": "sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-template-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-8.0.1.tgz",
+			"integrity": "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-typeof-symbol": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-8.0.1.tgz",
+			"integrity": "sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-unicode-escapes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
+			"integrity": "sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-unicode-property-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-8.0.1.tgz",
+			"integrity": "sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-unicode-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-8.0.1.tgz",
+			"integrity": "sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-8.0.1.tgz",
+			"integrity": "sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/preset-env": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-8.0.2.tgz",
+			"integrity": "sha512-CUGLn9hNBCF/eXnwdFAWERbniCcXCRvnKwLV9fegeUEIqv7YlU2MepsWMMM54GcILx5XYMnRh+JAL+K5G+mK6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^8.0.1",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^8.0.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^8.0.1",
+				"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^8.0.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^8.0.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^8.0.1",
+				"@babel/plugin-transform-arrow-functions": "^8.0.1",
+				"@babel/plugin-transform-async-generator-functions": "^8.0.1",
+				"@babel/plugin-transform-async-to-generator": "^8.0.1",
+				"@babel/plugin-transform-block-scoped-functions": "^8.0.1",
+				"@babel/plugin-transform-block-scoping": "^8.0.1",
+				"@babel/plugin-transform-class-properties": "^8.0.1",
+				"@babel/plugin-transform-class-static-block": "^8.0.1",
+				"@babel/plugin-transform-classes": "^8.0.1",
+				"@babel/plugin-transform-computed-properties": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-duplicate-keys": "^8.0.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-dynamic-import": "^8.0.1",
+				"@babel/plugin-transform-explicit-resource-management": "^8.0.1",
+				"@babel/plugin-transform-exponentiation-operator": "^8.0.1",
+				"@babel/plugin-transform-export-namespace-from": "^8.0.1",
+				"@babel/plugin-transform-for-of": "^8.0.1",
+				"@babel/plugin-transform-function-name": "^8.0.1",
+				"@babel/plugin-transform-json-strings": "^8.0.1",
+				"@babel/plugin-transform-literals": "^8.0.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^8.0.1",
+				"@babel/plugin-transform-member-expression-literals": "^8.0.1",
+				"@babel/plugin-transform-modules-amd": "^8.0.1",
+				"@babel/plugin-transform-modules-commonjs": "^8.0.1",
+				"@babel/plugin-transform-modules-systemjs": "^8.0.1",
+				"@babel/plugin-transform-modules-umd": "^8.0.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-new-target": "^8.0.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^8.0.1",
+				"@babel/plugin-transform-numeric-separator": "^8.0.1",
+				"@babel/plugin-transform-object-rest-spread": "^8.0.1",
+				"@babel/plugin-transform-object-super": "^8.0.1",
+				"@babel/plugin-transform-optional-catch-binding": "^8.0.1",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1",
+				"@babel/plugin-transform-private-methods": "^8.0.1",
+				"@babel/plugin-transform-private-property-in-object": "^8.0.1",
+				"@babel/plugin-transform-property-literals": "^8.0.1",
+				"@babel/plugin-transform-regenerator": "^8.0.2",
+				"@babel/plugin-transform-regexp-modifiers": "^8.0.1",
+				"@babel/plugin-transform-reserved-words": "^8.0.1",
+				"@babel/plugin-transform-shorthand-properties": "^8.0.1",
+				"@babel/plugin-transform-spread": "^8.0.1",
+				"@babel/plugin-transform-sticky-regex": "^8.0.1",
+				"@babel/plugin-transform-template-literals": "^8.0.1",
+				"@babel/plugin-transform-typeof-symbol": "^8.0.1",
+				"@babel/plugin-transform-unicode-escapes": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^8.0.1",
+				"@babel/preset-modules": "^0.2.0",
+				"babel-plugin-polyfill-corejs3": "^1.0.0",
+				"core-js-compat": "^3.48.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/preset-modules": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.2.0.tgz",
+			"integrity": "sha512-yz0RBN2fx4fjCeFcTWsWgL7PxSRltvTa0Qg14HkWCU3qS8MO7ZSJlBVbGceynd5C9NsJwwUHNQD3dc6tYO+jqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/types": "^8.0.0",
+				"esutils": "^2.0.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/preset-react": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+			"integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-transform-react-display-name": "^8.0.1",
+				"@babel/plugin-transform-react-jsx": "^8.0.1",
+				"@babel/plugin-transform-react-jsx-development": "^8.0.1",
+				"@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/template": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+			"integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/traverse": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+			"integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/parser": "^8.0.4",
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.4",
+				"obug": "^2.1.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-audience/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-1.0.0.tgz",
+			"integrity": "sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^1.0.0",
+				"core-js-compat": "^3.48.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
 		"fair-audience/node_modules/dotenv": {
 			"version": "16.6.1",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -126,6 +3331,23 @@
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
+			}
+		},
+		"fair-audience/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-audience/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"fair-audience/node_modules/npm-run-all2": {
@@ -155,6 +3377,19 @@
 				"npm": ">= 10"
 			}
 		},
+		"fair-audience/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"fair-events": {
 			"version": "1.12.0",
 			"license": "GPL-3.0-or-later",
@@ -177,13 +3412,14 @@
 				"react-easy-crop": "^5.5.6"
 			},
 			"devDependencies": {
-				"@babel/core": "^7.28.3",
-				"@babel/preset-env": "^7.28.3",
+				"@babel/core": "^8.0.1",
+				"@babel/preset-env": "^8.0.2",
+				"@babel/preset-react": "^8.0.1",
 				"@playwright/test": "^1.40.0",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@wordpress/scripts": "^32.4.0",
-				"babel-jest": "^30.0.5",
+				"babel-jest": "^30.4.1",
 				"dotenv": "^16.3.1",
 				"jest": "^30.0.0",
 				"webpack-bundle-output": "^1.1.0"
@@ -203,16 +3439,1621 @@
 				"recharts": "^3.0.0"
 			},
 			"devDependencies": {
-				"@babel/core": "^7.28.3",
-				"@babel/preset-env": "^7.28.3",
+				"@babel/core": "^8.0.1",
+				"@babel/preset-env": "^8.0.2",
+				"@babel/preset-react": "^8.0.1",
 				"@playwright/test": "^1.40.0",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@wordpress/scripts": "^32.4.0",
-				"babel-jest": "^30.0.5",
+				"babel-jest": "^30.4.1",
 				"jest": "^30.0.0",
 				"npm-run-all2": "^9.0.2",
 				"webpack-bundle-output": "^1.1.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/code-frame": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+			"integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"js-tokens": "^10.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/compat-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+			"integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/core": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+			"integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helpers": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@types/gensync": "^1.0.5",
+				"convert-source-map": "^2.0.0",
+				"empathic": "^2.0.1",
+				"gensync": "^1.0.0-beta.2",
+				"import-meta-resolve": "^4.2.0",
+				"json5": "^2.2.3",
+				"obug": "^2.1.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/generator": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+			"integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"@types/jsesc": "^2.5.0",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-annotate-as-pure": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+			"integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-compilation-targets": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+			"integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-validator-option": "^8.0.0",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^11.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-create-regexp-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"regexpu-core": "^6.3.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-1.0.0.tgz",
+			"integrity": "sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.0",
+				"lodash.debounce": "^4.0.8"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-globals": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+			"integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+			"integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-module-imports": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+			"integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-module-transforms": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+			"integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-optimise-call-expression": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+			"integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-remap-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-wrap-function": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-replace-supers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+			"integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+			"integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-validator-option": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+			"integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helper-wrap-function": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-8.0.0.tgz",
+			"integrity": "sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/helpers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/parser": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.4"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-8.0.1.tgz",
+			"integrity": "sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-8.0.1.tgz",
+			"integrity": "sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-8.0.1.tgz",
+			"integrity": "sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-8.0.1.tgz",
+			"integrity": "sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-8.0.1.tgz",
+			"integrity": "sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-syntax-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+			"integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-arrow-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-8.0.1.tgz",
+			"integrity": "sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-async-generator-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-8.0.1.tgz",
+			"integrity": "sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-block-scoped-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-8.0.1.tgz",
+			"integrity": "sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-block-scoping": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-8.0.1.tgz",
+			"integrity": "sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-class-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-8.0.1.tgz",
+			"integrity": "sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-class-static-block": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-8.0.1.tgz",
+			"integrity": "sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-classes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-8.0.1.tgz",
+			"integrity": "sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-computed-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-8.0.1.tgz",
+			"integrity": "sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-destructuring": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+			"integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-dotall-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-8.0.1.tgz",
+			"integrity": "sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-duplicate-keys": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-8.0.1.tgz",
+			"integrity": "sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-dynamic-import": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-8.0.1.tgz",
+			"integrity": "sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+			"integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-exponentiation-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-8.0.1.tgz",
+			"integrity": "sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-export-namespace-from": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-8.0.1.tgz",
+			"integrity": "sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-for-of": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-8.0.1.tgz",
+			"integrity": "sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-function-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-8.0.1.tgz",
+			"integrity": "sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-json-strings": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-8.0.1.tgz",
+			"integrity": "sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-8.0.1.tgz",
+			"integrity": "sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-8.0.1.tgz",
+			"integrity": "sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-member-expression-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-8.0.1.tgz",
+			"integrity": "sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-modules-amd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-8.0.1.tgz",
+			"integrity": "sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-modules-commonjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+			"integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-modules-systemjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-8.0.1.tgz",
+			"integrity": "sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-identifier": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-modules-umd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-8.0.1.tgz",
+			"integrity": "sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-new-target": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-8.0.1.tgz",
+			"integrity": "sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-8.0.1.tgz",
+			"integrity": "sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-numeric-separator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-8.0.1.tgz",
+			"integrity": "sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-object-rest-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-8.0.1.tgz",
+			"integrity": "sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-object-super": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-8.0.1.tgz",
+			"integrity": "sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-optional-catch-binding": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-8.0.1.tgz",
+			"integrity": "sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-parameters": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-8.0.1.tgz",
+			"integrity": "sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-private-methods": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-8.0.1.tgz",
+			"integrity": "sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-private-property-in-object": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-8.0.1.tgz",
+			"integrity": "sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-property-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-8.0.1.tgz",
+			"integrity": "sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+			"integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+			"integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-syntax-jsx": "^8.0.1",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+			"integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-react-pure-annotations": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+			"integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-regenerator": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-8.0.2.tgz",
+			"integrity": "sha512-aFfsjCRYducRV4dPnpsBbdRkLjboca9FVDg6HZCgy0Ahvk2ZQ/2exmCRC5qS9P6rsWwrmIheNaIM6A1j2F8KMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-8.0.1.tgz",
+			"integrity": "sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-reserved-words": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-8.0.1.tgz",
+			"integrity": "sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-shorthand-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-8.0.1.tgz",
+			"integrity": "sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-8.0.1.tgz",
+			"integrity": "sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-sticky-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-8.0.1.tgz",
+			"integrity": "sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-template-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-8.0.1.tgz",
+			"integrity": "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-typeof-symbol": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-8.0.1.tgz",
+			"integrity": "sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-unicode-escapes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
+			"integrity": "sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-unicode-property-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-8.0.1.tgz",
+			"integrity": "sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-unicode-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-8.0.1.tgz",
+			"integrity": "sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-8.0.1.tgz",
+			"integrity": "sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/preset-env": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-8.0.2.tgz",
+			"integrity": "sha512-CUGLn9hNBCF/eXnwdFAWERbniCcXCRvnKwLV9fegeUEIqv7YlU2MepsWMMM54GcILx5XYMnRh+JAL+K5G+mK6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^8.0.1",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^8.0.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^8.0.1",
+				"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^8.0.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^8.0.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^8.0.1",
+				"@babel/plugin-transform-arrow-functions": "^8.0.1",
+				"@babel/plugin-transform-async-generator-functions": "^8.0.1",
+				"@babel/plugin-transform-async-to-generator": "^8.0.1",
+				"@babel/plugin-transform-block-scoped-functions": "^8.0.1",
+				"@babel/plugin-transform-block-scoping": "^8.0.1",
+				"@babel/plugin-transform-class-properties": "^8.0.1",
+				"@babel/plugin-transform-class-static-block": "^8.0.1",
+				"@babel/plugin-transform-classes": "^8.0.1",
+				"@babel/plugin-transform-computed-properties": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-duplicate-keys": "^8.0.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-dynamic-import": "^8.0.1",
+				"@babel/plugin-transform-explicit-resource-management": "^8.0.1",
+				"@babel/plugin-transform-exponentiation-operator": "^8.0.1",
+				"@babel/plugin-transform-export-namespace-from": "^8.0.1",
+				"@babel/plugin-transform-for-of": "^8.0.1",
+				"@babel/plugin-transform-function-name": "^8.0.1",
+				"@babel/plugin-transform-json-strings": "^8.0.1",
+				"@babel/plugin-transform-literals": "^8.0.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^8.0.1",
+				"@babel/plugin-transform-member-expression-literals": "^8.0.1",
+				"@babel/plugin-transform-modules-amd": "^8.0.1",
+				"@babel/plugin-transform-modules-commonjs": "^8.0.1",
+				"@babel/plugin-transform-modules-systemjs": "^8.0.1",
+				"@babel/plugin-transform-modules-umd": "^8.0.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-new-target": "^8.0.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^8.0.1",
+				"@babel/plugin-transform-numeric-separator": "^8.0.1",
+				"@babel/plugin-transform-object-rest-spread": "^8.0.1",
+				"@babel/plugin-transform-object-super": "^8.0.1",
+				"@babel/plugin-transform-optional-catch-binding": "^8.0.1",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1",
+				"@babel/plugin-transform-private-methods": "^8.0.1",
+				"@babel/plugin-transform-private-property-in-object": "^8.0.1",
+				"@babel/plugin-transform-property-literals": "^8.0.1",
+				"@babel/plugin-transform-regenerator": "^8.0.2",
+				"@babel/plugin-transform-regexp-modifiers": "^8.0.1",
+				"@babel/plugin-transform-reserved-words": "^8.0.1",
+				"@babel/plugin-transform-shorthand-properties": "^8.0.1",
+				"@babel/plugin-transform-spread": "^8.0.1",
+				"@babel/plugin-transform-sticky-regex": "^8.0.1",
+				"@babel/plugin-transform-template-literals": "^8.0.1",
+				"@babel/plugin-transform-typeof-symbol": "^8.0.1",
+				"@babel/plugin-transform-unicode-escapes": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^8.0.1",
+				"@babel/preset-modules": "^0.2.0",
+				"babel-plugin-polyfill-corejs3": "^1.0.0",
+				"core-js-compat": "^3.48.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/preset-modules": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.2.0.tgz",
+			"integrity": "sha512-yz0RBN2fx4fjCeFcTWsWgL7PxSRltvTa0Qg14HkWCU3qS8MO7ZSJlBVbGceynd5C9NsJwwUHNQD3dc6tYO+jqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/types": "^8.0.0",
+				"esutils": "^2.0.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/preset-react": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+			"integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-transform-react-display-name": "^8.0.1",
+				"@babel/plugin-transform-react-jsx": "^8.0.1",
+				"@babel/plugin-transform-react-jsx-development": "^8.0.1",
+				"@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/template": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+			"integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/traverse": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+			"integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/parser": "^8.0.4",
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.4",
+				"obug": "^2.1.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-experimental/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-1.0.0.tgz",
+			"integrity": "sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^1.0.0",
+				"core-js-compat": "^3.48.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-events-experimental/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-events-experimental/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"fair-events-experimental/node_modules/npm-run-all2": {
@@ -242,6 +5083,19 @@
 				"npm": ">= 10"
 			}
 		},
+		"fair-events-experimental/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"fair-events-shared": {
 			"version": "0.5.0",
 			"license": "GPL-2.0-or-later",
@@ -250,6 +5104,3216 @@
 				"@wordpress/date": "^5.2.0",
 				"@wordpress/scripts": "^32.4.0",
 				"date-fns": "^4.0.0"
+			},
+			"devDependencies": {
+				"@babel/core": "^8.0.1",
+				"@babel/preset-env": "^8.0.2",
+				"@babel/preset-react": "^8.0.1",
+				"babel-jest": "^30.4.1"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/code-frame": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+			"integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"js-tokens": "^10.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/compat-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+			"integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/core": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+			"integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helpers": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@types/gensync": "^1.0.5",
+				"convert-source-map": "^2.0.0",
+				"empathic": "^2.0.1",
+				"gensync": "^1.0.0-beta.2",
+				"import-meta-resolve": "^4.2.0",
+				"json5": "^2.2.3",
+				"obug": "^2.1.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/generator": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+			"integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"@types/jsesc": "^2.5.0",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-annotate-as-pure": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+			"integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-compilation-targets": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+			"integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-validator-option": "^8.0.0",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^11.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-create-regexp-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"regexpu-core": "^6.3.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-1.0.0.tgz",
+			"integrity": "sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.0",
+				"lodash.debounce": "^4.0.8"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-globals": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+			"integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+			"integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-module-imports": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+			"integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-module-transforms": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+			"integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-optimise-call-expression": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+			"integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-remap-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-wrap-function": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-replace-supers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+			"integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+			"integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-validator-option": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+			"integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helper-wrap-function": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-8.0.0.tgz",
+			"integrity": "sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/helpers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/parser": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.4"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-8.0.1.tgz",
+			"integrity": "sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-8.0.1.tgz",
+			"integrity": "sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-8.0.1.tgz",
+			"integrity": "sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-8.0.1.tgz",
+			"integrity": "sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-8.0.1.tgz",
+			"integrity": "sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-syntax-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+			"integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-arrow-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-8.0.1.tgz",
+			"integrity": "sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-async-generator-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-8.0.1.tgz",
+			"integrity": "sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-block-scoped-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-8.0.1.tgz",
+			"integrity": "sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-block-scoping": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-8.0.1.tgz",
+			"integrity": "sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-class-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-8.0.1.tgz",
+			"integrity": "sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-class-static-block": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-8.0.1.tgz",
+			"integrity": "sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-classes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-8.0.1.tgz",
+			"integrity": "sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-computed-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-8.0.1.tgz",
+			"integrity": "sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-destructuring": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+			"integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-dotall-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-8.0.1.tgz",
+			"integrity": "sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-duplicate-keys": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-8.0.1.tgz",
+			"integrity": "sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-dynamic-import": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-8.0.1.tgz",
+			"integrity": "sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+			"integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-exponentiation-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-8.0.1.tgz",
+			"integrity": "sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-export-namespace-from": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-8.0.1.tgz",
+			"integrity": "sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-for-of": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-8.0.1.tgz",
+			"integrity": "sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-function-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-8.0.1.tgz",
+			"integrity": "sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-json-strings": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-8.0.1.tgz",
+			"integrity": "sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-8.0.1.tgz",
+			"integrity": "sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-8.0.1.tgz",
+			"integrity": "sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-member-expression-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-8.0.1.tgz",
+			"integrity": "sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-modules-amd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-8.0.1.tgz",
+			"integrity": "sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-modules-commonjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+			"integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-modules-systemjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-8.0.1.tgz",
+			"integrity": "sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-identifier": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-modules-umd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-8.0.1.tgz",
+			"integrity": "sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-new-target": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-8.0.1.tgz",
+			"integrity": "sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-8.0.1.tgz",
+			"integrity": "sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-numeric-separator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-8.0.1.tgz",
+			"integrity": "sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-object-rest-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-8.0.1.tgz",
+			"integrity": "sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-object-super": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-8.0.1.tgz",
+			"integrity": "sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-optional-catch-binding": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-8.0.1.tgz",
+			"integrity": "sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-parameters": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-8.0.1.tgz",
+			"integrity": "sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-private-methods": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-8.0.1.tgz",
+			"integrity": "sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-private-property-in-object": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-8.0.1.tgz",
+			"integrity": "sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-property-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-8.0.1.tgz",
+			"integrity": "sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+			"integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+			"integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-syntax-jsx": "^8.0.1",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+			"integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-react-pure-annotations": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+			"integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-regenerator": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-8.0.2.tgz",
+			"integrity": "sha512-aFfsjCRYducRV4dPnpsBbdRkLjboca9FVDg6HZCgy0Ahvk2ZQ/2exmCRC5qS9P6rsWwrmIheNaIM6A1j2F8KMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-8.0.1.tgz",
+			"integrity": "sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-reserved-words": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-8.0.1.tgz",
+			"integrity": "sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-shorthand-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-8.0.1.tgz",
+			"integrity": "sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-8.0.1.tgz",
+			"integrity": "sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-sticky-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-8.0.1.tgz",
+			"integrity": "sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-template-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-8.0.1.tgz",
+			"integrity": "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-typeof-symbol": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-8.0.1.tgz",
+			"integrity": "sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-unicode-escapes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
+			"integrity": "sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-unicode-property-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-8.0.1.tgz",
+			"integrity": "sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-unicode-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-8.0.1.tgz",
+			"integrity": "sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-8.0.1.tgz",
+			"integrity": "sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/preset-env": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-8.0.2.tgz",
+			"integrity": "sha512-CUGLn9hNBCF/eXnwdFAWERbniCcXCRvnKwLV9fegeUEIqv7YlU2MepsWMMM54GcILx5XYMnRh+JAL+K5G+mK6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^8.0.1",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^8.0.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^8.0.1",
+				"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^8.0.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^8.0.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^8.0.1",
+				"@babel/plugin-transform-arrow-functions": "^8.0.1",
+				"@babel/plugin-transform-async-generator-functions": "^8.0.1",
+				"@babel/plugin-transform-async-to-generator": "^8.0.1",
+				"@babel/plugin-transform-block-scoped-functions": "^8.0.1",
+				"@babel/plugin-transform-block-scoping": "^8.0.1",
+				"@babel/plugin-transform-class-properties": "^8.0.1",
+				"@babel/plugin-transform-class-static-block": "^8.0.1",
+				"@babel/plugin-transform-classes": "^8.0.1",
+				"@babel/plugin-transform-computed-properties": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-duplicate-keys": "^8.0.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-dynamic-import": "^8.0.1",
+				"@babel/plugin-transform-explicit-resource-management": "^8.0.1",
+				"@babel/plugin-transform-exponentiation-operator": "^8.0.1",
+				"@babel/plugin-transform-export-namespace-from": "^8.0.1",
+				"@babel/plugin-transform-for-of": "^8.0.1",
+				"@babel/plugin-transform-function-name": "^8.0.1",
+				"@babel/plugin-transform-json-strings": "^8.0.1",
+				"@babel/plugin-transform-literals": "^8.0.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^8.0.1",
+				"@babel/plugin-transform-member-expression-literals": "^8.0.1",
+				"@babel/plugin-transform-modules-amd": "^8.0.1",
+				"@babel/plugin-transform-modules-commonjs": "^8.0.1",
+				"@babel/plugin-transform-modules-systemjs": "^8.0.1",
+				"@babel/plugin-transform-modules-umd": "^8.0.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-new-target": "^8.0.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^8.0.1",
+				"@babel/plugin-transform-numeric-separator": "^8.0.1",
+				"@babel/plugin-transform-object-rest-spread": "^8.0.1",
+				"@babel/plugin-transform-object-super": "^8.0.1",
+				"@babel/plugin-transform-optional-catch-binding": "^8.0.1",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1",
+				"@babel/plugin-transform-private-methods": "^8.0.1",
+				"@babel/plugin-transform-private-property-in-object": "^8.0.1",
+				"@babel/plugin-transform-property-literals": "^8.0.1",
+				"@babel/plugin-transform-regenerator": "^8.0.2",
+				"@babel/plugin-transform-regexp-modifiers": "^8.0.1",
+				"@babel/plugin-transform-reserved-words": "^8.0.1",
+				"@babel/plugin-transform-shorthand-properties": "^8.0.1",
+				"@babel/plugin-transform-spread": "^8.0.1",
+				"@babel/plugin-transform-sticky-regex": "^8.0.1",
+				"@babel/plugin-transform-template-literals": "^8.0.1",
+				"@babel/plugin-transform-typeof-symbol": "^8.0.1",
+				"@babel/plugin-transform-unicode-escapes": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^8.0.1",
+				"@babel/preset-modules": "^0.2.0",
+				"babel-plugin-polyfill-corejs3": "^1.0.0",
+				"core-js-compat": "^3.48.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/preset-modules": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.2.0.tgz",
+			"integrity": "sha512-yz0RBN2fx4fjCeFcTWsWgL7PxSRltvTa0Qg14HkWCU3qS8MO7ZSJlBVbGceynd5C9NsJwwUHNQD3dc6tYO+jqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/types": "^8.0.0",
+				"esutils": "^2.0.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/preset-react": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+			"integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-transform-react-display-name": "^8.0.1",
+				"@babel/plugin-transform-react-jsx": "^8.0.1",
+				"@babel/plugin-transform-react-jsx-development": "^8.0.1",
+				"@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/template": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+			"integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/traverse": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+			"integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/parser": "^8.0.4",
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.4",
+				"obug": "^2.1.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events-shared/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-1.0.0.tgz",
+			"integrity": "sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^1.0.0",
+				"core-js-compat": "^3.48.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-events-shared/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-events-shared/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"fair-events-shared/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"fair-events/node_modules/@babel/code-frame": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+			"integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"js-tokens": "^10.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/compat-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+			"integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/core": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+			"integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helpers": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@types/gensync": "^1.0.5",
+				"convert-source-map": "^2.0.0",
+				"empathic": "^2.0.1",
+				"gensync": "^1.0.0-beta.2",
+				"import-meta-resolve": "^4.2.0",
+				"json5": "^2.2.3",
+				"obug": "^2.1.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"fair-events/node_modules/@babel/generator": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+			"integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"@types/jsesc": "^2.5.0",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-annotate-as-pure": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+			"integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-compilation-targets": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+			"integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-validator-option": "^8.0.0",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^11.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-create-regexp-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"regexpu-core": "^6.3.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-1.0.0.tgz",
+			"integrity": "sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.0",
+				"lodash.debounce": "^4.0.8"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-globals": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+			"integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+			"integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-module-imports": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+			"integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-module-transforms": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+			"integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-optimise-call-expression": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+			"integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-remap-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-wrap-function": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-replace-supers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+			"integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+			"integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-validator-option": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+			"integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helper-wrap-function": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-8.0.0.tgz",
+			"integrity": "sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/helpers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/parser": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.4"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-8.0.1.tgz",
+			"integrity": "sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-8.0.1.tgz",
+			"integrity": "sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-8.0.1.tgz",
+			"integrity": "sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-8.0.1.tgz",
+			"integrity": "sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-8.0.1.tgz",
+			"integrity": "sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-syntax-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+			"integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-arrow-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-8.0.1.tgz",
+			"integrity": "sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-async-generator-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-8.0.1.tgz",
+			"integrity": "sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-block-scoped-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-8.0.1.tgz",
+			"integrity": "sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-block-scoping": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-8.0.1.tgz",
+			"integrity": "sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-class-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-8.0.1.tgz",
+			"integrity": "sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-class-static-block": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-8.0.1.tgz",
+			"integrity": "sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-classes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-8.0.1.tgz",
+			"integrity": "sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-computed-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-8.0.1.tgz",
+			"integrity": "sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-destructuring": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+			"integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-dotall-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-8.0.1.tgz",
+			"integrity": "sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-duplicate-keys": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-8.0.1.tgz",
+			"integrity": "sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-dynamic-import": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-8.0.1.tgz",
+			"integrity": "sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+			"integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-exponentiation-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-8.0.1.tgz",
+			"integrity": "sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-export-namespace-from": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-8.0.1.tgz",
+			"integrity": "sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-for-of": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-8.0.1.tgz",
+			"integrity": "sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-function-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-8.0.1.tgz",
+			"integrity": "sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-json-strings": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-8.0.1.tgz",
+			"integrity": "sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-8.0.1.tgz",
+			"integrity": "sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-8.0.1.tgz",
+			"integrity": "sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-member-expression-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-8.0.1.tgz",
+			"integrity": "sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-modules-amd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-8.0.1.tgz",
+			"integrity": "sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-modules-commonjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+			"integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-modules-systemjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-8.0.1.tgz",
+			"integrity": "sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-identifier": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-modules-umd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-8.0.1.tgz",
+			"integrity": "sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-new-target": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-8.0.1.tgz",
+			"integrity": "sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-8.0.1.tgz",
+			"integrity": "sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-numeric-separator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-8.0.1.tgz",
+			"integrity": "sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-object-rest-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-8.0.1.tgz",
+			"integrity": "sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-object-super": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-8.0.1.tgz",
+			"integrity": "sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-optional-catch-binding": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-8.0.1.tgz",
+			"integrity": "sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-parameters": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-8.0.1.tgz",
+			"integrity": "sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-private-methods": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-8.0.1.tgz",
+			"integrity": "sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-private-property-in-object": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-8.0.1.tgz",
+			"integrity": "sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-property-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-8.0.1.tgz",
+			"integrity": "sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+			"integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+			"integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-syntax-jsx": "^8.0.1",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+			"integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-react-pure-annotations": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+			"integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-regenerator": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-8.0.2.tgz",
+			"integrity": "sha512-aFfsjCRYducRV4dPnpsBbdRkLjboca9FVDg6HZCgy0Ahvk2ZQ/2exmCRC5qS9P6rsWwrmIheNaIM6A1j2F8KMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-8.0.1.tgz",
+			"integrity": "sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-reserved-words": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-8.0.1.tgz",
+			"integrity": "sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-shorthand-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-8.0.1.tgz",
+			"integrity": "sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-8.0.1.tgz",
+			"integrity": "sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-sticky-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-8.0.1.tgz",
+			"integrity": "sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-template-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-8.0.1.tgz",
+			"integrity": "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-typeof-symbol": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-8.0.1.tgz",
+			"integrity": "sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-unicode-escapes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
+			"integrity": "sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-unicode-property-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-8.0.1.tgz",
+			"integrity": "sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-unicode-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-8.0.1.tgz",
+			"integrity": "sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-8.0.1.tgz",
+			"integrity": "sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/preset-env": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-8.0.2.tgz",
+			"integrity": "sha512-CUGLn9hNBCF/eXnwdFAWERbniCcXCRvnKwLV9fegeUEIqv7YlU2MepsWMMM54GcILx5XYMnRh+JAL+K5G+mK6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^8.0.1",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^8.0.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^8.0.1",
+				"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^8.0.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^8.0.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^8.0.1",
+				"@babel/plugin-transform-arrow-functions": "^8.0.1",
+				"@babel/plugin-transform-async-generator-functions": "^8.0.1",
+				"@babel/plugin-transform-async-to-generator": "^8.0.1",
+				"@babel/plugin-transform-block-scoped-functions": "^8.0.1",
+				"@babel/plugin-transform-block-scoping": "^8.0.1",
+				"@babel/plugin-transform-class-properties": "^8.0.1",
+				"@babel/plugin-transform-class-static-block": "^8.0.1",
+				"@babel/plugin-transform-classes": "^8.0.1",
+				"@babel/plugin-transform-computed-properties": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-duplicate-keys": "^8.0.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-dynamic-import": "^8.0.1",
+				"@babel/plugin-transform-explicit-resource-management": "^8.0.1",
+				"@babel/plugin-transform-exponentiation-operator": "^8.0.1",
+				"@babel/plugin-transform-export-namespace-from": "^8.0.1",
+				"@babel/plugin-transform-for-of": "^8.0.1",
+				"@babel/plugin-transform-function-name": "^8.0.1",
+				"@babel/plugin-transform-json-strings": "^8.0.1",
+				"@babel/plugin-transform-literals": "^8.0.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^8.0.1",
+				"@babel/plugin-transform-member-expression-literals": "^8.0.1",
+				"@babel/plugin-transform-modules-amd": "^8.0.1",
+				"@babel/plugin-transform-modules-commonjs": "^8.0.1",
+				"@babel/plugin-transform-modules-systemjs": "^8.0.1",
+				"@babel/plugin-transform-modules-umd": "^8.0.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-new-target": "^8.0.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^8.0.1",
+				"@babel/plugin-transform-numeric-separator": "^8.0.1",
+				"@babel/plugin-transform-object-rest-spread": "^8.0.1",
+				"@babel/plugin-transform-object-super": "^8.0.1",
+				"@babel/plugin-transform-optional-catch-binding": "^8.0.1",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1",
+				"@babel/plugin-transform-private-methods": "^8.0.1",
+				"@babel/plugin-transform-private-property-in-object": "^8.0.1",
+				"@babel/plugin-transform-property-literals": "^8.0.1",
+				"@babel/plugin-transform-regenerator": "^8.0.2",
+				"@babel/plugin-transform-regexp-modifiers": "^8.0.1",
+				"@babel/plugin-transform-reserved-words": "^8.0.1",
+				"@babel/plugin-transform-shorthand-properties": "^8.0.1",
+				"@babel/plugin-transform-spread": "^8.0.1",
+				"@babel/plugin-transform-sticky-regex": "^8.0.1",
+				"@babel/plugin-transform-template-literals": "^8.0.1",
+				"@babel/plugin-transform-typeof-symbol": "^8.0.1",
+				"@babel/plugin-transform-unicode-escapes": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^8.0.1",
+				"@babel/preset-modules": "^0.2.0",
+				"babel-plugin-polyfill-corejs3": "^1.0.0",
+				"core-js-compat": "^3.48.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/preset-modules": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.2.0.tgz",
+			"integrity": "sha512-yz0RBN2fx4fjCeFcTWsWgL7PxSRltvTa0Qg14HkWCU3qS8MO7ZSJlBVbGceynd5C9NsJwwUHNQD3dc6tYO+jqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/types": "^8.0.0",
+				"esutils": "^2.0.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/preset-react": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+			"integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-transform-react-display-name": "^8.0.1",
+				"@babel/plugin-transform-react-jsx": "^8.0.1",
+				"@babel/plugin-transform-react-jsx-development": "^8.0.1",
+				"@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-events/node_modules/@babel/template": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+			"integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/traverse": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+			"integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/parser": "^8.0.4",
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.4",
+				"obug": "^2.1.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-events/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-1.0.0.tgz",
+			"integrity": "sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^1.0.0",
+				"core-js-compat": "^3.48.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
 			}
 		},
 		"fair-events/node_modules/dotenv": {
@@ -265,6 +8329,36 @@
 				"url": "https://dotenvx.com"
 			}
 		},
+		"fair-events/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-events/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"fair-events/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"fair-finance": {
 			"version": "1.0.5",
 			"license": "GPL-2.0-or-later",
@@ -276,10 +8370,1631 @@
 				"fair-events-shared": "*"
 			},
 			"devDependencies": {
+				"@babel/core": "^8.0.1",
+				"@babel/preset-env": "^8.0.2",
+				"@babel/preset-react": "^8.0.1",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@wordpress/scripts": "^32.4.0",
+				"babel-jest": "^30.4.1",
 				"webpack-bundle-output": "^1.1.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/code-frame": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+			"integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"js-tokens": "^10.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/compat-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+			"integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/core": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+			"integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helpers": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@types/gensync": "^1.0.5",
+				"convert-source-map": "^2.0.0",
+				"empathic": "^2.0.1",
+				"gensync": "^1.0.0-beta.2",
+				"import-meta-resolve": "^4.2.0",
+				"json5": "^2.2.3",
+				"obug": "^2.1.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"fair-finance/node_modules/@babel/generator": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+			"integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"@types/jsesc": "^2.5.0",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-annotate-as-pure": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+			"integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-compilation-targets": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+			"integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-validator-option": "^8.0.0",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^11.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-create-regexp-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"regexpu-core": "^6.3.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-1.0.0.tgz",
+			"integrity": "sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.0",
+				"lodash.debounce": "^4.0.8"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-globals": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+			"integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+			"integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-module-imports": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+			"integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-module-transforms": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+			"integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-optimise-call-expression": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+			"integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-remap-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-wrap-function": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-replace-supers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+			"integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+			"integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-validator-option": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+			"integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helper-wrap-function": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-8.0.0.tgz",
+			"integrity": "sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/helpers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/parser": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.4"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-8.0.1.tgz",
+			"integrity": "sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-8.0.1.tgz",
+			"integrity": "sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-8.0.1.tgz",
+			"integrity": "sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-8.0.1.tgz",
+			"integrity": "sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-8.0.1.tgz",
+			"integrity": "sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-syntax-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+			"integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-arrow-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-8.0.1.tgz",
+			"integrity": "sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-async-generator-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-8.0.1.tgz",
+			"integrity": "sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-block-scoped-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-8.0.1.tgz",
+			"integrity": "sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-block-scoping": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-8.0.1.tgz",
+			"integrity": "sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-class-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-8.0.1.tgz",
+			"integrity": "sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-class-static-block": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-8.0.1.tgz",
+			"integrity": "sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-classes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-8.0.1.tgz",
+			"integrity": "sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-computed-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-8.0.1.tgz",
+			"integrity": "sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-destructuring": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+			"integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-dotall-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-8.0.1.tgz",
+			"integrity": "sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-duplicate-keys": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-8.0.1.tgz",
+			"integrity": "sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-dynamic-import": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-8.0.1.tgz",
+			"integrity": "sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+			"integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-exponentiation-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-8.0.1.tgz",
+			"integrity": "sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-export-namespace-from": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-8.0.1.tgz",
+			"integrity": "sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-for-of": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-8.0.1.tgz",
+			"integrity": "sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-function-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-8.0.1.tgz",
+			"integrity": "sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-json-strings": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-8.0.1.tgz",
+			"integrity": "sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-8.0.1.tgz",
+			"integrity": "sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-8.0.1.tgz",
+			"integrity": "sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-member-expression-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-8.0.1.tgz",
+			"integrity": "sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-modules-amd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-8.0.1.tgz",
+			"integrity": "sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-modules-commonjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+			"integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-modules-systemjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-8.0.1.tgz",
+			"integrity": "sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-identifier": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-modules-umd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-8.0.1.tgz",
+			"integrity": "sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-new-target": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-8.0.1.tgz",
+			"integrity": "sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-8.0.1.tgz",
+			"integrity": "sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-numeric-separator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-8.0.1.tgz",
+			"integrity": "sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-object-rest-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-8.0.1.tgz",
+			"integrity": "sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-object-super": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-8.0.1.tgz",
+			"integrity": "sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-optional-catch-binding": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-8.0.1.tgz",
+			"integrity": "sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-parameters": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-8.0.1.tgz",
+			"integrity": "sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-private-methods": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-8.0.1.tgz",
+			"integrity": "sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-private-property-in-object": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-8.0.1.tgz",
+			"integrity": "sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-property-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-8.0.1.tgz",
+			"integrity": "sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+			"integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+			"integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-syntax-jsx": "^8.0.1",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+			"integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-react-pure-annotations": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+			"integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-regenerator": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-8.0.2.tgz",
+			"integrity": "sha512-aFfsjCRYducRV4dPnpsBbdRkLjboca9FVDg6HZCgy0Ahvk2ZQ/2exmCRC5qS9P6rsWwrmIheNaIM6A1j2F8KMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-8.0.1.tgz",
+			"integrity": "sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-reserved-words": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-8.0.1.tgz",
+			"integrity": "sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-shorthand-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-8.0.1.tgz",
+			"integrity": "sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-8.0.1.tgz",
+			"integrity": "sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-sticky-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-8.0.1.tgz",
+			"integrity": "sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-template-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-8.0.1.tgz",
+			"integrity": "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-typeof-symbol": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-8.0.1.tgz",
+			"integrity": "sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-unicode-escapes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
+			"integrity": "sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-unicode-property-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-8.0.1.tgz",
+			"integrity": "sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-unicode-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-8.0.1.tgz",
+			"integrity": "sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-8.0.1.tgz",
+			"integrity": "sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/preset-env": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-8.0.2.tgz",
+			"integrity": "sha512-CUGLn9hNBCF/eXnwdFAWERbniCcXCRvnKwLV9fegeUEIqv7YlU2MepsWMMM54GcILx5XYMnRh+JAL+K5G+mK6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^8.0.1",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^8.0.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^8.0.1",
+				"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^8.0.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^8.0.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^8.0.1",
+				"@babel/plugin-transform-arrow-functions": "^8.0.1",
+				"@babel/plugin-transform-async-generator-functions": "^8.0.1",
+				"@babel/plugin-transform-async-to-generator": "^8.0.1",
+				"@babel/plugin-transform-block-scoped-functions": "^8.0.1",
+				"@babel/plugin-transform-block-scoping": "^8.0.1",
+				"@babel/plugin-transform-class-properties": "^8.0.1",
+				"@babel/plugin-transform-class-static-block": "^8.0.1",
+				"@babel/plugin-transform-classes": "^8.0.1",
+				"@babel/plugin-transform-computed-properties": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-duplicate-keys": "^8.0.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-dynamic-import": "^8.0.1",
+				"@babel/plugin-transform-explicit-resource-management": "^8.0.1",
+				"@babel/plugin-transform-exponentiation-operator": "^8.0.1",
+				"@babel/plugin-transform-export-namespace-from": "^8.0.1",
+				"@babel/plugin-transform-for-of": "^8.0.1",
+				"@babel/plugin-transform-function-name": "^8.0.1",
+				"@babel/plugin-transform-json-strings": "^8.0.1",
+				"@babel/plugin-transform-literals": "^8.0.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^8.0.1",
+				"@babel/plugin-transform-member-expression-literals": "^8.0.1",
+				"@babel/plugin-transform-modules-amd": "^8.0.1",
+				"@babel/plugin-transform-modules-commonjs": "^8.0.1",
+				"@babel/plugin-transform-modules-systemjs": "^8.0.1",
+				"@babel/plugin-transform-modules-umd": "^8.0.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-new-target": "^8.0.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^8.0.1",
+				"@babel/plugin-transform-numeric-separator": "^8.0.1",
+				"@babel/plugin-transform-object-rest-spread": "^8.0.1",
+				"@babel/plugin-transform-object-super": "^8.0.1",
+				"@babel/plugin-transform-optional-catch-binding": "^8.0.1",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1",
+				"@babel/plugin-transform-private-methods": "^8.0.1",
+				"@babel/plugin-transform-private-property-in-object": "^8.0.1",
+				"@babel/plugin-transform-property-literals": "^8.0.1",
+				"@babel/plugin-transform-regenerator": "^8.0.2",
+				"@babel/plugin-transform-regexp-modifiers": "^8.0.1",
+				"@babel/plugin-transform-reserved-words": "^8.0.1",
+				"@babel/plugin-transform-shorthand-properties": "^8.0.1",
+				"@babel/plugin-transform-spread": "^8.0.1",
+				"@babel/plugin-transform-sticky-regex": "^8.0.1",
+				"@babel/plugin-transform-template-literals": "^8.0.1",
+				"@babel/plugin-transform-typeof-symbol": "^8.0.1",
+				"@babel/plugin-transform-unicode-escapes": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^8.0.1",
+				"@babel/preset-modules": "^0.2.0",
+				"babel-plugin-polyfill-corejs3": "^1.0.0",
+				"core-js-compat": "^3.48.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/preset-modules": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.2.0.tgz",
+			"integrity": "sha512-yz0RBN2fx4fjCeFcTWsWgL7PxSRltvTa0Qg14HkWCU3qS8MO7ZSJlBVbGceynd5C9NsJwwUHNQD3dc6tYO+jqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/types": "^8.0.0",
+				"esutils": "^2.0.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/preset-react": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+			"integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-transform-react-display-name": "^8.0.1",
+				"@babel/plugin-transform-react-jsx": "^8.0.1",
+				"@babel/plugin-transform-react-jsx-development": "^8.0.1",
+				"@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/template": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+			"integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/traverse": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+			"integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/parser": "^8.0.4",
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.4",
+				"obug": "^2.1.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-finance/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-1.0.0.tgz",
+			"integrity": "sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^1.0.0",
+				"core-js-compat": "^3.48.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-finance/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-finance/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"fair-finance/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"fair-form": {
@@ -295,14 +10010,2416 @@
 				"fair-events-shared": "*"
 			},
 			"devDependencies": {
-				"@babel/core": "^7.28.3",
-				"@babel/preset-env": "^7.28.3",
-				"@babel/preset-react": "^7.28.3",
+				"@babel/core": "^8.0.1",
+				"@babel/preset-env": "^8.0.2",
+				"@babel/preset-react": "^8.0.1",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@wordpress/scripts": "^32.4.0",
-				"babel-jest": "^30.0.5",
+				"babel-jest": "^30.4.1",
 				"webpack-bundle-output": "^1.1.0"
+			}
+		},
+		"fair-form/node_modules/@babel/code-frame": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+			"integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"js-tokens": "^10.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/compat-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+			"integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/core": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+			"integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helpers": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@types/gensync": "^1.0.5",
+				"convert-source-map": "^2.0.0",
+				"empathic": "^2.0.1",
+				"gensync": "^1.0.0-beta.2",
+				"import-meta-resolve": "^4.2.0",
+				"json5": "^2.2.3",
+				"obug": "^2.1.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"fair-form/node_modules/@babel/generator": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+			"integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"@types/jsesc": "^2.5.0",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-annotate-as-pure": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+			"integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-compilation-targets": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+			"integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-validator-option": "^8.0.0",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^11.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-create-regexp-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"regexpu-core": "^6.3.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-1.0.0.tgz",
+			"integrity": "sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.0",
+				"lodash.debounce": "^4.0.8"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-define-polyfill-provider/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-globals": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+			"integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+			"integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-module-imports": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+			"integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-module-transforms": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+			"integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-optimise-call-expression": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+			"integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-remap-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-wrap-function": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-replace-supers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+			"integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+			"integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-validator-option": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+			"integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helper-wrap-function": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-8.0.0.tgz",
+			"integrity": "sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/helpers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/parser": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.4"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-8.0.1.tgz",
+			"integrity": "sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-8.0.1.tgz",
+			"integrity": "sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-8.0.1.tgz",
+			"integrity": "sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-8.0.1.tgz",
+			"integrity": "sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-8.0.1.tgz",
+			"integrity": "sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-syntax-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+			"integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-syntax-jsx/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-arrow-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-8.0.1.tgz",
+			"integrity": "sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-arrow-functions/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-async-generator-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-8.0.1.tgz",
+			"integrity": "sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-async-generator-functions/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-async-to-generator/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-block-scoped-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-8.0.1.tgz",
+			"integrity": "sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-block-scoped-functions/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-block-scoping": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-8.0.1.tgz",
+			"integrity": "sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-block-scoping/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-class-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-8.0.1.tgz",
+			"integrity": "sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-class-properties/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-class-static-block": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-8.0.1.tgz",
+			"integrity": "sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-class-static-block/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-classes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-8.0.1.tgz",
+			"integrity": "sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-classes/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-computed-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-8.0.1.tgz",
+			"integrity": "sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-computed-properties/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-destructuring": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+			"integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-destructuring/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-dotall-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-8.0.1.tgz",
+			"integrity": "sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-dotall-regex/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-duplicate-keys": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-8.0.1.tgz",
+			"integrity": "sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-duplicate-keys/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-dynamic-import": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-8.0.1.tgz",
+			"integrity": "sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-dynamic-import/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+			"integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-explicit-resource-management/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-exponentiation-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-8.0.1.tgz",
+			"integrity": "sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-exponentiation-operator/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-export-namespace-from": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-8.0.1.tgz",
+			"integrity": "sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-export-namespace-from/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-for-of": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-8.0.1.tgz",
+			"integrity": "sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-for-of/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-function-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-8.0.1.tgz",
+			"integrity": "sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-function-name/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-json-strings": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-8.0.1.tgz",
+			"integrity": "sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-json-strings/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-8.0.1.tgz",
+			"integrity": "sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-literals/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-8.0.1.tgz",
+			"integrity": "sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-logical-assignment-operators/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-member-expression-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-8.0.1.tgz",
+			"integrity": "sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-member-expression-literals/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-modules-amd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-8.0.1.tgz",
+			"integrity": "sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-modules-commonjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+			"integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-modules-systemjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-8.0.1.tgz",
+			"integrity": "sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-identifier": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-modules-umd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-8.0.1.tgz",
+			"integrity": "sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-named-capturing-groups-regex/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-new-target": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-8.0.1.tgz",
+			"integrity": "sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-new-target/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-8.0.1.tgz",
+			"integrity": "sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-nullish-coalescing-operator/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-numeric-separator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-8.0.1.tgz",
+			"integrity": "sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-numeric-separator/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-object-rest-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-8.0.1.tgz",
+			"integrity": "sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-object-rest-spread/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-object-super": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-8.0.1.tgz",
+			"integrity": "sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-object-super/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-optional-catch-binding": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-8.0.1.tgz",
+			"integrity": "sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-optional-catch-binding/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-optional-chaining/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-parameters": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-8.0.1.tgz",
+			"integrity": "sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-parameters/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-private-methods": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-8.0.1.tgz",
+			"integrity": "sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-private-methods/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-private-property-in-object": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-8.0.1.tgz",
+			"integrity": "sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-private-property-in-object/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-property-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-8.0.1.tgz",
+			"integrity": "sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-property-literals/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+			"integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-react-display-name/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+			"integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-syntax-jsx": "^8.0.1",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+			"integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-react-pure-annotations": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+			"integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-react-pure-annotations/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-regenerator": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-8.0.2.tgz",
+			"integrity": "sha512-aFfsjCRYducRV4dPnpsBbdRkLjboca9FVDg6HZCgy0Ahvk2ZQ/2exmCRC5qS9P6rsWwrmIheNaIM6A1j2F8KMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-regenerator/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-8.0.1.tgz",
+			"integrity": "sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-regexp-modifiers/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-reserved-words": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-8.0.1.tgz",
+			"integrity": "sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-reserved-words/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-shorthand-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-8.0.1.tgz",
+			"integrity": "sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-shorthand-properties/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-8.0.1.tgz",
+			"integrity": "sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-spread/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-sticky-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-8.0.1.tgz",
+			"integrity": "sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-sticky-regex/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-template-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-8.0.1.tgz",
+			"integrity": "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-template-literals/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-typeof-symbol": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-8.0.1.tgz",
+			"integrity": "sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-typeof-symbol/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-unicode-escapes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
+			"integrity": "sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-unicode-escapes/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-unicode-property-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-8.0.1.tgz",
+			"integrity": "sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-unicode-property-regex/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-unicode-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-8.0.1.tgz",
+			"integrity": "sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-unicode-regex/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-8.0.1.tgz",
+			"integrity": "sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/plugin-transform-unicode-sets-regex/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/preset-env": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-8.0.2.tgz",
+			"integrity": "sha512-CUGLn9hNBCF/eXnwdFAWERbniCcXCRvnKwLV9fegeUEIqv7YlU2MepsWMMM54GcILx5XYMnRh+JAL+K5G+mK6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^8.0.1",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^8.0.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^8.0.1",
+				"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^8.0.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^8.0.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^8.0.1",
+				"@babel/plugin-transform-arrow-functions": "^8.0.1",
+				"@babel/plugin-transform-async-generator-functions": "^8.0.1",
+				"@babel/plugin-transform-async-to-generator": "^8.0.1",
+				"@babel/plugin-transform-block-scoped-functions": "^8.0.1",
+				"@babel/plugin-transform-block-scoping": "^8.0.1",
+				"@babel/plugin-transform-class-properties": "^8.0.1",
+				"@babel/plugin-transform-class-static-block": "^8.0.1",
+				"@babel/plugin-transform-classes": "^8.0.1",
+				"@babel/plugin-transform-computed-properties": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-duplicate-keys": "^8.0.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-dynamic-import": "^8.0.1",
+				"@babel/plugin-transform-explicit-resource-management": "^8.0.1",
+				"@babel/plugin-transform-exponentiation-operator": "^8.0.1",
+				"@babel/plugin-transform-export-namespace-from": "^8.0.1",
+				"@babel/plugin-transform-for-of": "^8.0.1",
+				"@babel/plugin-transform-function-name": "^8.0.1",
+				"@babel/plugin-transform-json-strings": "^8.0.1",
+				"@babel/plugin-transform-literals": "^8.0.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^8.0.1",
+				"@babel/plugin-transform-member-expression-literals": "^8.0.1",
+				"@babel/plugin-transform-modules-amd": "^8.0.1",
+				"@babel/plugin-transform-modules-commonjs": "^8.0.1",
+				"@babel/plugin-transform-modules-systemjs": "^8.0.1",
+				"@babel/plugin-transform-modules-umd": "^8.0.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-new-target": "^8.0.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^8.0.1",
+				"@babel/plugin-transform-numeric-separator": "^8.0.1",
+				"@babel/plugin-transform-object-rest-spread": "^8.0.1",
+				"@babel/plugin-transform-object-super": "^8.0.1",
+				"@babel/plugin-transform-optional-catch-binding": "^8.0.1",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1",
+				"@babel/plugin-transform-private-methods": "^8.0.1",
+				"@babel/plugin-transform-private-property-in-object": "^8.0.1",
+				"@babel/plugin-transform-property-literals": "^8.0.1",
+				"@babel/plugin-transform-regenerator": "^8.0.2",
+				"@babel/plugin-transform-regexp-modifiers": "^8.0.1",
+				"@babel/plugin-transform-reserved-words": "^8.0.1",
+				"@babel/plugin-transform-shorthand-properties": "^8.0.1",
+				"@babel/plugin-transform-spread": "^8.0.1",
+				"@babel/plugin-transform-sticky-regex": "^8.0.1",
+				"@babel/plugin-transform-template-literals": "^8.0.1",
+				"@babel/plugin-transform-typeof-symbol": "^8.0.1",
+				"@babel/plugin-transform-unicode-escapes": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^8.0.1",
+				"@babel/preset-modules": "^0.2.0",
+				"babel-plugin-polyfill-corejs3": "^1.0.0",
+				"core-js-compat": "^3.48.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/preset-env/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/preset-modules": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.2.0.tgz",
+			"integrity": "sha512-yz0RBN2fx4fjCeFcTWsWgL7PxSRltvTa0Qg14HkWCU3qS8MO7ZSJlBVbGceynd5C9NsJwwUHNQD3dc6tYO+jqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/types": "^8.0.0",
+				"esutils": "^2.0.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/preset-modules/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/preset-react": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+			"integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-transform-react-display-name": "^8.0.1",
+				"@babel/plugin-transform-react-jsx": "^8.0.1",
+				"@babel/plugin-transform-react-jsx-development": "^8.0.1",
+				"@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/preset-react/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-form/node_modules/@babel/template": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+			"integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/traverse": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+			"integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/parser": "^8.0.4",
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.4",
+				"obug": "^2.1.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-form/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"fair-form/node_modules/@jest/transform": {
@@ -329,6 +12446,273 @@
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/code-frame": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/compat-data": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/core": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/remapping": "^2.3.5",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/generator": {
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+			"integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.8",
+				"@babel/types": "^7.29.8",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/helper-compilation-targets": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/helper-globals": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/helper-module-imports": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/helper-module-transforms": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/helper-string-parser": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/helper-validator-identifier": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/helper-validator-option": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/helpers": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/parser": {
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+			"integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.8"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/template": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/traverse": {
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+			"integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.8",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.8",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.8",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/@babel/types": {
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+			"integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^3.0.2"
+			}
+		},
+		"fair-form/node_modules/@jest/transform/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"fair-form/node_modules/@jest/types": {
@@ -422,6 +12806,23 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"fair-form/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-1.0.0.tgz",
+			"integrity": "sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^1.0.0",
+				"core-js-compat": "^3.48.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
 		"fair-form/node_modules/ci-info": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -491,6 +12892,23 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"fair-form/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-form/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"fair-form/node_modules/picomatch": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
@@ -502,6 +12920,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"fair-form/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"fair-form/node_modules/write-file-atomic": {
@@ -533,10 +12964,14 @@
 				"xlsx": "^0.18.5"
 			},
 			"devDependencies": {
+				"@babel/core": "^8.0.1",
+				"@babel/preset-env": "^8.0.2",
+				"@babel/preset-react": "^8.0.1",
 				"@playwright/test": "^1.40.0",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@wordpress/scripts": "^32.4.0",
+				"babel-jest": "^30.4.1",
 				"dotenv": "^16.3.1",
 				"webpack-bundle-output": "^1.1.0"
 			}
@@ -578,6 +13013,1593 @@
 				"react": "^18.0.0"
 			}
 		},
+		"fair-payments-connector/node_modules/@babel/code-frame": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+			"integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"js-tokens": "^10.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/compat-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+			"integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/core": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+			"integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helpers": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@types/gensync": "^1.0.5",
+				"convert-source-map": "^2.0.0",
+				"empathic": "^2.0.1",
+				"gensync": "^1.0.0-beta.2",
+				"import-meta-resolve": "^4.2.0",
+				"json5": "^2.2.3",
+				"obug": "^2.1.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/generator": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+			"integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"@types/jsesc": "^2.5.0",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-annotate-as-pure": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+			"integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-compilation-targets": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+			"integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-validator-option": "^8.0.0",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^11.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-create-regexp-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"regexpu-core": "^6.3.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-1.0.0.tgz",
+			"integrity": "sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.0",
+				"lodash.debounce": "^4.0.8"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-globals": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+			"integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+			"integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-module-imports": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+			"integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-module-transforms": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+			"integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-optimise-call-expression": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+			"integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-remap-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-wrap-function": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-replace-supers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+			"integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+			"integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-validator-option": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+			"integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helper-wrap-function": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-8.0.0.tgz",
+			"integrity": "sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/helpers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/parser": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.4"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-8.0.1.tgz",
+			"integrity": "sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-8.0.1.tgz",
+			"integrity": "sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-8.0.1.tgz",
+			"integrity": "sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-8.0.1.tgz",
+			"integrity": "sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-8.0.1.tgz",
+			"integrity": "sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-syntax-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+			"integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-arrow-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-8.0.1.tgz",
+			"integrity": "sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-async-generator-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-8.0.1.tgz",
+			"integrity": "sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-block-scoped-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-8.0.1.tgz",
+			"integrity": "sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-block-scoping": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-8.0.1.tgz",
+			"integrity": "sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-class-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-8.0.1.tgz",
+			"integrity": "sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-class-static-block": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-8.0.1.tgz",
+			"integrity": "sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-classes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-8.0.1.tgz",
+			"integrity": "sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-computed-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-8.0.1.tgz",
+			"integrity": "sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-destructuring": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+			"integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-dotall-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-8.0.1.tgz",
+			"integrity": "sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-duplicate-keys": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-8.0.1.tgz",
+			"integrity": "sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-dynamic-import": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-8.0.1.tgz",
+			"integrity": "sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+			"integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-exponentiation-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-8.0.1.tgz",
+			"integrity": "sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-export-namespace-from": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-8.0.1.tgz",
+			"integrity": "sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-for-of": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-8.0.1.tgz",
+			"integrity": "sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-function-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-8.0.1.tgz",
+			"integrity": "sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-json-strings": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-8.0.1.tgz",
+			"integrity": "sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-8.0.1.tgz",
+			"integrity": "sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-8.0.1.tgz",
+			"integrity": "sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-member-expression-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-8.0.1.tgz",
+			"integrity": "sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-modules-amd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-8.0.1.tgz",
+			"integrity": "sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-modules-commonjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+			"integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-modules-systemjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-8.0.1.tgz",
+			"integrity": "sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-identifier": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-modules-umd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-8.0.1.tgz",
+			"integrity": "sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-new-target": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-8.0.1.tgz",
+			"integrity": "sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-8.0.1.tgz",
+			"integrity": "sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-numeric-separator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-8.0.1.tgz",
+			"integrity": "sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-object-rest-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-8.0.1.tgz",
+			"integrity": "sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-object-super": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-8.0.1.tgz",
+			"integrity": "sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-optional-catch-binding": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-8.0.1.tgz",
+			"integrity": "sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-parameters": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-8.0.1.tgz",
+			"integrity": "sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-private-methods": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-8.0.1.tgz",
+			"integrity": "sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-private-property-in-object": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-8.0.1.tgz",
+			"integrity": "sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-property-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-8.0.1.tgz",
+			"integrity": "sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+			"integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+			"integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-syntax-jsx": "^8.0.1",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+			"integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-react-pure-annotations": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+			"integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-regenerator": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-8.0.2.tgz",
+			"integrity": "sha512-aFfsjCRYducRV4dPnpsBbdRkLjboca9FVDg6HZCgy0Ahvk2ZQ/2exmCRC5qS9P6rsWwrmIheNaIM6A1j2F8KMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-8.0.1.tgz",
+			"integrity": "sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-reserved-words": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-8.0.1.tgz",
+			"integrity": "sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-shorthand-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-8.0.1.tgz",
+			"integrity": "sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-8.0.1.tgz",
+			"integrity": "sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-sticky-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-8.0.1.tgz",
+			"integrity": "sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-template-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-8.0.1.tgz",
+			"integrity": "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-typeof-symbol": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-8.0.1.tgz",
+			"integrity": "sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-unicode-escapes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
+			"integrity": "sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-unicode-property-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-8.0.1.tgz",
+			"integrity": "sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-unicode-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-8.0.1.tgz",
+			"integrity": "sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-8.0.1.tgz",
+			"integrity": "sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/preset-env": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-8.0.2.tgz",
+			"integrity": "sha512-CUGLn9hNBCF/eXnwdFAWERbniCcXCRvnKwLV9fegeUEIqv7YlU2MepsWMMM54GcILx5XYMnRh+JAL+K5G+mK6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^8.0.1",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^8.0.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^8.0.1",
+				"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^8.0.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^8.0.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^8.0.1",
+				"@babel/plugin-transform-arrow-functions": "^8.0.1",
+				"@babel/plugin-transform-async-generator-functions": "^8.0.1",
+				"@babel/plugin-transform-async-to-generator": "^8.0.1",
+				"@babel/plugin-transform-block-scoped-functions": "^8.0.1",
+				"@babel/plugin-transform-block-scoping": "^8.0.1",
+				"@babel/plugin-transform-class-properties": "^8.0.1",
+				"@babel/plugin-transform-class-static-block": "^8.0.1",
+				"@babel/plugin-transform-classes": "^8.0.1",
+				"@babel/plugin-transform-computed-properties": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-duplicate-keys": "^8.0.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-dynamic-import": "^8.0.1",
+				"@babel/plugin-transform-explicit-resource-management": "^8.0.1",
+				"@babel/plugin-transform-exponentiation-operator": "^8.0.1",
+				"@babel/plugin-transform-export-namespace-from": "^8.0.1",
+				"@babel/plugin-transform-for-of": "^8.0.1",
+				"@babel/plugin-transform-function-name": "^8.0.1",
+				"@babel/plugin-transform-json-strings": "^8.0.1",
+				"@babel/plugin-transform-literals": "^8.0.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^8.0.1",
+				"@babel/plugin-transform-member-expression-literals": "^8.0.1",
+				"@babel/plugin-transform-modules-amd": "^8.0.1",
+				"@babel/plugin-transform-modules-commonjs": "^8.0.1",
+				"@babel/plugin-transform-modules-systemjs": "^8.0.1",
+				"@babel/plugin-transform-modules-umd": "^8.0.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-new-target": "^8.0.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^8.0.1",
+				"@babel/plugin-transform-numeric-separator": "^8.0.1",
+				"@babel/plugin-transform-object-rest-spread": "^8.0.1",
+				"@babel/plugin-transform-object-super": "^8.0.1",
+				"@babel/plugin-transform-optional-catch-binding": "^8.0.1",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1",
+				"@babel/plugin-transform-private-methods": "^8.0.1",
+				"@babel/plugin-transform-private-property-in-object": "^8.0.1",
+				"@babel/plugin-transform-property-literals": "^8.0.1",
+				"@babel/plugin-transform-regenerator": "^8.0.2",
+				"@babel/plugin-transform-regexp-modifiers": "^8.0.1",
+				"@babel/plugin-transform-reserved-words": "^8.0.1",
+				"@babel/plugin-transform-shorthand-properties": "^8.0.1",
+				"@babel/plugin-transform-spread": "^8.0.1",
+				"@babel/plugin-transform-sticky-regex": "^8.0.1",
+				"@babel/plugin-transform-template-literals": "^8.0.1",
+				"@babel/plugin-transform-typeof-symbol": "^8.0.1",
+				"@babel/plugin-transform-unicode-escapes": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^8.0.1",
+				"@babel/preset-modules": "^0.2.0",
+				"babel-plugin-polyfill-corejs3": "^1.0.0",
+				"core-js-compat": "^3.48.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/preset-modules": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.2.0.tgz",
+			"integrity": "sha512-yz0RBN2fx4fjCeFcTWsWgL7PxSRltvTa0Qg14HkWCU3qS8MO7ZSJlBVbGceynd5C9NsJwwUHNQD3dc6tYO+jqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/types": "^8.0.0",
+				"esutils": "^2.0.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/preset-react": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+			"integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-transform-react-display-name": "^8.0.1",
+				"@babel/plugin-transform-react-jsx": "^8.0.1",
+				"@babel/plugin-transform-react-jsx-development": "^8.0.1",
+				"@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/template": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+			"integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/traverse": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+			"integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/parser": "^8.0.4",
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.4",
+				"obug": "^2.1.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-1.0.0.tgz",
+			"integrity": "sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^1.0.0",
+				"core-js-compat": "^3.48.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
 		"fair-payments-connector/node_modules/dotenv": {
 			"version": "16.6.1",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -589,6 +14611,36 @@
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
+			}
+		},
+		"fair-payments-connector/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-payments-connector/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"fair-payments-connector/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"fair-platform": {
@@ -620,15 +14672,1496 @@
 				"date-fns": "^4.4.0"
 			},
 			"devDependencies": {
-				"@babel/core": "^7.28.3",
-				"@babel/preset-env": "^7.28.3",
+				"@babel/core": "^8.0.1",
+				"@babel/preset-env": "^8.0.2",
 				"@playwright/test": "^1.40.0",
 				"@wordpress/scripts": "^32.4.0",
-				"babel-jest": "^30.0.5",
+				"babel-jest": "^30.4.1",
 				"dotenv": "^16.3.1",
 				"jest": "^30.0.0",
 				"jest-environment-node": "^30.0.0",
 				"webpack-bundle-output": "^1.1.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/code-frame": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+			"integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"js-tokens": "^10.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/compat-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+			"integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/core": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+			"integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helpers": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@types/gensync": "^1.0.5",
+				"convert-source-map": "^2.0.0",
+				"empathic": "^2.0.1",
+				"gensync": "^1.0.0-beta.2",
+				"import-meta-resolve": "^4.2.0",
+				"json5": "^2.2.3",
+				"obug": "^2.1.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"fair-timetable/node_modules/@babel/generator": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+			"integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"@types/jsesc": "^2.5.0",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-annotate-as-pure": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+			"integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-compilation-targets": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+			"integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-validator-option": "^8.0.0",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^11.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-create-regexp-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"regexpu-core": "^6.3.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-1.0.0.tgz",
+			"integrity": "sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.0",
+				"lodash.debounce": "^4.0.8"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-globals": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+			"integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+			"integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-module-imports": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+			"integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-module-transforms": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+			"integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-optimise-call-expression": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+			"integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-remap-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-wrap-function": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-replace-supers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+			"integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+			"integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-validator-option": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+			"integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helper-wrap-function": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-8.0.0.tgz",
+			"integrity": "sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/helpers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/parser": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.4"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-8.0.1.tgz",
+			"integrity": "sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-8.0.1.tgz",
+			"integrity": "sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-8.0.1.tgz",
+			"integrity": "sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-8.0.1.tgz",
+			"integrity": "sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-8.0.1.tgz",
+			"integrity": "sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-arrow-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-8.0.1.tgz",
+			"integrity": "sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-async-generator-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-8.0.1.tgz",
+			"integrity": "sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-block-scoped-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-8.0.1.tgz",
+			"integrity": "sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-block-scoping": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-8.0.1.tgz",
+			"integrity": "sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-class-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-8.0.1.tgz",
+			"integrity": "sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-class-static-block": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-8.0.1.tgz",
+			"integrity": "sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-classes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-8.0.1.tgz",
+			"integrity": "sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-computed-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-8.0.1.tgz",
+			"integrity": "sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-destructuring": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+			"integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-dotall-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-8.0.1.tgz",
+			"integrity": "sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-duplicate-keys": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-8.0.1.tgz",
+			"integrity": "sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-dynamic-import": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-8.0.1.tgz",
+			"integrity": "sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+			"integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-exponentiation-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-8.0.1.tgz",
+			"integrity": "sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-export-namespace-from": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-8.0.1.tgz",
+			"integrity": "sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-for-of": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-8.0.1.tgz",
+			"integrity": "sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-function-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-8.0.1.tgz",
+			"integrity": "sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-json-strings": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-8.0.1.tgz",
+			"integrity": "sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-8.0.1.tgz",
+			"integrity": "sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-8.0.1.tgz",
+			"integrity": "sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-member-expression-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-8.0.1.tgz",
+			"integrity": "sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-modules-amd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-8.0.1.tgz",
+			"integrity": "sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-modules-commonjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+			"integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-modules-systemjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-8.0.1.tgz",
+			"integrity": "sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-identifier": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-modules-umd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-8.0.1.tgz",
+			"integrity": "sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-new-target": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-8.0.1.tgz",
+			"integrity": "sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-8.0.1.tgz",
+			"integrity": "sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-numeric-separator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-8.0.1.tgz",
+			"integrity": "sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-object-rest-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-8.0.1.tgz",
+			"integrity": "sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-object-super": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-8.0.1.tgz",
+			"integrity": "sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-optional-catch-binding": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-8.0.1.tgz",
+			"integrity": "sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-parameters": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-8.0.1.tgz",
+			"integrity": "sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-private-methods": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-8.0.1.tgz",
+			"integrity": "sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-private-property-in-object": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-8.0.1.tgz",
+			"integrity": "sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-property-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-8.0.1.tgz",
+			"integrity": "sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-regenerator": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-8.0.2.tgz",
+			"integrity": "sha512-aFfsjCRYducRV4dPnpsBbdRkLjboca9FVDg6HZCgy0Ahvk2ZQ/2exmCRC5qS9P6rsWwrmIheNaIM6A1j2F8KMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-8.0.1.tgz",
+			"integrity": "sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-reserved-words": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-8.0.1.tgz",
+			"integrity": "sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-shorthand-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-8.0.1.tgz",
+			"integrity": "sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-8.0.1.tgz",
+			"integrity": "sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-sticky-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-8.0.1.tgz",
+			"integrity": "sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-template-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-8.0.1.tgz",
+			"integrity": "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-typeof-symbol": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-8.0.1.tgz",
+			"integrity": "sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-unicode-escapes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
+			"integrity": "sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-unicode-property-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-8.0.1.tgz",
+			"integrity": "sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-unicode-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-8.0.1.tgz",
+			"integrity": "sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-8.0.1.tgz",
+			"integrity": "sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/preset-env": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-8.0.2.tgz",
+			"integrity": "sha512-CUGLn9hNBCF/eXnwdFAWERbniCcXCRvnKwLV9fegeUEIqv7YlU2MepsWMMM54GcILx5XYMnRh+JAL+K5G+mK6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^8.0.1",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^8.0.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^8.0.1",
+				"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^8.0.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^8.0.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^8.0.1",
+				"@babel/plugin-transform-arrow-functions": "^8.0.1",
+				"@babel/plugin-transform-async-generator-functions": "^8.0.1",
+				"@babel/plugin-transform-async-to-generator": "^8.0.1",
+				"@babel/plugin-transform-block-scoped-functions": "^8.0.1",
+				"@babel/plugin-transform-block-scoping": "^8.0.1",
+				"@babel/plugin-transform-class-properties": "^8.0.1",
+				"@babel/plugin-transform-class-static-block": "^8.0.1",
+				"@babel/plugin-transform-classes": "^8.0.1",
+				"@babel/plugin-transform-computed-properties": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-duplicate-keys": "^8.0.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-dynamic-import": "^8.0.1",
+				"@babel/plugin-transform-explicit-resource-management": "^8.0.1",
+				"@babel/plugin-transform-exponentiation-operator": "^8.0.1",
+				"@babel/plugin-transform-export-namespace-from": "^8.0.1",
+				"@babel/plugin-transform-for-of": "^8.0.1",
+				"@babel/plugin-transform-function-name": "^8.0.1",
+				"@babel/plugin-transform-json-strings": "^8.0.1",
+				"@babel/plugin-transform-literals": "^8.0.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^8.0.1",
+				"@babel/plugin-transform-member-expression-literals": "^8.0.1",
+				"@babel/plugin-transform-modules-amd": "^8.0.1",
+				"@babel/plugin-transform-modules-commonjs": "^8.0.1",
+				"@babel/plugin-transform-modules-systemjs": "^8.0.1",
+				"@babel/plugin-transform-modules-umd": "^8.0.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-new-target": "^8.0.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^8.0.1",
+				"@babel/plugin-transform-numeric-separator": "^8.0.1",
+				"@babel/plugin-transform-object-rest-spread": "^8.0.1",
+				"@babel/plugin-transform-object-super": "^8.0.1",
+				"@babel/plugin-transform-optional-catch-binding": "^8.0.1",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1",
+				"@babel/plugin-transform-private-methods": "^8.0.1",
+				"@babel/plugin-transform-private-property-in-object": "^8.0.1",
+				"@babel/plugin-transform-property-literals": "^8.0.1",
+				"@babel/plugin-transform-regenerator": "^8.0.2",
+				"@babel/plugin-transform-regexp-modifiers": "^8.0.1",
+				"@babel/plugin-transform-reserved-words": "^8.0.1",
+				"@babel/plugin-transform-shorthand-properties": "^8.0.1",
+				"@babel/plugin-transform-spread": "^8.0.1",
+				"@babel/plugin-transform-sticky-regex": "^8.0.1",
+				"@babel/plugin-transform-template-literals": "^8.0.1",
+				"@babel/plugin-transform-typeof-symbol": "^8.0.1",
+				"@babel/plugin-transform-unicode-escapes": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^8.0.1",
+				"@babel/preset-modules": "^0.2.0",
+				"babel-plugin-polyfill-corejs3": "^1.0.0",
+				"core-js-compat": "^3.48.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/preset-modules": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.2.0.tgz",
+			"integrity": "sha512-yz0RBN2fx4fjCeFcTWsWgL7PxSRltvTa0Qg14HkWCU3qS8MO7ZSJlBVbGceynd5C9NsJwwUHNQD3dc6tYO+jqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/types": "^8.0.0",
+				"esutils": "^2.0.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/template": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+			"integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/traverse": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+			"integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/parser": "^8.0.4",
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.4",
+				"obug": "^2.1.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-timetable/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-1.0.0.tgz",
+			"integrity": "sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^1.0.0",
+				"core-js-compat": "^3.48.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
 			}
 		},
 		"fair-timetable/node_modules/dotenv": {
@@ -676,6 +16209,36 @@
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"fair-timetable/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-timetable/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"fair-timetable/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@actions/core": {
@@ -7934,6 +23497,13 @@
 				"@types/send": "*"
 			}
 		},
+		"node_modules/@types/gensync": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+			"integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -8011,6 +23581,13 @@
 				"@types/tough-cookie": "*",
 				"parse5": "^7.0.0"
 			}
+		},
+		"node_modules/@types/jsesc": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+			"integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -18147,6 +33724,16 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/empathic": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+			"integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/encodeurl": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -21060,6 +36647,17 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/imurmurhash": {
@@ -25407,6 +41005,20 @@
 			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
 			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
 			"license": "MIT"
+		},
+		"node_modules/obug": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
 		},
 		"node_modules/octokit": {
 			"version": "3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12988,10 +12988,1584 @@
 				"@wordpress/icons": "^14.0.0"
 			},
 			"devDependencies": {
+				"@babel/core": "^8.0.1",
+				"@babel/preset-env": "^8.0.2",
+				"@babel/preset-react": "^8.0.1",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@wordpress/scripts": "^32.4.0",
+				"babel-jest": "^30.4.1",
 				"webpack-bundle-output": "^1.1.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/code-frame": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+			"integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"js-tokens": "^10.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/compat-data": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+			"integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/core": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+			"integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helpers": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@types/gensync": "^1.0.5",
+				"convert-source-map": "^2.0.0",
+				"empathic": "^2.0.1",
+				"gensync": "^1.0.0-beta.2",
+				"import-meta-resolve": "^4.2.0",
+				"json5": "^2.2.3",
+				"obug": "^2.1.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/generator": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+			"integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"@types/jsesc": "^2.5.0",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-annotate-as-pure": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+			"integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-compilation-targets": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+			"integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-validator-option": "^8.0.0",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^11.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-create-regexp-features-plugin": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-8.0.1.tgz",
+			"integrity": "sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"regexpu-core": "^6.3.1",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-1.0.0.tgz",
+			"integrity": "sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.0",
+				"lodash.debounce": "^4.0.8"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-globals": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+			"integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+			"integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-module-imports": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+			"integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-module-transforms": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+			"integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-optimise-call-expression": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+			"integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-plugin-utils": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+			"integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-remap-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-wrap-function": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-replace-supers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+			"integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^8.0.0",
+				"@babel/helper-optimise-call-expression": "^8.0.0",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+			"integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-string-parser": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+			"integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-validator-identifier": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+			"integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-validator-option": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+			"integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helper-wrap-function": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-8.0.0.tgz",
+			"integrity": "sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/traverse": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/helpers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/parser": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+			"integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^8.0.4"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-8.0.1.tgz",
+			"integrity": "sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-8.0.1.tgz",
+			"integrity": "sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-8.0.1.tgz",
+			"integrity": "sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-8.0.1.tgz",
+			"integrity": "sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-8.0.1.tgz",
+			"integrity": "sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-syntax-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+			"integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-arrow-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-8.0.1.tgz",
+			"integrity": "sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-async-generator-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-8.0.1.tgz",
+			"integrity": "sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-async-to-generator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-8.0.1.tgz",
+			"integrity": "sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-remap-async-to-generator": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-block-scoped-functions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-8.0.1.tgz",
+			"integrity": "sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-block-scoping": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-8.0.1.tgz",
+			"integrity": "sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-class-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-8.0.1.tgz",
+			"integrity": "sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-class-static-block": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-8.0.1.tgz",
+			"integrity": "sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-classes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-8.0.1.tgz",
+			"integrity": "sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1",
+				"@babel/traverse": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-computed-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-8.0.1.tgz",
+			"integrity": "sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-destructuring": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+			"integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-dotall-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-8.0.1.tgz",
+			"integrity": "sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-duplicate-keys": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-8.0.1.tgz",
+			"integrity": "sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-dynamic-import": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-8.0.1.tgz",
+			"integrity": "sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+			"integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-exponentiation-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-8.0.1.tgz",
+			"integrity": "sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-export-namespace-from": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-8.0.1.tgz",
+			"integrity": "sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-for-of": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-8.0.1.tgz",
+			"integrity": "sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-function-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-8.0.1.tgz",
+			"integrity": "sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-json-strings": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-8.0.1.tgz",
+			"integrity": "sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-8.0.1.tgz",
+			"integrity": "sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-logical-assignment-operators": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-8.0.1.tgz",
+			"integrity": "sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-member-expression-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-8.0.1.tgz",
+			"integrity": "sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-modules-amd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-8.0.1.tgz",
+			"integrity": "sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-modules-commonjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+			"integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-modules-systemjs": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-8.0.1.tgz",
+			"integrity": "sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-identifier": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-modules-umd": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-8.0.1.tgz",
+			"integrity": "sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-transforms": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-8.0.1.tgz",
+			"integrity": "sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-new-target": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-8.0.1.tgz",
+			"integrity": "sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-8.0.1.tgz",
+			"integrity": "sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-numeric-separator": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-8.0.1.tgz",
+			"integrity": "sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-object-rest-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-8.0.1.tgz",
+			"integrity": "sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-object-super": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-8.0.1.tgz",
+			"integrity": "sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-replace-supers": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-optional-catch-binding": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-8.0.1.tgz",
+			"integrity": "sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-optional-chaining": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-8.0.1.tgz",
+			"integrity": "sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-parameters": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-8.0.1.tgz",
+			"integrity": "sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-private-methods": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-8.0.1.tgz",
+			"integrity": "sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-private-property-in-object": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-8.0.1.tgz",
+			"integrity": "sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-create-class-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-property-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-8.0.1.tgz",
+			"integrity": "sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+			"integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+			"integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-module-imports": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-syntax-jsx": "^8.0.1",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+			"integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-react-pure-annotations": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+			"integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-regenerator": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-8.0.2.tgz",
+			"integrity": "sha512-aFfsjCRYducRV4dPnpsBbdRkLjboca9FVDg6HZCgy0Ahvk2ZQ/2exmCRC5qS9P6rsWwrmIheNaIM6A1j2F8KMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-8.0.1.tgz",
+			"integrity": "sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-reserved-words": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-8.0.1.tgz",
+			"integrity": "sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-shorthand-properties": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-8.0.1.tgz",
+			"integrity": "sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-spread": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-8.0.1.tgz",
+			"integrity": "sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-sticky-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-8.0.1.tgz",
+			"integrity": "sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-template-literals": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-8.0.1.tgz",
+			"integrity": "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-typeof-symbol": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-8.0.1.tgz",
+			"integrity": "sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-unicode-escapes": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
+			"integrity": "sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-unicode-property-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-8.0.1.tgz",
+			"integrity": "sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-unicode-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-8.0.1.tgz",
+			"integrity": "sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/plugin-transform-unicode-sets-regex": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-8.0.1.tgz",
+			"integrity": "sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^8.0.1",
+				"@babel/helper-plugin-utils": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/preset-env": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-8.0.2.tgz",
+			"integrity": "sha512-CUGLn9hNBCF/eXnwdFAWERbniCcXCRvnKwLV9fegeUEIqv7YlU2MepsWMMM54GcILx5XYMnRh+JAL+K5G+mK6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^8.0.0",
+				"@babel/helper-compilation-targets": "^8.0.0",
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^8.0.1",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^8.0.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^8.0.1",
+				"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^8.0.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^8.0.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^8.0.1",
+				"@babel/plugin-transform-arrow-functions": "^8.0.1",
+				"@babel/plugin-transform-async-generator-functions": "^8.0.1",
+				"@babel/plugin-transform-async-to-generator": "^8.0.1",
+				"@babel/plugin-transform-block-scoped-functions": "^8.0.1",
+				"@babel/plugin-transform-block-scoping": "^8.0.1",
+				"@babel/plugin-transform-class-properties": "^8.0.1",
+				"@babel/plugin-transform-class-static-block": "^8.0.1",
+				"@babel/plugin-transform-classes": "^8.0.1",
+				"@babel/plugin-transform-computed-properties": "^8.0.1",
+				"@babel/plugin-transform-destructuring": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-duplicate-keys": "^8.0.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-dynamic-import": "^8.0.1",
+				"@babel/plugin-transform-explicit-resource-management": "^8.0.1",
+				"@babel/plugin-transform-exponentiation-operator": "^8.0.1",
+				"@babel/plugin-transform-export-namespace-from": "^8.0.1",
+				"@babel/plugin-transform-for-of": "^8.0.1",
+				"@babel/plugin-transform-function-name": "^8.0.1",
+				"@babel/plugin-transform-json-strings": "^8.0.1",
+				"@babel/plugin-transform-literals": "^8.0.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^8.0.1",
+				"@babel/plugin-transform-member-expression-literals": "^8.0.1",
+				"@babel/plugin-transform-modules-amd": "^8.0.1",
+				"@babel/plugin-transform-modules-commonjs": "^8.0.1",
+				"@babel/plugin-transform-modules-systemjs": "^8.0.1",
+				"@babel/plugin-transform-modules-umd": "^8.0.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^8.0.1",
+				"@babel/plugin-transform-new-target": "^8.0.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^8.0.1",
+				"@babel/plugin-transform-numeric-separator": "^8.0.1",
+				"@babel/plugin-transform-object-rest-spread": "^8.0.1",
+				"@babel/plugin-transform-object-super": "^8.0.1",
+				"@babel/plugin-transform-optional-catch-binding": "^8.0.1",
+				"@babel/plugin-transform-optional-chaining": "^8.0.1",
+				"@babel/plugin-transform-parameters": "^8.0.1",
+				"@babel/plugin-transform-private-methods": "^8.0.1",
+				"@babel/plugin-transform-private-property-in-object": "^8.0.1",
+				"@babel/plugin-transform-property-literals": "^8.0.1",
+				"@babel/plugin-transform-regenerator": "^8.0.2",
+				"@babel/plugin-transform-regexp-modifiers": "^8.0.1",
+				"@babel/plugin-transform-reserved-words": "^8.0.1",
+				"@babel/plugin-transform-shorthand-properties": "^8.0.1",
+				"@babel/plugin-transform-spread": "^8.0.1",
+				"@babel/plugin-transform-sticky-regex": "^8.0.1",
+				"@babel/plugin-transform-template-literals": "^8.0.1",
+				"@babel/plugin-transform-typeof-symbol": "^8.0.1",
+				"@babel/plugin-transform-unicode-escapes": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^8.0.1",
+				"@babel/preset-modules": "^0.2.0",
+				"babel-plugin-polyfill-corejs3": "^1.0.0",
+				"core-js-compat": "^3.48.0",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/preset-modules": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.2.0.tgz",
+			"integrity": "sha512-yz0RBN2fx4fjCeFcTWsWgL7PxSRltvTa0Qg14HkWCU3qS8MO7ZSJlBVbGceynd5C9NsJwwUHNQD3dc6tYO+jqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/plugin-transform-dotall-regex": "^8.0.1",
+				"@babel/plugin-transform-unicode-property-regex": "^8.0.1",
+				"@babel/types": "^8.0.0",
+				"esutils": "^2.0.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/preset-react": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+			"integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^8.0.1",
+				"@babel/helper-validator-option": "^8.0.0",
+				"@babel/plugin-transform-react-display-name": "^8.0.1",
+				"@babel/plugin-transform-react-jsx": "^8.0.1",
+				"@babel/plugin-transform-react-jsx-development": "^8.0.1",
+				"@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/template": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+			"integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/parser": "^8.0.0",
+				"@babel/types": "^8.0.0"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/traverse": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+			"integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^8.0.0",
+				"@babel/generator": "^8.0.0",
+				"@babel/helper-globals": "^8.0.0",
+				"@babel/parser": "^8.0.4",
+				"@babel/template": "^8.0.0",
+				"@babel/types": "^8.0.4",
+				"obug": "^2.1.1"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/@babel/types": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+			"integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^8.0.0",
+				"@babel/helper-validator-identifier": "^8.0.4"
+			},
+			"engines": {
+				"node": "^22.18.0 || >=24.11.0"
 			}
 		},
 		"fair-payments-connector-experimental/node_modules/@wordpress/icons": {
@@ -13011,6 +14585,53 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-1.0.0.tgz",
+			"integrity": "sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^1.0.0",
+				"core-js-compat": "^3.48.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"fair-payments-connector-experimental/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"fair-payments-connector-experimental/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"fair-payments-connector/node_modules/@babel/code-frame": {


### PR DESCRIPTION
## Summary

First of two PRs implementing the [approved plan](https://github.com/marcin-wosinek/fair-event-plugins/issues/1265#issuecomment-5205036651) for #1265. This PR is Phase 1: bump the Babel toolchain (`@babel/core`, `@babel/preset-env`, `@babel/preset-react`) to 8.x, scoped to the Jest transform layer only.

- Babel is not part of the shipped build: `@wordpress/scripts` pins its own internal `@babel/core@^7.25.7` for webpack, so this change has zero effect on production assets — only on how Jest transforms test files.
- Bumps `@babel/core`/`preset-env`/`preset-react` to 8.x in every workspace that declares them (`fair-form`, `fair-timetable`, `fair-audience`, `fair-audience-experimental`, `fair-events`, `fair-events-experimental`), and adds `@babel/preset-react` explicitly to `fair-audience-experimental`, `fair-events`, and `fair-events-experimental`, which used it in their `jest.config.js` transform without declaring it (a phantom hoisted dependency).
- Adds `@babel/core`, `@babel/preset-env`, `@babel/preset-react`, and `babel-jest` explicitly to `fair-payments-connector` and `fair-finance` — flagged in the plan as relying on the hoisted copy despite using `babel-jest` directly in their `jest.config.js`.
- Also adds the same explicit `devDependencies` to `fair-events-shared`, which has the identical phantom-dependency problem (its `babel.config.cjs` and `jest` script use these packages without declaring them) — the plan's "Undeclared dependencies" list named only `fair-payments-connector`/`fair-finance`, but the same rationale applies here, so it's included for consistency.
- Bumps `babel-jest` to `30.4.1` everywhere it's used — `30.4.1` is the first line whose `peerDependencies` accept `@babel/core: ^8.0.0-0` (versions below `30.2.0` only accept `^7.11.0`).

Refs #1265

## Notes

- Reviewed both `babel.config.cjs` files (`fair-timetable`, `fair-events-shared`) against Babel 8's dropped options (`useBuiltIns`, `corejs`, `isPluginRequired`) — neither uses them, so no config rewrites were needed.
- Confirmed `.cjs` config files keep working under Babel 8 despite Babel's packages now shipping as ESM: Babel explicitly kept CommonJS consumers (like `babel-jest`'s `require()`) working via Node's `require(esm)` support, which is why Babel 8's `engines` floor (`^22.18.0 || >=24.11.0`) matches the Node versions where that support is stable. Verified empirically by running the `fair-timetable` and `fair-events-shared` suites, both of which use `babel.config.cjs`.
- Node: local dev is on `v24.11.0`, exactly at Babel 8's floor. CI's `actions/setup-node` pins `node-version: '24'`, which resolves to the latest 24.x — comfortably past `24.11.0`.
- `npm ls @babel/core` shows `8.0.1` correctly deduped across all 9 workspaces that use it; the only remaining `7.29.7` copies are nested inside `@wordpress/scripts`'s own internal `jest-preset-default`, which none of our workspaces' jest configs route through (every workspace's `jest.config.js` overrides `transform` explicitly).

## Test plan

- [x] `npm run test:js` passes in every affected workspace (`fair-form`, `fair-timetable`, `fair-audience`, `fair-audience-experimental`, `fair-events`, `fair-events-experimental`, `fair-events-shared`, `fair-payments-connector`, `fair-finance`) and at the root.
- [x] `npm ls @babel/core` / `npm ls babel-jest` confirm no duplicate-major resolution for the packages this PR touches.
- [x] `npm run format` — no formatting diff beyond what was already staged.
- [ ] No `npm run build` needed — this PR doesn't touch build-affecting packages or generated assets.
- [ ] No PHP changed — `phpcs` not applicable.

## Acceptance criteria (from #1265, scoped to this PR)

- [x] Babel core and the environment/React presets are on 8.x in every workspace that uses them, with transform configuration reviewed rather than carried over verbatim.
- [x] No duplicate/conflicting majors remain resolved in the lockfile for the packages this PR upgrades (`@babel/core`, `@babel/preset-env`, `@babel/preset-react`, `babel-jest`).
- [x] `npm run test:js` passes across all workspaces.
- Deferred to PR2 (WordPress editor/components/icons packages, build-scripts, and the full build/runtime/API/e2e/manual-verification criteria): those criteria depend on the build pipeline, which this PR does not touch.
