### PR TITLE
Give recurring event occurrence pages their own canonical tags

### DIFF
--- a/.changeset/occurrence-canonical-urls.md
+++ b/.changeset/occurrence-canonical-urls.md
@@ -1,0 +1,5 @@
+---
+"fair-events": minor
+---
+
+Give each occurrence of a recurring event its own canonical URL (and matching Open Graph/JSON-LD `url`), so individual dates can be indexed separately instead of collapsing into one canonical page.

--- a/fair-events/__tests__/Helpers/CanonicalUrlTest.php
+++ b/fair-events/__tests__/Helpers/CanonicalUrlTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Tests for CanonicalUrl::resolve_url().
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Helpers\CanonicalUrl;
+use FairEvents\Models\EventDates;
+
+/**
+ * Unit tests for the pure canonical-URL decision in CanonicalUrl.
+ */
+class CanonicalUrlTest extends TestCase {
+
+	/**
+	 * Build a minimal EventDates stub.
+	 *
+	 * @param array $props Associative array of property overrides.
+	 * @return EventDates
+	 */
+	private function make_row( array $props ): EventDates {
+		$row                 = new EventDates();
+		$row->id             = $props['id'] ?? 1;
+		$row->start_datetime = $props['start_datetime'] ?? '2026-07-01 10:00:00';
+		return $row;
+	}
+
+	/**
+	 * When the selected occurrence is the page's default (no param, or a
+	 * param that resolves to the pivot), the base URL is returned unchanged.
+	 *
+	 * @return void
+	 */
+	public function test_default_occurrence_keeps_base_url() {
+		$pivot    = $this->make_row( array( 'id' => 5 ) );
+		$selected = $this->make_row( array( 'id' => 5 ) );
+
+		$result = CanonicalUrl::resolve_url( 'https://example.com/event/', $selected, $pivot );
+
+		$this->assertSame( 'https://example.com/event/', $result );
+	}
+
+	/**
+	 * A non-default occurrence gets its own canonical: the base URL plus a
+	 * normalized `event_date` param.
+	 *
+	 * @return void
+	 */
+	public function test_non_default_occurrence_gets_event_date_param() {
+		$pivot    = $this->make_row(
+			array(
+				'id'             => 5,
+				'start_datetime' => '2026-07-01 10:00:00',
+			)
+		);
+		$selected = $this->make_row(
+			array(
+				'id'             => 6,
+				'start_datetime' => '2026-07-08 10:00:00',
+			)
+		);
+
+		$result = CanonicalUrl::resolve_url( 'https://example.com/event/', $selected, $pivot );
+
+		$this->assertSame( 'https://example.com/event/?event_date=2026-07-08', $result );
+	}
+
+	/**
+	 * A legacy-id-resolved row and a date-resolved row pointing at the same
+	 * occurrence produce an identical canonical URL, since both share the
+	 * same id/start_datetime once resolved.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_and_date_resolved_rows_produce_identical_canonical() {
+		$pivot = $this->make_row(
+			array(
+				'id'             => 5,
+				'start_datetime' => '2026-07-01 10:00:00',
+			)
+		);
+
+		$via_legacy_id  = $this->make_row(
+			array(
+				'id'             => 6,
+				'start_datetime' => '2026-07-08 10:00:00',
+			)
+		);
+		$via_date_param = $this->make_row(
+			array(
+				'id'             => 6,
+				'start_datetime' => '2026-07-08 10:00:00',
+			)
+		);
+
+		$result_a = CanonicalUrl::resolve_url( 'https://example.com/event/', $via_legacy_id, $pivot );
+		$result_b = CanonicalUrl::resolve_url( 'https://example.com/event/', $via_date_param, $pivot );
+
+		$this->assertSame( $result_a, $result_b );
+	}
+
+	/**
+	 * An invalid/unrelated param resolves to the pivot itself (per
+	 * SelectedOccurrence::resolve()'s fallback), so the canonical stays the
+	 * base URL.
+	 *
+	 * @return void
+	 */
+	public function test_selected_equal_to_pivot_keeps_base_url_regardless_of_object_identity() {
+		$pivot    = $this->make_row( array( 'id' => 7 ) );
+		$selected = $this->make_row( array( 'id' => 7 ) );
+
+		$result = CanonicalUrl::resolve_url( 'https://example.com/event/?utm_source=x', $selected, $pivot );
+
+		$this->assertSame( 'https://example.com/event/?utm_source=x', $result );
+	}
+}

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -118,6 +118,7 @@ class Plugin {
 		new \FairEvents\Hooks\OpenGraphHooks();
 		new \FairEvents\Hooks\OrganizationHooks();
 		new \FairEvents\Hooks\AdminBarHooks();
+		new \FairEvents\Hooks\CanonicalUrlHooks();
 		\FairEvents\Hooks\PaymentHooks::init();
 		\FairEvents\Hooks\SignupEmailHooks::init();
 	}

--- a/fair-events/src/Helpers/CanonicalUrl.php
+++ b/fair-events/src/Helpers/CanonicalUrl.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Canonical URL resolution for recurring event occurrence pages.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Helpers;
+
+use FairEvents\Models\EventDates;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * A recurring event's page can display any one of its occurrences via
+ * `?event_date=`, and each occurrence shows genuinely different content
+ * (date/time, location, structured data). Without a per-occurrence
+ * canonical, search engines treat every occurrence as a duplicate of the
+ * page's default view. This helper decides when a request's selected
+ * occurrence needs its own canonical URL (differs from the page's default)
+ * versus when it should collapse back to the plain page URL.
+ */
+class CanonicalUrl {
+
+	/**
+	 * Resolve the canonical URL for the current request against a post.
+	 *
+	 * @param int    $post_id  Post ID to resolve the event for.
+	 * @param string $base_url The plain event page URL (WordPress' own canonical).
+	 * @return string Canonical URL: $base_url unchanged, or $base_url with a
+	 *                normalized `event_date` param for a non-default occurrence.
+	 */
+	public static function for_post( int $post_id, string $base_url ): string {
+		$default = EventDates::get_by_event_id( $post_id );
+
+		if ( ! $default ) {
+			return $base_url;
+		}
+
+		$selected = SelectedOccurrence::resolve( $post_id, $default );
+		if ( ! $selected ) {
+			return $base_url;
+		}
+
+		$pivot = SelectedOccurrence::default_pivot( $default );
+
+		return self::resolve_url( $base_url, $selected, $pivot );
+	}
+
+	/**
+	 * Pure canonical-URL decision: same-id as the pivot collapses to the
+	 * base URL, anything else gets its own normalized `event_date` param.
+	 *
+	 * @param string     $base_url The plain event page URL.
+	 * @param EventDates $selected The occurrence resolved for this request.
+	 * @param EventDates $pivot    The page's default occurrence.
+	 * @return string Canonical URL.
+	 */
+	public static function resolve_url( string $base_url, EventDates $selected, EventDates $pivot ): string {
+		if ( (int) $selected->id === (int) $pivot->id ) {
+			return $base_url;
+		}
+
+		return add_query_arg( 'event_date', OccurrenceDateParam::format( $selected ), $base_url );
+	}
+}

--- a/fair-events/src/Helpers/EventSchema.php
+++ b/fair-events/src/Helpers/EventSchema.php
@@ -25,11 +25,13 @@ class EventSchema {
 	/**
 	 * Build the full Schema.org Event object for a single event page.
 	 *
-	 * @param EventDates $event_date Event date object.
-	 * @param int        $post_id    Linked post ID.
+	 * @param EventDates  $event_date Event date object.
+	 * @param int         $post_id    Linked post ID.
+	 * @param string|null $url        URL to report, e.g. a per-occurrence canonical.
+	 *                                Defaults to the post's plain permalink.
 	 * @return array|null Event object (without `@context`), or null when there is no start date.
 	 */
-	public static function event_to_jsonld( EventDates $event_date, $post_id ) {
+	public static function event_to_jsonld( EventDates $event_date, $post_id, $url = null ) {
 		if ( empty( $event_date->start_datetime ) ) {
 			return null;
 		}
@@ -40,7 +42,7 @@ class EventSchema {
 			'@type'       => 'Event',
 			'name'        => self::get_title( $post, $event_date ),
 			'startDate'   => DateHelper::local_to_iso8601( $event_date->start_datetime ),
-			'url'         => get_permalink( $post_id ),
+			'url'         => $url ?? get_permalink( $post_id ),
 			'eventStatus' => 'cancelled' === $event_date->status
 				? 'https://schema.org/EventCancelled'
 				: 'https://schema.org/EventScheduled',

--- a/fair-events/src/Helpers/SelectedOccurrence.php
+++ b/fair-events/src/Helpers/SelectedOccurrence.php
@@ -80,24 +80,33 @@ class SelectedOccurrence {
 			}
 		}
 
-		// No (valid) URL param: for recurring series, prefer today's
-		// occurrence if one exists, otherwise pivot to the closest upcoming
-		// occurrence (the master itself if its own date is still in the
-		// future, otherwise the next generated child) so all blocks on the
-		// page describe the relevant date instead of the abstract master
-		// row. Falls back to the master if no matching occurrences exist
-		// (e.g. series has fully ended).
-		if ( 'master' === $default->occurrence_type ) {
-			$today    = EventDates::get_by_master_id_and_date( (int) $default->id, current_time( 'Y-m-d' ) );
-			$upcoming = $today ? array() : EventDates::get_upcoming_by_master_id( (int) $default->id );
-			$pivot    = self::pick_default_pivot( $today, $upcoming );
+		// No (valid) URL param: fall back to the page's default occurrence.
+		return self::default_pivot( $default );
+	}
 
-			if ( $pivot ) {
-				return self::with_master_venue_fallback( $pivot, $default );
-			}
+	/**
+	 * Determine the page's default occurrence when no (valid) URL param is
+	 * present: for recurring series, prefer today's occurrence if one
+	 * exists, otherwise pivot to the closest upcoming occurrence (the
+	 * master itself if its own date is still in the future, otherwise the
+	 * next generated child) so all blocks on the page describe the
+	 * relevant date instead of the abstract master row. Falls back to the
+	 * master if no matching occurrences exist (e.g. series has fully
+	 * ended), and returns non-recurring rows unchanged.
+	 *
+	 * @param EventDates $default The post's default (master or single) row.
+	 * @return EventDates
+	 */
+	public static function default_pivot( EventDates $default ): EventDates {
+		if ( 'master' !== $default->occurrence_type ) {
+			return $default;
 		}
 
-		return $default;
+		$today    = EventDates::get_by_master_id_and_date( (int) $default->id, current_time( 'Y-m-d' ) );
+		$upcoming = $today ? array() : EventDates::get_upcoming_by_master_id( (int) $default->id );
+		$pivot    = self::pick_default_pivot( $today, $upcoming );
+
+		return $pivot ? self::with_master_venue_fallback( $pivot, $default ) : $default;
 	}
 
 	/**

--- a/fair-events/src/Hooks/CanonicalUrlHooks.php
+++ b/fair-events/src/Hooks/CanonicalUrlHooks.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Per-occurrence canonical URL for recurring event pages
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Hooks;
+
+use FairEvents\Helpers\CanonicalUrl;
+use FairEvents\Settings\Settings;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Filters WordPress' `get_canonical_url` so a recurring event page requested
+ * with a specific occurrence selector declares that occurrence's own
+ * canonical URL, instead of every occurrence collapsing onto the page's
+ * default view.
+ */
+class CanonicalUrlHooks {
+
+	/**
+	 * Constructor - registers WordPress hooks
+	 */
+	public function __construct() {
+		add_filter( 'get_canonical_url', array( $this, 'filter_canonical_url' ), 10, 2 );
+	}
+
+	/**
+	 * Adjust the canonical URL for a singular, enabled-post-type event page.
+	 *
+	 * @param string   $canonical_url WordPress' computed canonical URL.
+	 * @param \WP_Post $post          The queried post.
+	 * @return string Canonical URL.
+	 */
+	public function filter_canonical_url( $canonical_url, $post ) {
+		if ( ! is_singular() ) {
+			return $canonical_url;
+		}
+
+		$enabled_types = Settings::get_enabled_post_types();
+
+		if ( ! in_array( $post->post_type, $enabled_types, true ) ) {
+			return $canonical_url;
+		}
+
+		return CanonicalUrl::for_post( $post->ID, $canonical_url );
+	}
+}

--- a/fair-events/src/Hooks/OpenGraphHooks.php
+++ b/fair-events/src/Hooks/OpenGraphHooks.php
@@ -11,6 +11,7 @@
 
 namespace FairEvents\Hooks;
 
+use FairEvents\Helpers\CanonicalUrl;
 use FairEvents\Helpers\DateHelper;
 use FairEvents\Helpers\EventSchema;
 use FairEvents\Helpers\SelectedOccurrence;
@@ -50,7 +51,7 @@ class OpenGraphHooks {
 		// Standard OG tags.
 		$this->output_meta_tag( 'og:title', EventSchema::get_title( $post, $event_date ) );
 		$this->output_meta_tag( 'og:description', EventSchema::get_description( $post ) );
-		$this->output_meta_tag( 'og:url', get_permalink( $post_id ) );
+		$this->output_meta_tag( 'og:url', CanonicalUrl::for_post( $post_id, get_permalink( $post_id ) ) );
 		$this->output_meta_tag( 'og:type', 'event' );
 		$this->output_meta_tag( 'og:site_name', get_bloginfo( 'name' ) );
 
@@ -112,7 +113,9 @@ class OpenGraphHooks {
 			return;
 		}
 
-		$event = EventSchema::event_to_jsonld( $context['event_date'], $context['post_id'] );
+		$post_id = $context['post_id'];
+		$url     = CanonicalUrl::for_post( $post_id, get_permalink( $post_id ) );
+		$event   = EventSchema::event_to_jsonld( $context['event_date'], $post_id, $url );
 
 		// Never emit half-valid event markup: without a start date there is no
 		// event to describe (matches the OG event:* guard above).


### PR DESCRIPTION
## Summary

An event page requested with `?event_date=<date>` shows genuinely different content per occurrence (date/time, location, structured data), but every occurrence reported the same canonical URL — the bare event page. Search Console was flagging occurrence URLs as duplicates, so individual dates never got indexed on their own.

This adds a per-occurrence canonical URL: a request for a non-default occurrence now canonicalizes to the page URL plus a normalized `?event_date=<Y-m-d>`, while the default occurrence (or an invalid/missing selector) keeps canonicalizing to the plain page URL. Open Graph's `og:url` and the JSON-LD `url` are aligned with the same value so social previews and structured data agree with what gets indexed.

Closes #1388

## Implementation

- `SelectedOccurrence::default_pivot()` — extracted from `resolve()`'s existing no-param fallback branch (pure refactor, no behavior change) so the "page's default occurrence" logic is reusable.
- `CanonicalUrl::for_post()` / `resolve_url()` — new helper (`fair-events/src/Helpers/CanonicalUrl.php`) that returns the base URL unchanged when the selected occurrence is the page's default, or the base URL plus a normalized `event_date` param otherwise.
- `CanonicalUrlHooks` — new hook (`fair-events/src/Hooks/CanonicalUrlHooks.php`) filtering WordPress core's `get_canonical_url`, guarded the same way as the sibling `OpenGraphHooks`/`AdminBarHooks` (`is_singular()` + enabled post types). Registered in `Plugin.php`.
- `OpenGraphHooks::output_og_tags()` / `output_jsonld()` and `EventSchema::event_to_jsonld()` now compute/accept the same canonical URL instead of a bare `get_permalink()`.

## Acceptance criteria

- [x] Requesting an event page with a valid occurrence selector renders a canonical tag matching that occurrence's URL.
- [x] Requesting the same occurrence via its legacy (numeric) selector and its current (date-based) selector both render the same, normalized canonical URL.
- [x] Requesting an event page with no selector, or one that resolves to the default occurrence, renders the plain event page URL as canonical.
- [x] Requesting an event page with an invalid/unrelated selector falls back to the plain event page URL as canonical.
- [x] Test coverage added per TESTING.md (`fair-events/__tests__/Helpers/CanonicalUrlTest.php`, unit-level, mirroring `SelectedOccurrenceTest`/`OccurrenceDateParamTest`).

## Verification

- `vendor/bin/phpunit` — full fair-events suite (220 tests) passes.
- `vendor/bin/phpcs` — clean for all changed files.
- Manually verified against the running site (`docker compose`, WP-CLI) with a real master + two generated occurrences: confirmed `<link rel="canonical">` and `og:url` for no-param, pivot-date, non-default-date, legacy-numeric-id, and invalid-date requests all match the acceptance criteria.
