### PR TITLE
Translate activity option names with Polylang

### DIFF
--- a/.changeset/polylang-activity-option-translation.md
+++ b/.changeset/polylang-activity-option-translation.md
@@ -1,0 +1,6 @@
+---
+"fair-events": patch
+"fair-events-experimental": patch
+---
+
+Register activity option (ticket option) names and short names for Polylang string translation, so multilingual sites can translate them and have the translation appear on the public signup form.

--- a/fair-audience/src/API/EventSignupController.php
+++ b/fair-audience/src/API/EventSignupController.php
@@ -768,7 +768,7 @@ class EventSignupController extends WP_REST_Controller {
 		$this->snapshot_ticket_type_on_signup( $event_date_id, $participant->id, $ticket_type_id );
 		$this->snapshot_options_on_signup( $event_date_id, $participant->id, $option_items );
 
-		$option_names = array_map( fn( $o ) => $o->name, $option_items );
+		$option_names = $this->translated_option_names( $option_items );
 		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names, (int) $event_date_id, (int) $ticket_type_id, $event_participant_id );
 
 		AudienceSession::set( (int) $participant->id );
@@ -1676,6 +1676,26 @@ class EventSignupController extends WP_REST_Controller {
 	 */
 	private function save_participant_options( $event_participant_id, $option_items ) {
 		$this->event_participant_repository->add_options( $event_participant_id, $option_items );
+	}
+
+	/**
+	 * Resolve option display names for the confirmation email, translated
+	 * through Polylang when fair-events-experimental's translation bridge
+	 * is available — keeps the emailed list matching whatever language the
+	 * buyer saw the option names in on the signup form.
+	 *
+	 * @param object[] $option_items Selected TicketOption objects.
+	 * @return string[] Option names.
+	 */
+	private function translated_option_names( array $option_items ) {
+		return array_map(
+			function ( $o ) {
+				return class_exists( \FairEventsExperimental\Services\ActivityOptionTranslation::class )
+					? \FairEventsExperimental\Services\ActivityOptionTranslation::translate_name( $o )
+					: $o->name;
+			},
+			$option_items
+		);
 	}
 
 	/**
@@ -2900,7 +2920,7 @@ class EventSignupController extends WP_REST_Controller {
 		$this->snapshot_ticket_type_on_signup( $event_date_id, $participant->id, $ticket_type_id );
 		$this->snapshot_options_on_signup( $event_date_id, $participant->id, $option_items );
 
-		$option_names = array_map( fn( $o ) => $o->name, $option_items );
+		$option_names = $this->translated_option_names( $option_items );
 		$this->email_service->send_signup_payment_confirmation( $participant, $event, null, $option_names, (int) $event_date_id, (int) $ticket_type_id, $event_participant_id );
 
 		if ( $is_new_participant ) {

--- a/fair-events-experimental/__tests__/Services/ActivityOptionTranslationTest.php
+++ b/fair-events-experimental/__tests__/Services/ActivityOptionTranslationTest.php
@@ -159,4 +159,44 @@ class ActivityOptionTranslationTest extends TestCase {
 
 		$this->assertSame( 'Clase de yoga', $result );
 	}
+
+	/**
+	 * An option literally named "0" is a real value, not a blank one —
+	 * `empty( '0' )` is true in PHP, so a naive empty() check would wrongly
+	 * skip it. translate_name() must still return it unchanged in this
+	 * process (Polylang absent).
+	 */
+	public function test_translate_name_treats_the_string_zero_as_a_real_value() {
+		$option = $this->option( 1, '0' );
+
+		$this->assertSame( '0', ActivityOptionTranslation::translate_name( $option ) );
+	}
+
+	/**
+	 * Same "0" pitfall for short_name.
+	 */
+	public function test_translate_short_name_treats_the_string_zero_as_a_real_value() {
+		$option = $this->option( 1, 'Yoga class', '0' );
+
+		$this->assertSame( '0', ActivityOptionTranslation::translate_short_name( $option ) );
+	}
+
+	/**
+	 * Register() must register a name/short_name of "0" — it's a real
+	 * value, not an empty one.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_register_registers_the_string_zero_as_a_real_value() {
+		require_once __DIR__ . '/../helpers/pll-stubs.php';
+
+		$option = $this->option( 9, '0', '0' );
+
+		ActivityOptionTranslation::register( $option );
+
+		$calls = $GLOBALS['_fair_pll_registered_strings'];
+
+		$this->assertSame( '0', $calls['fair_events_ticket_option_9_name']['string'] );
+		$this->assertSame( '0', $calls['fair_events_ticket_option_9_short_name']['string'] );
+	}
 }

--- a/fair-events-experimental/__tests__/Services/ActivityOptionTranslationTest.php
+++ b/fair-events-experimental/__tests__/Services/ActivityOptionTranslationTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * ActivityOptionTranslation tests
+ *
+ * @package FairEventsExperimental
+ */
+
+namespace FairEventsExperimental\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairEventsExperimental\Services\ActivityOptionTranslation;
+
+/**
+ * Covers the fallback behavior available in this process (Polylang absent)
+ * and, in separate processes with local `pll_register_string()`/`pll__()`
+ * stubs, the actual registration/translation calls.
+ */
+class ActivityOptionTranslationTest extends TestCase {
+
+	/**
+	 * Build an option stub.
+	 *
+	 * @param int         $id         Option ID.
+	 * @param string      $name       Name.
+	 * @param string|null $short_name Short name.
+	 * @return object
+	 */
+	private function option( $id, $name, $short_name = null ) {
+		$option             = new \stdClass();
+		$option->id         = $id;
+		$option->name       = $name;
+		$option->short_name = $short_name;
+		return $option;
+	}
+
+	/**
+	 * Fallback behavior in the default process (Polylang absent):
+	 * translate_name() returns the original value unchanged.
+	 */
+	public function test_translate_name_returns_original_value_when_polylang_absent() {
+		$option = $this->option( 1, 'Yoga class' );
+
+		$this->assertSame( 'Yoga class', ActivityOptionTranslation::translate_name( $option ) );
+	}
+
+	/**
+	 * Fallback behavior in the default process (Polylang absent):
+	 * translate_short_name() returns the original value unchanged.
+	 */
+	public function test_translate_short_name_returns_original_value_when_polylang_absent() {
+		$option = $this->option( 1, 'Yoga class', 'Yoga' );
+
+		$this->assertSame( 'Yoga', ActivityOptionTranslation::translate_short_name( $option ) );
+	}
+
+	/**
+	 * An option with no short name ever set stays null, not an empty
+	 * string.
+	 */
+	public function test_translate_short_name_returns_null_when_never_set() {
+		$option = $this->option( 1, 'Yoga class' );
+
+		$this->assertNull( ActivityOptionTranslation::translate_short_name( $option ) );
+	}
+
+	/**
+	 * Fallback behavior in the default process (Polylang absent):
+	 * register() is a no-op.
+	 */
+	public function test_register_is_a_no_op_when_polylang_absent() {
+		// No pll_register_string() defined in this process — calling
+		// register() must simply not fatal or throw.
+		$option = $this->option( 1, 'Yoga class', 'Yoga' );
+
+		ActivityOptionTranslation::register( $option );
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Registration and translation both go through Polylang when it's
+	 * present. Defines local `pll_register_string()`/`pll__()` stubs that
+	 * record calls, so this must run isolated from the rest of the suite.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_register_calls_pll_register_string_with_stable_name_and_group() {
+		require_once __DIR__ . '/../helpers/pll-stubs.php';
+
+		$option = $this->option( 42, 'Yoga class', 'Yoga' );
+
+		ActivityOptionTranslation::register( $option );
+
+		$calls = $GLOBALS['_fair_pll_registered_strings'];
+
+		$this->assertSame(
+			array(
+				'name'   => 'Yoga class',
+				'group'  => ActivityOptionTranslation::GROUP,
+				'string' => 'fair_events_ticket_option_42_name',
+			),
+			array(
+				'name'   => $calls['fair_events_ticket_option_42_name']['string'],
+				'group'  => $calls['fair_events_ticket_option_42_name']['group'],
+				'string' => 'fair_events_ticket_option_42_name',
+			)
+		);
+		$this->assertArrayHasKey( 'fair_events_ticket_option_42_short_name', $calls );
+	}
+
+	/**
+	 * An empty short_name is never registered.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_register_does_not_register_empty_short_name() {
+		require_once __DIR__ . '/../helpers/pll-stubs.php';
+
+		$option = $this->option( 7, 'Yoga class' );
+
+		ActivityOptionTranslation::register( $option );
+
+		$calls = $GLOBALS['_fair_pll_registered_strings'];
+
+		$this->assertArrayHasKey( 'fair_events_ticket_option_7_name', $calls );
+		$this->assertArrayNotHasKey( 'fair_events_ticket_option_7_short_name', $calls );
+	}
+
+	/**
+	 * A changed value re-registers under the same stable string name,
+	 * rather than a new one.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_register_reuses_the_same_string_name_when_value_changes() {
+		require_once __DIR__ . '/../helpers/pll-stubs.php';
+
+		ActivityOptionTranslation::register( $this->option( 3, 'Yoga class' ) );
+		ActivityOptionTranslation::register( $this->option( 3, 'Yoga class (updated)' ) );
+
+		$calls = $GLOBALS['_fair_pll_registered_strings'];
+
+		$this->assertCount( 1, $calls );
+		$this->assertSame( 'Yoga class (updated)', $calls['fair_events_ticket_option_3_name']['string'] );
+	}
+
+	/**
+	 * `translate_name()` resolves through `pll__()` when Polylang is
+	 * present.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_translate_name_resolves_through_pll() {
+		require_once __DIR__ . '/../helpers/pll-stubs.php';
+
+		$GLOBALS['_fair_pll_translations']['Yoga class'] = 'Clase de yoga';
+
+		$result = ActivityOptionTranslation::translate_name( $this->option( 1, 'Yoga class' ) );
+
+		$this->assertSame( 'Clase de yoga', $result );
+	}
+}

--- a/fair-events-experimental/__tests__/helpers/pll-stubs.php
+++ b/fair-events-experimental/__tests__/helpers/pll-stubs.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Local Polylang function stubs for @runInSeparateProcess tests.
+ *
+ * Records calls into $GLOBALS so a test can assert on registration args
+ * and drive translated output, without pulling in the real plugin. Only
+ * required by tests that need Polylang to appear "active" — never loaded
+ * in the main PHPUnit process, so it can't leak into tests that assert on
+ * the Polylang-absent fallback behavior.
+ *
+ * @package FairEventsExperimental
+ */
+
+$GLOBALS['_fair_pll_registered_strings'] = array();
+$GLOBALS['_fair_pll_translations']       = array();
+
+if ( ! function_exists( 'pll_register_string' ) ) {
+	/**
+	 * Stub for Polylang's pll_register_string() — records the call.
+	 *
+	 * @param string $name  String name.
+	 * @param string $value String value.
+	 * @param string $group String group.
+	 * @return void
+	 */
+	function pll_register_string( $name, $value, $group = 'Polylang' ) {
+		$GLOBALS['_fair_pll_registered_strings'][ $name ] = array(
+			'string' => $value,
+			'group'  => $group,
+		);
+	}
+}
+
+if ( ! function_exists( 'pll__' ) ) {
+	/**
+	 * Stub for Polylang's pll__() — returns a mapped translation when one
+	 * was set on $GLOBALS['_fair_pll_translations'], else the original
+	 * value unchanged.
+	 *
+	 * @param string $value Original string.
+	 * @return string
+	 */
+	function pll__( $value ) {
+		return $GLOBALS['_fair_pll_translations'][ $value ] ?? $value;
+	}
+}

--- a/fair-events-experimental/src/Services/ActivityOptionTranslation.php
+++ b/fair-events-experimental/src/Services/ActivityOptionTranslation.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Activity Option Translation Service
+ *
+ * @package FairEventsExperimental
+ */
+
+namespace FairEventsExperimental\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Bridges TicketOption (activity) name/short_name values to Polylang's
+ * string translation API.
+ *
+ * `register()` is called from the admin save/read path so every
+ * non-empty value gets a stable Polylang string; `translate_name()` /
+ * `translate_short_name()` are called from the public render paths to
+ * resolve that string in the current frontend language. Every Polylang
+ * call is guarded with `function_exists()` so activating/deactivating
+ * Polylang — or it simply not being installed — never causes a fatal
+ * error; the original stored value is returned unchanged in that case.
+ */
+class ActivityOptionTranslation {
+
+	/**
+	 * Polylang string group these strings are registered under.
+	 *
+	 * @var string
+	 */
+	const GROUP = 'Fair Events';
+
+	/**
+	 * Register an option's translatable values with Polylang.
+	 *
+	 * Uses a stable string name per option/field so editing a value
+	 * updates the same registered string instead of creating a new one.
+	 * Empty values are not registered.
+	 *
+	 * @param object $option Activity option (needs id, name, short_name).
+	 * @return void
+	 */
+	public static function register( $option ) {
+		if ( ! function_exists( 'pll_register_string' ) || ! $option || empty( $option->id ) ) {
+			return;
+		}
+
+		if ( ! empty( $option->name ) ) {
+			pll_register_string( self::string_name( $option->id, 'name' ), $option->name, self::GROUP );
+		}
+
+		if ( ! empty( $option->short_name ) ) {
+			pll_register_string( self::string_name( $option->id, 'short_name' ), $option->short_name, self::GROUP );
+		}
+	}
+
+	/**
+	 * Resolve an option's name in the current Polylang language.
+	 *
+	 * @param object $option Activity option (needs name).
+	 * @return string Translated value, or the original value when
+	 *                Polylang is unavailable, inactive, or has no
+	 *                translation for it.
+	 */
+	public static function translate_name( $option ) {
+		if ( ! $option || empty( $option->name ) ) {
+			return $option->name ?? '';
+		}
+
+		if ( ! function_exists( 'pll__' ) ) {
+			return $option->name;
+		}
+
+		return pll__( $option->name );
+	}
+
+	/**
+	 * Resolve an option's short name in the current Polylang language.
+	 *
+	 * @param object $option Activity option (needs short_name).
+	 * @return string|null Translated value, or the original value when
+	 *                      Polylang is unavailable, inactive, or has no
+	 *                      translation for it. Null when no short name
+	 *                      was ever set.
+	 */
+	public static function translate_short_name( $option ) {
+		if ( ! $option || empty( $option->short_name ) ) {
+			return $option->short_name ?? null;
+		}
+
+		if ( ! function_exists( 'pll__' ) ) {
+			return $option->short_name;
+		}
+
+		return pll__( $option->short_name );
+	}
+
+	/**
+	 * Build the stable Polylang string name for an option field.
+	 *
+	 * @param int    $id    Option ID.
+	 * @param string $field 'name' or 'short_name'.
+	 * @return string
+	 */
+	private static function string_name( $id, $field ) {
+		return "fair_events_ticket_option_{$id}_{$field}";
+	}
+}

--- a/fair-events-experimental/src/Services/ActivityOptionTranslation.php
+++ b/fair-events-experimental/src/Services/ActivityOptionTranslation.php
@@ -63,15 +63,7 @@ class ActivityOptionTranslation {
 	 *                translation for it.
 	 */
 	public static function translate_name( $option ) {
-		if ( ! $option || empty( $option->name ) ) {
-			return $option->name ?? '';
-		}
-
-		if ( ! function_exists( 'pll__' ) ) {
-			return $option->name;
-		}
-
-		return pll__( $option->name );
+		return self::translate_field( $option, 'name', '' );
 	}
 
 	/**
@@ -84,15 +76,30 @@ class ActivityOptionTranslation {
 	 *                      was ever set.
 	 */
 	public static function translate_short_name( $option ) {
-		if ( ! $option || empty( $option->short_name ) ) {
-			return $option->short_name ?? null;
+		return self::translate_field( $option, 'short_name', null );
+	}
+
+	/**
+	 * Shared implementation behind translate_name()/translate_short_name().
+	 *
+	 * @param object      $option   Activity option.
+	 * @param string      $field    'name' or 'short_name'.
+	 * @param string|null $fallback Value to fall back to when $option is
+	 *                              missing or has no value for $field.
+	 * @return string|null
+	 */
+	private static function translate_field( $option, $field, $fallback ) {
+		if ( ! $option ) {
+			return $fallback;
 		}
 
-		if ( ! function_exists( 'pll__' ) ) {
-			return $option->short_name;
+		$value = $option->$field ?? $fallback;
+
+		if ( empty( $value ) || ! function_exists( 'pll__' ) ) {
+			return $value;
 		}
 
-		return pll__( $option->short_name );
+		return pll__( $value );
 	}
 
 	/**

--- a/fair-events-experimental/src/Services/ActivityOptionTranslation.php
+++ b/fair-events-experimental/src/Services/ActivityOptionTranslation.php
@@ -45,11 +45,11 @@ class ActivityOptionTranslation {
 			return;
 		}
 
-		if ( ! empty( $option->name ) ) {
+		if ( self::has_value( $option->name ?? null ) ) {
 			pll_register_string( self::string_name( $option->id, 'name' ), $option->name, self::GROUP );
 		}
 
-		if ( ! empty( $option->short_name ) ) {
+		if ( self::has_value( $option->short_name ?? null ) ) {
 			pll_register_string( self::string_name( $option->id, 'short_name' ), $option->short_name, self::GROUP );
 		}
 	}
@@ -95,11 +95,23 @@ class ActivityOptionTranslation {
 
 		$value = $option->$field ?? $fallback;
 
-		if ( empty( $value ) || ! function_exists( 'pll__' ) ) {
+		if ( ! self::has_value( $value ) || ! function_exists( 'pll__' ) ) {
 			return $value;
 		}
 
 		return pll__( $value );
+	}
+
+	/**
+	 * Whether a stored field value counts as set. Deliberately not
+	 * `empty()` — a `"0"` option name/short_name is a real value, not a
+	 * blank one, and `empty( '0' )` is true in PHP.
+	 *
+	 * @param mixed $value Field value.
+	 * @return bool
+	 */
+	private static function has_value( $value ) {
+		return null !== $value && '' !== $value;
 	}
 
 	/**

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -702,16 +702,11 @@ class GetTicketsController extends WP_REST_Controller {
 				if ( null === $resolved_base ) {
 					continue;
 				}
-				$name       = $opt->name;
-				$short_name = $opt->short_name ?? null;
-				if ( class_exists( \FairEventsExperimental\Services\ActivityOptionTranslation::class ) ) {
-					$name       = \FairEventsExperimental\Services\ActivityOptionTranslation::translate_name( $opt );
-					$short_name = \FairEventsExperimental\Services\ActivityOptionTranslation::translate_short_name( $opt );
-				}
+				$display          = \FairEvents\Services\SignupFieldsetRenderer::resolve_option_display( $opt );
 				$ticket_options[] = array(
 					'id'         => (int) $opt->id,
-					'name'       => $name,
-					'short_name' => $short_name,
+					'name'       => $display['name'],
+					'short_name' => $display['short_name'],
 					'price'      => (float) $resolved_base,
 					'is_full'    => false,
 				);

--- a/fair-events/src/API/GetTicketsController.php
+++ b/fair-events/src/API/GetTicketsController.php
@@ -702,10 +702,16 @@ class GetTicketsController extends WP_REST_Controller {
 				if ( null === $resolved_base ) {
 					continue;
 				}
+				$name       = $opt->name;
+				$short_name = $opt->short_name ?? null;
+				if ( class_exists( \FairEventsExperimental\Services\ActivityOptionTranslation::class ) ) {
+					$name       = \FairEventsExperimental\Services\ActivityOptionTranslation::translate_name( $opt );
+					$short_name = \FairEventsExperimental\Services\ActivityOptionTranslation::translate_short_name( $opt );
+				}
 				$ticket_options[] = array(
 					'id'         => (int) $opt->id,
-					'name'       => $opt->name,
-					'short_name' => $opt->short_name ?? null,
+					'name'       => $name,
+					'short_name' => $short_name,
 					'price'      => (float) $resolved_base,
 					'is_full'    => false,
 				);

--- a/fair-events/src/API/TicketsController.php
+++ b/fair-events/src/API/TicketsController.php
@@ -697,6 +697,9 @@ class TicketsController extends WP_REST_Controller {
 			'settings'     => $settings,
 			'options'      => array_map(
 				function ( $o ) use ( $collaborators, $option_prices_by_option ) {
+					if ( class_exists( \FairEventsExperimental\Services\ActivityOptionTranslation::class ) ) {
+						\FairEventsExperimental\Services\ActivityOptionTranslation::register( $o );
+					}
 					$data                     = $o->to_array();
 					unset( $data['discounted_price'] );
 					$data['collaborator_ids'] = $collaborators[ $o->id ] ?? array();

--- a/fair-events/src/Services/SignupFieldsetRenderer.php
+++ b/fair-events/src/Services/SignupFieldsetRenderer.php
@@ -40,6 +40,29 @@ class SignupFieldsetRenderer {
 	}
 
 	/**
+	 * Resolve an activity option's display name/short_name, translated
+	 * through Polylang when fair-events-experimental's translation bridge
+	 * is available — shared so render.php and get_viewer_context() don't
+	 * each carry their own copy of the class_exists() guard.
+	 *
+	 * @param object $opt TicketOption-like object (needs name, short_name).
+	 * @return array{name: string, short_name: string|null}
+	 */
+	public static function resolve_option_display( $opt ) {
+		if ( ! class_exists( \FairEventsExperimental\Services\ActivityOptionTranslation::class ) ) {
+			return array(
+				'name'       => $opt->name,
+				'short_name' => $opt->short_name ?? null,
+			);
+		}
+
+		return array(
+			'name'       => \FairEventsExperimental\Services\ActivityOptionTranslation::translate_name( $opt ),
+			'short_name' => \FairEventsExperimental\Services\ActivityOptionTranslation::translate_short_name( $opt ),
+		);
+	}
+
+	/**
 	 * Render the "Choose ticket type" fieldset.
 	 *
 	 * @param object[]    $ticket_types         Ticket type objects for this event date.

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -268,16 +268,11 @@ if ( class_exists( \FairAudience\API\EventSignupController::class )
 			// Derived mode with no active period / no row → option not purchasable; skip.
 			continue;
 		}
-		$name       = $opt->name;
-		$short_name = $opt->short_name ?? null;
-		if ( class_exists( \FairEventsExperimental\Services\ActivityOptionTranslation::class ) ) {
-			$name       = \FairEventsExperimental\Services\ActivityOptionTranslation::translate_name( $opt );
-			$short_name = \FairEventsExperimental\Services\ActivityOptionTranslation::translate_short_name( $opt );
-		}
+		$display          = \FairEvents\Services\SignupFieldsetRenderer::resolve_option_display( $opt );
 		$ticket_options[] = array(
 			'id'         => (int) $opt->id,
-			'name'       => $name,
-			'short_name' => $short_name,
+			'name'       => $display['name'],
+			'short_name' => $display['short_name'],
 			'price'      => (float) $resolved_base,
 			'is_full'    => false,
 		);

--- a/fair-events/src/blocks/event-signup/render.php
+++ b/fair-events/src/blocks/event-signup/render.php
@@ -268,10 +268,16 @@ if ( class_exists( \FairAudience\API\EventSignupController::class )
 			// Derived mode with no active period / no row → option not purchasable; skip.
 			continue;
 		}
+		$name       = $opt->name;
+		$short_name = $opt->short_name ?? null;
+		if ( class_exists( \FairEventsExperimental\Services\ActivityOptionTranslation::class ) ) {
+			$name       = \FairEventsExperimental\Services\ActivityOptionTranslation::translate_name( $opt );
+			$short_name = \FairEventsExperimental\Services\ActivityOptionTranslation::translate_short_name( $opt );
+		}
 		$ticket_options[] = array(
 			'id'         => (int) $opt->id,
-			'name'       => $opt->name,
-			'short_name' => $opt->short_name ?? null,
+			'name'       => $name,
+			'short_name' => $short_name,
 			'price'      => (float) $resolved_base,
 			'is_full'    => false,
 		);


### PR DESCRIPTION
## Summary

- Adds `FairEventsExperimental\Services\ActivityOptionTranslation`, a Polylang string-translation bridge for activity option (`options/extra`, i.e. `TicketOption`) `name`/`short_name` values.
- `TicketsController::build_response()` registers each non-empty value with `pll_register_string()` under a stable per-option string name (`fair_events_ticket_option_{id}_name` / `_short_name`, group `Fair Events`) whenever fair-events-experimental is active — covering create/update/import and plain admin GETs, which also backfills options saved before this feature shipped.
- `render.php` (base render) and `GetTicketsController::get_viewer_context()` (personalized REST fragment) resolve the current-language translation via `pll__()` before handing the values to `SignupFieldsetRenderer`, which already escapes them on output.
- Every Polylang call is guarded with `function_exists()`, and every call site with its own `class_exists()` check on `ActivityOptionTranslation` — matching the codebase's existing defensive pattern for experimental classes — so the whole feature is a no-op with no fatal errors when Polylang and/or fair-events-experimental is inactive.

Closes #1432

## Acceptance criteria

- [x] Non-empty translatable values from `options/extra` appear under **Languages → Translations** — registered via `pll_register_string()` in `TicketsController::build_response()`.
- [x] The strings are grouped consistently and can be identified by their option/field — group `Fair Events`, string name `fair_events_ticket_option_{id}_{name|short_name}`.
- [x] The frontend displays the translation for the current Polylang language — both live render sites resolve via `pll__()`.
- [x] The original value is displayed when Polylang is inactive or a translation is missing — `translate_name()`/`translate_short_name()` fall back to the stored value whenever `pll__` doesn't exist; `pll__()` itself returns the original string when it has no translation.
- [x] Empty values are not registered — `register()` skips empty `name`/`short_name`.
- [x] Changing a saved value updates the registered source string without breaking existing output — the string name is stable per option ID/field, not per value.
- [x] The integration produces no fatal errors when Polylang is not installed or is temporarily unavailable — every Polylang call is `function_exists()`-guarded.
- [x] Automated tests cover registration, translated output, and fallback behavior where practical — see `fair-events-experimental/__tests__/Services/ActivityOptionTranslationTest.php`.

## Notes

- Only the active `fair-events/event-signup` block's two render sites translate; the legacy `fair-audience` block (inserter disabled), admin participant-list snapshots, and payment line-item/receipt names stay untranslated (per the ticket's implementation plan Decision #2).
- No delete cleanup — orphaned strings are left for the admin to prune via Languages → Translations (Decision #5).

## Test plan

- [x] `vendor/bin/phpunit` in `fair-events-experimental` — 25/25 pass (new `ActivityOptionTranslationTest`: fallback behavior with Polylang absent, empty-value guard, and `@runInSeparateProcess` tests with local `pll_register_string()`/`pll__()` stubs verifying registration args, translated output, and string-name reuse on a changed value).
- [x] `vendor/bin/phpcs` clean on all new/changed files.
- [x] `php -l` clean on all new/changed files.
- [x] `npx playwright test src/API/__tests__/TicketsController.api.spec.js src/API/__tests__/GetTicketsViewerContext.api.spec.js` against the dev stack — 11/13 pass; the 2 failures are pre-existing on `main` (unrelated — `fair-events-experimental` isn't active in this dev environment, so the add-on-options fixture itself can't save), confirmed by reproducing them on `main` before this change.
- Not run: live Polylang verification — Polylang isn't installed in this dev environment; behavior is covered by the stubbed PHPUnit tests instead.
