### PR TITLE
Verify dist ZIPs include composer vendor/ before publish

### DIFF
--- a/.changeset/fix-dist-archive-vendor-check.md
+++ b/.changeset/fix-dist-archive-vendor-check.md
@@ -1,0 +1,5 @@
+---
+"fair-timetable": patch
+---
+
+Fix the WordPress.org packaging/release workflow to fail instead of silently continuing when the production `composer install` fails, and add a pre-publish check that the built ZIP actually contains `vendor/autoload.php`. Previously a failed dependency install could still produce and ship a ZIP missing `vendor/`, causing a fatal error on activation.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -131,6 +131,9 @@ jobs:
                   echo "Contents of dist directory:"
                   ls -lah ./dist/ || echo "dist directory not found"
 
+            - name: Verify dist archives include composer dependencies
+              run: node scripts/verify-dist-archive.cjs
+
             - name: Install dev PHP dependencies in all plugins
               run: npm run composer:install
 

--- a/.github/workflows/publish-to-svn.yml
+++ b/.github/workflows/publish-to-svn.yml
@@ -126,6 +126,13 @@ jobs:
                   SVN_TAG_REUSE_ZIP: ${{ steps.reuse.outputs.reuse == 'true' && '1' || '0' }}
               run: npm run svn:tag:${{ inputs.plugin }}
 
+            # Guards both the reuse and rebuild branches against shipping a
+            # ZIP whose entry point requires a file the archive doesn't
+            # contain (e.g. a missing vendor/ from a swallowed composer
+            # failure). See #1434.
+            - name: Verify dist archive includes composer dependencies
+              run: node scripts/verify-dist-archive.cjs ${{ inputs.plugin }} dist/${{ inputs.plugin }}.${{ inputs.version }}.zip
+
             # Rebuild path: refresh trunk + assets from source. Reuse path: trunk
             # is already populated from the extracted build by svn:tag, so only
             # the wordpress.org assets (banners/screenshots) need copying.

--- a/scripts/svn-tag.cjs
+++ b/scripts/svn-tag.cjs
@@ -85,9 +85,10 @@ try {
 					stdio: 'inherit',
 				});
 			} catch (error) {
-				console.warn(
-					'Warning: composer install failed, continuing anyway...'
+				console.error(
+					'Error: composer install --no-dev failed; aborting before packaging a broken zip.'
 				);
+				throw error;
 			}
 		}
 
@@ -156,11 +157,9 @@ try {
 			fs.mkdirSync(trunkDir, { recursive: true });
 		}
 		for (const entry of fs.readdirSync(tagDir)) {
-			fs.cpSync(
-				path.join(tagDir, entry),
-				path.join(trunkDir, entry),
-				{ recursive: true }
-			);
+			fs.cpSync(path.join(tagDir, entry), path.join(trunkDir, entry), {
+				recursive: true,
+			});
 		}
 	}
 
@@ -180,7 +179,9 @@ try {
 		}
 	}
 
-	console.log(`\n✓ Successfully created SVN tag ${version} for ${pluginName}`);
+	console.log(
+		`\n✓ Successfully created SVN tag ${version} for ${pluginName}`
+	);
 	console.log(`  Location: ${tagDir}`);
 	console.log(
 		`\nNext steps:\n  cd ${pluginName}/svn\n  svn add tags/${version}\n  svn ci -m "Tagging version ${version}"`

--- a/scripts/verify-dist-archive.cjs
+++ b/scripts/verify-dist-archive.cjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Verifies a built plugin ZIP includes its Composer-generated
+ * vendor/autoload.php. Every plugin with a composer.json requires that
+ * file unconditionally from its main entry point, so a ZIP missing it
+ * fatals on activation instead of failing at build time (see #1434).
+ *
+ * Usage:
+ *   node scripts/verify-dist-archive.cjs <plugin> <zipPath>   # targeted
+ *   node scripts/verify-dist-archive.cjs                      # every dist/*.zip
+ */
+
+const rootDir = path.join(__dirname, '..');
+const distDir = path.join(rootDir, 'dist');
+
+/**
+ * @param {string} pluginName
+ * @param {string} zipPath
+ * @returns {string|null} an error message, or null if the archive passes.
+ */
+function verify(pluginName, zipPath) {
+	const composerJsonPath = path.join(rootDir, pluginName, 'composer.json');
+	if (!fs.existsSync(composerJsonPath)) {
+		console.log(`${pluginName}: no composer.json, skipping.`);
+		return null;
+	}
+
+	if (!fs.existsSync(zipPath)) {
+		return `${pluginName}: archive not found at ${zipPath}`;
+	}
+
+	const listing = execSync(`unzip -l "${zipPath}"`, { encoding: 'utf8' });
+	const requiredEntry = `${pluginName}/vendor/autoload.php`;
+	if (!listing.includes(requiredEntry)) {
+		return `${pluginName}: ${zipPath} is missing ${requiredEntry} (composer.json exists, so the plugin's entry point requires it unconditionally)`;
+	}
+
+	console.log(`${pluginName}: ${zipPath} contains ${requiredEntry}.`);
+	return null;
+}
+
+/**
+ * Infers the plugin slug from a dist/*.zip filename by matching it
+ * against every top-level directory that has a composer.json. wp
+ * dist-archive names files "<plugin>.<version>.zip", but the version
+ * itself can contain dots and dashes (e.g. git-describe output), so a
+ * naive split on the first "." isn't reliable.
+ */
+function inferPlugin(zipFileName) {
+	const candidates = fs
+		.readdirSync(rootDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.filter((name) =>
+			fs.existsSync(path.join(rootDir, name, 'composer.json'))
+		);
+
+	return (
+		candidates.find((name) => zipFileName.startsWith(`${name}.`)) || null
+	);
+}
+
+const [pluginArg, zipArg] = process.argv.slice(2);
+
+const errors = [];
+
+if (pluginArg) {
+	if (!zipArg) {
+		console.error(
+			'Usage: node scripts/verify-dist-archive.cjs <plugin> <zipPath>'
+		);
+		process.exit(1);
+	}
+	const error = verify(pluginArg, zipArg);
+	if (error) {
+		errors.push(error);
+	}
+} else {
+	if (!fs.existsSync(distDir)) {
+		console.error(`Error: dist directory not found: ${distDir}`);
+		process.exit(1);
+	}
+	const zipFiles = fs
+		.readdirSync(distDir)
+		.filter((name) => name.endsWith('.zip'));
+
+	if (zipFiles.length === 0) {
+		console.error(`Error: no *.zip files found in ${distDir}`);
+		process.exit(1);
+	}
+
+	for (const zipFile of zipFiles) {
+		const pluginName = inferPlugin(zipFile);
+		if (!pluginName) {
+			errors.push(
+				`${zipFile}: could not infer plugin name from filename`
+			);
+			continue;
+		}
+		const error = verify(pluginName, path.join(distDir, zipFile));
+		if (error) {
+			errors.push(error);
+		}
+	}
+}
+
+if (errors.length > 0) {
+	console.error('\nDist archive verification failed:');
+	for (const error of errors) {
+		console.error(`  - ${error}`);
+	}
+	process.exit(1);
+}
+
+console.log('\n✓ Dist archive verification passed.');


### PR DESCRIPTION
## Summary

Fixes the WordPress.org release pipeline that shipped Fair Timetable 0.7.0
without `vendor/`, causing a fatal error on activation.

- `scripts/svn-tag.cjs`'s rebuild path re-ran `composer install --no-dev` and
  only **warned** on failure before packaging the ZIP anyway — the
  silent-failure gap. That catch block now rethrows, failing the script.
- New `scripts/verify-dist-archive.cjs`: whenever `<plugin>/composer.json`
  exists, asserts the built ZIP contains `<plugin>/vendor/autoload.php` (via
  `unzip -l`). Two modes — targeted (`<plugin> <zipPath>`) and no-args (globs
  `dist/*.zip`, inferring the plugin slug per file).
- Wired into `.github/workflows/publish-to-svn.yml` right after "Create SVN
  tag from dist archive", unconditionally, so it covers both the reuse and
  rebuild paths against the exact ZIP about to ship.
- Wired into `.github/workflows/continuous-integration.yml` right after
  "Create plugin ZIP files using wp dist-archive", checking every plugin on
  every push/PR.

Closes #1434

## Changeset

Per [discussion on the ticket](https://github.com/marcin-wosinek/fair-event-plugins/issues/1434#issuecomment-5230703569),
added a `"fair-timetable": patch` changeset even though the code change is
root-level workflow/script tooling — merging will cut fair-timetable 0.7.1 via
the normal Changesets flow. The post-merge republish (see below) should
target **0.7.1**, not 0.7.0 as the original plan text said, since a changeset
supersedes that.

## Acceptance criteria

- [x] The Fair Timetable ZIP downloaded from WordPress.org contains
      `fair-timetable/vendor/autoload.php` and the locked production
      dependencies — enforced by the new `verify-dist-archive.cjs` step in
      `publish-to-svn.yml`, which now fails the workflow if it's missing.
- [x] Installing and activating the ZIP in a clean WordPress environment
      completes without a PHP fatal error — follows from the above once the
      gate is green.
- [x] `composer install` for the distributable excludes development
      dependencies — unchanged behavior (`--no-dev --optimize-autoloader`),
      now failing loudly instead of warning on error.
- [x] The packaging/release workflow automatically fails when the generated
      artifact omits `vendor/autoload.php` — `verify-dist-archive.cjs` in both
      `publish-to-svn.yml` and `continuous-integration.yml`.
- [x] The verification test operates on the final distributable ZIP — it
      inspects the ZIP's contents via `unzip -l`, not the source tree.
- [ ] Republish a corrected Fair Timetable release to WordPress.org —
      operational, post-merge: dispatch "Publish to WordPress.org SVN" for
      `fair-timetable` / `0.7.1` (the version the new changeset produces),
      `dry_run=true` first to confirm `vendor/autoload.php` in the tag
      contents, then `dry_run=false`. Not part of this PR's code.

## Verification

- Ran `node scripts/verify-dist-archive.cjs` (no-args mode) against the
  existing `dist/*.zip` files for all 9 composer-based plugins — passes, and
  correctly handles version strings containing dashes (e.g.
  `fair-events.1.3.4-437-ge902e404.zip`).
- Ran targeted mode against a real archive (pass), a missing archive (fails
  with a clear message), and a ZIP built without `vendor/autoload.php` (fails
  with a clear message).
- `npm run lint:docs` passes.
