### PR TITLE
Keep scroll position on calendar/week nav clicks

### DIFF
--- a/.changeset/calendar-nav-keeps-scroll-position.md
+++ b/.changeset/calendar-nav-keeps-scroll-position.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix calendar month view and week view resetting scroll position to the top of the page when clicking next/previous navigation.

--- a/fair-events/e2e/calendar-navigation-scroll-position.spec.js
+++ b/fair-events/e2e/calendar-navigation-scroll-position.spec.js
@@ -1,0 +1,182 @@
+import { test, expect } from '@playwright/test';
+
+const WP_ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const WP_ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * Verifies (#1425) that clicking next/previous on the calendar month view and
+ * the week view lands the browser back on the block instead of resetting
+ * scroll to the top of the page, and that the URL still carries the
+ * month/year (or week) selection so it stays bookmarkable.
+ */
+
+async function apiFetch(page, options) {
+	const result = await page.evaluate(async (opts) => {
+		try {
+			// eslint-disable-next-line no-undef
+			const res = await wp.apiFetch(opts);
+			return { ok: true, data: res };
+		} catch (err) {
+			return {
+				ok: false,
+				error: {
+					message: err && err.message,
+					code: err && err.code,
+					data: err && err.data,
+					raw: JSON.stringify(err),
+				},
+			};
+		}
+	}, options);
+	if (!result.ok) {
+		throw new Error(
+			`apiFetch ${options.method || 'GET'} ${
+				options.path
+			} failed: ${JSON.stringify(result.error)}`
+		);
+	}
+	return result.data;
+}
+
+async function login(page) {
+	await page.goto('/wp-admin');
+	if (page.url().includes('wp-login.php')) {
+		await page.fill('#user_login', WP_ADMIN_USER);
+		await page.fill('#user_pass', WP_ADMIN_PASS);
+		await page.click('#wp-submit');
+	}
+	await page.waitForSelector('#wpadminbar');
+}
+
+async function createPage(page, title, content) {
+	const priorPages = await apiFetch(page, {
+		path: `/wp/v2/pages?search=${encodeURIComponent(title)}&per_page=20`,
+	});
+	for (const p of priorPages) {
+		await apiFetch(page, {
+			path: `/wp/v2/pages/${p.id}?force=true`,
+			method: 'DELETE',
+		}).catch(() => {});
+	}
+
+	return apiFetch(page, {
+		path: '/wp/v2/pages',
+		method: 'POST',
+		data: { title, status: 'publish', content },
+	});
+}
+
+// Enough leading filler that the block isn't already at the top of the page,
+// so a scroll-to-top regression is actually observable.
+const FILLER =
+	'<!-- wp:paragraph -->\n<p>Filler paragraph to push the block below the fold.</p>\n<!-- /wp:paragraph -->\n'.repeat(
+		40
+	);
+
+const viewports = [
+	{ name: 'desktop', size: { width: 1200, height: 900 } },
+	{ name: 'mobile', size: { width: 375, height: 667 } },
+];
+
+test.describe('Calendar navigation keeps scroll position (#1425)', () => {
+	for (const { name, size } of viewports) {
+		test(`month view: next keeps the calendar in view (${name})`, async ({
+			page,
+		}) => {
+			test.setTimeout(60_000);
+			await page.setViewportSize(size);
+			await login(page);
+			await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+			await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+			const testPage = await createPage(
+				page,
+				`Scroll Position Calendar ${name}`,
+				FILLER + '<!-- wp:fair-events/events-calendar /-->'
+			);
+
+			await page.goto(testPage.link || `/?page_id=${testPage.id}`);
+
+			const block = page.locator('#fair-events-calendar');
+			await expect(block).toBeVisible();
+			await block.scrollIntoViewIfNeeded();
+			// Nudge off the exact top edge so a scroll-to-top regression is
+			// distinguishable from "already there".
+			await page.evaluate(() => window.scrollBy(0, -100));
+
+			await page.locator('.nav-next').click();
+			await page.waitForLoadState('load');
+
+			// Bookmarkable URL: the month/year selection is still encoded.
+			const afterUrl = new URL(page.url());
+			expect(afterUrl.hash).toBe('#fair-events-calendar');
+			expect(afterUrl.searchParams.get('calendar_month')).toBeTruthy();
+			expect(afterUrl.searchParams.get('calendar_year')).toBeTruthy();
+
+			// The reload lands on the block instead of resetting to the top.
+			const scrollY = await page.evaluate(() => window.scrollY);
+			expect(scrollY).toBeGreaterThan(100);
+			const box = await block.boundingBox();
+			expect(box).not.toBeNull();
+			expect(box.y).toBeGreaterThan(-50);
+			expect(box.y).toBeLessThan(size.height / 2);
+
+			// Cleanup.
+			await apiFetch(page, {
+				path: `/wp/v2/pages/${testPage.id}?force=true`,
+				method: 'DELETE',
+			}).catch(() => {});
+		});
+
+		test(`week view: next keeps the week grid in view (${name})`, async ({
+			page,
+		}) => {
+			test.setTimeout(60_000);
+			await page.setViewportSize(size);
+			await login(page);
+			await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+			await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+			const testPage = await createPage(
+				page,
+				`Scroll Position Week ${name}`,
+				FILLER + '<!-- wp:fair-events/events-week /-->'
+			);
+
+			await page.goto(testPage.link || `/?page_id=${testPage.id}`);
+
+			const block = page.locator('#fair-events-week');
+			await expect(block).toBeVisible();
+			await block.scrollIntoViewIfNeeded();
+			await page.evaluate(() => window.scrollBy(0, -100));
+
+			const beforeWeek = new URL(page.url()).searchParams.get(
+				'week_view'
+			);
+
+			await page.locator('.nav-next').click();
+			await page.waitForLoadState('load');
+
+			// Bookmarkable URL: the week selection is still encoded, and changed.
+			const afterUrl = new URL(page.url());
+			expect(afterUrl.hash).toBe('#fair-events-week');
+			const afterWeek = afterUrl.searchParams.get('week_view');
+			expect(afterWeek).toBeTruthy();
+			expect(afterWeek).not.toBe(beforeWeek);
+
+			// The reload lands on the block instead of resetting to the top.
+			const scrollY = await page.evaluate(() => window.scrollY);
+			expect(scrollY).toBeGreaterThan(100);
+			const box = await block.boundingBox();
+			expect(box).not.toBeNull();
+			expect(box.y).toBeGreaterThan(-50);
+			expect(box.y).toBeLessThan(size.height / 2);
+
+			// Cleanup.
+			await apiFetch(page, {
+				path: `/wp/v2/pages/${testPage.id}?force=true`,
+				method: 'DELETE',
+			}).catch(() => {});
+		});
+	}
+});

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -277,6 +277,11 @@ $events_by_date = EventFeedProvider::group_by_day( $occurrences, $query_start, $
 
 $item_list = EventSchema::item_list_from_occurrences( $occurrences );
 
+// Id the browser scrolls to after navigation, so paging months doesn't jump
+// the visitor back to the top of the page. Defers to a site owner's own
+// custom anchor (block's Advanced panel) when one is set.
+$scroll_anchor_id = ! empty( $attributes['anchor'] ) ? $attributes['anchor'] : 'fair-events-calendar';
+
 // Calculate previous/next month URLs
 $prev_month_timestamp = strtotime( '-1 month', $first_day_of_month_ts );
 $next_month_timestamp = strtotime( '+1 month', $first_day_of_month_ts );
@@ -286,14 +291,14 @@ $prev_url = add_query_arg(
 		'calendar_month' => gmdate( 'm', $prev_month_timestamp ),
 		'calendar_year'  => gmdate( 'Y', $prev_month_timestamp ),
 	)
-);
+) . '#' . $scroll_anchor_id;
 
 $next_url = add_query_arg(
 	array(
 		'calendar_month' => gmdate( 'm', $next_month_timestamp ),
 		'calendar_year'  => gmdate( 'Y', $next_month_timestamp ),
 	)
-);
+) . '#' . $scroll_anchor_id;
 
 // Generate localized weekday labels using WordPress date formatting
 // Start from the configured start_of_week (0 = Sunday, 1 = Monday)
@@ -314,8 +319,15 @@ $today = current_time( 'Y-m-d' );
 // Subscription feed links (webcal:// + copyable https:// fallback).
 $subscribe_urls = fair_events_build_subscribe_urls( is_array( $categories ) ? $categories : array() );
 
+$wrapper_attributes = array( 'class' => 'wp-block-fair-events-events-calendar' );
+if ( empty( $attributes['anchor'] ) ) {
+	// No custom anchor set — fall back to the fixed scroll-target id so
+	// get_block_wrapper_attributes()'s own anchor-support merge (which
+	// always prefers an explicitly-set 'id') never fights this.
+	$wrapper_attributes['id'] = $scroll_anchor_id;
+}
 ?>
-<div <?php echo wp_kses_post( get_block_wrapper_attributes( array( 'class' => 'wp-block-fair-events-events-calendar' ) ) ); ?>>
+<div <?php echo wp_kses_post( get_block_wrapper_attributes( $wrapper_attributes ) ); ?>>
 	<?php if ( $show_navigation ) : ?>
 	<div class="fair-events-navigation" style="--fair-events-header-bg: <?php echo esc_attr( $header_bg_value ); ?>">
 		<div class="wp-block-button is-style-outline">

--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -208,10 +208,15 @@ if ( $start_year !== $end_year ) {
 	$nav_title = sprintf( '%s–%s %s %s', $start_day_num, $end_day_num, $end_month, $end_year );
 }
 
+// Id the browser scrolls to after navigation, so paging weeks doesn't jump
+// the visitor back to the top of the page. Defers to a site owner's own
+// custom anchor (block's Advanced panel) when one is set.
+$scroll_anchor_id = ! empty( $attributes['anchor'] ) ? $attributes['anchor'] : 'fair-events-week';
+
 $prev     = fair_events_offset_week( $year, $week, -1 );
 $next     = fair_events_offset_week( $year, $week, 1 );
-$prev_url = add_query_arg( 'week_view', sprintf( '%04d-W%02d', $prev['year'], $prev['week'] ) );
-$next_url = add_query_arg( 'week_view', sprintf( '%04d-W%02d', $next['year'], $next['week'] ) );
+$prev_url = add_query_arg( 'week_view', sprintf( '%04d-W%02d', $prev['year'], $prev['week'] ) ) . '#' . $scroll_anchor_id;
+$next_url = add_query_arg( 'week_view', sprintf( '%04d-W%02d', $next['year'], $next['week'] ) ) . '#' . $scroll_anchor_id;
 
 // Build copy summary text.
 $summary_text = '';
@@ -238,8 +243,15 @@ if ( $show_copy_summary ) {
 	$summary_text = implode( "\n", $summary_lines );
 }
 
+$wrapper_attributes = array( 'class' => 'wp-block-fair-events-events-week' );
+if ( empty( $attributes['anchor'] ) ) {
+	// No custom anchor set — fall back to the fixed scroll-target id so
+	// get_block_wrapper_attributes()'s own anchor-support merge (which
+	// always prefers an explicitly-set 'id') never fights this.
+	$wrapper_attributes['id'] = $scroll_anchor_id;
+}
 ?>
-<div <?php echo wp_kses_post( get_block_wrapper_attributes( array( 'class' => 'wp-block-fair-events-events-week' ) ) ); ?>>
+<div <?php echo wp_kses_post( get_block_wrapper_attributes( $wrapper_attributes ) ); ?>>
 
 	<?php if ( $show_navigation ) : ?>
 	<div class="fair-events-navigation" style="--fair-events-header-bg: <?php echo esc_attr( $header_bg_value ); ?>">


### PR DESCRIPTION
## Summary

Clicking "next"/"previous" on the calendar month view or week view did a full-page reload that reset scroll position to the top, disorienting visitors paging through several months/weeks in a row.

Both blocks already support a custom HTML anchor (`"anchor": true`). This appends the block's scroll-target id — the custom anchor if the site owner set one, otherwise a fixed `fair-events-calendar` / `fair-events-week` fallback — as a URL fragment on the prev/next links, and renders that id on the block's own wrapper. The browser's native anchor-scroll on page load then lands the visitor back on the block instead of the top of the page.

Closes #1425

## Acceptance criteria

- [x] Clicking "next" or "previous" on the calendar month view keeps the visitor's scroll position instead of jumping to the top of the page — verified with a new Playwright e2e spec plus manual check in the dev site.
- [x] Clicking "next" or "previous" on the week view keeps the visitor's scroll position instead of jumping to the top of the page — same spec covers the week block.
- [x] Behaviour confirmed on both desktop and mobile viewport widths — the e2e spec runs both scenarios at a 1200×900 desktop viewport and a 375×667 mobile viewport.
- [x] Existing navigation still updates the URL to reflect the selected month/week (bookmarking/sharing a specific month or week still works) — query args (`calendar_month`/`calendar_year`, `week_view`) are untouched; the spec asserts they're still present/updated after clicking next.

## Implementation notes

- No custom anchor set → wrapper gets the fixed fallback id. A site owner's own anchor (Advanced panel) is never overridden — the id is only passed through `get_block_wrapper_attributes()` when `$attributes['anchor']` is empty.
- Native anchor scroll, not JS-based scroll restore — keeps this a small, low-risk change around the existing full-page reload, per the ticket's own recommendation.
- No `scroll-margin-top`/sticky-header offset handling — not reported as a problem, and out of scope per the ticket.

## Testing

- New e2e spec `fair-events/e2e/calendar-navigation-scroll-position.spec.js`: creates a page with filler content above the block, scrolls down, clicks next, and asserts the reload lands the block back near the top of the viewport (not `scrollY === 0`) — at both desktop and mobile viewports, for both blocks. Also asserts the URL fragment and query args.
  - Verified the spec fails against the pre-fix code (no `#fair-events-calendar`/`#fair-events-week` id existed) and passes against the fix.
- `npm run test:js` — 214 passed.
- Existing `events-calendar-subscribe.spec.js` and `events-week-copy-summary.spec.js` still pass — no regressions in adjacent block behavior.
- `vendor/bin/phpcs` on both changed `render.php` files — no new findings (pre-existing findings unchanged, confirmed against baseline).
- `npm run build` in `fair-events`.
- Changeset added (`fair-events`, patch).
