### PR TITLE
Link calendar/week events to Polylang page translations

### DIFF
--- a/.changeset/polylang-calendar-week-translation.md
+++ b/.changeset/polylang-calendar-week-translation.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+On sites running Polylang, the Events Calendar and Events Week blocks now link each event to the translation of its linked page matching the calendar/week page's current language, falling back to the currently linked page when no matching translation exists.

--- a/fair-events/__tests__/Services/EventTranslationTest.php
+++ b/fair-events/__tests__/Services/EventTranslationTest.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * EventTranslation tests
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use FairEvents\Services\EventTranslation;
+
+/**
+ * Covers the fallback behavior available in this process (Polylang absent)
+ * and, in separate processes with local `pll_*` stubs, the actual
+ * translation-resolution calls.
+ */
+class EventTranslationTest extends TestCase {
+
+	/**
+	 * Build a post-linked occurrence DTO.
+	 *
+	 * @param array $overrides Fields to override on top of the defaults.
+	 * @return array Occurrence DTO.
+	 */
+	private function occurrence( array $overrides = array() ) {
+		return array_merge(
+			array(
+				'event_id'        => 5,
+				'occurrence_type' => 'single',
+				'source'          => 'post',
+				'title'           => 'Post 5',
+				'url'             => 'https://example.com/?p=5',
+				'start'           => '2026-08-11 10:00:00',
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Fallback behavior in the default process (Polylang absent):
+	 * translate_occurrences() returns the input unchanged.
+	 */
+	public function test_returns_occurrences_unchanged_when_polylang_absent() {
+		$occurrences = array( $this->occurrence() );
+
+		$this->assertSame( $occurrences, EventTranslation::translate_occurrences( $occurrences ) );
+	}
+
+	/**
+	 * Non-post-linked occurrences (standalone/external) are left alone even
+	 * when Polylang is present, since resolving a translation only makes
+	 * sense for a linked WordPress post.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_non_post_source_is_left_unchanged() {
+		require_once __DIR__ . '/../pll-stubs.php';
+
+		$GLOBALS['_fair_pll_current_language']         = 'fr';
+		$GLOBALS['_fair_pll_translated_posts']['5:fr'] = 6;
+
+		$occurrence = $this->occurrence(
+			array(
+				'source'   => 'standalone',
+				'event_id' => null,
+			)
+		);
+
+		$result = EventTranslation::translate_occurrences( array( $occurrence ) );
+
+		$this->assertSame( $occurrence, $result[0] );
+		$this->assertSame( array(), $GLOBALS['_fair_pll_get_post_calls'] );
+	}
+
+	/**
+	 * No translation mapped for the current language: falls back to the
+	 * original title/url unchanged.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_falls_back_when_no_translation_exists() {
+		require_once __DIR__ . '/../pll-stubs.php';
+
+		$GLOBALS['_fair_pll_current_language'] = 'fr';
+
+		$occurrence = $this->occurrence();
+
+		$result = EventTranslation::translate_occurrences( array( $occurrence ) );
+
+		$this->assertSame( $occurrence, $result[0] );
+	}
+
+	/**
+	 * A published translation swaps in the translated post's title/url.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_swaps_in_published_translation() {
+		require_once __DIR__ . '/../pll-stubs.php';
+
+		$GLOBALS['_fair_pll_current_language']         = 'fr';
+		$GLOBALS['_fair_pll_translated_posts']['5:fr'] = 6;
+
+		$result = EventTranslation::translate_occurrences( array( $this->occurrence() ) );
+
+		$this->assertSame( 'Post 6', $result[0]['title'] );
+		$this->assertSame( 'https://example.com/?p=6', $result[0]['url'] );
+	}
+
+	/**
+	 * A `generated` occurrence keeps its `?event_date=` disambiguation arg,
+	 * appended to the translated post's permalink.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_generated_occurrence_keeps_event_date_arg_on_translated_url() {
+		require_once __DIR__ . '/../pll-stubs.php';
+
+		$GLOBALS['_fair_pll_current_language']         = 'fr';
+		$GLOBALS['_fair_pll_translated_posts']['5:fr'] = 6;
+
+		$occurrence = $this->occurrence(
+			array(
+				'occurrence_type' => 'generated',
+				'start'           => '2026-08-18 10:00:00',
+			)
+		);
+
+		$result = EventTranslation::translate_occurrences( array( $occurrence ) );
+
+		$this->assertSame( 'https://example.com/?p=6&event_date=2026-08-18', $result[0]['url'] );
+	}
+
+	/**
+	 * A non-`generated` occurrence's translated url has no `event_date` arg
+	 * appended.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_single_occurrence_translated_url_has_no_event_date_arg() {
+		require_once __DIR__ . '/../pll-stubs.php';
+
+		$GLOBALS['_fair_pll_current_language']         = 'fr';
+		$GLOBALS['_fair_pll_translated_posts']['5:fr'] = 6;
+
+		$result = EventTranslation::translate_occurrences( array( $this->occurrence() ) );
+
+		$this->assertSame( 'https://example.com/?p=6', $result[0]['url'] );
+	}
+
+	/**
+	 * A translation that resolves to an unpublished post is treated as "no
+	 * translation" — falls back to the original occurrence.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_falls_back_when_translation_is_not_published() {
+		require_once __DIR__ . '/../pll-stubs.php';
+
+		$GLOBALS['_fair_pll_current_language']         = 'fr';
+		$GLOBALS['_fair_pll_translated_posts']['5:fr'] = 6;
+		$GLOBALS['_fair_test_post_status'][6]          = 'draft';
+
+		$occurrence = $this->occurrence();
+
+		$result = EventTranslation::translate_occurrences( array( $occurrence ) );
+
+		$this->assertSame( $occurrence, $result[0] );
+	}
+
+	/**
+	 * `pll_get_post()` resolving the original post id itself (Polylang's
+	 * documented behavior when no translation exists) is treated the same
+	 * as "no translation".
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_falls_back_when_translation_resolves_to_the_same_post() {
+		require_once __DIR__ . '/../pll-stubs.php';
+
+		$GLOBALS['_fair_pll_current_language']         = 'fr';
+		$GLOBALS['_fair_pll_translated_posts']['5:fr'] = 5;
+
+		$occurrence = $this->occurrence();
+
+		$result = EventTranslation::translate_occurrences( array( $occurrence ) );
+
+		$this->assertSame( $occurrence, $result[0] );
+	}
+
+	/**
+	 * The same event_id repeated across occurrences (a recurring series)
+	 * only resolves the Polylang translation once per render.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_caches_translation_lookup_across_occurrences() {
+		require_once __DIR__ . '/../pll-stubs.php';
+
+		$GLOBALS['_fair_pll_current_language']         = 'fr';
+		$GLOBALS['_fair_pll_translated_posts']['5:fr'] = 6;
+
+		EventTranslation::translate_occurrences(
+			array(
+				$this->occurrence( array( 'start' => '2026-08-11 10:00:00' ) ),
+				$this->occurrence( array( 'start' => '2026-08-18 10:00:00' ) ),
+			)
+		);
+
+		$this->assertSame( array( '5:fr' ), $GLOBALS['_fair_pll_get_post_calls'] );
+	}
+}

--- a/fair-events/__tests__/Services/EventTranslationTest.php
+++ b/fair-events/__tests__/Services/EventTranslationTest.php
@@ -29,6 +29,7 @@ class EventTranslationTest extends TestCase {
 				'event_id'        => 5,
 				'occurrence_type' => 'single',
 				'source'          => 'post',
+				'link_type'       => 'post',
 				'title'           => 'Post 5',
 				'url'             => 'https://example.com/?p=5',
 				'start'           => '2026-08-11 10:00:00',
@@ -64,6 +65,61 @@ class EventTranslationTest extends TestCase {
 			array(
 				'source'   => 'standalone',
 				'event_id' => null,
+			)
+		);
+
+		$result = EventTranslation::translate_occurrences( array( $occurrence ) );
+
+		$this->assertSame( $occurrence, $result[0] );
+		$this->assertSame( array(), $GLOBALS['_fair_pll_get_post_calls'] );
+	}
+
+	/**
+	 * A post-linked event date whose calendar link is configured as an
+	 * external URL (`link_type: 'external'`) is left unchanged, even though
+	 * `event_id`/`source: 'post'` are set — the event's own CPT post having
+	 * a translation is irrelevant, since the occurrence doesn't link there.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_external_link_type_is_left_unchanged() {
+		require_once __DIR__ . '/../pll-stubs.php';
+
+		$GLOBALS['_fair_pll_current_language']         = 'fr';
+		$GLOBALS['_fair_pll_translated_posts']['5:fr'] = 6;
+
+		$occurrence = $this->occurrence(
+			array(
+				'link_type' => 'external',
+				'url'       => 'https://tickets.example.com/event',
+			)
+		);
+
+		$result = EventTranslation::translate_occurrences( array( $occurrence ) );
+
+		$this->assertSame( $occurrence, $result[0] );
+		$this->assertSame( array(), $GLOBALS['_fair_pll_get_post_calls'] );
+	}
+
+	/**
+	 * A post-linked event date whose calendar link is configured to a
+	 * different junction-linked post (`link_type: 'none'`) is left
+	 * unchanged for the same reason — url/title didn't come from
+	 * `event_id`'s own post.
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_none_link_type_is_left_unchanged() {
+		require_once __DIR__ . '/../pll-stubs.php';
+
+		$GLOBALS['_fair_pll_current_language']         = 'fr';
+		$GLOBALS['_fair_pll_translated_posts']['5:fr'] = 6;
+
+		$occurrence = $this->occurrence(
+			array(
+				'link_type' => 'none',
+				'url'       => 'https://example.com/?p=99',
+				'title'     => 'Post 99',
 			)
 		);
 

--- a/fair-events/__tests__/bootstrap.php
+++ b/fair-events/__tests__/bootstrap.php
@@ -112,6 +112,21 @@ if ( ! function_exists( 'get_the_title' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_post_status' ) ) {
+	/**
+	 * Stub of WordPress get_post_status() backed by
+	 * $GLOBALS['_fair_test_post_status'][ $post_id ]. Defaults to 'publish'
+	 * when the post id isn't seeded.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Post status.
+	 */
+	function get_post_status( $post_id ) {
+		$statuses = isset( $GLOBALS['_fair_test_post_status'] ) ? $GLOBALS['_fair_test_post_status'] : array();
+		return $statuses[ (int) $post_id ] ?? 'publish';
+	}
+}
+
 if ( ! function_exists( 'wp_http_validate_url' ) ) {
 	/**
 	 * Stub of WordPress wp_http_validate_url() — delegates to PHP's

--- a/fair-events/__tests__/pll-stubs.php
+++ b/fair-events/__tests__/pll-stubs.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Local Polylang function stubs for @runInSeparateProcess tests.
+ *
+ * Records calls into $GLOBALS so a test can assert on which post/language
+ * pairs were resolved and drive translated output, without pulling in the
+ * real plugin. Only required by tests that need Polylang to appear
+ * "active" — never loaded in the main PHPUnit process, so it can't leak
+ * into tests that assert on the Polylang-absent fallback behavior.
+ *
+ * @package FairEvents
+ */
+
+$GLOBALS['_fair_pll_current_language'] = null;
+$GLOBALS['_fair_pll_translated_posts'] = array();
+$GLOBALS['_fair_pll_get_post_calls']   = array();
+
+if ( ! function_exists( 'pll_current_language' ) ) {
+	/**
+	 * Stub for Polylang's pll_current_language() — returns whatever the
+	 * test seeded on $GLOBALS['_fair_pll_current_language'].
+	 *
+	 * @return string|null
+	 */
+	function pll_current_language() {
+		return $GLOBALS['_fair_pll_current_language'];
+	}
+}
+
+if ( ! function_exists( 'pll_get_post' ) ) {
+	/**
+	 * Stub for Polylang's pll_get_post() — resolves through the
+	 * "{post_id}:{language}" map on $GLOBALS['_fair_pll_translated_posts'],
+	 * recording every call so tests can assert on cache behavior.
+	 *
+	 * @param int    $post_id  Original post ID.
+	 * @param string $language Target language slug.
+	 * @return int|false Translated post ID, or false when none is mapped.
+	 */
+	function pll_get_post( $post_id, $language ) {
+		$GLOBALS['_fair_pll_get_post_calls'][] = $post_id . ':' . $language;
+
+		$key = $post_id . ':' . $language;
+		return $GLOBALS['_fair_pll_translated_posts'][ $key ] ?? false;
+	}
+}

--- a/fair-events/src/Helpers/OccurrenceDateParam.php
+++ b/fair-events/src/Helpers/OccurrenceDateParam.php
@@ -26,7 +26,21 @@ class OccurrenceDateParam {
 	 * @return string Date in `Y-m-d` format.
 	 */
 	public static function format( EventDates $row ): string {
-		return gmdate( 'Y-m-d', strtotime( $row->start_datetime ) );
+		return self::format_datetime( $row->start_datetime );
+	}
+
+	/**
+	 * Format a raw naive start datetime for use as the public URL param.
+	 *
+	 * Same rule as format(), for callers (e.g. EventTranslation) that only
+	 * have an occurrence DTO's `start` string, not the EventDates row it
+	 * came from.
+	 *
+	 * @param string $start_datetime Naive 'Y-m-d H:i:s' datetime.
+	 * @return string Date in `Y-m-d` format.
+	 */
+	public static function format_datetime( string $start_datetime ): string {
+		return gmdate( 'Y-m-d', strtotime( $start_datetime ) );
 	}
 
 	/**

--- a/fair-events/src/Services/EventFeedProvider.php
+++ b/fair-events/src/Services/EventFeedProvider.php
@@ -26,8 +26,10 @@ defined( 'WPINC' ) || die;
  *
  * DTO shape: uid, event_date_id, event_id, occurrence_type, title,
  * description, start, end, all_day, url, categories, source
- * ('post'|'standalone'|'ical'|'api'), is_draft, source_color, location
- * (neutral shape from EventLocation::resolve(), or null).
+ * ('post'|'standalone'|'ical'|'api'), link_type (the row's own
+ * 'post'|'external'|'none', only meaningful for source === 'post' — see
+ * format_post_occurrence()), is_draft, source_color, location (neutral
+ * shape from EventLocation::resolve(), or null).
  *
  * `start`/`end` are naive site-local 'Y-m-d H:i:s' strings — the same form
  * every other internal consumer (EventDates, WeeklyEventsProvider, blocks)
@@ -273,6 +275,7 @@ class EventFeedProvider {
 			'url'             => $row->get_display_url(),
 			'categories'      => $this->get_category_objects( $post_category_ids ),
 			'source'          => 'post',
+			'link_type'       => $row->link_type,
 			'is_draft'        => $is_draft,
 			'source_color'    => null,
 			'location'        => EventLocation::resolve( $row, $event_id ),

--- a/fair-events/src/Services/EventTranslation.php
+++ b/fair-events/src/Services/EventTranslation.php
@@ -7,6 +7,8 @@
 
 namespace FairEvents\Services;
 
+use FairEvents\Helpers\OccurrenceDateParam;
+
 defined( 'WPINC' ) || die;
 
 /**
@@ -29,6 +31,17 @@ class EventTranslation {
 	 * @var array<string, int|null>
 	 */
 	private static $resolved_ids = array();
+
+	/**
+	 * Per-request cache of a translated post's title/permalink, keyed by
+	 * translated post id. Separate from $resolved_ids because a recurring
+	 * series' occurrences share one translated post but each need their own
+	 * `event_date` URL arg, so only the id-independent parts are cached
+	 * here.
+	 *
+	 * @var array<int, array{title: string, permalink: string}|null>
+	 */
+	private static $post_data = array();
 
 	/**
 	 * Translate every post-linked occurrence in place to the current
@@ -68,6 +81,15 @@ class EventTranslation {
 			return $occurrence;
 		}
 
+		// A post-linked event date can still route its title/url elsewhere
+		// (an admin-configured external URL, or a different junction-linked
+		// post) via link_type; only a plain 'post' link means title/url
+		// genuinely came from $event_id's own post, which is the only case
+		// this service knows how to swap for a translation.
+		if ( 'post' !== ( $occurrence['link_type'] ?? null ) ) {
+			return $occurrence;
+		}
+
 		$event_id      = (int) $occurrence['event_id'];
 		$translated_id = self::resolve_translated_id( $event_id, $language );
 
@@ -75,17 +97,18 @@ class EventTranslation {
 			return $occurrence;
 		}
 
-		if ( 'publish' !== get_post_status( $translated_id ) ) {
+		$post_data = self::resolve_post_data( $translated_id );
+		if ( null === $post_data ) {
 			return $occurrence;
 		}
 
-		$url = get_permalink( $translated_id );
-		if ( $url && 'generated' === $occurrence['occurrence_type'] ) {
-			$url = add_query_arg( 'event_date', gmdate( 'Y-m-d', strtotime( $occurrence['start'] ) ), $url );
+		$url = $post_data['permalink'];
+		if ( 'generated' === $occurrence['occurrence_type'] ) {
+			$url = add_query_arg( 'event_date', OccurrenceDateParam::format_datetime( $occurrence['start'] ), $url );
 		}
 
-		$occurrence['title'] = get_the_title( $translated_id );
-		$occurrence['url']   = $url ? $url : $occurrence['url'];
+		$occurrence['title'] = $post_data['title'];
+		$occurrence['url']   = $url;
 
 		return $occurrence;
 	}
@@ -109,5 +132,34 @@ class EventTranslation {
 		self::$resolved_ids[ $cache_key ] = $translated_id ? (int) $translated_id : null;
 
 		return self::$resolved_ids[ $cache_key ];
+	}
+
+	/**
+	 * Resolve (and cache) a translated post's title/permalink, or null when
+	 * it's unusable (not published, or no permalink).
+	 *
+	 * @param int $translated_id Translated post ID.
+	 * @return array{title: string, permalink: string}|null
+	 */
+	private static function resolve_post_data( $translated_id ) {
+		if ( array_key_exists( $translated_id, self::$post_data ) ) {
+			return self::$post_data[ $translated_id ];
+		}
+
+		$data = null;
+
+		if ( 'publish' === get_post_status( $translated_id ) ) {
+			$permalink = get_permalink( $translated_id );
+			if ( $permalink ) {
+				$data = array(
+					'title'     => get_the_title( $translated_id ),
+					'permalink' => $permalink,
+				);
+			}
+		}
+
+		self::$post_data[ $translated_id ] = $data;
+
+		return $data;
 	}
 }

--- a/fair-events/src/Services/EventTranslation.php
+++ b/fair-events/src/Services/EventTranslation.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Event Translation Service
+ *
+ * @package FairEvents
+ */
+
+namespace FairEvents\Services;
+
+defined( 'WPINC' ) || die;
+
+/**
+ * Resolves post-linked occurrence titles/URLs to their Polylang translation
+ * matching the current front-end language.
+ *
+ * Used by the Events Calendar and Events Week blocks only — not
+ * EventFeedProvider itself, so the iCal feed, Events List block, and the
+ * REST controllers that share EventFeedProvider are unaffected. Every
+ * Polylang call is guarded with `function_exists()` so sites without
+ * Polylang (or with it deactivated) see zero behaviour change.
+ */
+class EventTranslation {
+
+	/**
+	 * Per-request cache of resolved translated post IDs, keyed by
+	 * "{event_id}:{language}". Avoids re-resolving the same event across
+	 * every occurrence of a recurring series.
+	 *
+	 * @var array<string, int|null>
+	 */
+	private static $resolved_ids = array();
+
+	/**
+	 * Translate every post-linked occurrence in place to the current
+	 * Polylang language, falling back to the original title/url when no
+	 * published translation exists.
+	 *
+	 * @param array $occurrences Occurrence DTOs from EventFeedProvider::get_occurrences().
+	 * @return array Occurrence DTOs, translated where applicable.
+	 */
+	public static function translate_occurrences( array $occurrences ) {
+		if ( ! function_exists( 'pll_current_language' ) || ! function_exists( 'pll_get_post' ) ) {
+			return $occurrences;
+		}
+
+		$language = pll_current_language();
+		if ( ! $language ) {
+			return $occurrences;
+		}
+
+		return array_map(
+			static function ( $occurrence ) use ( $language ) {
+				return self::translate_occurrence( $occurrence, $language );
+			},
+			$occurrences
+		);
+	}
+
+	/**
+	 * Translate a single occurrence.
+	 *
+	 * @param array  $occurrence Occurrence DTO.
+	 * @param string $language   Current Polylang language slug.
+	 * @return array Occurrence DTO, translated if applicable.
+	 */
+	private static function translate_occurrence( array $occurrence, $language ) {
+		if ( 'post' !== $occurrence['source'] || empty( $occurrence['event_id'] ) ) {
+			return $occurrence;
+		}
+
+		$event_id      = (int) $occurrence['event_id'];
+		$translated_id = self::resolve_translated_id( $event_id, $language );
+
+		if ( ! $translated_id || $translated_id === $event_id ) {
+			return $occurrence;
+		}
+
+		if ( 'publish' !== get_post_status( $translated_id ) ) {
+			return $occurrence;
+		}
+
+		$url = get_permalink( $translated_id );
+		if ( $url && 'generated' === $occurrence['occurrence_type'] ) {
+			$url = add_query_arg( 'event_date', gmdate( 'Y-m-d', strtotime( $occurrence['start'] ) ), $url );
+		}
+
+		$occurrence['title'] = get_the_title( $translated_id );
+		$occurrence['url']   = $url ? $url : $occurrence['url'];
+
+		return $occurrence;
+	}
+
+	/**
+	 * Resolve (and cache) the translated post id for an event/language pair.
+	 *
+	 * @param int    $event_id Original linked post ID.
+	 * @param string $language Polylang language slug.
+	 * @return int|null Translated post ID, or null if none.
+	 */
+	private static function resolve_translated_id( $event_id, $language ) {
+		$cache_key = $event_id . ':' . $language;
+
+		if ( array_key_exists( $cache_key, self::$resolved_ids ) ) {
+			return self::$resolved_ids[ $cache_key ];
+		}
+
+		$translated_id = pll_get_post( $event_id, $language );
+
+		self::$resolved_ids[ $cache_key ] = $translated_id ? (int) $translated_id : null;
+
+		return self::$resolved_ids[ $cache_key ];
+	}
+}

--- a/fair-events/src/blocks/events-calendar/render.php
+++ b/fair-events/src/blocks/events-calendar/render.php
@@ -14,6 +14,7 @@ defined( 'WPINC' ) || die;
 use FairEvents\Helpers\CalendarMonthParam;
 use FairEvents\Helpers\EventSchema;
 use FairEvents\Services\EventFeedProvider;
+use FairEvents\Services\EventTranslation;
 use FairEvents\Settings\Settings;
 
 /**
@@ -277,6 +278,7 @@ $occurrences = $provider->get_occurrences(
 		'include_drafts'     => $show_drafts,
 	)
 );
+$occurrences = EventTranslation::translate_occurrences( $occurrences );
 
 $events_by_date = EventFeedProvider::group_by_day( $occurrences, $query_start, $query_end );
 

--- a/fair-events/src/blocks/events-week/render.php
+++ b/fair-events/src/blocks/events-week/render.php
@@ -20,6 +20,7 @@ use FairEvents\Helpers\DateHelper;
 use FairEvents\Helpers\EventSchema;
 use FairEvents\Helpers\WeekViewParam;
 use FairEvents\Services\EventFeedProvider;
+use FairEvents\Services\EventTranslation;
 use FairEvents\Settings\Settings;
 
 // Helper functions — guarded so they compose safely with weekly-schedule on the same page.
@@ -120,6 +121,7 @@ $occurrences = $provider->get_occurrences(
 		'include_drafts'     => $show_drafts,
 	)
 );
+$occurrences = EventTranslation::translate_occurrences( $occurrences );
 
 $occurrences_by_date = EventFeedProvider::group_by_day( $occurrences, $week_start, $week_end );
 


### PR DESCRIPTION
## Summary

On sites running Polylang, the Events Calendar block (month view) and the Events Week block now link each event to the Polylang translation of its linked page matching the language the calendar/weekly page is currently displayed in, falling back to the currently linked page when no matching translation exists.

New `FairEvents\Services\EventTranslation` service resolves this per occurrence, guarded entirely behind `function_exists()` checks so sites without Polylang see zero behaviour change. Wired into `events-calendar/render.php` and `events-week/render.php` right after `get_occurrences()`, before both the HTML render and the JSON-LD builder — so structured data and the rendered page automatically agree.

Closes #1433

## Acceptance criteria

- [x] On a site with Polylang active, an event whose linked page has a translation matching the calendar/weekly page's language shows that translation's title and links to it.
- [x] When no matching translation exists, the block falls back to the currently linked page — no blank event, no broken link.
- [x] Behaviour is unchanged on sites where Polylang is not active (`function_exists()` guards short-circuit to a no-op).
- [x] Behaviour is unchanged for events not linked to a WordPress page/post (only `source === 'post'` occurrences are touched).
- [x] Applies to both the Events Calendar block (month view) and the Events Week block.

## Implementation notes

- Scope matches the plan's Decisions: only `source === 'post'` occurrences (junction-linked standalone events are out of scope); an unpublished resolved translation is treated as "no translation" and falls back.
- Per-request static cache keyed by `"{event_id}:{language}"` so a recurring series only calls `pll_get_post()` once per event/language pair.
- New PHPUnit tests in `fair-events/__tests__/Services/EventTranslationTest.php`, with local `pll_current_language()`/`pll_get_post()` stubs in `fair-events/__tests__/pll-stubs.php` (matching this plugin's existing top-level `__tests__/*-stub*.php` convention, not the `__tests__/helpers/` layout used in fair-events-experimental — fair-events doesn't have that directory pattern). Added a `get_post_status()` stub to `bootstrap.php`.

## Definition of Done

- No JS/CSS changed — build not required.
- `npm run format` clean (no formatting noise staged).
- `vendor/bin/phpcs` clean on all changed/new files (pre-existing findings in the two `render.php` files are untouched by this change).
- `vendor/bin/phpunit` — full `fair-events` suite passes (277 tests, including 9 new ones).
- No new UI strings — no i18n catalog changes needed.
- Not a `responsive-ui` ticket — no screenshots required.
- Changeset added (`fair-events`, patch).
