### PR TITLE
Give calendar & week view dated URLs their own canonical tags

### DIFF
--- a/.changeset/dated-view-canonical-urls.md
+++ b/.changeset/dated-view-canonical-urls.md
@@ -1,0 +1,5 @@
+---
+"fair-events": minor
+---
+
+Give the events-calendar and events-week blocks' month/week views their own canonical URLs when requested within a bounded window (±3 months / ±12 weeks of today), so individual month/week pages can be indexed separately instead of collapsing into the default page's canonical.

--- a/fair-events/__tests__/Helpers/CalendarMonthParamTest.php
+++ b/fair-events/__tests__/Helpers/CalendarMonthParamTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Tests for CalendarMonthParam.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Helpers\CalendarMonthParam;
+
+/**
+ * Unit tests for the `calendar_month`/`calendar_year` URL param validation.
+ */
+class CalendarMonthParamTest extends TestCase {
+
+	/**
+	 * A valid month/year pair round-trips unchanged.
+	 *
+	 * @return void
+	 */
+	public function test_parse_accepts_valid_pair() {
+		$this->assertSame(
+			array(
+				'month' => '08',
+				'year'  => '2026',
+			),
+			CalendarMonthParam::parse( '08', '2026' )
+		);
+	}
+
+	/**
+	 * An out-of-range month is rejected.
+	 *
+	 * @return void
+	 */
+	public function test_parse_rejects_invalid_month() {
+		$this->assertNull( CalendarMonthParam::parse( '13', '2026' ) );
+		$this->assertNull( CalendarMonthParam::parse( '00', '2026' ) );
+		$this->assertNull( CalendarMonthParam::parse( '8', '2026' ) );
+	}
+
+	/**
+	 * A year outside 1900-2100, or not four digits, is rejected.
+	 *
+	 * @return void
+	 */
+	public function test_parse_rejects_invalid_year() {
+		$this->assertNull( CalendarMonthParam::parse( '08', '1899' ) );
+		$this->assertNull( CalendarMonthParam::parse( '08', '2101' ) );
+		$this->assertNull( CalendarMonthParam::parse( '08', '26' ) );
+	}
+
+	/**
+	 * Garbage/empty input is rejected.
+	 *
+	 * @return void
+	 */
+	public function test_parse_rejects_garbage_and_empty() {
+		$this->assertNull( CalendarMonthParam::parse( '', '' ) );
+		$this->assertNull( CalendarMonthParam::parse( 'aa', 'bbbb' ) );
+	}
+
+	/**
+	 * Current() returns today's month/year in the same shape as parse().
+	 *
+	 * @return void
+	 */
+	public function test_current_returns_todays_month_and_year() {
+		$current = CalendarMonthParam::current();
+
+		$this->assertSame( current_time( 'm' ), $current['month'] );
+		$this->assertSame( current_time( 'Y' ), $current['year'] );
+	}
+}

--- a/fair-events/__tests__/Helpers/DatedViewCanonicalUrlTest.php
+++ b/fair-events/__tests__/Helpers/DatedViewCanonicalUrlTest.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Tests for DatedViewCanonicalUrl::resolve_url().
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Helpers\DatedViewCanonicalUrl;
+
+/**
+ * Unit tests for the pure canonical-URL decision in DatedViewCanonicalUrl.
+ */
+class DatedViewCanonicalUrlTest extends TestCase {
+
+	const BASE_URL = 'https://example.com/events/';
+
+	const NOW_CALENDAR = array(
+		'month' => '06',
+		'year'  => '2026',
+	);
+
+	const NOW_WEEK = array(
+		'year' => 2026,
+		'week' => 24,
+	);
+
+	/**
+	 * An in-window calendar param, with the calendar block present, gets its
+	 * own canonical.
+	 *
+	 * @return void
+	 */
+	public function test_in_window_calendar_param_with_block_included() {
+		$calendar = array(
+			'month' => '08',
+			'year'  => '2026',
+		);
+
+		$result = DatedViewCanonicalUrl::resolve_url(
+			self::BASE_URL,
+			true,
+			$calendar,
+			self::NOW_CALENDAR,
+			false,
+			null,
+			self::NOW_WEEK
+		);
+
+		$this->assertSame(
+			self::BASE_URL . '?calendar_month=08&calendar_year=2026',
+			$result
+		);
+	}
+
+	/**
+	 * An in-window week param, with the week block present, gets its own
+	 * canonical.
+	 *
+	 * @return void
+	 */
+	public function test_in_window_week_param_with_block_included() {
+		$week = array(
+			'year' => 2026,
+			'week' => 30,
+		);
+
+		$result = DatedViewCanonicalUrl::resolve_url(
+			self::BASE_URL,
+			false,
+			null,
+			self::NOW_CALENDAR,
+			true,
+			$week,
+			self::NOW_WEEK
+		);
+
+		$this->assertSame(
+			self::BASE_URL . '?week_view=2026-W30',
+			$result
+		);
+	}
+
+	/**
+	 * No params present: canonical stays the bare page URL.
+	 *
+	 * @return void
+	 */
+	public function test_no_params_keeps_bare_url() {
+		$result = DatedViewCanonicalUrl::resolve_url(
+			self::BASE_URL,
+			true,
+			null,
+			self::NOW_CALENDAR,
+			true,
+			null,
+			self::NOW_WEEK
+		);
+
+		$this->assertSame( self::BASE_URL, $result );
+	}
+
+	/**
+	 * A param outside the supported window falls back to the bare page URL.
+	 *
+	 * @return void
+	 */
+	public function test_out_of_window_param_falls_back_to_bare_url() {
+		$calendar = array(
+			'month' => '01',
+			'year'  => '2027', // 7 months out — beyond the ±3 month window.
+		);
+
+		$result = DatedViewCanonicalUrl::resolve_url(
+			self::BASE_URL,
+			true,
+			$calendar,
+			self::NOW_CALENDAR,
+			false,
+			null,
+			self::NOW_WEEK
+		);
+
+		$this->assertSame( self::BASE_URL, $result );
+	}
+
+	/**
+	 * A week param outside the ±12 week window falls back to the bare URL.
+	 *
+	 * @return void
+	 */
+	public function test_out_of_window_week_param_falls_back_to_bare_url() {
+		$week = array(
+			'year' => 2026,
+			'week' => 40, // 16 weeks out — beyond the ±12 week window.
+		);
+
+		$result = DatedViewCanonicalUrl::resolve_url(
+			self::BASE_URL,
+			false,
+			null,
+			self::NOW_CALENDAR,
+			true,
+			$week,
+			self::NOW_WEEK
+		);
+
+		$this->assertSame( self::BASE_URL, $result );
+	}
+
+	/**
+	 * A param present in the request whose block is absent from the page is
+	 * dropped from the canonical — the "leftover param" case.
+	 *
+	 * @return void
+	 */
+	public function test_param_without_its_block_is_dropped() {
+		$calendar = array(
+			'month' => '08',
+			'year'  => '2026',
+		);
+
+		$result = DatedViewCanonicalUrl::resolve_url(
+			self::BASE_URL,
+			false, // Calendar block not on the page.
+			$calendar,
+			self::NOW_CALENDAR,
+			false,
+			null,
+			self::NOW_WEEK
+		);
+
+		$this->assertSame( self::BASE_URL, $result );
+	}
+
+	/**
+	 * Both blocks present, only one param in-window: only the relevant one
+	 * is included.
+	 *
+	 * @return void
+	 */
+	public function test_both_blocks_present_only_relevant_param_included() {
+		$calendar = array(
+			'month' => '08',
+			'year'  => '2026',
+		);
+
+		$result = DatedViewCanonicalUrl::resolve_url(
+			self::BASE_URL,
+			true,
+			$calendar,
+			self::NOW_CALENDAR,
+			true,
+			null, // No week param on this request.
+			self::NOW_WEEK
+		);
+
+		$this->assertSame(
+			self::BASE_URL . '?calendar_month=08&calendar_year=2026',
+			$result
+		);
+	}
+
+	/**
+	 * A calendar param matching "now" is the default view, so it collapses
+	 * to the bare URL even with the block present.
+	 *
+	 * @return void
+	 */
+	public function test_calendar_param_matching_now_keeps_bare_url() {
+		$result = DatedViewCanonicalUrl::resolve_url(
+			self::BASE_URL,
+			true,
+			self::NOW_CALENDAR,
+			self::NOW_CALENDAR,
+			false,
+			null,
+			self::NOW_WEEK
+		);
+
+		$this->assertSame( self::BASE_URL, $result );
+	}
+
+	/**
+	 * A week param matching "now" is the default view, so it collapses to
+	 * the bare URL even with the block present.
+	 *
+	 * @return void
+	 */
+	public function test_week_param_matching_now_keeps_bare_url() {
+		$result = DatedViewCanonicalUrl::resolve_url(
+			self::BASE_URL,
+			false,
+			null,
+			self::NOW_CALENDAR,
+			true,
+			self::NOW_WEEK,
+			self::NOW_WEEK
+		);
+
+		$this->assertSame( self::BASE_URL, $result );
+	}
+
+	/**
+	 * Both blocks present with in-window, non-default params: both survive
+	 * in the canonical URL.
+	 *
+	 * @return void
+	 */
+	public function test_both_params_included_when_both_in_window() {
+		$calendar = array(
+			'month' => '08',
+			'year'  => '2026',
+		);
+		$week     = array(
+			'year' => 2026,
+			'week' => 30,
+		);
+
+		$result = DatedViewCanonicalUrl::resolve_url(
+			self::BASE_URL,
+			true,
+			$calendar,
+			self::NOW_CALENDAR,
+			true,
+			$week,
+			self::NOW_WEEK
+		);
+
+		$this->assertSame(
+			self::BASE_URL . '?calendar_month=08&calendar_year=2026&week_view=2026-W30',
+			$result
+		);
+	}
+}

--- a/fair-events/__tests__/Helpers/WeekViewParamTest.php
+++ b/fair-events/__tests__/Helpers/WeekViewParamTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Tests for WeekViewParam.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Helpers\WeekViewParam;
+
+/**
+ * Unit tests for the `week_view` URL param parse/format/current logic.
+ */
+class WeekViewParamTest extends TestCase {
+
+	/**
+	 * A valid ISO week string parses into its year/week parts.
+	 *
+	 * @return void
+	 */
+	public function test_parse_accepts_valid_iso_week() {
+		$this->assertSame(
+			array(
+				'year' => 2026,
+				'week' => 33,
+			),
+			WeekViewParam::parse( '2026-W33' )
+		);
+	}
+
+	/**
+	 * An out-of-range year or week is rejected.
+	 *
+	 * @return void
+	 */
+	public function test_parse_rejects_out_of_range_values() {
+		$this->assertNull( WeekViewParam::parse( '1899-W01' ) );
+		$this->assertNull( WeekViewParam::parse( '2101-W01' ) );
+		$this->assertNull( WeekViewParam::parse( '2026-W00' ) );
+		$this->assertNull( WeekViewParam::parse( '2026-W54' ) );
+	}
+
+	/**
+	 * Garbage/empty input is rejected.
+	 *
+	 * @return void
+	 */
+	public function test_parse_rejects_garbage_and_empty() {
+		$this->assertNull( WeekViewParam::parse( '' ) );
+		$this->assertNull( WeekViewParam::parse( '2026-08' ) );
+		$this->assertNull( WeekViewParam::parse( 'not-a-week' ) );
+	}
+
+	/**
+	 * Format() and parse() round-trip.
+	 *
+	 * @return void
+	 */
+	public function test_format_and_parse_round_trip() {
+		$formatted = WeekViewParam::format( 2026, 33 );
+
+		$this->assertSame( '2026-W33', $formatted );
+		$this->assertSame(
+			array(
+				'year' => 2026,
+				'week' => 33,
+			),
+			WeekViewParam::parse( $formatted )
+		);
+	}
+
+	/**
+	 * Format() zero-pads single-digit week numbers.
+	 *
+	 * @return void
+	 */
+	public function test_format_zero_pads_week_number() {
+		$this->assertSame( '2026-W05', WeekViewParam::format( 2026, 5 ) );
+	}
+
+	/**
+	 * Current() returns today's ISO year/week.
+	 *
+	 * @return void
+	 */
+	public function test_current_returns_todays_iso_year_and_week() {
+		$now = new \DateTime( 'now', new \DateTimeZone( wp_timezone_string() ) );
+
+		$this->assertSame(
+			array(
+				'year' => (int) $now->format( 'o' ),
+				'week' => (int) $now->format( 'W' ),
+			),
+			WeekViewParam::current()
+		);
+	}
+}

--- a/fair-events/__tests__/Helpers/WeekViewParamTest.php
+++ b/fair-events/__tests__/Helpers/WeekViewParamTest.php
@@ -43,6 +43,32 @@ class WeekViewParamTest extends TestCase {
 	}
 
 	/**
+	 * Week 53 is accepted for a year that actually has one.
+	 *
+	 * @return void
+	 */
+	public function test_parse_accepts_week_53_for_a_53_week_year() {
+		$this->assertSame(
+			array(
+				'year' => 2026,
+				'week' => 53,
+			),
+			WeekViewParam::parse( '2026-W53' )
+		);
+	}
+
+	/**
+	 * Week 53 is rejected for a year that only has 52 ISO weeks, instead of
+	 * silently rolling over to the following year's week 1 (which would let
+	 * two different `week_view` values describe the same dates).
+	 *
+	 * @return void
+	 */
+	public function test_parse_rejects_week_53_for_a_52_week_year() {
+		$this->assertNull( WeekViewParam::parse( '2027-W53' ) );
+	}
+
+	/**
 	 * Garbage/empty input is rejected.
 	 *
 	 * @return void

--- a/fair-events/src/Core/Plugin.php
+++ b/fair-events/src/Core/Plugin.php
@@ -119,6 +119,7 @@ class Plugin {
 		new \FairEvents\Hooks\OrganizationHooks();
 		new \FairEvents\Hooks\AdminBarHooks();
 		new \FairEvents\Hooks\CanonicalUrlHooks();
+		new \FairEvents\Hooks\DatedViewCanonicalUrlHooks();
 		\FairEvents\Hooks\PaymentHooks::init();
 		\FairEvents\Hooks\SignupEmailHooks::init();
 	}

--- a/fair-events/src/Helpers/CalendarMonthParam.php
+++ b/fair-events/src/Helpers/CalendarMonthParam.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Parse and format the public `calendar_month`/`calendar_year` URL params.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Helpers;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * The events-calendar block reads which month to display from
+ * `?calendar_month=` + `?calendar_year=` (falling back to block attributes,
+ * then "now"). This helper is the single place that validates that pair, so
+ * the block's own render and the dated-view canonical-URL logic share one
+ * implementation instead of two regexes drifting apart.
+ */
+class CalendarMonthParam {
+
+	/**
+	 * Validate a raw month/year pair.
+	 *
+	 * @param string $month_raw Raw month value (expected `mm`, 01-12).
+	 * @param string $year_raw  Raw year value (expected `YYYY`, 1900-2100).
+	 * @return array{month: string, year: string}|null The validated pair, or
+	 *                                                  null if either value
+	 *                                                  fails validation.
+	 */
+	public static function parse( string $month_raw, string $year_raw ): ?array {
+		if ( ! preg_match( '/^(0[1-9]|1[0-2])$/', $month_raw ) ) {
+			return null;
+		}
+
+		if ( ! preg_match( '/^\d{4}$/', $year_raw ) || $year_raw < 1900 || $year_raw > 2100 ) {
+			return null;
+		}
+
+		return array(
+			'month' => $month_raw,
+			'year'  => $year_raw,
+		);
+	}
+
+	/**
+	 * The current month/year, in the same shape as parse().
+	 *
+	 * @return array{month: string, year: string}
+	 */
+	public static function current(): array {
+		return array(
+			'month' => current_time( 'm' ),
+			'year'  => current_time( 'Y' ),
+		);
+	}
+}

--- a/fair-events/src/Helpers/DatedViewCanonicalUrl.php
+++ b/fair-events/src/Helpers/DatedViewCanonicalUrl.php
@@ -56,21 +56,76 @@ class DatedViewCanonicalUrl {
 	 */
 	public static function for_post( \WP_Post $post, string $base_url ): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$calendar_month_raw = isset( $_GET['calendar_month'] ) ? sanitize_text_field( wp_unslash( $_GET['calendar_month'] ) ) : '';
+		$url_month = isset( $_GET['calendar_month'] ) ? sanitize_text_field( wp_unslash( $_GET['calendar_month'] ) ) : '';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$calendar_year_raw = isset( $_GET['calendar_year'] ) ? sanitize_text_field( wp_unslash( $_GET['calendar_year'] ) ) : '';
+		$url_year = isset( $_GET['calendar_year'] ) ? sanitize_text_field( wp_unslash( $_GET['calendar_year'] ) ) : '';
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$week_raw = isset( $_GET['week_view'] ) ? sanitize_text_field( wp_unslash( $_GET['week_view'] ) ) : '';
 
+		$has_calendar_block = has_block( 'fair-events/events-calendar', $post );
+
+		// Mirrors events-calendar/render.php's own precedence: a URL param
+		// wins, otherwise fall back to the block's own currentMonth/
+		// currentYear attributes. Without this, a block whose attributes
+		// render a non-default month (with no URL param present) would
+		// render one month but canonicalize to the bare page URL.
+		$calendar_month_raw = $url_month;
+		$calendar_year_raw  = $url_year;
+		if ( $has_calendar_block && ( '' === $url_month || '' === $url_year ) ) {
+			$block_attrs        = self::calendar_block_attributes( $post );
+			$calendar_month_raw = '' !== $url_month ? $url_month : (string) ( $block_attrs['currentMonth'] ?? '' );
+			$calendar_year_raw  = '' !== $url_year ? $url_year : (string) ( $block_attrs['currentYear'] ?? '' );
+		}
+
 		return self::resolve_url(
 			$base_url,
-			has_block( 'fair-events/events-calendar', $post ),
+			$has_calendar_block,
 			CalendarMonthParam::parse( $calendar_month_raw, $calendar_year_raw ),
 			CalendarMonthParam::current(),
 			has_block( 'fair-events/events-week', $post ),
 			WeekViewParam::parse( $week_raw ),
 			WeekViewParam::current()
 		);
+	}
+
+	/**
+	 * Read the events-calendar block's attributes from a post's content, so
+	 * for_post() can fall back to its currentMonth/currentYear the same way
+	 * events-calendar/render.php does when no URL param is present.
+	 *
+	 * @param \WP_Post $post The queried post.
+	 * @return array Attributes of the first fair-events/events-calendar
+	 *               block found, or an empty array if none is present.
+	 */
+	private static function calendar_block_attributes( \WP_Post $post ): array {
+		$attrs = self::find_block_attrs( parse_blocks( $post->post_content ), 'fair-events/events-calendar' );
+
+		return $attrs ?? array();
+	}
+
+	/**
+	 * Recursively search a parsed block tree for the first block matching a
+	 * given name, returning its attributes.
+	 *
+	 * @param array  $blocks     Parsed blocks (parse_blocks() output, or an innerBlocks slice).
+	 * @param string $block_name Fully-qualified block name to find.
+	 * @return array|null The matching block's attrs (possibly empty), or null if not found.
+	 */
+	private static function find_block_attrs( array $blocks, string $block_name ): ?array {
+		foreach ( $blocks as $block ) {
+			if ( isset( $block['blockName'] ) && $block_name === $block['blockName'] ) {
+				return $block['attrs'] ?? array();
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$found = self::find_block_attrs( $block['innerBlocks'], $block_name );
+				if ( null !== $found ) {
+					return $found;
+				}
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/fair-events/src/Helpers/DatedViewCanonicalUrl.php
+++ b/fair-events/src/Helpers/DatedViewCanonicalUrl.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Canonical URL resolution for the events-calendar and events-week blocks'
+ * dated views.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Helpers;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * The events-calendar and events-week blocks let visitors browse other
+ * months/weeks via `?calendar_month=`+`?calendar_year=` and `?week_view=`,
+ * but every dated view otherwise reports the same canonical URL as the
+ * page's default view — search engines then treat genuinely different
+ * content (a different month/week of events) as duplicates of one page.
+ *
+ * This helper decides when a request's dated-view params earn their own
+ * canonical URL: the relevant block must actually be on the page, the param
+ * must differ from "now" (the default view already canonicalizes there),
+ * and the param must fall within a bounded window so canonicals don't
+ * balloon into an unbounded, mostly-empty crawl surface. A param whose block
+ * isn't on the page (left over from navigating the other view) is dropped,
+ * so two requests that render identical content always resolve to the same
+ * canonical URL.
+ *
+ * Known limitation: `has_block()` only sees literal serialized block markup
+ * in post_content, so a calendar/week block inserted via a synced
+ * pattern/reusable block reference won't be detected and that page's
+ * canonical will drop the param even though the block renders. No existing
+ * code in this plugin resolves synced-pattern references either, so this
+ * matches current practice rather than regressing it.
+ */
+class DatedViewCanonicalUrl {
+
+	/**
+	 * How many months either side of "now" a calendar_month/year param still
+	 * earns its own canonical.
+	 */
+	const CALENDAR_WINDOW_MONTHS = 3;
+
+	/**
+	 * How many weeks either side of "now" a week_view param still earns its
+	 * own canonical.
+	 */
+	const WEEK_WINDOW_WEEKS = 12;
+
+	/**
+	 * Resolve the canonical URL for the current request against a post.
+	 *
+	 * @param \WP_Post $post     The queried post.
+	 * @param string   $base_url The plain page URL (WordPress' own canonical).
+	 * @return string Canonical URL.
+	 */
+	public static function for_post( \WP_Post $post, string $base_url ): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$calendar_month_raw = isset( $_GET['calendar_month'] ) ? sanitize_text_field( wp_unslash( $_GET['calendar_month'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$calendar_year_raw = isset( $_GET['calendar_year'] ) ? sanitize_text_field( wp_unslash( $_GET['calendar_year'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$week_raw = isset( $_GET['week_view'] ) ? sanitize_text_field( wp_unslash( $_GET['week_view'] ) ) : '';
+
+		return self::resolve_url(
+			$base_url,
+			has_block( 'fair-events/events-calendar', $post ),
+			CalendarMonthParam::parse( $calendar_month_raw, $calendar_year_raw ),
+			CalendarMonthParam::current(),
+			has_block( 'fair-events/events-week', $post ),
+			WeekViewParam::parse( $week_raw ),
+			WeekViewParam::current()
+		);
+	}
+
+	/**
+	 * Pure canonical-URL decision.
+	 *
+	 * @param string                                  $base_url           The plain page URL.
+	 * @param bool                                    $has_calendar_block Whether the events-calendar block is on the page.
+	 * @param array{month: string, year: string}|null $calendar           The request's parsed calendar param, or null if absent/invalid.
+	 * @param array{month: string, year: string}      $calendar_now       The current month/year.
+	 * @param bool                                    $has_week_block     Whether the events-week block is on the page.
+	 * @param array{year: int, week: int}|null        $week               The request's parsed week param, or null if absent/invalid.
+	 * @param array{year: int, week: int}             $week_now           The current ISO year/week.
+	 * @return string Canonical URL.
+	 */
+	public static function resolve_url(
+		string $base_url,
+		bool $has_calendar_block,
+		?array $calendar,
+		array $calendar_now,
+		bool $has_week_block,
+		?array $week,
+		array $week_now
+	): string {
+		$url = $base_url;
+
+		if ( self::calendar_param_is_indexable( $has_calendar_block, $calendar, $calendar_now ) ) {
+			$url = add_query_arg( 'calendar_month', $calendar['month'], $url );
+			$url = add_query_arg( 'calendar_year', $calendar['year'], $url );
+		}
+
+		if ( self::week_param_is_indexable( $has_week_block, $week, $week_now ) ) {
+			$url = add_query_arg( 'week_view', WeekViewParam::format( $week['year'], $week['week'] ), $url );
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Whether a calendar param earns its own canonical.
+	 *
+	 * @param bool                                    $has_calendar_block Whether the events-calendar block is on the page.
+	 * @param array{month: string, year: string}|null $calendar           The request's parsed calendar param.
+	 * @param array{month: string, year: string}      $calendar_now       The current month/year.
+	 * @return bool
+	 */
+	private static function calendar_param_is_indexable( bool $has_calendar_block, ?array $calendar, array $calendar_now ): bool {
+		if ( ! $has_calendar_block || null === $calendar ) {
+			return false;
+		}
+
+		if ( $calendar['month'] === $calendar_now['month'] && $calendar['year'] === $calendar_now['year'] ) {
+			return false;
+		}
+
+		$distance = self::month_distance( $calendar, $calendar_now );
+
+		return $distance <= self::CALENDAR_WINDOW_MONTHS;
+	}
+
+	/**
+	 * Whether a week param earns its own canonical.
+	 *
+	 * @param bool                             $has_week_block Whether the events-week block is on the page.
+	 * @param array{year: int, week: int}|null $week           The request's parsed week param.
+	 * @param array{year: int, week: int}      $week_now       The current ISO year/week.
+	 * @return bool
+	 */
+	private static function week_param_is_indexable( bool $has_week_block, ?array $week, array $week_now ): bool {
+		if ( ! $has_week_block || null === $week ) {
+			return false;
+		}
+
+		if ( $week['year'] === $week_now['year'] && $week['week'] === $week_now['week'] ) {
+			return false;
+		}
+
+		$distance = self::week_distance( $week, $week_now );
+
+		return $distance <= self::WEEK_WINDOW_WEEKS;
+	}
+
+	/**
+	 * Linear month distance between two month/year pairs.
+	 *
+	 * @param array{month: string, year: string} $a First month/year pair.
+	 * @param array{month: string, year: string} $b Second month/year pair.
+	 * @return int Absolute number of months between the two.
+	 */
+	private static function month_distance( array $a, array $b ): int {
+		$a_ordinal = ( (int) $a['year'] * 12 ) + (int) $a['month'];
+		$b_ordinal = ( (int) $b['year'] * 12 ) + (int) $b['month'];
+
+		return abs( $a_ordinal - $b_ordinal );
+	}
+
+	/**
+	 * Week distance between two ISO year/week pairs, via plain PHP date
+	 * arithmetic (no WP calls, so this stays pure/unit-testable).
+	 *
+	 * @param array{year: int, week: int} $a First ISO year/week pair.
+	 * @param array{year: int, week: int} $b Second ISO year/week pair.
+	 * @return int Absolute number of weeks between the two.
+	 */
+	private static function week_distance( array $a, array $b ): int {
+		$a_date = new \DateTime();
+		$a_date->setISODate( $a['year'], $a['week'] );
+
+		$b_date = new \DateTime();
+		$b_date->setISODate( $b['year'], $b['week'] );
+
+		$days = (int) $a_date->diff( $b_date )->days;
+
+		return (int) round( $days / 7 );
+	}
+}

--- a/fair-events/src/Helpers/WeekViewParam.php
+++ b/fair-events/src/Helpers/WeekViewParam.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Parse and format the public `week_view` URL param.
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Helpers;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * The events-week block reads which ISO week to display from
+ * `?week_view=YYYY-Www` (falling back to the current week). This helper is
+ * the single place that validates/formats that value, so the block's own
+ * render and the dated-view canonical-URL logic share one implementation
+ * instead of two regexes drifting apart.
+ */
+class WeekViewParam {
+
+	/**
+	 * Parse a raw `YYYY-Www` string into its year/week parts.
+	 *
+	 * @param string $raw Raw URL param value.
+	 * @return array{year: int, week: int}|null The parsed pair, or null if
+	 *                                           the value doesn't match the
+	 *                                           expected format/range.
+	 */
+	public static function parse( string $raw ): ?array {
+		if ( ! preg_match( '/^(\d{4})-W(\d{2})$/', $raw, $matches ) ) {
+			return null;
+		}
+
+		$year = (int) $matches[1];
+		$week = (int) $matches[2];
+
+		if ( $year < 1900 || $year > 2100 || $week < 1 || $week > 53 ) {
+			return null;
+		}
+
+		return array(
+			'year' => $year,
+			'week' => $week,
+		);
+	}
+
+	/**
+	 * Format a year/week pair into the public `YYYY-Www` URL param value.
+	 *
+	 * @param int $year ISO year.
+	 * @param int $week ISO week number.
+	 * @return string Formatted `YYYY-Www` value.
+	 */
+	public static function format( int $year, int $week ): string {
+		return sprintf( '%04d-W%02d', $year, $week );
+	}
+
+	/**
+	 * The current ISO year/week, in the same shape as parse().
+	 *
+	 * @return array{year: int, week: int}
+	 */
+	public static function current(): array {
+		$now = new \DateTime( 'now', new \DateTimeZone( wp_timezone_string() ) );
+
+		return array(
+			'year' => (int) $now->format( 'o' ),
+			'week' => (int) $now->format( 'W' ),
+		);
+	}
+}

--- a/fair-events/src/Helpers/WeekViewParam.php
+++ b/fair-events/src/Helpers/WeekViewParam.php
@@ -38,6 +38,18 @@ class WeekViewParam {
 			return null;
 		}
 
+		// Not every year has a 53rd ISO week. setISODate() silently rolls an
+		// out-of-range week over into the following year's week 1 instead of
+		// erroring, so round-trip and reject anything that didn't land back
+		// on the requested year/week (e.g. `2027-W53`, since 2027 only has
+		// 52 ISO weeks) — otherwise that param and next year's `-W01` would
+		// resolve to the same dates but mint two different canonical URLs.
+		$date = new \DateTime();
+		$date->setISODate( $year, $week );
+		if ( (int) $date->format( 'o' ) !== $year || (int) $date->format( 'W' ) !== $week ) {
+			return null;
+		}
+
 		return array(
 			'year' => $year,
 			'week' => $week,

--- a/fair-events/src/Hooks/DatedViewCanonicalUrlHooks.php
+++ b/fair-events/src/Hooks/DatedViewCanonicalUrlHooks.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Canonical URL for dated calendar/week views
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Hooks;
+
+use FairEvents\Helpers\DatedViewCanonicalUrl;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Filters WordPress' `get_canonical_url` so a page carrying an
+ * events-calendar or events-week block, requested with an in-window
+ * `calendar_month`/`calendar_year` or `week_view` param, declares that dated
+ * view's own canonical URL instead of collapsing onto the page's default
+ * (undated) view.
+ *
+ * Kept separate from CanonicalUrlHooks (per-occurrence event pages): that
+ * hook is scoped to Settings::get_enabled_post_types(), while these blocks
+ * can be placed on any singular post/page.
+ */
+class DatedViewCanonicalUrlHooks {
+
+	/**
+	 * Constructor - registers WordPress hooks
+	 */
+	public function __construct() {
+		add_filter( 'get_canonical_url', array( $this, 'filter_canonical_url' ), 10, 2 );
+	}
+
+	/**
+	 * Adjust the canonical URL for a singular page/post.
+	 *
+	 * @param string   $canonical_url WordPress' computed canonical URL.
+	 * @param \WP_Post $post          The queried post.
+	 * @return string Canonical URL.
+	 */
+	public function filter_canonical_url( $canonical_url, $post ) {
+		if ( ! is_singular() ) {
+			return $canonical_url;
+		}
+
+		return DatedViewCanonicalUrl::for_post( $post, $canonical_url );
+	}
+}

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -11,6 +11,7 @@
 
 defined( 'WPINC' ) || die;
 
+use FairEvents\Helpers\CalendarMonthParam;
 use FairEvents\Helpers\EventSchema;
 use FairEvents\Services\EventFeedProvider;
 use FairEvents\Settings\Settings;
@@ -226,21 +227,25 @@ $bg_color_value   = fair_events_convert_color_to_css( $bg_color );
 $text_color_value = fair_events_convert_color_to_css( $text_color );
 $header_bg_value  = fair_events_convert_color_to_css( $header_bg_color );
 
-// Get month/year from URL parameters or block attributes
-// URL params take precedence (for navigation), then block attributes, then current date
-$url_month     = isset( $_GET['calendar_month'] ) ? sanitize_text_field( $_GET['calendar_month'] ) : '';
-$url_year      = isset( $_GET['calendar_year'] ) ? sanitize_text_field( $_GET['calendar_year'] ) : '';
-$current_month = $url_month ?: ( $attributes['currentMonth'] ?: current_time( 'm' ) );
-$current_year  = $url_year ?: ( $attributes['currentYear'] ?: current_time( 'Y' ) );
+// Get month/year from URL parameters or block attributes.
+// URL params take precedence (for navigation), then block attributes, then current date.
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$url_month = isset( $_GET['calendar_month'] ) ? sanitize_text_field( wp_unslash( $_GET['calendar_month'] ) ) : '';
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$url_year = isset( $_GET['calendar_year'] ) ? sanitize_text_field( wp_unslash( $_GET['calendar_year'] ) ) : '';
 
-// Validate month (01-12)
-if ( ! preg_match( '/^(0[1-9]|1[0-2])$/', $current_month ) ) {
-	$current_month = current_time( 'm' );
-}
+$month_raw = $url_month ?: ( $attributes['currentMonth'] ?: '' );
+$year_raw  = $url_year ?: ( $attributes['currentYear'] ?: '' );
 
-// Validate year (1900-2100)
-if ( ! preg_match( '/^\d{4}$/', $current_year ) || $current_year < 1900 || $current_year > 2100 ) {
-	$current_year = current_time( 'Y' );
+$parsed = CalendarMonthParam::parse( (string) $month_raw, (string) $year_raw );
+
+if ( $parsed ) {
+	$current_month = $parsed['month'];
+	$current_year  = $parsed['year'];
+} else {
+	$now           = CalendarMonthParam::current();
+	$current_month = $now['month'];
+	$current_year  = $now['year'];
 }
 
 // Calculate grid structure early (needed for query range)

--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -18,37 +18,11 @@ defined( 'WPINC' ) || die;
 
 use FairEvents\Helpers\DateHelper;
 use FairEvents\Helpers\EventSchema;
+use FairEvents\Helpers\WeekViewParam;
 use FairEvents\Services\EventFeedProvider;
 use FairEvents\Settings\Settings;
 
 // Helper functions — guarded so they compose safely with weekly-schedule on the same page.
-if ( ! function_exists( 'fair_events_parse_iso_week' ) ) {
-	function fair_events_parse_iso_week( $iso_week_string ) {
-		if ( ! preg_match( '/^(\d{4})-W(\d{2})$/', $iso_week_string, $matches ) ) {
-			return null;
-		}
-		$year = (int) $matches[1];
-		$week = (int) $matches[2];
-		if ( $year < 1900 || $year > 2100 || $week < 1 || $week > 53 ) {
-			return null;
-		}
-		return array(
-			'year' => $year,
-			'week' => $week,
-		);
-	}
-}
-
-if ( ! function_exists( 'fair_events_get_current_week' ) ) {
-	function fair_events_get_current_week() {
-		$now = new DateTime( 'now', new DateTimeZone( wp_timezone_string() ) );
-		return array(
-			'year' => (int) $now->format( 'o' ),
-			'week' => (int) $now->format( 'W' ),
-		);
-	}
-}
-
 if ( ! function_exists( 'fair_events_get_week_boundaries' ) ) {
 	function fair_events_get_week_boundaries( $year, $week, $start_of_week ) {
 		$date = new DateTime();
@@ -103,13 +77,13 @@ if ( ! function_exists( 'fair_events_convert_color_to_css' ) ) {
 // Resolve which week to show — URL param takes precedence over current week.
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $url_week_param = isset( $_GET['week_view'] ) ? sanitize_text_field( wp_unslash( $_GET['week_view'] ) ) : '';
-$parsed         = fair_events_parse_iso_week( $url_week_param );
+$parsed         = WeekViewParam::parse( $url_week_param );
 
 if ( $parsed ) {
 	$year = $parsed['year'];
 	$week = $parsed['week'];
 } else {
-	$current = fair_events_get_current_week();
+	$current = WeekViewParam::current();
 	$year    = $current['year'];
 	$week    = $current['week'];
 }
@@ -215,8 +189,8 @@ $scroll_anchor_id = ! empty( $attributes['anchor'] ) ? $attributes['anchor'] : '
 
 $prev     = fair_events_offset_week( $year, $week, -1 );
 $next     = fair_events_offset_week( $year, $week, 1 );
-$prev_url = add_query_arg( 'week_view', sprintf( '%04d-W%02d', $prev['year'], $prev['week'] ) ) . '#' . $scroll_anchor_id;
-$next_url = add_query_arg( 'week_view', sprintf( '%04d-W%02d', $next['year'], $next['week'] ) ) . '#' . $scroll_anchor_id;
+$prev_url = add_query_arg( 'week_view', WeekViewParam::format( $prev['year'], $prev['week'] ) ) . '#' . $scroll_anchor_id;
+$next_url = add_query_arg( 'week_view', WeekViewParam::format( $next['year'], $next['week'] ) ) . '#' . $scroll_anchor_id;
 
 // Build copy summary text.
 $summary_text = '';


### PR DESCRIPTION
## Summary

- The events-calendar and events-week blocks let visitors browse other months/weeks via `calendar_month`/`calendar_year` and `week_view` URL params, but every dated view reported the same canonical URL as the undated default — search engines folded genuinely different content into one page and never indexed the rest.
- Adds `DatedViewCanonicalUrl` (pure/impure split, mirroring the existing per-occurrence `CanonicalUrl` precedent) so an in-window dated request gets its own canonical: **±3 months** for the calendar view, **±12 weeks** for week view. Outside that window, or when a param's block isn't actually on the page, the canonical collapses back to the bare page URL.
- Extracts the param validation each `render.php` already did inline into `CalendarMonthParam` and `WeekViewParam` so the blocks and the new canonical logic share one implementation.
- Wired via a new `DatedViewCanonicalUrlHooks`, registered separately from `CanonicalUrlHooks` since these blocks can sit on any singular post/page.

Closes #1386

## Acceptance criteria

- [x] Requesting the events page with a calendar month/year parameter within the supported window renders a canonical tag matching that URL (including the parameter). — verified live via WP-CLI and curl against `/proximos-eventos/?calendar_month=10&calendar_year=2026`.
- [x] Requesting the events page with a week parameter within the supported window renders a canonical tag matching that URL. — verified live with `?week_view=2026-W40`.
- [x] Requesting the events page with no date parameters still renders the plain page URL as canonical. — verified.
- [x] Requesting the events page with a date parameter outside the supported window falls back to the default page canonical. — verified (`calendar_month=01&calendar_year=2030`).
- [x] When both the calendar and week views are present on the same page, a parameter that doesn't affect rendered content is excluded from the canonical URL. — verified live: a `week_view` param on a calendar-only page is dropped from the canonical.
- [x] Test coverage added per TESTING.md — new `CalendarMonthParamTest`, `WeekViewParamTest`, and `DatedViewCanonicalUrlTest` (unit, PHPUnit), covering the full acceptance-criteria matrix.

## Notes

- Prev/next navigation links carrying over the other view's query param (flagged in the ticket as Open Question 1) is deliberately out of scope here, per the ticket's own recommendation — a separate follow-up ticket.
- `has_block()` only sees literal serialized block markup, so a calendar/week block inserted via a synced pattern/reusable block reference won't be detected and that page's canonical will drop the param even though the block renders. This matches existing plugin behavior elsewhere (documented in code).
- Changeset added (`fair-events`, minor).
