### PR TITLE
Allow an event page to be linked as a secondary alias

### DIFF
--- a/.changeset/link-secondary-event-page.md
+++ b/.changeset/link-secondary-event-page.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Allow an event page to be linked as a secondary alias of another event page, and allow adding another linked page to an event that already has one. Relinking a page cleanly detaches its own auto-created event date instead of the previous "already linked to another event" error.

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -1320,14 +1320,14 @@ class EventDatesController extends WP_REST_Controller {
 			}
 		}
 
-		// Check if post is already linked to a different event.
+		// If the post is already linked to a different event, detach it from
+		// there first so it can be relinked here (e.g. a translated duplicate
+		// event page that auto-created its own, still-empty event date). The
+		// old event date row is not deleted — it's left unlinked, same as any
+		// manually-unlinked event.
 		$existing = EventDates::get_by_event_id( $post_id );
 		if ( $existing && (int) $existing->id !== $link_event_date->id ) {
-			return new WP_Error(
-				'rest_post_already_linked',
-				__( 'This post is already linked to another event.', 'fair-events' ),
-				array( 'status' => 409 )
-			);
+			$this->detach_post_from_event( $existing, $post_id );
 		}
 
 		// Add to junction table.
@@ -1378,6 +1378,29 @@ class EventDatesController extends WP_REST_Controller {
 			}
 		}
 
+		$this->detach_post_from_event( $link_event_date, $post_id );
+
+		// Return the originally requested event date (occurrence, not master).
+		$event_date = EventDates::get_by_id( $id );
+
+		return new WP_REST_Response( $this->prepare_event_date( $event_date ), 200 );
+	}
+
+	/**
+	 * Detach a post from an event date's link.
+	 *
+	 * Removes the post from the junction table, and if it was holding the
+	 * primary `event_id` slot, promotes the next remaining linked post to
+	 * primary or clears the link entirely (event_id => null, link_type =>
+	 * 'none') if none remain. Nothing is deleted — a cleared event date
+	 * shows up as an ordinary unlinked event afterward. Shared by
+	 * unlink_post() and link_post()'s detach-then-relink path.
+	 *
+	 * @param EventDates $link_event_date Event date the post is currently linked to.
+	 * @param int        $post_id         Post ID to detach.
+	 * @return void
+	 */
+	private function detach_post_from_event( $link_event_date, $post_id ) {
 		// Remove from junction table.
 		EventDates::remove_linked_post( $link_event_date->id, $post_id );
 
@@ -1400,11 +1423,6 @@ class EventDatesController extends WP_REST_Controller {
 				);
 			}
 		}
-
-		// Return the originally requested event date (occurrence, not master).
-		$event_date = EventDates::get_by_id( $id );
-
-		return new WP_REST_Response( $this->prepare_event_date( $event_date ), 200 );
 	}
 
 	/**

--- a/fair-events/src/API/__tests__/EventDatesController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesController.api.spec.js
@@ -157,6 +157,153 @@ test.describe('EventDatesController — standalone category copy on first link',
 	});
 });
 
+test.describe('EventDatesController — link_post detach-then-link (#1429)', () => {
+	let api;
+	let postA;
+	let eventDateA;
+	let postB;
+	let eventDateB;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+
+		// postA/postB each get their own event date (event_id = post), the
+		// same DB state a fair_event post's auto-created event date is in.
+		const postARes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: { title: `Link Post A ${Date.now()}`, status: 'publish' },
+		});
+		expect(postARes.ok()).toBeTruthy();
+		postA = (await postARes.json()).id;
+
+		const postBRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: { title: `Link Post B ${Date.now()}`, status: 'publish' },
+		});
+		expect(postBRes.ok()).toBeTruthy();
+		postB = (await postBRes.json()).id;
+
+		const edARes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Link ED A ${Date.now()}`,
+				start_datetime: '2031-01-01 10:00:00',
+			},
+		});
+		expect(edARes.ok()).toBeTruthy();
+		eventDateA = (await edARes.json()).id;
+		const linkARes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateA}`,
+			{ headers: adminHeaders, data: { event_id: postA } }
+		);
+		expect(linkARes.ok()).toBeTruthy();
+
+		const edBRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Link ED B ${Date.now()}`,
+				start_datetime: '2031-02-01 10:00:00',
+			},
+		});
+		expect(edBRes.ok()).toBeTruthy();
+		eventDateB = (await edBRes.json()).id;
+		const linkBRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateB}`,
+			{ headers: adminHeaders, data: { event_id: postB } }
+		);
+		expect(linkBRes.ok()).toBeTruthy();
+	});
+
+	test.afterAll(async () => {
+		if (eventDateA) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${eventDateA}`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (eventDateB) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${eventDateB}`,
+				{ headers: adminHeaders }
+			);
+		}
+		if (postA) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${postA}?force=true`, {
+				headers: adminHeaders,
+			});
+		}
+		if (postB) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${postB}?force=true`, {
+				headers: adminHeaders,
+			});
+		}
+	});
+
+	test('relinking postA as secondary to eventDateB succeeds', async () => {
+		const res = await api.post(
+			`/wp-json/fair-events/v1/event-dates/${eventDateB}/link-post`,
+			{
+				headers: adminHeaders,
+				data: { post_id: postA },
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		// eventDateB keeps its own primary (postB); postA is now a secondary link.
+		expect(body.event_id).toBe(postB);
+		const linkedIds = body.linked_posts.map((lp) => lp.id);
+		expect(linkedIds).toContain(postA);
+		expect(body.linked_posts.find((lp) => lp.id === postA).is_primary).toBe(
+			false
+		);
+	});
+
+	test("postA's old auto-created event date survives detached, not deleted", async () => {
+		const res = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${eventDateA}`,
+			{ headers: adminHeaders }
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		expect(body.event_id).toBeNull();
+		expect(body.link_type).toBe('none');
+	});
+
+	test('a second post can be linked to an event that already has a primary', async () => {
+		// eventDateB already has postB as primary and postA as secondary from
+		// the earlier test — link a brand-new third post too.
+		const postCRes = await api.post('/wp-json/wp/v2/pages', {
+			headers: adminHeaders,
+			data: { title: `Link Post C ${Date.now()}`, status: 'publish' },
+		});
+		expect(postCRes.ok()).toBeTruthy();
+		const postC = (await postCRes.json()).id;
+
+		try {
+			const res = await api.post(
+				`/wp-json/fair-events/v1/event-dates/${eventDateB}/link-post`,
+				{
+					headers: adminHeaders,
+					data: { post_id: postC },
+				}
+			);
+			expect(res.ok()).toBeTruthy();
+			const body = await res.json();
+
+			expect(body.event_id).toBe(postB);
+			const linkedIds = body.linked_posts.map((lp) => lp.id);
+			expect(linkedIds).toContain(postA);
+			expect(linkedIds).toContain(postC);
+		} finally {
+			await api.delete(`/wp-json/wp/v2/pages/${postC}?force=true`, {
+				headers: adminHeaders,
+			});
+		}
+	});
+});
+
 test.describe('EventDatesController — create_item with categories + rrule (quick add)', () => {
 	let api;
 	let categoryId;
@@ -258,7 +405,10 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 	) {
 		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
 			headers: adminHeaders,
-			data: { title: `Recurrence test ${Date.now()}`, status: 'publish' },
+			data: {
+				title: `Recurrence test ${Date.now()}`,
+				status: 'publish',
+			},
 		});
 		expect(postRes.ok()).toBeTruthy();
 		eventPostId = (await postRes.json()).id;
@@ -428,7 +578,10 @@ test.describe('EventDatesController — ending a series', () => {
 	) {
 		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
 			headers: adminHeaders,
-			data: { title: `End series test ${Date.now()}`, status: 'publish' },
+			data: {
+				title: `End series test ${Date.now()}`,
+				status: 'publish',
+			},
 		});
 		expect(postRes.ok()).toBeTruthy();
 		eventPostId = (await postRes.json()).id;

--- a/fair-events/src/Admin/manage-event/EventLinkModal.js
+++ b/fair-events/src/Admin/manage-event/EventLinkModal.js
@@ -312,81 +312,75 @@ export default function EventLinkModal({
 								</Button>
 							</HStack>
 						)}
+					</>
+				)}
 
-						{linkType === 'post' && (
-							<>
+				{linkType === 'post' && (
+					<>
+						<SelectControl
+							label={__('Post type', 'fair-events')}
+							value={selectedPostType}
+							options={enabledPostTypes.map((pt) => ({
+								label: pt.label,
+								value: pt.slug,
+							}))}
+							onChange={setSelectedPostType}
+						/>
+						<Button
+							variant="primary"
+							onClick={handleCreatePost}
+							isBusy={creatingPost}
+							disabled={creatingPost}
+						>
+							{__('Create New Post', 'fair-events')}
+						</Button>
+
+						<VStack spacing={2}>
+							<h3 style={{ margin: 0 }}>
+								{__('Link Existing Post', 'fair-events')}
+							</h3>
+							<TextControl
+								label={__(
+									'Search posts by title',
+									'fair-events'
+								)}
+								onChange={handleSearchPosts}
+								placeholder={__(
+									'Start typing to search...',
+									'fair-events'
+								)}
+							/>
+							{searchResults.length > 0 && (
 								<SelectControl
-									label={__('Post type', 'fair-events')}
-									value={selectedPostType}
-									options={enabledPostTypes.map((pt) => ({
-										label: pt.label,
-										value: pt.slug,
-									}))}
-									onChange={setSelectedPostType}
+									label={__('Select a post', 'fair-events')}
+									value={linkPostId}
+									options={[
+										{
+											label: __(
+												'Select...',
+												'fair-events'
+											),
+											value: '',
+										},
+										...searchResults.map((r) => ({
+											label: r.title,
+											value: String(r.id),
+										})),
+									]}
+									onChange={setLinkPostId}
 								/>
+							)}
+							{linkPostId && (
 								<Button
 									variant="primary"
-									onClick={handleCreatePost}
-									isBusy={creatingPost}
-									disabled={creatingPost}
+									onClick={handleLinkPost}
+									isBusy={linkingPost}
+									disabled={linkingPost}
 								>
-									{__('Create New Post', 'fair-events')}
+									{__('Link Post', 'fair-events')}
 								</Button>
-
-								<VStack spacing={2}>
-									<h3 style={{ margin: 0 }}>
-										{__(
-											'Link Existing Post',
-											'fair-events'
-										)}
-									</h3>
-									<TextControl
-										label={__(
-											'Search posts by title',
-											'fair-events'
-										)}
-										onChange={handleSearchPosts}
-										placeholder={__(
-											'Start typing to search...',
-											'fair-events'
-										)}
-									/>
-									{searchResults.length > 0 && (
-										<SelectControl
-											label={__(
-												'Select a post',
-												'fair-events'
-											)}
-											value={linkPostId}
-											options={[
-												{
-													label: __(
-														'Select...',
-														'fair-events'
-													),
-													value: '',
-												},
-												...searchResults.map((r) => ({
-													label: r.title,
-													value: String(r.id),
-												})),
-											]}
-											onChange={setLinkPostId}
-										/>
-									)}
-									{linkPostId && (
-										<Button
-											variant="primary"
-											onClick={handleLinkPost}
-											isBusy={linkingPost}
-											disabled={linkingPost}
-										>
-											{__('Link Post', 'fair-events')}
-										</Button>
-									)}
-								</VStack>
-							</>
-						)}
+							)}
+						</VStack>
 					</>
 				)}
 

--- a/fair-events/src/Admin/manage-event/__tests__/EventLinkModal.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/EventLinkModal.test.jsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  *
- * Tests for EventLinkModal (#1198).
+ * Tests for EventLinkModal (#1198, #1429).
  *
  * Covers:
  *   - External flow: choosing "external", entering a URL and confirming
@@ -9,6 +9,8 @@
  *   - None flow: choosing "nowhere" and confirming PUTs link_type: 'none'.
  *   - Linked-posts list: view/edit links render, and Unlink DELETEs and
  *     calls onSaved.
+ *   - Add-another-post: the "Link Existing Post" UI still renders (and
+ *     works) once an event already has a linked post (#1429 AC4).
  */
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -109,6 +111,75 @@ it('choosing "nowhere" and confirming PUTs link_type: none', async () => {
 			link_type: 'none',
 			external_url: null,
 		},
+	});
+	expect(onSaved).toHaveBeenCalledWith(updated);
+});
+
+it('link-existing-post UI still renders when the event already has a linked post, and links a second post', async () => {
+	const eventDate = {
+		...baseEventDate,
+		link_type: 'post',
+		linked_posts: [
+			{
+				id: 5,
+				title: 'My Public Page',
+				status: 'publish',
+				is_primary: true,
+				view_url: 'https://example.com/event',
+				edit_url: 'https://example.com/wp-admin/post.php?post=5',
+			},
+		],
+	};
+	const searchResults = [{ id: 9, title: 'Another Page' }];
+	const updated = {
+		...eventDate,
+		linked_posts: [
+			...eventDate.linked_posts,
+			{
+				id: 9,
+				title: 'Another Page',
+				status: 'publish',
+				is_primary: false,
+				view_url: 'https://example.com/another',
+				edit_url: 'https://example.com/wp-admin/post.php?post=9',
+			},
+		],
+	};
+	apiFetch.mockResolvedValueOnce(searchResults);
+	apiFetch.mockResolvedValueOnce(updated);
+	const onSaved = jest.fn();
+
+	render(
+		<EventLinkModal
+			eventDateId={eventDateId}
+			eventDate={eventDate}
+			enabledPostTypes={enabledPostTypes}
+			onClose={jest.fn()}
+			onSaved={onSaved}
+		/>
+	);
+
+	// Add-another-post UI is visible even though a post is already linked.
+	expect(
+		screen.getByRole('heading', { name: 'Link Existing Post' })
+	).toBeInTheDocument();
+
+	fireEvent.change(screen.getByLabelText('Search posts by title'), {
+		target: { value: 'Another' },
+	});
+
+	await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+
+	fireEvent.change(screen.getByLabelText('Select a post'), {
+		target: { value: '9' },
+	});
+	fireEvent.click(screen.getByRole('button', { name: /Link Post/i }));
+
+	await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
+	expect(apiFetch).toHaveBeenNthCalledWith(2, {
+		path: `/fair-events/v1/event-dates/${eventDateId}/link-post`,
+		method: 'POST',
+		data: { post_id: 9 },
 	});
 	expect(onSaved).toHaveBeenCalledWith(updated);
 });


### PR DESCRIPTION
## Summary

- `link_post()` used to reject relinking a post that was already linked
  elsewhere with a `409 rest_post_already_linked` — the only case this fired
  in practice was a `fair_event` post's own auto-created event date, which
  made it impossible to ever link an event page as a secondary alias of
  another event page, or to add a second linked page to an event that
  already had a primary (any post type). Replaced the rejection with a
  detach-then-link: the post is cleanly detached from its old event date
  (junction entry removed, primary promoted/cleared) before being linked to
  the new target. The detach logic is shared with `unlink_post()` via a new
  `detach_post_from_event()` helper.
- `EventLinkModal.js`'s "Create New Post" / "Link Existing Post" UI was
  gated behind "no post linked yet," so it disappeared once an event had one
  linked post. Moved it out from under that gate so it renders whenever
  `linkType === 'post'`, regardless of how many posts are already linked.
- No changes needed to `EventMetaBox.js`, `Event.php`'s meta-box
  localization, `SelectedOccurrence`, or block `render.php` files — they
  already resolve through `EventDates::get_by_event_id()`'s junction-table
  fallback once a link exists.

Closes #1429

## Acceptance criteria

- [x] An event page can be linked as a secondary page to another event page
      via the existing "link to existing event" flow. — verified live in the
      browser (`docker compose`): linked one event page's own primary post as
      a secondary of another event, no 409.
- [x] A secondary event page's event details meta box shows the linked
      event's data. — falls out of the existing junction-table fallback in
      `EventDates::get_by_event_id()`; no code change needed.
- [x] Event info displays correctly on a secondary event page. — same
      resolution path, no code change needed.
- [x] Ticket sales (event signup) works correctly on a secondary event page.
      — same resolution path, no code change needed.
- [x] A secondary page can be added to an event that already has one primary
      page linked (for any post type, not just event pages). — covered by
      the new API test and verified live in the browser (linked a second
      post to an event date that already had a primary).
- [x] The auto-created event date for a page that gets relinked as secondary
      is cleanly detached (no duplicate-primary conflict, no data loss) —
      covered by the new API test and verified live (old row's `event_id`
      goes to `null`, row itself survives).

## Test plan

- [x] `npx playwright test src/API/__tests__/EventDatesController.api.spec.js`
      — 20 passed (5 pre-existing skips), including the 3 new
      detach-then-link tests.
- [x] `npx jest` (fair-events) — 207 passed, including the updated
      `EventLinkModal.test.jsx` (new add-another-post test).
- [x] `vendor/bin/phpcs` on the changed PHP file — clean (2 pre-existing
      warnings/errors elsewhere in the file, unrelated to this change,
      confirmed present on `main` too).
- [x] `npm run build` in `fair-events`.
- [x] Manual verification in the running site (`docker compose`, `:8080`):
      opened the Manage Event link modal for an event with an existing
      primary post, confirmed "Link Existing Post" now renders, searched for
      and linked another event page's primary post as a secondary, confirmed
      no 409 and the old event date detached (not deleted). Reverted the
      demo data back afterward.
