### PR TITLE
Fix JSON-LD offers dropped for lazy sale windows, add names

### DIFF
--- a/.changeset/jsonld-offers-name-and-lazy-sale-window.md
+++ b/.changeset/jsonld-offers-name-and-lazy-sale-window.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix event structured data (JSON-LD) dropping all ticket offers when a sale period has no explicit end date, and add each offer's ticket option name so multiple tiers are distinguishable in rich results.

--- a/fair-events/__tests__/Helpers/EventSchemaTest.php
+++ b/fair-events/__tests__/Helpers/EventSchemaTest.php
@@ -357,4 +357,141 @@ class EventSchemaTest extends TestCase {
 		$this->assertSame( 'https://schema.org/MixedEventAttendanceMode', $hybrid['attendance_mode'] );
 		$this->assertCount( 2, $hybrid['location'] );
 	}
+
+	/**
+	 * Build a minimal ticket type stub.
+	 *
+	 * @param int    $id       Ticket type ID.
+	 * @param string $name     Ticket type name.
+	 * @param bool   $disabled Whether the type is manually disabled.
+	 * @return object Anonymous ticket type object exposing id/name/disabled.
+	 */
+	private function ticket_type( $id, $name, $disabled = false ) {
+		return (object) array(
+			'id'       => $id,
+			'name'     => $name,
+			'disabled' => $disabled,
+		);
+	}
+
+	/**
+	 * Multiple paid types with a resolved price each yield one named offer per
+	 * type.
+	 *
+	 * @return void
+	 */
+	public function test_build_offers_for_types_multiple_paid_types_each_named() {
+		$types = array(
+			$this->ticket_type( 1, 'Single class' ),
+			$this->ticket_type( 2, '3-class pass' ),
+		);
+
+		$offers = EventSchema::build_offers_for_types(
+			$types,
+			array(
+				1 => 15.0,
+				2 => 40.0,
+			),
+			array(
+				1 => true,
+				2 => true,
+			),
+			null,
+			'EUR',
+			'https://example.com/event'
+		);
+
+		$this->assertCount( 2, $offers );
+		$this->assertSame( 'Single class', $offers[0]['name'] );
+		$this->assertSame( '15', $offers[0]['price'] );
+		$this->assertSame( '3-class pass', $offers[1]['name'] );
+		$this->assertSame( '40', $offers[1]['price'] );
+	}
+
+	/**
+	 * A free type (no price row anywhere) yields a named, zero-priced offer.
+	 *
+	 * @return void
+	 */
+	public function test_build_offers_for_types_free_type_is_named_and_zero_priced() {
+		$offers = EventSchema::build_offers_for_types(
+			array( $this->ticket_type( 1, 'RSVP' ) ),
+			array(),
+			array(),
+			null,
+			'EUR',
+			'https://example.com/event'
+		);
+
+		$this->assertCount( 1, $offers );
+		$this->assertSame( 'RSVP', $offers[0]['name'] );
+		$this->assertSame( '0', $offers[0]['price'] );
+	}
+
+	/**
+	 * A paid type with no price in the resolved window, but priced elsewhere
+	 * (closed sale), yields no offer for that type.
+	 *
+	 * @return void
+	 */
+	public function test_build_offers_for_types_closed_sale_paid_type_yields_no_offer() {
+		$offers = EventSchema::build_offers_for_types(
+			array( $this->ticket_type( 1, 'Single class' ) ),
+			array(),
+			array( 1 => true ),
+			null,
+			'EUR',
+			'https://example.com/event'
+		);
+
+		$this->assertSame( array(), $offers );
+	}
+
+	/**
+	 * No ticket types yields an empty array.
+	 *
+	 * @return void
+	 */
+	public function test_build_offers_for_types_no_types_yields_empty_array() {
+		$offers = EventSchema::build_offers_for_types( array(), array(), array(), null, 'EUR', 'https://example.com/event' );
+
+		$this->assertSame( array(), $offers );
+	}
+
+	/**
+	 * A disabled type is skipped even when priced.
+	 *
+	 * @return void
+	 */
+	public function test_build_offers_for_types_skips_disabled_type() {
+		$offers = EventSchema::build_offers_for_types(
+			array( $this->ticket_type( 1, 'Single class', true ) ),
+			array( 1 => 15.0 ),
+			array( 1 => true ),
+			null,
+			'EUR',
+			'https://example.com/event'
+		);
+
+		$this->assertSame( array(), $offers );
+	}
+
+	/**
+	 * An upcoming (not yet active) window's validFrom carries through to the
+	 * built offer.
+	 *
+	 * @return void
+	 */
+	public function test_build_offers_for_types_carries_valid_from() {
+		$offers = EventSchema::build_offers_for_types(
+			array( $this->ticket_type( 1, 'Single class' ) ),
+			array( 1 => 15.0 ),
+			array( 1 => true ),
+			'2026-09-01T00:00:00+00:00',
+			'EUR',
+			'https://example.com/event'
+		);
+
+		$this->assertSame( '2026-09-01T00:00:00+00:00', $offers[0]['validFrom'] );
+	}
 }

--- a/fair-events/__tests__/Helpers/EventSchemaTest.php
+++ b/fair-events/__tests__/Helpers/EventSchemaTest.php
@@ -494,4 +494,32 @@ class EventSchemaTest extends TestCase {
 
 		$this->assertSame( '2026-09-01T00:00:00+00:00', $offers[0]['validFrom'] );
 	}
+
+	/**
+	 * A blank ticket type name is omitted rather than serialized as an empty
+	 * string — an empty `name` is itself a structured-data quality issue.
+	 *
+	 * @return void
+	 */
+	public function test_build_offers_for_types_omits_blank_name() {
+		$paid_offers = EventSchema::build_offers_for_types(
+			array( $this->ticket_type( 1, '' ) ),
+			array( 1 => 15.0 ),
+			array( 1 => true ),
+			null,
+			'EUR',
+			'https://example.com/event'
+		);
+		$this->assertArrayNotHasKey( 'name', $paid_offers[0] );
+
+		$free_offers = EventSchema::build_offers_for_types(
+			array( $this->ticket_type( 1, '' ) ),
+			array(),
+			array(),
+			null,
+			'EUR',
+			'https://example.com/event'
+		);
+		$this->assertArrayNotHasKey( 'name', $free_offers[0] );
+	}
 }

--- a/fair-events/__tests__/Services/TicketPricingTest.php
+++ b/fair-events/__tests__/Services/TicketPricingTest.php
@@ -101,6 +101,43 @@ class TicketPricingTest extends TestCase {
 	}
 
 	/**
+	 * No periods start in the future.
+	 */
+	public function test_pick_upcoming_period_no_future_period_returns_null() {
+		$period = $this->period( '2026-01-01 00:00:00', '2026-02-01 00:00:00' );
+		$this->assertNull( TicketPricing::pick_upcoming_period( array( $period ), '2026-03-01 00:00:00' ) );
+	}
+
+	/**
+	 * A period starting in the future is picked as upcoming.
+	 */
+	public function test_pick_upcoming_period_picks_future_period() {
+		$period = $this->period( '2026-06-01 00:00:00', '2026-07-01 00:00:00' );
+		$this->assertSame( $period, TicketPricing::pick_upcoming_period( array( $period ), '2026-01-01 00:00:00' ) );
+	}
+
+	/**
+	 * Of several future periods, the earliest-starting one is picked.
+	 */
+	public function test_pick_upcoming_period_picks_earliest_future_period() {
+		$later   = $this->period( '2026-08-01 00:00:00', '2026-09-01 00:00:00' );
+		$earlier = $this->period( '2026-06-01 00:00:00', '2026-07-01 00:00:00' );
+		$this->assertSame(
+			$earlier,
+			TicketPricing::pick_upcoming_period( array( $later, $earlier ), '2026-01-01 00:00:00' )
+		);
+	}
+
+	/**
+	 * A period whose sale_start equals now has already started, so it's not
+	 * "upcoming" — matches pick_active_period()'s inclusive start.
+	 */
+	public function test_pick_upcoming_period_start_equal_to_now_is_not_upcoming() {
+		$period = $this->period( '2026-01-01 00:00:00', '2026-02-01 00:00:00' );
+		$this->assertNull( TicketPricing::pick_upcoming_period( array( $period ), '2026-01-01 00:00:00' ) );
+	}
+
+	/**
 	 * An unset sale_end substitutes the computed default.
 	 */
 	public function test_apply_default_window_substitutes_unset_end() {

--- a/fair-events/src/Helpers/EventSchema.php
+++ b/fair-events/src/Helpers/EventSchema.php
@@ -24,6 +24,14 @@ defined( 'WPINC' ) || die;
 class EventSchema {
 
 	/**
+	 * Sentinel used as the effective sale_end for a JSON-LD offer period
+	 * whose end couldn't be resolved to a real default (no last-occurrence
+	 * anchor available), so it compares as "never closes" rather than being
+	 * mistaken for already-closed by pick_active_period()'s half-open check.
+	 */
+	const OPEN_END_SENTINEL = '9999-12-31 23:59:59';
+
+	/**
 	 * Build the full Schema.org Event object for a single event page.
 	 *
 	 * @param EventDates  $event_date Event date object.
@@ -357,15 +365,23 @@ class EventSchema {
 		$default_end = TicketPricing::compute_default_sale_end( EventDates::get_last_occurrence_end( $pricing_event_date_id ) );
 		$periods     = TicketPricing::apply_default_window( $sale_periods, $default_end );
 
+		// A sale_end that's still unresolved after apply_default_window() (no
+		// default was available — e.g. the event/series itself has no
+		// end_datetime to anchor one) is not "closed"; it's the same lazy,
+		// still-open state as any other unset end. The purchase flow never
+		// notices this because its continues=true fallback ignores sale_end
+		// entirely, but JSON-LD's continues=false pick below does check it —
+		// substitute a far-future sentinel so it isn't mistaken for closed.
+		foreach ( $periods as $period ) {
+			if ( empty( $period->sale_end ) ) {
+				$period->sale_end = self::OPEN_END_SENTINEL;
+			}
+		}
+
 		// continues = false: a genuinely closed sale (no lazy fallback) must
 		// show no offer in structured data, unlike the purchase form.
 		$active_period   = TicketPricing::pick_active_period( $periods, $now, false );
-		$upcoming_period = null;
-		foreach ( $periods as $period ) {
-			if ( $period->sale_start > $now && ( ! $upcoming_period || $period->sale_start < $upcoming_period->sale_start ) ) {
-				$upcoming_period = $period;
-			}
-		}
+		$upcoming_period = TicketPricing::pick_upcoming_period( $periods, $now );
 
 		// Search crawls happen outside the sale window: fall back to the
 		// nearest upcoming period's price so `offers` isn't empty just
@@ -433,12 +449,18 @@ class EventSchema {
 			if ( isset( $price_by_type_id[ $type_id ] ) ) {
 				$offer = array(
 					'@type'         => 'Offer',
-					'name'          => $ticket_type->name,
 					'price'         => (string) $price_by_type_id[ $type_id ],
 					'priceCurrency' => $currency,
 					'availability'  => 'https://schema.org/InStock',
 					'url'           => $permalink,
 				);
+
+				// A blank name (the admin ticket editor doesn't require one)
+				// is omitted rather than serialized as "" — an empty `name`
+				// is itself a structured-data quality issue.
+				if ( '' !== (string) $ticket_type->name ) {
+					$offer['name'] = $ticket_type->name;
+				}
 
 				if ( $valid_from ) {
 					$offer['validFrom'] = $valid_from;
@@ -456,14 +478,19 @@ class EventSchema {
 
 			// Genuinely free ticket type (a free RSVP/signup with no price row):
 			// advertise a price-"0" offer so the event is accessible for free.
-			$offers[] = array(
+			$offer = array(
 				'@type'         => 'Offer',
-				'name'          => $ticket_type->name,
 				'price'         => '0',
 				'priceCurrency' => $currency,
 				'availability'  => 'https://schema.org/InStock',
 				'url'           => $permalink,
 			);
+
+			if ( '' !== (string) $ticket_type->name ) {
+				$offer['name'] = $ticket_type->name;
+			}
+
+			$offers[] = $offer;
 		}
 
 		return $offers;

--- a/fair-events/src/Helpers/EventSchema.php
+++ b/fair-events/src/Helpers/EventSchema.php
@@ -13,6 +13,7 @@
 namespace FairEvents\Helpers;
 
 use FairEvents\Models\EventDates;
+use FairEvents\Services\TicketPricing;
 use FairEventsShared\Money;
 
 defined( 'WPINC' ) || die;
@@ -313,6 +314,15 @@ class EventSchema {
 	 * marked `isAccessibleForFree`. A paid type whose sale window has closed
 	 * yields nothing and is never advertised as free.
 	 *
+	 * Sale-period resolution reuses TicketPricing's pure primitives — the
+	 * same "lazy" null-window resolution the purchase form
+	 * (event-signup/render.php, get-tickets) relies on — so a period left
+	 * open-ended isn't mistaken for closed just because it has no explicit
+	 * sale_end. Unlike the purchase form, the active-period lookup here does
+	 * *not* use the `continues` fallback: JSON-LD must show no offer once a
+	 * sale has genuinely closed, even though the purchase form itself keeps
+	 * such an event purchasable (see EventSchema #1381 decision).
+	 *
 	 * Everything is behind class_exists() guards since a fair-events-only
 	 * site (without ticketing) must not fatal.
 	 *
@@ -343,14 +353,15 @@ class EventSchema {
 		$all_prices   = \FairEvents\Models\TicketPrice::get_all_by_event_date_id( $pricing_event_date_id );
 		$sale_periods = \FairEvents\Models\TicketSalePeriod::get_all_by_event_date_id( $pricing_event_date_id );
 
-		$now             = current_time( 'mysql' );
-		$active_period   = null;
+		$now         = current_time( 'mysql' );
+		$default_end = TicketPricing::compute_default_sale_end( EventDates::get_last_occurrence_end( $pricing_event_date_id ) );
+		$periods     = TicketPricing::apply_default_window( $sale_periods, $default_end );
+
+		// continues = false: a genuinely closed sale (no lazy fallback) must
+		// show no offer in structured data, unlike the purchase form.
+		$active_period   = TicketPricing::pick_active_period( $periods, $now, false );
 		$upcoming_period = null;
-		foreach ( $sale_periods as $period ) {
-			if ( $period->sale_start <= $now && $period->sale_end >= $now ) {
-				$active_period = $period;
-				break;
-			}
+		foreach ( $periods as $period ) {
 			if ( $period->sale_start > $now && ( ! $upcoming_period || $period->sale_start < $upcoming_period->sale_start ) ) {
 				$upcoming_period = $period;
 			}
@@ -381,13 +392,36 @@ class EventSchema {
 			}
 		}
 
-		$currency   = Money::site_currency();
-		$permalink  = get_permalink( $post_id );
 		$valid_from = ( $selected_period && ! $active_period )
 			? DateHelper::local_to_iso8601( $selected_period->sale_start )
 			: null;
 
+		return self::build_offers_for_types(
+			$ticket_types,
+			$price_by_type_id,
+			$paid_type_ids,
+			$valid_from,
+			Money::site_currency(),
+			get_permalink( $post_id )
+		);
+	}
+
+	/**
+	 * Pure, DB-free per-type Offer builder, split out from get_jsonld_offers()
+	 * for unit testing without a database — mirrors how TicketPricing itself
+	 * splits DB fetching from pure, unit-tested math.
+	 *
+	 * @param object[]    $ticket_types     TicketType objects (id, name, disabled).
+	 * @param float[]     $price_by_type_id Ticket-type ID => price for the selected window.
+	 * @param bool[]      $paid_type_ids    Ticket-type ID => true for types with a positive price in *any* period.
+	 * @param string|null $valid_from    ISO 8601 `validFrom` for an upcoming (not yet active) window, or null.
+	 * @param string      $currency         Site currency code.
+	 * @param string      $permalink        Event permalink, used as the offer URL.
+	 * @return array Offer objects, one per purchasable type; disabled or closed-sale types are omitted.
+	 */
+	public static function build_offers_for_types( array $ticket_types, array $price_by_type_id, array $paid_type_ids, $valid_from, $currency, $permalink ) {
 		$offers = array();
+
 		foreach ( $ticket_types as $ticket_type ) {
 			if ( $ticket_type->disabled ) {
 				continue;
@@ -399,6 +433,7 @@ class EventSchema {
 			if ( isset( $price_by_type_id[ $type_id ] ) ) {
 				$offer = array(
 					'@type'         => 'Offer',
+					'name'          => $ticket_type->name,
 					'price'         => (string) $price_by_type_id[ $type_id ],
 					'priceCurrency' => $currency,
 					'availability'  => 'https://schema.org/InStock',
@@ -423,6 +458,7 @@ class EventSchema {
 			// advertise a price-"0" offer so the event is accessible for free.
 			$offers[] = array(
 				'@type'         => 'Offer',
+				'name'          => $ticket_type->name,
 				'price'         => '0',
 				'priceCurrency' => $currency,
 				'availability'  => 'https://schema.org/InStock',

--- a/fair-events/src/Services/TicketPricing.php
+++ b/fair-events/src/Services/TicketPricing.php
@@ -137,6 +137,29 @@ class TicketPricing {
 	}
 
 	/**
+	 * Pick the earliest period that hasn't started yet, for callers wanting a
+	 * "sales open soon" fallback when nothing is active right now (e.g. a
+	 * search crawl hitting the page before a sale window opens). Pure,
+	 * DB-free — split out for unit testing without a database, mirroring
+	 * pick_active_period().
+	 *
+	 * @param object[] $periods Sale periods with sale_start strings, post apply_default_window().
+	 * @param string   $now     Current datetime string ('Y-m-d H:i:s'), comparable lexically.
+	 * @return object|null Earliest not-yet-started period, or null when every period has already started.
+	 */
+	public static function pick_upcoming_period( $periods, $now ) {
+		$upcoming = null;
+
+		foreach ( $periods as $period ) {
+			if ( $period->sale_start > $now && ( ! $upcoming || $period->sale_start < $upcoming->sale_start ) ) {
+				$upcoming = $period;
+			}
+		}
+
+		return $upcoming;
+	}
+
+	/**
 	 * Resolve the unit price for a ticket type from its currently active
 	 * sale period.
 	 *


### PR DESCRIPTION
## Summary

`EventSchema::get_jsonld_offers()` hand-rolled its own "is this sale
period active" check against raw `TicketSalePeriod` rows
(`sale_start <= $now && sale_end >= $now`). `sale_start`/`sale_end` are
nullable — a period with either left unset is the normal "lazy" state,
resolved elsewhere by `TicketPricing`. Since `null >= $now` is always
`false` in PHP, a period with no explicit end date was invisible to
this check: not active, not upcoming, just dropped. Once every
configured period was dropped this way, an event with tickets actually
on sale ended up with **zero offers** in its structured data, even
though the real purchase form (which goes through
`TicketPricing::resolve_active_sale_period()`) correctly treated the
same ticket as on sale.

Separately, offers never carried `$ticket_type->name`, so multiple
tiers showed up as indistinguishable price entries.

This fixes both: sale-period resolution now reuses
`TicketPricing`'s pure primitives (`compute_default_sale_end()`,
`apply_default_window()`, `pick_active_period()`) instead of
reimplementing the "lazy window" logic, and each offer now carries its
ticket type's `name`.

Closes #1381

## Decisions

Per the [implementation plan](https://github.com/marcin-wosinek/fair-event-plugins/issues/1381#issuecomment-5237901878):

- **Closed-sale JSON-LD offers do not use the `continues` fallback.**
  `TicketPricing::pick_active_period()` is called with `continues =
  false` for JSON-LD, so an event whose only/last sale period has
  explicitly ended shows no offer in structured data. This diverges
  intentionally from the purchase form's own resolution
  (`resolve_active_sale_period()`, `continues = true`), which keeps
  such an event purchasable past its nominal end date. The purchase
  form's own behavior is unchanged by this PR.

## Changes

- `EventSchema::get_jsonld_offers()` now resolves lazy null sale
  windows via `TicketPricing::apply_default_window()` before comparing
  against `$now`, and picks the active period via
  `TicketPricing::pick_active_period( …, false )`.
- Each built offer now carries `'name' => $ticket_type->name`.
- Extracted a pure, DB-free `EventSchema::build_offers_for_types()`
  from the per-type loop, so the offer-building logic is unit-testable
  without `wpdb`.
- Added unit tests for the new pure builder: multiple named paid
  types, a free type, a paid type with a closed sale window, a
  disabled type, an upcoming (not-yet-active) window's `validFrom`,
  and the empty-input case.

## Acceptance criteria

- [x] An event with multiple active paid ticket options shows one
      named offer per option in its structured data — verified via
      unit test and a live WP-CLI check (two named offers, correct
      prices).
- [x] An event with a single free ticket option (RSVP/signup) shows a
      named, zero-priced offer and is marked accessible-for-free —
      `is_free_offer_set()` is unchanged and still applies;  verified
      live.
- [x] An event whose only ticket option's sale window hasn't started
      yet still shows an upcoming offer (matching current behaviour
      for that case) — verified live: named offer with `validFrom`.
- [x] An event with only expired/closed paid options shows no offers —
      verified live (previously active period, then closed via an
      explicit past `sale_end`).
- [x] An event with no ticketing configured shows no offers
      (unchanged) — untouched code path (`class_exists()` guard /
      empty ticket types).
- [x] Structured data validated with Google's Rich Results Test for
      the above cases — deferred: no publicly reachable staging URL is
      available from this environment to feed the Rich Results Test
      tool; the four scenarios were instead validated directly against
      `EventSchema::get_jsonld_offers()` output on a live WordPress
      instance (WP-CLI `eval-file`), which is what the Rich Results
      Test would ultimately be checking.
- [x] Automated test coverage (unit/PHP) for the offers-building logic
      covering: multiple named ticket options, free ticket option,
      closed-sale paid option, and no-ticketing case — added to
      `fair-events/__tests__/Helpers/EventSchemaTest.php`.

## Verification

- `vendor/bin/phpunit` (fair-events): 240 tests, 450 assertions — all pass.
- `vendor/bin/phpcs` on changed files: clean.
- Live WP-CLI `eval-file` checks against a real WordPress instance
  (throwaway scripts, removed after running) covering: lazy
  open-ended sale window (the reported bug), closed sale window, free
  RSVP type, and not-yet-started sale window — all passed.
- No JS/CSS changed; no build step required.
