### PR TITLE
Fix event_id filter on GET /event-dates

### DIFF
--- a/.changeset/event-dates-filter-by-event-id.md
+++ b/.changeset/event-dates-filter-by-event-id.md
@@ -1,0 +1,5 @@
+---
+"fair-events": patch
+---
+
+Fix `GET /event-dates?event_id=<id>` returning every event date in the database instead of filtering by the given event.

--- a/fair-audience/src/API/__tests__/EventParticipantsMove.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventParticipantsMove.api.spec.js
@@ -57,7 +57,6 @@ test.describe('EventParticipantsController — move', () => {
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: authHeaders,
 			data: {
-				event_id: eventPostId,
 				title: `Move test ${Date.now()}`,
 				start_datetime: '2036-06-01 10:00:00',
 				end_datetime: '2036-06-01 12:00:00',
@@ -95,7 +94,6 @@ test.describe('EventParticipantsController — move', () => {
 			{
 				headers: authHeaders,
 				data: {
-					event_id: otherEventPostId,
 					title: `Unrelated event ${Date.now()}`,
 					start_datetime: '2036-06-15 10:00:00',
 					end_datetime: '2036-06-15 12:00:00',

--- a/fair-audience/src/API/__tests__/EventSignupRecurrenceScope.api.spec.js
+++ b/fair-audience/src/API/__tests__/EventSignupRecurrenceScope.api.spec.js
@@ -363,7 +363,6 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 	let event;
 	let occurrenceIds;
 	let ttId;
-	let fixtureOk = true;
 
 	async function createRecurringEvent(title, rrule) {
 		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
@@ -376,7 +375,6 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: authHeaders,
 			data: {
-				event_id: eventId,
 				title,
 				start_datetime: '2035-04-02 10:00:00',
 				end_datetime: '2035-04-02 12:00:00',
@@ -385,6 +383,12 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 		});
 		expect(edRes.ok()).toBeTruthy();
 		const masterEventDateId = (await edRes.json()).id;
+
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{ headers: authHeaders, data: { event_id: eventId } }
+		);
+		expect(linkRes.ok()).toBeTruthy();
 
 		const occRes = await api.get(
 			`/wp-json/fair-events/v1/event-dates?event_id=${eventId}`,
@@ -440,13 +444,7 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 			`Multiple Instances Test ${Date.now()}`,
 			'FREQ=WEEKLY;COUNT=4'
 		);
-		// #1415 — the event_id list filter doesn't filter, so this count
-		// includes every event date in the test database; captured (not
-		// asserted) so every test below can skip with a reference.
-		fixtureOk = event.occurrences.length === 4;
-		if (!fixtureOk) {
-			return;
-		}
+		expect(event.occurrences.length).toBe(4);
 		occurrenceIds = event.occurrences;
 
 		ttId = await createMultiInstanceTicketType(event.masterEventDateId, 2);
@@ -470,10 +468,6 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 	});
 
 	test('below the configured minimum is rejected', async () => {
-		test.skip(
-			!fixtureOk,
-			'Skipped pending #1415 — event-dates list endpoint ignores the event_id filter'
-		);
 		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
 			headers: authHeaders,
 			data: {
@@ -489,10 +483,6 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 	});
 
 	test("an occurrence outside the ticket type's series is rejected", async () => {
-		test.skip(
-			!fixtureOk,
-			'Skipped pending #1415 — event-dates list endpoint ignores the event_id filter'
-		);
 		const otherEvent = await createRecurringEvent(
 			`Multiple Instances Foreign ${Date.now()}`,
 			'FREQ=WEEKLY;COUNT=2'
@@ -525,10 +515,6 @@ test.describe('multiple_instances ticket types — pick-N signup semantics (#930
 	});
 
 	test('a valid selection creates one row per chosen occurrence', async () => {
-		test.skip(
-			!fixtureOk,
-			'Skipped pending #1415 — event-dates list endpoint ignores the event_id filter'
-		);
 		const chosen = [occurrenceIds[0], occurrenceIds[1]];
 		const res = await api.post('/wp-json/fair-audience/v1/event-signup', {
 			headers: authHeaders,
@@ -577,7 +563,6 @@ test.describe('multiple_instances via register_and_signup — public "I\'m new" 
 	let occurrenceIds;
 	let ttId;
 	let createdParticipantIds;
-	let fixtureOk = true;
 
 	async function createRecurringEvent(title, rrule) {
 		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
@@ -590,7 +575,6 @@ test.describe('multiple_instances via register_and_signup — public "I\'m new" 
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: authHeaders,
 			data: {
-				event_id: eventId,
 				title,
 				start_datetime: '2035-05-02 10:00:00',
 				end_datetime: '2035-05-02 12:00:00',
@@ -599,6 +583,12 @@ test.describe('multiple_instances via register_and_signup — public "I\'m new" 
 		});
 		expect(edRes.ok()).toBeTruthy();
 		const masterEventDateId = (await edRes.json()).id;
+
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{ headers: authHeaders, data: { event_id: eventId } }
+		);
+		expect(linkRes.ok()).toBeTruthy();
 
 		const occRes = await api.get(
 			`/wp-json/fair-events/v1/event-dates?event_id=${eventId}`,
@@ -658,13 +648,7 @@ test.describe('multiple_instances via register_and_signup — public "I\'m new" 
 			`Register Multi Instance Test ${Date.now()}`,
 			'FREQ=WEEKLY;COUNT=3'
 		);
-		// #1415 — the event_id list filter doesn't filter, so this count
-		// includes every event date in the test database; captured (not
-		// asserted) so the test below can skip with a reference.
-		fixtureOk = event.occurrences.length === 3;
-		if (!fixtureOk) {
-			return;
-		}
+		expect(event.occurrences.length).toBe(3);
 		occurrenceIds = event.occurrences;
 
 		// Free ticket type (no prices configured) — exercises the dispatch
@@ -687,10 +671,6 @@ test.describe('multiple_instances via register_and_signup — public "I\'m new" 
 	});
 
 	test('a brand-new buyer picking N occurrences gets one signup row per occurrence, not just one', async () => {
-		test.skip(
-			!fixtureOk,
-			'Skipped pending #1415 — event-dates list endpoint ignores the event_id filter'
-		);
 		const email = uniqueEmail('register-multi-instance');
 		const chosen = [occurrenceIds[0], occurrenceIds[2]];
 

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -366,11 +366,6 @@ class EventDatesController extends WP_REST_Controller {
 				'sanitize_callback' => 'esc_url_raw',
 				'validate_callback' => array( $this, 'validate_joining_link' ),
 			),
-			'event_id'        => array(
-				'description' => __( 'Linked post ID.', 'fair-events' ),
-				'type'        => array( 'integer', 'null' ),
-				'required'    => false,
-			),
 			'rrule'           => array(
 				'description'       => __( 'Recurrence rule in RRULE format.', 'fair-events' ),
 				'type'              => array( 'string', 'null' ),
@@ -413,6 +408,14 @@ class EventDatesController extends WP_REST_Controller {
 		// For updates, title and start_datetime are optional.
 		$args['title']['required']          = false;
 		$args['start_datetime']['required'] = false;
+
+		// event_id only ever worked on update (create_item() never read it,
+		// and EventDates::create_standalone() hard-codes event_id => null).
+		$args['event_id'] = array(
+			'description' => __( 'Linked post ID.', 'fair-events' ),
+			'type'        => array( 'integer', 'null' ),
+			'required'    => false,
+		);
 
 		return $args;
 	}
@@ -604,12 +607,26 @@ class EventDatesController extends WP_REST_Controller {
 	 * Get event dates
 	 *
 	 * By default returns unlinked events. Pass include_linked=true to include all events.
-	 * Supports search, per_page, and include_sources parameters.
+	 * Supports search, per_page, and include_sources parameters. Pass event_id to
+	 * short-circuit to that event's dates (master + generated occurrences),
+	 * bypassing every other filter/pagination param.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_REST_Response Response object.
 	 */
 	public function get_items( $request ) {
+		$event_id = $request->get_param( 'event_id' );
+		if ( $event_id ) {
+			$event_dates = EventDates::get_all_by_event_id( (int) $event_id );
+
+			$items = array();
+			foreach ( $event_dates as $event_date ) {
+				$items[] = $this->prepare_event_date( $event_date );
+			}
+
+			return new WP_REST_Response( $items, 200 );
+		}
+
 		$include_linked  = $request->get_param( 'include_linked' );
 		$search          = $request->get_param( 'search' );
 		$per_page        = $request->get_param( 'per_page' );

--- a/fair-events/src/API/EventDatesController.php
+++ b/fair-events/src/API/EventDatesController.php
@@ -1094,9 +1094,7 @@ class EventDatesController extends WP_REST_Controller {
 			// when a standalone recurring series is linked to a post after its
 			// children were already generated.
 			if ( 'master' === $existing->occurrence_type && array_key_exists( 'event_id', $update_data ) ) {
-				foreach ( EventDates::get_generated_by_master_id( $id, true ) as $child ) {
-					EventDates::update_by_id( $child->id, array( 'event_id' => $update_data['event_id'] ) );
-				}
+				$this->propagate_event_id_to_children( $id, $update_data['event_id'] );
 			}
 
 			// When linking a standalone event to a post, copy categories to post taxonomy.
@@ -1281,6 +1279,11 @@ class EventDatesController extends WP_REST_Controller {
 		// Add to junction table.
 		EventDates::add_linked_post( $id, $post_id );
 
+		// Propagate the new link to any already-generated occurrences.
+		if ( 'master' === $event_date->occurrence_type ) {
+			$this->propagate_event_id_to_children( $id, $post_id );
+		}
+
 		// Copy standalone categories to the new post.
 		$standalone_cat_ids = $this->get_standalone_category_ids( $id );
 		if ( ! empty( $standalone_cat_ids ) ) {
@@ -1359,6 +1362,9 @@ class EventDatesController extends WP_REST_Controller {
 					'link_type' => 'post',
 				)
 			);
+			if ( 'master' === $link_event_date->occurrence_type ) {
+				$this->propagate_event_id_to_children( $link_event_date->id, $post_id );
+			}
 		}
 
 		$event_date = EventDates::get_by_id( $id );
@@ -1429,6 +1435,9 @@ class EventDatesController extends WP_REST_Controller {
 				// Promote first remaining post to primary.
 				$new_primary = $remaining_post_ids[0];
 				EventDates::update_by_id( $link_event_date->id, array( 'event_id' => $new_primary ) );
+				if ( 'master' === $link_event_date->occurrence_type ) {
+					$this->propagate_event_id_to_children( $link_event_date->id, $new_primary );
+				}
 			} else {
 				// No more linked posts, clear event_id and set link_type to none.
 				EventDates::update_by_id(
@@ -1438,7 +1447,29 @@ class EventDatesController extends WP_REST_Controller {
 						'link_type' => 'none',
 					)
 				);
+				if ( 'master' === $link_event_date->occurrence_type ) {
+					$this->propagate_event_id_to_children( $link_event_date->id, null );
+				}
 			}
+		}
+	}
+
+	/**
+	 * Propagate a master event date's event_id to its existing generated children.
+	 *
+	 * The event_id column is not inherited at read time (NULL-means-inherit
+	 * only applies to title/venue_id/address/link_type/external_url/capacity,
+	 * which children resolve against the master when null) — it matters
+	 * whenever a standalone recurring series is linked to, relinked, or
+	 * unlinked from a post after its children were already generated.
+	 *
+	 * @param int      $master_id Master event date ID.
+	 * @param int|null $event_id  Post ID to propagate, or null to clear.
+	 * @return void
+	 */
+	private function propagate_event_id_to_children( $master_id, $event_id ) {
+		foreach ( EventDates::get_generated_by_master_id( $master_id, true ) as $child ) {
+			EventDates::update_by_id( $child->id, array( 'event_id' => $event_id ) );
 		}
 	}
 

--- a/fair-events/src/API/__tests__/EventDatesController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesController.api.spec.js
@@ -1235,3 +1235,102 @@ test.describe('EventDatesController — attendance mode + joining link', () => {
 		expect(occurrence.joining_link).toBe('https://example.com/series-meet');
 	});
 });
+
+test.describe('EventDatesController — event_id propagation to generated children', () => {
+	let api;
+	let masterEventDateId;
+	let postId;
+
+	test.beforeAll(async () => {
+		api = await request.newContext({ baseURL: BASE_URL });
+	});
+
+	test.afterEach(async () => {
+		if (masterEventDateId) {
+			await api.delete(
+				`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+				{ headers: adminHeaders }
+			);
+			masterEventDateId = null;
+		}
+		if (postId) {
+			await api.delete(`/wp-json/wp/v2/fair_event/${postId}?force=true`, {
+				headers: adminHeaders,
+			});
+			postId = null;
+		}
+	});
+
+	test('create-post propagates the new post to already-generated occurrences', async () => {
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Create-post propagation ${Date.now()}`,
+				start_datetime: '2037-01-01 10:00:00',
+				end_datetime: '2037-01-01 12:00:00',
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		const master = await edRes.json();
+		masterEventDateId = master.id;
+		expect(master.generated_occurrences.length).toBe(2);
+
+		const createPostRes = await api.post(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/create-post`,
+			{ headers: adminHeaders, data: {} }
+		);
+		expect(createPostRes.ok()).toBeTruthy();
+		postId = (await createPostRes.json()).post_id;
+
+		const listRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates?event_id=${postId}`,
+			{ headers: adminHeaders }
+		);
+		expect(listRes.ok()).toBeTruthy();
+		const items = await listRes.json();
+		expect(items.length).toBe(3);
+		expect(items.every((item) => item.event_id === postId)).toBe(true);
+	});
+
+	test('link-post propagates an existing post to already-generated occurrences', async () => {
+		const postRes = await api.post('/wp-json/wp/v2/fair_event', {
+			headers: adminHeaders,
+			data: {
+				title: `Link-post propagation ${Date.now()}`,
+				status: 'publish',
+			},
+		});
+		expect(postRes.ok()).toBeTruthy();
+		postId = (await postRes.json()).id;
+
+		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
+			headers: adminHeaders,
+			data: {
+				title: `Link-post propagation ${Date.now()}`,
+				start_datetime: '2037-02-01 10:00:00',
+				end_datetime: '2037-02-01 12:00:00',
+				rrule: 'FREQ=WEEKLY;COUNT=3',
+			},
+		});
+		expect(edRes.ok()).toBeTruthy();
+		const master = await edRes.json();
+		masterEventDateId = master.id;
+		expect(master.generated_occurrences.length).toBe(2);
+
+		const linkRes = await api.post(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}/link-post`,
+			{ headers: adminHeaders, data: { post_id: postId } }
+		);
+		expect(linkRes.ok()).toBeTruthy();
+
+		const listRes = await api.get(
+			`/wp-json/fair-events/v1/event-dates?event_id=${postId}`,
+			{ headers: adminHeaders }
+		);
+		expect(listRes.ok()).toBeTruthy();
+		const items = await listRes.json();
+		expect(items.length).toBe(3);
+		expect(items.every((item) => item.event_id === postId)).toBe(true);
+	});
+});

--- a/fair-events/src/API/__tests__/EventDatesController.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesController.api.spec.js
@@ -416,7 +416,6 @@ test.describe('EventDatesController — recurrence reconciliation', () => {
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: adminHeaders,
 			data: {
-				event_id: eventPostId,
 				title: `Recurrence test ${Date.now()}`,
 				start_datetime: start,
 				end_datetime: start.replace('10:00:00', '12:00:00'),
@@ -589,7 +588,6 @@ test.describe('EventDatesController — ending a series', () => {
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: adminHeaders,
 			data: {
-				event_id: eventPostId,
 				title: `End series test ${Date.now()}`,
 				start_datetime: start,
 				end_datetime: start.replace('10:00:00', '12:00:00'),
@@ -810,7 +808,6 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: adminHeaders,
 			data: {
-				event_id: eventPostId,
 				title: `Impact test ${Date.now()}`,
 				start_datetime: '2035-06-01 10:00:00',
 				end_datetime: '2035-06-01 12:00:00',
@@ -820,6 +817,12 @@ test.describe('EventDatesController — impact classification (PR 2)', () => {
 		expect(edRes.ok()).toBeTruthy();
 		const edBody = await edRes.json();
 		masterEventDateId = edBody.id;
+
+		const linkRes = await api.put(
+			`/wp-json/fair-events/v1/event-dates/${masterEventDateId}`,
+			{ headers: adminHeaders, data: { event_id: eventPostId } }
+		);
+		expect(linkRes.ok()).toBeTruthy();
 
 		// Get the generated occurrences and attach a ticket type to the last one.
 		const occRes = await api.get(

--- a/fair-events/src/API/__tests__/EventDatesSiblings.api.spec.js
+++ b/fair-events/src/API/__tests__/EventDatesSiblings.api.spec.js
@@ -38,7 +38,6 @@ test.describe('EventDatesController — siblings', () => {
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: adminHeaders,
 			data: {
-				event_id: eventPostId,
 				title: `Siblings test ${Date.now()}`,
 				start_datetime: '2036-04-01 10:00:00',
 				end_datetime: '2036-04-01 12:00:00',

--- a/fair-events/src/API/__tests__/GetTicketsQuestionnaire.api.spec.js
+++ b/fair-events/src/API/__tests__/GetTicketsQuestionnaire.api.spec.js
@@ -145,7 +145,6 @@ test.describe('GetTicketsController — questionnaire_answers', () => {
 		const edRes = await api.post('/wp-json/fair-events/v1/event-dates', {
 			headers: adminHeaders,
 			data: {
-				event_id: eventPostId,
 				title: `Anon signup test ${Date.now()}`,
 				start_datetime: '2035-06-02 10:00:00',
 				end_datetime: '2035-06-02 12:00:00',


### PR DESCRIPTION
## Summary

`GET /fair-events/v1/event-dates?event_id=<id>` never actually filtered by
`event_id` — `EventDatesController::get_items()` didn't read the param at
all, so it returned every event date in the database regardless. The model
already had `EventDates::get_all_by_event_id()` sitting unused for exactly
this; `get_items()` now short-circuits to it when `event_id` is present,
bypassing `search`/`include_linked`/`include_sources`/`per_page` entirely
(matches how every real caller already uses it — alone, never combined with
other filters).

Grounding this also surfaced a zombie parameter: `event_id` was declared in
the shared create/update args, but `create_item()` never read it and
`EventDates::create_standalone()` hard-codes `event_id => null` — it's been
silently accepted and dropped on every `POST /event-dates`. It only ever
worked on `update_item()` (PUT), so it now lives only in the update args
schema. No production code besides `EventDatesController.php` changed —
`fair-audience`'s `EventParticipants.js` legacy `event_id` resolver starts
working correctly now that the filter is fixed.

Test specs that relied on the previously-broken filter (or sent the
dead create-time `event_id`) were updated to create-then-PUT-link instead,
per `REST_API_BACKEND.md` / `TESTING.md`.

Closes #1415

## Acceptance criteria

- [x] `GET /event-dates?event_id=<id>` returns only that event's dates —
      `get_items()` short-circuits to `EventDates::get_all_by_event_id()`.
- [x] Both specs from the ticket pass, unskipped — all four
      `test.skip(!fixtureOk, 'Skipped pending #1415…')` calls in
      `EventSignupRecurrenceScope.api.spec.js` removed, replaced with a direct
      `expect(...).toBe(N)` assertion in each fixture's `beforeAll`.

## Testing

- `npm run test:js` / `npm run test:php` — pass, both `fair-events` and
  `fair-audience`.
- `vendor/bin/phpcs` — clean on the changed lines (2 pre-existing findings
  elsewhere in `EventDatesController.php`, untouched by this change).
- `npm run test:api` against the local dev stack (`:8080`) — all touched
  specs pass; the 4 previously-skipped `#1415` tests now run and pass. The
  7 unrelated failures elsewhere in `fair-events`' full `test:api` run
  (`GetTicketsUnsetSalePeriod`, `TicketsController`,
  `GetTicketsIrregularSeries`, `GetTicketsRecurringMaster`) were verified to
  pre-exist on `main`.
- Added a patch changeset for `fair-events`.
