### PR TITLE
Support multiple sessions per day in irregular series

### DIFF
--- a/.changeset/multiple-sessions-per-day.md
+++ b/.changeset/multiple-sessions-per-day.md
@@ -1,0 +1,6 @@
+---
+"fair-events": minor
+"fair-events-shared": minor
+---
+
+Support more than one session per calendar day in the irregular (hand-picked dates) series editor. Picking an already-used date now adds another session instead of being rejected as a duplicate, each session has its own independent start/end time, and the calendar picker shows a badge on days with more than one session. Ticket sales and public listings already showed each session separately once created — this just makes them createable.

--- a/fair-events-shared/src/MiniCalendar.js
+++ b/fair-events-shared/src/MiniCalendar.js
@@ -13,6 +13,8 @@
  *   - `background`/`color`/`opacity`/`border`/`fontWeight`/`textDecoration`
  *   - `ariaLabel`           overrides the default full-date label
  *   - `tooltip`             wraps the cell in a Tooltip
+ *   - `badge`               small corner overlay (e.g. a session count) — opt-in,
+ *                           callers that never return it render unchanged
  *
  * A day with none of `href`/`interactive` renders as a plain, non-operable
  * cell.
@@ -308,6 +310,34 @@ function DayCell({ date, dateStr, day, todayStr, dayProps }) {
 		);
 	} else {
 		cell = <div style={cellStyle}>{day}</div>;
+	}
+
+	if (props.badge) {
+		cell = (
+			<div style={{ position: 'relative' }}>
+				{cell}
+				<span
+					aria-hidden="true"
+					style={{
+						position: 'absolute',
+						top: '-4px',
+						right: '-4px',
+						minWidth: '14px',
+						height: '14px',
+						padding: '0 2px',
+						borderRadius: '7px',
+						background: '#cc1818',
+						color: '#fff',
+						fontSize: '9px',
+						fontWeight: 700,
+						lineHeight: '14px',
+						textAlign: 'center',
+					}}
+				>
+					{props.badge}
+				</span>
+			</div>
+		);
 	}
 
 	if (props.tooltip) {

--- a/fair-events-shared/src/__tests__/MiniCalendar.test.js
+++ b/fair-events-shared/src/__tests__/MiniCalendar.test.js
@@ -212,4 +212,31 @@ describe('MiniCalendar', () => {
 		fireEvent.click(masterButton);
 		expect(onActivate).not.toHaveBeenCalled();
 	});
+
+	test('a day with a badge renders it as a corner overlay; a day without one does not', () => {
+		const dayProps = (dateStr) =>
+			dateStr === '2026-07-05'
+				? { interactive: true, ariaLabel: 'Badged', badge: '3' }
+				: { interactive: true, ariaLabel: `Plain-${dateStr}` };
+
+		render(
+			<MiniCalendar
+				minDate="2026-07-01"
+				maxDate="2026-07-01"
+				dayProps={dayProps}
+			/>
+		);
+
+		const badgedButton = screen.getByRole('button', { name: 'Badged' });
+		const badge = badgedButton.parentElement.querySelector(
+			'span[aria-hidden="true"]'
+		);
+		expect(badge).toHaveTextContent('3');
+
+		// Only the badged cell gets the extra overlay wrapper — every other
+		// day in the grid renders as a bare button with no relative wrapper.
+		expect(
+			document.querySelectorAll('span[aria-hidden="true"]')
+		).toHaveLength(1);
+	});
 });

--- a/fair-events/__tests__/Services/RecurrenceServiceTest.php
+++ b/fair-events/__tests__/Services/RecurrenceServiceTest.php
@@ -120,50 +120,91 @@ class RecurrenceServiceTest extends TestCase {
 	}
 
 	// -----------------------------------------------------------------------
-	// build_manual_occurrences — pure, no DB
+	// build_manual_sessions — pure, no DB (#1414)
 	// -----------------------------------------------------------------------
 
 	/**
-	 * Dates are sorted ascending regardless of input order, each taking the
-	 * reference row's time-of-day and duration.
+	 * Sessions are sorted ascending by start_datetime regardless of input
+	 * order; each session's own start/end passes through untouched (no
+	 * reference time-of-day/duration is applied, unlike the old
+	 * date-only manual model).
 	 */
-	public function test_build_manual_occurrences_sorts_and_applies_time_and_duration() {
-		$occurrences = RecurrenceService::build_manual_occurrences(
-			'2035-03-01 10:00:00',
-			'2035-03-01 12:00:00',
-			array( '2035-03-15', '2035-03-01', '2035-03-08' )
+	public function test_build_manual_sessions_sorts_by_start() {
+		$sessions = RecurrenceService::build_manual_sessions(
+			array(
+				array(
+					'id'             => 3,
+					'start_datetime' => '2035-03-15 09:00:00',
+					'end_datetime'   => '2035-03-15 11:00:00',
+				),
+				array(
+					'id'             => 1,
+					'start_datetime' => '2035-03-01 10:00:00',
+					'end_datetime'   => '2035-03-01 12:00:00',
+				),
+				array(
+					'id'             => 2,
+					'start_datetime' => '2035-03-08 14:00:00',
+					'end_datetime'   => '2035-03-08 16:00:00',
+				),
+			)
 		);
 
-		$this->assertCount( 3, $occurrences );
-		$this->assertSame( '2035-03-01T10:00:00', $occurrences[0]['start'] );
-		$this->assertSame( '2035-03-01T12:00:00', $occurrences[0]['end'] );
-		$this->assertSame( '2035-03-08T10:00:00', $occurrences[1]['start'] );
-		$this->assertSame( '2035-03-15T10:00:00', $occurrences[2]['start'] );
+		$this->assertCount( 3, $sessions );
+		$this->assertSame( '2035-03-01 10:00:00', $sessions[0]['start_datetime'] );
+		$this->assertSame( '2035-03-08 14:00:00', $sessions[1]['start_datetime'] );
+		$this->assertSame( '2035-03-15 09:00:00', $sessions[2]['start_datetime'] );
 	}
 
 	/**
-	 * Duplicate dates are collapsed to a single occurrence.
+	 * Two sessions sharing the same calendar day (with different times) are
+	 * both kept — this is the entire point of #1414, unlike the old
+	 * date-only model which deduplicated by date.
 	 */
-	public function test_build_manual_occurrences_deduplicates() {
-		$occurrences = RecurrenceService::build_manual_occurrences(
-			'2035-03-01 10:00:00',
-			'2035-03-01 12:00:00',
-			array( '2035-03-01', '2035-03-01' )
+	public function test_build_manual_sessions_keeps_multiple_sessions_same_day() {
+		$sessions = RecurrenceService::build_manual_sessions(
+			array(
+				array(
+					'id'             => null,
+					'start_datetime' => '2035-03-01 14:00:00',
+					'end_datetime'   => '2035-03-01 16:00:00',
+				),
+				array(
+					'id'             => null,
+					'start_datetime' => '2035-03-01 09:00:00',
+					'end_datetime'   => '2035-03-01 11:00:00',
+				),
+			)
 		);
 
-		$this->assertCount( 1, $occurrences );
+		$this->assertCount( 2, $sessions );
+		$this->assertSame( '2035-03-01 09:00:00', $sessions[0]['start_datetime'] );
+		$this->assertSame( '2035-03-01 14:00:00', $sessions[1]['start_datetime'] );
 	}
 
 	/**
-	 * An empty date list produces no occurrences (caller falls back / no-ops).
+	 * A falsy/empty id normalizes to null (a new session to insert).
 	 */
-	public function test_build_manual_occurrences_empty_list() {
-		$occurrences = RecurrenceService::build_manual_occurrences(
-			'2035-03-01 10:00:00',
-			'2035-03-01 12:00:00',
-			array()
+	public function test_build_manual_sessions_normalizes_empty_id_to_null() {
+		$sessions = RecurrenceService::build_manual_sessions(
+			array(
+				array(
+					'id'             => 0,
+					'start_datetime' => '2035-03-01 10:00:00',
+					'end_datetime'   => '2035-03-01 12:00:00',
+				),
+			)
 		);
 
-		$this->assertSame( array(), $occurrences );
+		$this->assertNull( $sessions[0]['id'] );
+	}
+
+	/**
+	 * An empty session list produces no sessions (caller falls back / no-ops).
+	 */
+	public function test_build_manual_sessions_empty_list() {
+		$sessions = RecurrenceService::build_manual_sessions( array() );
+
+		$this->assertSame( array(), $sessions );
 	}
 }

--- a/fair-events/e2e/manual-series-master-date-edit.spec.js
+++ b/fair-events/e2e/manual-series-master-date-edit.spec.js
@@ -9,6 +9,11 @@ const WP_ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
  * not the "Edit series" modal — used to fall into the rrule-regenerate path
  * in EventDatesController::update_item(), which treated the manual master's
  * null rrule as "series ended" and wiped every hand-picked date.
+ *
+ * Also covers #1414: each session now carries its own independent
+ * start/end, so editing only the master's own time must NOT reflow onto its
+ * sibling sessions (the old date-only model applied the master's new
+ * time-of-day to every date; the new model leaves siblings untouched).
  */
 
 async function apiFetch(page, options) {
@@ -49,7 +54,7 @@ async function login(page) {
 }
 
 test.describe('Manual (irregular) series survives editing the master date', () => {
-	test('PUT with only start_datetime keeps recurrence_mode=manual and the other dates', async ({
+	test('PUT with only start_datetime keeps recurrence_mode=manual and leaves sibling sessions untouched', async ({
 		page,
 	}) => {
 		await login(page);
@@ -73,7 +78,23 @@ test.describe('Manual (irregular) series survives editing the master date', () =
 				method: 'PUT',
 				data: {
 					recurrence_mode: 'manual',
-					manual_dates: ['2026-08-01', '2026-08-15', '2026-09-01'],
+					manual_sessions: [
+						{
+							id: master.id,
+							start_datetime: '2026-08-01 18:00:00',
+							end_datetime: '2026-08-01 20:00:00',
+						},
+						{
+							id: null,
+							start_datetime: '2026-08-15 18:00:00',
+							end_datetime: '2026-08-15 20:00:00',
+						},
+						{
+							id: null,
+							start_datetime: '2026-09-01 18:00:00',
+							end_datetime: '2026-09-01 20:00:00',
+						},
+					],
 				},
 			});
 
@@ -84,7 +105,7 @@ test.describe('Manual (irregular) series survives editing the master date', () =
 			expect(afterCreate.generated_occurrences).toHaveLength(2);
 
 			// Edit only the master's own start/end time — what the Event
-			// Details start-date field sends — with no rrule/manual_dates.
+			// Details start-date field sends — with no rrule/manual_sessions.
 			await apiFetch(page, {
 				path: `/fair-events/v1/event-dates/${master.id}`,
 				method: 'PUT',
@@ -103,12 +124,15 @@ test.describe('Manual (irregular) series survives editing the master date', () =
 			expect(afterEdit.start_datetime).toBe('2026-08-01 19:00:00');
 			expect(afterEdit.generated_occurrences).toHaveLength(2);
 
+			// Each session carries its own independent time (#1414) — editing
+			// only the master's own time must not reflow onto its siblings,
+			// which keep their originally-set 18:00 start.
 			const dates = afterEdit.generated_occurrences
 				.map((occ) => occ.start_datetime)
 				.sort();
 			expect(dates).toEqual([
-				'2026-08-15 19:00:00',
-				'2026-09-01 19:00:00',
+				'2026-08-15 18:00:00',
+				'2026-09-01 18:00:00',
 			]);
 		} finally {
 			await apiFetch(page, {

--- a/fair-events/e2e/manual-series-multiple-sessions-per-day.spec.js
+++ b/fair-events/e2e/manual-series-multiple-sessions-per-day.spec.js
@@ -1,0 +1,203 @@
+import { test, expect } from '@playwright/test';
+
+const WP_ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const WP_ADMIN_PASS = process.env.WP_ADMIN_PASS || 'password';
+
+/**
+ * E2E coverage for #1414: an organizer adds a second session on a day that
+ * already has one in the irregular series editor (via the "Sessions" list's
+ * "+ Add session" control, not the calendar toggle), and a participant sees
+ * both as separately selectable/purchasable occurrences on the public
+ * signup form.
+ */
+
+async function apiFetch(page, options) {
+	const result = await page.evaluate(async (opts) => {
+		try {
+			// eslint-disable-next-line no-undef
+			const res = await wp.apiFetch(opts);
+			return { ok: true, data: res };
+		} catch (err) {
+			return {
+				ok: false,
+				error: {
+					message: err && err.message,
+					code: err && err.code,
+					data: err && err.data,
+				},
+			};
+		}
+	}, options);
+	if (!result.ok) {
+		throw new Error(
+			`apiFetch ${options.method || 'GET'} ${
+				options.path
+			} failed: ${JSON.stringify(result.error)}`
+		);
+	}
+	return result.data;
+}
+
+async function login(page) {
+	await page.goto('/wp-admin');
+	if (page.url().includes('wp-login.php')) {
+		await page.fill('#user_login', WP_ADMIN_USER);
+		await page.fill('#user_pass', WP_ADMIN_PASS);
+		await page.click('#wp-submit');
+	}
+	await page.waitForSelector('#wpadminbar');
+}
+
+test('organizer adds a second session on one day, and a participant can purchase either one separately', async ({
+	page,
+	browser,
+}) => {
+	await login(page);
+	await page.goto('/wp-admin/admin.php?page=fair-events-all-events');
+	await page.waitForFunction(() => window.wp && window.wp.apiFetch);
+
+	const eventPost = await apiFetch(page, {
+		path: '/wp/v2/fair_event',
+		method: 'POST',
+		data: {
+			title: `Multi-session day e2e ${Date.now()}`,
+			status: 'publish',
+		},
+	});
+
+	const eventDate = await apiFetch(page, {
+		path: '/fair-events/v1/event-dates',
+		method: 'POST',
+		data: {
+			title: 'Multi-session day e2e',
+			link_type: 'post',
+			start_datetime: '2032-05-01 09:00:00',
+			end_datetime: '2032-05-01 11:00:00',
+		},
+	});
+
+	await apiFetch(page, {
+		path: `/fair-events/v1/event-dates/${eventDate.id}`,
+		method: 'PUT',
+		data: { event_id: eventPost.id },
+	});
+
+	let signupPageId;
+	let visitorContext;
+
+	try {
+		// --- Organizer: add a second session on the master's own day, via
+		// the irregular series editor's "+ Add session" control. ---
+		await page.goto(
+			`/wp-admin/admin.php?page=fair-events-manage-event&event_date_id=${eventDate.id}`
+		);
+
+		await page.getByRole('button', { name: 'Turn into a series' }).click();
+		await page.getByRole('tab', { name: 'Irregular series' }).click();
+
+		// Only the master's own date group exists yet, so exactly one
+		// "+ Add session" control is on screen.
+		await page.getByRole('button', { name: '+ Add session' }).click();
+
+		// Give the newly-added session its own, distinct time — independent
+		// of the master's 09:00–11:00 session on the same calendar day.
+		await page.getByLabel('Session start time').fill('14:00');
+		await page.getByLabel('Session end time').fill('16:00');
+
+		await page.getByRole('button', { name: /Create series/ }).click();
+
+		// Modal closes and the card now offers "Edit series" instead of
+		// "Turn into a series" — confirms the save round-tripped.
+		await expect(
+			page.getByRole('button', { name: 'Edit series' })
+		).toBeVisible();
+
+		const afterSave = await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}`,
+		});
+		expect(afterSave.recurrence_mode).toBe('manual');
+		expect(afterSave.generated_occurrences).toHaveLength(1);
+		expect(afterSave.generated_occurrences[0].start_datetime).toBe(
+			'2032-05-01 14:00:00'
+		);
+
+		// --- Sell a ticket type and publish a signup page. ---
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}/tickets`,
+			method: 'PUT',
+			data: {
+				ticket_types: [
+					{
+						name: 'General admission',
+						recurrence_scope: 'single_instance',
+						capacity: null,
+						minimum_activities: 0,
+						disable_at: null,
+						group_ids: [],
+					},
+				],
+				sale_periods: [
+					{
+						name: 'Always on',
+						sale_start: '2020-01-01 00:00:00',
+						sale_end: '2099-01-01 00:00:00',
+					},
+				],
+				prices: [
+					{ ticket_type_index: 0, sale_period_index: 0, price: 0 },
+				],
+				settings: {},
+			},
+		});
+
+		const signupPage = await apiFetch(page, {
+			path: '/wp/v2/pages',
+			method: 'POST',
+			data: {
+				title: `Multi-session day e2e page ${Date.now()}`,
+				status: 'publish',
+				content: `<!-- wp:fair-events/event-signup {"eventDateId":${eventDate.id}} /-->`,
+			},
+		});
+		signupPageId = signupPage.id;
+
+		// --- Participant: both sessions on the shared day are separately
+		// selectable in the occurrence picker. ---
+		visitorContext = await browser.newContext();
+		const visitorPage = await visitorContext.newPage();
+		await visitorPage.goto(`/?page_id=${signupPageId}`);
+
+		const options = visitorPage.locator(
+			'.fair-events-occurrence-select option'
+		);
+		await expect(options).toHaveCount(2);
+
+		const labels = await options.allTextContents();
+		expect(labels[0].trim()).not.toBe(labels[1].trim());
+
+		const values = await options.evaluateAll((opts) =>
+			opts.map((o) => o.value)
+		);
+		expect(new Set(values).size).toBe(2);
+	} finally {
+		if (visitorContext) {
+			await visitorContext.close();
+		}
+		if (signupPageId) {
+			await apiFetch(page, {
+				path: `/wp/v2/pages/${signupPageId}`,
+				method: 'DELETE',
+				data: { force: true },
+			}).catch(() => {});
+		}
+		await apiFetch(page, {
+			path: `/wp/v2/fair_event/${eventPost.id}`,
+			method: 'DELETE',
+			data: { force: true },
+		}).catch(() => {});
+		await apiFetch(page, {
+			path: `/fair-events/v1/event-dates/${eventDate.id}`,
+			method: 'DELETE',
+		}).catch(() => {});
+	}
+});

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -383,15 +383,25 @@ class EventDatesController extends WP_REST_Controller {
 				'required'    => false,
 				'enum'        => array( 'none', 'rule', 'manual' ),
 			),
-			'manual_dates'    => array(
-				'description'       => __( 'Hand-picked occurrence dates (Y-m-d) for a manual-mode series. The earliest date becomes the master.', 'fair-events' ),
+			'manual_sessions' => array(
+				'description'       => __( 'Hand-picked sessions ({id, start_datetime, end_datetime}) for a manual-mode series. More than one session may share a calendar day; the earliest session becomes the master.', 'fair-events' ),
 				'type'              => 'array',
 				'required'          => false,
 				'items'             => array(
-					'type'   => 'string',
-					'format' => 'date',
+					'type'       => 'object',
+					'properties' => array(
+						'id'             => array(
+							'type' => array( 'integer', 'null' ),
+						),
+						'start_datetime' => array(
+							'type' => 'string',
+						),
+						'end_datetime'   => array(
+							'type' => 'string',
+						),
+					),
 				),
-				'validate_callback' => array( $this, 'validate_manual_dates' ),
+				'validate_callback' => array( $this, 'validate_manual_sessions' ),
 			),
 			'categories'      => array(
 				'description' => __( 'Category term IDs.', 'fair-events' ),
@@ -418,65 +428,122 @@ class EventDatesController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Validate the `manual_dates` param for a manual-mode series.
+	 * Validate the `manual_sessions` param for a manual-mode series.
 	 *
-	 * Rejects malformed/non-calendar dates, duplicate days (a manual series
-	 * supports one occurrence per day, same as reconcile_occurrences()'
-	 * anchor keying), and lists longer than RecurrenceService::MAX_OCCURRENCES.
+	 * Rejects malformed sessions (missing/invalid datetimes, end not after
+	 * start), lists longer than RecurrenceService::MAX_OCCURRENCES, a
+	 * non-null id repeated within the request, and — for an update request
+	 * (URL carries an `id`) — a non-null id that doesn't belong to this
+	 * series (isn't the master id or an existing generated child under it),
+	 * which would otherwise let a spoofed id repoint an unrelated
+	 * `event_dates` row. Duplicate calendar days are explicitly allowed —
+	 * that's the entire point of #1414.
 	 *
 	 * @param mixed           $value   Raw param value.
 	 * @param WP_REST_Request $request Full request object.
 	 * @param string          $param   Param name.
 	 * @return true|WP_Error True if valid, WP_Error otherwise.
 	 */
-	public function validate_manual_dates( $value, $request, $param ) {
+	public function validate_manual_sessions( $value, $request, $param ) {
 		if ( ! is_array( $value ) ) {
 			return new WP_Error(
 				'rest_invalid_param',
-				__( 'manual_dates must be an array of Y-m-d dates.', 'fair-events' ),
+				__( 'manual_sessions must be an array of sessions.', 'fair-events' ),
 				array( 'status' => 400 )
 			);
 		}
 
 		if ( count( $value ) > RecurrenceService::MAX_OCCURRENCES ) {
 			return new WP_Error(
-				'rest_too_many_manual_dates',
+				'rest_too_many_manual_sessions',
 				sprintf(
 					/* translators: %d: maximum allowed occurrence count. */
-					__( 'A series can have at most %d dates.', 'fair-events' ),
+					__( 'A series can have at most %d sessions.', 'fair-events' ),
 					RecurrenceService::MAX_OCCURRENCES
 				),
 				array( 'status' => 400 )
 			);
 		}
 
-		$seen = array();
-		foreach ( $value as $date ) {
-			if ( ! is_string( $date ) || ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
+		// Resolve which existing row ids belong to this series, when editing
+		// one — a create request (no `id` route param) has nothing to own
+		// yet, so any client-supplied id is simply treated as new below.
+		$request_id = (int) $request->get_param( 'id' );
+		$owned_ids  = array();
+		if ( $request_id ) {
+			$existing = EventDates::get_by_id( $request_id );
+			if ( $existing ) {
+				$owned_master_id               = ( 'generated' === $existing->occurrence_type && $existing->master_id )
+					? $existing->master_id
+					: $request_id;
+				$owned_ids[ $owned_master_id ] = true;
+				foreach ( EventDates::get_generated_by_master_id( $owned_master_id, true ) as $child ) {
+					$owned_ids[ $child->id ] = true;
+				}
+			}
+		}
+
+		$seen_ids = array();
+		foreach ( $value as $session ) {
+			if ( ! is_array( $session ) ) {
 				return new WP_Error(
-					'rest_invalid_manual_date',
-					__( 'Each manual date must be in Y-m-d format.', 'fair-events' ),
+					'rest_invalid_manual_session',
+					__( 'Each session must be an object with start_datetime and end_datetime.', 'fair-events' ),
 					array( 'status' => 400 )
 				);
 			}
 
-			$parsed = \DateTime::createFromFormat( 'Y-m-d', $date );
-			if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $date ) {
+			$start = $session['start_datetime'] ?? null;
+			$end   = $session['end_datetime'] ?? null;
+
+			if ( empty( $start ) || empty( $end ) ) {
 				return new WP_Error(
-					'rest_invalid_manual_date',
-					__( 'Each manual date must be a valid calendar date.', 'fair-events' ),
+					'rest_invalid_manual_session',
+					__( 'Each session needs a start_datetime and end_datetime.', 'fair-events' ),
 					array( 'status' => 400 )
 				);
 			}
 
-			if ( isset( $seen[ $date ] ) ) {
+			$start_dt = \DateTime::createFromFormat( 'Y-m-d H:i:s', $start );
+			$end_dt   = \DateTime::createFromFormat( 'Y-m-d H:i:s', $end );
+
+			if ( ! $start_dt || ! $end_dt ) {
 				return new WP_Error(
-					'rest_duplicate_manual_date',
-					__( 'Manual dates must not contain duplicates — only one occurrence per day is supported.', 'fair-events' ),
+					'rest_invalid_manual_session',
+					__( 'Session start_datetime/end_datetime must be valid Y-m-d H:i:s datetimes.', 'fair-events' ),
 					array( 'status' => 400 )
 				);
 			}
-			$seen[ $date ] = true;
+
+			if ( $end_dt <= $start_dt ) {
+				return new WP_Error(
+					'rest_invalid_manual_session',
+					__( "Each session's end time must be after its start time.", 'fair-events' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			$id = $session['id'] ?? null;
+			if ( null !== $id && '' !== $id ) {
+				$id = (int) $id;
+
+				if ( isset( $seen_ids[ $id ] ) ) {
+					return new WP_Error(
+						'rest_duplicate_manual_session_id',
+						__( 'Each session id can only appear once.', 'fair-events' ),
+						array( 'status' => 400 )
+					);
+				}
+				$seen_ids[ $id ] = true;
+
+				if ( $request_id && ! isset( $owned_ids[ $id ] ) ) {
+					return new WP_Error(
+						'rest_invalid_manual_session_id',
+						__( 'A session id must belong to this series.', 'fair-events' ),
+						array( 'status' => 403 )
+					);
+				}
+			}
 		}
 
 		return true;
@@ -573,12 +640,12 @@ class EventDatesController extends WP_REST_Controller {
 			RecurrenceService::regenerate_standalone_occurrences( $id, $rrule );
 		}
 
-		// Set a hand-picked (manual) occurrence list, if provided.
+		// Set a hand-picked (manual) session list, if provided.
 		$recurrence_mode = $request->get_param( 'recurrence_mode' );
-		$manual_dates    = $request->get_param( 'manual_dates' );
-		$is_manual       = 'manual' === $recurrence_mode && ! empty( $manual_dates );
+		$manual_sessions = $request->get_param( 'manual_sessions' );
+		$is_manual       = 'manual' === $recurrence_mode && ! empty( $manual_sessions );
 		if ( $is_manual ) {
-			RecurrenceService::set_manual_occurrences( $id, $manual_dates );
+			RecurrenceService::set_manual_sessions( $id, $manual_sessions );
 		}
 
 		// Set categories for standalone event date.
@@ -1025,23 +1092,23 @@ class EventDatesController extends WP_REST_Controller {
 			$dates_changed_on_recurring = $dates_changed && ( $existing->occurrence_type === 'master' || $rrule_changed );
 
 			if ( 'manual' === $existing->recurrence_mode && ! $rrule_changed && $dates_changed_on_recurring ) {
-				// A manual (hand-picked-dates) master's own start/end changed via a
-				// plain field edit (e.g. the Event Details start-date field), not via
-				// the recurrence_mode/manual_dates params handled below. Reflow the
-				// shared time-of-day + duration across the existing hand-picked dates
-				// instead of falling into the rrule-regenerate branch below, which
+				// A manual (hand-picked-sessions) master's own start/end changed via
+				// a plain field edit (e.g. the Event Details start-date field), not
+				// via the recurrence_mode/manual_sessions params handled below.
+				// Each session now carries its own independent start/end (#1414),
+				// so — unlike the old date-only model, which reflowed the shared
+				// time-of-day/duration across every hand-picked date — there's
+				// nothing to reflow across siblings; only the master's own
+				// recurrence_anchor needs to stay in sync with its new date. This
+				// intentionally skips the rrule-regenerate branch below, which
 				// would treat the manual master's null rrule as "series ended" and
 				// wipe the whole series (#979).
-				$existing_dates = array_merge(
-					array( ( new \DateTime( $update_data['start_datetime'] ?? $existing->start_datetime ) )->format( 'Y-m-d' ) ),
-					array_map(
-						static function ( $child ) {
-							return ( new \DateTime( $child->start_datetime ) )->format( 'Y-m-d' );
-						},
-						EventDates::get_generated_by_master_id( $id, true )
+				EventDates::update_by_id(
+					$id,
+					array(
+						'recurrence_anchor' => ( new \DateTime( $update_data['start_datetime'] ?? $existing->start_datetime ) )->format( 'Y-m-d' ),
 					)
 				);
-				RecurrenceService::set_manual_occurrences( $id, $existing_dates );
 			} elseif ( $rrule_changed || $dates_changed_on_recurring ) {
 				$effective_rrule = $update_data['rrule'] ?? $existing->rrule;
 
@@ -1105,33 +1172,27 @@ class EventDatesController extends WP_REST_Controller {
 			}
 		}
 
-		// Set a hand-picked (manual) occurrence list. Not folded into the
-		// $update_data block above since recurrence_mode/manual_dates can be
-		// sent without any other field changing, and the manual path reads
-		// the master's (already-updated) start_datetime/end_datetime itself
-		// rather than needing them threaded through here.
+		// Set a hand-picked (manual) session list. Not folded into the
+		// $update_data block above since recurrence_mode/manual_sessions can
+		// be sent without any other field changing — each session already
+		// carries its own start_datetime/end_datetime, so nothing needs to be
+		// threaded through from the master row here.
 		$recurrence_mode = $request->get_param( 'recurrence_mode' );
-		$manual_dates    = $request->get_param( 'manual_dates' );
-		if ( 'manual' === $recurrence_mode && is_array( $manual_dates ) ) {
+		$manual_sessions = $request->get_param( 'manual_sessions' );
+		if ( 'manual' === $recurrence_mode && is_array( $manual_sessions ) ) {
 			$manual_master_id = ( 'generated' === $existing->occurrence_type && $existing->master_id )
 				? $existing->master_id
 				: $id;
-			$manual_master    = EventDates::get_by_id( $manual_master_id );
 
 			// Classify the impact before applying, for informational purposes
-			// only — reconcile_occurrences() soft-cancels stale rows, so
-			// there's no destructive-change guard to gate this on.
-			$manual_occurrences = RecurrenceService::build_manual_occurrences(
-				$manual_master->start_datetime,
-				$manual_master->end_datetime,
-				$manual_dates
-			);
-			$recurrence_impact  = RecurrenceService::classify_change(
+			// only — reconcile_sessions() soft-cancels stale rows, so there's
+			// no destructive-change guard to gate this on.
+			$recurrence_impact = RecurrenceService::classify_manual_sessions_change(
 				$manual_master_id,
-				array_slice( $manual_occurrences, 1 )
+				$manual_sessions
 			);
 
-			RecurrenceService::set_manual_occurrences( $manual_master_id, $manual_dates );
+			RecurrenceService::set_manual_sessions( $manual_master_id, $manual_sessions );
 		}
 
 		// Handle categories parameter.
@@ -1746,6 +1807,7 @@ class EventDatesController extends WP_REST_Controller {
 					return array(
 						'id'             => $occ->id,
 						'start_datetime' => $occ->start_datetime,
+						'end_datetime'   => $occ->end_datetime,
 						'title'          => $occ->title,
 						'status'         => $occ->status,
 					);

--- a/fair-events/src/API/__tests__/EventDatesManualSessions.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesManualSessions.api.spec.js
@@ -1,0 +1,282 @@
+/**
+ * Playwright API tests for multiple sessions per day in an irregular
+ * (manual) series (#1414).
+ *
+ * Covers:
+ * - Creating a manual series with two sessions on the same calendar date —
+ *   both persist as distinct rows instead of being rejected/collapsed.
+ * - Editing one session's time by id preserves that session's id (and, by
+ *   extension, anything attached to it) without touching its same-day
+ *   sibling.
+ * - Removing one of two same-day sessions soft-cancels it (id survives,
+ *   status flips to 'cancelled') and leaves the sibling active and
+ *   untouched.
+ */
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8080';
+const ADMIN_USER = process.env.WP_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD || 'password';
+
+const adminHeaders = {
+	Authorization:
+		'Basic ' +
+		Buffer.from(`${ADMIN_USER}:${ADMIN_PASSWORD}`).toString('base64'),
+};
+
+test.describe('EventDatesController — manual series with multiple sessions per day', () => {
+	let api;
+	let eventDateId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterAll(async () => {
+		if (eventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+				{ headers: adminHeaders }
+			);
+		}
+		await api.dispose();
+	});
+
+	test('creating a manual series with two sessions on the same date persists both', async () => {
+		const res = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Multi-session day test ${Date.now()}`,
+				start_datetime: '2030-06-01 09:00:00',
+				end_datetime: '2030-06-01 11:00:00',
+				recurrence_mode: 'manual',
+				manual_sessions: [
+					{
+						id: null,
+						start_datetime: '2030-06-01 09:00:00',
+						end_datetime: '2030-06-01 11:00:00',
+					},
+					{
+						id: null,
+						start_datetime: '2030-06-01 14:00:00',
+						end_datetime: '2030-06-01 16:00:00',
+					},
+				],
+			},
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+		eventDateId = body.id;
+
+		expect(body.recurrence_mode).toBe('manual');
+		expect(body.occurrence_type).toBe('master');
+		// The earliest session (09:00) becomes the master row.
+		expect(body.start_datetime).toBe('2030-06-01 09:00:00');
+
+		// The other same-day session persists as its own generated child —
+		// not rejected/collapsed as a duplicate date.
+		expect(body.generated_occurrences).toHaveLength(1);
+		const child = body.generated_occurrences[0];
+		expect(child.start_datetime).toBe('2030-06-01 14:00:00');
+		expect(child.end_datetime).toBe('2030-06-01 16:00:00');
+		expect(child.status).toBe('active');
+	});
+
+	test("editing one session's time by id preserves its id and leaves its same-day sibling untouched", async () => {
+		const before = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{ headers: adminHeaders }
+		);
+		const beforeBody = await before.json();
+		const childId = beforeBody.generated_occurrences[0].id;
+
+		const res = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{
+				headers: adminHeaders,
+				data: {
+					recurrence_mode: 'manual',
+					manual_sessions: [
+						{
+							id: eventDateId,
+							start_datetime: '2030-06-01 09:00:00',
+							end_datetime: '2030-06-01 11:00:00',
+						},
+						{
+							id: childId,
+							start_datetime: '2030-06-01 15:30:00',
+							end_datetime: '2030-06-01 17:30:00',
+						},
+					],
+				},
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		expect(body.generated_occurrences).toHaveLength(1);
+		const child = body.generated_occurrences[0];
+		// Same id — the row was updated in place, not replaced.
+		expect(child.id).toBe(childId);
+		expect(child.start_datetime).toBe('2030-06-01 15:30:00');
+		expect(child.end_datetime).toBe('2030-06-01 17:30:00');
+		// The master's own session is untouched by the sibling's edit.
+		expect(body.start_datetime).toBe('2030-06-01 09:00:00');
+	});
+
+	test('removing one of several same-day sessions soft-cancels it and leaves the others active', async () => {
+		// The previous test left one child (15:30) on the master's date —
+		// grow to two children by referencing that existing id alongside a
+		// brand-new session, so removing one still leaves the master a
+		// genuine (not collapsed-to-single) series — collapsing to a single
+		// occurrence is set_manual_sessions()'s own documented behavior when
+		// only the master remains, so it's tested separately rather than
+		// conflated with the soft-cancel path here.
+		const before = await api.get(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{ headers: adminHeaders }
+		);
+		const beforeBody = await before.json();
+		const survivorId = beforeBody.generated_occurrences[0].id;
+
+		const seedRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{
+				headers: adminHeaders,
+				data: {
+					recurrence_mode: 'manual',
+					manual_sessions: [
+						{
+							id: eventDateId,
+							start_datetime: '2030-06-01 09:00:00',
+							end_datetime: '2030-06-01 11:00:00',
+						},
+						{
+							id: survivorId,
+							start_datetime: '2030-06-01 15:30:00',
+							end_datetime: '2030-06-01 17:30:00',
+						},
+						{
+							id: null,
+							start_datetime: '2030-06-01 13:00:00',
+							end_datetime: '2030-06-01 14:00:00',
+						},
+					],
+				},
+			}
+		);
+		expect(seedRes.ok()).toBeTruthy();
+		const seedBody = await seedRes.json();
+		expect(seedBody.generated_occurrences).toHaveLength(2);
+		const keptId = seedBody.generated_occurrences.find(
+			(occ) => occ.id !== survivorId
+		).id;
+
+		// Save again dropping the 15:30 session only — it should be
+		// soft-cancelled while the 13:00 sibling stays active.
+		const res = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${eventDateId}`,
+			{
+				headers: adminHeaders,
+				data: {
+					recurrence_mode: 'manual',
+					manual_sessions: [
+						{
+							id: eventDateId,
+							start_datetime: '2030-06-01 09:00:00',
+							end_datetime: '2030-06-01 11:00:00',
+						},
+						{
+							id: keptId,
+							start_datetime: '2030-06-01 13:00:00',
+							end_datetime: '2030-06-01 14:00:00',
+						},
+					],
+				},
+			}
+		);
+		expect(res.ok()).toBeTruthy();
+		const body = await res.json();
+
+		expect(body.generated_occurrences).toHaveLength(2);
+		const kept = body.generated_occurrences.find(
+			(occ) => occ.id === keptId
+		);
+		const cancelled = body.generated_occurrences.find(
+			(occ) => occ.id === survivorId
+		);
+		expect(kept.status).toBe('active');
+		// Id and start/end survive — soft-cancelled, not deleted.
+		expect(cancelled.status).toBe('cancelled');
+		expect(cancelled.start_datetime).toBe('2030-06-01 15:30:00');
+	});
+
+	test('a client-supplied session id belonging to another series is rejected', async () => {
+		// Self-contained (its own master + own "foreign" id) rather than
+		// reusing the outer `eventDateId`, so this test's outcome never
+		// depends on state left behind by the tests above it.
+		const ownRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Ownership check master ${Date.now()}`,
+				start_datetime: '2030-08-01 09:00:00',
+				end_datetime: '2030-08-01 11:00:00',
+			},
+		});
+		expect(ownRes.ok()).toBeTruthy();
+		const ownId = (await ownRes.json()).id;
+
+		const otherRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Unrelated series ${Date.now()}`,
+				start_datetime: '2030-07-01 09:00:00',
+				end_datetime: '2030-07-01 11:00:00',
+			},
+		});
+		expect(otherRes.ok()).toBeTruthy();
+		const otherId = (await otherRes.json()).id;
+
+		try {
+			const res = await api.put(
+				`/wp-json/fair-events/v1/event-dates/${ownId}`,
+				{
+					headers: adminHeaders,
+					data: {
+						recurrence_mode: 'manual',
+						manual_sessions: [
+							{
+								id: ownId,
+								start_datetime: '2030-08-01 09:00:00',
+								end_datetime: '2030-08-01 11:00:00',
+							},
+							{
+								// Belongs to `otherId`'s series, not this one.
+								id: otherId,
+								start_datetime: '2030-08-02 09:00:00',
+								end_datetime: '2030-08-02 11:00:00',
+							},
+						],
+					},
+				}
+			);
+			// WordPress wraps a param validate_callback's WP_Error in a
+			// generic 400 rest_invalid_param response — the callback's own
+			// status (403) survives underneath, in details.
+			expect(res.status()).toBe(400);
+			const body = await res.json();
+			expect(body.data.details.manual_sessions.data.status).toBe(403);
+			expect(body.data.details.manual_sessions.code).toBe(
+				'rest_invalid_manual_session_id'
+			);
+		} finally {
+			await api.delete(`/wp-json/fair-events/v1/event-dates/${ownId}`, {
+				headers: adminHeaders,
+			});
+			await api.delete(`/wp-json/fair-events/v1/event-dates/${otherId}`, {
+				headers: adminHeaders,
+			});
+		}
+	});
+});

--- a/fair-events/src/API/__tests__/GetTicketsIrregularSeries.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsIrregularSeries.api.spec.js
@@ -51,7 +51,23 @@ test.describe('GetTicketsController — irregular (manual) series whole_series s
 				start_datetime: '2035-07-01 10:00:00',
 				end_datetime: '2035-07-01 12:00:00',
 				recurrence_mode: 'manual',
-				manual_dates: ['2035-07-01', '2035-07-10', '2035-07-20'],
+				manual_sessions: [
+					{
+						id: null,
+						start_datetime: '2035-07-01 10:00:00',
+						end_datetime: '2035-07-01 12:00:00',
+					},
+					{
+						id: null,
+						start_datetime: '2035-07-10 10:00:00',
+						end_datetime: '2035-07-10 12:00:00',
+					},
+					{
+						id: null,
+						start_datetime: '2035-07-20 10:00:00',
+						end_datetime: '2035-07-20 12:00:00',
+					},
+				],
 			},
 		});
 		expect(edRes.ok()).toBeTruthy();

--- a/fair-events/src/Admin/manage-event/ManageEventApp.js
+++ b/fair-events/src/Admin/manage-event/ManageEventApp.js
@@ -1249,6 +1249,7 @@ export default function ManageEventApp() {
 					initialRrule={eventDate.rrule}
 					initialRecurrenceMode={eventDate.recurrence_mode}
 					startDatetime={eventDate.start_datetime}
+					endDatetime={eventDate.end_datetime}
 					generatedOccurrences={eventDate.generated_occurrences}
 					onClose={() => setSeriesModalOpen(false)}
 					onSaved={handleSeriesSaved}

--- a/fair-events/src/Admin/manage-event/SeriesModal.js
+++ b/fair-events/src/Admin/manage-event/SeriesModal.js
@@ -4,7 +4,9 @@
  * Owns the frequency/ends fields and a live schedule preview, and saves
  * immediately on confirm (recurrence no longer rides along with the details
  * form's dirty-snapshot / Save flow). Also owns the "Irregular series"
- * click-to-toggle date picker.
+ * click-to-toggle date picker, which supports more than one session per day
+ * (#1414) — a date can hold an independently-timed extra session alongside
+ * (or instead of) the series master's own session.
  *
  * @package FairEvents
  */
@@ -15,6 +17,7 @@ import {
 	Modal,
 	Notice,
 	TabPanel,
+	TextControl,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -25,6 +28,7 @@ import {
 	expandRRulePreview,
 	parseRRule,
 	formatDateOnly,
+	generateUuid,
 	MiniCalendar,
 	RecurrenceControl,
 } from 'fair-events-shared';
@@ -37,29 +41,62 @@ const DEFAULT_RECURRENCE = {
 	until: '',
 };
 
-// Naive site-local Y-m-d slice — mirrors formatDateOnly's no-reconversion
-// rule (UI_GUIDELINES.md "Dates and times").
+// Naive site-local Y-m-d / H:i slices — mirrors formatDateOnly's
+// no-reconversion rule (UI_GUIDELINES.md "Dates and times").
 function dateOnly(datetime) {
 	return datetime ? datetime.slice(0, 10) : '';
 }
+function timeOnly(datetime) {
+	return datetime ? datetime.slice(11, 16) : '';
+}
 
 /**
- * Seed the extra (non-master) manual dates from whatever the modal already
- * knows about the series: an existing manual series' generated occurrences,
- * or (lossless rule → manual seeding) an existing rule series' generated
- * occurrences. The master's own date is tracked separately and never appears
- * in this list — see the `masterDate` prop of the "Irregular series" tab.
- *
- * @param {string}           masterDateStr        Master row's own date (Y-m-d).
- * @param {Array|undefined} generatedOccurrences Existing generated children, if any.
- * @return {string[]} Sorted, deduplicated Y-m-d dates, excluding the master's own date.
+ * Minutes between two "HH:MM" times, assumed same-day (a session's start and
+ * end always share a date in this editor).
  */
-function seedManualDates(masterDateStr, generatedOccurrences) {
-	const dates = (generatedOccurrences || [])
-		.map((occ) => dateOnly(occ.start_datetime))
-		.filter((d) => Boolean(d) && d !== masterDateStr);
+function minutesBetween(startTime, endTime) {
+	const [sh, sm] = startTime.split(':').map(Number);
+	const [eh, em] = endTime.split(':').map(Number);
+	return eh * 60 + em - (sh * 60 + sm);
+}
 
-	return [...new Set(dates)].sort();
+function addMinutes(time, minutes) {
+	const [h, m] = time.split(':').map(Number);
+	const total = (((h * 60 + m + minutes) % 1440) + 1440) % 1440;
+	const hh = String(Math.floor(total / 60)).padStart(2, '0');
+	const mm = String(total % 60).padStart(2, '0');
+	return `${hh}:${mm}`;
+}
+
+/**
+ * Seed the extra (non-master) sessions from whatever the modal already knows
+ * about the series: an existing manual series' generated occurrences, or
+ * (lossless rule → manual seeding) an existing rule series' generated
+ * occurrences. The master's own session is tracked separately and never
+ * appears in this list — see the `masterDateStr` handling below. A local
+ * `key` (independent of the server `id`) gives every row — including
+ * not-yet-saved ones sharing `id: null` — a stable React key and
+ * remove/edit target.
+ *
+ * @param {Array|undefined} generatedOccurrences Existing generated children, if any.
+ * @return {Array} Sessions sorted by date then start time.
+ */
+function seedManualSessions(generatedOccurrences) {
+	const sessions = (generatedOccurrences || [])
+		.filter((occ) => Boolean(occ.start_datetime))
+		.map((occ) => ({
+			key: generateUuid(),
+			id: occ.id,
+			date: dateOnly(occ.start_datetime),
+			startTime: timeOnly(occ.start_datetime),
+			endTime: timeOnly(occ.end_datetime) || timeOnly(occ.start_datetime),
+		}));
+
+	sessions.sort((a, b) =>
+		`${a.date}${a.startTime}`.localeCompare(`${b.date}${b.startTime}`)
+	);
+
+	return sessions;
 }
 
 /**
@@ -67,8 +104,9 @@ function seedManualDates(masterDateStr, generatedOccurrences) {
  * @param {number}        props.eventDateId            The event date being edited.
  * @param {string|null}   props.initialRrule           Stored rrule, or null when creating a new series.
  * @param {string|null}   props.initialRecurrenceMode  Stored recurrence_mode ('none'|'rule'|'manual'), or null.
- * @param {string}        props.startDatetime          Naive "Y-m-d H:i:s" start of the first occurrence, for the preview.
- * @param {Array}         [props.generatedOccurrences] Existing generated children, used to seed the manual-dates editor.
+ * @param {string}        props.startDatetime          Naive "Y-m-d H:i:s" start of the master's own session.
+ * @param {string}        props.endDatetime            Naive "Y-m-d H:i:s" end of the master's own session — supplies the time/duration seeded onto new sessions.
+ * @param {Array}         [props.generatedOccurrences] Existing generated children, used to seed the sessions editor.
  * @param {Function}      props.onClose                Called to dismiss the modal without saving.
  * @param {Function}      props.onSaved                Called with the updated event date after a successful save.
  * @param {Function}      props.onImpact               Called with `{ impact, blocked }` (or null) after save succeeds or fails.
@@ -78,6 +116,7 @@ export default function SeriesModal({
 	initialRrule,
 	initialRecurrenceMode,
 	startDatetime,
+	endDatetime,
 	generatedOccurrences,
 	onClose,
 	onSaved,
@@ -95,12 +134,22 @@ export default function SeriesModal({
 			? { enabled: true, ...parseRRule(initialRrule) }
 			: { ...DEFAULT_RECURRENCE }
 	);
-	// The master's own date is fixed — it's edited from the Event Details
-	// form, not from this modal. Only the extra occurrence dates are
-	// editable here.
+
+	// The master's own date and time are fixed — edited from the Event
+	// Details form, not from this modal.
 	const masterDateStr = dateOnly(startDatetime);
-	const [manualDates, setManualDates] = useState(() =>
-		seedManualDates(masterDateStr, generatedOccurrences)
+	const masterStartTime = timeOnly(startDatetime);
+	const masterEndTime = timeOnly(endDatetime);
+	const masterDurationMinutes = minutesBetween(
+		masterStartTime,
+		masterEndTime
+	);
+
+	// Extra sessions only — the master's own session is never part of this
+	// list (see masterDateStr above), so a date can appear here more than
+	// once (multiple sessions sharing a day) or not at all.
+	const [manualSessions, setManualSessions] = useState(() =>
+		seedManualSessions(generatedOccurrences)
 	);
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState(null);
@@ -125,24 +174,74 @@ export default function SeriesModal({
 		};
 	};
 
-	const allManualDates = [masterDateStr, ...manualDates];
-	const uniqueManualDates = new Set(allManualDates);
-	const hasDuplicateManualDates =
-		uniqueManualDates.size !== allManualDates.length;
-	const sortedSelectedDates = [...uniqueManualDates].sort();
+	const sessionsByDate = useMemo(() => {
+		const map = new Map();
+		for (const session of manualSessions) {
+			if (!map.has(session.date)) map.set(session.date, []);
+			map.get(session.date).push(session);
+		}
+		return map;
+	}, [manualSessions]);
 
-	const toggleManualDate = (dateStr) => {
+	const selectedDates = useMemo(() => {
+		const set = new Set([masterDateStr]);
+		manualSessions.forEach((session) => set.add(session.date));
+		return set;
+	}, [manualSessions, masterDateStr]);
+
+	const sortedDates = useMemo(
+		() => [...selectedDates].sort(),
+		[selectedDates]
+	);
+
+	const sessionCountForDate = (dateStr) =>
+		(dateStr === masterDateStr ? 1 : 0) +
+		(sessionsByDate.get(dateStr)?.length || 0);
+
+	const newSessionFor = (dateStr) => ({
+		key: generateUuid(),
+		id: null,
+		date: dateStr,
+		startTime: masterStartTime,
+		endTime:
+			masterDurationMinutes > 0
+				? addMinutes(masterStartTime, masterDurationMinutes)
+				: masterStartTime,
+	});
+
+	const toggleDate = (dateStr) => {
 		if (dateStr === masterDateStr) return;
-		setManualDates((prev) =>
-			prev.includes(dateStr)
-				? prev.filter((d) => d !== dateStr)
-				: [...prev, dateStr].sort()
+		setManualSessions((prev) => {
+			const hasAny = prev.some((session) => session.date === dateStr);
+			return hasAny
+				? prev.filter((session) => session.date !== dateStr)
+				: [...prev, newSessionFor(dateStr)];
+		});
+	};
+
+	const addSession = (dateStr) => {
+		setManualSessions((prev) => [...prev, newSessionFor(dateStr)]);
+	};
+
+	const removeSession = (key) => {
+		setManualSessions((prev) =>
+			prev.filter((session) => session.key !== key)
+		);
+	};
+
+	const updateSessionTime = (key, field, value) => {
+		setManualSessions((prev) =>
+			prev.map((session) =>
+				session.key === key ? { ...session, [field]: value } : session
+			)
 		);
 	};
 
 	const irregularDayProps = (dateStr) => {
 		const isMaster = dateStr === masterDateStr;
-		const isSelected = uniqueManualDates.has(dateStr);
+		const isSelected = selectedDates.has(dateStr);
+		const count = sessionCountForDate(dateStr);
+		const badge = count > 1 ? String(count) : undefined;
 
 		if (isMaster) {
 			return {
@@ -152,6 +251,7 @@ export default function SeriesModal({
 				interactive: true,
 				disabled: true,
 				ariaPressed: true,
+				badge,
 				tooltip: __(
 					'Master date — edit it from Event Details',
 					'fair-events'
@@ -165,14 +265,38 @@ export default function SeriesModal({
 			fontWeight: isSelected ? 600 : 400,
 			interactive: true,
 			ariaPressed: isSelected,
-			onActivate: () => toggleManualDate(dateStr),
+			badge,
+			onActivate: () => toggleDate(dateStr),
 			tooltip: isSelected
-				? __('Selected — click to remove this date', 'fair-events')
-				: __('Click to add this date', 'fair-events'),
+				? __(
+						'Selected — click to remove every session on this date',
+						'fair-events'
+				  )
+				: __('Click to add a session on this date', 'fair-events'),
 		};
 	};
 
 	const isManualTab = 'irregular' === activeTab;
+
+	const hasInvalidSessions = manualSessions.some(
+		(session) =>
+			!session.startTime ||
+			!session.endTime ||
+			session.endTime <= session.startTime
+	);
+
+	const buildManualSessionsPayload = () => [
+		{
+			id: eventDateId,
+			start_datetime: startDatetime,
+			end_datetime: endDatetime,
+		},
+		...manualSessions.map((session) => ({
+			id: session.id,
+			start_datetime: `${session.date} ${session.startTime}:00`,
+			end_datetime: `${session.date} ${session.endTime}:00`,
+		})),
+	];
 
 	const handleConfirm = async () => {
 		setSaving(true);
@@ -182,7 +306,7 @@ export default function SeriesModal({
 			const data = isManualTab
 				? {
 						recurrence_mode: 'manual',
-						manual_dates: allManualDates,
+						manual_sessions: buildManualSessionsPayload(),
 				  }
 				: { rrule };
 
@@ -211,7 +335,7 @@ export default function SeriesModal({
 		}
 	};
 
-	const manualDateCount = uniqueManualDates.size;
+	const manualDateCount = selectedDates.size;
 
 	const confirmLabel = isManualTab
 		? isEditing
@@ -240,7 +364,7 @@ export default function SeriesModal({
 	const confirmDisabled = saving
 		? true
 		: isManualTab
-		? hasDuplicateManualDates
+		? hasInvalidSessions
 		: preview.totalCount === 0;
 
 	const tabs = [
@@ -331,44 +455,147 @@ export default function SeriesModal({
 						<VStack spacing={3} style={{ marginTop: '16px' }}>
 							<p>
 								{__(
-									'Pick the exact dates this event happens on.',
-									'fair-events'
-								)}
-							</p>
-							<p style={{ color: '#757575' }}>
-								{__(
-									'One session per day. All dates share the event’s start time and length.',
+									'Pick the dates this event happens on. Click a date to add or remove it — a day can hold more than one session.',
 									'fair-events'
 								)}
 							</p>
 
-							{hasDuplicateManualDates && (
+							{hasInvalidSessions && (
 								<Notice status="error" isDismissible={false}>
 									{__(
-										'Each date can only be used once — remove the duplicate before saving.',
+										'Every session needs a start and end time, with the end after the start.',
 										'fair-events'
 									)}
 								</Notice>
 							)}
 
 							<MiniCalendar
-								minDate={sortedSelectedDates[0]}
-								maxDate={
-									sortedSelectedDates[
-										sortedSelectedDates.length - 1
-									]
-								}
+								minDate={sortedDates[0]}
+								maxDate={sortedDates[sortedDates.length - 1]}
 								dayProps={irregularDayProps}
 								allowForwardBeyondRange
 							/>
 
-							<p style={{ color: '#757575' }}>
-								{sprintf(
-									/* translators: %d: number of selected dates */
-									__('%d dates selected', 'fair-events'),
-									manualDateCount
-								)}
-							</p>
+							<VStack spacing={3}>
+								<strong>{__('Sessions', 'fair-events')}</strong>
+								{sortedDates.map((dateStr) => {
+									const sessions = (
+										sessionsByDate.get(dateStr) || []
+									)
+										.slice()
+										.sort((a, b) =>
+											a.startTime.localeCompare(
+												b.startTime
+											)
+										);
+
+									return (
+										<VStack
+											key={dateStr}
+											spacing={2}
+											style={{
+												borderTop: '1px solid #e0e0e0',
+												paddingTop: '8px',
+											}}
+										>
+											<strong
+												style={{ fontSize: '13px' }}
+											>
+												{formatDateOnly(
+													dateStr,
+													'long'
+												)}
+											</strong>
+
+											{dateStr === masterDateStr && (
+												<span
+													style={{
+														color: '#757575',
+													}}
+												>
+													{sprintf(
+														/* translators: 1: start time, 2: end time */
+														__(
+															'%1$s–%2$s (master — edit from Event Details)',
+															'fair-events'
+														),
+														masterStartTime,
+														masterEndTime
+													)}
+												</span>
+											)}
+
+											{sessions.map((session) => (
+												<HStack
+													key={session.key}
+													spacing={2}
+													alignment="center"
+												>
+													<TextControl
+														label={__(
+															'Session start time',
+															'fair-events'
+														)}
+														hideLabelFromVision
+														type="time"
+														value={
+															session.startTime
+														}
+														onChange={(value) =>
+															updateSessionTime(
+																session.key,
+																'startTime',
+																value
+															)
+														}
+													/>
+													<TextControl
+														label={__(
+															'Session end time',
+															'fair-events'
+														)}
+														hideLabelFromVision
+														type="time"
+														value={session.endTime}
+														onChange={(value) =>
+															updateSessionTime(
+																session.key,
+																'endTime',
+																value
+															)
+														}
+													/>
+													<Button
+														icon="no-alt"
+														label={__(
+															'Remove session',
+															'fair-events'
+														)}
+														isDestructive
+														onClick={() =>
+															removeSession(
+																session.key
+															)
+														}
+													/>
+												</HStack>
+											))}
+
+											<Button
+												variant="link"
+												onClick={() =>
+													addSession(dateStr)
+												}
+											>
+												{__(
+													'+ Add session',
+													'fair-events'
+												)}
+											</Button>
+										</VStack>
+									);
+								})}
+							</VStack>
 						</VStack>
 					)
 				}

--- a/fair-events/src/Admin/manage-event/__tests__/SeriesModal.test.jsx
+++ b/fair-events/src/Admin/manage-event/__tests__/SeriesModal.test.jsx
@@ -2,17 +2,20 @@
  * @jest-environment jsdom
  *
  * Tests for SeriesModal's "Regular schedule" and "Irregular series" tabs
- * (#979, #1127).
+ * (#979, #1127, #1414).
  *
  * Covers:
  *   - Regular tab: a display-only calendar highlights every rule-generated
  *     date and a compact "N dates, until <date>" summary line replaces the
  *     old text list.
- *   - Irregular tab: seeding the selection from existing generated
+ *   - Irregular tab: seeding the session list from existing generated
  *     occurrences, the master's own date is fixed (disabled button, can't be
- *     toggled), clicking an unselected day adds it and clicking a selected
- *     day removes it, and confirm still sends
- *     { recurrence_mode: 'manual', manual_dates }.
+ *     toggled), clicking an unselected day adds a session and clicking a
+ *     selected day removes every session on it, adding a second session to
+ *     an already-selected date via "+ Add session" instead of being
+ *     rejected as a duplicate, editing a session's own time, removing one
+ *     session while its same-day sibling survives, and confirm sends
+ *     { recurrence_mode: 'manual', manual_sessions }.
  */
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -70,17 +73,20 @@ function openIrregularTab() {
 	fireEvent.click(screen.getByRole('tab', { name: 'Irregular series' }));
 }
 
+const baseProps = {
+	eventDateId: 1,
+	initialRrule: null,
+	initialRecurrenceMode: null,
+	startDatetime: '2026-07-01 18:00:00',
+	endDatetime: '2026-07-01 20:00:00',
+	generatedOccurrences: [],
+	onClose: () => {},
+	onSaved: () => {},
+	onImpact: () => {},
+};
+
 it('Regular tab shows a display-only calendar and a compact dates summary', async () => {
-	await renderModal({
-		eventDateId: 1,
-		initialRrule: null,
-		initialRecurrenceMode: null,
-		startDatetime: '2026-07-01 18:00:00',
-		generatedOccurrences: [],
-		onClose: () => {},
-		onSaved: () => {},
-		onImpact: () => {},
-	});
+	await renderModal(baseProps);
 
 	// Default recurrence is weekly, 10 occurrences (DEFAULT_RECURRENCE).
 	expect(screen.getByText('July 2026')).toBeInTheDocument();
@@ -92,19 +98,22 @@ it('Regular tab shows a display-only calendar and a compact dates summary', asyn
 	expect(screen.queryAllByRole('button', { pressed: false })).toHaveLength(0);
 });
 
-it('seeds the calendar selection from existing generated occurrences when editing a manual series', async () => {
+it('seeds the session list from existing generated occurrences when editing a manual series', async () => {
 	await renderModal({
-		eventDateId: 1,
-		initialRrule: null,
+		...baseProps,
 		initialRecurrenceMode: 'manual',
-		startDatetime: '2026-07-01 18:00:00',
 		generatedOccurrences: [
-			{ id: 2, start_datetime: '2026-07-08 18:00:00' },
-			{ id: 3, start_datetime: '2026-07-20 18:00:00' },
+			{
+				id: 2,
+				start_datetime: '2026-07-08 09:00:00',
+				end_datetime: '2026-07-08 11:00:00',
+			},
+			{
+				id: 3,
+				start_datetime: '2026-07-20 09:00:00',
+				end_datetime: '2026-07-20 11:00:00',
+			},
 		],
-		onClose: () => {},
-		onSaved: () => {},
-		onImpact: () => {},
 	});
 
 	openIrregularTab();
@@ -125,20 +134,13 @@ it('seeds the calendar selection from existing generated occurrences when editin
 		screen.getByRole('button', { name: fullDateLabel('2026-07-15') })
 	).toHaveAttribute('aria-pressed', 'false');
 
-	expect(screen.getByText('3 dates selected')).toBeInTheDocument();
+	// One row per session in the list, with its own editable start/end time.
+	expect(screen.getAllByDisplayValue('09:00')).toHaveLength(2);
+	expect(screen.getAllByDisplayValue('11:00')).toHaveLength(2);
 });
 
-it('clicking an unselected day adds it and clicking it again removes it, keeping the master date fixed', async () => {
-	await renderModal({
-		eventDateId: 1,
-		initialRrule: null,
-		initialRecurrenceMode: null,
-		startDatetime: '2026-07-01 18:00:00',
-		generatedOccurrences: [],
-		onClose: () => {},
-		onSaved: () => {},
-		onImpact: () => {},
-	});
+it('clicking an unselected day adds a session and clicking it again removes it, keeping the master date fixed', async () => {
+	await renderModal(baseProps);
 
 	openIrregularTab();
 
@@ -146,10 +148,9 @@ it('clicking an unselected day adds it and clicking it again removes it, keeping
 		name: fullDateLabel('2026-07-01'),
 	});
 	expect(masterButton).toBeDisabled();
-	expect(screen.getByText('1 dates selected')).toBeInTheDocument();
 
 	fireEvent.click(masterButton);
-	expect(screen.getByText('1 dates selected')).toBeInTheDocument();
+	expect(masterButton).toBeDisabled();
 
 	const dayButton = screen.getByRole('button', {
 		name: fullDateLabel('2026-07-05'),
@@ -158,14 +159,110 @@ it('clicking an unselected day adds it and clicking it again removes it, keeping
 
 	fireEvent.click(dayButton);
 	expect(dayButton).toHaveAttribute('aria-pressed', 'true');
-	expect(screen.getByText('2 dates selected')).toBeInTheDocument();
+	// A seeded session takes the master's own time/duration.
+	expect(screen.getByDisplayValue('18:00')).toBeInTheDocument();
+	expect(screen.getByDisplayValue('20:00')).toBeInTheDocument();
 
 	fireEvent.click(dayButton);
 	expect(dayButton).toHaveAttribute('aria-pressed', 'false');
-	expect(screen.getByText('1 dates selected')).toBeInTheDocument();
+	expect(screen.queryByDisplayValue('18:00')).not.toBeInTheDocument();
 });
 
-it('sends recurrence_mode + manual_dates on confirm from the Irregular tab', async () => {
+it('adding a second session to an already-selected date is not rejected as a duplicate, and shows a badge', async () => {
+	await renderModal({
+		...baseProps,
+		generatedOccurrences: [
+			{
+				id: 5,
+				start_datetime: '2026-07-05 09:00:00',
+				end_datetime: '2026-07-05 11:00:00',
+			},
+		],
+	});
+
+	openIrregularTab();
+
+	// "+ Add session" appears once per selected date group — the master's
+	// own date and 2026-07-05 (seeded above) both have one.
+	const addButtons = screen.getAllByRole('button', {
+		name: '+ Add session',
+	});
+	expect(addButtons).toHaveLength(2);
+
+	// Add a second session on 2026-07-05, which already has one.
+	fireEvent.click(addButtons[1]);
+
+	// Two independent start-time fields now exist for that date's sessions.
+	expect(screen.getAllByLabelText('Session start time')).toHaveLength(2);
+
+	// The calendar badge reflects the day now holding 2 sessions.
+	const dayButton = screen.getByRole('button', {
+		name: fullDateLabel('2026-07-05'),
+	});
+	expect(dayButton.parentElement.querySelector('span')).toHaveTextContent(
+		'2'
+	);
+});
+
+it('removing one session on a shared day leaves its sibling intact', async () => {
+	await renderModal({
+		...baseProps,
+		generatedOccurrences: [
+			{
+				id: 5,
+				start_datetime: '2026-07-05 09:00:00',
+				end_datetime: '2026-07-05 11:00:00',
+			},
+			{
+				id: 6,
+				start_datetime: '2026-07-05 14:00:00',
+				end_datetime: '2026-07-05 16:00:00',
+			},
+		],
+	});
+
+	openIrregularTab();
+
+	expect(screen.getByDisplayValue('09:00')).toBeInTheDocument();
+	expect(screen.getByDisplayValue('14:00')).toBeInTheDocument();
+
+	const removeButtons = screen.getAllByRole('button', {
+		name: 'Remove session',
+	});
+	// Remove the first (09:00) session.
+	fireEvent.click(removeButtons[0]);
+
+	expect(screen.queryByDisplayValue('09:00')).not.toBeInTheDocument();
+	expect(screen.getByDisplayValue('14:00')).toBeInTheDocument();
+	// The date itself is still selected — one session remains.
+	expect(
+		screen.getByRole('button', { name: fullDateLabel('2026-07-05') })
+	).toHaveAttribute('aria-pressed', 'true');
+});
+
+it('editing a session start/end time updates that session only', async () => {
+	await renderModal({
+		...baseProps,
+		generatedOccurrences: [
+			{
+				id: 5,
+				start_datetime: '2026-07-05 09:00:00',
+				end_datetime: '2026-07-05 11:00:00',
+			},
+		],
+	});
+
+	openIrregularTab();
+
+	fireEvent.change(screen.getByDisplayValue('09:00'), {
+		target: { value: '13:30' },
+	});
+
+	expect(screen.getByDisplayValue('13:30')).toBeInTheDocument();
+	expect(screen.getByDisplayValue('11:00')).toBeInTheDocument();
+});
+
+it('sends recurrence_mode + manual_sessions on confirm from the Irregular tab', async () => {
 	apiFetch.mockResolvedValue({
 		recurrence_mode: 'manual',
 		generated_occurrences: [],
@@ -174,14 +271,9 @@ it('sends recurrence_mode + manual_dates on confirm from the Irregular tab', asy
 	const onSaved = jest.fn();
 
 	await renderModal({
+		...baseProps,
 		eventDateId: 7,
-		initialRrule: null,
-		initialRecurrenceMode: null,
-		startDatetime: '2026-07-01 18:00:00',
-		generatedOccurrences: [],
-		onClose: () => {},
 		onSaved,
-		onImpact: () => {},
 	});
 
 	openIrregularTab();
@@ -199,7 +291,18 @@ it('sends recurrence_mode + manual_dates on confirm from the Irregular tab', asy
 			method: 'PUT',
 			data: {
 				recurrence_mode: 'manual',
-				manual_dates: ['2026-07-01', '2026-07-15'],
+				manual_sessions: [
+					{
+						id: 7,
+						start_datetime: '2026-07-01 18:00:00',
+						end_datetime: '2026-07-01 20:00:00',
+					},
+					{
+						id: null,
+						start_datetime: '2026-07-15 18:00:00',
+						end_datetime: '2026-07-15 20:00:00',
+					},
+				],
 			},
 		})
 	);

--- a/fair-events/src/Models/EventDates.php
+++ b/fair-events/src/Models/EventDates.php
@@ -1125,6 +1125,41 @@ class EventDates {
 	}
 
 	/**
+	 * Get all rows belonging to a recurring series (the master row itself plus
+	 * every generated child), keyed by row id.
+	 *
+	 * Used by RecurrenceService's manual-sessions reconciliation (#1414),
+	 * which — unlike reconcile_occurrences()'s anchor-keyed matching — needs
+	 * to address more than one row sharing the same calendar day, so it
+	 * matches desired sessions against existing rows by id instead.
+	 *
+	 * @param int $master_id Master event date ID.
+	 * @return array<int, EventDates> Map of row id → EventDates.
+	 */
+	public static function get_all_by_master_id_flat( $master_id ) {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'fair_event_dates';
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE id = %d OR master_id = %d ORDER BY start_datetime ASC',
+				$table_name,
+				$master_id,
+				$master_id
+			)
+		);
+
+		$map = array();
+		foreach ( $results as $result ) {
+			$row             = self::hydrate( $result );
+			$map[ $row->id ] = $row;
+		}
+
+		return $map;
+	}
+
+	/**
 	 * Delete generated occurrences by master ID
 	 *
 	 * Used for standalone events that have no event_id.
@@ -1181,7 +1216,13 @@ class EventDates {
 			'status'            => $data['status'] ?? 'active',
 		);
 
-		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s' );
+		// One %s per string field (was missing one — 15 formats for 16
+		// fields — which misaligned every field from joining_link onward:
+		// joining_link (a URL) was cast with %d, silently truncating it to
+		// an integer, and the trailing status field got no format at all.
+		// Found while adding reconcile_sessions() (#1414), which calls this
+		// for every new session on a standalone (unlinked) manual series.
+		$format = array( '%d', '%s', '%s', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s' );
 
 		$result = $wpdb->insert( $table_name, $insert_data, $format );
 

--- a/fair-events/src/Services/RecurrenceService.php
+++ b/fair-events/src/Services/RecurrenceService.php
@@ -346,72 +346,69 @@ class RecurrenceService {
 	}
 
 	/**
-	 * Build the {start,end} occurrence set for a hand-picked list of dates.
+	 * Normalize/sort a hand-picked list of sessions for a manual series.
 	 *
-	 * Pure — no DB access. Each date takes the reference row's time-of-day
-	 * and duration (mirrors the RRULE path's duration handling in
-	 * generate_occurrences()). Dates are deduplicated and sorted ascending
-	 * so the first is always the earliest.
+	 * Pure — no DB access. Unlike the old date-only manual model, each
+	 * session already carries its own independent start/end (#1414) — no
+	 * reference time-of-day/duration is applied. Sessions are sorted
+	 * ascending by start so the first is always the earliest (and therefore
+	 * becomes the master — see set_manual_sessions()).
 	 *
-	 * @param string   $reference_start Reference start datetime (Y-m-d H:i:s) —
-	 *                                  supplies time-of-day and duration.
-	 * @param string   $reference_end   Reference end datetime (Y-m-d H:i:s).
-	 * @param string[] $dates           Occurrence dates (Y-m-d), any order, may contain duplicates.
-	 * @return array Array of occurrences with 'start' and 'end' keys, sorted ascending.
+	 * @param array $sessions Sessions, each `{ id: int|null, start_datetime, end_datetime }`
+	 *                        (Y-m-d H:i:s), any order.
+	 * @return array Same shape, sorted ascending by start_datetime.
 	 */
-	public static function build_manual_occurrences( $reference_start, $reference_end, array $dates ) {
-		$dates = array_values( array_unique( $dates ) );
-		sort( $dates );
+	public static function build_manual_sessions( array $sessions ) {
+		$sessions = array_map(
+			function ( $session ) {
+				return array(
+					'id'             => empty( $session['id'] ) ? null : (int) $session['id'],
+					'start_datetime' => $session['start_datetime'],
+					'end_datetime'   => $session['end_datetime'],
+				);
+			},
+			$sessions
+		);
 
-		if ( empty( $dates ) ) {
-			return array();
-		}
+		usort(
+			$sessions,
+			function ( $a, $b ) {
+				return strcmp( $a['start_datetime'], $b['start_datetime'] );
+			}
+		);
 
-		$start    = new \DateTime( $reference_start );
-		$end      = new \DateTime( $reference_end );
-		$duration = $start->diff( $end );
-		$time     = $start->format( 'H:i:s' );
-
-		$occurrences = array();
-		foreach ( $dates as $date ) {
-			$occ_start     = new \DateTime( $date . ' ' . $time );
-			$occ_end       = ( clone $occ_start )->add( $duration );
-			$occurrences[] = array(
-				'start' => $occ_start->format( 'Y-m-d\TH:i:s' ),
-				'end'   => $occ_end->format( 'Y-m-d\TH:i:s' ),
-			);
-		}
-
-		return $occurrences;
+		return $sessions;
 	}
 
 	/**
-	 * Set a series to a hand-picked (manual) list of occurrence dates.
+	 * Set a series to a hand-picked (manual) list of sessions, allowing more
+	 * than one session on the same calendar day (#1414).
 	 *
-	 * Uses reconcile_occurrences() so existing row IDs are preserved when
-	 * dates shift, same as the RRULE paths above. The earliest date becomes
-	 * the master; when only one date remains, the series collapses to a
-	 * plain 'none' single occurrence rather than a one-item manual series.
+	 * The earliest session's start/end is written onto the master row (same
+	 * "earliest becomes master" convention as the old date-only model); when
+	 * only one session remains, the series collapses to a plain 'none'
+	 * single occurrence rather than a one-item manual series. Every other
+	 * session is reconciled by id — see reconcile_sessions().
 	 *
-	 * @param int      $master_id Master (or single) event date row ID.
-	 * @param string[] $dates     Occurrence dates (Y-m-d).
-	 * @return int Number of occurrences set (master + surviving children).
+	 * @param int   $master_id Master (or single) event date row ID.
+	 * @param array $sessions  Sessions, each `{ id: int|null, start_datetime, end_datetime }`.
+	 * @return int Number of sessions set (master + surviving children).
 	 */
-	public static function set_manual_occurrences( $master_id, array $dates ) {
+	public static function set_manual_sessions( $master_id, array $sessions ) {
 		$master = EventDates::get_by_id( $master_id );
 
 		if ( ! $master ) {
 			return 0;
 		}
 
-		$occurrences = self::build_manual_occurrences( $master->start_datetime, $master->end_datetime, $dates );
+		$sessions = self::build_manual_sessions( $sessions );
 
-		if ( empty( $occurrences ) ) {
+		if ( empty( $sessions ) ) {
 			return 0;
 		}
 
-		$is_single = 1 === count( $occurrences );
-		$first     = $occurrences[0];
+		$is_single = 1 === count( $sessions );
+		$first     = $sessions[0];
 
 		EventDates::update_by_id(
 			$master_id,
@@ -419,20 +416,197 @@ class RecurrenceService {
 				'occurrence_type'   => $is_single ? 'single' : 'master',
 				'rrule'             => null,
 				'recurrence_mode'   => $is_single ? 'none' : 'manual',
-				'start_datetime'    => $first['start'],
-				'end_datetime'      => $first['end'],
-				'recurrence_anchor' => ( new \DateTime( $first['start'] ) )->format( 'Y-m-d' ),
+				'start_datetime'    => $first['start_datetime'],
+				'end_datetime'      => $first['end_datetime'],
+				'recurrence_anchor' => ( new \DateTime( $first['start_datetime'] ) )->format( 'Y-m-d' ),
 			)
 		);
 
 		// Inheritable fields are NOT propagated here — see regenerate_event_occurrences().
-		$generated = array_slice( $occurrences, 1 );
-		return 1 + self::reconcile_occurrences(
+		$rest = array_slice( $sessions, 1 );
+		return 1 + self::reconcile_sessions(
 			$master_id,
-			$generated,
+			$rest,
 			$master->all_day,
 			array( 'event_id' => $master->event_id )
 		);
+	}
+
+	/**
+	 * Reconcile the non-master sessions of a manual series against existing
+	 * generated rows, matched by id instead of anchor date (#1414) — the
+	 * anchor-keyed reconcile_occurrences() collapses same-day sessions onto
+	 * a single map entry, so manual mode needs its own id-keyed variant.
+	 *
+	 * - A session whose id matches an existing generated row updates that
+	 *   row in place (preserving id); a cancelled row whose id reappears is
+	 *   restored to active.
+	 * - A session with no id (or an id that isn't an existing generated
+	 *   child of this master) is inserted as a new row.
+	 * - An existing generated row whose id isn't present in `$desired` is
+	 *   soft-cancelled instead of deleted, so dependents (ticket types,
+	 *   signups) survive and the session can come back if re-added later.
+	 *
+	 * @param int   $master_id    Master event date row ID.
+	 * @param array $desired      Desired non-master sessions — each entry has
+	 *                            'id' (int|null), 'start_datetime', 'end_datetime'.
+	 * @param bool  $all_day      All-day flag to apply to inserted/updated rows.
+	 * @param array $master_props Non-inherited fields to copy onto children (currently just event_id).
+	 * @return int Number of surviving sessions (updated + inserted).
+	 */
+	private static function reconcile_sessions( $master_id, $desired, $all_day, $master_props = array() ) {
+		$existing = EventDates::get_all_by_master_id_flat( $master_id );
+		// The master row itself is handled separately by set_manual_sessions() —
+		// reconcile only touches generated children.
+		unset( $existing[ $master_id ] );
+
+		$count = 0;
+
+		foreach ( $desired as $session ) {
+			$anchor = ( new \DateTime( $session['start_datetime'] ) )->format( 'Y-m-d' );
+			$id     = $session['id'];
+
+			if ( $id && isset( $existing[ $id ] ) ) {
+				// Match — update in place, preserving id. Inheritable fields
+				// (title, venue_id, address, link_type, external_url,
+				// capacity, attendance_mode, joining_link) are intentionally
+				// NOT touched: instances hold NULL for them unless explicitly
+				// overridden, and resolve against the master at read time.
+				$row    = $existing[ $id ];
+				$update = array(
+					'start_datetime'    => $session['start_datetime'],
+					'end_datetime'      => $session['end_datetime'],
+					'all_day'           => $all_day ? 1 : 0,
+					'recurrence_anchor' => $anchor,
+				);
+				if ( array_key_exists( 'event_id', $master_props ) ) {
+					$update['event_id'] = $master_props['event_id'];
+				}
+				// Restore on regrow: a previously soft-cancelled session
+				// that's back in the desired set becomes active again.
+				if ( 'cancelled' === $row->status ) {
+					$update['status'] = 'active';
+				}
+				EventDates::update_by_id( $row->id, $update );
+				unset( $existing[ $id ] );
+				++$count;
+			} else {
+				// No id, or an id that isn't an existing generated child of
+				// this master (the controller's validate_manual_sessions()
+				// already rejects a spoofed id belonging to another series) —
+				// insert a new row.
+				if ( ! empty( $master_props['event_id'] ) ) {
+					EventDates::save_occurrence(
+						$master_props['event_id'],
+						$session['start_datetime'],
+						$session['end_datetime'],
+						$all_day,
+						'generated',
+						$master_id,
+						$anchor
+					);
+				} else {
+					EventDates::create_standalone_occurrence(
+						array(
+							'start_datetime'    => $session['start_datetime'],
+							'end_datetime'      => $session['end_datetime'],
+							'all_day'           => $all_day,
+							'master_id'         => $master_id,
+							'recurrence_anchor' => $anchor,
+						)
+					);
+				}
+				++$count;
+			}
+		}
+
+		// Soft-cancel rows whose id is no longer in the desired set instead
+		// of deleting them — dependents (ticket types, signups) survive, and
+		// the session can come back active if re-added later.
+		foreach ( $existing as $stale_row ) {
+			if ( 'cancelled' !== $stale_row->status ) {
+				EventDates::update_by_id( $stale_row->id, array( 'status' => 'cancelled' ) );
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Classify the impact of a proposed manual-sessions change on generated
+	 * children, matched by id (see reconcile_sessions()). Same
+	 * unchanged/shifted/added/removed shape as classify_change(), for the
+	 * impact-preview banner.
+	 *
+	 * Only classifies non-master sessions — the master row is always
+	 * preserved (its content is overwritten to the earliest session by
+	 * set_manual_sessions(), never removed).
+	 *
+	 * @param int   $master_id Master event date row ID.
+	 * @param array $sessions  Full desired session list (including the
+	 *                         master's own entry) — each entry has 'id'
+	 *                         (int|null), 'start_datetime', 'end_datetime'.
+	 * @return array {
+	 *     @type array $unchanged  Sessions that would remain identical.
+	 *     @type array $shifted    Sessions that would be updated in place (id matches, times differ).
+	 *     @type array $added      Sessions with no existing row.
+	 *     @type array $removed    Existing rows no longer desired.
+	 * }
+	 */
+	public static function classify_manual_sessions_change( $master_id, array $sessions ) {
+		$sessions = self::build_manual_sessions( $sessions );
+		$desired  = array_slice( $sessions, 1 );
+
+		$existing = EventDates::get_all_by_master_id_flat( $master_id );
+		unset( $existing[ $master_id ] );
+
+		$now = current_time( 'mysql' );
+
+		$result = array(
+			'unchanged' => array(),
+			'shifted'   => array(),
+			'added'     => array(),
+			'removed'   => array(),
+		);
+
+		foreach ( $desired as $session ) {
+			$id = $session['id'];
+
+			if ( $id && isset( $existing[ $id ] ) ) {
+				$row = $existing[ $id ];
+
+				if ( $row->start_datetime === $session['start_datetime'] && $row->end_datetime === $session['end_datetime'] ) {
+					$result['unchanged'][] = array(
+						'id'             => $row->id,
+						'start_datetime' => $row->start_datetime,
+					);
+				} else {
+					$result['shifted'][] = array(
+						'id'                 => $row->id,
+						'start_datetime'     => $row->start_datetime,
+						'new_start_datetime' => $session['start_datetime'],
+						'is_past'            => $row->start_datetime < $now,
+						'dependents'         => self::count_dependents( $row->id ),
+					);
+				}
+				unset( $existing[ $id ] );
+			} else {
+				$result['added'][] = array(
+					'start_datetime' => $session['start_datetime'],
+				);
+			}
+		}
+
+		foreach ( $existing as $stale_row ) {
+			$result['removed'][] = array(
+				'id'             => $stale_row->id,
+				'start_datetime' => $stale_row->start_datetime,
+				'is_past'        => $stale_row->start_datetime < $now,
+				'dependents'     => self::count_dependents( $stale_row->id ),
+			);
+		}
+
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds support for more than one session per calendar day in the irregular (hand-picked dates) series editor. Picking an already-used date now adds another session instead of being rejected as a duplicate, each session has its own independent start/end time, and the calendar picker badges days with more than one session.

- `RecurrenceService` gains id-matched `build_manual_sessions()` / `set_manual_sessions()` / `classify_manual_sessions_change()` / `reconcile_sessions()`, replacing the anchor-date-matched `build_manual_occurrences()` / `set_manual_occurrences()` (now dead code, removed).
- `EventDatesController`'s `manual_dates` param is replaced by `manual_sessions` (`{id, start_datetime, end_datetime}[]`), with ownership validation so a client-supplied id can't repoint another series' row.
- `SeriesModal`'s Irregular tab replaces the flat date list with a per-date **Sessions** list: independent start/end time inputs, a remove button per session, and a "+ Add session" control per date group.
- `MiniCalendar` gets an opt-in `badge` field on its `dayProps` contract, used here to show a session count on multi-session days.
- Fixes a latent bug in `EventDates::create_standalone_occurrence()` found while wiring this up: its `$format` array had one fewer entry than `$insert_data`, silently casting `joining_link` (a URL) with `%d` and leaving `status` unformatted for every standalone (unlinked) generated occurrence.

Ticket sales, the public event listing, and calendar exports already worked per `event_date_id` row rather than per calendar date, so no changes were needed there — they show each session separately once the series holds distinct rows for the day.

Closes #1414

## Acceptance criteria

- [x] Organizer can add a second (or more) session to a date that already has one, without it being rejected as a duplicate — via "+ Add session" per date group.
- [x] Each session on a shared date has its own editable start and end time, independent of the series master.
- [x] The calendar picker visually indicates when a day has more than one session — numeric badge.
- [x] Removing one session from a day leaves the other session(s) on that day intact — soft-cancel by id, siblings untouched.
- [x] Ticket sales / public event listing show and allow purchase of each session separately when a day has multiple — verified end-to-end (see Test plan).
- [x] Existing single-session-per-day series continue to work with no behaviour change — RRULE path (`reconcile_occurrences`/`classify_change`) untouched; `badge` is opt-in so other `MiniCalendar` callers are unaffected.
- [x] API spec tests cover creating/reading a series with multiple sessions on the same date.
- [x] Component test covers the irregular series editor accepting a duplicate date with a distinct time.
- [x] E2E test covers an organizer adding two sessions on one day and a participant seeing both as separately purchasable sessions.

## Notes

- The old date-only manual model's "master's own time reflows onto every sibling date" behavior (see `manual-series-master-date-edit.spec.js`) no longer applies — each session now carries its own independent time, so editing the master's own date/time (via Event Details) only updates the master's own row.
- `EventDates::get_all_by_master_id_flat()` is new (id-keyed, mirroring the existing anchor-keyed `get_all_by_master_id()`), used by the new id-based reconciliation.
- The `EditInstancesModal` (date-based cancel/restore) and `toggle_exdate` endpoint are unchanged — they remain date-anchored and are unaffected by same-day multi-session state for the common (single-session-per-day) case; a multi-session day's exdate toggle is out of scope for this ticket per the implementation plan.

## Test plan

- [x] `npm run test:php` (fair-events) — 269 tests pass.
- [x] `npm run test:js` (fair-events) — 217 tests pass.
- [x] `npm run test` (fair-events-shared) — 238 tests pass.
- [x] `vendor/bin/phpcs` clean for changed PHP (same pre-existing baseline errors, none new).
- [x] `npm run build` (fair-events) succeeds.
- [x] Verified live against the running dev instance (`docker compose up`):
  - `src/API/__tests__/EventDatesManualSessions.api.spec.js` (new) — creating two sessions on one date, editing one by id without disturbing its sibling, soft-cancelling one of several same-day sessions, and rejecting a spoofed session id — all pass via real HTTP requests.
  - `e2e/manual-series-multiple-sessions-per-day.spec.js` (new) — organizer adds a second session via the actual admin UI, participant sees two distinct purchasable options on the public signup form — passes.
  - `e2e/manual-series-master-date-edit.spec.js` (updated) — editing the master's own date no longer reflows onto sibling sessions — passes.
  - Manually confirmed the `create_standalone_occurrence` format-array fix via a WP-CLI `eval-file` script (before/after).
  - Visually confirmed the Sessions list + badge in the running admin UI (Irregular series tab).

