### PR TITLE
Give questionnaire Markdown export a heading and long date

### DIFF
--- a/.changeset/questionnaire-markdown-export.md
+++ b/.changeset/questionnaire-markdown-export.md
@@ -1,0 +1,5 @@
+---
+"fair-form": patch
+---
+
+Give questionnaire responses' Markdown export a readable submission heading, a long-format "Submission date" label, and blank lines between every field, instead of a raw timestamp mixed in with the answers.

--- a/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
+++ b/fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js
@@ -15,7 +15,7 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
-import { formatDate } from '../utils/format-date.js';
+import { formatDate, formatDateLong } from '../utils/format-date.js';
 import { formatSiteLocalDatetime, formatDateOnly } from 'fair-events-shared';
 
 const DEFAULT_VIEW = {
@@ -554,11 +554,36 @@ export default function QuestionnaireResponses() {
 
 		// Markdown.
 		return responses
-			.map((item) =>
+			.map((item) => {
+				const hasHeading = Boolean(item.participant_id);
+				const lines = [];
+
+				if (hasHeading) {
+					const respondent =
+						item.participant_name ||
+						item.participant_email ||
+						`#${item.id}`;
+					lines.push(`## ${respondent}`, '');
+				}
+
 				columns
-					.map((c) => `**${c.label}:** ${c.getValue({ item }) || ''}`)
-					.join('\n')
-			)
+					.filter((c) => !hasHeading || c.id !== 'participant_name')
+					.forEach((c) => {
+						const label =
+							c.id === 'created_at'
+								? __('Submission date', 'fair-form')
+								: c.label;
+						const value =
+							c.id === 'created_at'
+								? formatDateLong(item.created_at)
+								: c.getValue({ item }) || '';
+						lines.push(`**${label}:** ${value}`, '');
+					});
+
+				// Drop the trailing blank line before joining responses.
+				lines.pop();
+				return lines.join('\n');
+			})
 			.join('\n\n---\n\n');
 	};
 

--- a/fair-form/src/Admin/questionnaire-responses/__tests__/QuestionnaireResponses.test.jsx
+++ b/fair-form/src/Admin/questionnaire-responses/__tests__/QuestionnaireResponses.test.jsx
@@ -172,6 +172,44 @@ describe('QuestionnaireResponses — empty state', () => {
 	});
 });
 
+describe('QuestionnaireResponses — Markdown export (#1422)', () => {
+	it('headings link submissions to their participant, dates get the long label/format, and every field is blank-line separated', async () => {
+		mockResponses([...LINKED_RESPONSES, ...STANDALONE_RESPONSES]);
+		const writeText = jest.fn(() => Promise.resolve());
+		Object.assign(navigator, { clipboard: { writeText } });
+
+		render(<QuestionnaireResponses />);
+		await screen.findByText('Friend');
+
+		fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+		fireEvent.click(
+			await screen.findByRole('button', { name: 'Copy to clipboard' })
+		);
+
+		await screen.findByText('Message copied to clipboard.');
+
+		const message = writeText.mock.calls[0][0];
+
+		// (a) participant-linked submission: heading, no duplicate Name line.
+		expect(message).toContain('## Jane Doe');
+		expect(message).not.toContain('**Name:** Jane Doe');
+
+		// (b) submission without a participant link: no heading.
+		expect(message).not.toContain('## #1');
+
+		// (c) date line uses the long label, no seconds.
+		expect(message).toContain('**Submission date:**');
+		expect(message).not.toContain('**Date:**');
+		expect(message).not.toMatch(
+			/\*\*Submission date:\*\*[^\n]*\d{2}:\d{2}:\d{2}/
+		);
+
+		// (d) every field is followed by a blank line.
+		const linkedBlock = message.split('\n\n---\n\n')[0];
+		expect(linkedBlock.split('\n\n').length).toBeGreaterThan(1);
+	});
+});
+
 describe('QuestionnaireResponses — table containment', () => {
 	it('scopes the DataViews table in a scrollable CardBody so a wide table cannot drag the page sideways', async () => {
 		mockResponses(STANDALONE_RESPONSES);

--- a/fair-form/src/Admin/utils/__tests__/format-date.test.js
+++ b/fair-form/src/Admin/utils/__tests__/format-date.test.js
@@ -1,0 +1,26 @@
+import { formatDate, formatDateLong } from '../format-date.js';
+
+describe('formatDateLong', () => {
+	it('returns an empty string for empty/undefined input', () => {
+		expect(formatDateLong('')).toBe('');
+		expect(formatDateLong(undefined)).toBe('');
+	});
+
+	it('formats a stored UTC datetime as a long, human-readable date', () => {
+		const result = formatDateLong('2026-07-31 18:19:00');
+
+		// Assert structurally rather than locale-exact: Jest's default locale
+		// may not match the site's, but day/year must be present and the time
+		// must be minute-precision (no seconds).
+		expect(result).toContain('2026');
+		expect(result).toContain('31');
+		expect(result).not.toMatch(/\d{2}:\d{2}:\d{2}/);
+	});
+});
+
+describe('formatDate', () => {
+	it('returns an empty string for empty/undefined input', () => {
+		expect(formatDate('')).toBe('');
+		expect(formatDate(undefined)).toBe('');
+	});
+});

--- a/fair-form/src/Admin/utils/format-date.js
+++ b/fair-form/src/Admin/utils/format-date.js
@@ -6,3 +6,20 @@ export function formatDate(dateString) {
 	const date = new Date(dateString + 'Z');
 	return date.toLocaleString();
 }
+
+// Same UTC convention as formatDate(), but a human-readable long form
+// (e.g. "31 de julio de 2026, 20:19") for exports meant to be read, not sorted.
+export function formatDateLong(dateString) {
+	if (!dateString) {
+		return '';
+	}
+	const date = new Date(dateString + 'Z');
+	return date.toLocaleString(undefined, {
+		day: 'numeric',
+		month: 'long',
+		year: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: false,
+	});
+}


### PR DESCRIPTION
## Summary

Improves the questionnaire responses admin page's Markdown export: participant-linked submissions now get a `## {name}` heading, the submission date row is labeled "Submission date" and rendered in a long, human-readable format, and every field is separated by a blank line.

Closes #1422

## Changes

- `fair-form/src/Admin/utils/format-date.js`: add `formatDateLong()` — same UTC parsing convention as the existing `formatDate()`, but formatted as `31 July 2026, 20:19` (browser locale, long month, no seconds) for exports meant to be read rather than sorted.
- `fair-form/src/Admin/questionnaire-responses/QuestionnaireResponses.js`: rewrite the Markdown branch of `buildWaMessage()` — add a `## {respondent}` heading for participant-linked submissions (dropping the now-redundant Name field), swap the `created_at` row's label/value for "Submission date" + `formatDateLong()`, and add a blank line after every field. CSV and "one line per person" formats are unchanged.

## Acceptance criteria

- [x] Display the submission date under the label `Fecha de envío` — English source string is `Submission date`; the `es_ES` translation is regenerated through the standard translation-catalog pipeline (this repo doesn't hand-edit `.po` files per PR — see `TRANSLATIONS.md`).
- [x] Format the date as a human-readable, localized date, e.g. `31 de julio de 2026, 20:19` — verified against real data: `29 July 2026 at 15:55` in the browser's English locale.
- [x] Preserve the remaining questionnaire answers as bold labels followed by their values.
- [x] Keep a blank line between the heading and each exported field for readable Markdown — applied to every field, not just the one after the heading, matching the ticket's desired output.

## Verification

- `npm run test:js` (fair-form): 47/47 passing, including new coverage for `formatDateLong()` and the Export modal's Markdown output (heading presence/absence, date label/format, field spacing).
- `npm run build` (fair-form).
- Manually exercised in the running site (`:8080`) against real linked-participant data via the Export → Copy to clipboard flow; confirmed output:
  ```
  ## Phone Tester

  **Email:** phone-ok-...@example.test

  **Submission date:** 29 July 2026 at 15:55

  **Favorite color?:** ...
  ```
- Added a changeset for `fair-form` (patch).

Not `responsive-ui` — no before/after screenshots needed.
