### PR TITLE
Add spacing between last question and Get Tickets button

### DIFF
--- a/.changeset/signup-questions-spacing.md
+++ b/.changeset/signup-questions-spacing.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Add spacing between the last custom question and the "Get Tickets" button in the event signup form, matching the gap used between other fields.

--- a/fair-events/src/blocks/event-signup/frontend.css
+++ b/fair-events/src/blocks/event-signup/frontend.css
@@ -130,6 +130,13 @@
 	margin-bottom: 16px;
 }
 
+/* The last question's own margin-bottom has no sibling .form-row to pair
+ * with before the submit button, so it collapses flush against it. Give
+ * the wrapper the same 16px gap used between other fields (issue #1404). */
+.fair-events-get-tickets-form .fair-events-event-signup-questions {
+	margin-bottom: 16px;
+}
+
 .fair-events-get-tickets-form .fair-form-question > label {
 	display: block;
 	font-weight: 600;


### PR DESCRIPTION
## Summary

The last custom question in the event signup form sat flush against the
"Get Tickets" button, with no gap, while every other field has a consistent
16px margin between it and its neighbor. This adds that missing margin to
the questions wrapper.

Closes #1404

## Change

`.fair-events-event-signup-questions` (the wrapper around fair-form question
blocks, only rendered when the form has ≥1 question) now gets the same
`margin-bottom: 16px` used by `.form-row` elsewhere in the form.

## Acceptance criteria

- [x] When an event's signup form includes one or more custom questions,
  there is visible spacing between the last question and the "Get Tickets"
  button, consistent with spacing elsewhere in the form — verified on a live
  page with a short-text question attached.
- [x] When an event's signup form has no custom questions, no extra/empty
  spacing is introduced before the button — the wrapper (and its margin)
  simply isn't rendered in that case; verified on a live page with zero
  questions.
- [x] Spacing is verified on both the frontend signup form and matches (or
  intentionally differs from) the editor preview — frontend now matches
  other fields; the editor's "Form content" box keeps its own distinct
  dashed-border chrome, which is existing, intentional editing affordance
  unrelated to this fix.

## Verification

CSS-only, one-line change — no automated test warranted (per the plan). Manually verified on a local WordPress instance:
- Built `fair-events` assets.
- Created a test page with the signup form + one short-text question — confirmed a visible 16px gap now separates it from the button.
- Created a test page with the signup form and zero questions — confirmed no extra gap appears before the button.
